### PR TITLE
Record why the variable-time variant is not a setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3988,6 +3988,37 @@ documented at release-notes length in the first place, and are still in
   of that conversion is the three products an entry costs, which the
   isomorphic construction pays in its own coin.
 
+- **Choosing the variable-time variant is not offered as a setting, and
+  the census says what it would have bought** (issue #849). The `_var`
+  suffix marks the functions whose work the operand decides, so the list
+  of places a switch could flip is exact, and `btclib.curves`'s docstring
+  now carries it.
+
+  The first line of it settles the question. On the generator the regular
+  form is also the faster one, by a factor of four: `_mult_fixed_base`
+  makes no doubling at all, where a wNAF makes one per bit however wide
+  its table is and however thoroughly it is cached -- 571 us against 130
+  over the memoized odd multiples of G, at w=8, w=10 and w=12 alike. So
+  the arm every key derivation, every BIP32 child and every signing nonce
+  runs has nothing faster to switch to.
+
+  What is left is a variable-base `mult` with a secret scalar, which in
+  this package is `ecc.dh`: 1.13x on secp256k1, 1.03x on nistp256, the
+  second being that measurement's own noise. The blinded nonce inverse is
+  1.5 us of a 414 us signature, the projective blinding of #805 is 1%,
+  and every verification is already `_var`. And `btclib_secp256k1` is a
+  required dependency, so the 1.13x is reached only by first switching
+  the bindings off, which is a test and benchmark configuration and not a
+  deployment: a caller who does not switch them off is on the same
+  program whatever the setting says.
+
+  Against that, a switch on what #254 asked for and #805 added is a
+  security setting, with both of its values to test everywhere it is read
+  at a coverage gate of 100%. `SECURITY.md` already publishes that this
+  arithmetic is not constant-time in CPython's integers; making the shape
+  optional too would sell the one defence left for a factor the table
+  above does not show.
+
 ### Tests
 
 - **The input-validation gate's own verdict is exercised** (issue #776).

--- a/btclib/curves/__init__.py
+++ b/btclib/curves/__init__.py
@@ -44,6 +44,22 @@ _mult_fixed_base and _double_mult_regular_window make the same number for
 every scalar of the curve. CONTRIBUTING.md states the rule, and states
 what its absence does not promise: nothing here is constant-time.
 
+**Which one runs is not a setting, and a census says why it is not**
+(issue #849). On the generator the regular form is also the faster one,
+by a factor of four: _mult_fixed_base makes no doubling at all, where a
+wNAF makes one per bit however wide its table is and however thoroughly
+it is cached -- 571 us against 130 over the memoized odd multiples of G,
+at w=8, w=10 and w=12 alike. So the arm every key derivation, every BIP32
+child and every signing nonce runs has no variable-time alternative to
+offer. What is left is a variable-base mult with a secret scalar, which
+in this package is ecc.dh: 1.13x on secp256k1 and 1.03x on nistp256, the
+second being that measurement's own noise. Beside it, the blinded nonce
+inverse is 1.5 us of a 414 us signature, the projective blinding of
+curve_group._blinded_jac is 1%, and every verification is already _var.
+And btclib_secp256k1 is a required dependency, so the 1.13x is reached
+only by first switching the bindings off: a caller who does not is on
+the same program either way.
+
 They are implementations of one operation, kept side by side to be measured
 against each other, and a menu of them is not an API: a caller reading them
 would find every way of multiplying a point this package implements and


### PR DESCRIPTION
#849 asked what a `_var_available` switch would buy. The answer is
written down rather than built, in the paragraph of `btclib.curves` that
already explains what the suffix means -- which is where someone who has
the idea again will be reading.

Measured with the bindings switched off, 20 random scalars per case,
alternating rounds, best of five:

| operation | today | fastest `_var` | |
| --- | ---: | ---: | ---: |
| `mult(m, G)`, secp256k1 | 130.4 us | 570.7 us | **0.23x** |
| `mult(m, G)`, nistp256 | 133.6 us | 636.7 us | **0.21x** |
| `mult(m, Q)`, secp256k1 | 540.1 us | 479.3 us | 1.13x |
| `mult(m, Q)`, nistp256 | 777.3 us | 756.2 us | 1.03x |
| `mod_inv` on the order | 10.8 us | 9.3 us | 1.16x |
| projective blinding, secp256k1 | 540.1 us | 535.1 us | 1.01x |
| every verification | | already `_var` | 1.00x |

The first row settles it: on the generator the constant-shape algorithm
is also the fastest, by a factor of four. `_mult_fixed_base` makes no
doubling at all, where a wNAF makes one per bit however wide its table is
-- w=8, w=10 and w=12 over G's memoized odd multiples measure 573.7,
572.3 and 570.7 us. The arm every key derivation, every BIP32 child and
every signing nonce runs has nothing faster to switch to.

What is left is a variable-base `mult` with a secret scalar, which here
is `ecc.dh`, and `btclib_secp256k1` is a required dependency, so on
secp256k1 that call delegates whatever a switch said. The 1.13x is
reachable only after switching the bindings off too -- a test and
benchmark configuration, not a deployment.

Prose only: no behaviour changes and no name moves.

## Gates

`uv run pytest` (27170 passed, coverage 100%), `uv run pre-commit run
--all-files` and the `-W` sphinx build all exit 0, at 8875a45a.

Issue #849, which closes as not planned once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the rationale and performance measurements for not exposing a variable-time elliptic curve variant as a configurable setting.

Documentation:
- Explain in CHANGELOG why variable-time variants are not offered as a user setting, including benchmark-based justification and security considerations.
- Extend btclib.curves documentation with a census of _var-suffixed operations and their performance to clarify why the constant-shape path remains the default.