### PR TITLE
Give the batch inverse its blinded twin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1455,6 +1455,35 @@ documented at release-notes length in the first place, and are still in
   1.03x and `Sig.assert_valid` 1.03x. The inverse inside each is real and
   is diluted: 1.32x on 10 us of a 40 us verification.
   `ellswift._constants` is memoized on the curve and receives no value.
+- **`mod_inv_batch` is the blinded twin of `mod_inv_batch_var`**, so the
+  batch inverse has the pair every other primitive got. Montgomery's
+  trick spends one extended Euclid on a running product every element
+  went into, and that is the same channel as a single inverse, no smaller
+  for being shared: the one caller in the library is
+  `aff_from_jac_batch_var`, on table `Z` coordinates that `_blinded_jac`
+  has already randomized or that belong to the generator, but the method
+  is public API and an outside caller can hand it coordinates derived
+  from a secret. Now there is something for them to call.
+
+  A factor per element, not one for the sequence: `inv(a_i * b_i) * b_i`
+  is `inv(a_i)`, and one shared factor would blind the product while
+  leaving the ratios `a_i / a_j` in the running products the inverses are
+  peeled back off.
+
+  The draws are the cost. On secp256k1's `p` over 16 random elements,
+  best of nine alternating rounds: 43.7 us against the 20.9 of
+  `mod_inv_batch_var`, 2.1x, the 22.8 us of difference being 16 draws of
+  1.6. It stays worth batching -- 16 separate `mod_inv` calls are
+  155.9 us, so blinding the batch is 3.6x cheaper than blinding one at a
+  time, where the unblinded batch is 6.3x cheaper than the unblinded
+  singles' 131.3.
+
+  `ellswift._xswiftec_inv_var` is the other name that has no twin, and it
+  is not getting one this way: what the census measured there is a branch
+  and not an operand, so a random factor has nothing to hide. What would
+  make it uniform is computing every case and selecting, which is a
+  different function; its operands are the public key being encoded and
+  the `u` that is published beside it, so nothing asks for one today.
 
 - **The bindings switch has a name** (issue #848).
   `_libsecp256k1_applicable(ec, hf)` answered one question — can the

--- a/btclib/number_theory.py
+++ b/btclib/number_theory.py
@@ -26,6 +26,7 @@ from btclib.utils import hex_string, is_integer
 __all__ = [
     "legendre_symbol_var",
     "mod_inv",
+    "mod_inv_batch",
     "mod_inv_batch_var",
     "mod_inv_var",
     "mod_sqrt_var",
@@ -173,6 +174,60 @@ def mod_inv(a: int, m: int) -> int:
         # asked about in the library is the order of a group, which
         # `curves.Curve` requires prime
         return mod_inv_var(a, m)
+
+
+def mod_inv_batch(a: Sequence[int], m: int) -> list[int]:
+    """Return every inverse, each timed on a random value instead.
+
+    What `mod_inv` is to `mod_inv_var`, this is to `mod_inv_batch_var`:
+    the twin a secret may be handed. Montgomery's trick inverts one
+    running product for the whole sequence, so the single extended Euclid
+    it spends is timed on a value every element went into -- which is the
+    channel, the same one and no smaller for being shared.
+
+    Each element is blinded with a factor of its own rather than the
+    sequence with one: `inv(a_i * b_i) * b_i` is `inv(a_i)`, and the
+    product the batch forms is then a product of blinded values. One
+    factor for all of them would blind that product and leave the ratios
+    `a_i / a_j` in the peeled-back inverses, which is what the running
+    products are made of.
+
+    So it costs `n` draws from `secrets` and 2n multiplications on top of
+    the trick, and the draws are the whole of it: measured on secp256k1's
+    `p` over 16 random elements, best of nine alternating rounds, 43.7 us
+    against the 20.9 of `mod_inv_batch_var` -- 2.1x, and 22.8 us of
+    difference for 16 draws of 1.6.
+
+    It is still the trick, which is the point of it being a batch at all:
+    16 separate `mod_inv` calls are 155.9 us over the same elements, so
+    blinding the batch is 3.6x cheaper than blinding one at a time, where
+    the unblinded batch is 6.3x cheaper than the unblinded singles' 131.3.
+    The saving shrinks as the draws grow with n and the one Euclid does
+    not; the trick still wins at every size worth batching.
+
+    Not constant-time, for the reasons `mod_inv` gives at length. The
+    empty sequence is not an error here either.
+    """
+    _assert_valid_modulus(m)
+    for x in a:
+        _assert_valid_operand(x)
+
+    if not a:
+        return []
+
+    # a nonzero factor each, as `mod_inv` draws its one; m == 1 leaves
+    # only the factor 1, every integer being zero modulo it
+    factors = [1 + secrets.randbelow(m - 1) if m > 1 else 1 for _ in a]
+    blinded = [x * b % m for x, b in zip(a, factors, strict=True)]
+    try:
+        inverses = mod_inv_batch_var(blinded, m)
+    except BTClibValueError:
+        # a product is invertible only if every factor is, so an element
+        # with no inverse is the caller's own error and is named as such
+        # -- and a factor that a composite m made a zero divisor lands
+        # here too, where `mod_inv` says what is lost and what is not
+        return [mod_inv(x, m) for x in a]
+    return [i * b % m for i, b in zip(inverses, factors, strict=True)]
 
 
 def mod_inv_batch_var(a: Sequence[int], m: int) -> list[int]:

--- a/tests/number_theory_test.py
+++ b/tests/number_theory_test.py
@@ -16,6 +16,7 @@ from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.number_theory import (
     legendre_symbol_var,
     mod_inv,
+    mod_inv_batch,
     mod_inv_batch_var,
     mod_inv_var,
     mod_sqrt_var,
@@ -430,3 +431,76 @@ def test_mod_inv_blinded_inverts(a: int, m: int) -> None:
     inverse = mod_inv(a, m)
     assert 0 <= inverse < m
     assert a * inverse % m == 1 % m
+
+
+def test_mod_inv_batch_is_mod_inv_batch_var() -> None:
+    """The blinding changes what is timed and not what is answered.
+
+    Over a prime modulus, which is what the library batches against, and
+    over the composite ones where an element with no inverse still has
+    none and is named as `mod_inv` names it.
+    """
+    for m in (7, 97, 2**521 - 1):
+        values = [1, 2, m - 1, 3, m - 2]
+        assert mod_inv_batch(values, m) == mod_inv_batch_var(values, m)
+        assert mod_inv_batch([2], m) == [mod_inv_var(2, m)]
+    assert mod_inv_batch([], 7) == []
+    assert mod_inv_batch([7], 1) == [0]
+
+    with pytest.raises(BTClibValueError, match="no inverse for 0 mod 7"):
+        mod_inv_batch([1, 2, 0, 3], 7)
+    with pytest.raises(BTClibValueError, match="no inverse for 3 mod 9"):
+        mod_inv_batch([2, 3], 9)
+
+    for value in (2.0, True, None):
+        with pytest.raises(BTClibTypeError, match="not an integer: "):
+            mod_inv_batch([1, value], 7)  # type: ignore[list-item]
+    for bad_modulus in (0, -7, 3.0, False):
+        with pytest.raises((BTClibTypeError, BTClibValueError)):
+            mod_inv_batch([1], bad_modulus)  # type: ignore[arg-type]
+
+
+def test_mod_inv_batch_blinds_each_element_on_its_own(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One factor per element, not one for the sequence.
+
+    A single factor would blind the product the trick inverts and leave
+    the ratios of the elements in the running products it is peeled back
+    off, so the factors have to be independent -- which is what the
+    recorded draws show, none of them repeated.
+    """
+    drawn: list[int] = []
+    real_randbelow = secrets.randbelow
+
+    def recording_randbelow(upper: int) -> int:
+        value = real_randbelow(upper)
+        drawn.append(value)
+        return value
+
+    monkeypatch.setattr(secrets, "randbelow", recording_randbelow)
+
+    m = 2**256 - 2**32 - 977
+    values = [1 + real_randbelow(m - 1) for _ in range(8)]
+    assert mod_inv_batch(values, m) == mod_inv_batch_var(values, m)
+
+    assert len(drawn) == len(values)
+    assert len(set(drawn)) == len(drawn)
+
+
+@given(values=st.lists(st.integers(), max_size=8), m=st.integers(min_value=1))
+def test_mod_inv_batch_blinded_inverts(values: list[int], m: int) -> None:
+    """`test_mod_inv_batch_inverts`, of the blinded spelling.
+
+    m from one rather than from two: the degenerate modulus is a branch
+    here, where `mod_inv_batch_var` has none.
+    """
+    if any(math.gcd(v % m, m) != 1 for v in values) and m != 1:
+        with pytest.raises(BTClibValueError, match="no inverse"):
+            mod_inv_batch(values, m)
+        return
+    inverses = mod_inv_batch(values, m)
+    assert len(inverses) == len(values)
+    for v, inverse in zip(values, inverses, strict=True):
+        assert 0 <= inverse < m
+        assert v * inverse % m == 1 % m


### PR DESCRIPTION
`mod_inv_batch_var` was the one primitive left without the pair every
other one got. Montgomery's trick spends a single extended Euclid on a
running product every element went into — that is the same channel as a
single inverse, and no smaller for being shared.

The one caller in the library is `aff_from_jac_batch_var`, on table `Z`
coordinates that `_blinded_jac` has already randomized or that belong to
the generator. But that method is public API, so an outside caller can
hand it coordinates derived from a secret, and until now had nothing else
to call.

## A factor per element, not one for the sequence

`inv(a_i * b_i) * b_i` is `inv(a_i)`. One shared factor would blind the
product while leaving the ratios `a_i / a_j` in the running products the
inverses are peeled back off — which is what the trick is made of, so it
would be a blinding that blinds nothing. `test_mod_inv_batch_blinds_each_element_on_its_own`
records the draws and asserts they are independent.

## The draws are the cost

On secp256k1's `p` over 16 random elements, best of nine alternating
rounds:

| | µs |
| --- | --- |
| `mod_inv_batch_var` | 20.9 |
| `mod_inv_batch` (blinded) | 43.7 |
| 16× `mod_inv_var` | 131.3 |
| 16× `mod_inv` | 155.9 |

2.1x, and the 22.8 µs of difference is 16 draws of 1.6. It stays worth
batching: blinding the batch is **3.6x cheaper than blinding one at a
time**, where the unblinded batch is 6.3x cheaper than the unblinded
singles.

## The other name with no twin is not getting one this way

`ellswift._xswiftec_inv_var`'s 29.62x is a **branch and not an operand** —
28 calls of 50 return early — so a random factor has nothing to hide.
What would make it uniform is computing every case and selecting, which
is a different function; its operands are the public key being encoded
and the `u` published beside it, so nothing asks for one today. Saying so
is the deliverable there, rather than a blinding that would cost and buy
nothing.

## Gates

`pytest` (27209 passed, coverage 100%), `pre-commit run --all-files` and
the `-W` sphinx build all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a blinded batch modular inverse helper mirroring the existing variable-time batch inverse, and document its rationale and limitations.

New Features:
- Add a public mod_inv_batch function that provides a blinded batch modular inverse API analogous to mod_inv.
- Expose mod_inv_batch in the number_theory module’s public interface.

Enhancements:
- Implement per-element blinding on batch modular inversions while preserving batch performance characteristics.
- Update the changelog to explain the new blinded batch inverse, its performance trade-offs, and why similar blinding is not applied to other helpers.

Tests:
- Add unit tests ensuring mod_inv_batch matches mod_inv_batch_var’s outputs and error behavior across edge cases.
- Add tests verifying that batch blinding uses independent randomness per element rather than a shared factor.
- Add property-based tests confirming that mod_inv_batch correctly inverts batched inputs over valid moduli.