### PR TITLE
Name the bindings switch, and stop switching them off by monkeypatch

### DIFF
--- a/.github/mutation/bms.toml
+++ b/.github/mutation/bms.toml
@@ -77,7 +77,7 @@ excluded-modules = []
 # exactly 20 or 32 bytes, both already caught by `> 20`; the base64
 # decode's own `validate=True` against `False`, undone by the re-encode
 # comparison the line right after it already makes; and
-# `_libsecp256k1_applicable`'s branch negated, both paths already held
+# `_libsecp256k1_serves`'s branch negated, both paths already held
 # to the same answer by `test_the_python_path_answers_the_same`.
 #
 # One survivor left open: `compressed = sig.rf > 30` needs `rf == 30`

--- a/.github/mutation/curve_group.toml
+++ b/.github/mutation/curve_group.toml
@@ -10,8 +10,8 @@
 # import and call the underscore-prefixed algorithm functions directly
 # -- `_mult`, `_multi_mult`, `_mult_endomorphism_secp256k1`,
 # `_double_mult_w_NAF`, and the rest -- secp256k1 included, so a mutant
-# of either module is reached without patching `curve.py`'s
-# `_libsecp256k1_applicable` off the way `curve_test.py`'s own
+# of either module is reached without switching `curve.py`'s
+# `_libsecp256k1_available` off the way `curve_test.py`'s own
 # `no_bindings` fixture has to for the same code reached through `mult`,
 # `double_mult_var` and `multi_mult_var`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1426,6 +1426,38 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **The bindings switch has a name** (issue #848).
+  `_libsecp256k1_applicable(ec, hf)` answered one question — can the
+  bindings serve this curve and this hash function — while a second one
+  beside it, may the bindings be used at all, had no name and was
+  answered by monkeypatching. The predicate is now
+  `_libsecp256k1_serves(ec, hf)`, which says what it decides, and the
+  switch beside it is `_libsecp256k1_available`, a module-level bool in
+  `curves/curve.py` that the predicate reads on every call.
+
+  What the switch buys is that one assignment turns the delegation off
+  everywhere. Rebinding the predicate reaches one module of the nine
+  that import it by name, and a copy per module is what produced a wrong
+  measurement: `scripts/benchmark.py` said it patched "every namespace"
+  and patched three, so its pure-Python public-key row was timing C at
+  8.47 us against the bindings' 8.39 — `to_pub_key` asks
+  `curves.sec_point`, which was not among the three. That row now reads
+  193.26 us against the same 8.39, and no row added later can
+  reintroduce the omission. `benchmark.py`, `benchmark_python.py`, `curve_test.py`'s
+  `no_bindings` and `wycheproof_test.py` all take the switch instead of
+  naming modules.
+
+  The patches that stay are the ones whose partiality is the point:
+  `script_engine/python_path_test.py` puts the Python *verdict* in front
+  of the consensus vectors while leaving the arithmetic under it
+  delegated, and `dsa_test.py` climbs a two-step ladder — the module's
+  dispatch off with `double_mult_var` still delegated, then the switch on
+  top. A global switch cannot express either, and both are cheaper for
+  it.
+
+  Neither name is a public break: both are private, and nothing outside
+  `btclib` imports either.
+
 - **The ECDSA nonce is inverted blinded**, and `number_theory.mod_inv`
   is now that blinded inverse, `dsa`'s signing being its one caller in
   the library. The extended Euclid it used to be is `mod_inv_var`, under

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -388,8 +388,23 @@ CURVES = SEC2v1 | NIST | Brainpool
 secp256k1 = CURVES["secp256k1"]
 
 
-def _libsecp256k1_applicable(ec: Curve, hf: HashF | None) -> bool:
-    """Return True if the libsecp256k1 bindings can serve ec and hf.
+# whether the bindings may be used at all: the one question
+# _libsecp256k1_serves below does not answer, which is not "can these
+# bindings serve this call" but "may they serve any of them". Assigning
+# False turns the delegation off across the whole package, because every
+# dispatch asks the predicate and the predicate reads this global --
+# whereas rebinding the predicate itself reaches one module of the nine
+# that import it by name, which is how a benchmark once timed C and
+# called it Python.
+#
+# btclib_secp256k1 is a required dependency, so this is never False
+# because the bindings are missing. It is the seam the test suite closes
+# to exercise the Python arithmetic, and scripts/benchmark.py to time it
+_libsecp256k1_available = True
+
+
+def _libsecp256k1_serves(ec: Curve, hf: HashF | None) -> bool:
+    """Return True if the libsecp256k1 bindings serve this ec and hf.
 
     Every dispatch to the bindings asks here, so that the predicates
     cannot drift apart the way hand-written copies would; a caller
@@ -401,6 +416,8 @@ def _libsecp256k1_applicable(ec: Curve, hf: HashF | None) -> bool:
     as functools.partial(sha256) falls back to the Python path. That is
     the conservative direction -- slower, never wrong.
     """
+    if not _libsecp256k1_available:
+        return False
     if ec != secp256k1:
         return False
     return hf is None or hf is sha256
@@ -416,7 +433,7 @@ def _compressed_sec(x: int, ec: Curve) -> bytes | None:
     element, ec_pubkey_parse taking no x-coordinate at or above ec.p and
     x.to_bytes raising OverflowError rather than answering for one.
     """
-    if not _libsecp256k1_applicable(ec, None) or not 0 <= x < ec.p:
+    if not _libsecp256k1_serves(ec, None) or not 0 <= x < ec.p:
         return None
     return b"\x02" + x.to_bytes(ec.p_size, "big")
 
@@ -584,7 +601,7 @@ def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point
     m: int = int_from_integer(m_int) % ec.n
 
     # m == 0 is the infinity point, which the bindings reject as a scalar
-    if m and _libsecp256k1_applicable(ec, None):
+    if m and _libsecp256k1_serves(ec, None):
         # the generator is ec_pubkey_create, with no point to parse first
         if Q is None or Q == ec.G:
             return libsecp256k1_mult(m)
@@ -607,7 +624,7 @@ def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point
 
     # what reaches here on secp256k1 is the arguments the bindings decline
     # -- a zero scalar, or infinity -- and, with the dispatch
-    # above patched off, every multiplication of the curve: that is the
+    # above switched off, every multiplication of the curve: that is the
     # reference implementation the test suite holds the bindings against,
     # and the GLV endomorphism is its fastest form, 0.59 ms against the
     # 0.82 of _mult, the decomposition being secp256k1's own lambda and
@@ -615,9 +632,9 @@ def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point
     # is the same for every scalar, which is what a private key or a nonce
     # arriving here needs and what issue 254 is about -- the endomorphism
     # over interleaved wNAFs would be 0.51 ms and 51 to 64 additions.
-    # Not spelled as _libsecp256k1_applicable, though it is the same
+    # Not spelled as _libsecp256k1_serves, though it is the same
     # test today: what decides here is whether the curve has that
-    # endomorphism, so patching the bindings off must leave this arm --
+    # endomorphism, so switching the bindings off must leave this arm --
     # python_path_test.py's pattern, which otherwise would compare the
     # bindings against the generic double-and-add of every other curve
     # the scalar of a mult is a private key or a nonce in every caller
@@ -647,15 +664,15 @@ def _double_mult_python(
     is to `_mult`: the same answer for ~128 doublings instead of ~256.
 
     Dispatched on the curve having the endomorphism, not on
-    `_libsecp256k1_applicable` -- the same test today, and not the same
-    question. `mult` says why at length: patching the bindings off is how
+    `_libsecp256k1_serves` -- the same test today, and not the same
+    question. `mult` says why at length: switching the bindings off is how
     python_path_test.py holds them against the Python arithmetic, and a
     dispatch spelled the other way would answer that test with the generic
     interleaved wNAF every other curve runs instead of with secp256k1's
     own fastest path.
 
     Which makes this the second curve comparison of the call, the guard
-    above having asked `_libsecp256k1_applicable` the first: 0.394 us on a
+    above having asked `_libsecp256k1_serves` the first: 0.394 us on a
     curve that is not secp256k1, the frame and `Curve.__eq__`'s two
     _eq_key tuples together, where the identical object short-circuits on
     identity. That is 8% of a low-cardinality double multiplication and
@@ -686,7 +703,7 @@ def double_mult_var(
     # term they make is nothing: dropping it here would leave the empty
     # sum -- infinity -- to answer for as well, which the Python path
     # below answers already, so the whole call goes there instead
-    if u and v and H[1] and Q[1] and _libsecp256k1_applicable(ec, None):
+    if u and v and H[1] and Q[1] and _libsecp256k1_serves(ec, None):
         return _libsecp256k1_multi_mult([u, v], [H, Q])
 
     HJ = _jac_from_aff(H)
@@ -723,7 +740,7 @@ def _jac_double_mult(u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: Curve) -> J
     mod_inv_var(1) on the way back out, the same inversion again on the
     cheapest operand it has.
     """
-    if not _libsecp256k1_applicable(ec, None):
+    if not _libsecp256k1_serves(ec, None):
         return _double_mult_python(u, HJ, v, QJ, ec)
 
     R = double_mult_var(u, ec.aff_from_jac_var(HJ), v, ec.aff_from_jac_var(QJ), ec)
@@ -754,7 +771,7 @@ def multi_mult_var(
     # all, an error the Python path below is the one to raise
     if (
         len(points) > 1
-        and _libsecp256k1_applicable(ec, None)
+        and _libsecp256k1_serves(ec, None)
         and all(m and Q[1] for m, Q in zip(ints, points, strict=True))
     ):
         return _libsecp256k1_multi_mult(ints, points)

--- a/btclib/curves/sec_point.py
+++ b/btclib/curves/sec_point.py
@@ -14,7 +14,7 @@ from btclib_secp256k1.keys import (
 from btclib.alias import Integer, Octets, Point
 from btclib.curves.curve import (
     Curve,
-    _libsecp256k1_applicable,
+    _libsecp256k1_serves,
     _y_even_var,
     mult,
     secp256k1,
@@ -69,7 +69,7 @@ def bytes_from_prv_key_int(
     q = int_from_integer(prv_key_int) % ec.n
 
     # q == 0 is the infinity point, which the bindings reject as a scalar
-    if q and _libsecp256k1_applicable(ec, None):
+    if q and _libsecp256k1_serves(ec, None):
         return libsecp256k1_pubkey_from_prvkey(q, compressed)
 
     return bytes_from_point(mult(q, ec=ec), ec, compressed)
@@ -167,7 +167,7 @@ def _sec_from_octets(pub_key: bytes, ec: Curve) -> bytes:
     and there is nothing to ask here.
     """
     compressed = len(pub_key) == ec.p_size + 1
-    if compressed and _libsecp256k1_applicable(ec, None):
+    if compressed and _libsecp256k1_serves(ec, None):
         with contextlib.suppress(ValueError):
             libsecp256k1_pubkey_parse(pub_key)
             return pub_key

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -119,7 +119,7 @@ from btclib.alias import BinaryData, Octets, String
 from btclib.b32 import is_segwit_prefixed, p2wpkh, witness_from_address
 from btclib.b58 import h160_from_address, p2pkh, p2wpkh_p2sh, wif_from_prv_key
 from btclib.curves import bytes_from_point, bytes_from_prv_key_int, secp256k1
-from btclib.curves.curve import _libsecp256k1_applicable
+from btclib.curves.curve import _libsecp256k1_serves
 from btclib.ecc import dsa
 from btclib.ecc.dsa import _libsecp256k1_recover_sec_
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
@@ -397,7 +397,7 @@ def assert_as_valid(msg: Octets, addr: String, sig: Sig | String) -> None:
     # an affine conversion not paid either. `verify` is 25 us against 2782,
     # the mean over 40 random keys, of which some 20 are the recovery
     # itself and 2.4 the r-congruence check of the Sig validation above
-    if _libsecp256k1_applicable(secp256k1, None):
+    if _libsecp256k1_serves(secp256k1, None):
         pub_key = _libsecp256k1_recover_sec_(
             key_id, reduce_to_hlen(magic_msg), sig.dsa_sig, compressed, lower_s=False
         )

--- a/btclib/ecc/commit_nonce.py
+++ b/btclib/ecc/commit_nonce.py
@@ -66,7 +66,7 @@ from btclib_secp256k1 import keys as libsecp256k1_keys
 
 from btclib.alias import HashF, Octets, Point
 from btclib.curves import Curve, bytes_from_point, mult, secp256k1
-from btclib.curves.curve import _libsecp256k1_applicable
+from btclib.curves.curve import _libsecp256k1_serves
 from btclib.exceptions import BTClibRuntimeError
 from btclib.hashes import tagged_hash
 from btclib.to_prv_key import PrvKey, int_from_prv_key
@@ -141,7 +141,7 @@ def commit_nonce_(
     # the delegation removes. Gated on the curve alone, as BIP32
     # derivation gates the same call: hf enters only the tagged hash
     # above, computed in Python either way
-    if _libsecp256k1_applicable(ec, None):
+    if _libsecp256k1_serves(ec, None):
         try:
             tweaked = libsecp256k1_keys.prvkey_tweak_add(nonce, tweak)
         except ValueError as e:
@@ -186,7 +186,7 @@ def commit_point_(
     # raised. bytes_from_point's own refusal of an infinite receipt is a
     # BTClibValueError, a ValueError too, and falls through the same way
     # for the same reason
-    if _libsecp256k1_applicable(ec, None):
+    if _libsecp256k1_serves(ec, None):
         try:
             sec = bytes_from_point(receipt, ec, compressed=False)
             tweaked = libsecp256k1_keys.pubkey_tweak_add(sec, tweak, compressed=False)

--- a/btclib/ecc/dh.py
+++ b/btclib/ecc/dh.py
@@ -21,7 +21,7 @@ from btclib_secp256k1 import keys as libsecp256k1_keys
 
 from btclib.alias import HashF, Point
 from btclib.curves import Curve, bytes_from_point, mult, secp256k1
-from btclib.curves.curve import _libsecp256k1_applicable
+from btclib.curves.curve import _libsecp256k1_serves
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
 from btclib.utils import is_integer
 
@@ -104,7 +104,7 @@ def diffie_hellman(
     # scalar; so is a low-order QV on a curve with a cofactor, which
     # they have no serialization for either. Both are the Python path's
     # to answer, and it answers them below
-    if d and _libsecp256k1_applicable(ec, None):
+    if d and _libsecp256k1_serves(ec, None):
         sec = libsecp256k1_keys.pubkey_tweak_mul(bytes_from_point(QV, ec), d)
         return ansi_x9_63_kdf(sec[1:], size, hf, shared_info)
 

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -50,7 +50,7 @@ from btclib.curves import Curve, mult, secp256k1
 from btclib.curves.curve import (
     _is_x_coordinate_var,
     _jac_double_mult,
-    _libsecp256k1_applicable,
+    _libsecp256k1_serves,
     _y_even_var,
 )
 from btclib.ecc.commit_nonce import commit_entropy_, commit_nonce_, commit_point_
@@ -572,7 +572,7 @@ def sign_(
     # it is not the reason to decline: `ndata` is what the bindings take
     # it as, so grinding stays where the signing is
     if (
-        _libsecp256k1_applicable(ec, hf)
+        _libsecp256k1_serves(ec, hf)
         and nonce is None
         and lower_s
         and commit_hash is None
@@ -731,7 +731,7 @@ def sign_recoverable_(
     # themselves, so a requested nonce is for the Python path below. The
     # recoverable signing they offer is lower-s like the plain one, and
     # lower_s=False is the caller asking for the s that was computed
-    if _libsecp256k1_applicable(ec, hf) and nonce is None and lower_s:
+    if _libsecp256k1_serves(ec, hf) and nonce is None and lower_s:
         # the compact form, r || s, and the recid beside it: the DER
         # encoding sign_ parses would have to be taken apart again, the
         # key_id being what this call is made for
@@ -883,7 +883,7 @@ def assert_as_valid_(
     # the second one
     _assert_commitment_(commit_hash, receipt, sig, hf)
 
-    if _libsecp256k1_applicable(sig.ec, hf):
+    if _libsecp256k1_serves(sig.ec, hf):
         msg_hash_bytes = bytes_from_octets(msg_hash, 32)
         pubkey_bytes = pub_keyinfo_from_pub_key(key)[0]
         # check_validity=False, because assert_valid has just run above --
@@ -1138,7 +1138,7 @@ def _recover_pub_keys_(
 
     # The Python enumeration: `recover_pub_keys_` above asks the bindings
     # for each of the four recids instead, so what reaches here is every
-    # other curve, every other hash function, and the tests that patch the
+    # other curve, every other hash function, and the tests that switch the
     # dispatch off -- where this is the implementation held against the
     # bindings, they being the authority on the answer.
     #
@@ -1197,11 +1197,11 @@ def recover_pub_keys_(
     # has, but each candidate in it is a recid the bindings answer for, so
     # what runs here is four `recover` calls: 83 us against 854 (issue
     # 286). A recid is two bits, i.e. every candidate a curve of cofactor
-    # 1 has, and _libsecp256k1_applicable admits no other curve --
+    # 1 has, and _libsecp256k1_serves admits no other curve --
     # secp256k1's cofactor is 1, so `range(4)` here is the
     # `range(2 * (ec.cofactor + 1))` of the Python enumeration above, in
     # the same order, key_id by key_id
-    if _libsecp256k1_applicable(sig.ec, hf):
+    if _libsecp256k1_serves(sig.ec, hf):
         keys: list[Point] = []
         for key_id in range(4):
             # a candidate that recovers nothing is dropped rather than
@@ -1290,7 +1290,7 @@ def _recover_pub_key_(
 def _libsecp256k1_recover_sec_(
     key_id: int, msg_hash: bytes, sig: Sig, compressed: bool, *, lower_s: bool
 ) -> bytes:
-    # Private function: the caller has asked _libsecp256k1_applicable
+    # Private function: the caller has asked _libsecp256k1_serves
     # already, and hands in a 32-byte msg_hash and a key_id in [0, 3].
     #
     # secp256k1_ecdsa_recover is step 1.6 of SEC 1 v.2 section 4.1.6 for
@@ -1342,7 +1342,7 @@ def _libsecp256k1_recover_sec_(
 def _libsecp256k1_recover_point_(
     key_id: int, msg_hash: bytes, sig: Sig, *, lower_s: bool
 ) -> Point:
-    # Private function: the caller has asked _libsecp256k1_applicable
+    # Private function: the caller has asked _libsecp256k1_serves
     # already, and hands in a 32-byte msg_hash and a key_id in [0, 3].
     #
     # 0x04 || x || y (SEC 1 v.2, section 2.3.3), read rather than parsed
@@ -1390,7 +1390,7 @@ def recover_pub_key_(
     # r < ec.p - ec.n for j = 1, and the % ec.p of the Python path leaves
     # x_K = r + ec.n - ec.p otherwise, which fails step 1.6.2 for every r
     # -- passing it would need ec.p ≡ 0 mod ec.n
-    if _libsecp256k1_applicable(sig.ec, hf) and 0 <= key_id <= 3:
+    if _libsecp256k1_serves(sig.ec, hf) and 0 <= key_id <= 3:
         return _libsecp256k1_recover_point_(key_id, msg_hash, sig, lower_s=False)
 
     c = challenge_(msg_hash, sig.ec, hf)  # 1.5

--- a/btclib/ecc/ellswift.py
+++ b/btclib/ecc/ellswift.py
@@ -49,7 +49,7 @@ from btclib.alias import Octets, Point
 from btclib.curves import Curve, bytes_from_point, mult, secp256k1
 from btclib.curves.curve import (
     _is_x_coordinate_var,
-    _libsecp256k1_applicable,
+    _libsecp256k1_serves,
     _y_even_var,
 )
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
@@ -269,7 +269,7 @@ def create(prv_key: PrvKey, ec: Curve = secp256k1) -> bytes:
 
     # the bindings hold the private key to the same 1..n-1 int_from_prv_key
     # does, so what reaches them is a key they take
-    if _libsecp256k1_applicable(ec, None):
+    if _libsecp256k1_serves(ec, None):
         return libsecp256k1_ellswift.create(q)
 
     _constants(ec)  # the curve is refused here rather than after a mult
@@ -286,7 +286,7 @@ def encode(pub_key: PubKey, ec: Curve = secp256k1) -> bytes:
     """
     Q = point_from_pub_key(pub_key, ec)
 
-    if _libsecp256k1_applicable(ec, None):
+    if _libsecp256k1_serves(ec, None):
         return libsecp256k1_ellswift.encode(bytes_from_point(Q, ec))
 
     _constants(ec)
@@ -304,7 +304,7 @@ def decode(ell: Octets, ec: Curve = secp256k1) -> Point:
     # the bindings answer with a compressed public key, whose y is the
     # one the prefix names: _y_even_var lifts the x and the prefix picks the
     # root, which is a parse rather than the square root it looks like
-    if _libsecp256k1_applicable(ec, None):
+    if _libsecp256k1_serves(ec, None):
         sec = libsecp256k1_ellswift.decode(ell)
         x = int.from_bytes(sec[1:], byteorder="big", signed=False)
         y = _y_even_var(x, ec)
@@ -336,7 +336,7 @@ def xdh(
         raise BTClibValueError(err_msg)
     q = int_from_prv_key(prv_key, ec)
 
-    if _libsecp256k1_applicable(ec, None):
+    if _libsecp256k1_serves(ec, None):
         return libsecp256k1_ellswift.xdh(ell_a, ell_b, q, party)
 
     # the shared x-coordinate is the same for either y of the decoded

--- a/btclib/ecc/pedersen.py
+++ b/btclib/ecc/pedersen.py
@@ -43,7 +43,7 @@ __all__ = [
 # (ec, hf) is the cache key: both change the answer, and both are
 # hashable -- Curve.__hash__ exists precisely so that equal curves
 # share cache entries (curve.py's _eq_key), and hf is compared by
-# identity, the same conservative choice _libsecp256k1_applicable
+# identity, the same conservative choice _libsecp256k1_serves
 # makes for sha256. maxsize is a number, not None: ec is
 # caller-supplied, and an unbounded cache on it would be a memory
 # leak. The cached value is a Point, i.e. a tuple, so returning the

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -67,7 +67,7 @@ from btclib.curves import Curve, secp256k1
 from btclib.curves.curve import (
     _is_x_coordinate_var,
     _jac_double_mult,
-    _libsecp256k1_applicable,
+    _libsecp256k1_serves,
     _y_even_var,
     mult,
     multi_mult_var,
@@ -415,7 +415,7 @@ def sign_(
     #
     # A commitment stays with the Python path: it tweaks the nonce, and
     # the nonce is the bindings' own to derive
-    if _libsecp256k1_applicable(ec, hf) and commit_hash is None:
+    if _libsecp256k1_serves(ec, hf) and commit_hash is None:
         # the bindings take a scalar, not the many representations of a
         # private key btclib accepts
         q = int_from_prv_key(prv_key, ec)
@@ -593,7 +593,7 @@ def assert_as_valid_(
     # message of any size -- what sent the four arbitrary-size vectors of
     # issue 169 down the Python path was the 32-byte gate in front of it,
     # never the call itself, and they are verified here now
-    if _libsecp256k1_applicable(sig.ec, hf):
+    if _libsecp256k1_serves(sig.ec, hf):
         pubkey_bytes = x_Q.to_bytes(32, "big")
         # check_validity=False, because assert_valid has just run above --
         # on the Sig handed in, or inside the Sig.parse that made one. What

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -28,7 +28,7 @@ from btclib.alias import (
     TaprootScriptTree,
 )
 from btclib.curves import bytes_from_prv_key_int, mult, secp256k1
-from btclib.curves.curve import _libsecp256k1_applicable, _y_even_var
+from btclib.curves.curve import _libsecp256k1_serves, _y_even_var
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import tagged_hash
 from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE
@@ -271,11 +271,11 @@ def _tweaked_pubkey(pub_key: bytes, h: bytes) -> tuple[bytes, int]:
     #
     # The predicate is a constant now that the curve is, and the three
     # guards in this module keep it rather than saying so: it is the
-    # seam the suite patches -- taproot._libsecp256k1_applicable set to
+    # seam the suite closes -- curve._libsecp256k1_available set to
     # False -- to reach the Python arithmetic below, which is the
     # reference implementation the bindings are checked against and not
     # a path any caller takes. Stated here for all three
-    if _libsecp256k1_applicable(secp256k1, None):
+    if _libsecp256k1_serves(secp256k1, None):
         return libsecp256k1_xonly.tweak_add(pub_key, t)
 
     P_x = int.from_bytes(pub_key, "big")
@@ -334,7 +334,7 @@ def _tweaked_prvkey(internal_prvkey: int, h: bytes) -> int:
     # for themselves: 32.0 us against 82.3 over 2000 tweaks, the
     # difference being the point this path never materializes and
     # the square root it never takes to check that point's parity
-    if _libsecp256k1_applicable(secp256k1, None):
+    if _libsecp256k1_serves(secp256k1, None):
         pub_key = bytes_from_prv_key_int(internal_prvkey, secp256k1)[1:]
         t = _tap_tweak(pub_key, h)
         tweaked = libsecp256k1_xonly.prvkey_tweak_add(internal_prvkey, t)
@@ -435,7 +435,7 @@ def check_output_pubkey(q: Octets, script: Octets, control: Octets) -> bool:
     # unequal either -- b"\x00" + 32 bytes reads as the same integer the
     # comparison below makes -- so the answer for it stays the Python
     # one rather than becoming an exception
-    if _libsecp256k1_applicable(secp256k1, None) and len(q) == 32:
+    if _libsecp256k1_serves(secp256k1, None) and len(q) == 32:
         try:
             return libsecp256k1_xonly.tweak_add_check(q, control[0] & 1, p_bytes, t)
         except ValueError as e:

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -20,7 +20,7 @@ measurement or discards an outlier.
 
 The pure Python side is reached by turning btclib's own dispatch off,
 which `python_arithmetic_only` below does and says why: every one of the
-timed functions asks `_libsecp256k1_applicable` first and would
+timed functions asks `_libsecp256k1_serves` first and would
 otherwise answer from the bindings, the very path the other half of this
 script already timed.
 
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable
-from typing import Any, cast
 
 from btclib.curves import curve
 from btclib.ecc import dsa, ssa
@@ -58,30 +57,20 @@ ssa_sig = ssa.sign_(msg_hash, prvkey, aux=bytes(32))
 
 
 def python_arithmetic_only() -> None:
-    """Turn btclib's libsecp256k1 dispatch off, in the three timed here.
+    """Turn btclib's libsecp256k1 dispatch off, everywhere at once.
 
-    `_libsecp256k1_applicable` is defined in `curves.curve` and imported
-    by name into nine modules, so patching one leaves the other eight
-    delegating and a row meant to measure Python measures C -- dsa's and
-    ssa's own verification calls into curve's double multiplication
-    underneath whichever implementation answers the boundary check first.
-
-    Three are enough for the rows below and not for a row that derives a
-    public key: `curves.sec_point` asks the same question in
-    `bytes_from_prv_key_int`, which is what `benchmark_python.py` found
-    when its pure-Python public key came back at bindings speed. A row
-    added here has to add its module to the tuple.
+    `_libsecp256k1_serves` reads `_libsecp256k1_available` on every call,
+    so this one assignment reaches the nine modules that imported the
+    predicate by name. Naming modules instead is what left a row meant to
+    measure Python measuring C: `benchmark_python.py` patched three and
+    its pure-Python public key came back at bindings speed, `to_pub_key`
+    asking `curves.sec_point`, which was not among them. A row added
+    below cannot reintroduce that.
 
     Called once, after the fixtures above are signed: they go through
     the bindings too, and there is no reason to slow those down.
-
-    Cast to Any rather than assigned directly: mypy sees the loop
-    variable as a plain module, none of the three concrete modules in
-    particular, and a plain module has no `_libsecp256k1_applicable` of
-    its own to assign.
     """
-    for module in (dsa, ssa, curve):
-        cast(Any, module)._libsecp256k1_applicable = lambda *_: False
+    curve._libsecp256k1_available = False
 
 
 def mult_bindings() -> None:

--- a/scripts/benchmark_python.py
+++ b/scripts/benchmark_python.py
@@ -32,12 +32,10 @@ numbers is the whole reason both exist.
 
 ## How each row is held to Python, and how that was checked
 
-- **btclib**: `_libsecp256k1_applicable` is imported by name into every
-  module these rows reach, so every one of them is patched, as
-  `benchmark.py` does and for the reason its docstring gives: a partial
-  patch leaves a row meant to measure Python measuring C underneath.
-  `python_arithmetic_only` below names them and says which row found
-  the one that had been left out.
+- **btclib**: `curves.curve._libsecp256k1_available` is the switch every
+  dispatch reads, so clearing it turns the delegation off for every
+  module at once, as `benchmark.py` does. `python_arithmetic_only` below
+  says which row caught the partial patching that preceded it.
 - **pycoin** decides at import: `pycoin.ecdsa.native.secp256k1` and
   `.openssl` each read `PYCOIN_NATIVE` and return their no-op unless it
   names them. `os.environ` is set at the top of this file, before the
@@ -88,7 +86,6 @@ import time
 from collections.abc import Callable
 from hashlib import sha256
 from importlib.metadata import version
-from typing import Any, cast
 
 import buidl.pecc
 import ecdsa
@@ -96,7 +93,7 @@ import pycoin.symbols.btc
 import secp256k1lab.bip340
 from secp256k1lab.secp256k1 import G as LAB_G
 
-from btclib.curves import curve, sec_point
+from btclib.curves import curve
 from btclib.ecc import dsa, ssa
 from btclib.hashes import reduce_to_hlen
 from btclib.to_pub_key import pub_keyinfo_from_prv_key
@@ -359,31 +356,20 @@ REFERENCE = {
 
 
 def python_arithmetic_only() -> None:
-    """Turn btclib's libsecp256k1 dispatch off, in the namespaces timed here.
+    """Turn btclib's libsecp256k1 dispatch off, everywhere at once.
 
-    `_libsecp256k1_applicable` is defined in `curves.curve` and imported
-    by name into nine modules, so patching it in one leaves the other
-    eight delegating and a row meant to measure Python measures C.
-    `curves.sec_point` is the one this script needed and `benchmark.py`
-    did not: `bytes_from_prv_key_int` asks it there, so a public key
-    derived through `to_pub_key` came back at bindings speed with the
-    other three patched -- 8.47 us against the 8.39 of the reference,
-    which is how the omission was found rather than reasoned about.
-
-    The four here are the ones the rows below reach. The others -- `bms`,
-    `commit_nonce`, `dh`, `ellswift`, `pedersen`, `taproot` -- are not
-    timed and are left alone; a row added later has to add its module to
-    this tuple, which is why they are named rather than globbed.
+    `_libsecp256k1_serves` reads `_libsecp256k1_available` on every call,
+    so this one assignment reaches the nine modules that imported the
+    predicate by name -- where naming modules one at a time left a row
+    meant to measure Python measuring C, `curves.sec_point` being the
+    one omitted: a public key derived through `to_pub_key` came back at
+    8.47 us against the 8.39 of the reference, which is how the omission
+    was found rather than reasoned about. No row can reintroduce it.
 
     Called after the reference above and after every fixture is signed,
     both of which want the bindings.
-
-    Cast to Any rather than assigned directly: mypy sees the loop
-    variable as a plain module, none of the four in particular, and a
-    plain module has no `_libsecp256k1_applicable` of its own.
     """
-    for module in (dsa, ssa, curve, sec_point):
-        cast(Any, module)._libsecp256k1_applicable = lambda *_: False
+    curve._libsecp256k1_available = False
 
 
 python_arithmetic_only()

--- a/tests/README.md
+++ b/tests/README.md
@@ -234,9 +234,9 @@ What to know before reading one:
 
 - **the point arithmetic of `curves/curve_group.py` dominates the self
   time**, and what drives it is the two places that ask for the
-  arithmetic the bindings do not do: `python_path_test.py` patches the
-  delegation away on purpose, and the low-cardinality tests of `dsa` and
-  `ssa` run toy curves `_libsecp256k1_applicable` refuses by definition.
+  arithmetic the bindings do not do: `python_path_test.py` turns the
+  delegation off on purpose, and the low-cardinality tests of `dsa` and
+  `ssa` run toy curves `_libsecp256k1_serves` refuses by definition.
   The profile therefore ranks the fallback, and a change meant for what
   a user's secp256k1 call reaches has to be measured on a run that is
   not denying it the bindings.

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -1544,9 +1544,9 @@ live in `testvectors_v1/`. Not `testvectors/`, which upstream removed
 on 2025-09-02 and which no refresh can reach again. They are read by
 `tests/ecc/wycheproof_test.py`, which is also where the split between
 the two ECDSA profiles is explained, and where the difference the files
-under a hash other than sha256 make is: `_libsecp256k1_applicable`
+under a hash other than sha256 make is: `_libsecp256k1_serves`
 admits sha256 alone, so those reach the Python arithmetic without the
-dispatch being patched off, and are run once rather than twice.
+dispatch being switched off, and are run once rather than twice.
 
 The SHAKE files need one thing the others do not, and it is a type
 rather than a reader: `hashlib.shake_128` is not a `HashF`, an

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -17,8 +17,8 @@ from btclib.curves import (
     Curve,
     CurveGroup,
     bytes_from_point,
-    # the module, not only the names in it: the libsecp256k1 dispatch is a
-    # module attribute, and patching it off is how no_bindings below
+    # the module, not only the names in it: `_libsecp256k1_available` is a
+    # module attribute, and switching it off is how no_bindings below
     # reaches the Python arithmetic underneath
     curve,
     double_mult_var,
@@ -37,8 +37,8 @@ from btclib.curves.curve import (
     SEC2v2,
     SEC2v2_params2,
     _is_x_coordinate_var,
-    _libsecp256k1_applicable,
     _libsecp256k1_multi_mult_,
+    _libsecp256k1_serves,
     _sec_from_point,
     _y_even_var,
 )
@@ -674,7 +674,7 @@ def test_curve_equality() -> None:
     assert secp256k1_bis is not secp256k1
     assert secp256k1_bis == secp256k1
     assert hash(secp256k1_bis) == hash(secp256k1)
-    assert _libsecp256k1_applicable(secp256k1_bis, None)
+    assert _libsecp256k1_serves(secp256k1_bis, None)
     assert mult(3, None, secp256k1_bis) == mult(3)
 
     # equal curves are equal lru_cache keys, so they share the entries
@@ -743,16 +743,26 @@ def test_each_catalogue_holds_what_it_is_named_after() -> None:
             assert CURVES[ec_name] is ec
 
 
-def test_libsecp256k1_applicable() -> None:
+def test_libsecp256k1_serves() -> None:
     """Verify the dispatch takes secp256k1 with sha256, nothing else."""
-    assert _libsecp256k1_applicable(secp256k1, None)
-    assert _libsecp256k1_applicable(secp256k1, sha256)
-    assert not _libsecp256k1_applicable(CURVES["secp256r1"], None)
-    assert not _libsecp256k1_applicable(CURVES["secp256r1"], sha256)
-    assert not _libsecp256k1_applicable(secp256k1, sha512)
+    assert _libsecp256k1_serves(secp256k1, None)
+    assert _libsecp256k1_serves(secp256k1, sha256)
+    assert not _libsecp256k1_serves(CURVES["secp256r1"], None)
+    assert not _libsecp256k1_serves(CURVES["secp256r1"], sha256)
+    assert not _libsecp256k1_serves(secp256k1, sha512)
     # hf is compared by identity, deliberately: a wrapper around sha256
     # takes the Python path, which is slower and never wrong
-    assert not _libsecp256k1_applicable(secp256k1, partial(sha256))
+    assert not _libsecp256k1_serves(secp256k1, partial(sha256))
+
+
+def test_libsecp256k1_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The switch refuses the pair the predicate otherwise takes."""
+    # read on every call and not captured at import, which is the whole
+    # point of it: one assignment reaches the nine modules that imported
+    # the predicate by name
+    monkeypatch.setattr(curve, "_libsecp256k1_available", False)
+    assert not _libsecp256k1_serves(secp256k1, None)
+    assert not _libsecp256k1_serves(secp256k1, sha256)
 
 
 def test_is_on_curve() -> None:
@@ -957,13 +967,14 @@ def test_multi_mult() -> None:
 
 
 def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Patch the libsecp256k1 dispatch off, and the bindings out of reach.
+    """Switch the libsecp256k1 dispatch off, and the bindings out of reach.
 
-    The predicate is what mult, double_mult_var and multi_mult_var ask, and
-    patching it is the pattern of tests/script_engine/python_path_test.py.
-    Replacing the three bindings functions besides is what proves they
-    were not asked anyway: a dispatch this does not cover raises here
-    instead of quietly measuring the bindings against themselves.
+    `_libsecp256k1_available` is what `_libsecp256k1_serves` reads on
+    every call, so clearing it is the whole package's dispatch and not
+    this module's copy of a predicate. Replacing the five bindings
+    functions besides is what proves they were not asked anyway: a
+    dispatch this does not cover raises here instead of quietly measuring
+    the bindings against themselves.
     """
 
     def refuse(*_: object, **__: object) -> bytes:
@@ -971,10 +982,10 @@ def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
         # same one borromean and bms carry, for a line the arithmetic --
         # here the dispatch above it -- rules out
         raise AssertionError(  # pragma: no cover
-            "the libsecp256k1 dispatch is patched off"
+            "the libsecp256k1 dispatch is switched off"
         )
 
-    monkeypatch.setattr(curve, "_libsecp256k1_applicable", lambda *_: False)
+    monkeypatch.setattr(curve, "_libsecp256k1_available", False)
     monkeypatch.setattr(curve, "libsecp256k1_mult", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_tweak_mul", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_combine", refuse)

--- a/tests/curves/sec_point_test.py
+++ b/tests/curves/sec_point_test.py
@@ -11,13 +11,12 @@ from btclib.curves import (
     Curve,
     bytes_from_point,
     bytes_from_prv_key_int,
-    # the modules, not only the names in them: the libsecp256k1 dispatch is
-    # a module attribute in each, and patching it off is how the tests
-    # below reach the Python arithmetic underneath
+    # the module, not only the names in it: `_libsecp256k1_available` is
+    # an attribute of it, and switching it off is how the tests below
+    # reach the Python arithmetic underneath
     curve,
     mult,
     point_from_octets,
-    sec_point,
 )
 from btclib.curves.curve import CURVES
 from btclib.curves.sec_point import _sec_from_octets
@@ -164,8 +163,7 @@ def test_sec_from_octets(bindings: bool, monkeypatch: pytest.MonkeyPatch) -> Non
     them.
     """
     if not bindings:
-        monkeypatch.setattr(sec_point, "_libsecp256k1_applicable", lambda *_: False)
-        monkeypatch.setattr(curve, "_libsecp256k1_applicable", lambda *_: False)
+        monkeypatch.setattr(curve, "_libsecp256k1_available", False)
 
     for ec in all_curves.values():
         for Q in (ec.G, mult(2, ec.G, ec), mult(3, ec.G, ec)):

--- a/tests/ecc/bms_test.py
+++ b/tests/ecc/bms_test.py
@@ -27,7 +27,7 @@ from btclib import b32, b58
 from btclib.alias import Point
 from btclib.b58 import h160_from_address
 from btclib.bip32 import bip32
-from btclib.curves import mult, secp256k1
+from btclib.curves import curve, mult, secp256k1
 from btclib.curves.curve import CURVES
 from btclib.ecc import bms, dsa
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
@@ -979,7 +979,7 @@ def test_recoverable_signing_answers_the_key_id_the_search_finds(
         # and the search asked of the implementation that did not report
         # the key_id, so that the two derivations are independent
         with monkeypatch.context() as no_bindings:
-            no_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+            no_bindings.setattr(dsa, "_libsecp256k1_serves", lambda *_: False)
             assert key_id == _search_key_id(magic_msg, dsa_sig, q)
 
         bms.assert_as_valid(msg, addr, bms_sig)
@@ -1023,15 +1023,14 @@ def test_the_python_path_answers_the_same(
     Python implementation stays as the reference the delegation is held
     against, and this is what reaches it.
 
-    Two patches, one per module, because signing and verifying ask in
-    different places: `dsa.sign_recoverable` under `sign` asks for itself,
-    while `assert_as_valid` asks here before it recovers. Patching dsa
-    alone would leave verification delegated, and bms alone would leave
-    every signature delegated.
+    The switch rather than a patch per module, because signing and
+    verifying ask in different places: `dsa.sign_recoverable` under
+    `sign` asks for itself, while `assert_as_valid` asks in `bms` before
+    it recovers. Clearing `_libsecp256k1_available` reaches both, where
+    naming one module would leave the other delegated.
     """
     with monkeypatch.context() as no_bindings:
-        no_bindings.setattr(bms, "_libsecp256k1_applicable", lambda *_: False)
-        no_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+        no_bindings.setattr(curve, "_libsecp256k1_available", False)
         vector_test()
 
 

--- a/tests/ecc/commit_nonce_test.py
+++ b/tests/ecc/commit_nonce_test.py
@@ -421,9 +421,7 @@ def test_the_python_tweaks_are_the_bindings_tweaks(
         delegated_point = commit_point_(commit_hash, receipt, _S2C_POINT_TAG, ec, hf)
         parities.add(delegated_point[1] % 2)
         with monkeypatch.context() as no_bindings:
-            no_bindings.setattr(
-                commit_nonce, "_libsecp256k1_applicable", lambda *_: False
-            )
+            no_bindings.setattr(commit_nonce, "_libsecp256k1_serves", lambda *_: False)
             assert commit_nonce_(commit_hash, nonce, _S2C_POINT_TAG, ec, hf) == (
                 delegated_nonce,
                 receipt,

--- a/tests/ecc/dh_test.py
+++ b/tests/ecc/dh_test.py
@@ -305,7 +305,7 @@ def test_the_python_shared_point_is_the_bindings_one(
     shared_key = diffie_hellman(a, B, 32)
     assert diffie_hellman(b, A, 32) == shared_key
     with monkeypatch.context() as no_bindings:
-        no_bindings.setattr(dh, "_libsecp256k1_applicable", lambda *_: False)
+        no_bindings.setattr(dh, "_libsecp256k1_serves", lambda *_: False)
         assert diffie_hellman(a, B, 32) == shared_key
 
 

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -532,7 +532,7 @@ def test_the_two_secret_multiplications_answer_the_python_point(
         sig = dsa._sign_(0x1234, q, nonce, True, ec)
 
         with monkeypatch.context() as no_bindings:
-            no_bindings.setattr(curve, "_libsecp256k1_applicable", lambda *_: False)
+            no_bindings.setattr(curve, "_libsecp256k1_serves", lambda *_: False)
             assert dsa.gen_keys(q)[1] == Q
             assert dsa._sign_(0x1234, q, nonce, True, ec) == sig
 
@@ -652,7 +652,7 @@ def test_grinding_agrees_on_both_arithmetics(monkeypatch: pytest.MonkeyPatch) ->
         msg = f"btclib grind {i}".encode()
         delegated = dsa.sign(msg, q, grind=True)
         with monkeypatch.context() as no_dsa_bindings:
-            no_dsa_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+            no_dsa_bindings.setattr(dsa, "_libsecp256k1_serves", lambda *_: False)
             python = dsa.sign(msg, q, grind=True)
         assert delegated == python
         assert delegated.r < _LOW_R
@@ -859,7 +859,7 @@ def test_libsecp256k1_recovery(monkeypatch: pytest.MonkeyPatch) -> None:
         for key_id in range(2 * (secp256k1.cofactor + 1)):
             delegated = _recovered(key_id, msg, sig)
             with monkeypatch.context() as no_bindings:
-                no_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+                no_bindings.setattr(dsa, "_libsecp256k1_serves", lambda *_: False)
                 python = _recovered(key_id, msg, sig)
             assert delegated == python
             if delegated is not None:
@@ -880,7 +880,7 @@ def test_libsecp256k1_recovery(monkeypatch: pytest.MonkeyPatch) -> None:
         malleated = dsa.Sig(sig.r, secp256k1.n - sig.s)
         assert _recovered(key_id ^ 1, msg, malleated) == Q
         with monkeypatch.context() as no_bindings:
-            no_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+            no_bindings.setattr(dsa, "_libsecp256k1_serves", lambda *_: False)
             assert _recovered(key_id ^ 1, msg, malleated) == Q
 
 
@@ -938,7 +938,7 @@ def test_the_low_s_rule_is_asked_for_and_not_assumed(
     dsa._assert_as_valid_(c, QJ, sig.r, sig.s, secp256k1, lower_s=True)
     assert dsa._libsecp256k1_recover_point_(key_id, msg_hash, sig, lower_s=True) == Q
     with monkeypatch.context() as no_bindings:
-        no_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+        no_bindings.setattr(dsa, "_libsecp256k1_serves", lambda *_: False)
         assert dsa.recover_pub_key(key_id, msg, sig) == Q
 
 
@@ -1018,7 +1018,7 @@ def test_recovery_multiplies_in_libsecp256k1(
 
         with monkeypatch.context() as patch:
             # the Python enumeration, its double_mult_var still delegated
-            patch.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+            patch.setattr(dsa, "_libsecp256k1_serves", lambda *_: False)
             assert dsa.recover_pub_keys(msg, sig) == keys
             assert [_recovered(key_id, msg, sig) for key_id in key_ids] == recovered
 
@@ -1064,7 +1064,7 @@ def test_the_enumeration_asks_for_the_j_one_candidates(
     assert [key for key in candidates if key is not None] == keys
 
     with monkeypatch.context() as patch:
-        patch.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+        patch.setattr(dsa, "_libsecp256k1_serves", lambda *_: False)
         assert dsa.recover_pub_keys_(msg_hash, sig) == keys
         no_bindings(patch)
         assert dsa.recover_pub_keys_(msg_hash, sig) == keys
@@ -1142,7 +1142,7 @@ def test_sign_recoverable_is_sign_plus_the_key_id_a_search_would_find(
         assert key_id == recid
 
         with monkeypatch.context() as no_bindings:
-            no_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+            no_bindings.setattr(dsa, "_libsecp256k1_serves", lambda *_: False)
             assert dsa.sign_recoverable(msg, prv_key) == (sig, key_id)
 
 
@@ -1172,7 +1172,7 @@ def test_the_key_id_survives_what_the_bindings_decline(
         hf = kwargs.get("hf", sha256)
         assert dsa.recover_pub_key(key_id, msg, sig, hf) == Q
         with monkeypatch.context() as no_bindings:
-            no_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+            no_bindings.setattr(dsa, "_libsecp256k1_serves", lambda *_: False)
             assert dsa.sign_recoverable(msg, prv_key, **kwargs) == (sig, key_id)
 
     ec = CURVES["secp112r2"]

--- a/tests/ecc/ellswift_test.py
+++ b/tests/ecc/ellswift_test.py
@@ -91,7 +91,7 @@ def test_the_python_decode_is_the_bindings_one(
     ell = bytes.fromhex(row[0])
     expected = ellswift.decode(ell)
     with monkeypatch.context() as no_bindings:
-        no_bindings.setattr(ellswift, "_libsecp256k1_applicable", lambda *_: False)
+        no_bindings.setattr(ellswift, "_libsecp256k1_serves", lambda *_: False)
         assert ellswift.decode(ell) == expected
 
 
@@ -152,7 +152,7 @@ def test_the_python_create_and_encode_are_the_bindings_ones(
         sec = bytes_from_point(Q)
 
         with monkeypatch.context() as no_bindings:
-            no_bindings.setattr(ellswift, "_libsecp256k1_applicable", lambda *_: False)
+            no_bindings.setattr(ellswift, "_libsecp256k1_serves", lambda *_: False)
             python_create = ellswift.create(q)
             python_encode = ellswift.encode(Q)
             # the Python path also decodes what the bindings created
@@ -183,7 +183,7 @@ def test_xdh_agrees_between_parties_and_with_the_bindings(
         assert ellswift.xdh(ell_a, ell_b, b, 1) == shared
 
         with monkeypatch.context() as no_bindings:
-            no_bindings.setattr(ellswift, "_libsecp256k1_applicable", lambda *_: False)
+            no_bindings.setattr(ellswift, "_libsecp256k1_serves", lambda *_: False)
             assert ellswift.xdh(ell_a, ell_b, a, 0) == shared
             assert ellswift.xdh(ell_a, ell_b, b, 1) == shared
 

--- a/tests/ecc/wycheproof_test.py
+++ b/tests/ecc/wycheproof_test.py
@@ -48,8 +48,8 @@ Bitcoin signs with sha256 and nothing else, so the sha512, SHA3 and SHAKE
 files are not bitcoin signatures and are not here pretending to be: what
 they hold to account is the *generic* ECDSA `dsa.verify_` promises, and
 they are the only adversarial vectors that reach it.
-`_libsecp256k1_applicable` declines every hash but sha256, so those files
-land on the Python path by construction rather than by a patch -- the
+`_libsecp256k1_serves` declines every hash but sha256, so those files
+land on the Python path by construction rather than by the switch -- the
 path `SECURITY.md` publishes as not constant-time, under an adversary for
 the first time.
 
@@ -77,7 +77,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from hashlib import sha3_256, sha3_512, sha256, sha512, shake_128, shake_256
 from io import BytesIO
-from types import ModuleType
 from typing import Any, Protocol
 
 import pytest
@@ -118,19 +117,6 @@ _SECP256K1 = bytes.fromhex("2b8104000a")
 # the octets of keying data asked of the KDF: any size answers the same
 # question, this one being the size of the shared field element itself
 _KEY_SIZE = 32
-
-
-def _python_path(monkeypatch: pytest.MonkeyPatch, module: ModuleType) -> None:
-    """Send the dispatch, and the arithmetic under it, down the Python path.
-
-    Two patches because there are two dispatches: the module's own decides
-    whether libsecp256k1 answers the whole verification or agreement, and
-    `curves.curve`'s decides it again for each multiplication the Python
-    implementation of that then makes -- `_jac_double_mult` delegates too,
-    so patching only the first leaves the arithmetic where it was.
-    """
-    no_bindings(monkeypatch)
-    monkeypatch.setattr(module, "_libsecp256k1_applicable", lambda *_: False)
 
 
 def _read_element(stream: BytesIO) -> tuple[int, bytes]:
@@ -336,7 +322,7 @@ _SHAKE256 = _pinned(shake_256, secp256k1.n_size)
 def _paths(hf: HashF) -> list[bool]:
     """Say which implementations answer a vector: both, or Python alone.
 
-    `_libsecp256k1_applicable` compares the hash function by identity and
+    `_libsecp256k1_serves` compares the hash function by identity and
     admits sha256 alone, so under sha512 or SHA3 the bindings decline
     before the dispatch is even reached. Running such a vector a second
     time with the dispatch patched off would be the same Python
@@ -467,7 +453,7 @@ def test_ecdsa_der(
     exercise and what the sha256 ones cannot.
     """
     if not bindings:
-        _python_path(monkeypatch, dsa)
+        no_bindings(monkeypatch)
 
     msg_hash = _digest(hf, bytes.fromhex(vector["msg"]))
     sig = bytes.fromhex(vector["sig"])
@@ -510,7 +496,7 @@ def test_ecdsa_p1363(
     to the width of the order, which no wider digest changes.
     """
     if not bindings:
-        _python_path(monkeypatch, dsa)
+        no_bindings(monkeypatch)
 
     raw = bytes.fromhex(vector["sig"])
     size = secp256k1.n_size
@@ -562,7 +548,7 @@ def test_ecdh(
     would fail this file just as one that accepted everything does.
     """
     if not bindings:
-        _python_path(monkeypatch, dh)
+        no_bindings(monkeypatch)
 
     prv_key = int(vector["private"], 16)
     try:

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -132,7 +132,7 @@ def test_the_python_tweak_is_the_bindings_tweak(
         delegated = output_pubkey(pub_key, script_tree)
         delegated_prvkey = output_prvkey(prv_key, script_tree)
         with monkeypatch.context() as no_bindings:
-            no_bindings.setattr(taproot, "_libsecp256k1_applicable", lambda *_: False)
+            no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
             assert output_pubkey(pub_key, script_tree) == delegated
             assert output_prvkey(prv_key, script_tree) == delegated_prvkey
 
@@ -170,7 +170,7 @@ def test_the_python_prvkey_tweak_lifts_nothing(
         )
 
     with monkeypatch.context() as no_bindings:
-        no_bindings.setattr(taproot, "_libsecp256k1_applicable", lambda *_: False)
+        no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
         no_bindings.setattr(curve_group, "mod_sqrt_var", refuse)
         for tree, expected in zip(SCRIPT_TREES, delegated, strict=True):
             assert output_prvkey(prv_key, tree) == expected
@@ -195,7 +195,7 @@ def test_the_python_commitment_check_is_the_bindings_one(
     assert check_output_pubkey(q, script_bytes, control)
     assert not check_output_pubkey(not_q, script_bytes, control)
     with monkeypatch.context() as no_bindings:
-        no_bindings.setattr(taproot, "_libsecp256k1_applicable", lambda *_: False)
+        no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
         assert check_output_pubkey(q, script_bytes, control)
         assert not check_output_pubkey(not_q, script_bytes, control)
 
@@ -234,7 +234,7 @@ def test_check_output_pubkey_of_an_internal_key_that_is_not_a_point(
     with pytest.raises(BTClibValueError, match=err_msg):
         check_output_pubkey(b"\x00" * 32, b"\x51", control)
     with monkeypatch.context() as no_bindings:
-        no_bindings.setattr(taproot, "_libsecp256k1_applicable", lambda *_: False)
+        no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
         with pytest.raises(BTClibValueError, match=err_msg):
             check_output_pubkey(b"\x00" * 32, b"\x51", control)
 
@@ -543,6 +543,6 @@ def test_the_control_block_commits_to_the_output_key_parity(
     assert check_output_pubkey(q, script_bytes, control)
     assert not check_output_pubkey(q, script_bytes, flipped)
     with monkeypatch.context() as no_bindings:
-        no_bindings.setattr(taproot, "_libsecp256k1_applicable", lambda *_: False)
+        no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
         assert check_output_pubkey(q, script_bytes, control)
         assert not check_output_pubkey(q, script_bytes, flipped)

--- a/tests/script_engine/python_path_test.py
+++ b/tests/script_engine/python_path_test.py
@@ -97,8 +97,8 @@ def python_verification(monkeypatch: pytest.MonkeyPatch) -> None:
     The field and group arithmetic under all of that is the bindings',
     as it is everywhere else.
     """
-    monkeypatch.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
-    monkeypatch.setattr(ssa, "_libsecp256k1_applicable", lambda *_: False)
+    monkeypatch.setattr(dsa, "_libsecp256k1_serves", lambda *_: False)
+    monkeypatch.setattr(ssa, "_libsecp256k1_serves", lambda *_: False)
     monkeypatch.setattr(engine_script, "_libsecp256k1_dsa_verify", python_dsa_verify)
     monkeypatch.setattr(engine_tapscript, "_libsecp256k1_ssa_verify", python_ssa_verify)
 


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/848

`_libsecp256k1_applicable(ec, hf)` answered one question — can the
bindings serve this curve and this hash function — while a second one
beside it, may the bindings be used at all, had no name and was answered
by monkeypatching. The predicate is now `_libsecp256k1_serves(ec, hf)`,
which says what it decides, and the switch beside it is
`_libsecp256k1_available`, a module-level bool in `curves/curve.py` that
the predicate reads on every call. Option 1 of the issue, as proposed.

## What the switch buys

One assignment turns the delegation off everywhere. Rebinding the
predicate reaches one module of the nine that import it by name, and a
copy per module is what produced the wrong measurement the issue cites:
`scripts/benchmark.py` said it patched "every namespace" and patched
three, so its pure-Python public-key row was timing C at 8.47 us against
the bindings' 8.39 — `to_pub_key` asks `curves.sec_point`, which was not
among the three.

That row now reads **193.26 us against the same 8.39**, and no row added
later can reintroduce the omission.

`benchmark.py`, `benchmark_python.py`, `curve_test.py`'s `no_bindings`
and `wycheproof_test.py` take the switch instead of naming modules;
`wycheproof_test.py`'s `_python_path` wrapper becomes `no_bindings`
itself, having nothing left to add.

## The patches that stay, and why

The issue asks for `python_path_test.py` to stop patching. Two sites
resist that, and both deliberately:

- `tests/script_engine/python_path_test.py` puts the Python *verdict* in
  front of the consensus vectors while leaving the arithmetic under it
  delegated. That is https://github.com/btclib-org/btclib/pull/778, which
  measured the difference at 8.6x on that module.
- `tests/ecc/dsa_test.py` climbs a two-step ladder: the module's dispatch
  off with `double_mult_var` still delegated, then the switch on top —
  two distinct assertions.

A global switch is all-or-nothing and cannot express either. Both keep a
per-module patch, which still works: the predicate is what they rebind,
and it is the predicate that reads the global.

(The issue names `tests/curves/python_path_test.py`; no such file exists —
the module is `tests/script_engine/python_path_test.py`.)

Neither name is a public break: both are private, and nothing outside
`btclib` imports either.

## Gates

- `uv run pytest` — 27206 passed, 6 skipped, coverage 100%
- `uv run pre-commit run --all-files` — exit 0
- sphinx `-W --keep-going` — build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a named global switch controlling use of libsecp256k1 bindings and update predicates, benchmarks, and tests to use it instead of per-module monkeypatching.

Bug Fixes:
- Fix benchmark and test configurations that previously only partially disabled bindings, which could misclassify C-backed runs as pure-Python.

Enhancements:
- Rename the libsecp256k1 applicability predicate to `_libsecp256k1_serves` and add a global `_libsecp256k1_available` flag that it consults on each call.
- Adjust curve arithmetic, ECDSA/SSA, Taproot, EllSwift, Diffie-Hellman, BMS, sec_point, and commit-nonce logic to gate delegation to bindings via the new predicate and switch.
- Simplify benchmark scripts by disabling bindings through the global switch rather than patching individual modules, ensuring consistent pure-Python measurements.
- Refine comments and internal documentation to reflect the new bindings switch semantics and clarify how tests and benchmarks reach the Python code paths.

Documentation:
- Document the new bindings predicate and switch in the changelog and testing READMEs, including the impact on benchmarks and Python-path testing patterns.

Tests:
- Update and add tests to cover the new `_libsecp256k1_serves` predicate and `_libsecp256k1_available` switch, and to replace per-module monkeypatching with the global switch where full delegation control is desired.