### PR TITLE
Read an argument-less member instead of calling it (#814)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2652,6 +2652,50 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **An argument-less member is a read, and nine were calls** (issue
+  #814). The bool rule generalised to every return type, and the census
+  is what settled it: 168 public members take nothing but `self`, and
+  before this 114 were properties against 54 methods -- but of those 54,
+  45 are not reads at all. `assert_*` refuses, and a property that
+  refuses is a trap: reading `obj.assert_valid` evaluates the method and
+  throws it away. `get_*` talks to a node or an explorer. `to_*` hands
+  back a new object. `close` is an action. `HashObject`'s `digest`,
+  `hexdigest` and `copy` are hashlib's own spelling, and hashlib draws
+  the same line there, `block_size` and `digest_size` being attributes.
+
+  What was left was nine calls that read something already in hand:
+  `PsbtSigner.master_fingerprint` and `capabilities`, the two
+  argument-less members of the signer contract, with their three
+  implementations each, and `PsbtView.prevouts`.
+
+  `PsbtView` is the plainest of the two. `lock_time` and `tx` are
+  properties and `prevouts` was a method -- three reads of one lazy view,
+  two spellings -- and the docstrings gave it away: `tx` says "a copy, as
+  `Psbt.tx` is one" and `prevouts` says "a copy, for the reason `tx` is
+  one", so the second cited the first while being shaped differently.
+
+  The contract's two took a measurement rather than an argument. Every
+  implementation of them returns something it already holds:
+  `HwiSigner` the fingerprint it was selected by -- "not asked of the
+  device again" -- `SoftwareSigner` a value derived from a key it has, a
+  decorator a forward, and both test doubles a stored value or a fresh
+  dataclass. So no implementation pays for the shape, which is what makes
+  the property a promise the contract can keep. HWI's own
+  `HardwareWalletClient.get_master_fingerprint` *is* a device call -- it
+  fetches m/0h and reads the parent fingerprint -- and the Protocol's
+  docstring says so, because that is the adapter that would ask for a
+  method back, and the answer then is to relax the contract deliberately
+  rather than to leave room for it in advance.
+
+  `tests/name_contract_test.py` gates the rule by shape and not by a list
+  of names, which is what keeps it from needing one: a member whose name
+  is a refusal, a network call, a conversion or an action stays a method,
+  everything else is read. Writing it found two things about the walk
+  rather than about the tree -- `functools.cached_property` is a read and
+  testing a decorator set for `"property"` alone misses it, which is what
+  `_is_a_read` exists to stop being written twice, and `Tx.assert_valid`
+  takes an `unsigned_template` and so is not argument-less at all.
+
 - **A bool about the object is a property, and six were not** (issue
   #814). `Tx.is_segwit`, `Tx.is_coinbase`, `TxIn.is_segwit`,
   `TxIn.is_coinbase`, `OutPoint.is_coinbase` and `Block.is_segwit` took

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -892,9 +892,30 @@ prefixes below, or is one of the English predicates
 and `is_` would cost the reading. A bool that is neither fails that gate,
 so a new one is a prefix or a decision somebody wrote down.
 
-**A bool that takes nothing but `self` is a `@property`**, and that is
-gated too: it is read off the object rather than called, so `tx.is_segwit`
-and not `tx.is_segwit()`. Thirty were properties and six were methods,
+**A member that takes nothing but `self` is a `@property`**, whatever it
+answers, and that is gated: it is read off the object rather than called,
+so `tx.is_segwit` and not `tx.is_segwit()`, `view.prevouts` and not
+`view.prevouts()`. `functools.cached_property` is one of these — a read
+that parses once, as `Script.asm` does.
+
+What is *not* a read is exempt by shape rather than by a list of names:
+`assert_*` refuses, and a property that refuses is a trap, since reading
+`obj.assert_valid` evaluates the method and throws it away; `get_*` talks
+to a node or an explorer, so the prefix is the warning a property would
+hide; `to_*` hands back a new object; and `close` is an action. The one
+exemption named individually is `alias.HashObject`'s `digest`,
+`hexdigest` and `copy`, because hashlib calls them that way — and hashlib
+draws the same line itself, `block_size` and `digest_size` being
+attributes there as they are properties here.
+
+A `Protocol` member is under the rule too, and that makes the shape a
+promise: declaring `PsbtSigner.master_fingerprint` a property says
+reading it is free, which every implementation of it can keep. Where a
+future one cannot — HWI's own `get_master_fingerprint` is a device call —
+the answer is to relax the contract deliberately, not to leave room for
+it in advance.
+
+The bool half of the same rule: Thirty were properties and six were methods,
 which made the six the exception; they are properties now. It also makes
 the forgotten-parentheses bug unsayable — `if tx.is_segwit:` on a method
 is a bound method, and every bound method is true. mypy's

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -31,6 +31,22 @@ full year, short month, short day (YYYY-M-D)
   CONTRIBUTING.md lists what measured at the floor and kept its plain
   name, with the figure for each.
 
+- **nine more reads are properties, `master_fingerprint` and
+  `capabilities` among them.** `PsbtSigner.master_fingerprint` and
+  `PsbtSigner.capabilities` -- the two argument-less members of the signer
+  contract -- are properties, and so are `HwiSigner`'s,
+  `SoftwareSigner`'s and `SignerDecorator`'s implementations of them, plus
+  `PsbtView.prevouts`. Drop the parentheses.
+
+  For an adapter written against the contract this is a change to
+  implement and not merely to call: a signer of your own declares
+  `master_fingerprint` and `capabilities` with `@property` now, or as a
+  plain attribute, which a Protocol property accepts as well.
+  `psbt_signer_contract.assert_psbt_signer` reports the mismatch if you
+  forget. Nothing costs a device round trip in any implementation that
+  exists -- HWI's own `get_master_fingerprint` does, and if that is the
+  signer being wrapped, the contract can be relaxed deliberately.
+
 - **six `bool` methods are properties: `tx.is_segwit`, not
   `tx.is_segwit()`.** `Tx.is_segwit`, `Tx.is_coinbase`, `TxIn.is_segwit`,
   `TxIn.is_coinbase`, `OutPoint.is_coinbase` and `Block.is_segwit` took

--- a/btclib/hwi.py
+++ b/btclib/hwi.py
@@ -544,6 +544,7 @@ class HwiSigner:
             raise SignerError(err_msg)
         return str(answer[field])
 
+    @property
     def master_fingerprint(self) -> bytes:
         """Return the fingerprint this signer was selected by.
 
@@ -636,6 +637,7 @@ class HwiSigner:
         text = add_checksum(str(at_index(descriptor, index)))
         return self._answer(["displayaddress", "--desc", text], "address")
 
+    @property
     def capabilities(self) -> SignerCapabilities:
         """Return what the caller said this device can be asked to sign."""
         return self._capabilities

--- a/btclib/psbt/psbt_view.py
+++ b/btclib/psbt/psbt_view.py
@@ -454,6 +454,7 @@ class PsbtView:
         """
         return deepcopy(self._transaction())
 
+    @property
     def prevouts(self) -> list[TxOut]:
         """Return the output each input spends, `psbt.prevouts` over a stream.
 

--- a/btclib/psbt_signer.py
+++ b/btclib/psbt_signer.py
@@ -128,8 +128,26 @@ class PsbtSigner(Protocol):
     driver.
     """
 
+    @property
     def master_fingerprint(self) -> bytes:
-        """Return the four bytes identifying the master key, BIP32's own."""
+        """Return the four bytes identifying the master key, BIP32's own.
+
+        A property, and that is a promise the contract makes: reading it
+        is free. Every implementation there is keeps it -- `HwiSigner`
+        holds the fingerprint it was selected by and says so ("not asked
+        of the device again"), `SoftwareSigner` derives it from a key it
+        already has, and a decorator forwards -- so nothing is asked to
+        pay for the shape (issue #814).
+
+        It is worth knowing what would ask for the shape back. HWI's own
+        `HardwareWalletClient.get_master_fingerprint` *is* a device call:
+        it fetches the key at m/0h and reads the parent fingerprint off
+        it. An adapter written against that library rather than against
+        the command line would want a method here, and the way to give it
+        one is to relax this to a method again -- which is a change to the
+        contract, made deliberately, and not something to leave room for
+        in advance.
+        """
         ...
 
     def xpub(self, der_path: DerPath) -> str:
@@ -145,8 +163,13 @@ class PsbtSigner(Protocol):
         """
         ...
 
+    @property
     def capabilities(self) -> SignerCapabilities:
-        """Return what this signer can be asked to sign."""
+        """Return what this signer can be asked to sign.
+
+        A property for `master_fingerprint`'s reason: what every
+        implementation answers is a value it was given or built once.
+        """
         ...
 
     def close(self) -> None:
@@ -283,9 +306,10 @@ class SignerDecorator:
             if hasattr(signer, operation) and not hasattr(type(self), operation):
                 setattr(self, operation, getattr(signer, operation))
 
+    @property
     def master_fingerprint(self) -> bytes:
         """Return the wrapped signer's master fingerprint."""
-        return self.signer.master_fingerprint()
+        return self.signer.master_fingerprint
 
     def xpub(self, der_path: DerPath) -> str:
         """Return the wrapped signer's extended public key at a path."""
@@ -295,9 +319,10 @@ class SignerDecorator:
         """Return what the wrapped signer answers, this adding no rule."""
         return self.signer.sign_psbt(psbt)
 
+    @property
     def capabilities(self) -> SignerCapabilities:
         """Return what the wrapped signer can be asked to sign."""
-        return self.signer.capabilities()
+        return self.signer.capabilities
 
     def close(self) -> None:
         """Close the wrapped signer, and whatever it was holding open."""
@@ -423,7 +448,7 @@ def export_account(
     for the same descriptor, which is `display_address`.
     """
     return account_descriptors(
-        signer.xpub(der_path), der_path, signer.master_fingerprint(), script_type
+        signer.xpub(der_path), der_path, signer.master_fingerprint, script_type
     )
 
 
@@ -614,6 +639,7 @@ class SoftwareSigner:
             BIP32KeyData.b58decode(key).is_private for key in self._keys.values()
         )
 
+    @property
     def master_fingerprint(self) -> bytes:
         """Return the fingerprint of the key this signer was built on.
 
@@ -656,6 +682,7 @@ class SoftwareSigner:
             raise BTClibValueError("watch-only signer: it holds no key that signs")
         return sign(psbt, self)[0]
 
+    @property
     def capabilities(self) -> SignerCapabilities:
         """Return what this signer can be asked to sign.
 

--- a/btclib/psbt_signer_contract.py
+++ b/btclib/psbt_signer_contract.py
@@ -120,10 +120,10 @@ def unsignable_psbt(fingerprint: bytes) -> Psbt:
 
 def _check_fingerprint(signer: PsbtSigner) -> bytes:
     """Check the master fingerprint and return it, the rest needing it."""
-    fingerprint = signer.master_fingerprint()
+    fingerprint = signer.master_fingerprint
     if len(fingerprint) != _FINGERPRINT_SIZE:
         _fail(f"master_fingerprint is {len(fingerprint)} bytes, not 4")
-    if signer.master_fingerprint() != fingerprint:
+    if signer.master_fingerprint != fingerprint:
         _fail("master_fingerprint answered two different values")
     return fingerprint
 
@@ -135,7 +135,7 @@ def _check_capabilities(signer: PsbtSigner) -> None:
     the rest of the session: a signer that answers differently the
     second time has already been acted on.
     """
-    if signer.capabilities() != signer.capabilities():
+    if signer.capabilities != signer.capabilities:
         _fail("capabilities answered two different values")
 
 

--- a/tests/hwi_test.py
+++ b/tests/hwi_test.py
@@ -209,15 +209,15 @@ def test_the_adapter_answers_the_signer_contract(hwi: list[str]) -> None:
     assert isinstance(device, AddressDisplay)
     assert isinstance(device, MessageSigner)
 
-    assert device.master_fingerprint() == bytes.fromhex(FINGERPRINT)
+    assert device.master_fingerprint == bytes.fromhex(FINGERPRINT)
     assert device.xpub("m/84h/0h/0h") == xpub_from_xprv(
         derive(XPRV_ROOT, "m/84h/0h/0h")
     )
-    assert device.capabilities() == SignerCapabilities()
+    assert device.capabilities == SignerCapabilities()
     # what a model supports is not in the json a command line answers, so
     # a caller that knows its device is what says so
     taproot = signer(hwi, capabilities=SignerCapabilities(taproot=True))
-    assert taproot.capabilities().taproot
+    assert taproot.capabilities.taproot
 
 
 def test_enumerate_reads_hwi_s_own_shape(tmp_path: Path) -> None:
@@ -261,7 +261,7 @@ def test_a_device_is_named_by_its_fingerprint(tmp_path: Path) -> None:
     one = {"type": "stand-in", "model": "m", "path": "a", "fingerprint": FINGERPRINT}
     other = {**one, "path": "b", "fingerprint": "deadbeef"}
 
-    assert HwiSigner(executable=stand_in(tmp_path, {})).master_fingerprint().hex() == (
+    assert HwiSigner(executable=stand_in(tmp_path, {})).master_fingerprint.hex() == (
         FINGERPRINT
     )
     hwi = stand_in(tmp_path, {"enumerate": [one, other]})
@@ -584,7 +584,7 @@ def test_a_closed_signer_runs_nothing(hwi: list[str]) -> None:
     device.close()
     device.close()
 
-    assert device.master_fingerprint() == bytes.fromhex(FINGERPRINT)
+    assert device.master_fingerprint == bytes.fromhex(FINGERPRINT)
     with pytest.raises(SignerError, match="the signer is closed"):
         device.xpub("m/0")
 

--- a/tests/integration/hwi_device_test.py
+++ b/tests/integration/hwi_device_test.py
@@ -123,12 +123,12 @@ def test_hwi_answers_the_contract(device: HwiSigner) -> None:
     an extended key btclib reads back.
     """
     assert isinstance(device, PsbtSigner)
-    assert len(device.master_fingerprint()) == 4
+    assert len(device.master_fingerprint) == 4
 
     receive, change = export_account(device, "m/84h/0h/0h")
     origin = receive.key_expressions[0].origin
     assert origin is not None
-    assert origin.master_fingerprint == device.master_fingerprint()
+    assert origin.master_fingerprint == device.master_fingerprint
     assert receive.address(0) != change.address(0)
 
 

--- a/tests/integration/regtest_test.py
+++ b/tests/integration/regtest_test.py
@@ -191,7 +191,7 @@ def test_the_change_output_is_what_the_node_calls_change(
     decoded = node.call("decodepsbt", [psbt.b64encode()])
 
     ((origin,),) = [output["bip32_derivs"] for output in decoded["outputs"] if output]
-    assert origin["master_fingerprint"] == signer.master_fingerprint().hex()
+    assert origin["master_fingerprint"] == signer.master_fingerprint.hex()
     assert origin["path"] == f"{DECODE_ACCOUNT}/1/0"
     assert decoded["outputs"][0] == {}
 

--- a/tests/name_contract_test.py
+++ b/tests/name_contract_test.py
@@ -171,7 +171,89 @@ def _argument_less_bools() -> dict[str, bool]:
             if arguments:
                 continue
             decorated = {ast.unparse(d) for d in node.decorator_list}
-            found[f"{module}.{node.name}"] = "property" in decorated
+            found[f"{module}.{node.name}"] = _is_a_read(decorated)
+    return found
+
+
+# an argument-less member of a public class is a read, and a read is a
+# `@property`. These are the shapes that are not a read, by what they do
+# rather than by a list of names -- which is what keeps the rule from
+# needing one (issue #814):
+#
+# - `assert_*` refuses, and a property that refuses is a trap: reading
+#   `obj.assert_valid` evaluates the method and throws it away
+# - `get_*` talks to a node or an explorer, so it costs a round trip and
+#   can fail; the prefix is the warning and a property would hide it
+# - `to_*` converts, and hands back a new object rather than a read of
+#   this one
+# - `close` is an action with a side effect
+_NOT_A_READ = ("assert_", "get_", "to_")
+_AN_ACTION = frozenset({"close"})
+
+# hashlib's own API, mirrored in a Protocol, and hashlib draws the line
+# itself: `digest()`, `hexdigest()` and `copy()` are calls where
+# `block_size`, `digest_size` and `name` are attributes. So these three
+# are named one by one rather than the class being exempt -- a property
+# here would stop anything `hashlib.new` returns from satisfying
+# HashObject, and the other three are reads and stay properties
+_MIRRORS_HASHLIB = frozenset(
+    {
+        "btclib.alias.HashObject.copy",
+        "btclib.alias.HashObject.digest",
+        "btclib.alias.HashObject.hexdigest",
+    }
+)
+
+
+def _is_a_read(decorated: set[str]) -> bool:
+    """Return whether the decorators make this a read rather than a call.
+
+    `functools.cached_property` is one as much as `property` is --
+    `Script.asm` parses once and is read thereafter -- and testing the set
+    for `"property"` alone missed it, which is what this function exists
+    to stop being written twice.
+    """
+    return bool(
+        decorated & {"property", "cached_property", "functools.cached_property"}
+    )
+
+
+def _class_members() -> dict[str, bool]:
+    """Return every argument-less member of a public class, property or not.
+
+    A property is a class thing, so a module-level function is out of
+    scope however few arguments it takes -- `fetch.fetcher.client_errors`
+    is a context manager and could not be one. Methods of a private class
+    are out too: `_Decoder` is not API.
+    """
+    found: dict[str, bool] = {}
+    for path in sorted(_LIBRARY.rglob("*.py")):
+        module = ".".join(path.relative_to(_LIBRARY.parent).with_suffix("").parts)
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for cls in ast.walk(tree):
+            if not isinstance(cls, ast.ClassDef) or cls.name.startswith("_"):
+                continue
+            for node in cls.body:
+                if not isinstance(node, ast.FunctionDef) or node.name.startswith("_"):
+                    continue
+                decorated = {ast.unparse(d) for d in node.decorator_list}
+                if {"staticmethod", "classmethod"} & decorated:
+                    continue
+                # no filter for a `@x.setter`: one takes the value it
+                # sets, so the argument count below excludes it already
+                arguments = [
+                    a.arg
+                    for a in [
+                        *node.args.posonlyargs,
+                        *node.args.args,
+                        *node.args.kwonlyargs,
+                    ]
+                    if a.arg != "self"
+                ]
+                if arguments or node.args.vararg or node.args.kwarg:
+                    continue
+                key = f"{module}.{cls.name}.{node.name}"
+                found[key] = _is_a_read(decorated)
     return found
 
 
@@ -198,6 +280,7 @@ _NAMED = _named()
 _GATED = sorted(set(_NAMED) - _OTHER_CONTRACT.keys())
 _PUBLIC_BOOLS = _public_bools()
 _ARGUMENT_LESS_BOOLS = _argument_less_bools()
+_CLASS_MEMBERS = _class_members()
 
 
 @pytest.mark.parametrize("dotted", _GATED)
@@ -316,3 +399,47 @@ def test_the_walk_reaches_both_shapes() -> None:
     # a bool of an argument is a function of it, and no property can be
     assert "btclib.script.script_pub_key.is_p2sh" not in _ARGUMENT_LESS_BOOLS
     assert "btclib.ecc.dsa.verify" not in _ARGUMENT_LESS_BOOLS
+
+
+@pytest.mark.parametrize("dotted", sorted(_CLASS_MEMBERS))
+def test_an_argument_less_member_is_read_not_called(dotted: str) -> None:
+    """Whatever it answers, a member that takes nothing is a `@property`.
+
+    The bool rule above, generalised to every return type: `PsbtView.tx`
+    was a property and `PsbtView.prevouts` a method, two reads of one
+    lazy view spelled two ways, and `master_fingerprint` and
+    `capabilities` were methods on the signer contract while every
+    implementation of them returned a stored value.
+
+    What is not a read is here by shape and not by a list of names, which
+    is what keeps this rule from needing one.
+    """
+    name = dotted.rpartition(".")[2]
+    if name.startswith(_NOT_A_READ) or name in _AN_ACTION or dotted in _MIRRORS_HASHLIB:
+        assert not _CLASS_MEMBERS[dotted], (
+            f"{dotted} is a @property and its name says it is not a read:"
+            " rename it, or drop the decorator"
+        )
+        return
+    assert _CLASS_MEMBERS[dotted], (
+        f"{dotted} takes nothing but self: it is a @property, not a method"
+    )
+
+
+def test_the_walk_reaches_every_shape_of_member() -> None:
+    """One of each, so neither branch above is running over nothing."""
+    assert _CLASS_MEMBERS["btclib.psbt.psbt_view.PsbtView.prevouts"] is True
+    assert _CLASS_MEMBERS["btclib.psbt_signer.PsbtSigner.master_fingerprint"] is True
+    # a cached_property is a read too, which testing for "property" alone
+    # would have missed
+    assert _CLASS_MEMBERS["btclib.script.script.Script.asm"] is True
+    # and the three of HashObject that hashlib spells as attributes
+    assert _CLASS_MEMBERS["btclib.alias.HashObject.digest_size"] is True
+    # and the four shapes that are not a read
+    # OutPoint's and not Tx's, which takes an `unsigned_template` and so
+    # is not argument-less at all
+    assert _CLASS_MEMBERS["btclib.tx.out_point.OutPoint.assert_valid"] is False
+    assert _CLASS_MEMBERS["btclib.psbt.psbt.Psbt.to_v2"] is False
+    assert _CLASS_MEMBERS["btclib.hwi.HwiSigner.close"] is False
+    assert _CLASS_MEMBERS["btclib.alias.HashObject.digest"] is False
+    assert _CLASS_MEMBERS["btclib.fetch.fetcher.Fetcher.get_block_count"] is False

--- a/tests/psbt/psbt_view_test.py
+++ b/tests/psbt/psbt_view_test.py
@@ -157,7 +157,10 @@ def test_the_outputs_being_spent_are_the_objects(test_vector: dict[str, Any]) ->
     well.
     """
     raw = _raw(test_vector)
-    assert _answer(PsbtView(raw).prevouts) == _answer(prevouts, Psbt.parse(raw))
+    # a lambda around the view's, `prevouts` being a property there: what
+    # `_answer` needs is something it can call *after* the try, and a
+    # property has already answered by the time it is passed
+    assert _answer(lambda: PsbtView(raw).prevouts) == _answer(prevouts, Psbt.parse(raw))
 
 
 @pytest.mark.parametrize("test_vector", _INVALID)
@@ -408,12 +411,12 @@ def test_the_transaction_and_the_outputs_spent_are_copies() -> None:
     tx = view.tx
     tx.lock_time += 1
     tx.vout[0] = elsewhere
-    spent = view.prevouts()
+    spent = view.prevouts
     spent[0] = elsewhere
 
     assert view.tx.lock_time != tx.lock_time
     assert view.tx.vout[0] != elsewhere
-    assert view.prevouts()[0] != elsewhere
+    assert view.prevouts[0] != elsewhere
     assert view.taproot_sig_hash(0) == before
 
 

--- a/tests/psbt_signer_contract_test.py
+++ b/tests/psbt_signer_contract_test.py
@@ -59,8 +59,9 @@ class _Wrapper:
     def __init__(self) -> None:
         self._signer = _signer()
 
+    @property
     def master_fingerprint(self) -> bytes:
-        return self._signer.master_fingerprint()
+        return self._signer.master_fingerprint
 
     def xpub(self, der_path: DerPath) -> str:
         return self._signer.xpub(der_path)
@@ -68,8 +69,9 @@ class _Wrapper:
     def sign_psbt(self, psbt: Psbt) -> Psbt:
         return self._signer.sign_psbt(psbt)
 
+    @property
     def capabilities(self) -> SignerCapabilities:
-        return self._signer.capabilities()
+        return self._signer.capabilities
 
     def close(self) -> None:
         self._signer.close()
@@ -90,7 +92,7 @@ def _signable() -> Psbt:
     psbt_in = psbt.inputs[0]
     psbt_in.witness_utxo = TxOut(10_000, script_pub_key)
     psbt_in.hd_key_paths[pub_key] = BIP32KeyOrigin(
-        signer.master_fingerprint(), f"{_ACCOUNT}/0/0"
+        signer.master_fingerprint, f"{_ACCOUNT}/0/0"
     )
     return psbt
 
@@ -116,6 +118,7 @@ def test_a_fingerprint_of_the_wrong_width_is_refused() -> None:
     """Four bytes is BIP32's own, and every key origin is written to it."""
 
     class _TooLong(_Wrapper):
+        @property
         def master_fingerprint(self) -> bytes:
             return b"\x00" * 5
 
@@ -125,6 +128,7 @@ def test_a_fingerprint_of_the_wrong_width_is_refused() -> None:
     # and short of it, which a width checked as a ceiling would accept: a
     # three-byte fingerprint is what a key origin would then be written to
     class _TooShort(_Wrapper):
+        @property
         def master_fingerprint(self) -> bytes:
             return b"\x00" * 3
 
@@ -140,6 +144,7 @@ def test_a_fingerprint_that_changes_is_refused() -> None:
             super().__init__()
             self._asked = 0
 
+        @property
         def master_fingerprint(self) -> bytes:
             self._asked += 1
             return bytes([self._asked, 0, 0, 0])
@@ -155,6 +160,7 @@ def test_a_fingerprint_that_changes_is_refused() -> None:
             super().__init__()
             self._asked = 4
 
+        @property
         def master_fingerprint(self) -> bytes:
             self._asked -= 1
             return bytes([self._asked, 0, 0, 0])
@@ -254,7 +260,7 @@ def test_a_signer_that_signs_nothing_it_was_said_to_sign_is_refused() -> None:
 
 def test_the_unsignable_psbt_names_another_master() -> None:
     """What the psbt is for, said against the psbt itself."""
-    fingerprint = _signer().master_fingerprint()
+    fingerprint = _signer().master_fingerprint
     psbt = unsignable_psbt(fingerprint)
     ((_, origin),) = psbt.inputs[0].hd_key_paths.items()
     assert origin.master_fingerprint != fingerprint
@@ -296,6 +302,7 @@ def test_capabilities_that_change_are_refused() -> None:
             super().__init__()
             self._asked = 0
 
+        @property
         def capabilities(self) -> SignerCapabilities:
             self._asked += 1
             return SignerCapabilities(taproot=self._asked % 2 == 0)
@@ -338,7 +345,7 @@ def _partly_signed_quorum() -> Psbt:
     psbt_in.witness_script = witness_script
     for key, one in zip(keys, roots, strict=True):
         psbt_in.hd_key_paths[key] = BIP32KeyOrigin(
-            SoftwareSigner(one).master_fingerprint(), f"{_ACCOUNT}/0/0"
+            SoftwareSigner(one).master_fingerprint, f"{_ACCOUNT}/0/0"
         )
 
     # the other two sign first, which is what leaves the reference signer

--- a/tests/psbt_signer_test.py
+++ b/tests/psbt_signer_test.py
@@ -121,6 +121,7 @@ class _Signer:
         self.answer: Psbt | None = None
         self.closed = False
 
+    @property
     def master_fingerprint(self) -> bytes:
         """Return the fingerprint of the key this signer holds."""
         return fingerprint(self.xprv)
@@ -135,6 +136,7 @@ class _Signer:
             return self.answer
         return sign(psbt, _KeyManager(self.xprv))[0]
 
+    @property
     def capabilities(self) -> SignerCapabilities:
         """Return what this double can sign: no taproot, no musig2."""
         return SignerCapabilities()
@@ -170,7 +172,7 @@ def test_the_protocols_are_what_a_signer_is_asked_for() -> None:
     assert not isinstance(signer, AddressDisplay)
     assert not isinstance(signer, MessageSigner)
 
-    assert signer.capabilities() == SignerCapabilities(taproot=False, musig2=False)
+    assert signer.capabilities == SignerCapabilities(taproot=False, musig2=False)
     signer.close()
     signer.close()
     assert signer.closed
@@ -258,7 +260,7 @@ def test_a_signer_holding_none_of_the_keys_adds_nothing() -> None:
     taproot_psbt.inputs[0].witness_utxo = TxOut(10_000, script_pub_key)
     taproot_psbt = taproot.update_psbt_input(taproot_psbt, 0)
 
-    assert not signer.capabilities().taproot
+    assert not signer.capabilities.taproot
     signed = request_signatures(signer, taproot_psbt)
     assert not signed.inputs[0].taproot_key_spend_signature
     assert not signed.inputs[0].taproot_script_spend_signatures
@@ -511,9 +513,9 @@ def test_a_decorated_signer_answers_what_the_signer_underneath_answers() -> None
     wrapped = SignerDecorator(signer)
     assert isinstance(wrapped, PsbtSigner)
 
-    assert wrapped.master_fingerprint() == signer.master_fingerprint()
+    assert wrapped.master_fingerprint == signer.master_fingerprint
     assert wrapped.xpub(ACCOUNT) == signer.xpub(ACCOUNT)
-    assert wrapped.capabilities() == signer.capabilities()
+    assert wrapped.capabilities == signer.capabilities
 
     psbt, _ = account_psbt(signer)
     assert wrapped.sign_psbt(deepcopy(psbt)) == signer.sign_psbt(deepcopy(psbt))

--- a/tests/software_signer_test.py
+++ b/tests/software_signer_test.py
@@ -79,10 +79,10 @@ def test_the_software_signer_answers_every_protocol() -> None:
     assert isinstance(signer, AddressDisplay)
     assert isinstance(signer, MessageSigner)
 
-    assert signer.capabilities() == SignerCapabilities(taproot=True, musig2=False)
-    assert SoftwareSigner(XPRV_ROOT, musig2=True).capabilities().musig2
+    assert signer.capabilities == SignerCapabilities(taproot=True, musig2=False)
+    assert SoftwareSigner(XPRV_ROOT, musig2=True).capabilities.musig2
     assert not signer.is_watch_only
-    assert signer.master_fingerprint().hex() == "73c5da0a"
+    assert signer.master_fingerprint.hex() == "73c5da0a"
     assert signer.xpub("m/84h/0h/0h") == xpub_from_xprv(
         derive(XPRV_ROOT, "m/84h/0h/0h")
     )
@@ -137,7 +137,7 @@ def test_a_taproot_script_path_is_signed_and_spends() -> None:
     for that leaf" and is what the signer is asked by.
     """
     signer = SoftwareSigner(XPRV_ROOT)
-    key = f"[{signer.master_fingerprint().hex()}/86h/0h/0h]{signer.xpub('m/86h/0h/0h')}"
+    key = f"[{signer.master_fingerprint.hex()}/86h/0h/0h]{signer.xpub('m/86h/0h/0h')}"
     nums = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
     receive = parse(add_checksum(f"tr({nums},pk({key}/0/*))"))
     change = parse(add_checksum(f"tr({nums},pk({key}/1/*))"))
@@ -172,7 +172,7 @@ def test_the_change_output_carries_what_a_device_reads() -> None:
     psbt_out = psbt.outputs[1]
     ((pub_key, origin),) = psbt_out.hd_key_paths.items()
     assert pub_key == change.key_expressions[0].sec(5)
-    assert origin.master_fingerprint == signer.master_fingerprint()
+    assert origin.master_fingerprint == signer.master_fingerprint
     assert origin.description == "73c5da0a/84h/0h/0h/1/5"
     # the payment is not the wallet's, so nothing was written on it
     assert not psbt.outputs[0].hd_key_paths
@@ -206,7 +206,7 @@ def test_the_signer_answers_for_its_own_keys_only() -> None:
 
     # a hardened step under an xpub, which no derivation can take
     watch_only = SoftwareSigner(xpub_from_xprv(derive(XPRV_ROOT, "m/84h/0h/0h")))
-    hardened = BIP32KeyOrigin(watch_only.master_fingerprint(), "m/0h")
+    hardened = BIP32KeyOrigin(watch_only.master_fingerprint, "m/0h")
     assert watch_only.sign_ecdsa(pub_key, hardened, msg_hash) is None
 
     # the path walks, and leads to another key than the one named
@@ -217,7 +217,7 @@ def test_the_signer_answers_for_its_own_keys_only() -> None:
     # x-only spelling of the same 33 bytes
     taproot = export_account(signer, "m/86h/0h/0h")[0]
     x_only = taproot.key_expressions[0].sec(0)[1:]
-    tr_origin = BIP32KeyOrigin(signer.master_fingerprint(), "m/86h/0h/0h/0/0")
+    tr_origin = BIP32KeyOrigin(signer.master_fingerprint, "m/86h/0h/0h/0/0")
     assert signer.sign_schnorr(x_only, tr_origin, msg_hash, b"") is not None
     assert signer.sign_schnorr(x_only, None, msg_hash, b"") is None
     assert signer.sign_schnorr(x_only, elsewhere, msg_hash, b"") is None
@@ -249,7 +249,7 @@ def test_a_watch_only_signer_shows_and_derives_but_does_not_sign() -> None:
     root_xpub = xpub_from_xprv(XPRV_ROOT)
     signer = SoftwareSigner(root_xpub)
     assert signer.is_watch_only
-    assert signer.master_fingerprint() == SoftwareSigner(XPRV_ROOT).master_fingerprint()
+    assert signer.master_fingerprint == SoftwareSigner(XPRV_ROOT).master_fingerprint
     assert signer.xpub("m/0") == derive(root_xpub, "m/0")
 
     with pytest.raises(BTClibValueError, match="hardened derivation from public key"):
@@ -284,7 +284,7 @@ def test_a_closed_signer_answers_nothing() -> None:
     signer.close()
     signer.close()
 
-    assert signer.master_fingerprint().hex() == "73c5da0a"
+    assert signer.master_fingerprint.hex() == "73c5da0a"
     with pytest.raises(BTClibValueError, match="the signer is closed"):
         signer.xpub("m/0")
     with pytest.raises(BTClibValueError, match="the signer is closed"):
@@ -340,10 +340,10 @@ def test_a_signer_of_accounts_answers_for_the_master_it_names() -> None:
     account = derive(XPRV_ROOT, account_path)
     master = SoftwareSigner(XPRV_ROOT)
     signer = SoftwareSigner.from_accounts(
-        master.master_fingerprint(), {account_path: account}
+        master.master_fingerprint, {account_path: account}
     )
 
-    assert signer.master_fingerprint() == master.master_fingerprint()
+    assert signer.master_fingerprint == master.master_fingerprint
     assert signer.xpub(account_path) == master.xpub(account_path)
     assert not signer.is_watch_only
     assert isinstance(signer, PsbtSigner)
@@ -362,14 +362,14 @@ def test_a_signer_of_accounts_answers_for_the_master_it_names() -> None:
     # the same key, built on the ordinary way: its own fingerprint is
     # four other bytes, and no origin of this psbt names them
     plain = SoftwareSigner(account)
-    assert plain.master_fingerprint() != master.master_fingerprint()
+    assert plain.master_fingerprint != master.master_fingerprint
     assert plain.sign_psbt(psbt) == psbt
 
 
 def test_the_longest_account_prefixing_an_origin_answers() -> None:
     """Two accounts on one path, and the deeper one has less left to derive."""
     signer = SoftwareSigner.from_accounts(
-        SoftwareSigner(XPRV_ROOT).master_fingerprint(),
+        SoftwareSigner(XPRV_ROOT).master_fingerprint,
         {
             "m/84h/0h": derive(XPRV_ROOT, "m/84h/0h"),
             "m/84h/0h/0h": derive(XPRV_ROOT, "m/84h/0h/0h"),
@@ -393,7 +393,7 @@ def test_a_signer_of_accounts_has_no_single_key() -> None:
     """`xkey` is the key a signer was built on, and there was none."""
     account_path = "m/84h/0h/0h"
     signer = SoftwareSigner.from_accounts(
-        SoftwareSigner(XPRV_ROOT).master_fingerprint(),
+        SoftwareSigner(XPRV_ROOT).master_fingerprint,
         {account_path: derive(XPRV_ROOT, account_path)},
     )
     with pytest.raises(BTClibValueError, match="holds accounts, not one key"):
@@ -424,7 +424,7 @@ def test_an_account_paired_with_the_wrong_master_answers_for_nothing() -> None:
     # another master's account, told this master's fingerprint
     other_root = derive(XPRV_ROOT, "m/9h")
     liar = SoftwareSigner.from_accounts(
-        honest.master_fingerprint(), {account_path: derive(other_root, account_path)}
+        honest.master_fingerprint, {account_path: derive(other_root, account_path)}
     )
     assert liar.sign_psbt(psbt) == psbt
 
@@ -434,7 +434,7 @@ def test_a_signer_of_watch_only_accounts_derives_but_does_not_sign() -> None:
     account_path = "m/84h/0h/0h"
     account = xpub_from_xprv(derive(XPRV_ROOT, account_path))
     signer = SoftwareSigner.from_accounts(
-        SoftwareSigner(XPRV_ROOT).master_fingerprint(), {account_path: account}
+        SoftwareSigner(XPRV_ROOT).master_fingerprint, {account_path: account}
     )
 
     assert signer.is_watch_only


### PR DESCRIPTION
The bool rule of https://github.com/btclib-org/btclib/pull/851
generalised to every return type, and it answers the question you asked
about `master_fingerprint` and `capabilities` with a measurement rather
than an argument.

Source-breaking, deliberately, under the policy
https://github.com/btclib-org/btclib/pull/851 wrote into CONTRIBUTING.md.

## The census, which is what settled it

**168** public members take nothing but `self`: 114 properties against 54
methods. But **45 of those 54 are not reads at all**, and by shape rather
than by an accident of naming:

| shape | count | why it stays a call |
| --- | ---: | --- |
| `assert_*` | 28 | it refuses, and a property that refuses is a trap — reading `obj.assert_valid` evaluates the method and throws it away |
| `get_*` | 6 | it talks to a node or an explorer; the prefix is the warning a property would hide |
| `close` | 4 | an action with a side effect |
| `to_*` | 2 | it hands back a new object |
| `HashObject.digest`, `hexdigest`, `copy` | 3 | hashlib's own spelling — and hashlib draws the same line, `block_size` and `digest_size` being attributes there as they are properties here |

**Nine were left**, and each reads something already in hand.

## `PsbtView.prevouts` — the docstrings gave it away

`lock_time` and `tx` are properties, `prevouts` was a method: three reads
of one lazy view, two spellings. And `tx` says *"a copy, as `Psbt.tx` is
one"* while `prevouts` says *"a copy, for the reason `tx` is one"* — the
second cites the first while being shaped differently.

## `master_fingerprint` and `capabilities` — measured, as you asked

**No implementation that exists does a non-cheap read:**

| implementation | what it returns |
| --- | --- |
| `HwiSigner` | `self._fingerprint`, the value it was *selected by* — its docstring says "not asked of the device again" |
| `SoftwareSigner` | derived from a key it already holds |
| `SignerDecorator` | forwards |
| the two test doubles | a stored value, and a fresh `SignerCapabilities()` |

So nothing is harmed today, and the property becomes a promise the
contract can keep.

**And the external evidence, since you pointed at HWI:** HWI's own
`HardwareWalletClient.get_master_fingerprint` **is** a device call — it
fetches the key at `m/0h` and reads the parent fingerprint off it. btclib's
adapter never takes that path, because the CLI needs the fingerprint as a
`--fingerprint` selector up front. That is recorded in the Protocol's
docstring, because it is precisely the adapter that would ask for a method
back — and then the contract gets relaxed deliberately, rather than
leaving room for it in advance.

## The gate

`tests/name_contract_test.py` checks the rule **by shape, not by a list of
names** — which is what keeps it from needing one.

Writing it found two things about the walk rather than about the tree, both
worth knowing:

- `functools.cached_property` is a read, and testing a decorator set for
  `"property"` alone misses it — `Script.asm` parses once and is read
  thereafter. `_is_a_read` exists so that is not written wrongly twice.
- `Tx.assert_valid` takes an `unsigned_template`, so it is not
  argument-less at all and never was in scope.

## One test changed shape rather than spelling

`psbt_view_test._answer` takes something it can call *after* the `try`, so
that "raises this" can be compared as a value. A property has already
answered by the time it is passed — so the view's `prevouts` goes in as a
lambda. That is the one ergonomic cost of the property form, and it is
worth seeing once.

## Gates

- `uv run pytest` — 27375 passed, coverage 100.00%
- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0

HISTORY.md's entry says what an adapter author has to *implement*, not
merely call: `@property`, or a plain attribute, which a Protocol property
accepts as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Generalize the "argument-less member is a read" rule across the codebase by converting remaining zero-argument members that represent stored values into properties, updating tests and documentation to enforce and describe the contract change.

New Features:
- Treat signer protocol members `master_fingerprint` and `capabilities` as properties (or plain attributes) that must represent cheap reads, extending the public API shape for signers.
- Expose `PsbtView.prevouts` as a property to match other read-only, lazy-view accessors.

Enhancements:
- Strengthen the name contract by adding a shape-based gate that ensures argument-less public class members are properties unless their names indicate actions, conversions, network calls, or specific hashlib-like methods.
- Improve contributor guidance in CONTRIBUTING.md and CHANGELOG/HISTORY to document the generalized property rule for argument-less members and its impact on protocols and adapters.

Tests:
- Extend `name_contract_test` with a new walk over class members, plus shape-based checks and fixtures, to assert that argument-less members are properties except for explicitly exempted patterns.
- Update PSBT signer, HWI, software signer, protocol contract, and PSBT view tests to use property access for `master_fingerprint`, `capabilities`, and `prevouts`, and to validate the new contract semantics.
- Add contract tests ensuring PsbtSigner implementations expose `master_fingerprint` and `capabilities` as stable, repeatable reads rather than calls.