### PR TITLE
Stop naming the benchmarks where they are not the subject

### DIFF
--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -398,9 +398,8 @@ secp256k1 = CURVES["secp256k1"]
 # silence wherever it forgets one, and times C while calling it Python.
 #
 # btclib_secp256k1 is a required dependency, so this is never False
-# because the bindings are missing. It is the seam the test suite closes
-# to exercise the Python arithmetic, and the one btclib-benchmarks closes
-# to time it
+# because the bindings are missing: it is the seam whatever wants the
+# Python arithmetic closes to reach it, the test suite included
 _libsecp256k1_available = True
 
 

--- a/tests/verify_dist_contents_test.py
+++ b/tests/verify_dist_contents_test.py
@@ -210,7 +210,7 @@ def test_a_missing_wheel_member_is_named(
     [
         ((".editorconfig",), (), (), "is a root file the sdist does not ship"),
         (
-            ("benchmarks/timing.py",),
+            ("examples/demo.py",),
             (),
             (),
             "is not under one of the directories the sdist ships",
@@ -257,7 +257,7 @@ def test_a_planted_sdist_member_is_named(
 @pytest.mark.parametrize(
     "directory, expected",
     [
-        ("benchmarks", "is a directory the sdist does not ship"),
+        ("examples", "is a directory the sdist does not ship"),
         # the one case the forbidden suffixes do not reach: an empty
         # bytecode directory is a directory member and no `.pyc`
         ("btclib/__pycache__", "is under __pycache__"),


### PR DESCRIPTION
Follow-up to https://github.com/btclib-org/btclib/pull/862, which took
the benchmarks out of CHANGELOG.md and HISTORY.md. Two mentions were
left standing there, and both are better without.

`btclib/curves/curve.py`'s comment on `_libsecp256k1_available` said the
seam is closed by the test suite and by btclib-benchmarks. Naming one
external consumer reads as a list, and a second one would have to be
added to it: the seam is closed by whatever wants the Python arithmetic,
which the sentence now says.

`tests/verify_dist_contents_test.py` planted `benchmarks/timing.py` and
a `benchmarks` directory as the members the sdist must refuse. Nothing
of that name has ever been in the tree, so the fixture only echoed the
scripts that were. `examples/demo.py` and `examples` are a directory the
sdist does not ship either -- `SDIST_DIRECTORIES` holds `btclib`,
`btclib.egg-info`, `docs` and `tests` -- so the two cases assert exactly
what they did.

Gates: `uv run pytest` green (27420 passed) and `uv run pre-commit run
--all-files` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify comments about the secp256k1 bindings seam and align distribution content tests with actual non-shipped example files and directories.

Bug Fixes:
- Correct the sdist content verification tests to reference real non-shipped example files and directories instead of non-existent benchmark paths.

Enhancements:
- Simplify and generalize the curve module comment on libsecp256k1 availability to avoid naming specific external consumers.