### PR TITLE
Drop the check-manifest ignore for a directory that is gone

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,10 +169,6 @@ ignore = [
     "tests/generate_sbom_test.py",
     "tests/mutation_counts_test.py",
     "tests/verify_dist_contents_test.py",
-    # a developer's own tool, run by hand against a checkout rather than
-    # against an install: it needs no third-party dependency, but it is no
-    # more part of the distributed package than the website above is
-    "scripts/**",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Follow-up to https://github.com/btclib-org/btclib/pull/862.

`[tool.check-manifest]`'s ignore list still carried `scripts/**`, with a
comment describing "a developer's own tool, run by hand against a
checkout". That tool was the benchmarks, and the directory left this
repository with https://github.com/btclib-org/btclib/pull/861:
check-manifest ignores nothing by the entry today, and would ignore the
wrong thing if `scripts/` ever came back for another reason.

Gates: `uv run pre-commit run --all-files` green, check-manifest hook
included, and `uv run pytest` green (27375 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)