### PR TITLE
Ask a SolutionSizer's arguments too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2523,13 +2523,13 @@ documented at release-notes length in the first place, and are still in
 
 - **The input contract is gated over a function taking an object somebody
   already built** (issue #856). Neither of the two gates reaches
-  `assert_signatures_only`, `estimated_input_sizes` or `KeyGroup`: their
-  parameters are a `Psbt`, a `PsbtIn` and a sequence of extended keys, and
-  no vocabulary of wrong values builds one, so
-  `tests/built_object_contract_test.py` builds them from BIP174's own
-  vectors. `check_validity=False` is what makes the family worth a gate --
-  it says *do not check now*, not *this object is exempt from here on*, so
-  an invalid object is something a caller may legitimately hold and hand
+  `assert_signatures_only`, `estimated_input_sizes`, the two
+  `SolutionSizer`s or `KeyGroup`: their parameters are a `Psbt`, a `PsbtIn`
+  and a sequence of extended keys, and no vocabulary of wrong values builds
+  one, so `tests/built_object_contract_test.py` builds them from BIP174's
+  own vectors. `check_validity=False` is what makes the family worth a gate
+  -- it says *do not check now*, not *this object is exempt from here on*,
+  so an invalid object is something a caller may legitimately hold and hand
   back.
 
   It found the shapes issue #856 predicted, and one it did not.
@@ -2540,9 +2540,16 @@ documented at release-notes length in the first place, and are still in
   origin an `AttributeError` about a field name -- and `Sequence[BIP32Key]`
   accepts a `str`, every character of it being a `BIP32Key` as far as the
   annotation says, so one xpub handed where the list was meant was 111
-  keys. `assert_signatures_only` and `estimated_input_sizes` read a field
-  off whatever they were given, which is the wrong error for the one
-  function whose whole job is to distrust an answer from elsewhere.
+  keys -- and `satisfaction_sizer` takes an `Iterable[Octets]`, which
+  accepts a `str` and a `bytes` for the same reason, so one key handed
+  where the list was meant was as many keys as it had characters.
+  `assert_signatures_only`, `estimated_input_sizes` and both
+  `SolutionSizer`s read a field off whatever they were given, which is the
+  wrong error for the one function whose whole job is to distrust an answer
+  from elsewhere. `miniscript_sizer` does not read its `tx_in` at all and
+  checks it anyway: the pair is what the `SolutionSizer` type declares, so
+  the guarantee is the signature's rather than one body's, and
+  `psbt_size._assert_input_types` is the one place either sizer asks.
   `Psbt.assert_valid` compared its three int fields against a range before
   asking their type, `Tx.assert_valid` having had that check for the same
   reason -- and a bool passed every one of those comparisons as one or

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,14 +20,16 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
-- **three arguments that used to be accepted are refused.**
+- **four arguments that used to be accepted are refused.**
   `KeyGroup(1.5, keys)` built a group with a float quorum and
   `KeyGroup(keys, verify="no")` one with `verify=True`, `"no"` being
   truthy; `estimated_input_sizes(psbt_in, tx_in, sizer=<not callable>)`
   went through for every input the function answers for on its own, the
-  sizer being consulted in one branch. All three raise a
-  `BTClibTypeError` now. A caller handing any of them a value of the
-  declared type is unaffected, and mypy already refused the three.
+  sizer being consulted in one branch; and `satisfaction_sizer(one_key)`
+  took the key for a list of them, `Iterable[Octets]` accepting a `str`
+  and a `bytes`. All four raise a `BTClibTypeError` now. A caller handing
+  any of them a value of the declared type is unaffected, and mypy already
+  refused the first three.
 
 - **the `_var` suffix finishes its sweep: `ellswift.encode_var`,
   `decode_var`, `create_var`, and `dsa.crack_prv_key_var`.** The map of

--- a/btclib/descriptors/descriptors.py
+++ b/btclib/descriptors/descriptors.py
@@ -182,13 +182,13 @@ from btclib.descriptors.miniscript import (
 )
 from btclib.descriptors.miniscript import from_script as _miniscript_from_script
 from btclib.descriptors.miniscript import parse as _parse_miniscript
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
 from btclib.network import NETWORKS, network_from_xkeyversion
 from btclib.psbt.psbt import Psbt
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.psbt.psbt_out import PsbtOut
-from btclib.psbt.psbt_size import SIG_SIZE, SolutionSizer
+from btclib.psbt.psbt_size import SIG_SIZE, SolutionSizer, _assert_input_types
 from btclib.script.script import op_int, serialize
 from btclib.script.script import parse as _parse_script
 from btclib.script.script_pub_key import ScriptPubKey, _validated_script_from
@@ -2447,6 +2447,10 @@ def miniscript_sizer(psbt_in: PsbtIn, tx_in: TxIn) -> list[int] | None:
     caller then answers as it did before, which for the last of those is a
     refusal: a script nobody can spend has no spend to estimate.
     """
+    # `tx_in` is unread here and checked anyway: the pair is what a
+    # `SolutionSizer` declares, so the guarantee is the signature's rather
+    # than this body's, and the sizer beside this one does read it
+    _assert_input_types(psbt_in, tx_in)
     if not psbt_in.witness_script:
         return None
     known = (*psbt_in.partial_sigs, *psbt_in.hd_key_paths)
@@ -2501,9 +2505,18 @@ def satisfaction_sizer(keys: Iterable[Octets]) -> SolutionSizer:
     then falls back exactly as it would for any other sizer answering
     "not mine".
     """
+    # a str and a bytes are each an `Octets` and each an iterable of one,
+    # so `Iterable[Octets]` accepts either as far as the annotation goes:
+    # one key handed where the list was meant is as many keys as it has
+    # characters, and each of them invalid
+    if isinstance(keys, (str, bytes, bytearray)):
+        raise BTClibTypeError(f"invalid keys type: {type(keys).__name__}")
+    if not isinstance(keys, Iterable):
+        raise BTClibTypeError(f"invalid keys type: {type(keys).__name__}")
     signer_keys = tuple(bytes_from_octets(key) for key in keys)
 
     def sizer(psbt_in: PsbtIn, tx_in: TxIn) -> list[int] | None:
+        _assert_input_types(psbt_in, tx_in)
         if not psbt_in.witness_script:
             return None
         known = (*psbt_in.partial_sigs, *psbt_in.hd_key_paths, *signer_keys)

--- a/btclib/psbt/psbt_size.py
+++ b/btclib/psbt/psbt_size.py
@@ -228,16 +228,15 @@ def _taproot_witness_sizes(
     return [_taproot_sig_size(psbt_in)]
 
 
-def _assert_arguments(
-    psbt_in: PsbtIn, tx_in: TxIn, sizer: SolutionSizer | None
-) -> None:
-    """Refuse an argument of the wrong type before any field is read.
+def _assert_input_types(psbt_in: PsbtIn, tx_in: TxIn) -> None:
+    """Refuse either object before a field is read off it.
 
-    The two objects are read for their fields, so a value of another type
-    is an AttributeError about a field name rather than a refusal. The
-    sizer is asked for here and not where it is consulted, which is a
-    single branch: one of no callable type went unnoticed for every input
-    `estimated_input_sizes` answers for on its own.
+    Both are read for their fields, so a value of another type is an
+    AttributeError about a field name rather than a refusal. Every
+    `SolutionSizer` takes the same pair and owes its callers the same
+    check, so `descriptors`' two sizers ask this one -- the layering
+    allows it, `descriptors` importing this module and nothing here
+    importing back.
     """
     if not isinstance(psbt_in, PsbtIn):
         err_msg = f"invalid psbt_in type: {type(psbt_in).__name__}"  # type: ignore[unreachable]
@@ -245,6 +244,18 @@ def _assert_arguments(
     if not isinstance(tx_in, TxIn):
         err_msg = f"invalid tx_in type: {type(tx_in).__name__}"  # type: ignore[unreachable]
         raise BTClibTypeError(err_msg)
+
+
+def _assert_arguments(
+    psbt_in: PsbtIn, tx_in: TxIn, sizer: SolutionSizer | None
+) -> None:
+    """Refuse an argument of the wrong type before any field is read.
+
+    The sizer is asked for here and not where it is consulted, which is a
+    single branch: one of no callable type went unnoticed for every input
+    `estimated_input_sizes` answers for on its own.
+    """
+    _assert_input_types(psbt_in, tx_in)
     if sizer is not None and not callable(sizer):
         err_msg = f"invalid sizer type: {type(sizer).__name__}"  # type: ignore[unreachable]
         raise BTClibTypeError(err_msg)

--- a/tests/built_object_contract_test.py
+++ b/tests/built_object_contract_test.py
@@ -24,12 +24,19 @@ rules are the same two everywhere else obeys:
 
 Both were open when this file was written, in the four shapes issue #856
 predicted: a sequence walked before it is checked (`KeyGroup`'s `keys` and
-`origins`), an argument reaching a comparison before its type is asked
-(`KeyGroup`'s `threshold`, `Psbt.assert_valid`'s three int fields), and an
-argument read for a field it has not got (`assert_signatures_only`,
-`estimated_input_sizes`). The fifth was silence: `estimated_input_sizes`
-took a `sizer` of no callable type for every input it answers for on its
-own, and `KeyGroup` a float threshold.
+`origins`, `satisfaction_sizer`'s), an argument reaching a comparison
+before its type is asked (`KeyGroup`'s `threshold`,
+`Psbt.assert_valid`'s three int fields), and an argument read for a field
+it has not got (`assert_signatures_only`, `estimated_input_sizes`, both
+sizers). The fifth was silence: `estimated_input_sizes` took a `sizer` of
+no callable type for every input it answers for on its own, and `KeyGroup`
+a float threshold.
+
+Two of the annotations *accept* the mistake, which is why neither gate nor
+mypy could see it: `Sequence[BIP32Key]` accepts a `str`, and
+`Iterable[Octets]` accepts a `str` and a `bytes`, every character being a
+key as far as the type goes. One xpub handed where the list was meant was
+111 keys.
 
 A `bool` parameter is not driven here, and the line is
 `musig2._flag`'s: a flag that decides *what is computed* is a kind and not
@@ -54,6 +61,7 @@ import pytest
 
 from btclib import slip132
 from btclib.bip32.bip32 import rootxprv_from_seed, xpub_from_xprv
+from btclib.descriptors.descriptors import miniscript_sizer, satisfaction_sizer
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.psbt.psbt import Psbt, assert_signatures_only
 from btclib.psbt.psbt_in import PsbtIn
@@ -85,6 +93,9 @@ _CHANGED.unknown = {b"\x00": b"\x01"}
 
 _PSBT_IN = _SIGNED.inputs[0]
 _TX_IN = _SIGNED.tx.vin[0]
+# the input's own keys, which is the caller a satisfaction sizer is for:
+# it sizes the branch these will take, so the quorum has to be theirs
+_SIGNER_KEYS = list(_PSBT_IN.hd_key_paths)
 
 # a value of a declared type that no valid input carries
 _WRONG_KEY_VALUE = "not a key"
@@ -165,6 +176,16 @@ _CASES = (
         # which is what this function raises about rather than guesses at
         {0: PsbtIn()},
     ),
+    # the two SolutionSizers, which take the same pair and owe a caller the
+    # same check. Neither has a wrong *value*: "not mine" is what a sizer
+    # answers with None, so nothing of the declared type is refused
+    _Case("descriptors.miniscript_sizer", miniscript_sizer, (_PSBT_IN, _TX_IN), {}),
+    _Case(
+        "descriptors.satisfaction_sizer(...)",
+        satisfaction_sizer(_SIGNER_KEYS),
+        (_PSBT_IN, _TX_IN),
+        {},
+    ),
 )
 
 _IDS = tuple(case.label for case in _CASES)
@@ -224,6 +245,20 @@ def test_an_origin_that_is_no_origin_is_refused_as_a_type() -> None:
     for wrong in ([1, 2], "ab"):
         with pytest.raises(BTClibTypeError, match="invalid origin type"):
             KeyGroup(2, [_XPUB, _XPUB], origins=wrong)  # type: ignore[arg-type]
+
+
+def test_the_keys_a_satisfaction_sizer_is_built_from() -> None:
+    """The factory's own argument, which the table cannot reach.
+
+    `Iterable[Octets]` accepts a `str` and a `bytes`, each of them being an
+    `Octets` and an iterable of one, so a single key handed where the list
+    was meant is as many keys as it has characters -- and each of those
+    would be refused as octets, which reports the wrong mistake.
+    """
+    assert satisfaction_sizer(_SIGNER_KEYS)(_PSBT_IN, _TX_IN) == [0, 72, 72, 71]
+    for wrong in (*_WRONG_TYPES, _SIGNER_KEYS[0], _SIGNER_KEYS[0].hex()):
+        with pytest.raises(BTClibTypeError, match="invalid keys type"):
+            satisfaction_sizer(wrong)  # type: ignore[arg-type]
 
 
 def test_the_sizer_is_asked_for_before_it_is_needed() -> None:


### PR DESCRIPTION
Follow-up to https://github.com/btclib-org/btclib/pull/863, and a
correction of mine in it: I reported `miniscript_sizer` as no longer
existing, on the strength of a grep that silently matched nothing.
[It exists](https://github.com/btclib-org/btclib/blob/main/btclib/descriptors/descriptors.py#L2427)
— in `btclib/descriptors/descriptors.py`, not in `btclib/psbt/psbt_size.py`
where https://github.com/btclib-org/btclib/issues/856 §5.1 puts it. So
does `satisfaction_sizer` beside it. Both are public, both were undriven,
and both are the same shape as the family #863 closed.

## The two sizers

Each reads a field off whatever it is handed, so a `None` was an
`AttributeError` about a field name.

`miniscript_sizer` **does not read its `tx_in` at all** and is checked
anyway: the pair is what the `SolutionSizer` type declares, so the
guarantee belongs to the signature rather than to one body — and the sizer
beside it does read the sequence off it. `psbt_size._assert_input_types` is
the one place either asks, which the layering allows: `descriptors` imports
`psbt_size` and nothing there imports back.

## `satisfaction_sizer(keys)`

The sequence shape again, and with the trap `Sequence[BIP32Key]` had:
`Iterable[Octets]` accepts a `str` **and** a `bytes`, each being an
`Octets` and an iterable of one. So `satisfaction_sizer(one_key)` was as
many keys as that key had characters, each then refused as octets — which
reports the wrong mistake and at the wrong place.

## Breaking

`satisfaction_sizer(one_key)` raises a `BTClibTypeError` instead of a
`BTClibValueError` about hex. HISTORY.md's bullet from #863 goes from three
arguments to four.

## Verified

- `uv run pytest`: 27420 passed, coverage 100.00%
- `uv run pre-commit run --all-files`: exit 0
- `sphinx-build -W --keep-going`: build succeeded

`tests/built_object_contract_test.py` gains both, so its table is ten
functions. The satisfaction sizer is built from the psbt input's own
`hd_key_paths` — a sizer given keys that cannot satisfy the script answers
None, which would make the case pass by answering nothing.

Part of https://github.com/btclib-org/btclib/issues/856, §5.1.

## Summary by Sourcery

Tighten type gating and tests around PSBT solution sizing to ensure descriptors miniscript and satisfaction sizers validate their inputs and key collections consistently.

Bug Fixes:
- Prevent miniscript and satisfaction solution sizers from operating on PSBT inputs and transaction inputs of incorrect types by centralizing input type checks.
- Reject invalid key collections passed to the satisfaction sizer (e.g., single strings/bytes instead of iterable key lists) with BTClibTypeError rather than value-level errors.

Enhancements:
- Share a common PSBT/TxIn input type check helper across solution sizing functions to enforce the same contract for all SolutionSizer implementations.
- Extend the built-object contract test table to cover descriptors miniscript_sizer and satisfaction_sizer and add a dedicated test for satisfaction_sizer key argument validation.

Documentation:
- Update CHANGELOG and HISTORY to document the additional gated arguments and the stricter input and key-type validation for solution sizers.