### PR TITLE
Say in the README what a _var name means

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3979,6 +3979,15 @@ documented at release-notes length in the first place, and are still in
 
 ### Documentation and the website
 
+- **The README says what a `_var` name means**, in the section on where
+  constant time ends. The convention decides which of two spellings a
+  caller reaches for — `mod_inv` blinds its operand where `mod_inv_var`
+  is the bare extended Euclid — so it belongs on the page a caller reads
+  before handing btclib a private key, not only in CONTRIBUTING.md where
+  the rule for adding one lives. Three sentences and no second copy of
+  the rule: what the suffix means, that the plain name is the one a
+  secret may be handed, and that it is not a promise of constant time.
+
 - **The guide by task answers the question BIP85 is for.** "One backup
   behind many wallets" is a section of `docs/source/guide.rst` now,
   between the mnemonic and the account: the derived BIP39 sentence, the

--- a/README.md
+++ b/README.md
@@ -215,6 +215,20 @@ should stay on the delegated paths, or keep the key out of the process
 altogether: `btclib.hwi` drives a hardware wallet through HWI, behind the
 same `PsbtSigner` contract a software signer answers.
 
+What that path does about it is in the names, and it is worth knowing
+before calling one. **A function whose duration follows the value it is
+given ends in `_var`, and the plain name beside it is the one a secret may
+be handed**: `mod_inv` draws a random blinding factor where `mod_inv_var`
+is the bare extended Euclid, and `mult` makes the same additions for every
+scalar where `double_mult_var` does not. It is libsecp256k1's own
+convention, and forgetting to choose gives the safer call rather than the
+faster one.
+
+The suffix is not a safety label, and no name here promises constant time.
+It says which of two spellings to reach for, and each one was measured
+rather than assumed — including the ones that kept a plain name, which
+CONTRIBUTING lists with the figure that earned it.
+
 <!-- The link is to the file and not to its section: the documentation
 build renders this README with myst, which mints no heading ids, so a
 fragment naming one is an unresolved reference and fails sphinx-build -W.


### PR DESCRIPTION
The `_var` convention that #846, #853 and #857 established decides which
of two spellings a caller reaches for — `mod_inv` blinds its operand
where `mod_inv_var` is the bare extended Euclid, and forgetting to choose
gives the safer call rather than the faster one. That is a fact about
*using* the library, so it belongs on the page read before handing btclib
a private key. CONTRIBUTING.md keeps what it had: the rule for adding
such a name, and the measurement each one had to earn.

Three sentences in "Secrets, and where constant time ends", and no second
copy of the rule: what the suffix means, that the plain name beside it is
the one a secret may be handed, and that it is not a promise of constant
time. SECURITY.md stays the canonical text and that section stays the
pointer to it.

Nothing else in the README went stale, which is the reason this is only
an addition: it names no renamed function and carries no API examples —
its two code blocks are install commands.

The README is btclib.org's homepage as well as the repository's front
page, and the docs build renders it with myst, so the `-W` sphinx build
is part of the evidence below rather than an afterthought.

## Gates

`pre-commit run --all-files`, the `-W` sphinx build, and `pytest` (27209
passed, coverage 100%) all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the `_var` naming convention and its implications for constant-time behavior in the README, and record this documentation change in the changelog.

Documentation:
- Explain in the README what the `_var` suffix means, which variant is appropriate for secrets, and clarify that it is not a guarantee of constant-time execution.
- Update the changelog to note that the README now documents the `_var` naming convention and its role in guiding callers toward safer defaults.