### PR TITLE
An ec is a curve or it is nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2521,6 +2521,57 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **The input contract reaches `ec`, which had no check anywhere** (issue
+  #868). The census of parameters behind a default put it fourth by
+  frequency and first by exposure: `hf` and `network` are gated where their
+  own checks live, and `ec` was not gated at all, so `dsa.sign(msg, q,
+  ec=None)` left as `AttributeError: 'NoneType' object has no attribute
+  'n'` — a field read off whatever arrived, which is the third of the four
+  shapes issue #856 named. Forty-two public functions take it, across
+  `curves/`, `ecc/` and the two key converters, and every one of them
+  answered that way.
+
+  `curve._assert_valid_ec` is the check and `hashes._assert_valid_hf` is
+  its shape: one guard, asked where each function first reads the
+  parameter, which is nineteen places rather than forty-two — the three
+  multiplications, the three SEC point functions, `int_from_prv_key`,
+  `point_from_key`, `point_from_pub_key`, and the ten `ecc` entries that
+  read a field off the curve before reaching any of those.
+  `curve_group._assert_valid_ec` is its twin for the two group explorers,
+  whose parameter is a `CurveGroup`. The Curve check is `isinstance(ec,
+  Curve)` and not the group it derives from, because `n` and `G` are
+  Curve's own: a group would pass the wider check and fail on the field
+  it has not got. 22 ns, one to four times in what a caller calls one
+  operation — 45 ns of the 17.5 us of a signature, 88 of the 39.2 of a
+  verification.
+
+  Two of the nineteen were reporting the mistake as somebody else's.
+  `int_from_prv_key` and `point_from_key` compare the curve a WIF or an
+  xprv names against the `ec` they were handed, and an `ec` of no curve
+  type compares unequal to every network's, so a caller's own error left
+  as "ec / network (mainnet) mismatch" and "Curve mismatch". Both
+  refusals stand for a curve that really is the wrong one, which is the
+  value half of the rule and the only wrong *value* this parameter has:
+  every curve is a valid `ec`, the low-cardinality ones included.
+
+  `Network.assert_valid` had said so out loud: `# no check on self.curve`
+  sat where the check is now. Its parameter is spelled `curve` rather than
+  `ec`, being a field of the network, and the network's curve is what the
+  two comparisons above compare an `ec` against.
+
+  `tests/curve_parameter_test.py` is the gate,
+  `built_object_contract_test.py`'s shape over a family the automatic walk
+  cannot reach — driving a parameter behind a default needs every argument
+  in front of it to be valid, which is the table of valid values
+  `input_validation_test.py` is built to do without. It carries a walk of
+  its own, keyed on the annotation and not on the name, so a public
+  function declaring a `Curve` or a `CurveGroup` is either in the table or
+  the run is red: no exemption list. A union that merely contains one is
+  not declaring a curve — `networks_from_key_value` takes a `str | bytes |
+  Curve` to compare against every network's field, and a value of another
+  type there is "no network carries this prefix", which is the answer a
+  lookup owes a caller.
+
 - **The input contract is gated over a function taking an object somebody
   already built** (issue #856). Neither of the two gates reaches
   `assert_signatures_only`, `estimated_input_sizes`, the two

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -875,9 +875,14 @@ wrong values can build. `tests/built_object_contract_test.py` does the
 same for a function whose parameter is an object the caller already built
 — a `Psbt`, a `PsbtIn`, a sequence of extended keys — which is the family
 `check_validity=False` makes reachable, an invalid object being something a
-caller may legitimately hold. None of the three has an exemption list,
-which is the state to keep: a finding is a red test, to be fixed or to be
-given a reason of its own beside the two families that have one.
+caller may legitimately hold. `tests/curve_parameter_test.py` is the
+fourth, over a parameter that carries a *default*: reaching one means every
+argument in front of it has to be valid, which is the table of valid values
+the automatic walk exists to do without, so `ec` is driven from a table
+there as `hf` and `network` are driven where their own checks live. None of
+the four has an exemption list, which is the state to keep: a finding is a
+red test, to be fixed or to be given a reason of its own beside the two
+families that have one.
 
 **A `bool` parameter is a kind or a truth, and only the first is
 type-checked.** A flag that decides *what is computed* refuses a non-bool,

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -54,7 +54,7 @@ from btclib.curves.curve_group_2 import (
     _double_mult_w_NAF_var,
     _mult_endomorphism_secp256k1,
 )
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.number_theory import legendre_symbol_var
 from btclib.utils import hex_string, int_from_integer
 
@@ -311,6 +311,30 @@ class Curve(CurveGroup):
         # curves differing in it hold the same points under a different
         # correspondence with the integers modulo n
         return (*super()._eq_key(), *self.G, self.n, self.cofactor)
+
+
+def _assert_valid_ec(ec: Curve) -> None:
+    """Refuse an ec that is not a prime-order curve.
+
+    The Curve twin of `curve_group._assert_valid_ec`, and it is the class
+    and not the group it derives from because `n` and `G` are Curve's:
+    every multiplication below reduces its scalar mod n, so a CurveGroup
+    would pass a group check and fail on a field it has not got.
+
+    `isinstance` and not a field lookup, the way
+    `hashes._assert_valid_hf` asks `callable` rather than making a digest:
+    an ec is an object of the library's own making, with no conversion
+    from anything else the way a network name has one, so the type is the
+    whole of the question.
+
+    22 ns, asked where each public function first reads the parameter,
+    which is one to four times in what a caller calls one operation: 45 ns
+    of the 17.5 us of a signature, 88 of the 39.2 of a verification, and
+    two guards in the 39.1 us of a five-level BIP32 derivation.
+    """
+    if not isinstance(ec, Curve):
+        err_msg = f"invalid ec type: {type(ec).__name__}"  # type: ignore[unreachable]
+        raise BTClibTypeError(err_msg)
 
 
 datadir = Path(__file__).parent / "_data"
@@ -598,6 +622,7 @@ _FIXED_BASE_W = 6
 
 def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point:
     """Elliptic curve scalar multiplication."""
+    _assert_valid_ec(ec)
     m: int = int_from_integer(m_int) % ec.n
 
     # m == 0 is the infinity point, which the bindings reject as a scalar
@@ -693,6 +718,7 @@ def double_mult_var(
     u: Integer, H: Point, v: Integer, Q: Point, ec: Curve = secp256k1
 ) -> Point:
     """Double scalar multiplication (u*H + v*Q)."""
+    _assert_valid_ec(ec)
     ec.require_on_curve(H)
     ec.require_on_curve(Q)
 
@@ -758,6 +784,7 @@ def multi_mult_var(
     is the one caller that hands them many scalars at once -- libsecp256k1
     exposing no batch verification, ssa's is built on this.
     """
+    _assert_valid_ec(ec)
     if len(scalars) != len(points):
         err_msg = "mismatch between number of scalars and points: "
         err_msg += f"{len(scalars)} vs {len(points)}"

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -700,6 +700,26 @@ class CurveGroup:
         return self.y_var(x)
 
 
+def _assert_valid_ec(ec: CurveGroup) -> None:
+    """Refuse an ec that is not a group of curve points.
+
+    `hashes._assert_valid_hf` is the shape: one check where the parameter
+    is first read, rather than one per function that takes it. What it
+    catches is what an `ec` of no curve type otherwise becomes -- a field
+    read off it, `'NoneType' object has no attribute 'p'`, which is a
+    caller's own mistake reported from underneath the library.
+
+    Every public function whose `ec` is a `CurveGroup` asks here, and the
+    ones whose `ec` is a `Curve` ask `curve._assert_valid_ec` instead:
+    `n` and `G` are Curve's parameters and this class has neither, so
+    the group check would pass an ec that the multiplication then reads a
+    missing field off.
+    """
+    if not isinstance(ec, CurveGroup):
+        err_msg = f"invalid ec type: {type(ec).__name__}"  # type: ignore[unreachable]
+        raise BTClibTypeError(err_msg)
+
+
 def _mult_recursive_aff_var(m: int, Q: Point, ec: CurveGroup) -> Point:
     """Scalar multiplication of a curve point in affine coordinates.
 

--- a/btclib/curves/curve_group_f.py
+++ b/btclib/curves/curve_group_f.py
@@ -12,7 +12,7 @@ never used -- in the rest of the library.
 from __future__ import annotations
 
 from btclib.alias import INF, Point
-from btclib.curves.curve_group import CurveGroup
+from btclib.curves.curve_group import CurveGroup, _assert_valid_ec
 from btclib.exceptions import BTClibValueError
 
 __all__ = [
@@ -26,6 +26,7 @@ def find_all_points(ec: CurveGroup) -> list[Point]:
 
     Very unsofisticated walk-through approach, for didactic sake only.
     """
+    _assert_valid_ec(ec)
     if ec.p > 10000:
         err_msg = f"p is too big to count all group points: {ec.p}"
         raise BTClibValueError(err_msg)
@@ -49,6 +50,7 @@ def find_subgroup_points(ec: CurveGroup, G: Point) -> list[Point]:
 
     Very unsofisticated walk-through approach, for didactic sake only.
     """
+    _assert_valid_ec(ec)
     if ec.p > 10000:
         err_msg = f"p is too big to count all subgroup points: {ec.p}"
         raise BTClibValueError(err_msg)

--- a/btclib/curves/sec_point.py
+++ b/btclib/curves/sec_point.py
@@ -14,6 +14,7 @@ from btclib_secp256k1.keys import (
 from btclib.alias import Integer, Octets, Point
 from btclib.curves.curve import (
     Curve,
+    _assert_valid_ec,
     _libsecp256k1_serves,
     _y_even_var,
     mult,
@@ -35,6 +36,7 @@ def bytes_from_point(Q: Point, ec: Curve = secp256k1, compressed: bool = True) -
     Return a point as compressed (0x02, 0x03) or uncompressed (0x04)
     octet sequence, according to SEC 1 v.2, section 2.3.3.
     """
+    _assert_valid_ec(ec)
     # check that Q is a point and that is on curve
     ec.require_on_curve(Q)
 
@@ -66,6 +68,7 @@ def bytes_from_prv_key_int(
     the compressed encoding rather than btclib slicing it out of the
     uncompressed one (issue #459).
     """
+    _assert_valid_ec(ec)
     q = int_from_integer(prv_key_int) % ec.n
 
     # q == 0 is the infinity point, which the bindings reject as a scalar
@@ -100,6 +103,7 @@ def point_from_octets(
     under STRICTENC, so the script engine is the one caller that asks for
     them (issue #129).
     """
+    _assert_valid_ec(ec)
     pub_key = bytes_from_octets(pub_key, (ec.p_size + 1, 2 * ec.p_size + 1))
 
     bsize = len(pub_key)  # bytes

--- a/btclib/ecc/dh.py
+++ b/btclib/ecc/dh.py
@@ -21,7 +21,7 @@ from btclib_secp256k1 import keys as libsecp256k1_keys
 
 from btclib.alias import HashF, Point
 from btclib.curves import Curve, bytes_from_point, mult, secp256k1
-from btclib.curves.curve import _libsecp256k1_serves
+from btclib.curves.curve import _assert_valid_ec, _libsecp256k1_serves
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
 from btclib.utils import is_integer
 
@@ -98,6 +98,7 @@ def diffie_hellman(
     a substitute: it hashes the compressed shared point with SHA256,
     libsecp256k1's default, where this derives through ANSI-X9.63-KDF.
     """
+    _assert_valid_ec(ec)
     d = dU % ec.n
 
     # d == 0 is the infinity point, which the bindings reject as a

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -48,6 +48,7 @@ from btclib import var_bytes
 from btclib.alias import BinaryData, HashF, JacPoint, Octets, Point
 from btclib.curves import Curve, mult, secp256k1
 from btclib.curves.curve import (
+    _assert_valid_ec,
     _is_x_coordinate_var,
     _jac_double_mult,
     _libsecp256k1_serves,
@@ -216,6 +217,12 @@ class Sig:
 
     def assert_valid(self) -> None:
         """Refuse an r or s outside 1..n-1, or an r no x is congruent to."""
+        # the curve first: it is what 1..n-1 is measured in, and
+        # check_validity=False is what makes a Sig holding an ec of no
+        # curve type reachable at all -- built with the flag off, or the
+        # field assigned afterwards, as psbt.assert_valid's int fields are
+        _assert_valid_ec(self.ec)
+
         # r is a scalar, fail if r is not in [1, n-1]
         if not 0 < self.r < self.ec.n:
             err_msg = "scalar r not in 1..n-1: "
@@ -329,6 +336,11 @@ class Sig:
 
 def gen_keys(prv_key: PrvKey | None = None, ec: Curve = secp256k1) -> tuple[int, Point]:
     """Return a private/public (int, Point) key-pair."""
+    # here rather than in the branch below that reads n off the curve: a
+    # key that was given reaches int_from_prv_key's own check, and one
+    # that is drawn reaches nothing else
+    _assert_valid_ec(ec)
+
     if prv_key is None:
         # q in the range [1, ec.n-1]
         q = 1 + secrets.randbelow(ec.n - 1)

--- a/btclib/ecc/ellswift.py
+++ b/btclib/ecc/ellswift.py
@@ -48,6 +48,7 @@ from btclib_secp256k1 import ellswift as libsecp256k1_ellswift
 from btclib.alias import Octets, Point
 from btclib.curves import Curve, bytes_from_point, mult, secp256k1
 from btclib.curves.curve import (
+    _assert_valid_ec,
     _is_x_coordinate_var,
     _libsecp256k1_serves,
     _y_even_var,
@@ -249,6 +250,10 @@ def _ell_from_point(Q: Point, ec: Curve) -> bytes:
 
 def _ell_from_octets(ell: Octets, ec: Curve) -> bytes:
     """Return the encoding as the octets the map reads, size checked."""
+    # the size is the curve's, so this is where `decode_var` and `xdh`
+    # first read theirs; `create_var` and `encode_var` take no encoding in
+    # and reach the curve through the key converters instead
+    _assert_valid_ec(ec)
     ell = bytes_from_octets(ell)
     if len(ell) != 2 * ec.p_size:
         err_msg = f"invalid ElligatorSwift size: {len(ell)}"

--- a/btclib/ecc/pedersen.py
+++ b/btclib/ecc/pedersen.py
@@ -29,6 +29,7 @@ from hashlib import sha256
 
 from btclib.alias import HashF, Point
 from btclib.curves import Curve, bytes_from_point, double_mult_var, secp256k1
+from btclib.curves.curve import _assert_valid_ec
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
 from btclib.utils import int_from_bits
 
@@ -69,6 +70,12 @@ def second_generator(ec: Curve = secp256k1, hf: HashF = sha256) -> Point:
     source:
     https://github.com/ElementsProject/secp256k1-zkp/blob/secp256k1-zkp/src/modules/rangeproof/main_impl.h
     """
+    # the generator is read off the curve before anything is done with
+    # it, so this is where the three functions below first reach theirs;
+    # and it is inside the cache rather than in front of it, an ec of no
+    # curve type being a key like any other -- hashable, so lru_cache
+    # would take it, and never stored, exceptions not being cached
+    _assert_valid_ec(ec)
     G_bytes = bytes_from_point(ec.G, ec, compressed=False)
     hash_ = hf()
     hash_.update(G_bytes)

--- a/btclib/ecc/rfc6979_nonce.py
+++ b/btclib/ecc/rfc6979_nonce.py
@@ -30,6 +30,7 @@ from hashlib import sha256
 
 from btclib.alias import HashF, Octets
 from btclib.curves import Curve, secp256k1
+from btclib.curves.curve import _assert_valid_ec
 from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.utils import bytes_from_octets, int_from_bits
 
@@ -48,6 +49,11 @@ def challenge_(
     reduced mod n. The message enters already reduced -- a digest of
     hf's size, which is what the trailing underscore says.
     """
+    # the challenge is the first thing `rfc6979_nonce_` and dsa's signing
+    # and anti-exfil entry points compute, so the curve they were handed
+    # is read here first
+    _assert_valid_ec(ec)
+
     # the message msg_hash: a hf_len array
     hf_len = hf().digest_size
     msg_hash = bytes_from_octets(msg_hash, hf_len)

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -65,6 +65,7 @@ from btclib.alias import BinaryData, HashF, Integer, JacPoint, Octets, Point
 from btclib.bip32 import BIP32Key
 from btclib.curves import Curve, secp256k1
 from btclib.curves.curve import (
+    _assert_valid_ec,
     _is_x_coordinate_var,
     _jac_double_mult,
     _libsecp256k1_serves,
@@ -150,6 +151,10 @@ class Sig:
 
     def assert_valid(self) -> None:
         """Refuse an r that is no x-coordinate, or an s outside 0..n-1."""
+        # the curve first, as in dsa.Sig.assert_valid and for its reason:
+        # both fields below are read against it
+        _assert_valid_ec(self.ec)
+
         # r is a field element, fail if r is not a valid x-coordinate.
         # The question is existence: BIP340 fixes the y even, and
         # verification recomputes the point from the scalars rather than
@@ -240,6 +245,8 @@ def point_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve = secp256k1) -> Point:
     - BIP340 Octets (bytes or hex-string, p-size Point x-coordinate)
     - native tuple
     """
+    _assert_valid_ec(ec)
+
     # every branch below ends in the same lift, an x-only key being an x
     # and the even y that goes with it: _y_even_var is ec.y_even_var answered by
     # libsecp256k1 for secp256k1, 2.9 us against the 75 of a modular
@@ -268,6 +275,9 @@ def point_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve = secp256k1) -> Point:
 
 def gen_keys(prv_key: PrvKey | None = None, ec: Curve = secp256k1) -> tuple[int, int]:
     """Return a BIP340 private/public (int, int) key-pair."""
+    # as in dsa.gen_keys, and for its reason
+    _assert_valid_ec(ec)
+
     if prv_key is None:
         q = 1 + secrets.randbelow(ec.n - 1)
     else:
@@ -288,6 +298,8 @@ def challenge_(msg: Octets, x_Q: int, x_K: int, ec: Curve, hf: HashF) -> int:
     trailing underscore says throughout this module: no reduction by
     hf happens here.
     """
+    _assert_valid_ec(ec)
+
     # the message, of any size ("Messages of Arbitrary Size" in BIP340):
     # the tagged hash below absorbs any length unambiguously, x_K and x_Q
     # being fixed at p_size each

--- a/btclib/network.py
+++ b/btclib/network.py
@@ -40,7 +40,7 @@ from typing import Any
 
 from btclib.alias import NetworkField, NetworkName, NetworkType, Octets
 from btclib.curves import Curve
-from btclib.curves.curve import CURVES
+from btclib.curves.curve import CURVES, _assert_valid_ec
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.utils import bytes_from_octets
 
@@ -262,7 +262,12 @@ class Network:
 
     def assert_valid(self) -> None:
         """Refuse a field of the wrong type, size, or network_type value."""
-        # no check on self.curve
+        # the curve is what every key of this network lives on, and it is
+        # read for its own fields wherever the network is: `curve.name`
+        # goes into to_dict, and `network_from_name(net).curve` is what
+        # the key converters compare an `ec` against. Same check as the
+        # one in front of those, `curve._assert_valid_ec`
+        _assert_valid_ec(self.curve)
 
         # the hrp is the human-readable part of every bech32 address of this
         # network, so it has to be a str. An isinstance check, because

--- a/btclib/to_prv_key.py
+++ b/btclib/to_prv_key.py
@@ -10,6 +10,7 @@ from btclib.alias import String
 from btclib.base58 import decode as b58decode
 from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, _key_data_from_bip32_key
 from btclib.curves import Curve, secp256k1
+from btclib.curves.curve import _assert_valid_ec
 from btclib.exceptions import (
     BTClibTypeError,
     BTClibValueError,
@@ -78,6 +79,11 @@ def int_from_prv_key(prv_key: PrvKey, ec: Curve = secp256k1) -> int:
     Network and compressed information from the input key
     are not used.
     """
+    # before the key, because every branch below reaches the curve: an
+    # xprv or a WIF is compared against it rather than parsed with it, and
+    # an ec of no curve type compares unequal to every network's -- which
+    # is "ec / network mismatch" for what is a caller's own mistake
+    _assert_valid_ec(ec)
     _assert_prv_key_type(prv_key)
 
     if isinstance(prv_key, int):

--- a/btclib/to_pub_key.py
+++ b/btclib/to_pub_key.py
@@ -18,6 +18,7 @@ from btclib.curves import (
     point_from_octets,
     secp256k1,
 )
+from btclib.curves.curve import _assert_valid_ec
 from btclib.curves.sec_point import _sec_from_octets
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
@@ -114,6 +115,11 @@ def point_from_key(key: Key, ec: Curve = secp256k1) -> Point:
     - SEC Octets (bytes or hex-string, with 02, 03, or 04 prefix)
     - native tuple
     """
+    # as in `point_from_pub_key` below and `to_prv_key.int_from_prv_key`:
+    # a WIF is compared against the curve rather than parsed with it, and
+    # an ec of no curve type compares unequal to every network's, which is
+    # "Curve mismatch" for what is a caller's own mistake
+    _assert_valid_ec(ec)
     _assert_key_type(key)
 
     if isinstance(key, tuple):
@@ -135,6 +141,7 @@ def point_from_key(key: Key, ec: Curve = secp256k1) -> Point:
 
 def point_from_pub_key(pub_key: PubKey, ec: Curve = secp256k1) -> Point:
     """Return an elliptic curve point tuple from a public key."""
+    _assert_valid_ec(ec)
     _assert_pub_key_type(pub_key)
 
     if isinstance(pub_key, tuple):

--- a/tests/curve_parameter_test.py
+++ b/tests/curve_parameter_test.py
@@ -1,0 +1,500 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The gate for `ec`, the parameter that says which curve is meant.
+
+`input_validation_test.py` drives every public function whose *required*
+parameters are all library input types, and its docstring says why a
+parameter behind a default is out of its reach: the arguments in front of
+it would have to be valid, and a table of valid values per position is
+what that walk is built to do without. `hf` and `network` are gated by
+hand for that reason, where their own checks live. This is the table for
+the third of the three, and it is the widest of them.
+
+Issue #868 is where the count is, and `ec` had no check of its own when
+this file was written: every function below answered a wrong one with
+`AttributeError: 'NoneType' object has no attribute 'n'`, a field read off
+whatever arrived, which is the third of the four shapes issue #856 named.
+`Network.assert_valid` said so out loud, with a comment reading "no check
+on self.curve" where the check now is.
+
+## The rule, and what the second half of it has to ask here
+
+CONTRIBUTING.md's "Every public function validates its inputs": a value
+of a type the signature does not declare leaves as a `BTClibTypeError`,
+and a value of a declared type that no valid input carries as a
+`BTClibValueError`.
+
+The first half is the whole of the table below. The second half is
+answered in two places and not in the table, because **every curve is a
+valid ec** -- that is what the parameter is for, and the low-cardinality
+curves of `curve_test.py` are the proof that no value of the type is
+refused for being unusual. What can be wrong is a curve the *key* names:
+an xprv, an xpub or a WIF carries a network, and a network has a curve,
+so a mismatch there is a fact about the pair and a `BTClibValueError`.
+`test_the_curve_a_key_names_is_still_a_value` is that half, and it is in
+this file because the guard sits in front of those comparisons: an ec of
+no curve type compares unequal to every network's curve, which is the one
+place where the type rule taking over is the point rather than a side
+effect -- a caller's own mistake would otherwise be reported as a
+statement about the key.
+
+A `bool` answer is no exemption from the first half either:
+`borromean.verify` and `pedersen.verify` answer `False` about a
+commitment or a ring, not about the curve they were told to work in, and
+their `except (ValueError, BTClibRuntimeError)` lets a `BTClibTypeError`
+through for the same reason `dsa.verify` does.
+
+## The walk is what makes the table complete
+
+`_curve_parameters` reads every public function of the package whose
+signature declares a `Curve` or a `CurveGroup`, so
+`test_the_table_is_every_curve_parameter` fails on a function this file
+does not drive -- a new one, or one that gains the parameter. There is no
+exemption list, and that is the state to keep.
+
+Arguments go in by keyword, which is what lets one driver replace `ec`
+in every call whatever its position: `ec` is the last parameter of the
+`curves` functions, the fifth of `dsa.sign_` and the first of the two
+group explorers, and none of these signatures has a positional-only
+parameter.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from btclib.b58 import wif_from_prv_key
+from btclib.bip32.bip32 import BIP32KeyData, rootxprv_from_seed, xpub_from_xprv
+from btclib.curves import CurveGroup, secp256k1
+from btclib.curves.curve import (
+    Curve,
+    double_mult_var,
+    mult,
+    multi_mult_var,
+)
+from btclib.curves.curve_group_f import find_all_points, find_subgroup_points
+from btclib.curves.sec_point import (
+    bytes_from_point,
+    bytes_from_prv_key_int,
+    point_from_octets,
+)
+from btclib.ecc import borromean, dsa, ellswift, pedersen, ssa
+from btclib.ecc.bip340_nonce import bip340_nonce_
+from btclib.ecc.commit_nonce import commit_nonce_, commit_point_
+from btclib.ecc.dh import diffie_hellman
+from btclib.ecc.rfc6979_nonce import challenge_, rfc6979_nonce_
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.network import NETWORKS, Network
+from btclib.to_prv_key import int_from_prv_key
+from btclib.to_pub_key import point_from_key, point_from_pub_key
+from tests.curves.curve_test import low_card_curves
+
+_LIBRARY = Path(__file__).parents[1] / "btclib"
+
+# a value of no type any `ec` declares, and both are calls mypy refuses
+_WRONG_TYPES: tuple[Any, ...] = (None, 1.5)
+
+_PRV_KEY = 0xC28FCA386C7A227600B2FE50B7CAE11EC86D3BF1FBE471BE89827E19D72AA1D
+_PRV_KEY_2, _PUB_KEY_2 = dsa.gen_keys(_PRV_KEY + 1)
+_PUB_KEY = mult(_PRV_KEY)
+_SEC = bytes_from_point(_PUB_KEY)
+_MSG = b"Satoshi Nakamoto"
+_MSG_HASH = sha256(_MSG).digest()
+_DSA_SIG = dsa.sign(_MSG, _PRV_KEY)
+_SSA_SIG = ssa.sign(_MSG, _PRV_KEY)
+_ELL = ellswift.encode_var(_PUB_KEY)
+_ELL_2 = ellswift.encode_var(_PUB_KEY_2)
+_COMMITMENT = pedersen.commit(1, 2)
+
+# two rings of two keys, the smallest borromean signature there is: what
+# this file asks of it is the curve, and a wider ring would only be a
+# slower way of asking
+_RING_KEYS = [dsa.gen_keys(_PRV_KEY + i) for i in range(2, 6)]
+_PUBK_RINGS = [
+    [_RING_KEYS[0][1], _RING_KEYS[1][1]],
+    [_RING_KEYS[2][1], _RING_KEYS[3][1]],
+]
+_SIGN_KEY_IDX = [0, 1]
+_SIGN_KEYS = [_RING_KEYS[0][0], _RING_KEYS[3][0]]
+_E0, _S = borromean.sign(_MSG, [1, 2], _SIGN_KEY_IDX, _SIGN_KEYS, _PUBK_RINGS)
+
+# the two group explorers walk every point, so their ec is a group small
+# enough to be walked -- and a CurveGroup, which is the type they declare:
+# it has p, a and b and neither the n nor the G a Curve adds
+_GROUP = CurveGroup(13, 0, 2)
+_GROUP_G = (1, 9)
+
+# every field of mainnet but its curve, in the hex spelling to_dict writes
+# and the constructor takes
+_NETWORK_ARGS = {
+    key: value for key, value in NETWORKS["mainnet"].to_dict().items() if key != "curve"
+}
+
+
+@dataclass(frozen=True)
+class _Case:
+    """A function taking an ec, and a call of it that works."""
+
+    dotted: str
+    function: Any
+    # every argument but ec, by keyword
+    args: dict[str, Any] = field(default_factory=dict)
+    # the valid ec, which is a Curve unless the signature says CurveGroup
+    ec: CurveGroup = secp256k1
+    # a label of its own, where one function is driven by two cases
+    label: str = ""
+    # what the parameter is called: `ec` everywhere but in `Network`,
+    # whose curve is a field of the network and is spelled `curve`
+    parameter: str = "ec"
+
+
+_CASES = (
+    _Case("btclib.curves.curve.mult", mult, {"m_int": _PRV_KEY, "Q": _PUB_KEY}),
+    _Case(
+        "btclib.curves.curve.double_mult_var",
+        double_mult_var,
+        {"u": _PRV_KEY, "H": _PUB_KEY, "v": _PRV_KEY_2, "Q": _PUB_KEY_2},
+    ),
+    _Case(
+        "btclib.curves.curve.multi_mult_var",
+        multi_mult_var,
+        {"scalars": [_PRV_KEY, _PRV_KEY_2], "points": [_PUB_KEY, _PUB_KEY_2]},
+    ),
+    _Case("btclib.curves.curve_group_f.find_all_points", find_all_points, ec=_GROUP),
+    _Case(
+        "btclib.curves.curve_group_f.find_subgroup_points",
+        find_subgroup_points,
+        {"G": _GROUP_G},
+        ec=_GROUP,
+    ),
+    _Case(
+        "btclib.curves.sec_point.bytes_from_point",
+        bytes_from_point,
+        {"Q": _PUB_KEY},
+    ),
+    _Case(
+        "btclib.curves.sec_point.bytes_from_prv_key_int",
+        bytes_from_prv_key_int,
+        {"prv_key_int": _PRV_KEY},
+    ),
+    _Case(
+        "btclib.curves.sec_point.point_from_octets",
+        point_from_octets,
+        {"pub_key": _SEC},
+    ),
+    _Case(
+        "btclib.ecc.bip340_nonce.bip340_nonce_",
+        bip340_nonce_,
+        {"msg": _MSG, "prv_key": _PRV_KEY},
+    ),
+    _Case(
+        "btclib.ecc.borromean.sign",
+        borromean.sign,
+        {
+            "msg": _MSG,
+            "ks": [1, 2],
+            "sign_key_idx": _SIGN_KEY_IDX,
+            "sign_keys": _SIGN_KEYS,
+            "pubk_rings": _PUBK_RINGS,
+        },
+    ),
+    _Case(
+        "btclib.ecc.borromean.verify",
+        borromean.verify,
+        {"msg": _MSG, "e0": _E0, "s": _S, "pubk_rings": _PUBK_RINGS},
+    ),
+    _Case(
+        "btclib.ecc.borromean.assert_as_valid",
+        borromean.assert_as_valid,
+        {"msg": _MSG, "e0": _E0, "s": _S, "pubk_rings": _PUBK_RINGS},
+    ),
+    _Case(
+        "btclib.ecc.commit_nonce.commit_nonce_",
+        commit_nonce_,
+        {"commit_hash": _MSG_HASH, "nonce": _PRV_KEY, "tag": b"tag"},
+    ),
+    _Case(
+        "btclib.ecc.commit_nonce.commit_point_",
+        commit_point_,
+        {"commit_hash": _MSG_HASH, "receipt": _PUB_KEY, "tag": b"tag"},
+    ),
+    _Case(
+        "btclib.ecc.dh.diffie_hellman",
+        diffie_hellman,
+        {"dU": _PRV_KEY, "QV": _PUB_KEY_2, "size": 32},
+    ),
+    _Case(
+        "btclib.ecc.dsa.Sig.__init__",
+        dsa.Sig,
+        {"r": _DSA_SIG.r, "s": _DSA_SIG.s},
+    ),
+    _Case("btclib.ecc.dsa.gen_keys", dsa.gen_keys, {"prv_key": _PRV_KEY}),
+    # the same function with the key it draws itself, which is the branch
+    # that reads n off the curve rather than reaching int_from_prv_key
+    _Case(
+        "btclib.ecc.dsa.gen_keys",
+        dsa.gen_keys,
+        {"prv_key": None},
+        label="btclib.ecc.dsa.gen_keys(None)",
+    ),
+    _Case(
+        "btclib.ecc.dsa.sign_", dsa.sign_, {"msg_hash": _MSG_HASH, "prv_key": _PRV_KEY}
+    ),
+    _Case("btclib.ecc.dsa.sign", dsa.sign, {"msg": _MSG, "prv_key": _PRV_KEY}),
+    _Case(
+        "btclib.ecc.dsa.sign_recoverable_",
+        dsa.sign_recoverable_,
+        {"msg_hash": _MSG_HASH, "prv_key": _PRV_KEY},
+    ),
+    _Case(
+        "btclib.ecc.dsa.sign_recoverable",
+        dsa.sign_recoverable,
+        {"msg": _MSG, "prv_key": _PRV_KEY},
+    ),
+    _Case(
+        "btclib.ecc.dsa.anti_exfil_signer_commit",
+        dsa.anti_exfil_signer_commit,
+        {"msg_hash": _MSG_HASH, "prv_key": _PRV_KEY, "host_commitment": _MSG_HASH},
+    ),
+    _Case(
+        "btclib.ecc.dsa.anti_exfil_sign",
+        dsa.anti_exfil_sign,
+        {"msg_hash": _MSG_HASH, "prv_key": _PRV_KEY, "rho": _MSG_HASH},
+    ),
+    _Case("btclib.ecc.ellswift.create_var", ellswift.create_var, {"prv_key": _PRV_KEY}),
+    _Case("btclib.ecc.ellswift.encode_var", ellswift.encode_var, {"pub_key": _PUB_KEY}),
+    _Case("btclib.ecc.ellswift.decode_var", ellswift.decode_var, {"ell": _ELL}),
+    _Case(
+        "btclib.ecc.ellswift.xdh",
+        ellswift.xdh,
+        {"ell_a": _ELL, "ell_b": _ELL_2, "prv_key": _PRV_KEY, "party": 0},
+    ),
+    _Case("btclib.ecc.pedersen.second_generator", pedersen.second_generator),
+    _Case("btclib.ecc.pedersen.commit", pedersen.commit, {"r": 1, "v": 2}),
+    _Case(
+        "btclib.ecc.pedersen.assert_as_valid",
+        pedersen.assert_as_valid,
+        {"r": 1, "v": 2, "commitment": _COMMITMENT},
+    ),
+    _Case(
+        "btclib.ecc.pedersen.verify",
+        pedersen.verify,
+        {"r": 1, "v": 2, "commitment": _COMMITMENT},
+    ),
+    _Case("btclib.ecc.rfc6979_nonce.challenge_", challenge_, {"msg_hash": _MSG_HASH}),
+    _Case(
+        "btclib.ecc.rfc6979_nonce.rfc6979_nonce_",
+        rfc6979_nonce_,
+        {"msg_hash": _MSG_HASH, "prv_key": _PRV_KEY},
+    ),
+    _Case(
+        "btclib.ecc.ssa.Sig.__init__",
+        ssa.Sig,
+        {"r": _SSA_SIG.r, "s": _SSA_SIG.s},
+    ),
+    _Case(
+        "btclib.ecc.ssa.point_from_bip340pub_key",
+        ssa.point_from_bip340pub_key,
+        {"x_Q": _PUB_KEY[0]},
+    ),
+    _Case("btclib.ecc.ssa.gen_keys", ssa.gen_keys, {"prv_key": _PRV_KEY}),
+    _Case(
+        "btclib.ecc.ssa.gen_keys",
+        ssa.gen_keys,
+        {"prv_key": None},
+        label="btclib.ecc.ssa.gen_keys(None)",
+    ),
+    # ec and hf are required here, this being the prepared-challenge
+    # spelling BIP340 verification is built on
+    _Case(
+        "btclib.ecc.ssa.challenge_",
+        ssa.challenge_,
+        {"msg": _MSG, "x_Q": _PUB_KEY[0], "x_K": _SSA_SIG.r, "hf": sha256},
+    ),
+    _Case("btclib.ecc.ssa.sign_", ssa.sign_, {"msg": _MSG, "prv_key": _PRV_KEY}),
+    _Case("btclib.ecc.ssa.sign", ssa.sign, {"msg": _MSG, "prv_key": _PRV_KEY}),
+    _Case(
+        "btclib.to_prv_key.int_from_prv_key",
+        int_from_prv_key,
+        {"prv_key": _PRV_KEY},
+    ),
+    _Case("btclib.to_pub_key.point_from_key", point_from_key, {"key": _SEC}),
+    _Case(
+        "btclib.to_pub_key.point_from_pub_key", point_from_pub_key, {"pub_key": _SEC}
+    ),
+    # the one curve parameter that is a field rather than an argument to
+    # compute with, and the one not called `ec`. `to_dict`'s keys are the
+    # constructor's parameter names, the curve excepted -- it goes out as a
+    # name and comes back as the catalogued curve -- so the valid call is
+    # mainnet rebuilt from its own dict
+    _Case(
+        "btclib.network.Network.__init__",
+        Network,
+        _NETWORK_ARGS,
+        parameter="curve",
+    ),
+)
+
+_IDS = tuple(case.label or case.dotted for case in _CASES)
+
+# the functions whose ec is a Curve, which is every one of them but the
+# two group explorers: a CurveGroup is a wrong type for these and the
+# right one for those
+_CURVE_CASES = tuple(case for case in _CASES if isinstance(case.ec, Curve))
+_CURVE_IDS = tuple(case.label or case.dotted for case in _CURVE_CASES)
+
+
+def _curve_parameters() -> set[str]:
+    """Return every public function of the package taking a curve.
+
+    The **annotation** and not the name `ec`: `Network.__init__` spells
+    its own `curve`, and a walk keyed on the spelling would leave the one
+    curve parameter that is a field out of the table.
+
+    `Curve` and `CurveGroup` exactly, and not a union containing one:
+    `network.networks_from_key_value` takes a `str | bytes | Curve` to
+    *compare* against every network's field, and its docstring says what
+    a value of any other type gets there -- "no network carries this
+    prefix", the answer a lookup owes a caller, where these functions
+    have a curve to compute in.
+
+    A method counts, `dsa.Sig.__init__` and `ssa.Sig.__init__` being two
+    of them, and a private function does not: the guard is what those call.
+    An `@overload` stub is not a function to drive -- `dsa.sign_` has
+    three of them in front of the one implementation, and driving a stub
+    would be driving `...`.
+    """
+    found: set[str] = set()
+
+    def walk(node: ast.Module | ast.ClassDef, module: str, prefix: str) -> None:
+        for child in node.body:
+            if isinstance(child, ast.ClassDef):
+                walk(child, module, f"{prefix}{child.name}.")
+            elif isinstance(child, ast.FunctionDef):
+                if child.name.startswith("_") and not child.name.startswith("__"):
+                    continue
+                if any(ast.unparse(d) == "overload" for d in child.decorator_list):
+                    continue
+                arguments = [
+                    *child.args.posonlyargs,
+                    *child.args.args,
+                    *child.args.kwonlyargs,
+                ]
+                if any(
+                    a.annotation is not None
+                    and ast.unparse(a.annotation) in {"Curve", "CurveGroup"}
+                    for a in arguments
+                ):
+                    found.add(f"{module}.{prefix}{child.name}")
+
+    for path in sorted(_LIBRARY.rglob("*.py")):
+        module = ".".join(path.relative_to(_LIBRARY.parent).with_suffix("").parts)
+        walk(ast.parse(path.read_text(encoding="utf-8")), module, "")
+    return found
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_IDS)
+def test_the_call_works(case: _Case) -> None:
+    """The fixture is valid, which is what makes a refusal below a finding.
+
+    Without this a case whose arguments had gone stale would pass every
+    test in the file by refusing everything it is handed.
+    """
+    case.function(**case.args, **{case.parameter: case.ec})
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_IDS)
+def test_a_wrong_type_leaves_as_a_btclib_type_error(case: _Case) -> None:
+    """The rule, with every other argument left valid.
+
+    `BTClibTypeError` and not `BTClibException`, which is where the class
+    is the point: the two failures this is around are an `AttributeError`
+    from underneath the library -- a field read off whatever arrived --
+    and a `BTClibValueError`, which would be the library calling a
+    caller's mistake a fact about the curve.
+    """
+    for wrong in _WRONG_TYPES:
+        with pytest.raises(BTClibTypeError, match="invalid ec type"):
+            case.function(**case.args, **{case.parameter: wrong})
+
+
+@pytest.mark.parametrize("case", _CURVE_CASES, ids=_CURVE_IDS)
+def test_a_curve_group_is_not_a_curve(case: _Case) -> None:
+    """The wrong type a check against the group would let through.
+
+    `CurveGroup` is what `Curve` derives from and it is a type mypy
+    refuses here, which is the whole reason `curve._assert_valid_ec` asks
+    for the subclass: the group has p, a and b, so a check spelled against
+    it would pass an ec that the very next line reads an `n` or a `G` off.
+    """
+    with pytest.raises(BTClibTypeError, match="invalid ec type: CurveGroup"):
+        case.function(**case.args, **{case.parameter: _GROUP})
+
+
+def test_the_table_is_every_curve_parameter() -> None:
+    """No exemption list: a function taking a curve is one driven here.
+
+    The walk is the inventory, so a new `ec` parameter -- or an existing
+    function that gains one -- fails here rather than going ungated in
+    silence.
+    """
+    driven = {case.dotted for case in _CASES}
+    found = _curve_parameters()
+    assert driven == found, f"not driven: {sorted(found - driven)}"
+
+
+def test_the_walk_reaches_what_it_claims() -> None:
+    """The shapes the walk must find, and the three it must not.
+
+    A walk that found nothing would pass the test above.
+    """
+    found = _curve_parameters()
+    # a defaulted ec, a required one, and a constructor's
+    assert "btclib.ecc.dsa.sign" in found
+    assert "btclib.curves.curve_group_f.find_all_points" in found
+    assert "btclib.ecc.dsa.Sig.__init__" in found
+
+    # the guards themselves, which take an ec and are what the rest call
+    assert "btclib.curves.curve._assert_valid_ec" not in found
+    assert "btclib.curves.curve_group._assert_valid_ec" not in found
+    # a function of another name, and one with no ec at all
+    assert "btclib.ecc.dsa.verify" not in found
+    assert "btclib.hashes.sha256" not in found
+
+
+def test_the_curve_a_key_names_is_still_a_value() -> None:
+    """The second rule, which is the one the guard sits in front of.
+
+    A key that names a network names its curve, so an ec that is not that
+    curve is a fact about the pair and a `BTClibValueError`. All three
+    compare rather than parse, which is why the type check comes first: an
+    ec of no curve type compares unequal to every network's curve, so
+    without it a caller's own mistake leaves as this same mismatch -- a
+    statement about the key, about which nothing was wrong.
+    """
+    ec = low_card_curves["ec23_31"]
+
+    # derived rather than written out: what makes it a mainnet WIF is the
+    # network, which is the whole of what this test is about
+    wif = wif_from_prv_key(_PRV_KEY)
+    with pytest.raises(BTClibValueError, match="ec / network"):
+        int_from_prv_key(wif, ec)
+    with pytest.raises(BTClibValueError, match="Curve mismatch"):
+        point_from_key(wif, ec)
+
+    # the parsed form, and not the string it b58decodes from: a spelling
+    # this converter has to guess at is tried as octets after the xkey
+    # branch declines it, so the mismatch is reported as "not a public
+    # key" -- the pair is what is wrong, and which of the two spellings
+    # says so is `point_from_pub_key`'s own business
+    xpub = BIP32KeyData.b58decode(xpub_from_xprv(rootxprv_from_seed("00" * 32)))
+    with pytest.raises(BTClibValueError, match="ec/xpub version"):
+        point_from_pub_key(xpub, ec)


### PR DESCRIPTION
Section 5.3 of https://github.com/btclib-org/btclib/issues/856, counted in
https://github.com/btclib-org/btclib/issues/868: which parameters behind a
default go unchecked. `hf` and `network` are gated where their own checks
live, and `ec` was not gated at all.

## What was open

Forty-two public functions take an `ec` — `curves/`, `ecc/` and the two key
converters — and every one of them answered a wrong one from underneath the
library:

```text
dsa.sign(msg, q, ec=None)  -> AttributeError: 'NoneType' object has no attribute 'n'
ssa.sign(msg, q, ec=1.5)   -> AttributeError: 'float' object has no attribute 'n'
```

A field read off whatever arrived, which is the third of the four shapes
#856 named.

## The guard

`curve._assert_valid_ec`, `hashes._assert_valid_hf`'s shape: one check,
asked where each function **first reads** the parameter, which is nineteen
places rather than forty-two — the three multiplications, the three SEC
point functions, `int_from_prv_key`, `point_from_key`,
`point_from_pub_key`, and the ten `ecc` entries that read a field off the
curve before reaching any of those. Everything else composes one of them.

`curve_group._assert_valid_ec` is its twin for the two group explorers,
whose parameter is a `CurveGroup`. The Curve check is `isinstance(ec,
Curve)` and not the group it derives from, because `n` and `G` are Curve's
own: a group would pass the wider check and fail on the field it has not
got, which `test_a_curve_group_is_not_a_curve` pins over every case.

22 ns, one to four times in what a caller calls one operation: 45 ns of the
17.5 us of a signature, 88 of the 39.2 of a verification, two guards in the
39.1 us of a five-level BIP32 derivation.

## Two were reporting the mistake as somebody else's

`int_from_prv_key` and `point_from_key` compare the curve a WIF or an xprv
names against the `ec` they were handed, and an `ec` of no curve type
compares unequal to every network's:

```text
int_from_prv_key(wif, ec=1.5)  -> BTClibValueError: ec / network (mainnet) mismatch
point_from_key(wif, ec=1.5)    -> BTClibValueError: Curve mismatch
```

Both refusals stand for a curve that really is the wrong one, which is the
value half of the rule and the only wrong *value* this parameter has: every
curve is a valid `ec`, the low-cardinality ones included.
`test_the_curve_a_key_names_is_still_a_value` is that half.

## `Network` said it out loud

`Network.assert_valid` carried `# no check on self.curve` where the check
now is. Its parameter is spelled `curve` rather than `ec`, being a field of
the network — and the network's curve is what the two comparisons above
compare an `ec` against.

## The gate

`tests/curve_parameter_test.py`, `built_object_contract_test.py`'s shape
over a family the automatic walk cannot reach: driving a parameter behind a
default needs every argument in front of it to be valid, which is the table
of valid values `input_validation_test.py` exists to do without. Each case
asserts the valid call works first, so a stale fixture fails instead of
passing by refusing everything.

It carries a walk of its own, keyed on the **annotation** and not on the
name, so a public function declaring a `Curve` or a `CurveGroup` is either
in the table or the run is red — no exemption list. A union that merely
contains one is not declaring a curve: `networks_from_key_value` takes a
`str | bytes | Curve` to compare against every network's field, and a value
of another type there is "no network carries this prefix", the answer a
lookup owes a caller.

## Breaking

Nothing that was accepted is refused. What changes is the class of the
exception a wrong `ec` raises: `AttributeError` becomes `BTClibTypeError`,
which is what CONTRIBUTING.md promises and what mypy already refused to
write. No HISTORY.md bullet for that reason; CHANGELOG.md carries the
entry.

## Verified

- `uv run pytest`: 27556 passed, coverage 100.00%
- `uv run pre-commit run --all-files`: exit 0
- `sphinx-build -W --keep-going`: build succeeded

Part of https://github.com/btclib-org/btclib/issues/868, which stays open
for the second half — the census of `bool` parameters against the
kind-or-truth line, `lower_s` and `compressed` being the two it names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add explicit type validation for elliptic curve parameters (`ec`) across the public API and introduce tests to enforce that every curve-annotated parameter is gated, ensuring wrong curve types yield `BTClibTypeError` instead of leaking lower-level errors.

New Features:
- Introduce `_assert_valid_ec` helpers for `Curve` and `CurveGroup` to validate elliptic-curve parameters in core curve, ECC, key conversion, DH, Pedersen, and network APIs.

Bug Fixes:
- Ensure invalid or non-curve `ec` arguments consistently raise `BTClibTypeError` rather than `AttributeError` or misleading value errors in signing, verification, key conversion, and network-related functions.
- Fix network validation to check its `curve` field, preventing invalid curve objects from being accepted as part of a `Network` configuration.

Enhancements:
- Document the new `ec` input contract and gating behavior in `CHANGELOG.md` and `CONTRIBUTING.md`.
- Add a test suite (`curve_parameter_test.py`) that dynamically discovers all public functions with `Curve`/`CurveGroup` parameters and verifies their behavior with valid curves, wrong types, and curve group mismatches.

Tests:
- Add `curve_parameter_test.py` to systematically drive all public functions that declare `Curve` or `CurveGroup` parameters, checking valid calls, type errors for invalid `ec` values, and ensuring no curve-parameter function is left ungated.