### PR TITLE
Carry _var into the layer that spends the primitives

### DIFF
--- a/.github/mutation/signatures.toml
+++ b/.github/mutation/signatures.toml
@@ -73,7 +73,7 @@ excluded-modules = []
 #
 # A second pass worked through that data. The most consequential real
 # gap this session found, in either module, is in `ssa._assert_as_valid_`:
-# `if ec.y_aff_from_jac(KJ) % 2:` -- "Fail if y_K is odd" -- weakened to
+# `if ec.y_aff_from_jac_var(KJ) % 2:` -- "Fail if y_K is odd" -- weakened to
 # `% 1` is always zero, so the check never fires. Every existing vector
 # missed it because a wrong `s` almost always moves K by whole multiples
 # of the generator, which moves its x-coordinate too, so 'Fail if x_K !=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1498,6 +1498,26 @@ documented at release-notes length in the first place, and are still in
   btclib caller those coefficients are a signature and a message hash,
   which is why the suffix is a label and not a defect.
 
+  The layer above the primitives takes it too, each name measured over
+  the value it is handed rather than inherited from what it calls:
+  `CurveGroup.aff_from_jac_var` (2.96x in its `Z`),
+  `x_aff_from_jac_var` (1.93x), `aff_from_jac_batch_var` (1.67x),
+  `y_aff_from_jac_var` (1.42x), `double_aff_var` (1.32x),
+  `add_aff_var` (1.23x) and the `add_var` over them (1.22x). `y_var`,
+  `y_even_var`, `y_low_var` and `y_quadratic_residue_var` are flat on
+  secp256k1 and 1.84x on `secp224k1`, whose `p` is 1 mod 4 and whose
+  square root is therefore Tonelli-Shanks; the private `_y_even_var` and
+  `_is_x_coordinate_var` of `curves.curve` go with them, each being the
+  bindings on secp256k1 and the Python root or symbol elsewhere.
+
+  Measured and not inherited is what keeps the suffix meaningful, and the
+  count says why: 636 functions reach one of these primitives through
+  some chain of calls, 344 of them public, which would put `_var` on
+  `hex_string` and `p2pkh`. Blinding breaks the chain — `mult` is 0.99x
+  in its scalar because `_blinded_jac` randomized the `Z` its inverse is
+  timed on — and so does a public operand, `point_from_octets` measuring
+  1.05x. CONTRIBUTING.md carries the rule and both counterexamples.
+
 - **`mod_inv` delegates its extended Euclid to CPython** (issue #779).
   `pow(a, -1, m)` is `long_invmod`, the same algorithm `xgcd` runs with
   the second cofactor dropped -- CPython carries that loop as a comment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -987,9 +987,31 @@ random operands of 256 bits down to 64, the ratio between the two ends:
     and `tonelli_var`, whose 1.54x is spread within one operand size
     rather than across sizes — Tonelli-Shanks iterates on the value, not
     on its length. `mod_sqrt_var` reaches that loop only for a `p` of 1
-    mod 4; for the 3 mod 4 of every catalogued curve it is one
-    exponentiation with a fixed exponent and measures 1.01x, and it
-    carries the suffix all the same, because the caller picks the `p`
+    mod 4: on a 3 mod 4 one it is a single exponentiation with a fixed
+    exponent and measures 1.01x, and the catalogue holds both kinds —
+    `secp224k1`, `secp224r1` and `nistp224` are 1 mod 4 — so the caller
+    picks which it gets and the suffix states the worse case
+- one modular inverse, in the layer above: `aff_from_jac_var` at 2.96x,
+    `x_aff_from_jac_var` at 1.93x, `aff_from_jac_batch_var` at 1.67x and
+    `y_aff_from_jac_var` at 1.42x follow the `Z` they are handed;
+    `double_aff_var` at 1.32x, `add_aff_var` at 1.23x and the `add_var`
+    over them at 1.22x follow the coordinates. `y_var` and its three
+    tiebreakers follow their `x` on the 1 mod 4 curves above, 1.84x on
+    `secp224k1`, where on secp256k1 they are flat
+
+**The suffix is measured, never inherited, and that is what stops it.**
+Every function that *reaches* one of these through some chain of calls
+would otherwise take it: there are 636 of them, 344 public, which is
+`hex_string`, `ripemd160` and `p2pkh` — a suffix on the library, saying
+nothing. Two things break the chain, and both are facts about the caller
+rather than about the callee. Blinding is one: `mult` calls
+`aff_from_jac_var` and is 0.99x in its scalar, because `_blinded_jac`
+randomized the `Z` that inverse is timed on. A public operand is the
+other: `point_from_octets` measures 1.05x, its `y_even_var` being one
+fixed exponent on secp256k1 and its `_is_x_coordinate_var` reaching the
+bindings. So the question to ask of a new name is not what it calls, but
+what its own clock does with what it was handed — and the answer is a
+measurement.
 
 Three tiers of duration follow, of which only the first is constant-time:
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -54,18 +54,23 @@ full year, short month, short day (YYYY-M-D)
   `AttributeError` around one of those two `verify` calls has to catch
   `TypeError` or `BTClibException`. `pedersen.verify` refuses a
   commitment of a type no point has, where it answered False.
-- **six functions gain a `_var` suffix, and `mod_inv` changes meaning.**
-  The suffix marks a duration that follows the operand, so the plain
-  name beside it is the one a secret may be handed:
-  `number_theory.mod_inv` is `mod_inv_var`, `xgcd` is `xgcd_var`,
-  `legendre_symbol` is `legendre_symbol_var`, `mod_sqrt` is
-  `mod_sqrt_var`, `tonelli` is `tonelli_var`, and `curves.double_mult`
-  and `curves.multi_mult` are `double_mult_var` and `multi_mult_var`.
-  `curves.mult` is unchanged, its two arms making the same additions for
-  every scalar.
+- **the functions whose duration follows their operand gain a `_var`
+  suffix, and `mod_inv` changes meaning.** The plain name beside the
+  suffix is the one a secret may be handed. In `number_theory`,
+  `mod_inv` is `mod_inv_var`, `xgcd` is `xgcd_var`, `legendre_symbol` is
+  `legendre_symbol_var`, `mod_sqrt` is `mod_sqrt_var` and `tonelli` is
+  `tonelli_var`; in `curves`, `double_mult` and `multi_mult` are
+  `double_mult_var` and `multi_mult_var`, and `CurveGroup` renames
+  `aff_from_jac`, `aff_from_jac_batch`, `x_aff_from_jac`,
+  `y_aff_from_jac`, `add`, `add_aff`, `double_aff`, `y`, `y_even`,
+  `y_low` and `y_quadratic_residue` the same way. `curves.mult` is
+  unchanged, its two arms making the same additions for every scalar,
+  and so is everything above the arithmetic: the suffix is measured on
+  the value a function receives, not inherited from what it calls.
 
-  An import of one of the six old spellings is an `ImportError`, and each
-  new name is a rename with no change of signature or behaviour.
+  An import or a call of one of the old spellings is an `AttributeError`
+  or an `ImportError`, and each new name is a rename with no change of
+  signature or behaviour.
   `mod_inv` is the exception and does not raise: the name survives and
   now returns the same inverse computed with a random blinding factor,
   so a caller inverting a secret is protected without changing a line,

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -40,7 +40,7 @@ from btclib.curves import (
     bytes_from_prv_key_int,
     secp256k1,
 )
-from btclib.curves.curve import _is_x_coordinate
+from btclib.curves.curve import _is_x_coordinate_var
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
 from btclib.network import (
@@ -162,14 +162,14 @@ def _assert_valid_key(version: bytes, key: bytes) -> None:
             err_msg += f"0x{key[:1].hex()}"
             raise BTClibValueError(err_msg)
         # existence and nothing else, the y having been computed and
-        # dropped: this is the caller _is_x_coordinate's docstring
+        # dropped: this is the caller _is_x_coordinate_var's docstring
         # describes, and the square root it exists not to pay was paid
         # once per extended key, so by every level of every derivation
         # path (issue 615). A predicate has no exception to chain, so
         # the message below is the whole of the error where it used to
         # be raised from curve_group's "invalid x-coordinate"
         x = int.from_bytes(key[1:], byteorder="big", signed=False)
-        if not _is_x_coordinate(x, secp256k1):
+        if not _is_x_coordinate_var(x, secp256k1):
             raise BTClibValueError(f"invalid public key: 0x{key.hex()}")
     else:
         raise BTClibValueError(f"unknown extended key version: 0x{version.hex()}")

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -421,7 +421,7 @@ def _compressed_sec(x: int, ec: Curve) -> bytes | None:
     return b"\x02" + x.to_bytes(ec.p_size, "big")
 
 
-def _is_x_coordinate(x: int, ec: Curve) -> bool:
+def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
     """Return True if x is the x-coordinate of a point of the curve.
 
     Existence and nothing else, which is what a caller with no use for
@@ -435,7 +435,7 @@ def _is_x_coordinate(x: int, ec: Curve) -> bool:
     A bool rather than an exception, because the value that names itself
     in an error message is the caller's and not this x: dsa.Sig's
     congruence check tries every x congruent to r and reports r. That is
-    also what keeps the refusal cheap, where _y_even below cannot: half
+    also what keeps the refusal cheap, where _y_even_var below cannot: half
     of the field elements are not x-coordinates, and the symbol costs the
     same for those as for the others.
     """
@@ -455,21 +455,21 @@ def _is_x_coordinate(x: int, ec: Curve) -> bool:
     return legendre_symbol_var(ec._y2(x), ec.p) != -1
 
 
-def _y_even(x: int, ec: Curve) -> int:
+def _y_even_var(x: int, ec: Curve) -> int:
     """Return the even y-coordinate associated to x.
 
-    ec.y_even, delegated for secp256k1: the parity a compressed public
+    ec.y_even_var, delegated for secp256k1: the parity a compressed public
     key carries in its prefix is the same tiebreaker, so 0x02 || x names
     the even-y point and the uncompressed serialization of it hands back
     the y that was lifted -- 2.9 us against 75. That is 0.5 more than
-    _is_x_coordinate above, which is why both exist.
+    _is_x_coordinate_var above, which is why both exist.
 
-    An x the bindings refuse falls through to ec.y_even instead of
+    An x the bindings refuse falls through to ec.y_even_var instead of
     raising here, so that the message stays in the one place that has the
     value to name: "invalid x-coordinate" is curve_group's to phrase, and
     the callers of this function wrap that message rather than restating
     it. The fallthrough pays the Python square root on a path whose
-    answer is an exception, which is the trade _is_x_coordinate exists
+    answer is an exception, which is the trade _is_x_coordinate_var exists
     not to make.
     """
     sec = _compressed_sec(x, ec)
@@ -479,7 +479,7 @@ def _y_even(x: int, ec: Curve) -> int:
             uncompressed = libsecp256k1_pubkey_serialize(pubkey, compressed=False)
             return int.from_bytes(uncompressed[ec.p_size + 1 :], "big")
 
-    return ec.y_even(x)
+    return ec.y_even_var(x)
 
 
 def _sec_from_point(Q: Point) -> bytes:
@@ -600,7 +600,7 @@ def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point
         # built once and kept and the multiplication makes no doubling at
         # all. It is faster than the endomorphism below on secp256k1 too,
         # so the test is on the point before it is on the curve
-        return ec.aff_from_jac(_mult_fixed_base(m, ec.GJ, ec, _FIXED_BASE_W))
+        return ec.aff_from_jac_var(_mult_fixed_base(m, ec.GJ, ec, _FIXED_BASE_W))
 
     ec.require_on_curve(Q)
     QJ = _jac_from_aff(Q)
@@ -632,7 +632,7 @@ def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point
         if ec == secp256k1
         else _mult(m, QJ, ec)
     )
-    return ec.aff_from_jac(R)
+    return ec.aff_from_jac_var(R)
 
 
 def _double_mult_python(
@@ -692,7 +692,7 @@ def double_mult_var(
     HJ = _jac_from_aff(H)
     QJ = _jac_from_aff(Q)
     R = _double_mult_python(u, HJ, v, QJ, ec)
-    return ec.aff_from_jac(R)
+    return ec.aff_from_jac_var(R)
 
 
 def _jac_double_mult(u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: Curve) -> JacPoint:
@@ -726,7 +726,7 @@ def _jac_double_mult(u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: Curve) -> J
     if not _libsecp256k1_applicable(ec, None):
         return _double_mult_python(u, HJ, v, QJ, ec)
 
-    R = double_mult_var(u, ec.aff_from_jac(HJ), v, ec.aff_from_jac(QJ), ec)
+    R = double_mult_var(u, ec.aff_from_jac_var(HJ), v, ec.aff_from_jac_var(QJ), ec)
     return _jac_from_aff(R)
 
 
@@ -761,4 +761,4 @@ def multi_mult_var(
 
     jac_points = [_jac_from_aff(Q) for Q in points]
     R = _multi_mult_var(ints, jac_points, ec)
-    return ec.aff_from_jac(R)
+    return ec.aff_from_jac_var(R)

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -282,7 +282,7 @@ class CurveGroup:
             return Q[0], (self.p - Q[1]) % self.p, Q[2]
         raise BTClibTypeError("not a Jacobian point")
 
-    def aff_from_jac(self, Q: JacPoint) -> Point:
+    def aff_from_jac_var(self, Q: JacPoint) -> Point:
         """Return the affine point: one modular inversion.
 
         The input point is assumed to be on the curve; infinity comes
@@ -293,10 +293,10 @@ class CurveGroup:
 
         return self._aff_from_z_inv(Q, mod_inv_var(Q[2], self.p))
 
-    def aff_from_jac_batch(self, Qs: Sequence[JacPoint]) -> list[Point]:
+    def aff_from_jac_batch_var(self, Qs: Sequence[JacPoint]) -> list[Point]:
         """Return the affine points: one modular inversion for all of them.
 
-        `aff_from_jac` over a sequence, with `mod_inv_batch_var` in place of
+        `aff_from_jac_var` over a sequence, with `mod_inv_batch_var` in place of
         the one inverse each: the conversion is two products a point once
         the inverse is in hand, so a caller holding several Jacobian
         points pays one extended Euclid instead of one per point.
@@ -321,10 +321,10 @@ class CurveGroup:
         z_inv2 = z_inv * z_inv % p
         return Q[0] * z_inv2 % p, Q[1] * z_inv2 % p * z_inv % p
 
-    def x_aff_from_jac(self, Q: JacPoint) -> int:
+    def x_aff_from_jac_var(self, Q: JacPoint) -> int:
         """Return the affine x alone, without the products y costs.
 
-        One inversion, as `aff_from_jac`, of Z^2 rather than of Z: the
+        One inversion, as `aff_from_jac_var`, of Z^2 rather than of Z: the
         power x wants is the one inverted, so nothing is rebuilt from it.
         The input point is assumed to be on the curve; infinity has no
         x and is refused.
@@ -335,11 +335,11 @@ class CurveGroup:
         Z2 = Q[2] * Q[2]
         return (Q[0] * mod_inv_var(Z2, self.p)) % self.p
 
-    def y_aff_from_jac(self, Q: JacPoint) -> int:
+    def y_aff_from_jac_var(self, Q: JacPoint) -> int:
         """Return the affine y alone, without the product x costs.
 
-        One inversion, as `aff_from_jac`, of Z^3 rather than of Z, for
-        the same reason `x_aff_from_jac` inverts Z^2.
+        One inversion, as `aff_from_jac_var`, of Z^3 rather than of Z, for
+        the same reason `x_aff_from_jac_var` inverts Z^2.
         The input point is assumed to be on the curve; infinity has no
         y and is refused.
         """
@@ -365,7 +365,7 @@ class CurveGroup:
 
     # methods using _a, _b, p
 
-    def add(self, Q1: Point, Q2: Point) -> Point:
+    def add_var(self, Q1: Point, Q2: Point) -> Point:
         """Return the sum of two points.
 
         The input points must be on the curve.
@@ -373,10 +373,10 @@ class CurveGroup:
         self.require_on_curve(Q1)
         self.require_on_curve(Q2)
         # affine arithmetic, and it is not the inversion that decides it:
-        # aff_from_jac makes one, add_aff makes one. The products decide,
-        # and reaching this sum through Jacobian coordinates and back
-        # makes more of them than add_aff does
-        return self.add_aff(Q1, Q2)
+        # aff_from_jac_var makes one, add_aff_var makes one. The products
+        # decide, and reaching this sum through Jacobian coordinates and
+        # back makes more of them than add_aff_var does
+        return self.add_aff_var(Q1, Q2)
 
     def add_jac(self, Q: JacPoint, R: JacPoint) -> JacPoint:
         """Return the sum of two Jacobian points, branch-free.
@@ -573,7 +573,7 @@ class CurveGroup:
         Z = 2 * Q[1] * Q[2] % p
         return X, Y, Z
 
-    def add_aff(self, Q: Point, R: Point) -> Point:
+    def add_aff_var(self, Q: Point, R: Point) -> Point:
         """Return the sum of two affine points, assumed on the curve.
 
         One modular inversion; the special cases are branched on, the
@@ -605,7 +605,7 @@ class CurveGroup:
         # iteration count follows the value it is inverting, so the affine
         # law cannot be made uniform whatever is done to these three tests
         if R[0] == Q[0]:
-            return self.double_aff(R) if R[1] == Q[1] else INF
+            return self.double_aff_var(R) if R[1] == Q[1] else INF
 
         p = self.p
         # lam reduced before it is squared, as in add_jac, though here it
@@ -617,7 +617,7 @@ class CurveGroup:
         y = (lam * (Q[0] - x) - Q[1]) % p
         return x, y
 
-    def double_aff(self, Q: Point) -> Point:
+    def double_aff_var(self, Q: Point) -> Point:
         """Return twice the affine point, assumed to be on the curve."""
         if Q[1] == 0:  # Infinity point in affine coordinates
             return INF
@@ -634,7 +634,7 @@ class CurveGroup:
         # This is a good reason to keep this method private
         return ((x**2 + self._a) * x + self._b) % self.p
 
-    def y(self, x: int) -> int:
+    def y_var(self, x: int) -> int:
         """Return the y coordinate from x, as in (x, y)."""
         if not 0 <= x < self.p:
             err_msg = "x-coordinate not in 0..p-1: "
@@ -672,18 +672,18 @@ class CurveGroup:
 
     #  y-symmetry tiebreaker criteria: even/odd, low/high, or quadratic residue
 
-    def y_even(self, x: int) -> int:
+    def y_even_var(self, x: int) -> int:
         """Return the odd/even affine y-coordinate associated to x."""
-        root = self.y(x)
+        root = self.y_var(x)
         # switch even/odd root as needed (XORing the conditions)
         return self.p - root if root % 2 else root
 
-    def y_low(self, x: int) -> int:
+    def y_low_var(self, x: int) -> int:
         """Return the low/high affine y-coordinate associated to x."""
-        root = self.y(x)
+        root = self.y_var(x)
         return root if root <= self.p // 2 else self.p - root
 
-    def y_quadratic_residue(self, x: int) -> int:
+    def y_quadratic_residue_var(self, x: int) -> int:
         """Return the quadratic residue affine y-coordinate."""
         if not self.p_is_3_mod_4:
             err_msg = "field prime is not equal to 3 mod 4: "
@@ -697,7 +697,7 @@ class CurveGroup:
         # one modulo such a p. Asking legendre_symbol_var which of the two
         # this is would spend a second exponentiation the size of the
         # first to be told what the exponent settles
-        return self.y(x)
+        return self.y_var(x)
 
 
 def _mult_recursive_aff_var(m: int, Q: Point, ec: CurveGroup) -> Point:
@@ -717,9 +717,9 @@ def _mult_recursive_aff_var(m: int, Q: Point, ec: CurveGroup) -> Point:
         return INF
 
     if m % 2 == 1:
-        return ec.add_aff(Q, _mult_recursive_aff_var((m - 1), Q, ec))
+        return ec.add_aff_var(Q, _mult_recursive_aff_var((m - 1), Q, ec))
 
-    return _mult_recursive_aff_var((m // 2), ec.double_aff(Q), ec)
+    return _mult_recursive_aff_var((m // 2), ec.double_aff_var(Q), ec)
 
 
 def _mult_recursive_jac_var(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
@@ -765,13 +765,13 @@ def _mult_aff_var(m: int, Q: Point, ec: CurveGroup) -> Point:
     m >>= 1
     while m > 0:
         # the doubling part of 'double & add'
-        Q = ec.double_aff(Q)
+        Q = ec.double_aff_var(Q)
         # always perform the 'add', even if useless: one addition per bit
-        # whatever the bit is, as in _mult_jac_var. It buys less here, add_aff
-        # branching on its own special cases and mod_inv_var taking the time
+        # whatever the bit is, as in _mult_jac_var. It buys less here,
+        # add_aff_var branching on its own cases and mod_inv_var taking the time
         # its input asks for, which is why the affine variants are the
         # readable ones rather than the ones to sign with
-        R[1] = ec.add_aff(R[0], Q)
+        R[1] = ec.add_aff_var(R[0], Q)
         # if least significant bit of m is 1, then add Q to R[0]
         R[0] = R[m & 1]
         m >>= 1
@@ -1002,14 +1002,14 @@ def _odd_multiples_aff(Q: JacPoint, ec: CurveGroup, w: int) -> list[Point]:
     What it buys is the loop that indexes it: `add_jac_aff` makes five
     products fewer than `add_jac` on every addition, and a windowed
     multiplication makes one addition per window. What it costs is one
-    extended Euclid, `aff_from_jac_batch` sharing it across the entries --
+    extended Euclid, `aff_from_jac_batch_var` sharing it across the entries --
     at w=4 one inverse and some forty products, against five saved on each
     of the ~63 additions a 256-bit scalar makes.
 
     The inversion is a function of the point and not of the scalar, so a
     multiplication that is regular in its scalar stays regular in it.
     """
-    return ec.aff_from_jac_batch(_odd_multiples(Q, ec, w))
+    return ec.aff_from_jac_batch_var(_odd_multiples(Q, ec, w))
 
 
 # the width a point of ec._fixed_points has its table built at, against
@@ -1562,12 +1562,12 @@ def _multi_mult_w_NAF_var(
             pending.append((i, _odd_multiples(PJ, ec, width)))
 
     # one extended Euclid for every table the call builds, where a table
-    # at a time is one apiece: the batch of `aff_from_jac_batch` over the
+    # at a time is one apiece: the batch of `aff_from_jac_batch_var` over the
     # concatenation rather than over one point's share of it, which is
     # libsecp256k1's `secp256k1_ge_set_all_gej_var` over the whole of its
     # `pre_a`. An empty concatenation is not a case to test for: every
     # point being memoized leaves nothing to convert and nothing to do
-    aff = ec.aff_from_jac_batch([P for _, jac in pending for P in jac])
+    aff = ec.aff_from_jac_batch_var([P for _, jac in pending for P in jac])
     at = 0
     for i, jac in pending:
         tables[i] = aff[at : at + len(jac)]

--- a/btclib/curves/curve_group_f.py
+++ b/btclib/curves/curve_group_f.py
@@ -33,7 +33,7 @@ def find_all_points(ec: CurveGroup) -> list[Point]:
     points: list[Point] = [INF]
     for x in range(ec.p):
         try:
-            y = ec.y(x)
+            y = ec.y_var(x)
         except BTClibValueError:
             continue
 
@@ -55,7 +55,7 @@ def find_subgroup_points(ec: CurveGroup, G: Point) -> list[Point]:
 
     points = [G]
     while points[-1] != INF:
-        Q = ec.add(points[-1], G)
+        Q = ec.add_var(points[-1], G)
         points.append(Q)
 
     return points

--- a/btclib/curves/sec_point.py
+++ b/btclib/curves/sec_point.py
@@ -15,7 +15,7 @@ from btclib.alias import Integer, Octets, Point
 from btclib.curves.curve import (
     Curve,
     _libsecp256k1_applicable,
-    _y_even,
+    _y_even_var,
     mult,
     secp256k1,
 )
@@ -111,7 +111,7 @@ def point_from_octets(
             raise BTClibValueError(err_msg)
         x_Q = int.from_bytes(pub_key[1:], byteorder="big")
         try:
-            y_Q = _y_even(x_Q, ec)  # also check x_Q validity
+            y_Q = _y_even_var(x_Q, ec)  # also check x_Q validity
             return x_Q, y_Q if prefix == 0x02 else ec.p - y_Q
         except BTClibValueError as e:
             msg = f"invalid x-coordinate: '{hex_string(x_Q)}'"

--- a/btclib/ecc/commit_nonce.py
+++ b/btclib/ecc/commit_nonce.py
@@ -197,4 +197,4 @@ def commit_point_(
             y = int.from_bytes(tweaked[33:], byteorder="big", signed=False)
             return x, y
 
-    return ec.add(receipt, mult(tweak, ec.G, ec))
+    return ec.add_var(receipt, mult(tweak, ec.G, ec))

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -48,10 +48,10 @@ from btclib import var_bytes
 from btclib.alias import BinaryData, HashF, JacPoint, Octets, Point
 from btclib.curves import Curve, mult, secp256k1
 from btclib.curves.curve import (
-    _is_x_coordinate,
+    _is_x_coordinate_var,
     _jac_double_mult,
     _libsecp256k1_applicable,
-    _y_even,
+    _y_even_var,
 )
 from btclib.ecc.commit_nonce import commit_entropy_, commit_nonce_, commit_point_
 from btclib.ecc.rfc6979_nonce import _rfc6979_nonce_, challenge_
@@ -233,7 +233,7 @@ class Sig:
         r = self.r
         congruence_not_found = True
         while congruence_not_found and r < self.ec.p:
-            if _is_x_coordinate(r, self.ec):
+            if _is_x_coordinate_var(r, self.ec):
                 congruence_not_found = False
             else:
                 r += self.ec.n
@@ -1219,7 +1219,7 @@ def recover_pub_keys_(
     QJs = _recover_pub_keys_(c, sig.r, sig.s, sig.ec, lower_s=False)
     # the candidates converted together: one extended Euclid for the list
     # where one per candidate is what the loop above would have paid
-    return sig.ec.aff_from_jac_batch(QJs)
+    return sig.ec.aff_from_jac_batch_var(QJs)
 
 
 def recover_pub_keys(msg: Octets, sig: Sig | Octets, hf: HashF = sha256) -> list[Point]:
@@ -1265,7 +1265,7 @@ def _recover_pub_key_(
     # path of recovery, but the root it takes to turn a candidate x_K into
     # a point is libsecp256k1's for secp256k1 all the same -- reached with
     # a key_id above 3, which the dispatch does not hand over
-    y = _y_even(x_K, ec)
+    y = _y_even_var(x_K, ec)
     y_K = ec.p - y if i else y
     KJ = x_K, y_K, 1  # 1.2, 1.3, and 1.4
     # 1.5 has been performed in the recover_pub_keys calling function
@@ -1281,7 +1281,7 @@ def _recover_pub_key_(
     # It is the same point either way and not the same triple: what comes
     # back is _jac_from_aff, i.e. z == 1, where the wNAF answered whatever
     # representative its ladder reached. Every caller converts with
-    # aff_from_jac, which is what a Jacobian coordinate is for
+    # aff_from_jac_var, which is what a Jacobian coordinate is for
     QJ = _jac_double_mult(r1s, KJ, r1e, ec.GJ, ec)  # 1.6.1
     _assert_as_valid_(c, QJ, r, s, ec, lower_s=lower_s)  # 1.6.2
     return QJ
@@ -1396,7 +1396,7 @@ def recover_pub_key_(
     c = challenge_(msg_hash, sig.ec, hf)  # 1.5
 
     QJ = _recover_pub_key_(key_id, c, sig.r, sig.s, sig.ec, lower_s=False)
-    return sig.ec.aff_from_jac(QJ)
+    return sig.ec.aff_from_jac_var(QJ)
 
 
 def recover_pub_key(

--- a/btclib/ecc/ellswift.py
+++ b/btclib/ecc/ellswift.py
@@ -48,9 +48,9 @@ from btclib_secp256k1 import ellswift as libsecp256k1_ellswift
 from btclib.alias import Octets, Point
 from btclib.curves import Curve, bytes_from_point, mult, secp256k1
 from btclib.curves.curve import (
-    _is_x_coordinate,
+    _is_x_coordinate_var,
     _libsecp256k1_applicable,
-    _y_even,
+    _y_even_var,
 )
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.hashes import tagged_hash
@@ -144,7 +144,7 @@ def _xswiftec(u: int, t: int, ec: Curve) -> int:
         (-X * inv_Y - u) * inv2 % p,
         (X * inv_Y - u) * inv2 % p,
     ):
-        if _is_x_coordinate(x, ec):
+        if _is_x_coordinate_var(x, ec):
             return x
     # unreachable, and here for the return type rather than for the case:
     # the map is total -- the SwiftEC paper's result is that one of the
@@ -171,7 +171,7 @@ def _xswiftec_inv(x: int, u: int, case: int, ec: Curve) -> int | None:  # noqa: 
         # -x-u being an x-coordinate means the pair would decode through
         # the third candidate of _xswiftec, which has priority: the
         # encoding would not round-trip, so this case has no answer
-        if _is_x_coordinate((-x - u) % p, ec):
+        if _is_x_coordinate_var((-x - u) % p, ec):
             return None
         v = x
         s = -(pow(u, 3, p) + b) * mod_inv_var((u * u + u * v + v * v) % p, p) % p
@@ -218,7 +218,7 @@ def _point_from_ell(ell: bytes, ec: Curve) -> Point:
     # encoding BIP324's own reference implementation leaves out: it maps
     # to an x-coordinate and stops, where libsecp256k1's decode lifts the
     # point with secp256k1_fe_is_odd(t) as the tiebreaker
-    y = _y_even(x, ec)
+    y = _y_even_var(x, ec)
     return x, (ec.p - y if t % 2 else y)
 
 
@@ -302,12 +302,12 @@ def decode(ell: Octets, ec: Curve = secp256k1) -> Point:
     ell = _ell_from_octets(ell, ec)
 
     # the bindings answer with a compressed public key, whose y is the
-    # one the prefix names: _y_even lifts the x and the prefix picks the
+    # one the prefix names: _y_even_var lifts the x and the prefix picks the
     # root, which is a parse rather than the square root it looks like
     if _libsecp256k1_applicable(ec, None):
         sec = libsecp256k1_ellswift.decode(ell)
         x = int.from_bytes(sec[1:], byteorder="big", signed=False)
-        y = _y_even(x, ec)
+        y = _y_even_var(x, ec)
         return x, (ec.p - y if sec[0] == 3 else y)
 
     return _point_from_ell(ell, ec)
@@ -343,6 +343,6 @@ def xdh(
     # point, q*P and q*(-P) differing by their own y alone, so the t
     # parity the decoding would apply does not reach the secret
     x_theirs, _ = _x_t_from_ell(ell_b if party == 0 else ell_a, ec)
-    x = mult(q, (x_theirs, _y_even(x_theirs, ec)), ec)[0]
+    x = mult(q, (x_theirs, _y_even_var(x_theirs, ec)), ec)[0]
     preimage = ell_a + ell_b + x.to_bytes(ec.p_size, byteorder="big", signed=False)
     return tagged_hash(XDH_TAG, preimage)

--- a/btclib/ecc/musig2.py
+++ b/btclib/ecc/musig2.py
@@ -303,7 +303,7 @@ def key_agg(pub_keys: Sequence[Octets]) -> KeyAggContext:
             P_i = _cpoint(pk)
         except BTClibValueError as e:
             raise InvalidContributionError(i, "pubkey") from e
-        Q = secp256k1.add(Q, mult(_key_agg_coeff_(L, second, pk), P_i, secp256k1))
+        Q = secp256k1.add_var(Q, mult(_key_agg_coeff_(L, second, pk), P_i, secp256k1))
     if Q[1] == 0:  # pragma: no cover
         # the coefficients are hashes, so cancelling them all out is the
         # discrete-log problem rather than a case to handle: raise where
@@ -334,7 +334,7 @@ def apply_tweak(
     t = int.from_bytes(tweak, "big")
     if t >= secp256k1.n:
         raise BTClibValueError(_TWEAK_RANGE_ERR)
-    Q = secp256k1.add(mult(g, Q, secp256k1), mult(t, secp256k1.G, secp256k1))
+    Q = secp256k1.add_var(mult(g, Q, secp256k1), mult(t, secp256k1.G, secp256k1))
     if Q[1] == 0:
         # t*G cancelling g*Q exactly: unreachable for a tweak nobody
         # chose to do it, reachable for one that did, and a key of
@@ -485,7 +485,7 @@ def nonce_agg(pub_nonces: Sequence[Octets]) -> bytes:
                 R_ij = _cpoint(pub_nonce[j * _PK_SIZE : (j + 1) * _PK_SIZE])
             except BTClibValueError as e:
                 raise InvalidContributionError(i, "pubnonce") from e
-            R_j = secp256k1.add(R_j, R_ij)
+            R_j = secp256k1.add_var(R_j, R_ij)
         agg_nonce += _cbytes_ext(R_j)
     return agg_nonce
 
@@ -558,7 +558,7 @@ def session_values(session_ctx: SessionContext) -> SessionValues:
         R_2 = _cpoint_ext(session_ctx.agg_nonce[_PK_SIZE:])
     except BTClibValueError as err:
         raise InvalidContributionError(None, "aggnonce") from err
-    R = secp256k1.add(R_1, mult(b, R_2, secp256k1))
+    R = secp256k1.add_var(R_1, mult(b, R_2, secp256k1))
     # an aggregate nonce of infinity is a session the signers can still
     # complete: G stands in for R, the resulting signature is invalid
     # for everybody equally, and no signer is singled out as the one who
@@ -702,7 +702,7 @@ def partial_sig_verify_(
     pub_nonce = bytes_from_octets(pub_nonce, _NONCE_SIZE)
     R_s1 = _cpoint(pub_nonce[:_PK_SIZE])
     R_s2 = _cpoint(pub_nonce[_PK_SIZE:])
-    R_s = secp256k1.add(R_s1, mult(values.b, R_s2, secp256k1))
+    R_s = secp256k1.add_var(R_s1, mult(values.b, R_s2, secp256k1))
     if values.R[1] % 2:
         R_s = secp256k1.negate(R_s)
     pub_key = bytes_from_octets(pub_key, _PK_SIZE)
@@ -711,7 +711,7 @@ def partial_sig_verify_(
     g = 1 if values.Q[1] % 2 == 0 else secp256k1.n - 1
     g = g * values.gacc % secp256k1.n
     lhs = mult(s, secp256k1.G, secp256k1)
-    rhs = secp256k1.add(R_s, mult(values.e * a * g % secp256k1.n, P, secp256k1))
+    rhs = secp256k1.add_var(R_s, mult(values.e * a * g % secp256k1.n, P, secp256k1))
     return lhs == rhs
 
 

--- a/btclib/ecc/pedersen.py
+++ b/btclib/ecc/pedersen.py
@@ -76,7 +76,7 @@ def second_generator(ec: Curve = secp256k1, hf: HashF = sha256) -> Point:
     x_H = int_from_bits(hash_digest, ec.nlen) % ec.n
     while True:
         try:
-            y_H = ec.y_even(x_H)
+            y_H = ec.y_even_var(x_H)
         except BTClibValueError:
             x_H += 1
             x_H %= ec.p

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -65,10 +65,10 @@ from btclib.alias import BinaryData, HashF, Integer, JacPoint, Octets, Point
 from btclib.bip32 import BIP32Key
 from btclib.curves import Curve, secp256k1
 from btclib.curves.curve import (
-    _is_x_coordinate,
+    _is_x_coordinate_var,
     _jac_double_mult,
     _libsecp256k1_applicable,
-    _y_even,
+    _y_even_var,
     mult,
     multi_mult_var,
 )
@@ -153,10 +153,10 @@ class Sig:
         # r is a field element, fail if r is not a valid x-coordinate.
         # The question is existence: BIP340 fixes the y even, and
         # verification recomputes the point from the scalars rather than
-        # lifting this r, so _is_x_coordinate and not the _y_even that
+        # lifting this r, so _is_x_coordinate_var and not the _y_even_var that
         # was here (issue 622). The delegated lift was already 2.9 us
         # against 75 on the accepting path, and 0.65 of that is not the
-        # reason: _y_even falls back to ec.y_even for an x the bindings
+        # reason: _y_even_var falls back to ec.y_even_var for an x the bindings
         # refuse -- that being where the message naming the value comes
         # from -- so refusing cost the whole Python square root, 78.7 us
         # against the 22.4 of verifying a good signature. The expensive
@@ -168,7 +168,7 @@ class Sig:
         # of the two fields was wrong. dsa.Sig phrases its own for the
         # same reason, with the congruence this one has no use for -- r
         # is a field element here, not a scalar reduced mod n
-        if not _is_x_coordinate(self.r, self.ec):
+        if not _is_x_coordinate_var(self.r, self.ec):
             err_msg = "r is not a valid x-coordinate: "
             err_msg += f"'{hex_string(self.r)}'" if self.r > 0xFFFFFFFF else f"{self.r}"
             raise BTClibValueError(err_msg)
@@ -241,13 +241,13 @@ def point_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve = secp256k1) -> Point:
     - native tuple
     """
     # every branch below ends in the same lift, an x-only key being an x
-    # and the even y that goes with it: _y_even is ec.y_even answered by
+    # and the even y that goes with it: _y_even_var is ec.y_even_var answered by
     # libsecp256k1 for secp256k1, 2.9 us against the 75 of a modular
     # square root, and the Python one for every other curve
 
     # BIP340 key as integer
     if isinstance(x_Q, int):
-        return x_Q, _y_even(x_Q, ec)
+        return x_Q, _y_even_var(x_Q, ec)
 
     # (tuple) Point, (dict or str) BIP32Key, or 33/65 bytes
     # both classes, this being a guess at the spelling: a type no public
@@ -256,12 +256,12 @@ def point_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve = secp256k1) -> Point:
     # at the end
     with contextlib.suppress(BTClibTypeError, BTClibValueError):
         x_Q = point_from_pub_key(x_Q, ec)[0]
-        return x_Q, _y_even(x_Q, ec)
+        return x_Q, _y_even_var(x_Q, ec)
     # BIP340 key as bytes or hex-string
     if isinstance(x_Q, (str, bytes)):
         Q = bytes_from_octets(x_Q, ec.p_size)
         x_Q = int.from_bytes(Q, "big", signed=False)
-        return x_Q, _y_even(x_Q, ec)
+        return x_Q, _y_even_var(x_Q, ec)
 
     raise BTClibTypeError("not a BIP340 public key")
 
@@ -521,7 +521,7 @@ def _assert_as_valid_(c: int, QJ: JacPoint, r: int, s: int, ec: Curve) -> None:
     # if moved after 'Fail if x_K ≠ r' it would never be executed
     # Fail if infinite(KJ).
     # Fail if y_K is odd.
-    if ec.y_aff_from_jac(KJ) % 2:
+    if ec.y_aff_from_jac_var(KJ) % 2:
         raise BTClibRuntimeError("y_K is odd")
 
     # Fail if x_K ≠ r
@@ -697,7 +697,7 @@ def _recover_pub_key_(c: int, r: int, s: int, ec: Curve) -> int:
     if c == 0:
         raise BTClibRuntimeError("invalid zero challenge")
 
-    KJ = r, _y_even(r, ec), 1
+    KJ = r, _y_even_var(r, ec), 1
 
     e1 = mod_inv_var(c, ec.n)
     # libsecp256k1 recovers no x-only key -- its recovery module is ECDSA
@@ -715,7 +715,7 @@ def _recover_pub_key_(c: int, r: int, s: int, ec: Curve) -> int:
     if QJ[2] == 0:
         err_msg = "invalid (INF) key"
         raise BTClibRuntimeError(err_msg)
-    return int(ec.x_aff_from_jac(QJ))
+    return int(ec.x_aff_from_jac_var(QJ))
 
 
 def _err_msg(size: int, msgs_or_sigs: str, arg2: Sequence[Octets | Sig]) -> str:
@@ -807,7 +807,7 @@ def assert_batch_as_valid_(
         # any size, as in sign_ and assert_as_valid_
         msg = bytes_from_octets(msg)  # noqa: PLW2901
 
-        K = sig.r, _y_even(sig.r, ec)
+        K = sig.r, _y_even_var(sig.r, ec)
 
         x_Q, y_Q = point_from_bip340pub_key(Q, ec)
 

--- a/btclib/number_theory.py
+++ b/btclib/number_theory.py
@@ -247,7 +247,7 @@ def legendre_symbol_var(a: int, p: int) -> int:
     The loop's length follows `a`, where an exponentiation's did not.
     SECURITY.md publishes the Python path as variable-time, and nothing
     in the tree asks this about a value that has to stay hidden:
-    `curves.curve._is_x_coordinate` is the one caller, and what reaches
+    `curves.curve._is_x_coordinate_var` is the one caller, and what reaches
     it is a signature's r, the x-coordinate of a serialized xpub, or a
     candidate x of an ElligatorSwift encoding -- each of them public, and
     on secp256k1 each answered by the bindings before this is reached.

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -28,7 +28,7 @@ from btclib.alias import (
     TaprootScriptTree,
 )
 from btclib.curves import bytes_from_prv_key_int, mult, secp256k1
-from btclib.curves.curve import _libsecp256k1_applicable, _y_even
+from btclib.curves.curve import _libsecp256k1_applicable, _y_even_var
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import tagged_hash
 from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE
@@ -264,7 +264,7 @@ def _tweaked_pubkey(pub_key: bytes, h: bytes) -> tuple[bytes, int]:
     # secp256k1_xonly_pubkey_tweak_add is this very operation, parity
     # included, and it answers the pair this function returns. 12.0 us
     # against 109.3 for the three lines below, over 2000 tweaks: the
-    # Python path lifts the x-only key to a point with secp256k1.y_even,
+    # Python path lifts the x-only key to a point with secp256k1.y_even_var,
     # i.e. a modular square root, which is 74 us of that on its own --
     # while libsecp256k1 needs no such lift, having the y coordinate as
     # it goes.
@@ -279,7 +279,7 @@ def _tweaked_pubkey(pub_key: bytes, h: bytes) -> tuple[bytes, int]:
         return libsecp256k1_xonly.tweak_add(pub_key, t)
 
     P_x = int.from_bytes(pub_key, "big")
-    Q = secp256k1.add((P_x, secp256k1.y_even(P_x)), mult(t))
+    Q = secp256k1.add_var((P_x, secp256k1.y_even_var(P_x)), mult(t))
     return Q[0].to_bytes(32, "big"), Q[1] % 2
 
 
@@ -341,7 +341,7 @@ def _tweaked_prvkey(internal_prvkey: int, h: bytes) -> int:
         return int.from_bytes(tweaked, "big")
 
     P = mult(internal_prvkey)
-    # the parity of a y already in hand: secp256k1.y_even(P[0]) lifted
+    # the parity of a y already in hand: secp256k1.y_even_var(P[0]) lifted
     # the x back to the point P is -- 74.6 us of modular square root
     # against 0.03 -- to compare its y with the one beside it (issue
     # 619). Not a delegation but a deletion, which is what this path
@@ -441,16 +441,16 @@ def check_output_pubkey(q: Octets, script: Octets, control: Octets) -> bool:
         except ValueError as e:
             # an internal key that is not a point leaves the bindings
             # through a plain ValueError and the Python path below
-            # through the BTClibValueError of _y_even. The engine
+            # through the BTClibValueError of _y_even_var. The engine
             # catches the library's own error, so the two must agree on
             # what they raise as well as on what they answer
             raise BTClibValueError(f"invalid internal public key: {e}") from e
 
-    # _y_even, i.e. secp256k1.y_even with the lift delegated: this is the path a
-    # q of any other length takes, secp256k1 included, so the modular
-    # square root is worth not taking here either
-    P = (p, _y_even(p, secp256k1))
-    Q = secp256k1.add(P, mult(t))
+    # _y_even_var, i.e. secp256k1.y_even_var with the lift delegated: this is
+    # the path a q of any other length takes, secp256k1 included, so the
+    # modular square root is worth not taking here either
+    P = (p, _y_even_var(p, secp256k1))
+    Q = secp256k1.add_var(P, mult(t))
     return Q[0] == int.from_bytes(q, "big") and control[0] & 1 == Q[1] % 2
 
 

--- a/btclib/silent_payments.py
+++ b/btclib/silent_payments.py
@@ -311,7 +311,7 @@ def labeled_address_from_keys(
     recovering a wallet from a seed alone.
     """
     B_scan = mult(int_from_prv_key(b_scan))
-    B_m = secp256k1.add(point_from_pub_key(B_spend), mult(label_tweak(b_scan, m)))
+    B_m = secp256k1.add_var(point_from_pub_key(B_spend), mult(label_tweak(b_scan, m)))
     return address_from_keys(B_scan, B_m, network)
 
 
@@ -469,7 +469,7 @@ def pub_key_sum(pub_keys: Sequence[PubKey]) -> Point:
     """
     total: Point = INF
     for pub_key in pub_keys:
-        total = secp256k1.add(total, point_from_pub_key(pub_key))
+        total = secp256k1.add_var(total, point_from_pub_key(pub_key))
     if total[1] == 0:
         raise BTClibValueError("input public keys sum to infinity")
     return total
@@ -538,7 +538,7 @@ def output_key(secret: PubKey, B_m: PubKey, k: int) -> bytes:
     `k` is the recipient's position in its group, which is what stops two
     payments to one scan key landing on one output.
     """
-    P = secp256k1.add(
+    P = secp256k1.add_var(
         point_from_pub_key(B_m), mult(_output_tweak(point_from_pub_key(secret), k))
     )
     return _x_only(P)
@@ -632,12 +632,12 @@ def _labelled(
         return None
 
     for point in (candidate, secp256k1.negate(candidate)):
-        label_point = secp256k1.add(point, secp256k1.negate(P_k))
+        label_point = secp256k1.add_var(point, secp256k1.negate(P_k))
         # infinity cannot happen here: it would mean the output equals
         # P_k up to parity, which the x-only comparison already caught
         tweak = labels.get(bytes_from_point(label_point, secp256k1))
         if tweak is not None:
-            return secp256k1.add(P_k, label_point), int_from_prv_key(tweak)
+            return secp256k1.add_var(P_k, label_point), int_from_prv_key(tweak)
     return None
 
 
@@ -675,7 +675,7 @@ def scan_outputs(
     found = []
     for k in range(K_MAX):
         t_k = _output_tweak(secret, k)
-        P_k = secp256k1.add(B, mult(t_k))
+        P_k = secp256k1.add_var(B, mult(t_k))
         x_only_P_k = _x_only(P_k)
         match = None
         for output in remaining:

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -719,7 +719,7 @@ def test_derivation_is_the_arithmetic_bip32_defines() -> None:
         32, byteorder="big", signed=False
     )
 
-    child_pub_key_point = ec.add(point_from_octets(parent_pub_key), mult(offset))
+    child_pub_key_point = ec.add_var(point_from_octets(parent_pub_key), mult(offset))
     child_pub = BIP32KeyData.b58decode(derive(xpub_from_xprv(rootxprv), f"m/{index}"))
     assert child_pub.chain_code == hmac_[32:]
     assert child_pub.key == bytes_from_point(child_pub_key_point)
@@ -1158,7 +1158,7 @@ def test_the_tweaks_of_a_public_derivation_are_the_derivation() -> None:
     derived = BIP32KeyData.b58decode(derive(xpub_from_xprv(rootxprv), "m/1/2"))
     point = point_from_octets(xpub.key, ec)
     for tweak in tweaks:
-        point = ec.add(point, mult(int.from_bytes(tweak, "big"), ec.G, ec))
+        point = ec.add_var(point, mult(int.from_bytes(tweak, "big"), ec.G, ec))
     assert bytes_from_point(point, ec) == derived.key
 
     # a hardened index needs the private key, and the refusal comes before

--- a/tests/curves/curve_group_f_test.py
+++ b/tests/curves/curve_group_f_test.py
@@ -24,12 +24,12 @@ def test_ecf() -> None:
     # Point Addition
     X = (5274, 2841)
     Y = (8669, 740)
-    assert ec.add(X, Y) == (1024, 4440)
-    assert ec.add(X, X) == (7284, 2107)
+    assert ec.add_var(X, Y) == (1024, 4440)
+    assert ec.add_var(X, X) == (7284, 2107)
     P = (493, 5564)
     Q = (1539, 4742)
     R = (4403, 5202)
-    S = ec.add(ec.add(ec.add(P, P), Q), R)
+    S = ec.add_var(ec.add_var(ec.add_var(P, P), Q), R)
     ec.require_on_curve(S)
     S_exp = (4215, 2162)
     assert S_exp == S

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -57,14 +57,14 @@ def test_mult_recursive_aff() -> None:
         assert _mult_recursive_aff_var(1, INF, ec) == INF
         assert _mult_aff_var(1, ec.G, ec) == ec.G
 
-        Q = ec.add_aff(ec.G, ec.G)
+        Q = ec.add_aff_var(ec.G, ec.G)
         assert _mult_recursive_aff_var(2, ec.G, ec) == Q
 
         Q = _mult_recursive_aff_var(ec.n - 1, ec.G, ec)
         assert ec.negate(ec.G) == Q
         assert _mult_recursive_aff_var(ec.n - 1, INF, ec) == INF
 
-        assert ec.add_aff(Q, ec.G) == INF
+        assert ec.add_aff_var(Q, ec.G) == INF
         assert _mult_recursive_aff_var(ec.n, ec.G, ec) == INF
         assert _mult_recursive_aff_var(ec.n, INF, ec) == INF
 
@@ -76,8 +76,8 @@ def test_mult_recursive_aff() -> None:
             Q = _mult_recursive_aff_var(q, ec.G, ec)
             assert ec.is_on_curve(Q), f"{q}, {ec}"
             QJ = _mult(q, ec.GJ, ec)
-            assert ec.is_on_curve(ec.aff_from_jac(QJ)), f"{q}, {ec}"
-            assert ec.aff_from_jac(QJ) == Q, f"{q}, {ec}"
+            assert ec.is_on_curve(ec.aff_from_jac_var(QJ)), f"{q}, {ec}"
+            assert ec.aff_from_jac_var(QJ) == Q, f"{q}, {ec}"
             assert _mult_recursive_aff_var(q, INF, ec) == INF, f"{q}, {ec}"
             assert ec.is_jac_equal(INFJ, _mult(q, INFJ, ec)), f"{q}, {ec}"
 
@@ -120,14 +120,14 @@ def test_mult_aff() -> None:
         assert _mult_aff_var(1, INF, ec) == INF
         assert _mult_aff_var(1, ec.G, ec) == ec.G
 
-        Q = ec.add_aff(ec.G, ec.G)
+        Q = ec.add_aff_var(ec.G, ec.G)
         assert _mult_aff_var(2, ec.G, ec) == Q
 
         Q = _mult_aff_var(ec.n - 1, ec.G, ec)
         assert ec.negate(ec.G) == Q
         assert _mult_aff_var(ec.n - 1, INF, ec) == INF
 
-        assert ec.add_aff(Q, ec.G) == INF
+        assert ec.add_aff_var(Q, ec.G) == INF
         assert _mult_aff_var(ec.n, ec.G, ec) == INF
         assert _mult_aff_var(ec.n, INF, ec) == INF
 
@@ -139,8 +139,8 @@ def test_mult_aff() -> None:
             Q = _mult_aff_var(q, ec.G, ec)
             assert ec.is_on_curve(Q), f"{q}, {ec}"
             QJ = _mult(q, ec.GJ, ec)
-            assert ec.is_on_curve(ec.aff_from_jac(QJ)), f"{q}, {ec}"
-            assert ec.aff_from_jac(QJ) == Q, f"{q}, {ec}"
+            assert ec.is_on_curve(ec.aff_from_jac_var(QJ)), f"{q}, {ec}"
+            assert ec.aff_from_jac_var(QJ) == Q, f"{q}, {ec}"
             assert _mult_aff_var(q, INF, ec) == INF, f"{q}, {ec}"
             assert ec.is_jac_equal(INFJ, _mult(q, INFJ, ec)), f"{q}, {ec}"
 
@@ -397,7 +397,7 @@ def test_signed_odd_multiples_aff() -> None:
             T = _signed_odd_multiples_aff(ec.GJ, ec, w)
             assert len(T) == 2**w
             for d in range(-(2**w - 1), 2**w, 2):
-                expected = ec.aff_from_jac(_mult_jac_var(d % ec.n, ec.GJ, ec))
+                expected = ec.aff_from_jac_var(_mult_jac_var(d % ec.n, ec.GJ, ec))
                 assert T[(d + 2**w - 1) // 2] == expected, (d, w)
 
 
@@ -615,39 +615,41 @@ def test_assorted_jac_mult() -> None:
             K2J = _mult(k2, HJ, ec)
 
             shamir = _double_mult_var(k1, ec.GJ, k2, ec.GJ, ec)
-            assert ec.is_on_curve(ec.aff_from_jac(shamir))
+            assert ec.is_on_curve(ec.aff_from_jac_var(shamir))
             assert ec.is_jac_equal(shamir, _mult(k1 + k2, ec.GJ, ec))
 
             shamir = _double_mult_var(k1, INFJ, k2, HJ, ec)
-            assert ec.is_on_curve(ec.aff_from_jac(shamir))
+            assert ec.is_on_curve(ec.aff_from_jac_var(shamir))
             assert ec.is_jac_equal(shamir, K2J)
 
             shamir = _double_mult_var(k1, ec.GJ, k2, INFJ, ec)
-            assert ec.is_on_curve(ec.aff_from_jac(shamir))
+            assert ec.is_on_curve(ec.aff_from_jac_var(shamir))
             assert ec.is_jac_equal(shamir, K1J)
 
             shamir = _double_mult_var(k1, ec.GJ, k2, HJ, ec)
-            assert ec.is_on_curve(ec.aff_from_jac(shamir))
+            assert ec.is_on_curve(ec.aff_from_jac_var(shamir))
             K1JK2J = ec.add_jac(K1J, K2J)
             assert ec.is_jac_equal(K1JK2J, shamir)
 
             k3 = ec.n // 3  # just a point, not INF
             K3J = _mult(k3, ec.GJ, ec)
             K1JK2JK3J = ec.add_jac(K1JK2J, K3J)
-            assert ec.is_on_curve(ec.aff_from_jac(K1JK2JK3J))
+            assert ec.is_on_curve(ec.aff_from_jac_var(K1JK2JK3J))
             boscoster = _multi_mult_var([k1, k2, k3], [ec.GJ, HJ, ec.GJ], ec)
-            assert ec.is_on_curve(ec.aff_from_jac(boscoster))
-            assert ec.aff_from_jac(K1JK2JK3J) == ec.aff_from_jac(boscoster), k3
+            assert ec.is_on_curve(ec.aff_from_jac_var(boscoster))
+            assert ec.aff_from_jac_var(K1JK2JK3J) == ec.aff_from_jac_var(boscoster), k3
             assert ec.is_jac_equal(K1JK2JK3J, boscoster)
 
             k4 = ec.n // 4  # just a point, not INF
             K4J = _mult(k4, HJ, ec)
             K1JK2JK3JK4J = ec.add_jac(K1JK2JK3J, K4J)
-            assert ec.is_on_curve(ec.aff_from_jac(K1JK2JK3JK4J))
+            assert ec.is_on_curve(ec.aff_from_jac_var(K1JK2JK3JK4J))
             points = [ec.GJ, HJ, ec.GJ, HJ]
             boscoster = _multi_mult_var([k1, k2, k3, k4], points, ec)
-            assert ec.is_on_curve(ec.aff_from_jac(boscoster))
-            assert ec.aff_from_jac(K1JK2JK3JK4J) == ec.aff_from_jac(boscoster), k4
+            assert ec.is_on_curve(ec.aff_from_jac_var(boscoster))
+            assert ec.aff_from_jac_var(K1JK2JK3JK4J) == ec.aff_from_jac_var(
+                boscoster
+            ), k4
             assert ec.is_jac_equal(K1JK2JK3JK4J, boscoster)
             assert ec.is_jac_equal(
                 K1JK2JK3J, _multi_mult_var([k1, k2, k3, 0], points, ec)
@@ -700,10 +702,10 @@ def test_mult_on_a_characteristic_7_curve() -> None:
     for k in range(ec.n):
         expected = _mult_aff_var(k, ec.G, ec)
         for name, mult_f in variants:
-            assert ec.aff_from_jac(mult_f(k, ec.GJ, ec)) == expected, name
+            assert ec.aff_from_jac_var(mult_f(k, ec.GJ, ec)) == expected, name
         for j in range(ec.n):
             shamir = _double_mult_var(k, ec.GJ, j, ec.GJ, ec)
-            assert ec.aff_from_jac(shamir) == _mult_aff_var(k + j, ec.G, ec), (k, j)
+            assert ec.aff_from_jac_var(shamir) == _mult_aff_var(k + j, ec.G, ec), (k, j)
 
 
 def _sum_of_mults(
@@ -901,9 +903,9 @@ def test_INF() -> None:
     assert INF[1] == 0
 
     with pytest.raises(BTClibValueError, match="invalid x-coordinate: "):
-        secp256k1.y(INF[0])
+        secp256k1.y_var(INF[0])
     with pytest.raises(BTClibValueError, match="invalid x-coordinate: "):
-        secp256k1.y(INF[0] + secp256k1.n)
+        secp256k1.y_var(INF[0] + secp256k1.n)
 
 
 def test_aff_from_jac_batch_is_aff_from_jac_over_a_sequence() -> None:
@@ -915,16 +917,18 @@ def test_aff_from_jac_batch_is_aff_from_jac_over_a_sequence() -> None:
     """
     for ec in all_curves.values():
         QJs = [_mult(k, ec.GJ, ec) for k in (1, 2, 3, ec.n - 1)]
-        assert ec.aff_from_jac_batch(QJs) == [ec.aff_from_jac(QJ) for QJ in QJs]
+        assert ec.aff_from_jac_batch_var(QJs) == [ec.aff_from_jac_var(QJ) for QJ in QJs]
 
         # infinity first, last and in between, so that the peeling back
         # off the running products starts and stops beside one
         mixed = [INFJ, QJs[0], INFJ, INFJ, QJs[1], INFJ]
-        assert ec.aff_from_jac_batch(mixed) == [ec.aff_from_jac(QJ) for QJ in mixed]
+        assert ec.aff_from_jac_batch_var(mixed) == [
+            ec.aff_from_jac_var(QJ) for QJ in mixed
+        ]
 
         # nothing to invert at all, and nothing to convert at all
-        assert ec.aff_from_jac_batch([INFJ, INFJ]) == [INF, INF]
-        assert ec.aff_from_jac_batch([]) == []
+        assert ec.aff_from_jac_batch_var([INFJ, INFJ]) == [INF, INF]
+        assert ec.aff_from_jac_batch_var([]) == []
 
 
 def test_blinding_changes_the_coordinates_and_not_the_point() -> None:
@@ -940,7 +944,7 @@ def test_blinding_changes_the_coordinates_and_not_the_point() -> None:
             QJ = _mult(k, ec.GJ, ec)
             blinded = [_blinded_jac(QJ, ec) for _ in range(8)]
             for B in blinded:
-                assert ec.aff_from_jac(B) == ec.aff_from_jac(QJ)
+                assert ec.aff_from_jac_var(B) == ec.aff_from_jac_var(QJ)
                 assert ec.is_jac_equal(B, QJ)
             # a curve of eleven points has eleven values of l to draw
             # from, so the Z's are only expected to differ where p is big

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -36,11 +36,11 @@ from btclib.curves.curve import (
     SEC2v1_params2,
     SEC2v2,
     SEC2v2_params2,
-    _is_x_coordinate,
+    _is_x_coordinate_var,
     _libsecp256k1_applicable,
     _libsecp256k1_multi_mult_,
     _sec_from_point,
-    _y_even,
+    _y_even_var,
 )
 
 # _cached_multiples and _jac_from_aff are implementation helpers of
@@ -231,7 +231,7 @@ def test_curves_with_n_above_p() -> None:
         ec = low_card_curves[name]
         # every point of the curve, x below n, so nothing to reduce
         for q in range(1, ec.n):
-            x_K = ec.x_aff_from_jac(_mult_jac_var(q, ec.GJ, ec))
+            x_K = ec.x_aff_from_jac_var(_mult_jac_var(q, ec.GJ, ec))
             assert x_K < ec.n
             assert x_K % ec.n == x_K
 
@@ -303,41 +303,41 @@ def test_aff_jac_conversions() -> None:
         # just a point, not INF
         Q = ec.G
         QJ = _jac_from_aff(Q)
-        assert ec.aff_from_jac(QJ) == Q
-        x_Q = ec.x_aff_from_jac(QJ)
+        assert ec.aff_from_jac_var(QJ) == Q
+        x_Q = ec.x_aff_from_jac_var(QJ)
         assert Q[0] == x_Q
-        y_Q = ec.y_aff_from_jac(QJ)
+        y_Q = ec.y_aff_from_jac_var(QJ)
         assert Q[1] == y_Q
 
-        assert ec.aff_from_jac(_jac_from_aff(INF)) == INF
+        assert ec.aff_from_jac_var(_jac_from_aff(INF)) == INF
 
         with pytest.raises(BTClibValueError, match="INF has no x-coordinate"):
-            ec.x_aff_from_jac(INFJ)
+            ec.x_aff_from_jac_var(INFJ)
 
         with pytest.raises(BTClibValueError, match="INF has no y-coordinate"):
-            ec.y_aff_from_jac(INFJ)
+            ec.y_aff_from_jac_var(INFJ)
 
 
 def test_add_double_aff() -> None:
     """Test self-consistency of add and double in affine coordinates."""
     for ec in all_curves.values():
         # add G and the infinity point
-        assert ec.add_aff(ec.G, INF) == ec.G
-        assert ec.add_aff(INF, ec.G) == ec.G
+        assert ec.add_aff_var(ec.G, INF) == ec.G
+        assert ec.add_aff_var(INF, ec.G) == ec.G
 
         # double G
-        G2 = ec.add_aff(ec.G, ec.G)
-        assert ec.double_aff(ec.G) == G2
+        G2 = ec.add_aff_var(ec.G, ec.G)
+        assert ec.double_aff_var(ec.G) == G2
 
         # double INF
-        assert ec.add_aff(INF, INF) == INF
-        assert ec.double_aff(INF) == INF
+        assert ec.add_aff_var(INF, INF) == INF
+        assert ec.double_aff_var(INF) == INF
 
         # add G and minus G
-        assert ec.add_aff(ec.G, ec.negate(ec.G)) == INF
+        assert ec.add_aff_var(ec.G, ec.negate(ec.G)) == INF
 
         # add INF and "minus" INF
-        assert ec.add_aff(INF, ec.negate(INF)) == INF
+        assert ec.add_aff_var(INF, ec.negate(INF)) == INF
 
 
 def test_add_double_jac() -> None:
@@ -370,15 +370,15 @@ def test_add_double_aff_jac() -> None:
         QJ = _jac_from_aff(Q)
 
         # add Q and G
-        R = ec.add_aff(Q, ec.G)
+        R = ec.add_aff_var(Q, ec.G)
         RJ = ec.add_jac(QJ, ec.GJ)
-        assert ec.aff_from_jac(RJ) == R
+        assert ec.aff_from_jac_var(RJ) == R
 
         # double Q
-        R = ec.double_aff(Q)
+        R = ec.double_aff_var(Q)
         RJ = ec.double_jac(QJ)
-        assert ec.aff_from_jac(RJ) == R
-        assert ec.add_aff(Q, Q) == R
+        assert ec.aff_from_jac_var(RJ) == R
+        assert ec.add_aff_var(Q, Q) == R
         assert ec.is_jac_equal(RJ, ec.add_jac(QJ, QJ))
 
 
@@ -449,9 +449,9 @@ def test_point_addition_exhaustive() -> None:
                 for PJ in _jac_spellings(ec, P):
                     for QJ in _jac_spellings(ec, Q):
                         RJ = ec.add_jac(PJ, QJ)
-                        got = None if RJ[2] == 0 else ec.aff_from_jac(RJ)
+                        got = None if RJ[2] == 0 else ec.aff_from_jac_var(RJ)
                         assert got == expected, f"{name}: {PJ} + {QJ}"
-                R = ec.add_aff(INF if P is None else P, INF if Q is None else Q)
+                R = ec.add_aff_var(INF if P is None else P, INF if Q is None else Q)
                 assert (INF if expected is None else expected) == R, (
                     f"{name}: {P} + {Q}"
                 )
@@ -474,8 +474,8 @@ def test_add_jac_infinity_is_not_a_doubling() -> None:
         secp256k1,
     ):
         for infinity in (INFJ, _jac_from_aff(INF), (0, 0, 0)):
-            assert ec.aff_from_jac(ec.add_jac(ec.GJ, infinity)) == ec.G
-            assert ec.aff_from_jac(ec.add_jac(infinity, ec.GJ)) == ec.G
+            assert ec.aff_from_jac_var(ec.add_jac(ec.GJ, infinity)) == ec.G
+            assert ec.aff_from_jac_var(ec.add_jac(infinity, ec.GJ)) == ec.G
             assert ec.add_jac(infinity, infinity)[2] == 0
 
 
@@ -601,7 +601,7 @@ def test_add_jac_does_the_same_arithmetic_around_infinity() -> None:
 
 
 def test_add_aff_takes_infinity_before_doubling() -> None:
-    """The order of add_aff's two special cases is the working one.
+    """The order of add_aff_var's two special cases is the working one.
 
     Not an inelegance to be tidied by testing for doubling first (issue
     171): INF is (5, 0) and its x-coordinate is arbitrary, so a doubling
@@ -612,8 +612,8 @@ def test_add_aff_takes_infinity_before_doubling() -> None:
     """
     ec = low_card_curves["ec23_19"]
     assert ec.G[0] == INF[0]
-    assert ec.add_aff(INF, ec.G) == ec.G
-    assert ec.add_aff(ec.G, INF) == ec.G
+    assert ec.add_aff_var(INF, ec.G) == ec.G
+    assert ec.add_aff_var(ec.G, INF) == ec.G
 
 
 def test_ec_repr() -> None:
@@ -767,7 +767,7 @@ def test_is_on_curve() -> None:
             ec.is_on_curve((1, 2, 3))  # type: ignore[arg-type]
 
         with pytest.raises(BTClibValueError, match="x-coordinate not in 0..p-1: "):
-            ec.y(ec.p)
+            ec.y_var(ec.p)
 
         # just a point, not INF
         Q = ec.G
@@ -781,7 +781,7 @@ def test_negate() -> None:
         # just a point, not INF
         Q = ec.G
         minus_Q = ec.negate(Q)
-        assert ec.add(Q, minus_Q) == INF
+        assert ec.add_var(Q, minus_Q) == INF
 
         # Jacobian coordinates
         QJ = _jac_from_aff(Q)
@@ -810,15 +810,15 @@ def test_symmetry() -> None:
         Q = ec.G
         x_Q = Q[0]
 
-        assert not ec.y_even(x_Q) % 2
-        assert ec.y_low(x_Q) <= ec.p // 2
+        assert not ec.y_even_var(x_Q) % 2
+        assert ec.y_low_var(x_Q) <= ec.p // 2
 
         # compute all quadratic residues
         hasRoot = {1}
         hasRoot.update(i * i % ec.p for i in range(2, ec.p))
 
         if ec.p % 4 == 3:
-            quad_res = ec.y_quadratic_residue(x_Q)
+            quad_res = ec.y_quadratic_residue_var(x_Q)
 
             # in this case only quad_res is a quadratic residue
             assert quad_res in hasRoot
@@ -832,39 +832,39 @@ def test_symmetry() -> None:
                 mod_sqrt_var(ec.p - quad_res, ec.p)
         else:
             assert ec.p % 4 == 1
-            # cannot use y_quadratic_residue in this case
+            # cannot use y_quadratic_residue_var in this case
             err_msg = "field prime is not equal to 3 mod 4: "
             with pytest.raises(BTClibValueError, match=err_msg):
-                ec.y_quadratic_residue(x_Q)
+                ec.y_quadratic_residue_var(x_Q)
 
-            y_even = ec.y_even(x_Q)
-            y_odd = ec.p - y_even
+            y_even_var = ec.y_even_var(x_Q)
+            y_odd = ec.p - y_even_var
             # in this case neither or both y_Q are quadratic residues
-            neither = y_odd not in hasRoot and y_even not in hasRoot
-            both = y_odd in hasRoot and y_even in hasRoot
+            neither = y_odd not in hasRoot and y_even_var not in hasRoot
+            both = y_odd in hasRoot and y_even_var in hasRoot
             assert neither or both
             if y_odd in hasRoot:  # both have roots
                 root = mod_sqrt_var(y_odd, ec.p)
                 assert y_odd == (root * root) % ec.p
                 root = ec.p - root
                 assert y_odd == (root * root) % ec.p
-                root = mod_sqrt_var(y_even, ec.p)
-                assert y_even == (root * root) % ec.p
+                root = mod_sqrt_var(y_even_var, ec.p)
+                assert y_even_var == (root * root) % ec.p
                 root = ec.p - root
-                assert y_even == (root * root) % ec.p
+                assert y_even_var == (root * root) % ec.p
             else:
                 err_msg = "no root for "
                 with pytest.raises(BTClibValueError, match=err_msg):
                     mod_sqrt_var(y_odd, ec.p)
                 with pytest.raises(BTClibValueError, match=err_msg):
-                    mod_sqrt_var(y_even, ec.p)
+                    mod_sqrt_var(y_even_var, ec.p)
 
     with pytest.raises(BTClibValueError, match="invalid x-coordinate: "):
-        secp256k1.y_even(INF[0])
+        secp256k1.y_even_var(INF[0])
     with pytest.raises(BTClibValueError, match="invalid x-coordinate: "):
-        secp256k1.y_low(INF[0])
+        secp256k1.y_low_var(INF[0])
     with pytest.raises(BTClibValueError, match="invalid x-coordinate: "):
-        secp256k1.y_quadratic_residue(INF[0])
+        secp256k1.y_quadratic_residue_var(INF[0])
 
 
 def test_assorted_mult() -> None:
@@ -889,12 +889,12 @@ def test_assorted_mult() -> None:
 
             shamir = double_mult_var(k1, ec.G, k2, H, ec)
             assert ec.is_on_curve(shamir)
-            K1K2 = ec.add(K1, K2)
+            K1K2 = ec.add_var(K1, K2)
             assert shamir == K1K2
 
             k3 = ec.n // 3  # just a random point, not INF
             K3 = mult(k3, ec.G, ec)
-            K1K2K3 = ec.add(K1K2, K3)
+            K1K2K3 = ec.add_var(K1K2, K3)
             assert ec.is_on_curve(K1K2K3)
             boscoster = multi_mult_var([k1, k2, k3], [ec.G, H, ec.G], ec)
             assert ec.is_on_curve(boscoster)
@@ -902,7 +902,7 @@ def test_assorted_mult() -> None:
 
             k4 = ec.n // 4  # just a random point, not INF
             K4 = mult(k4, H, ec)
-            K1K2K3K4 = ec.add(K1K2K3, K4)
+            K1K2K3K4 = ec.add_var(K1K2K3, K4)
             assert ec.is_on_curve(K1K2K3K4)
             points = [ec.G, H, ec.G, H]
             boscoster = multi_mult_var([k1, k2, k3, k4], points, ec)
@@ -926,7 +926,7 @@ def test_double_mult() -> None:
     assert double_mult_var(1, G, 0, H) == G
     assert double_mult_var(0, G, 1, H) == H
     for i, j in itertools.product(range(-1, 3), range(-1, 3)):
-        exp = secp256k1.add(mult(i), mult(j, H))
+        exp = secp256k1.add_var(mult(i), mult(j, H))
         assert exp == double_mult_var(i, G, j, H)
 
 
@@ -1102,8 +1102,8 @@ def test_x_coordinate_lift(bindings: bool, monkeypatch: pytest.MonkeyPatch) -> N
     """The two delegated square roots, against the Python arithmetic.
 
     A compressed public key is "this x, and the y that goes with it", so
-    ec_pubkey_parse answers both of the questions `_is_x_coordinate` and
-    `_y_even` ask (issue 284) -- and `ec.y_even` is what they are held
+    ec_pubkey_parse answers both of the questions `_is_x_coordinate_var` and
+    `_y_even_var` ask (issue 284) -- and `ec.y_even_var` is what they are held
     against, over the 400 smallest field elements, of which 208 are not
     x-coordinates at all. It is those that have to be checked: an
     implementation accepting one would take a public key consensus
@@ -1121,33 +1121,33 @@ def test_x_coordinate_lift(bindings: bool, monkeypatch: pytest.MonkeyPatch) -> N
     refused = 0
     for x in range(400):
         try:
-            y_even = ec.y_even(x)
+            y_even_var = ec.y_even_var(x)
         except BTClibValueError as e:
             refused += 1
             python_msg = str(e)
-            assert not _is_x_coordinate(x, ec)
+            assert not _is_x_coordinate_var(x, ec)
             # the message names the value, which is why the refusal stays
             # curve_group's to phrase rather than the bindings' to raise
             with pytest.raises(BTClibValueError, match="invalid x-coordinate: ") as err:
-                _y_even(x, ec)
+                _y_even_var(x, ec)
             assert str(err.value) == python_msg
         else:
-            assert _is_x_coordinate(x, ec)
-            assert _y_even(x, ec) == y_even
-            assert y_even % 2 == 0
-            assert ec.is_on_curve((x, y_even))
+            assert _is_x_coordinate_var(x, ec)
+            assert _y_even_var(x, ec) == y_even_var
+            assert y_even_var % 2 == 0
+            assert ec.is_on_curve((x, y_even_var))
     assert refused == 208
 
     # the x of a point, which is the case every caller has
-    assert _is_x_coordinate(ec.G[0], ec)
-    assert _y_even(ec.G[0], ec) == ec.G[1]
+    assert _is_x_coordinate_var(ec.G[0], ec)
+    assert _y_even_var(ec.G[0], ec) == ec.G[1]
 
     # outside the field, where there is no x-coordinate to have and no
     # p-size serialization to ask the bindings about either
     for x in (-1, ec.p, ec.p + 1, 2**256):
-        assert not _is_x_coordinate(x, ec)
+        assert not _is_x_coordinate_var(x, ec)
         with pytest.raises(BTClibValueError, match="x-coordinate not in 0..p-1"):
-            _y_even(x, ec)
+            _y_even_var(x, ec)
 
 
 def test_x_coordinate_lift_of_every_other_curve() -> None:
@@ -1161,11 +1161,11 @@ def test_x_coordinate_lift_of_every_other_curve() -> None:
     for ec in (CURVES["secp256r1"], low_card_curves["ec13_11"]):
         for x in range(min(ec.p, 24)):
             try:
-                y_even = ec.y_even(x)
+                y_even_var = ec.y_even_var(x)
             except BTClibValueError:
-                assert not _is_x_coordinate(x, ec)
+                assert not _is_x_coordinate_var(x, ec)
                 with pytest.raises(BTClibValueError, match="x-coordinate"):
-                    _y_even(x, ec)
+                    _y_even_var(x, ec)
             else:
-                assert _is_x_coordinate(x, ec)
-                assert _y_even(x, ec) == y_even
+                assert _is_x_coordinate_var(x, ec)
+                assert _y_even_var(x, ec) == y_even_var

--- a/tests/ecc/anti_exfil_test.py
+++ b/tests/ecc/anti_exfil_test.py
@@ -148,7 +148,7 @@ def test_the_whole_handshake() -> None:
         _PUB_KEY,
         sig,
         _RHO,
-        secp256k1.add(R, secp256k1.G),
+        secp256k1.add_var(R, secp256k1.G),
     )
 
     # the malleated twin shares r, so the commitment opens to it as well,

--- a/tests/ecc/bms_test.py
+++ b/tests/ecc/bms_test.py
@@ -938,7 +938,7 @@ def test_a_key_id_that_recovers_nothing() -> None:
         assert _recovers(key_id, magic_msg, bms_sig.dsa_sig) is None
         # either exception, which is why the helper suppresses both: the
         # wrapped x may miss the curve, and BTClibValueError comes out of
-        # y_even, or it may land on it and recover a key that does not
+        # y_even_var, or it may land on it and recover a key that does not
         # verify, which is the BTClibRuntimeError
         with pytest.raises((BTClibValueError, BTClibRuntimeError)):
             dsa.recover_pub_key(key_id, magic_msg, bms_sig.dsa_sig)

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -226,7 +226,7 @@ def test_low_cardinality(name: str) -> None:
         QJ = _mult(q, ec.GJ, ec)  # public key
         for k in range(1, ec.n):  # all possible ephemeral keys
             RJ = _mult(k, ec.GJ, ec)
-            r = ec.x_aff_from_jac(RJ) % ec.n
+            r = ec.x_aff_from_jac_var(RJ) % ec.n
             k_inv = mod_inv_var(k, ec.n)
             for e in range(ec.n):  # all possible challenges
                 s = k_inv * (e + q * r) % ec.n
@@ -247,8 +247,8 @@ def test_low_cardinality(name: str) -> None:
                     dsa._assert_as_valid_(e, QJ, r, s, ec, lower_s=lower_s)
 
                     jac_keys = dsa._recover_pub_keys_(e, r, s, ec, lower_s=lower_s)
-                    Qs = [ec.aff_from_jac(key) for key in jac_keys]
-                    assert ec.aff_from_jac(QJ) in Qs
+                    Qs = [ec.aff_from_jac_var(key) for key in jac_keys]
+                    assert ec.aff_from_jac_var(QJ) in Qs
                     assert len(jac_keys) in {2, 4}
 
 
@@ -285,9 +285,9 @@ def test_key_id_is_j_above_the_parity_bit() -> None:
         assert ec.cofactor == 2
         cases = 0
         for q in range(1, ec.n):
-            Q = ec.aff_from_jac(_mult(q, ec.GJ, ec))
+            Q = ec.aff_from_jac_var(_mult(q, ec.GJ, ec))
             for k in range(1, ec.n):
-                x_K = ec.x_aff_from_jac(_mult(k, ec.GJ, ec))
+                x_K = ec.x_aff_from_jac_var(_mult(k, ec.GJ, ec))
                 if not ec.n < x_K < ec.p:  # else x_K is r itself
                     continue
                 r = x_K % ec.n
@@ -306,7 +306,7 @@ def test_key_id_is_j_above_the_parity_bit() -> None:
                             )
                         except (BTClibValueError, BTClibRuntimeError):
                             continue
-                        recovered.append((key_id, ec.aff_from_jac(QJ)))
+                        recovered.append((key_id, ec.aff_from_jac_var(QJ)))
 
                     key_ids = [key_id for key_id, Q_ in recovered if Q_ == Q]
                     assert key_ids, "the signer's own key is not recoverable"
@@ -315,7 +315,7 @@ def test_key_id_is_j_above_the_parity_bit() -> None:
 
                     # and the plural is that range, less what dropped out
                     jac_keys = dsa._recover_pub_keys_(e, r, s, ec, lower_s=False)
-                    assert [ec.aff_from_jac(QJ) for QJ in jac_keys] == [
+                    assert [ec.aff_from_jac_var(QJ) for QJ in jac_keys] == [
                         Q_ for _, Q_ in recovered
                     ]
                     cases += 1
@@ -340,9 +340,9 @@ def test_key_id_is_the_j_zero_pair_when_n_is_above_p() -> None:
     assert ec.n > ec.p
     cases = 0
     for q in range(1, ec.n):
-        Q = ec.aff_from_jac(_mult(q, ec.GJ, ec))
+        Q = ec.aff_from_jac_var(_mult(q, ec.GJ, ec))
         for k in range(1, ec.n):
-            r = ec.x_aff_from_jac(_mult(k, ec.GJ, ec)) % ec.n
+            r = ec.x_aff_from_jac_var(_mult(k, ec.GJ, ec)) % ec.n
             # asserted, not skipped: this is the n > p property the
             # docstring names -- x_K < p < n, so x_K % n is x_K, and no
             # multiple of G on this curve has x_K == 0 (measured: the r
@@ -362,7 +362,7 @@ def test_key_id_is_the_j_zero_pair_when_n_is_above_p() -> None:
                         QJ = dsa._recover_pub_key_(key_id, e, r, s, ec, lower_s=False)
                     except (BTClibValueError, BTClibRuntimeError):
                         continue
-                    if ec.aff_from_jac(QJ) == Q:
+                    if ec.aff_from_jac_var(QJ) == Q:
                         key_ids.append(key_id)
 
                 assert key_ids, "the signer's own key is not recoverable"
@@ -404,7 +404,7 @@ def test_crack_prv_key() -> None:
 
     a = ec._a
     b = ec._b
-    alt_ec = Curve(ec.p, a, b, ec.double_aff(ec.G), ec.n, ec.cofactor)
+    alt_ec = Curve(ec.p, a, b, ec.double_aff_var(ec.G), ec.n, ec.cofactor)
     sig = dsa.Sig(sig1.r, sig1.s, alt_ec)
     with pytest.raises(BTClibValueError, match="not the same curve in signatures"):
         dsa.crack_prv_key(msg1, sig, msg2, sig2)
@@ -536,8 +536,8 @@ def test_the_two_secret_multiplications_answer_the_python_point(
             assert dsa.gen_keys(q)[1] == Q
             assert dsa._sign_(0x1234, q, nonce, True, ec) == sig
 
-        assert ec.aff_from_jac(_mult(q, ec.GJ, ec)) == Q
-        assert sig.r == ec.x_aff_from_jac(_mult(nonce, ec.GJ, ec)) % ec.n
+        assert ec.aff_from_jac_var(_mult(q, ec.GJ, ec)) == Q
+        assert sig.r == ec.x_aff_from_jac_var(_mult(nonce, ec.GJ, ec)) % ec.n
 
 
 def test_libsecp256k1() -> None:
@@ -1258,7 +1258,7 @@ def test_the_key_id_names_j_where_j_is_reachable() -> None:
         cases = 0
         j_reached = 0
         for q in range(1, ec.n):
-            Q = ec.aff_from_jac(_mult(q, ec.GJ, ec))
+            Q = ec.aff_from_jac_var(_mult(q, ec.GJ, ec))
             for k in range(1, ec.n):
                 for c in range(ec.n):
                     for lower_s in (True, False):
@@ -1269,7 +1269,7 @@ def test_the_key_id_names_j_where_j_is_reachable() -> None:
                         QJ = dsa._recover_pub_key_(
                             key_id, c, sig.r, sig.s, ec, lower_s=lower_s
                         )
-                        assert ec.aff_from_jac(QJ) == Q
+                        assert ec.aff_from_jac_var(QJ) == Q
                         cases += 1
                         j_reached += key_id >> 1
         assert cases == expected

--- a/tests/ecc/pedersen_test.py
+++ b/tests/ecc/pedersen_test.py
@@ -73,7 +73,7 @@ def test_commitment() -> None:
     # Pedersen Commitment is additively homomorphic
     # Commit(r_1, v1) + Commit(r_2, v2) = Commit(r_1+r_2, v1+r_2)
     R = pedersen.commit(r_1 + r_2, v1 + v2, ec, hf)
-    assert ec.add(C1, C2) == R
+    assert ec.add_var(C1, C2) == R
 
     pedersen.assert_as_valid(r_1, v1, C1, ec, hf)
 

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -84,7 +84,7 @@ def test_signature() -> None:
     # r outside the field and r inside it with no point are one refusal
     # now, phrased by Sig rather than by the lift it no longer takes
     # (issue 622): "x-coordinate not in 0..p-1" was ec.y's, reached
-    # through _y_even, and a predicate has no such message to pass on
+    # through _y_even_var, and a predicate has no such message to pass on
     err_msg = "r is not a valid x-coordinate: "
     with pytest.raises(BTClibValueError, match=err_msg):
         ssa.assert_as_valid(msg, x_Q, sig_invalid)
@@ -214,8 +214,8 @@ def test_refusing_an_r_takes_no_square_root(
 ) -> None:
     """The r of a signature is refused by a predicate, not by a lift.
 
-    Refusing used to cost more than verifying: `_y_even` falls back to
-    `ec.y_even` for an x the bindings reject, that being where the
+    Refusing used to cost more than verifying: `_y_even_var` falls back to
+    `ec.y_even_var` for an x the bindings reject, that being where the
     message naming the value came from, so a bad r paid the whole Python
     square root -- 78.7 us against the 22.4 of verifying a good
     signature (issue 622). Half of the field elements are no
@@ -323,7 +323,7 @@ def test_low_cardinality() -> None:
     for ec in test_curves:
         for q in range(1, ec.n // 2):  # all possible private keys
             q_fixed, x_Q = ssa.gen_keys(q, ec)
-            QJ = _jac_from_aff((x_Q, ec.y_even(x_Q)))
+            QJ = _jac_from_aff((x_Q, ec.y_even_var(x_Q)))
             sig: ssa.Sig | None = None
             while sig is None:
                 try:
@@ -377,7 +377,7 @@ def test_assert_as_valid_rejects_the_odd_y_twin_of_a_correct_k() -> None:
     """
     ec = secp256k1
     q, x_Q = ssa.gen_keys()
-    QJ = _jac_from_aff((x_Q, ec.y_even(x_Q)))
+    QJ = _jac_from_aff((x_Q, ec.y_even_var(x_Q)))
     k, r = ssa.gen_keys()  # k's point has even y, by gen_keys' own normalization
     e = 5
 
@@ -677,7 +677,7 @@ def test_musig() -> None:
     Q1 = mult(q1)
     Q2 = mult(q2)
     Q3 = mult(q3)
-    Q = ec.add(double_mult_var(a1, Q1, a2, Q2), mult(a3, Q3))
+    Q = ec.add_var(double_mult_var(a1, Q1, a2, Q2), mult(a3, Q3))
     # the parity of the aggregated key is a coin flip on every run, so
     # the negation executes in half of them: the pragmas keep the
     # coverage gate deterministic. Keys pinned offline for an odd
@@ -705,7 +705,7 @@ def test_musig() -> None:
     # before sharing {s_i}
 
     # same for all signers
-    K = ec.add(ec.add(K1, K2), K3)
+    K = ec.add_var(ec.add_var(K1, K2), K3)
     # the same coin flip as above, on the aggregated nonce
     if K[1] % 2:
         k1 = ec.n - k1  # pragma: no cover
@@ -745,7 +745,7 @@ def _commitment(commits: list[Point], x: int, ec: Curve) -> Point:
     """
     RHS = INF
     for i, commit in enumerate(commits):
-        RHS = ec.add(RHS, mult(pow(x, i), commit))
+        RHS = ec.add_var(RHS, mult(pow(x, i), commit))
     return RHS
 
 
@@ -797,9 +797,9 @@ def _partial_sig_point(
     with, so the constant term is only right when it is taken from the
     negated points.
     """
-    RHS = ec.add(K, mult(e, Q))
+    RHS = ec.add_var(K, mult(e, Q))
     for i in range(1, len(A)):
-        RHS = ec.add(RHS, double_mult_var(pow(x, i), B[i], e * pow(x, i), A[i]))
+        RHS = ec.add_var(RHS, double_mult_var(pow(x, i), B[i], e * pow(x, i), A[i]))
     return RHS
 
 
@@ -852,7 +852,7 @@ def test_threshold() -> None:
     assert mult(alpha13) == _commitment(A1, 3, ec), "signer one is cheating"
     assert mult(alpha23) == _commitment(A2, 3, ec), "signer two is cheating"
     # commitment at the global sharing polynomial
-    A = [ec.add(A1[i], ec.add(A2[i], A3[i])) for i in range(m)]
+    A = [ec.add_var(A1[i], ec.add_var(A2[i], A3[i])) for i in range(m)]
     # aggregated public key
     Q = A[0]
     # the same coin flip as in test_musig: fresh keys, random parity
@@ -897,7 +897,7 @@ def test_threshold() -> None:
     assert mult(beta13) == _commitment(B1, 3, ec), "signer one is cheating"
 
     # commitment at the global sharing polynomial
-    B = [ec.add(B1[i], B3[i]) for i in range(m)]
+    B = [ec.add_var(B1[i], B3[i]) for i in range(m)]
     # aggregated public nonce
     K = B[0]
     # the same coin flip again, and here pinning the keys would not

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -225,7 +225,7 @@ def test_check_output_pubkey_of_an_internal_key_that_is_not_a_point(
 
     x = 5 is not the x-coordinate of a secp256k1 point: 5**3 + 7 is not
     a quadratic residue. libsecp256k1 rejects it while parsing and
-    ec.y_even while lifting it, and the two errors have to be the same
+    ec.y_even_var while lifting it, and the two errors have to be the same
     kind, the script engine catching the library's own.
     """
     control = b"\xc0" + (5).to_bytes(32, "big")

--- a/tests/silent_payments_test.py
+++ b/tests/silent_payments_test.py
@@ -316,7 +316,7 @@ def test_a_labeled_address_differs_in_the_spend_key_alone() -> None:
         assert labeled_spend != B_spend
         # and the difference is the label tweak times G
         tweak = silent_payments.label_tweak(_B_SCAN_PRV, m)
-        assert labeled_spend == secp256k1.add(B_spend, mult(tweak))
+        assert labeled_spend == secp256k1.add_var(B_spend, mult(tweak))
 
 
 def test_a_label_is_a_32_bit_unsigned_integer() -> None:


### PR DESCRIPTION
Follow-up to #846, which suffixed the primitives and stopped there. So
`add_aff` and `aff_from_jac` spent a variable-time inverse under a plain
name, and the call site could not answer the question the convention
exists to answer.

## Extended by measurement, not by call graph

Each name measured over the value it is handed:

| name | ratio | what it follows |
| --- | --- | --- |
| `aff_from_jac_var` | 2.96x | the `Z` it inverts |
| `x_aff_from_jac_var` | 1.93x | `Z²` |
| `aff_from_jac_batch_var` | 1.67x | the product of the `Z`s |
| `y_aff_from_jac_var` | 1.42x | `Z³` |
| `double_aff_var` | 1.32x | `2y` |
| `add_aff_var` | 1.23x | the affine slope denominator |
| `add_var` | 1.22x | inherits from `add_aff_var` |
| `y_var` + 3 tiebreakers | 1.84x on `secp224k1` | its `x`, via Tonelli-Shanks |

`y_var` is flat on secp256k1 and variable on a `p` of 1 mod 4. **The
catalogue holds three such curves** — `secp224k1`, `secp224r1`,
`nistp224` — so #846's claim that every catalogued `p` is 3 mod 4 was
wrong, and this corrects it. The private `_y_even_var` and
`_is_x_coordinate_var` go with them, each being the bindings on
secp256k1 and the Python root or symbol elsewhere.

## What stops the suffix

**Measured, never inherited** — and the count is why. 636 functions
reach one of these primitives through some chain of calls, 344 of them
public: that is `hex_string`, `ripemd160` and `p2pkh`, a suffix on the
library saying nothing about anything, which is the failure CONTRIBUTING
already warned about.

Two things break the chain, and both are facts about the caller rather
than the callee:

- **blinding** — `mult` calls `aff_from_jac_var` and measures **0.99x**
  in its scalar, because `_blinded_jac` randomized the `Z` that inverse
  is timed on
- **a public operand** — `point_from_octets` measures **1.05x**, its
  `y_even_var` being one fixed exponent on secp256k1 and its
  `_is_x_coordinate_var` reaching the bindings

So the question to ask of a new name is not what it calls, but what its
own clock does with what it was handed. CONTRIBUTING.md carries the rule
and both counterexamples.

## Breaking

Eleven public `CurveGroup` names move; HISTORY.md's bullet from #846 is
extended rather than duplicated. `curves.mult` is unchanged.

One trap worth naming: a mechanical pass had taken `KeyWallet.add` with
the group law's `add`, and it is reverted — the two are unrelated, and
`set.add` sits in the same blast radius.

## Gates

`pytest` (27170 passed, coverage 100%), `pre-commit run --all-files` and
the `-W` sphinx build all exit 0, rebased onto 8875a45a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extend the `_var` naming convention to higher-level elliptic-curve operations whose runtime depends on their operands, and propagate these API renames through the cryptographic codebase, tests, and documentation while keeping behavior unchanged.

Enhancements:
- Rename CurveGroup affine conversion, point addition, doubling, and y-coordinate helper methods to `_var`-suffixed forms to mark operand-dependent timing and update all internal callers accordingly.
- Adjust higher-level ECC modules (SSA, DSA, Musig2, Pedersen, Taproot, Ellswift, Silent Payments, BIP32, commit_nonce, sec_point, etc.) to use the new `_var`-suffixed curve operations without changing their semantics.
- Clarify the `_var` suffix policy in CONTRIBUTING, HISTORY, and CHANGELOG, including documenting operand-based timing for affine operations and correcting the catalog of primes with respect to `p % 4`.
- Ensure public APIs raise AttributeError/ImportError for legacy non-`_var` names while preserving existing constant-time paths like `mult`.

Documentation:
- Update CONTRIBUTING.md, HISTORY.md, and CHANGELOG.md to describe the extended `_var` suffix usage, its measurement-based rationale, and the presence of 1 mod 4 curves in the catalogue.

Tests:
- Update curve, ECC, script, BIP32, and silent payments test suites to call the new `_var`-suffixed methods and verify unchanged mathematical behavior, timing expectations, and error messages.