### PR TITLE
Ask an object's type before reading a field off it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2679,6 +2679,46 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **The input contract is gated over a function taking an object somebody
+  already built** (issue #856). Neither of the two gates reaches
+  `assert_signatures_only`, `estimated_input_sizes` or `KeyGroup`: their
+  parameters are a `Psbt`, a `PsbtIn` and a sequence of extended keys, and
+  no vocabulary of wrong values builds one, so
+  `tests/built_object_contract_test.py` builds them from BIP174's own
+  vectors. `check_validity=False` is what makes the family worth a gate --
+  it says *do not check now*, not *this object is exempt from here on*, so
+  an invalid object is something a caller may legitimately hold and hand
+  back.
+
+  It found the shapes issue #856 predicted, and one it did not.
+  `KeyGroup`'s `threshold` reached a comparison before its type was asked,
+  so `None` raised from underneath the library and **1.5 was accepted**, a
+  float quorum written into a script; `keys` and `origins` were walked
+  unchecked, so a non-sequence was "not iterable" and an origin that is no
+  origin an `AttributeError` about a field name -- and `Sequence[BIP32Key]`
+  accepts a `str`, every character of it being a `BIP32Key` as far as the
+  annotation says, so one xpub handed where the list was meant was 111
+  keys. `assert_signatures_only` and `estimated_input_sizes` read a field
+  off whatever they were given, which is the wrong error for the one
+  function whose whole job is to distrust an answer from elsewhere.
+  `Psbt.assert_valid` compared its three int fields against a range before
+  asking their type, `Tx.assert_valid` having had that check for the same
+  reason -- and a bool passed every one of those comparisons as one or
+  zero, so those three join `integer_policy_test.py`'s inventory.
+
+  The one it did not predict was silence rather than a wrong exception:
+  `estimated_input_sizes` consults its `sizer` in a single branch, so a
+  value of no callable type was accepted by every call that did not need
+  one. It is asked for up front now.
+
+  `KeyGroup(verify=)` refuses a non-bool, which is the other half of the
+  same argument and a line CONTRIBUTING.md now draws: a flag deciding
+  *what is computed* is a kind and not a truth, `musig2._flag`'s
+  reasoning, because a wallet built from a configuration file reading
+  `"false"` would compute every address of the other script.
+  `check_validity` and `slip132`'s `check_root_xkey` decide only whether a
+  check runs, so they stay read for their truth.
+
 - **An argument-less member is a read, and nine were calls** (issue
   #814). The bool rule generalised to every return type, and the census
   is what settled it: 168 public members take nothing but `self`, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -871,9 +871,23 @@ function whose required parameters are all library input types.
 `tests/bool_contract_test.py` drives them from hand-written fixtures over
 the verifications that walk cannot reach — a signature verification needs
 a valid message, key and signature, and a `Sig | Octets` no vocabulary of
-wrong values can build. Neither has an exemption list, which is the state
-to keep: a finding is a red test, to be fixed or to be given a reason of
-its own beside the two families that have one.
+wrong values can build. `tests/built_object_contract_test.py` does the
+same for a function whose parameter is an object the caller already built
+— a `Psbt`, a `PsbtIn`, a sequence of extended keys — which is the family
+`check_validity=False` makes reachable, an invalid object being something a
+caller may legitimately hold. None of the three has an exemption list,
+which is the state to keep: a finding is a red test, to be fixed or to be
+given a reason of its own beside the two families that have one.
+
+**A `bool` parameter is a kind or a truth, and only the first is
+type-checked.** A flag that decides *what is computed* refuses a non-bool,
+`musig2._flag` stating the reason: a kind written down and read back — json,
+a configuration file, a coordinator's message — arrives as whatever it was
+written as, and `"false"` is true, so `KeyGroup(verify=)` would compute
+every address of the other script rather than raise. A flag that decides
+only *whether a check runs* is read for its truth: `check_validity` and
+`slip132`'s `check_root_xkey` either run a check or skip one, and neither
+changes an answer. `tests/check_validity_test.py` owns that convention.
 
 Four shapes were what the second gate found when it was written, and they
 are worth knowing because each is a way of being handed an argument

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,6 +27,15 @@ Clone btclib-benchmarks and run them there.
 
 ### Breaking changes
 
+- **three arguments that used to be accepted are refused.**
+  `KeyGroup(1.5, keys)` built a group with a float quorum and
+  `KeyGroup(keys, verify="no")` one with `verify=True`, `"no"` being
+  truthy; `estimated_input_sizes(psbt_in, tx_in, sizer=<not callable>)`
+  went through for every input the function answers for on its own, the
+  sizer being consulted in one branch. All three raise a
+  `BTClibTypeError` now. A caller handing any of them a value of the
+  declared type is unaffected, and mypy already refused the three.
+
 - **the `_var` suffix finishes its sweep: `ellswift.encode_var`,
   `decode_var`, `create_var`, and `dsa.crack_prv_key_var`.** The map of
   BIP324's ElligatorSwift branches on its data — its inverse measures

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -43,7 +43,7 @@ from btclib.bip32 import (
     encode_to_bip32_derivs,
 )
 from btclib.ecc import dsa, ssa
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160, sha256
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.psbt.psbt_out import PsbtOut
@@ -92,6 +92,7 @@ from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
     bytesio_from_binarydata,
+    is_integer,
 )
 
 __all__ = [
@@ -233,7 +234,34 @@ def _global_version(global_map: Mapping[bytes, bytes]) -> int:
     return 0
 
 
+def _assert_int_field_types(
+    tx_modifiable: int | None, fallback_lock_time: int | None
+) -> None:
+    """Refuse a value of no integer type in either of the two int fields.
+
+    Asked before any rule reads either, which for `tx_modifiable` is not
+    the range: a v0 psbt refuses the field outright, and that is a
+    statement about the value of a field whose type has not been asked
+    yet. Both are optional, so None is the one non-integer value either of
+    them carries -- and a bool is not one, `utils.is_integer` stating why
+    for every integer field of this library.
+    """
+    for value, name in (
+        (tx_modifiable, "tx modifiable"),
+        (fallback_lock_time, "fallback locktime"),
+    ):
+        if value is not None and not is_integer(value):
+            raise BTClibTypeError(f"invalid {name} type: {type(value).__name__}")
+
+
 def _assert_valid_version(version: int) -> None:
+    # the type before the range, as Tx.assert_valid checks its own two int
+    # fields: a comparison against a value of no integer type raises from
+    # underneath the library, and a bool passes every one of them as one
+    # or zero -- `to_dict`/`from_dict` being a json boundary, where `true`
+    # would be version 0 rather than a schema error
+    if not is_integer(version):
+        raise BTClibTypeError(f"invalid version type: {type(version).__name__}")
     # must be a 4-bytes int
     if not 0 <= version <= 0xFFFFFFFF:
         raise BTClibValueError(f"invalid version: {version}")
@@ -1083,6 +1111,10 @@ class Psbt:
         """
         # first, the version being what every rule below is read under
         _assert_valid_version(self.version)
+
+        # then the type of the other two int fields, before any rule
+        # reads either
+        _assert_int_field_types(self.tx_modifiable, self.fallback_lock_time)
 
         for i, psbt_in in enumerate(self.inputs):
             _assert_valid_input_fields(psbt_in, self.version, i)
@@ -2745,6 +2777,20 @@ def _assert_taproot_sigs_verify(
             raise BTClibValueError(err_msg)
 
 
+def _assert_psbt_pair(request: Psbt, returned: Psbt) -> None:
+    """Refuse either of the pair before either is read.
+
+    An answer arrives from somewhere else -- an external signer, a device,
+    a cosigner -- so "not a psbt at all" is exactly the case
+    `assert_signatures_only` is called to rule out, and it must not arrive
+    as an AttributeError about a field name.
+    """
+    for psbt, what in ((request, "request"), (returned, "returned")):
+        if not isinstance(psbt, Psbt):
+            err_msg = f"invalid {what} type: {type(psbt).__name__}"  # type: ignore[unreachable]
+            raise BTClibTypeError(err_msg)
+
+
 def assert_signatures_only(request: Psbt, returned: Psbt) -> None:
     """Raise unless `returned` is `request` with signatures added, and no more.
 
@@ -2784,6 +2830,7 @@ def assert_signatures_only(request: Psbt, returned: Psbt) -> None:
     refuses an aggregate that does not verify, which is the check that
     can be made once the session is complete.
     """
+    _assert_psbt_pair(request, returned)
     returned.assert_valid()
 
     if returned.version != request.version:

--- a/btclib/psbt/psbt_size.py
+++ b/btclib/psbt/psbt_size.py
@@ -50,7 +50,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from btclib.alias import Command
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.script import serialize, type_and_payload
@@ -228,6 +228,28 @@ def _taproot_witness_sizes(
     return [_taproot_sig_size(psbt_in)]
 
 
+def _assert_arguments(
+    psbt_in: PsbtIn, tx_in: TxIn, sizer: SolutionSizer | None
+) -> None:
+    """Refuse an argument of the wrong type before any field is read.
+
+    The two objects are read for their fields, so a value of another type
+    is an AttributeError about a field name rather than a refusal. The
+    sizer is asked for here and not where it is consulted, which is a
+    single branch: one of no callable type went unnoticed for every input
+    `estimated_input_sizes` answers for on its own.
+    """
+    if not isinstance(psbt_in, PsbtIn):
+        err_msg = f"invalid psbt_in type: {type(psbt_in).__name__}"  # type: ignore[unreachable]
+        raise BTClibTypeError(err_msg)
+    if not isinstance(tx_in, TxIn):
+        err_msg = f"invalid tx_in type: {type(tx_in).__name__}"  # type: ignore[unreachable]
+        raise BTClibTypeError(err_msg)
+    if sizer is not None and not callable(sizer):
+        err_msg = f"invalid sizer type: {type(sizer).__name__}"  # type: ignore[unreachable]
+        raise BTClibTypeError(err_msg)
+
+
 def estimated_input_sizes(
     psbt_in: PsbtIn,
     tx_in: TxIn,
@@ -245,6 +267,8 @@ def estimated_input_sizes(
     read raises, unless `sizer` answers for it. All three rules, and why,
     are in the module docstring.
     """
+    _assert_arguments(psbt_in, tx_in, sizer)
+
     if psbt_in.final_script_sig or psbt_in.final_script_witness:
         # nothing to estimate: a Finalizer has been here, and what it
         # produced is what the transaction will carry

--- a/btclib/wallet/script_wallet.py
+++ b/btclib/wallet/script_wallet.py
@@ -143,7 +143,12 @@ from btclib.descriptors.descriptors import parse as _parse_descriptor
 from btclib.descriptors.key_expression import KeyExpression
 from btclib.descriptors.miniscript import P2WSH, Miniscript
 from btclib.descriptors.miniscript import from_script as _miniscript_from_script
-from btclib.exceptions import BTClibRuntimeError, BTClibValueError, NoDescriptorError
+from btclib.exceptions import (
+    BTClibRuntimeError,
+    BTClibTypeError,
+    BTClibValueError,
+    NoDescriptorError,
+)
 from btclib.psbt.psbt import Psbt
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.psbt.psbt_out import PsbtOut
@@ -151,6 +156,7 @@ from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE, MAX_SCRIPT_SIZE
 from btclib.script.script import op_int, serialize
 from btclib.script.script_pub_key import ScriptPubKey
 from btclib.to_pub_key import fingerprint, pub_keyinfo_from_key
+from btclib.utils import is_integer
 from btclib.wallet.wallet import RangedWallet
 
 __all__ = [
@@ -285,6 +291,54 @@ def _account_sec(xkey: BIP32KeyData) -> bytes:
     return pub_keyinfo_from_key(xkey)[0]
 
 
+def _assert_group_arguments(
+    threshold: int,
+    keys: Sequence[BIP32Key],
+    verify: bool,
+    origins: Sequence[BIP32KeyOrigin | None] | None,
+) -> None:
+    """Refuse an argument of the wrong type before a group is built of one.
+
+    A group is what a script, and therefore an address, is computed from,
+    so every parameter is asked here rather than at the comparisons and
+    the walks that follow: a float `threshold` was accepted outright, and
+    a `keys` or `origins` of no sequence type was "not iterable" from
+    underneath the library.
+
+    A `str` is a Sequence and one of xpubs it is not, which the annotation
+    cannot say: `Sequence[BIP32Key]` accepts a `str`, every character of it
+    being a `BIP32Key` as far as the type goes, so one xpub handed where
+    the list was meant is 111 keys.
+
+    `verify` decides which opcode the script ends with, so it is a kind and
+    not a truth, `musig2._flag`'s distinction: a wallet built from a
+    configuration file where it reads "false" would compute the other
+    script, and every address with it.
+    """
+    if not is_integer(threshold):
+        raise BTClibTypeError(f"invalid threshold type: {type(threshold).__name__}")
+    if isinstance(keys, str) or not isinstance(keys, Sequence):
+        raise BTClibTypeError(f"invalid keys type: {type(keys).__name__}")
+    if origins is not None and not isinstance(origins, Sequence):
+        raise BTClibTypeError(f"invalid origins type: {type(origins).__name__}")
+    if not isinstance(verify, bool):
+        err_msg = f"invalid verify type: {type(verify).__name__}"  # type: ignore[unreachable]
+        raise BTClibTypeError(err_msg)
+
+
+def _assert_origin_types(origins: tuple[BIP32KeyOrigin | None, ...]) -> None:
+    """Refuse an entry that is no origin, before the count is compared.
+
+    The type before the value: a `str` is a Sequence, so `origins="abc"`
+    is three of them as far as the count is concerned and the report would
+    be about the number rather than about the type.
+    """
+    for origin in origins:
+        if origin is not None and not isinstance(origin, BIP32KeyOrigin):
+            err_msg = f"invalid origin type: {type(origin).__name__}"  # type: ignore[unreachable]
+            raise BTClibTypeError(err_msg)
+
+
 class KeyGroup:
     """A quorum of extended keys, as a template writes it into a script.
 
@@ -323,12 +377,15 @@ class KeyGroup:
         verify: bool = False,
         origins: Sequence[BIP32KeyOrigin | None] | None = None,
     ) -> None:
+        _assert_group_arguments(threshold, keys, verify, origins)
+
         self.keys = tuple(_key_data_from_bip32_key(key) for key in keys)
         # one per key, so that the pairing is positional and stays so
         # through the account order, which sorts the keys and not this
         self.origins: tuple[BIP32KeyOrigin | None, ...] = (
             (None,) * len(self.keys) if origins is None else tuple(origins)
         )
+        _assert_origin_types(self.origins)
         if len(self.origins) != len(self.keys):
             err_msg = f"{len(self.origins)} origins for {len(self.keys)} keys:"
             err_msg += " a key origin is positional, and None is what a key"

--- a/tests/built_object_contract_test.py
+++ b/tests/built_object_contract_test.py
@@ -1,0 +1,292 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The gate for a function taking an object the caller already built.
+
+CONTRIBUTING.md's "Every public function validates its inputs" is driven
+automatically by `input_validation_test.py`, over the functions whose every
+required parameter is a library input type, and by hand in
+`bool_contract_test.py`, over the ones that answer a `bool`. Neither
+reaches a function whose parameter is a `Psbt`, a `PsbtIn` or a sequence of
+extended keys: no vocabulary of wrong values builds one, so a fixture has
+to, and issue #856 is where that ceiling is written down.
+
+`check_validity=False` is why this family is worth a gate of its own.
+CONTRIBUTING.md's "it says *do not check now*, not *this object is exempt
+from here on*" makes an invalid object something a caller can legitimately
+hold, so a public name accepting one is a name that has to ask -- and the
+rules are the same two everywhere else obeys:
+
+- a **wrong type** leaves as a `BTClibTypeError`
+- a **wrong value** of a declared type leaves as a `BTClibValueError`,
+  these functions answering no `bool` about their argument
+
+Both were open when this file was written, in the four shapes issue #856
+predicted: a sequence walked before it is checked (`KeyGroup`'s `keys` and
+`origins`), an argument reaching a comparison before its type is asked
+(`KeyGroup`'s `threshold`, `Psbt.assert_valid`'s three int fields), and an
+argument read for a field it has not got (`assert_signatures_only`,
+`estimated_input_sizes`). The fifth was silence: `estimated_input_sizes`
+took a `sizer` of no callable type for every input it answers for on its
+own, and `KeyGroup` a float threshold.
+
+A `bool` parameter is not driven here, and the line is
+`musig2._flag`'s: a flag that decides *what is computed* is a kind and not
+a truth, so `KeyGroup(verify=)` refuses a non-bool -- it chooses the
+closing opcode, and a wallet built from a configuration file reading
+"false" would compute every address of the other script. A flag that
+decides only *whether a check runs* -- `check_validity`, and
+`slip132`'s `check_root_xkey` -- is read for its truth, a wrong value
+there running a check or skipping one and never changing an answer.
+`check_validity_test.py` owns that convention.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from copy import deepcopy
+from dataclasses import dataclass
+from functools import partial
+from typing import Any
+
+import pytest
+
+from btclib import slip132
+from btclib.bip32.bip32 import rootxprv_from_seed, xpub_from_xprv
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.psbt.psbt import Psbt, assert_signatures_only
+from btclib.psbt.psbt_in import PsbtIn
+from btclib.psbt.psbt_size import estimated_input_sizes
+from btclib.wallet.script_wallet import KeyGroup
+from tests.psbt import psbt_cases
+
+_ROOT_XPRV = rootxprv_from_seed("00" * 32)
+_XPUB = xpub_from_xprv(_ROOT_XPRV)
+
+# the first BIP174 vector carrying signatures, which is what makes a
+# request-and-answer pair out of one published psbt: the answer is the
+# vector, the request is the same psbt before a Signer touched it
+_SIGNED = next(
+    psbt
+    for psbt in (
+        Psbt.b64decode(case["encoded psbt"])
+        for case in psbt_cases("bip174_test_vectors.json", "valid psbts")
+    )
+    if any(psbt_in.partial_sigs for psbt_in in psbt.inputs)
+)
+_REQUEST = deepcopy(_SIGNED)
+for _psbt_in in _REQUEST.inputs:
+    _psbt_in.partial_sigs = {}
+# an answer that changed something no answer may change, which is a psbt
+# of a perfectly good type and the wrong value of it
+_CHANGED = deepcopy(_SIGNED)
+_CHANGED.unknown = {b"\x00": b"\x01"}
+
+_PSBT_IN = _SIGNED.inputs[0]
+_TX_IN = _SIGNED.tx.vin[0]
+
+# a value of a declared type that no valid input carries
+_WRONG_KEY_VALUE = "not a key"
+
+# a value of no type any of these positions declares
+_WRONG_TYPES = (None, 1.5)
+
+
+@dataclass(frozen=True)
+class _Case:
+    """A function, a call of it that works, and what to drive."""
+
+    label: str
+    function: Any
+    args: tuple[Any, ...]
+    # position -> a wrong value of the type that position declares
+    wrong_values: dict[int, Any]
+    # positions whose annotation is `| None`, where None is therefore a
+    # declared type and not a wrong one. A statement about the signature,
+    # not an exemption from the rule: it is read off the annotation, and a
+    # position missing from here is one the rule applies to in full
+    optional: frozenset[int] = frozenset()
+
+
+_CASES = (
+    _Case(
+        "slip132.address_from_xkey",
+        slip132.address_from_xkey,
+        (_XPUB,),
+        {0: _WRONG_KEY_VALUE},
+    ),
+    _Case(
+        "slip132.address_from_xpub",
+        slip132.address_from_xpub,
+        (_XPUB,),
+        {0: _WRONG_KEY_VALUE},
+    ),
+    _Case(
+        "slip132.p2pkh_xkey", slip132.p2pkh_xkey, (_ROOT_XPRV,), {0: _WRONG_KEY_VALUE}
+    ),
+    _Case(
+        "slip132.p2wpkh_xkey",
+        slip132.p2wpkh_xkey,
+        (_ROOT_XPRV,),
+        {0: _WRONG_KEY_VALUE},
+    ),
+    _Case(
+        "slip132.p2wpkh_p2sh_xkey",
+        slip132.p2wpkh_p2sh_xkey,
+        (_ROOT_XPRV,),
+        {0: _WRONG_KEY_VALUE},
+    ),
+    _Case(
+        "KeyGroup",
+        KeyGroup,
+        # all four positions written out, the two with a default included:
+        # `verify` and `origins` are as much a part of what a group
+        # computes as the keys are, and a default is not an exemption
+        (2, [_XPUB, _XPUB], False, [None, None]),
+        # every value of an int is one, so a threshold no quorum of two
+        # keys has is the wrong value rather than a malformed number; and
+        # one origin for two keys is a list of the right type and the
+        # wrong length
+        {0: 0, 1: [_WRONG_KEY_VALUE, _XPUB], 3: [None]},
+        optional=frozenset({3}),
+    ),
+    _Case(
+        "psbt.assert_signatures_only",
+        assert_signatures_only,
+        (_REQUEST, _SIGNED),
+        {0: _CHANGED, 1: _CHANGED},
+    ),
+    _Case(
+        "psbt_size.estimated_input_sizes",
+        estimated_input_sizes,
+        (_PSBT_IN, _TX_IN),
+        # an input carrying no utxo is a PsbtIn whose type cannot be read,
+        # which is what this function raises about rather than guesses at
+        {0: PsbtIn()},
+    ),
+)
+
+_IDS = tuple(case.label for case in _CASES)
+
+
+def _driven(case: _Case, position: int, wrong: Any) -> Callable[[], Any]:
+    """Return the call with one position replaced, the others left valid."""
+    args = list(case.args)
+    args[position] = wrong
+    return partial(case.function, *args)
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_IDS)
+def test_the_call_works(case: _Case) -> None:
+    """The fixture is valid, which is what makes a refusal below a finding.
+
+    Without this a case whose arguments had gone stale would pass every
+    test in the file by refusing everything it is handed.
+    """
+    case.function(*case.args)
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_IDS)
+def test_a_wrong_type_leaves_as_a_btclib_type_error(case: _Case) -> None:
+    """The first rule, one position at a time, the others left valid."""
+    for position in range(len(case.args)):
+        for wrong in _WRONG_TYPES:
+            if wrong is None and position in case.optional:
+                continue
+            with pytest.raises(BTClibTypeError):
+                _driven(case, position, wrong)()
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_IDS)
+def test_a_wrong_value_leaves_as_a_btclib_value_error(case: _Case) -> None:
+    """The second rule: a value of a declared type is refused as a value.
+
+    `BTClibValueError` and not `BTClibException`, which would be the
+    contract read literally: a type error is one of those too, so the
+    wider class would let the first rule's failures through as the
+    second's answer.
+    """
+    for position, wrong in sorted(case.wrong_values.items()):
+        with pytest.raises(BTClibValueError):
+            _driven(case, position, wrong)()
+
+
+def test_an_origin_that_is_no_origin_is_refused_as_a_type() -> None:
+    """A sequence of the right shape whose entries are of the wrong type.
+
+    Driven separately because the table replaces a whole argument: what a
+    `Sequence[BIP32KeyOrigin | None]` declares is checked entry by entry,
+    and a `str` is the case that makes the order matter -- three
+    characters are three origins as far as the count is concerned, so the
+    report would be about the number rather than about the type.
+    """
+    for wrong in ([1, 2], "ab"):
+        with pytest.raises(BTClibTypeError, match="invalid origin type"):
+            KeyGroup(2, [_XPUB, _XPUB], origins=wrong)  # type: ignore[arg-type]
+
+
+def test_the_sizer_is_asked_for_before_it_is_needed() -> None:
+    """A keyword-only parameter, and the one consulted in a single branch.
+
+    Which is why it went unchecked: an input this function answers for on
+    its own never calls the sizer, so a value of no callable type was
+    accepted by every call that did not need it.
+    """
+    assert estimated_input_sizes(_PSBT_IN, _TX_IN, sizer=None) == (35, [0, 72, 72, 71])
+    for wrong in _WRONG_TYPES[1:]:
+        with pytest.raises(BTClibTypeError, match="invalid sizer type"):
+            estimated_input_sizes(_PSBT_IN, _TX_IN, sizer=wrong)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "field, what",
+    [
+        ("version", "version"),
+        ("tx_modifiable", "tx modifiable"),
+        ("fallback_lock_time", "fallback locktime"),
+    ],
+)
+def test_psbt_assert_valid_asks_the_type_of_its_int_fields(
+    field: str, what: str
+) -> None:
+    """The object *is* the input here, so the fields are what to drive.
+
+    `check_validity=False` on the way in is what makes this reachable:
+    the three are compared against a range, and a value of no integer type
+    raised from underneath the library rather than being refused by it.
+
+    Neither `None` nor a `bool` is in the list: two of the three are
+    optional, so `None` is a value they declare, and a bool is refused as
+    a type by the one policy `integer_policy_test.py` holds every integer
+    field to.
+    """
+    for wrong in (1.5, "one"):
+        psbt = deepcopy(_SIGNED)
+        setattr(psbt, field, wrong)
+        with pytest.raises(BTClibTypeError, match=f"invalid {what} type"):
+            psbt.assert_valid()
+
+
+def test_the_psbt_int_fields_a_refusal_must_not_take_with_it() -> None:
+    """The same fields with a number, which is what the refusal is around.
+
+    And `None` where the field declares it: the version is the one of the
+    three that does not, every psbt having one.
+    """
+    psbt = deepcopy(_SIGNED)
+    psbt.assert_valid()
+
+    psbt.fallback_lock_time = 0
+    psbt.assert_valid()
+    psbt.fallback_lock_time = None
+    psbt.assert_valid()
+
+    psbt.fallback_lock_time = -1
+    with pytest.raises(BTClibValueError, match="invalid fallback locktime"):
+        psbt.assert_valid()
+
+    psbt = deepcopy(_SIGNED)
+    psbt.version = None  # type: ignore[assignment]
+    with pytest.raises(BTClibTypeError, match="invalid version type"):
+        psbt.assert_valid()

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -25,6 +25,7 @@ from btclib import base58, bech32, var_int
 from btclib.alias import TaprootScriptTree
 from btclib.amount import valid_sats_amount
 from btclib.bip32 import BIP32KeyData
+from btclib.bip32.bip32 import rootxprv_from_seed, xpub_from_xprv
 from btclib.bip32.der_path import (
     bytes_from_der_path,
     indexes_from_der_path,
@@ -41,9 +42,11 @@ from btclib.fee import FeeRate, fee_from_vsize
 from btclib.hashes import merkle_root_from_branch, sha256
 from btclib.mnemonic.entropy import bin_str_entropy_from_wordlist_indexes
 from btclib.number_theory import mod_inv, mod_inv_batch_var, mod_inv_var
+from btclib.psbt.psbt import PSBT_V2, Psbt
 from btclib.script import input_script_sig, sig_hash
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from btclib.utils import bytes_from_octets, encode_num, is_integer
+from btclib.wallet.script_wallet import KeyGroup
 
 _TX_ID = "01" * 32
 _RATE = FeeRate(sats_per_kvbyte=1000)
@@ -52,6 +55,7 @@ _NOW = datetime(2026, 8, 4, tzinfo=timezone.utc)
 # two index parameters below have to be handed something valid to index
 _SCRIPT_TREE: TaprootScriptTree = [(0xC0, ["OP_1"])]
 _PREVOUTS = [TxOut(1, b"")]
+_XPUB = xpub_from_xprv(rootxprv_from_seed("00" * 32))
 
 
 def _tx(version: Any = 1, lock_time: Any = 0) -> Tx:
@@ -61,6 +65,23 @@ def _tx(version: Any = 1, lock_time: Any = 0) -> Tx:
         [TxIn(OutPoint(_TX_ID, 0), b"", 0xFFFFFFFF)],
         [TxOut(1, b"")],
     )
+
+
+def _psbt(**field: Any) -> Psbt:
+    """Return the shortest psbt there is, with one field of it replaced.
+
+    Version 2, whose fields are its own: a v0 psbt refuses
+    `tx_modifiable` outright, which is a rule about the value of a field
+    whose type has to be asked first.
+    """
+    fields: dict[str, Any] = {
+        "tx_version": 1,
+        "inputs": [],
+        "outputs": [],
+        "version": PSBT_V2,
+        "hd_key_paths": {},
+    }
+    return Psbt(**(fields | field), check_validity=False)
 
 
 def _header(version: Any = 1, nonce: Any = 1) -> BlockHeader:
@@ -89,6 +110,12 @@ _CASES: list[tuple[str, Callable[[Any], object]]] = [
     ("input sequence", lambda v: TxIn(OutPoint(_TX_ID, 0), b"", v)),
     ("transaction version", _tx),
     ("transaction lock time", lambda v: _tx(lock_time=v)),
+    # a psbt is asked by `assert_valid`, `check_validity=False` on the way
+    # in being what lets a field of any type at all into one
+    ("psbt version", lambda v: _psbt(version=v).assert_valid()),
+    ("psbt tx modifiable", lambda v: _psbt(tx_modifiable=v).assert_valid()),
+    ("psbt fallback lock time", lambda v: _psbt(fallback_lock_time=v).assert_valid()),
+    ("key group threshold", lambda v: KeyGroup(v, [_XPUB])),
     ("header version", _header),
     ("header nonce", lambda v: _header(nonce=v)),
     ("block height", lambda v: BlockContext(v, _NOW)),
@@ -175,6 +202,8 @@ def test_the_integers_a_bool_refusal_must_not_take_with_it() -> None:
     assert OutPoint.from_dict({"txid": _TX_ID, "vout": 1}).vout == 1
     assert TxIn(OutPoint(_TX_ID, 0), b"", 1).sequence == 1
     assert _tx(version=1, lock_time=1).lock_time == 1
+    assert _psbt(fallback_lock_time=1).fallback_lock_time == 1
+    assert KeyGroup(1, [_XPUB]).threshold == 1
     assert _header(nonce=1).nonce == 1
     assert BlockContext(1, _NOW).height == 1
     assert valid_sats_amount(1, dust=1) == 1


### PR DESCRIPTION
Section 5.1 of https://github.com/btclib-org/btclib/issues/856: the
`assert_valid`-on-an-object-somebody-already-built family, which the issue
names as the one to take first and gives the reason for --
`check_validity=False` says *do not check now*, not *this object is exempt
from here on*, so an invalid object is something a caller may legitimately
hold and hand back.

## The third gate

`tests/built_object_contract_test.py`, the shape of
`tests/bool_contract_test.py` over a family neither existing gate reaches:
`assert_signatures_only` takes two `Psbt`, `KeyGroup` a sequence of
extended keys, `estimated_input_sizes` a `PsbtIn` and a `TxIn`, and no
vocabulary of wrong values builds one of those. The fixtures are BIP174's
own vectors -- the first that carries signatures is the answer, the same
psbt stripped of them is the request. Eight functions, the two rules asked
one position at a time with the others left valid, and no exemption list.

`slip132`'s five are in it and were already clean: the file is a gate, not
a bug list, and what it buys there is that they stay clean.

## What it found

| shape | where |
| --- | --- |
| a comparison before the type is asked | `KeyGroup`'s `threshold`, `Psbt.assert_valid`'s three int fields |
| a sequence walked unchecked | `KeyGroup`'s `keys` and `origins` |
| a field read off whatever arrived | `assert_signatures_only`, `estimated_input_sizes` |
| silence | `estimated_input_sizes`' `sizer` |

Two are worse than a wrong exception class, because they were accepted:
**`KeyGroup(1.5, keys)` built a group with a float quorum**, and a `sizer`
of no callable type went through for every input `estimated_input_sizes`
answers for on its own, the sizer being consulted in a single branch.

And one the annotation cannot catch: `Sequence[BIP32Key]` accepts a `str`,
every character of it being a `BIP32Key` as far as the type says, so one
xpub handed where the list was meant was 111 keys.

`Psbt.assert_valid`'s three int fields join `integer_policy_test.py`'s
inventory as well -- a bool passed every one of those range comparisons as
one or zero, which is the json boundary that policy exists for --
alongside `KeyGroup`'s threshold.

## `verify` is a kind, `check_validity` is a truth

`KeyGroup(verify=)` refuses a non-bool. The line, which CONTRIBUTING.md
now states, is `musig2._flag`'s: a flag deciding *what is computed* is a
kind, and a kind written down and read back arrives as whatever it was
written as -- `"false"` is true, and this one chooses the closing opcode,
so a wallet built from a configuration file would compute every address of
the other script rather than raise. A flag deciding only *whether a check
runs* -- `check_validity`, `slip132`'s `check_root_xkey` -- is read for its
truth: it runs a check or skips one and never changes an answer.

## Breaking

Three arguments that used to be accepted now raise a `BTClibTypeError`:
`KeyGroup(1.5, keys)`, `KeyGroup(keys, verify=<not a bool>)` and
`estimated_input_sizes(..., sizer=<not callable>)`. mypy already refused
all three. HISTORY.md carries the bullet.

## Verified

- `uv run pytest`: 27413 passed, coverage 100.00%
- `uv run pre-commit run --all-files`: exit 0
- `sphinx-build -W --keep-going`: build succeeded

The four guards are extracted into named private helpers rather than
inlined, `complex-structure` being what says the constructors and
`assert_valid` had no room left for a fourth `if`.

Part of https://github.com/btclib-org/btclib/issues/856, which stays open
for sections 5.2 and 5.3.

## Summary by Sourcery

Tighten input validation for functions that operate on already-built objects, ensuring type checks happen before field access or value checks, and extend the integer-validation policy to PSBT fields and key groups.

New Features:
- Add a dedicated test suite that gates functions taking pre-built objects (Psbt, PsbtIn, key sequences) to enforce consistent input contracts across the public API.

Bug Fixes:
- Ensure KeyGroup validates threshold, key sequences, origins, and the verify flag types up front, preventing float quorums, string key sequences, and non-bool verify values from being silently accepted.
- Validate Psbt.assert_valid integer fields (version, tx_modifiable, fallback_lock_time) for proper integer types before range checks, avoiding incorrect handling of non-integer and boolean values.
- Add explicit type checks in assert_signatures_only for the request/returned Psbt pair to raise BTClibTypeError instead of AttributeError when given non-Psbt inputs.
- Guard estimated_input_sizes with type checks for PsbtIn, TxIn, and the sizer callable, so non-conforming arguments fail with BTClibTypeError rather than passing silently or raising attribute errors.

Enhancements:
- Factor new private helper functions to centralize type-checking logic for key groups, PSBT integer fields, PSBT pairs, and input-size estimation.
- Document the "kind vs truth" convention for bool parameters and align KeyGroup.verify with that rule, clarifying behavior for configuration-driven callers.
- Extend integer_policy_test coverage to include PSBT integer fields and KeyGroup thresholds, ensuring future changes respect the shared integer validation policy.

Documentation:
- Update CONTRIBUTING.md to describe the new built-object contract tests and the bool parameter "kind vs truth" convention.
- Add detailed changelog entries in HISTORY.md explaining the new input-validation behavior and the resulting breaking changes.

Tests:
- Introduce tests/built_object_contract_test.py to systematically verify type and value error behavior for functions operating on pre-built objects.
- Expand integer_policy_test.py to cover PSBT version, tx_modifiable, fallback_lock_time, and KeyGroup thresholds as part of the shared integer policy suite.

Chores:
- Record the new BTClibTypeError-based rejections of previously accepted arguments in HISTORY.md as breaking changes.