### PR TITLE
Gate the serialization boundary: parse, serialize, to_dict, from_dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2571,6 +2571,72 @@ documented at release-notes length in the first place, and are still in
   Curve` to compare against every network's field, and a value of another
   type there is "no network carries this prefix", which is the answer a
   lookup owes a caller.
+- **The input contract is gated at the serialization boundary: `parse`,
+  `serialize`, `to_dict` and `from_dict`** (issue #867).
+  `tests/serialization_boundary_test.py` is the gate, and it is not the
+  contract `parse_contract_test.py` holds -- where the bytes end is a
+  different question from what type the argument is -- so the walk that
+  finds every one of those methods moves to `tests/__init__.py`, where
+  neither file owns it.
+
+  **`from_dict` had no gate at all, and it is the json boundary**: its
+  input is whatever a schema mistake produced, and all twelve walked the
+  mapping before asking whether it was one. A `None` left as "not
+  subscriptable", a `str` as "string indices must be integers", and a
+  mapping missing a field as a `KeyError` -- which is neither a
+  `BTClibException` nor a `ValueError`, so a caller catching either never
+  caught it, and `exceptions.py` lists that gap as issue #776's.
+  `utils.fields_from_json_object` answers both in one line per
+  `from_dict`, naming the object and the field it has not got.
+
+  The arrays those methods walk are `utils.list_from_json_array`'s, and
+  they are #856's "annotation that accepts the mistake" again: a
+  `Sequence[Any]` accepts a `str` and a `Mapping`, so one input handed
+  where the list of them was meant was as many inputs as it had
+  characters, each refused for what it is not. `Witness.from_dict` was
+  worse than a wrong message: its constructor reads `stack or ()`, so a
+  `None` stack **was accepted**, as a witness of no elements.
+
+  Two fields are converted before any constructor sees them, and both
+  raised from underneath the library: a block header's `time` through
+  `datetime.fromisoformat`, and a network's `curve` through a `CURVES`
+  lookup that answered an unknown name with a `KeyError` and an
+  unhashable one with a TypeError about dict keys.
+
+  **What `serialize` takes was accepted whatever it was.**
+  `Tx.serialize(include_witness)` and `Block.serialize`'s read the flag
+  for its truth, so a value of no boolean type answered the stripped
+  serialization -- what the transaction id is computed over -- where the
+  wire one was asked for; the line is `built_object_contract_test.py`'s,
+  a flag that decides what is computed being a kind and not a truth.
+  `PsbtIn` and `PsbtOut` take a `psbt_version` in `serialize` and in
+  `parse`, compared against 0 alone, so a `None`, a 3 or a string wrote
+  and read a version 2 map and said nothing: both ask
+  `psbt_utils.assert_valid_psbt_version` now, which is `psbt.py`'s own
+  check moved down to the module the maps and the psbt share --
+  `psbt_in` and `psbt_out` cannot import `psbt`. `PSBT_V0` and `PSBT_V2`
+  move with it and `psbt.py` names them still, which is the third entry
+  in `all_test.py`'s `REEXPORTED` and the same shape as the second.
+
+  The text decoders were the other half. `Psbt.b64decode` and
+  `ecies.Envelope.b64decode` handed what is neither `str` nor `bytes` to
+  `base64` or to `.strip`, where `bms.Sig.b64decode` had been fixed for
+  exactly that (issue #814); `BIP32KeyData.b58decode` asks the type
+  before the cache in front of `base58.decode`, which keys on the
+  argument and so refused an unhashable one for being unhashable rather
+  than for not being base58. `Bip21.parse` refused a non-`str` with a
+  `BTClibValueError` where the rule says `BTClibTypeError`, and
+  `Envelope.parse`'s `magic` was compared rather than asked, so a magic
+  of no bytes type refused every envelope for the bytes it does carry.
+
+  The four module-level members of the family are gated too, and two of
+  them had nothing: `descriptors.parse` and `miniscript.parse` left
+  "'NoneType' object has no attribute 'partition'" and "object of type
+  'float' has no len()". `script.serialize` takes a `Sequence[Command]`,
+  which accepts a `str` and a `bytes` for the reason above --
+  `serialize("OP_DUP")` was six one-character commands and
+  `serialize(b"\x76")` a script of one integer command per byte, which is
+  a script and the wrong one.
 
 - **The input contract is gated over a function taking an object somebody
   already built** (issue #856). Neither of the two gates reaches

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,18 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **the serialization boundary refuses what it used to take, and reports
+  through the exception contract.** A `from_dict` handed a mapping
+  without a field raises `BTClibValueError` where it raised a bare
+  `KeyError`, so an `except KeyError` around one catches nothing now;
+  `Witness.from_dict({"stack": None})` was an empty witness and is
+  refused; `tx.serialize(1)` and `block.serialize(0)` want the `bool`
+  they declare; `PsbtIn.serialize(psbt_version=3)` and `PsbtOut`'s want
+  one of the two versions there are; and `Bip21.parse(b"bitcoin:...")`
+  raises `BTClibTypeError` rather than `BTClibValueError`, which an
+  `except BTClibValueError` written against it no longer catches. A
+  caller passing values of the declared types is unaffected.
+
 - **four arguments that used to be accepted are refused.**
   `KeyGroup(1.5, keys)` built a group with a float quorum and
   `KeyGroup(keys, verify="no")` one with `verify=True`, `"no"` being

--- a/btclib/bip21.py
+++ b/btclib/bip21.py
@@ -39,6 +39,7 @@ from btclib.alias import NetworkType
 from btclib.amount import valid_btc_amount
 from btclib.exceptions import BTClibValueError
 from btclib.network import network_type_from_network
+from btclib.utils import assert_type
 
 __all__ = [
     "Bip21",
@@ -203,9 +204,13 @@ class Bip21:
 
     @classmethod
     def parse(cls, uri: str, *, check_validity: bool = True) -> Bip21:
-        """Return the Bip21 of a `bitcoin:` URI."""
-        if not isinstance(uri, str):
-            raise BTClibValueError(f"not a string: {type(uri).__name__}")
+        """Return the Bip21 of a `bitcoin:` URI.
+
+        A `str` and not the `String` the octet decoders take: a URI is
+        text, and a `BTClibTypeError` for what is not it -- the rule
+        CONTRIBUTING.md states, this parameter declaring one type.
+        """
+        assert_type(uri, str, "uri")
 
         scheme, separator, rest = uri.partition(":")
         # RFC 3986 makes a scheme case-insensitive, and a QR code writes

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -51,6 +51,7 @@ from btclib.network import (
 )
 from btclib.utils import (
     assert_no_trailing,
+    assert_type,
     bytes_from_octets,
     bytesio_from_binarydata,
     hex_string,
@@ -361,7 +362,16 @@ class BIP32KeyData:
     def b58decode(
         cls: type[BIP32KeyData], address: String, *, check_validity: bool = True
     ) -> BIP32KeyData:
-        """Build a BIP32KeyData from its xprv/xpub Base58Check text."""
+        """Build a BIP32KeyData from its xprv/xpub Base58Check text.
+
+        The type is asked here rather than left to `base58.decode`, which
+        does ask it: the cache in front of that call keys on the argument,
+        so an unhashable one -- a list, a bytearray, the mutable buffers
+        `String` does not cover -- left as a TypeError about hashing
+        instead of the refusal decoding would have given.
+        """
+        assert_type(address, (str, bytes), "base58 string")
+
         if isinstance(address, str):
             address = address.strip()
 

--- a/btclib/bip32/key_origin.py
+++ b/btclib/bip32/key_origin.py
@@ -18,7 +18,12 @@ from btclib.bip32.der_path import (
     str_from_der_path,
 )
 from btclib.exceptions import BTClibValueError
-from btclib.utils import bytes_from_octets, read_exactly
+from btclib.utils import (
+    bytes_from_octets,
+    fields_from_json_object,
+    list_from_json_array,
+    read_exactly,
+)
 
 __all__ = [
     "BIP32KeyOrigin",
@@ -99,6 +104,7 @@ class BIP32KeyOrigin:
         check_validity: bool = True,
     ) -> BIP32KeyOrigin:
         """Build a BIP32KeyOrigin from the dict shape to_dict writes."""
+        dict_ = fields_from_json_object(dict_, "key origin")
         return cls(
             dict_["master_fingerprint"],
             dict_["path"],
@@ -201,6 +207,7 @@ def _decode_from_bip32_deriv(
     *,
     check_validity: bool,
 ) -> tuple[bytes, BIP32KeyOrigin]:
+    bip32_deriv = fields_from_json_object(bip32_deriv, "bip32 derivation")
     master_fingerprint = bytes_from_octets(
         bip32_deriv["master_fingerprint"], 4 if check_validity else None
     )
@@ -220,6 +227,6 @@ def decode_from_bip32_derivs(
     return dict(
         sorted(
             _decode_from_bip32_deriv(item, check_validity=check_validity)
-            for item in bip32_derivs
+            for item in list_from_json_array(bip32_derivs, "bip32 derivations")
         )
     )

--- a/btclib/block/block.py
+++ b/btclib/block/block.py
@@ -33,9 +33,12 @@ from btclib.script.script import serialize as serialize_script
 from btclib.tx import Tx
 from btclib.utils import (
     assert_no_trailing,
+    assert_type,
     bytesio_from_binarydata,
     decode_num,
+    fields_from_json_object,
     is_integer,
+    list_from_json_array,
 )
 
 __all__ = [
@@ -238,9 +241,15 @@ class Block:
         cls: type[Block], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> Block:
         """Build a Block from the dict shape to_dict writes."""
+        dict_ = fields_from_json_object(dict_, "block")
         return cls(
             BlockHeader.from_dict(dict_["header"], check_validity=False),
-            [Tx.from_dict(tx, check_validity=False) for tx in dict_["transactions"]],
+            [
+                Tx.from_dict(tx, check_validity=False)
+                for tx in list_from_json_array(
+                    dict_["transactions"], "block transactions"
+                )
+            ],
             check_validity=check_validity,
         )
 
@@ -563,8 +572,11 @@ class Block:
         """Return the wire serialization: header, count, transactions.
 
         `include_witness` False gives the block as a legacy node
-        relays it, every witness stripped.
+        relays it, every witness stripped -- a bool and nothing else,
+        for the reason `Tx.serialize` states.
         """
+        assert_type(include_witness, bool, "include_witness")
+
         if check_validity:
             self.assert_valid()
 

--- a/btclib/block/block_header.py
+++ b/btclib/block/block_header.py
@@ -22,8 +22,10 @@ from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash256
 from btclib.utils import (
     assert_no_trailing,
+    assert_type,
     bytes_from_octets,
     bytesio_from_binarydata,
+    fields_from_json_object,
     int_from_json_number,
     is_integer,
 )
@@ -48,6 +50,22 @@ _REQUIRED_LENGTH = 4 + _HF_LEN + 32 + 4 + 4 + 4
 # the signature is what lets ruff's B008 stay enabled to catch the
 # mutable defaults that are not.
 _EPOCH = datetime.fromtimestamp(0, timezone.utc)
+
+
+def _time_from_isoformat(time: Any) -> datetime:
+    """Return the time of an ISO 8601 string, which is what to_dict wrote.
+
+    The one field `from_dict` converts before the constructor sees it, so
+    it is the one whose wrong value `assert_valid` cannot answer for:
+    `datetime.fromisoformat` refuses what is not a string with a
+    TypeError of its own and an unparsable string with a bare
+    ValueError, and a json boundary owes its caller neither.
+    """
+    assert_type(time, str, "time")
+    try:
+        return datetime.fromisoformat(time)
+    except ValueError as e:
+        raise BTClibValueError(f"invalid time: {e}") from e
 
 
 @dataclass
@@ -180,11 +198,12 @@ class BlockHeader:
         cls: type[BlockHeader], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> BlockHeader:
         """Build a BlockHeader from the dict shape to_dict writes."""
+        dict_ = fields_from_json_object(dict_, "block header")
         return cls(
             dict_["version"],
             dict_["previous_block_hash"],
             dict_["merkle_root"],
-            datetime.fromisoformat(dict_["time"]),
+            _time_from_isoformat(dict_["time"]),
             dict_["bits"],
             dict_["nonce"],
             check_validity=check_validity,

--- a/btclib/descriptors/descriptors.py
+++ b/btclib/descriptors/descriptors.py
@@ -201,7 +201,7 @@ from btclib.script.taproot import (
 from btclib.script.witness import Witness
 from btclib.to_pub_key import fingerprint
 from btclib.tx.tx_in import TxIn
-from btclib.utils import bytes_from_octets
+from btclib.utils import assert_type, bytes_from_octets
 
 __all__ = [
     "AddrDescriptor",
@@ -2251,7 +2251,15 @@ def parse(
     network: str = "mainnet",
     prv_keys: dict[str, str] | None = None,
 ) -> Descriptor:
-    """Return the Descriptor of a descriptor string, checksum verified."""
+    """Return the Descriptor of a descriptor string, checksum verified.
+
+    A `str`, an output descriptor being text: what was neither reached
+    `strip_checksum` untouched and left as an AttributeError about
+    `partition`, or as a TypeError about mixing bytes and str -- neither
+    of them a word about the descriptor that was passed.
+    """
+    assert_type(descriptor, str, "descriptor")
+
     if prv_keys is None:
         prv_keys = {}
     return _parse_expression(strip_checksum(descriptor), _TOP, network, prv_keys)

--- a/btclib/descriptors/miniscript.py
+++ b/btclib/descriptors/miniscript.py
@@ -90,7 +90,7 @@ from btclib.script.script import (
     push_int,
     serialize,
 )
-from btclib.utils import bytes_from_octets, decode_num, encode_num
+from btclib.utils import assert_type, bytes_from_octets, decode_num, encode_num
 from btclib.var_int import serialize as var_int_serialize
 
 __all__ = [
@@ -2048,7 +2048,13 @@ def parse(
     `prv_keys` is `descriptors.parse`'s: the mapping an extended private
     key is filed in, under the extended public key that replaces it, so
     that what a parsed expression holds is public.
+
+    A `str`, a BIP379 expression being text, and refused as a type for
+    the reason `descriptors.parse` gives: what was neither reached the
+    slicing below and left as "object of type X has no len()".
     """
+    assert_type(expression, str, "miniscript")
+
     if prv_keys is None:
         prv_keys = {}
     to_parse: list[tuple[str, int, int]] = [(_WRAPPED_EXPR, 0, 0)]

--- a/btclib/ecc/ecies.py
+++ b/btclib/ecc/ecies.py
@@ -81,7 +81,7 @@ from btclib.curves import bytes_from_point, mult, secp256k1
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.to_pub_key import PubKey, point_from_pub_key
-from btclib.utils import bytes_from_octets
+from btclib.utils import assert_type, bytes_from_octets, str_from_string
 
 __all__ = [
     "MAGIC",
@@ -255,7 +255,15 @@ class Envelope:
         The magic is compared here rather than left to the caller: the
         first four bytes are what answer "is this a BIE1 envelope at all",
         and every offset below is meaningless if they do not.
+
+        Its type is asked before that comparison, and `b64decode` is
+        covered by the same question, handing this one what it was given:
+        a magic of no bytes type is unequal to whatever the buffer starts
+        with, so every envelope would have been refused for the bytes it
+        does carry rather than for the argument that cannot be any.
         """
+        assert_type(magic, bytes, "magic")
+
         data = bytes_from_octets(data)
         # the shortest envelope there can be: the four fixed-size fields
         # with a single block of ciphertext between them
@@ -294,11 +302,15 @@ class Envelope:
         # validate=True rejects that junk, and requiring the canonical
         # re-encoding covers what validate leaves to the interpreter --
         # see the same reasoning, at length, on bms.Sig.b64decode.
-        # Stripping covers bytes as well as str: the whitespace around a
-        # copied and pasted envelope is the one laxity worth tolerating
-        data = data.strip()
+        # The coercion before the strip, as that method does it and for
+        # the reason issue #814 gives: what is neither text nor bytes
+        # reached `.strip` untouched and left as an AttributeError about
+        # a missing method. Stripping covers bytes as well as str: the
+        # whitespace around a copied and pasted envelope is the one
+        # laxity worth tolerating
+        text = str_from_string(data, "base64 envelope").strip()
         try:
-            data_bin = data.encode("ascii") if isinstance(data, str) else data
+            data_bin = text.encode("ascii")
             data_decoded = base64.b64decode(data_bin, validate=True)
         except ValueError as e:  # binascii.Error and UnicodeEncodeError
             raise BTClibValueError(f"invalid base64 encoding: {e}") from e

--- a/btclib/network.py
+++ b/btclib/network.py
@@ -42,7 +42,7 @@ from btclib.alias import NetworkField, NetworkName, NetworkType, Octets
 from btclib.curves import Curve
 from btclib.curves.curve import CURVES, _assert_valid_ec
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.utils import bytes_from_octets
+from btclib.utils import assert_type, bytes_from_octets, fields_from_json_object
 
 __all__ = [
     "NETWORKS",
@@ -79,6 +79,20 @@ _KEY_SIZE: list[tuple[NetworkField, int]] = [
     ("slip132_p2wsh_p2sh_prv", 4),
     ("slip132_p2wsh_p2sh_pub", 4),
 ]
+
+
+def _curve_from_name(name: Any) -> Curve:
+    """Return the curve `to_dict` names, refusing what names none.
+
+    `CURVES[...]` alone answers an unknown name with a `KeyError`, which
+    is neither a `BTClibException` nor a `ValueError`, and an unhashable
+    one with a `TypeError` about dict keys -- the field `from_dict` reads
+    before the constructor, so `assert_valid` never sees either.
+    """
+    assert_type(name, str, "curve name")
+    if name not in CURVES:
+        raise BTClibValueError(f"unknown curve: {name}")
+    return CURVES[name]
 
 
 @dataclass(frozen=True)
@@ -237,8 +251,9 @@ class Network:
         cls: type[Network], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> Network:
         """Build a Network from the dict shape to_dict writes."""
+        dict_ = fields_from_json_object(dict_, "network")
         return cls(
-            CURVES[dict_["curve"]],
+            _curve_from_name(dict_["curve"]),
             dict_["genesis_block"],
             dict_["wif"],
             dict_["p2pkh"],

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -52,10 +52,13 @@ from btclib.psbt.psbt_utils import (
     LEAF_HASH_SIZE,
     MUSIG2_PUB_KEY_SIZE,
     PSBT_SEPARATOR,
+    PSBT_V0,
+    PSBT_V2,
     SP_DLEQ_PROOF_SIZE,
     SP_ECDH_SHARE_SIZE,
     SP_V0_INFO_VERSION,
     assert_not_a_v2_field,
+    assert_valid_psbt_version,
     assert_valid_sp_scan_key_map,
     assert_valid_unknown,
     decode_dict_bytes_bytes,
@@ -92,7 +95,10 @@ from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
     bytesio_from_binarydata,
+    fields_from_json_object,
     is_integer,
+    list_from_json_array,
+    str_from_string,
 )
 
 __all__ = [
@@ -165,12 +171,6 @@ PSBT_GLOBAL_VERSION = b"\xfb"
 # 0xfc is reserved for proprietary use, and needs no constant of its own:
 # explicit support for proprietary (and por) is unnecessary,
 # see https://github.com/bitcoin/bips/pull/1038
-
-# the two versions there are. Version 1 is not one of them and never will
-# be: BIP370 skipped the number because version 0 had been colloquially
-# called version 1 while it was being designed
-PSBT_V0 = 0
-PSBT_V2 = 2
 
 # the global fields BIP370 defines, which a version 0 psbt must not
 # carry: in version 2 the unsigned transaction stops being a field and
@@ -252,25 +252,6 @@ def _assert_int_field_types(
     ):
         if value is not None and not is_integer(value):
             raise BTClibTypeError(f"invalid {name} type: {type(value).__name__}")
-
-
-def _assert_valid_version(version: int) -> None:
-    # the type before the range, as Tx.assert_valid checks its own two int
-    # fields: a comparison against a value of no integer type raises from
-    # underneath the library, and a bool passes every one of them as one
-    # or zero -- `to_dict`/`from_dict` being a json boundary, where `true`
-    # would be version 0 rather than a schema error
-    if not is_integer(version):
-        raise BTClibTypeError(f"invalid version type: {type(version).__name__}")
-    # must be a 4-bytes int
-    if not 0 <= version <= 0xFFFFFFFF:
-        raise BTClibValueError(f"invalid version: {version}")
-    # and one of the two that exist, which is a narrower rule than "a
-    # version btclib does not know": a psbt claiming version 3 is not a
-    # psbt of a later BIP, no such BIP being written -- version 1 was
-    # skipped and nothing has taken any number since
-    if version not in {PSBT_V0, PSBT_V2}:
-        raise BTClibValueError(f"invalid psbt version: {version}")
 
 
 def _required_lock_times(psbt_in: PsbtIn) -> tuple[int | None, int | None]:
@@ -1110,7 +1091,7 @@ class Psbt:
         unsigned transaction.
         """
         # first, the version being what every rule below is read under
-        _assert_valid_version(self.version)
+        assert_valid_psbt_version(self.version)
 
         # then the type of the other two int fields, before any rule
         # reads either
@@ -1228,6 +1209,7 @@ class Psbt:
         cls: type[Psbt], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> Psbt:
         """Build a Psbt from the dict shape to_dict writes."""
+        dict_ = fields_from_json_object(dict_, "psbt")
         hd_key_paths = cast(
             Mapping[Octets, BIP32KeyOrigin],
             # check_validity=False, as for every other element here (issue
@@ -1243,11 +1225,11 @@ class Psbt:
             # psbts BIP174 lists as valid (issue 170)
             [
                 PsbtIn.from_dict(psbt_in, check_validity=False)
-                for psbt_in in dict_["inputs"]
+                for psbt_in in list_from_json_array(dict_["inputs"], "psbt inputs")
             ],
             [
                 PsbtOut.from_dict(psbt_out, check_validity=False)
-                for psbt_out in dict_["outputs"]
+                for psbt_out in list_from_json_array(dict_["outputs"], "psbt outputs")
             ],
             dict_["version"],
             hd_key_paths,
@@ -1321,7 +1303,7 @@ class Psbt:
             # fields are written *is* the version, so a version with no
             # answer to that has no serialization for the check to be
             # skipped over
-            _assert_valid_version(self.version)
+            assert_valid_psbt_version(self.version)
 
         # written by both versions, BIP322 allowing it in either, and
         # written here rather than in the two branches above for that
@@ -1376,7 +1358,7 @@ class Psbt:
         # BIP370 defining twelve of them that version 0 must not carry, and
         # a map has no order to put the version first in
         version = _global_version(global_map)
-        _assert_valid_version(version)
+        assert_valid_psbt_version(version)
         (
             tx,
             globals_,
@@ -1441,9 +1423,16 @@ class Psbt:
     def b64decode(
         cls: type[Psbt], psbt_str: String, *, check_validity: bool = True
     ) -> Psbt:
-        """Build a Psbt from its base64 text, stripping whitespace."""
-        if isinstance(psbt_str, str):
-            psbt_str = psbt_str.strip()
+        """Build a Psbt from its base64 text, stripping whitespace.
+
+        The coercion before the strip, as `bms.Sig.b64decode` does it and
+        for the reason issue #814 gives: what is neither text nor bytes
+        used to reach `base64.b64decode` untouched, and left as its
+        "argument should be a bytes-like object or ASCII string" -- a
+        complaint about a builtin rather than about the psbt that was
+        passed.
+        """
+        psbt_str = str_from_string(psbt_str, "base64 psbt").strip()
 
         # base64 answers a string it cannot read with binascii.Error, and
         # a str carrying a non-ascii character with a plain ValueError.

--- a/btclib/psbt/psbt_in.py
+++ b/btclib/psbt/psbt_in.py
@@ -38,6 +38,7 @@ from btclib.psbt.psbt_utils import (
     assert_valid_leaf_scripts,
     assert_valid_musig2_participant_pub_keys,
     assert_valid_musig2_session_data,
+    assert_valid_psbt_version,
     assert_valid_redeem_script,
     assert_valid_sp_scan_key_map,
     assert_valid_taproot_bip32_derivation,
@@ -76,6 +77,7 @@ from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
     bytesio_from_binarydata,
+    fields_from_json_object,
 )
 
 __all__ = [
@@ -821,6 +823,7 @@ class PsbtIn:
         cls: type[PsbtIn], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> PsbtIn:
         """Build a PsbtIn from the dict shape to_dict writes."""
+        dict_ = fields_from_json_object(dict_, "psbt input")
         hd_key_paths = cast(
             Mapping[Octets, BIP32KeyOrigin],
             # check_validity=False, as for every other element here (issue
@@ -877,8 +880,13 @@ class PsbtIn:
         psbt_version is the version of the psbt the map belongs to, and
         it decides whether the BIP370 fields are written here or folded
         into the psbt's unsigned transaction; an input serialized on its
-        own is written as version 0, the version BIP174 defines.
+        own is written as version 0, the version BIP174 defines. It is
+        asked for, and not read for its truth: every version that is not
+        0 wrote the BIP370 fields, so a `None` or a 3 wrote a version 2
+        input and said nothing.
         """
+        assert_valid_psbt_version(psbt_version)
+
         if check_validity:
             self.assert_valid()
 
@@ -918,13 +926,16 @@ class PsbtIn:
         psbt_version is the version of the psbt the map belongs to, which
         decides whether a BIP370 type byte is a field of this input or
         one this version must not carry; an input read on its own is read
-        as version 0, the version BIP174 defines.
+        as version 0, the version BIP174 defines. Asked for as
+        `serialize` asks for it, and for the same reason.
 
         Octets are one whole input and a stream is the caller's, as they
         are for the psbt these maps make: `Psbt.parse` threads one stream
         through the inputs and the outputs, and what follows an input in it
         is the next one.
         """
+        assert_valid_psbt_version(psbt_version)
+
         stream = bytesio_from_binarydata(data)
         input_map = deserialize_map(stream)
         assert_no_trailing(data, stream, "psbt input")

--- a/btclib/psbt/psbt_out.py
+++ b/btclib/psbt/psbt_out.py
@@ -29,6 +29,7 @@ from btclib.psbt.psbt_utils import (
     PSBT_SEPARATOR,
     assert_not_a_v2_field,
     assert_valid_musig2_participant_pub_keys,
+    assert_valid_psbt_version,
     assert_valid_redeem_script,
     assert_valid_sp_v0_info,
     assert_valid_taproot_bip32_derivation,
@@ -63,6 +64,7 @@ from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
     bytesio_from_binarydata,
+    fields_from_json_object,
 )
 
 __all__ = [
@@ -312,6 +314,7 @@ class PsbtOut:
         cls: type[PsbtOut], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> PsbtOut:
         """Build a PsbtOut from the dict shape to_dict writes."""
+        dict_ = fields_from_json_object(dict_, "psbt output")
         hd_key_paths = cast(
             Mapping[Octets, BIP32KeyOrigin],
             # check_validity=False, as for every other element here (issue
@@ -348,8 +351,12 @@ class PsbtOut:
         it decides whether the two BIP370 fields are written here or
         folded into the psbt's unsigned transaction; an output
         serialized on its own is written as version 0, the version
-        BIP174 defines.
+        BIP174 defines. It is asked for, and not read for its truth:
+        every version that is not 0 wrote the BIP370 fields, so a `None`
+        or a 3 wrote a version 2 output and said nothing.
         """
+        assert_valid_psbt_version(psbt_version)
+
         if check_validity:
             self.assert_valid()
 
@@ -415,13 +422,16 @@ class PsbtOut:
         psbt_version is the version of the psbt the map belongs to, which
         decides whether a BIP370 type byte is a field of this output or
         one this version must not carry; an output read on its own is
-        read as version 0, the version BIP174 defines.
+        read as version 0, the version BIP174 defines. Asked for as
+        `serialize` asks for it, and for the same reason.
 
         Octets are one whole output and a stream is the caller's, as they
         are for the psbt these maps make: `Psbt.parse` threads one stream
         through the inputs and the outputs, and what follows an output in it
         is the next one.
         """
+        assert_valid_psbt_version(psbt_version)
+
         stream = bytesio_from_binarydata(data)
         output_map = deserialize_map(stream)
         assert_no_trailing(data, stream, "psbt output")

--- a/btclib/psbt/psbt_utils.py
+++ b/btclib/psbt/psbt_utils.py
@@ -18,11 +18,18 @@ from btclib.alias import BinaryData, Octets
 from btclib.bip32 import BIP32KeyOrigin
 from btclib.bip32.der_path import indexes_from_der_path, str_from_der_path
 from btclib.curves import sec_point
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.script.sig_hash import DEFAULT, SIG_HASH_TYPES
 from btclib.script.taproot import assert_valid_control_block
 from btclib.tx import Tx
-from btclib.utils import bytes_from_octets, bytesio_from_binarydata, read_exactly
+from btclib.utils import (
+    bytes_from_octets,
+    bytesio_from_binarydata,
+    fields_from_json_object,
+    is_integer,
+    list_from_json_array,
+    read_exactly,
+)
 
 __all__ = [
     "FINGERPRINT_SIZE",
@@ -32,6 +39,8 @@ __all__ = [
     "MUSIG2_PUB_NONCE_SIZE",
     "MUSIG2_SESSION_KEY_SIZES",
     "PSBT_SEPARATOR",
+    "PSBT_V0",
+    "PSBT_V2",
     "SP_DLEQ_PROOF_SIZE",
     "SP_ECDH_SHARE_SIZE",
     "SP_SCAN_KEY_SIZE",
@@ -43,6 +52,7 @@ __all__ = [
     "assert_valid_musig2_participant_pub_keys",
     "assert_valid_musig2_pub_key",
     "assert_valid_musig2_session_data",
+    "assert_valid_psbt_version",
     "assert_valid_redeem_script",
     "assert_valid_sp_scan_key_map",
     "assert_valid_sp_v0_info",
@@ -141,6 +151,12 @@ SP_V0_INFO_VERSION = b"\x00"
 # one; the 0xff has no constant of its own, being part of
 # psbt.PSBT_MAGIC_BYTES, which is where the header says the rest
 PSBT_SEPARATOR = b"\x00"
+
+# the two versions there are, here rather than in `psbt.py` for the reason
+# `assert_valid_psbt_version` below states: the maps take one as an
+# argument, and they are underneath the psbt that has one as a field
+PSBT_V0 = 0
+PSBT_V2 = 2
 
 
 def deserialize_map(data: BinaryData) -> dict[bytes, bytes]:
@@ -403,7 +419,12 @@ def taproot_bip32_from_dict(
     """Return a tap_bip32_derivation from its json representation."""
     return {
         bytes_from_octets(bip32_deriv["pub_key"], 32 if check_validity else None): (
-            [bytes_from_octets(x) for x in bip32_deriv["leaf_hashes"]],
+            [
+                bytes_from_octets(x)
+                for x in list_from_json_array(
+                    bip32_deriv["leaf_hashes"], "taproot leaf hashes"
+                )
+            ],
             BIP32KeyOrigin(
                 bytes_from_octets(
                     bip32_deriv["master_fingerprint"], 4 if check_validity else None
@@ -412,7 +433,12 @@ def taproot_bip32_from_dict(
                 check_validity=check_validity,
             ),
         )
-        for bip32_deriv in taproot_hd_key_paths
+        for bip32_deriv in (
+            fields_from_json_object(item, "taproot bip32 derivation")
+            for item in list_from_json_array(
+                taproot_hd_key_paths, "taproot bip32 derivations"
+            )
+        )
     }
 
 
@@ -658,6 +684,37 @@ def assert_valid_unknown(data: Mapping[bytes, bytes]) -> None:
     for key, value in data.items():
         bytes(key)
         bytes(value)
+
+
+def assert_valid_psbt_version(version: Any) -> None:
+    """Refuse a psbt version that is not one of the two there are.
+
+    Here rather than in `psbt.py`, where the psbt is: the version is as
+    much an argument of `PsbtIn.serialize` and `PsbtOut.parse`, which
+    decide by it whether the BIP370 fields belong to the map or to the
+    unsigned transaction, and those two modules are underneath `psbt.py`
+    and cannot import from it.
+
+    The type before the range, as `Tx.assert_valid` checks its own two
+    int fields: a comparison against a value of no integer type raises
+    from underneath the library, and a bool passes every one of them as
+    one or zero -- `to_dict`/`from_dict` being a json boundary, where
+    `true` would be version 0 rather than a schema error.
+
+    Then the two versions there are, which is a narrower rule than "a
+    version btclib does not know": a psbt claiming version 3 is not a
+    psbt of a later BIP, no such BIP being written. Version 1 is not one
+    of them and never will be -- BIP370 skipped the number because
+    version 0 had been colloquially called version 1 while it was being
+    designed.
+    """
+    if not is_integer(version):
+        raise BTClibTypeError(f"invalid version type: {type(version).__name__}")
+    # must be a 4-bytes int
+    if not 0 <= version <= 0xFFFFFFFF:
+        raise BTClibValueError(f"invalid version: {version}")
+    if version not in {PSBT_V0, PSBT_V2}:
+        raise BTClibValueError(f"invalid psbt version: {version}")
 
 
 def assert_not_a_v2_field(

--- a/btclib/psbt/psbt_view.py
+++ b/btclib/psbt/psbt_view.py
@@ -90,7 +90,6 @@ from btclib.psbt.psbt import (
     _assert_valid_input_fields,
     _assert_valid_output_fields,
     _assert_valid_utxo,
-    _assert_valid_version,
     _ecdsa_sig_hash,
     _global_version,
     _lock_time,
@@ -109,6 +108,7 @@ from btclib.psbt.psbt_out import PsbtOut
 from btclib.psbt.psbt_utils import (
     SP_DLEQ_PROOF_SIZE,
     SP_ECDH_SHARE_SIZE,
+    assert_valid_psbt_version,
     assert_valid_sp_scan_key_map,
     assert_valid_unknown,
     decode_dict_bytes_bytes,
@@ -239,7 +239,7 @@ class PsbtView:
         # it, as in `Psbt.parse`: what a type byte means is version
         # dependent, and a map has no order to put the version first in
         version = _global_version(global_map)
-        _assert_valid_version(version)
+        assert_valid_psbt_version(version)
         (
             tx,
             globals_,

--- a/btclib/script/script.py
+++ b/btclib/script/script.py
@@ -34,8 +34,13 @@ from typing import cast
 from warnings import warn
 
 from btclib.alias import BinaryData, Command, Octets, ScriptList
-from btclib.exceptions import BTClibUserWarning, BTClibValueError
-from btclib.utils import bytes_from_octets, bytesio_from_binarydata, encode_num
+from btclib.exceptions import BTClibTypeError, BTClibUserWarning, BTClibValueError
+from btclib.utils import (
+    bytes_from_octets,
+    bytesio_from_binarydata,
+    encode_num,
+    fields_from_json_object,
+)
 
 __all__ = [
     "BYTE_FROM_OP_CODE_NAME",
@@ -456,7 +461,22 @@ def serialize(script: Sequence[Command]) -> bytes:
     empty vector is what `encode_num` writes for it, and the push of an
     empty vector is OP_0, so `serialize([0])` is the op code -- as Core's
     `CScript() << 0` is -- with nothing shorter left to suggest.
+
+    A sequence of commands and not one command: `Sequence[Command]`
+    accepts a `str` and a `bytes`, each of them being a sequence of
+    `Command` as far as the type goes, so `serialize("OP_DUP")` was six
+    one-character commands and a `bytes` handed here a script of one
+    integer command per byte -- the first refused for a character it
+    could not read as an op code, the second accepted and wrong. What
+    is not a sequence at all was "not iterable" from underneath the
+    library.
     """
+    if isinstance(script, (str, bytes, bytearray, memoryview)) or not isinstance(
+        script, Sequence
+    ):
+        err_msg = f"invalid script commands type: {type(script).__name__}"
+        raise BTClibTypeError(err_msg)
+
     r: list[bytes] = []
     for command in script:
         if isinstance(command, int):
@@ -594,6 +614,7 @@ def script_from_dict(value: Mapping[str, str] | Octets) -> bytes:
     if not isinstance(value, Mapping):
         return bytes_from_octets(value)
 
+    value = fields_from_json_object(value, "script")
     script = bytes_from_octets(value["hex"])
     asm = value.get("asm")
     # compared against what to_dict would emit, not against a second

--- a/btclib/script/witness.py
+++ b/btclib/script/witness.py
@@ -16,6 +16,8 @@ from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
     bytesio_from_binarydata,
+    fields_from_json_object,
+    list_from_json_array,
 )
 
 __all__ = [
@@ -88,8 +90,16 @@ class Witness:
         *,
         check_validity: bool = True,
     ) -> Witness:
-        """Build a Witness from the dict shape to_dict writes."""
-        return cls(dict_["stack"], check_validity=check_validity)
+        """Build a Witness from the dict shape to_dict writes.
+
+        The stack is asked for as an array rather than left to the
+        constructor, which reads `stack or []`: a `None` there is an
+        empty witness, so a schema mistake was a witness of no elements
+        instead of an error.
+        """
+        dict_ = fields_from_json_object(dict_, "witness")
+        stack = list_from_json_array(dict_["stack"], "witness stack")
+        return cls(stack, check_validity=check_validity)
 
     def _serialized_size(self) -> int:
         """Return what serialize writes, without writing it."""

--- a/btclib/tx/out_point.py
+++ b/btclib/tx/out_point.py
@@ -16,6 +16,7 @@ from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
     bytesio_from_binarydata,
+    fields_from_json_object,
     is_integer,
     read_exactly,
 )
@@ -124,6 +125,7 @@ class OutPoint:
         cls: type[OutPoint], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> OutPoint:
         """Build an OutPoint from the dict shape to_dict writes."""
+        dict_ = fields_from_json_object(dict_, "outpoint")
         return cls(dict_["txid"], dict_["vout"], check_validity=check_validity)
 
     def _serialized_size(self) -> int:

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -25,8 +25,11 @@ from btclib.tx.tx_in import TX_IN_COMPARES_WITNESS, TxIn
 from btclib.tx.tx_out import TxOut
 from btclib.utils import (
     assert_no_trailing,
+    assert_type,
     bytesio_from_binarydata,
+    fields_from_json_object,
     is_integer,
+    list_from_json_array,
     read_exactly,
 )
 
@@ -282,11 +285,18 @@ class Tx:  # noqa: PLW1641
         cls: type[Tx], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> Tx:
         """Build a Tx from the dict shape to_dict writes."""
+        dict_ = fields_from_json_object(dict_, "transaction")
         return cls(
             dict_["version"],
             dict_["locktime"],
-            [TxIn.from_dict(tx_in, check_validity=False) for tx_in in dict_["vin"]],
-            [TxOut.from_dict(tx_out, check_validity=False) for tx_out in dict_["vout"]],
+            [
+                TxIn.from_dict(tx_in, check_validity=False)
+                for tx_in in list_from_json_array(dict_["vin"], "transaction inputs")
+            ],
+            [
+                TxOut.from_dict(tx_out, check_validity=False)
+                for tx_out in list_from_json_array(dict_["vout"], "transaction outputs")
+            ],
             check_validity=check_validity,
         )
 
@@ -361,7 +371,15 @@ class Tx:  # noqa: PLW1641
         the txid is computed over; True adds the marker and the
         witnesses only if some input has one, a marker over empty
         witnesses not being what the wire writes.
+
+        A bool and nothing else, which is the line
+        `tests/built_object_contract_test.py` draws: this flag decides
+        *what is computed* rather than whether a check runs, so a value
+        read for its truth would answer a stripped serialization -- a
+        different transaction id -- where the wire one was meant.
         """
+        assert_type(include_witness, bool, "include_witness")
+
         if check_validity:
             self.assert_valid()
         else:

--- a/btclib/tx/tx_in.py
+++ b/btclib/tx/tx_in.py
@@ -19,6 +19,7 @@ from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
     bytesio_from_binarydata,
+    fields_from_json_object,
     is_integer,
     read_exactly,
 )
@@ -172,6 +173,7 @@ class TxIn:
         cls: type[TxIn], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> TxIn:
         """Build a TxIn from the dict shape to_dict writes."""
+        dict_ = fields_from_json_object(dict_, "transaction input")
         return cls(
             OutPoint.from_dict(dict_["prev_out"], check_validity=False),
             script_from_dict(dict_["scriptSig"]),

--- a/btclib/tx/tx_out.py
+++ b/btclib/tx/tx_out.py
@@ -18,6 +18,7 @@ from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
     bytesio_from_binarydata,
+    fields_from_json_object,
     read_exactly,
 )
 
@@ -138,6 +139,7 @@ class TxOut:
         cls: type[TxOut], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> TxOut:
         """Build a TxOut from the dict shape to_dict writes."""
+        dict_ = fields_from_json_object(dict_, "transaction output")
         value = sats_from_btc(dict_["value"])
         script_bin = script_from_dict(dict_["scriptPubKey"])
         network = dict_.get("network", "mainnet")

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -52,7 +52,7 @@ read under.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from io import BytesIO
 from typing import Any, BinaryIO
 
@@ -62,15 +62,18 @@ from btclib.exceptions import BTClibTypeError, BTClibValueError
 __all__ = [
     "NoneOneOrMoreInt",
     "assert_no_trailing",
+    "assert_type",
     "bytes_from_octets",
     "bytesio_from_binarydata",
     "decode_num",
     "encode_num",
+    "fields_from_json_object",
     "hex_string",
     "int_from_bits",
     "int_from_integer",
     "int_from_json_number",
     "is_integer",
+    "list_from_json_array",
     "read_exactly",
     "str_from_string",
 ]
@@ -298,6 +301,91 @@ def int_from_json_number(value: Any, what: str) -> int:
         raise BTClibTypeError(f"invalid {what} type: {type(value).__name__}") from e
     except ValueError as e:
         raise BTClibValueError(f"invalid {what}: {value!r}") from e
+
+
+def assert_type(value: Any, expected: Any, what: str) -> None:
+    """Refuse a value of a type the signature does not declare.
+
+    `expected` is what `isinstance` takes: one type, or a tuple of them.
+    `bytes_from_octets` and `str_from_string` are the two coercions this
+    library has, and each refuses what it cannot convert; this is the
+    refusal for a position that takes neither -- a `bool` flag deciding
+    which of two serializations is written, the text of a URI or a
+    descriptor, the magic bytes an envelope is read against. Every one of
+    those was compared, walked or handed to a builtin unasked, and left
+    as a complaint about that builtin.
+
+    `value` is `Any` rather than the declared type, which is what makes
+    the check reachable: mypy proves the argument cannot be wrong, and
+    the caller who has not run mypy is who this is for.
+    """
+    if not isinstance(value, expected):
+        raise BTClibTypeError(f"invalid {what} type: {type(value).__name__}")
+
+
+class _JsonObject(dict[str, Any]):
+    """A json object that says which field it has not got.
+
+    `dict.__getitem__` calls `__missing__` on a key it does not hold, and
+    the default raises the `KeyError` that is not a `BTClibException`; a
+    subclass is what lets every `dict_[...]` in a `from_dict` stay the
+    plain lookup it reads as and still answer through the contract.
+    """
+
+    def __init__(self, what: str, dict_: Mapping[str, Any]) -> None:
+        super().__init__(dict_)
+        self.what = what
+
+    def __missing__(self, key: str) -> Any:
+        raise BTClibValueError(f"missing {self.what} field: {key}")
+
+
+def fields_from_json_object(dict_: Any, what: str) -> Mapping[str, Any]:
+    """Return the fields of a json object, refusing what is not one.
+
+    The first line of every `from_dict`, and it answers the two questions
+    that boundary owes its caller before a field is read:
+
+    - a `Mapping[str, Any]` is what the signature declares, and what is
+      not one used to be walked anyway: `dict_["version"]` on a None is a
+      TypeError about subscripting, on a str a TypeError about string
+      indices, and neither says btclib refused anything
+    - a mapping that is one and has not got the field is a value no valid
+      input carries, so it is a `BTClibValueError` naming the field --
+      `from_dict` is fed whatever a schema mistake produced, and a bare
+      `KeyError` is neither a `BTClibException` nor a `ValueError`
+
+    `what` names the object, the caller knowing what it is reading and
+    this not, as `read_exactly` names a field. `.get` is untouched and
+    stays the spelling for a field that may be absent.
+
+    `Any` rather than the `Mapping` every caller declares, for the reason
+    `assert_type` takes one: the check is here for the caller mypy did
+    not read.
+    """
+    if not isinstance(dict_, Mapping):
+        err_msg = f"invalid {what} dict type: {type(dict_).__name__}"
+        raise BTClibTypeError(err_msg)
+    return _JsonObject(what, dict_)
+
+
+def list_from_json_array(value: Any, what: str) -> list[Any]:
+    """Return the list of a json array, a str and a mapping not being one.
+
+    What `fields_from_json_object` is to the object, for the arrays a
+    `from_dict` walks: the inputs of a transaction, the transactions of a
+    block, the stack of a witness. Unasked, a non-iterable is "not
+    iterable" from underneath the library, and the two iterables that are
+    not arrays are worse than that -- a `str` is a list of its characters
+    and a `Mapping` a list of its keys, so each element is refused for
+    what it is not rather than the whole for what it is.
+    """
+    if isinstance(
+        value, (str, bytes, bytearray, memoryview, Mapping)
+    ) or not isinstance(value, Iterable):
+        err_msg = f"invalid {what} type: {type(value).__name__}"
+        raise BTClibTypeError(err_msg)
+    return list(value)
 
 
 def int_from_bits(octets: Octets, nlen: int) -> int:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -29,13 +29,52 @@ beside the helpers of `tests/script/__init__.py` and
 """
 
 import csv
+import importlib
 import json
+import pkgutil
 import re
 from dataclasses import fields
 from pathlib import Path
 from typing import Any
 
+import btclib
+
 _TESTS_DIR = Path(__file__).parent
+
+
+def public_classes_with(method_name: str) -> set[str]:
+    """Return every public btclib class offering that method, module included.
+
+    Found rather than listed, which is what makes an inventory a promise:
+    a class added to the library has to appear in the test that holds the
+    method to its contract, or be named an exclusion there. A class this
+    walk cannot reach is one no caller can import either.
+
+    The module is part of the name because three classes are called
+    `Sig`. A private class is skipped, the contract being about what a
+    caller can reach.
+
+    Here rather than in the one test that first needed it: two files hold
+    the same classes to two different contracts -- where the bytes end,
+    and what type the argument is -- and neither owns the walk.
+    """
+    module_names = [
+        "btclib",
+        *(module.name for module in pkgutil.walk_packages(btclib.__path__, "btclib.")),
+    ]
+    found = set()
+    for module_name in module_names:
+        module = importlib.import_module(module_name)
+        for obj in vars(module).values():
+            if not isinstance(obj, type):
+                continue
+            if not getattr(obj, "__module__", "").startswith("btclib"):
+                continue
+            if obj.__qualname__.startswith("_"):
+                continue
+            if callable(getattr(obj, method_name, None)):
+                found.add(f"{obj.__module__}.{obj.__qualname__}")
+    return found
 
 
 def load(*relative_path: str, encoding: str = "ascii") -> Any:

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -67,7 +67,7 @@ UNEXPORTED = {
 }
 
 # what a module exports without defining it, which for a module rather than a
-# package is a leak -- and these three are the exception, on two decisions.
+# package is a leak -- and these four are the exception, on three decisions.
 # The `bitcoin-core-rpc` package is the canonical source of the rpc client and
 # of the transport under it, and btclib depends on it rather than carrying a
 # copy; the first two modules below are where those objects were before it was
@@ -82,10 +82,16 @@ UNEXPORTED = {
 # being where the rest of Core's header is and where a caller reading a
 # block's own rules goes.
 #
+# `btclib.psbt.psbt_utils` is the third, and it is the same shape: the two
+# psbt versions decide what an input and an output map write and read, and
+# neither `psbt_in` nor `psbt_out` can import `psbt`, so the pair is defined
+# below all three. `btclib.psbt.psbt` names them still, being where the rest
+# of the format's constants are.
+#
 # So a name here is not a name about to leak: it is the same object under the
 # name a caller already had, which each entry records its canonical module for
-# and the test below asserts. What would be a leak is a *fourth* module, or a
-# name in these three that the canonical module does not export
+# and the test below asserts. What would be a leak is a *fifth* module, or a
+# name in these four that the canonical module does not export
 REEXPORTED = {
     "btclib.fetch.bitcoin_core": (
         bitcoin_core_rpc,
@@ -111,6 +117,10 @@ REEXPORTED = {
     "btclib.block.limits": (
         consensus,
         ["MAX_BLOCK_WEIGHT", "WITNESS_SCALE_FACTOR"],
+    ),
+    "btclib.psbt.psbt": (
+        psbt_utils,
+        ["PSBT_V0", "PSBT_V2"],
     ),
 }
 
@@ -590,12 +600,13 @@ def test_no_module_exports_a_name_it_imported() -> None:
     module with a reason to re-export something is a conversation to have
     with this test, not around it.
 
-    `REEXPORTED` is that conversation, held twice: the two modules whose
-    objects moved into the `bitcoin-core-rpc` package alias them back under
-    the names callers had, a transport having one bounded-read policy to
-    keep; and `btclib.block.limits` names the two constants `btclib.consensus`
+    `REEXPORTED` is that conversation, held three times: the two modules
+    whose objects moved into the `bitcoin-core-rpc` package alias them back
+    under the names callers had, a transport having one bounded-read policy
+    to keep; `btclib.block.limits` names the two constants `btclib.consensus`
     defines below the package, which is where a caller reading a block's
-    rules looks for them.
+    rules looks for them; and `btclib.psbt.psbt` names the two psbt versions
+    that `psbt_utils` defines below the maps taking one as an argument.
 
     Asserted both ways, because a skip list is only half a table: it says
     which names may be re-exported and nothing about whether they still are,

--- a/tests/bip21_test.py
+++ b/tests/bip21_test.py
@@ -25,7 +25,7 @@ from decimal import Decimal
 import pytest
 
 from btclib.bip21 import Bip21
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 
 # BIP21's example address, with its last character corrected
 ADDR = "175tWpb8K1S7NmH4Zx6rewF9WQrcZv2456"
@@ -240,7 +240,9 @@ def test_a_uri_that_is_not_one() -> None:
         with pytest.raises(BTClibValueError, match="not a bitcoin URI"):
             Bip21.parse(uri)
 
-    with pytest.raises(BTClibValueError, match="not a string"):
+    # a type and not a value, `uri` declaring `str` alone: the bytes of a
+    # URI are not a spelling of it, where the octets of a signature are
+    with pytest.raises(BTClibTypeError, match="invalid uri type"):
         Bip21.parse(b"bitcoin:")  # type: ignore[arg-type]
 
     # the scheme with nothing after it

--- a/tests/parse_contract_test.py
+++ b/tests/parse_contract_test.py
@@ -20,8 +20,6 @@ added to btclib and forgotten here would otherwise be held to nothing.
 
 from __future__ import annotations
 
-import importlib
-import pkgutil
 from collections.abc import Callable
 from io import BytesIO
 from pathlib import Path
@@ -29,7 +27,6 @@ from typing import Any
 
 import pytest
 
-import btclib
 from btclib.bip32 import BIP32KeyData, BIP32KeyOrigin
 from btclib.block import Block, BlockHeader
 from btclib.ecc import bms, ssa
@@ -37,6 +34,7 @@ from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueEr
 from btclib.psbt import Psbt, PsbtIn, PsbtOut
 from btclib.script import Witness
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
+from tests import public_classes_with
 
 # what btclib promises to raise, and the whole of it: a truncated buffer
 # has to be refused as one of these three, and never as an IndexError or a
@@ -272,45 +270,19 @@ _EXCLUDED = {
 }
 
 
-def _public_parsers() -> set[str]:
-    """Return every public btclib class offering a `parse`, module included.
-
-    Found rather than listed, which is the whole point: a parser added to
-    the library has to appear in the inventory above or be named an
-    exclusion, and a class the walk cannot reach is one no caller can
-    import either.
-
-    The module is part of the name because three classes are called `Sig`.
-    A private class is skipped, the contract being about what a caller can
-    reach -- `_BIP32KeyData` is the one such today, and its public
-    subclass is in the inventory.
-    """
-    module_names = [
-        "btclib",
-        *(module.name for module in pkgutil.walk_packages(btclib.__path__, "btclib.")),
-    ]
-    parsers = set()
-    for module_name in module_names:
-        module = importlib.import_module(module_name)
-        for obj in vars(module).values():
-            if not isinstance(obj, type):
-                continue
-            if not getattr(obj, "__module__", "").startswith("btclib"):
-                continue
-            if obj.__qualname__.startswith("_"):
-                continue
-            if callable(getattr(obj, "parse", None)):
-                parsers.add(f"{obj.__module__}.{obj.__qualname__}")
-    return parsers
-
-
 def test_every_parser_is_covered_or_named_an_exclusion() -> None:
     """The inventory is a promise only if omission is what fails.
 
     A parser added to btclib and forgotten here is the failure this
     catches: the tests above would go on passing on the parsers they were
     given, and the new one would be held to nothing.
+
+    `public_classes_with` is the walk, and it is `tests/__init__.py`'s
+    because `serialization_boundary_test.py` holds these same parsers to
+    a different contract -- where the bytes end is not what type the
+    argument is. A private class is skipped there, which is what leaves
+    `_BIP32KeyData` out here; its public subclass is in the inventory.
     """
     covered = {f"{cls.__module__}.{cls.__qualname__}" for _, cls, _ in _CASES}
     assert not covered & _EXCLUDED.keys()
-    assert _public_parsers() == covered | _EXCLUDED.keys()
+    assert public_classes_with("parse") == covered | _EXCLUDED.keys()

--- a/tests/serialization_boundary_test.py
+++ b/tests/serialization_boundary_test.py
@@ -1,0 +1,620 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The gate for what `parse`, `serialize`, `to_dict` and `from_dict` take.
+
+CONTRIBUTING.md's "Every public function validates its inputs", at the
+boundary where an object meets octets, text or json: a value of a type
+the signature does not declare leaves as a `BTClibTypeError`, a value of
+a declared type that no valid input carries as a `BTClibValueError`.
+Issue #867 is where the family was measured.
+
+**Not the contract `parse_contract_test.py` holds.** That file asks where
+the bytes end -- a field is as long as its encoding says, a complete octet
+string is one whole object, a caller's stream is the caller's -- and this
+one asks what type the argument is. The two are different questions about
+the same methods, which is why the walk that finds every one of them is
+`tests/__init__.py`'s and neither file's.
+
+**`from_dict` is where the hazard is sharpest**, and it had no gate at
+all: it is the json boundary, so its input is whatever a schema mistake
+produced, and every one of the twelve walked the mapping before asking
+whether it was one. A `None` was "not subscriptable", a `str` was "string
+indices must be integers", and a mapping missing a field was a `KeyError`
+-- which is neither a `BTClibException` nor a `ValueError`, so a caller
+catching either never caught it. `utils.fields_from_json_object` is the
+one line that answers both, and `utils.list_from_json_array` the arrays
+it walks: `Sequence[Any]` accepts a `str` and a `Mapping`, so an input
+handed where the list of them was meant was as many inputs as it had
+characters -- issue #856's "annotation that accepts the mistake", at the
+boundary that reads a file.
+
+**`to_dict`, `serialize` and `b64encode` mostly have nothing to drive**:
+their input is the object, which `check_validity_test.py` and
+`built_object_contract_test.py` own between them. The exceptions are the
+four arguments `_EXTRA_ARGUMENTS` records, and the last test is what
+keeps that record honest -- a fifth added to this family fails here until
+it is driven.
+
+`check_validity` is not driven anywhere in this file: it is a flag that
+decides whether a check runs rather than what is computed, so it is read
+for its truth, and `check_validity_test.py` owns that convention.
+`dsa.Sig.parse`'s `strict` is the same kind of flag and the same
+exemption, recorded below beside the arguments that are not.
+"""
+
+from __future__ import annotations
+
+import json
+import pkgutil
+from collections.abc import Callable
+from copy import deepcopy
+from dataclasses import dataclass
+from importlib import import_module
+from inspect import signature
+from typing import Any
+
+import pytest
+
+import btclib
+from btclib import bip322, var_bytes, var_int
+from btclib.bip21 import Bip21
+from btclib.bip32.bip32 import BIP32KeyData
+from btclib.bip32.key_origin import BIP32KeyOrigin
+from btclib.block import Block, BlockHeader
+from btclib.descriptors import descriptors, miniscript
+from btclib.ecc import bms, dsa, ecies, ssa
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.network import NETWORKS, Network
+from btclib.psbt import Psbt, PsbtIn, PsbtOut
+from btclib.psbt.psbt_utils import PSBT_V0, PSBT_V2
+from btclib.script import Witness, script, taproot
+from btclib.to_pub_key import pub_keyinfo_from_prv_key
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
+from tests import load_bin, public_classes_with
+from tests.psbt import psbt_cases
+
+# a value of no type any of these positions declares. `Any`, because
+# every position they are handed to declares something narrower: what
+# these tests are about is the caller who has not run mypy
+_WRONG_TYPES: tuple[Any, ...] = (None, 1.5, [1, 2])
+
+# and the two iterables that are not a json array: each is walked element
+# by element unless it is asked about whole, so what fails is the element
+# rather than the argument
+_NOT_AN_ARRAY: tuple[Any, ...] = (*_WRONG_TYPES, "ab", {"a": 1})
+
+_TX_ID = "01" * 32
+
+_TX = Tx(1, 0x12345678, [TxIn(OutPoint(_TX_ID, 0), b"", 0xFFFFFFFF)], [TxOut(1, b"")])
+_BLOCK = Block.parse(load_bin("block", "_data", "block_1.bin"))
+# a published psbt rather than one built here: what makes the json cases
+# worth running is a mapping with something in it, and the BIP174 vectors
+# are where a psbt carrying derivations, scripts and signatures comes from
+_PSBT = next(
+    psbt
+    for psbt in (
+        Psbt.b64decode(case["encoded psbt"])
+        for case in psbt_cases("bip174_test_vectors.json", "valid psbts")
+    )
+    if any(psbt_in.hd_key_paths for psbt_in in psbt.inputs)
+)
+# framed rather than encrypted: `ecies.encrypt` takes a block cipher this
+# library does not carry, and the framing is all this file is about
+_ENVELOPE = ecies.Envelope.from_ciphertext(
+    pub_keyinfo_from_prv_key(1)[0], b"\x00" * 16, b"key material"
+)
+
+
+@dataclass(frozen=True)
+class _JsonCase:
+    """A class with a `to_dict`/`from_dict` pair, and one valid object."""
+
+    label: str
+    cls: type[Any]
+    obj: Any
+
+
+# every public class with a json boundary, which the last test is what
+# makes a promise: one of these per `from_dict` in the library
+_JSON_CASES = (
+    _JsonCase("OutPoint", OutPoint, _TX.vin[0].prev_out),
+    _JsonCase("TxIn", TxIn, _TX.vin[0]),
+    _JsonCase("TxOut", TxOut, _TX.vout[0]),
+    _JsonCase("Tx", Tx, _TX),
+    _JsonCase("BlockHeader", BlockHeader, _BLOCK.header),
+    _JsonCase("Block", Block, _BLOCK),
+    _JsonCase("Psbt", Psbt, _PSBT),
+    _JsonCase("PsbtIn", PsbtIn, _PSBT.inputs[0]),
+    _JsonCase("PsbtOut", PsbtOut, _PSBT.outputs[0]),
+    _JsonCase("Witness", Witness, Witness([b"\x51", b"\x52\x53"])),
+    _JsonCase("BIP32KeyOrigin", BIP32KeyOrigin, BIP32KeyOrigin("deadbeef", "m/44h/0h")),
+    _JsonCase("Network", Network, NETWORKS["mainnet"]),
+)
+
+_JSON_IDS = tuple(case.label for case in _JSON_CASES)
+
+# the arrays a `from_dict` walks, one per key: the class, the key, and
+# nothing else -- what a wrong value there costs is stated in the test
+_JSON_ARRAYS = (
+    ("Tx", Tx, _TX, "vin"),
+    ("Tx", Tx, _TX, "vout"),
+    ("Block", Block, _BLOCK, "transactions"),
+    ("Psbt", Psbt, _PSBT, "inputs"),
+    ("Psbt", Psbt, _PSBT, "outputs"),
+    ("Psbt", Psbt, _PSBT, "bip32_derivs"),
+    ("PsbtIn", PsbtIn, _PSBT.inputs[0], "bip32_derivs"),
+    ("PsbtOut", PsbtOut, _PSBT.outputs[0], "taproot_hd_key_paths"),
+    ("Witness", Witness, Witness([b"\x51"]), "stack"),
+)
+
+_ARRAY_IDS = tuple(f"{label}-{key}" for label, _, _, key in _JSON_ARRAYS)
+
+# what reads octets: every `parse` but Bip21's, a URI being text. The
+# class and the method name, so that the walk at the end can say which
+# decoders are covered
+_OCTETS_DECODERS = (
+    ("OutPoint.parse", OutPoint, "parse"),
+    ("TxIn.parse", TxIn, "parse"),
+    ("TxOut.parse", TxOut, "parse"),
+    ("Tx.parse", Tx, "parse"),
+    ("BlockHeader.parse", BlockHeader, "parse"),
+    ("Block.parse", Block, "parse"),
+    ("Psbt.parse", Psbt, "parse"),
+    ("PsbtIn.parse", PsbtIn, "parse"),
+    ("PsbtOut.parse", PsbtOut, "parse"),
+    ("Witness.parse", Witness, "parse"),
+    ("BIP32KeyData.parse", BIP32KeyData, "parse"),
+    ("BIP32KeyOrigin.parse", BIP32KeyOrigin, "parse"),
+    ("bms.Sig.parse", bms.Sig, "parse"),
+    ("ssa.Sig.parse", ssa.Sig, "parse"),
+    ("dsa.Sig.parse", dsa.Sig, "parse"),
+    ("ecies.Envelope.parse", ecies.Envelope, "parse"),
+)
+
+_OCTETS_IDS = tuple(label for label, _, _ in _OCTETS_DECODERS)
+
+# and what reads text: the base64 and base58 decoders, and the one
+# `parse` whose argument is a string
+_TEXT_DECODERS = (
+    ("Bip21.parse", Bip21, "parse"),
+    ("BIP32KeyData.b58decode", BIP32KeyData, "b58decode"),
+    ("Psbt.b64decode", Psbt, "b64decode"),
+    ("bms.Sig.b64decode", bms.Sig, "b64decode"),
+    ("bip322.Sig.b64decode", bip322.Sig, "b64decode"),
+    ("ecies.Envelope.b64decode", ecies.Envelope, "b64decode"),
+)
+
+_TEXT_IDS = tuple(label for label, _, _ in _TEXT_DECODERS)
+
+# what any of these methods takes beyond the object it is about, the
+# octets or the mapping it reads, and the `check_validity` that
+# `check_validity_test.py` owns. Nine arguments over seventy methods,
+# which is the shape of the family: the object is the input, and this is
+# everything else a caller can get wrong.
+#
+# Each is driven below except `strict`, which is a flag deciding whether a
+# check runs -- Bitcoin Core's IsValidSignatureEncoding, and `dsa.Sig.parse`
+# says where it does it -- and is therefore read for its truth, as
+# `check_validity` is
+_EXTRA_ARGUMENTS = {
+    ("btclib.tx.tx.Tx", "serialize"): "include_witness",
+    ("btclib.block.block.Block", "serialize"): "include_witness",
+    ("btclib.psbt.psbt_in.PsbtIn", "serialize"): "psbt_version",
+    ("btclib.psbt.psbt_in.PsbtIn", "parse"): "psbt_version",
+    ("btclib.psbt.psbt_out.PsbtOut", "serialize"): "psbt_version",
+    ("btclib.psbt.psbt_out.PsbtOut", "parse"): "psbt_version",
+    ("btclib.ecc.ecies.Envelope", "parse"): "magic",
+    ("btclib.ecc.ecies.Envelope", "b64decode"): "magic",
+    ("btclib.ecc.dsa.Sig", "parse"): "strict",
+}
+
+# the eight names issue #867 measured, which is what the walk runs over,
+# split by which of them is handed an encoding: a reader takes one as its
+# first argument, a writer starts from the object and takes none
+_READERS = ("parse", "from_dict", "b64decode", "b58decode")
+_WRITERS = ("serialize", "to_dict", "b64encode", "b58encode")
+_FAMILY = (*_READERS, *_WRITERS)
+
+# and the same family where it is a module function rather than a method:
+# four codecs with no class between them and the encoding. Each is driven
+# on what it converts, which is its first argument
+_MODULE_READERS = (
+    ("var_int.parse", var_int.parse, "invalid octets type"),
+    ("var_bytes.parse", var_bytes.parse, "invalid octets type"),
+    ("script.parse", script.parse, "invalid octets type"),
+    ("taproot.parse", taproot.parse, "invalid octets type"),
+    ("descriptors.parse", descriptors.parse, "invalid descriptor type"),
+    ("miniscript.parse", miniscript.parse, "invalid miniscript type"),
+)
+
+_MODULE_READER_IDS = tuple(label for label, _, _ in _MODULE_READERS)
+
+# the writers, each with what it converts and what is not one of those.
+# A command sequence takes the two iterables that a `Sequence[Command]`
+# accepts and a caller never means: `serialize("OP_DUP")` is six
+# one-character commands and `serialize(b"\x76")` one integer command per
+# byte, which is a script and the wrong one
+_MODULE_WRITERS = (
+    ("var_int.serialize", var_int.serialize, 1, (None, 1.5, "1", b"\x01")),
+    ("var_bytes.serialize", var_bytes.serialize, b"\x01", (None, 1.5, [1, 2])),
+    ("script.serialize", script.serialize, ["OP_DUP"], (None, 1.5, "OP_DUP", b"\x76")),
+    (
+        "taproot.serialize",
+        taproot.serialize,
+        ["OP_DUP"],
+        (None, 1.5, "OP_DUP", b"\x76"),
+    ),
+)
+
+_MODULE_WRITER_IDS = tuple(label for label, _, _, _ in _MODULE_WRITERS)
+
+# what those ten take besides the thing they convert. Every one of them
+# is a parameter behind a default, which is issue #868's census and not
+# this file's: `max_size` and `context` are asked where they are read,
+# `forbid_zero_size` and `exit_on_op_success` are flags, and `network`
+# and `prv_keys` are the descriptor family's own inputs
+_MODULE_EXTRA_ARGUMENTS = {
+    ("btclib.var_int", "parse"): ["max_size"],
+    ("btclib.var_bytes", "parse"): ["forbid_zero_size"],
+    ("btclib.script.taproot", "parse"): ["exit_on_op_success"],
+    ("btclib.descriptors.descriptors", "parse"): ["network", "prv_keys"],
+    ("btclib.descriptors.miniscript", "parse"): ["context", "prv_keys"],
+}
+
+
+def _as_json(obj: Any) -> dict[str, Any]:
+    """Return what `to_dict` wrote, round-tripped through json itself.
+
+    Through `json` and not straight from `to_dict`: what these tests
+    drive is the boundary a stored file arrives at, and a dict that
+    never went through a serializer is one whose tuples are still tuples
+    and whose ints are still ints of Python's making.
+    """
+    dict_: dict[str, Any] = json.loads(json.dumps(obj.to_dict()))
+    return dict_
+
+
+@pytest.mark.parametrize("case", _JSON_CASES, ids=_JSON_IDS)
+def test_the_json_round_trip_is_exact(case: _JsonCase) -> None:
+    """The fixture is valid, which is what makes a refusal below a finding.
+
+    Without this a case whose object had gone stale would pass every test
+    in this file by refusing everything it is handed.
+    """
+    assert case.cls.from_dict(_as_json(case.obj)) == case.obj
+
+
+@pytest.mark.parametrize("case", _JSON_CASES, ids=_JSON_IDS)
+def test_from_dict_refuses_what_is_no_json_object(case: _JsonCase) -> None:
+    """The first rule at the json boundary: a `Mapping` or nothing.
+
+    A `str` is the one worth naming: it is not a mapping and is
+    subscriptable, so it reached `dict_["version"]` and left as "string
+    indices must be integers" -- a complaint about a builtin, and about
+    the key rather than about the argument.
+    """
+    for wrong in (*_WRONG_TYPES, "a string"):
+        with pytest.raises(BTClibTypeError, match="dict type"):
+            case.cls.from_dict(wrong)
+
+
+@pytest.mark.parametrize("case", _JSON_CASES, ids=_JSON_IDS)
+def test_from_dict_names_the_field_it_has_not_got(case: _JsonCase) -> None:
+    """The second rule: a mapping without the field is a wrong value.
+
+    Every key in turn, and a key `from_dict` ignores -- a transaction's
+    txid, a header's difficulty, the psbt's derived "tx" -- is one whose
+    absence is no error at all, which is why the assertion is on what a
+    failure may be rather than on which keys fail. What must never happen
+    is the `KeyError` that used to: `exceptions.py` lists it as one of
+    the native exceptions still reaching a caller, and this family was
+    where it did.
+
+    The count is asserted too, or a `from_dict` that stopped reading its
+    mapping would pass this by never failing.
+    """
+    dict_ = _as_json(case.obj)
+    refused = []
+    for key in dict_:
+        without = {k: v for k, v in dict_.items() if k != key}
+        try:
+            case.cls.from_dict(without)
+        except BTClibValueError as e:
+            refused.append((key, str(e)))
+    assert refused, f"{case.label}.from_dict requires none of its fields"
+    for key, err_msg in refused:
+        assert key in err_msg
+
+
+@pytest.mark.parametrize("label, cls, obj, key", _JSON_ARRAYS, ids=_ARRAY_IDS)
+def test_a_json_array_is_asked_before_it_is_walked(
+    label: str, cls: type[Any], obj: Any, key: str
+) -> None:
+    """A list field, driven with what a schema mistake puts there.
+
+    The two iterables are the point: a `str` is a list of its characters
+    and a `Mapping` a list of its keys, so one input handed where the
+    array of them was meant was as many inputs as it had characters --
+    each refused for what it is not, which reports the wrong mistake.
+    `Witness`'s stack is worse than that and was the finding here: its
+    constructor reads `stack or []`, so a `None` was a witness of no
+    elements rather than an error.
+    """
+    dict_ = _as_json(obj)
+    for wrong in _NOT_AN_ARRAY:
+        broken = deepcopy(dict_)
+        broken[key] = wrong
+        with pytest.raises(BTClibTypeError):
+            cls.from_dict(broken)
+
+
+def test_the_two_fields_from_dict_converts_itself() -> None:
+    """The two fields no constructor sees as they were written.
+
+    A header's time and a network's curve. Every other field of every
+    `from_dict` here is handed to a constructor, which is where
+    `assert_valid` asks about it; these two
+    are converted first -- one by `datetime.fromisoformat`, which
+    refuses what is not a string with a TypeError of its own and an
+    unreadable one with a bare ValueError, and one by a lookup in
+    `CURVES`, which answers an unknown name with a `KeyError` and an
+    unhashable one with a TypeError about dict keys.
+    """
+    header = _as_json(_BLOCK.header)
+    for wrong in _WRONG_TYPES:
+        with pytest.raises(BTClibTypeError, match="invalid time type"):
+            BlockHeader.from_dict({**header, "time": wrong})
+    with pytest.raises(BTClibValueError, match="invalid time"):
+        BlockHeader.from_dict({**header, "time": "the block after genesis"})
+
+    network = _as_json(NETWORKS["mainnet"])
+    for wrong in (*_WRONG_TYPES, {"a": 1}):
+        with pytest.raises(BTClibTypeError, match="invalid curve name type"):
+            Network.from_dict({**network, "curve": wrong})
+    with pytest.raises(BTClibValueError, match="unknown curve"):
+        Network.from_dict({**network, "curve": "secp256k2"})
+
+
+@pytest.mark.parametrize("label, cls, method", _OCTETS_DECODERS, ids=_OCTETS_IDS)
+def test_the_octets_boundary_refuses_what_is_no_octets(
+    label: str, cls: type[Any], method: str
+) -> None:
+    """`bytes_from_octets` is the one coercion, and it is the one refusal."""
+    for wrong in _WRONG_TYPES:
+        with pytest.raises(BTClibTypeError, match="invalid octets type"):
+            getattr(cls, method)(wrong)
+
+
+@pytest.mark.parametrize("label, cls, method", _TEXT_DECODERS, ids=_TEXT_IDS)
+def test_the_text_boundary_refuses_what_is_no_text(
+    label: str, cls: type[Any], method: str
+) -> None:
+    """The same rule where the encoding is text rather than octets.
+
+    Three of these left a native exception: the base64 decoders handed
+    what is neither `str` nor `bytes` to `base64` -- "argument should be
+    a bytes-like object or ASCII string" -- or to `.strip`, and
+    `b58decode` to the cache in front of `base58.decode`, which keys on
+    the argument and so refused an unhashable one for being unhashable.
+    """
+    for wrong in _WRONG_TYPES:
+        with pytest.raises(BTClibTypeError, match="type"):
+            getattr(cls, method)(wrong)
+
+
+@pytest.mark.parametrize(
+    "label, function, err_msg", _MODULE_READERS, ids=_MODULE_READER_IDS
+)
+def test_a_codec_that_is_a_function_refuses_a_wrong_type_too(
+    label: str, function: Callable[..., Any], err_msg: str
+) -> None:
+    """The same rule where there is no class between the two sides.
+
+    The four octet codecs went through `bytes_from_octets` already; the
+    two descriptor parsers went through nothing, and left "'NoneType'
+    object has no attribute 'partition'" and "object of type 'float' has
+    no len()".
+    """
+    for wrong in _WRONG_TYPES:
+        with pytest.raises(BTClibTypeError, match=err_msg):
+            function(wrong)
+
+
+@pytest.mark.parametrize(
+    "label, function, valid, wrong_values", _MODULE_WRITERS, ids=_MODULE_WRITER_IDS
+)
+def test_a_codec_that_is_a_function_asks_what_it_is_given_to_write(
+    label: str,
+    function: Callable[..., Any],
+    valid: Any,
+    wrong_values: tuple[Any, ...],
+) -> None:
+    """The writing half, where the argument is the thing being converted.
+
+    The valid call is asserted for the reason every case in
+    `built_object_contract_test.py` asserts one: a function that refused
+    everything would pass the rest of this by refusing these too.
+    """
+    assert function(valid)
+
+    for wrong in wrong_values:
+        with pytest.raises(BTClibTypeError):
+            function(wrong)
+
+
+def test_a_transaction_says_which_serialization_it_is_asked_for() -> None:
+    """`include_witness` decides what is computed, so it is a bool.
+
+    The line `built_object_contract_test.py` draws, and the cost of not
+    drawing it here is the sharpest there is: read for its truth, a value
+    of no boolean type answers the stripped serialization -- which is
+    what the transaction id is computed over -- where the wire one was
+    asked for.
+    """
+    assert Tx.parse(_TX.serialize(include_witness=True)) == _TX
+    assert _TX.serialize(False) != _TX.serialize(True) or not _TX.is_segwit
+    assert Block.parse(_BLOCK.serialize(include_witness=True)) == _BLOCK
+
+    for wrong in (*_WRONG_TYPES, 0, 1):
+        with pytest.raises(BTClibTypeError, match="invalid include_witness type"):
+            _TX.serialize(wrong)
+        with pytest.raises(BTClibTypeError, match="invalid include_witness type"):
+            _BLOCK.serialize(wrong)
+
+
+@pytest.mark.parametrize("cls", [PsbtIn, PsbtOut], ids=["PsbtIn", "PsbtOut"])
+def test_a_map_is_written_and_read_as_a_version_that_exists(cls: type[Any]) -> None:
+    """`psbt_version` decides which fields a map carries, so it is asked.
+
+    Every version that is not 0 wrote and read the BIP370 fields, so a
+    `None`, a 3 or a string was a version 2 map and said nothing -- and
+    the psbt they belong to holds its own version to `PSBT_V0` or
+    `PSBT_V2` already, which is the same question one layer up.
+    """
+    map_ = _PSBT.inputs[0] if cls is PsbtIn else _PSBT.outputs[0]
+    for version in (PSBT_V0, PSBT_V2):
+        assert cls.parse(map_.serialize(psbt_version=version), psbt_version=version)
+
+    for wrong in _WRONG_TYPES:
+        with pytest.raises(BTClibTypeError, match="invalid version type"):
+            map_.serialize(psbt_version=wrong)
+        with pytest.raises(BTClibTypeError, match="invalid version type"):
+            cls.parse(map_.serialize(), psbt_version=wrong)
+
+    for wrong_value in (1, 3):
+        with pytest.raises(BTClibValueError, match="invalid psbt version"):
+            map_.serialize(psbt_version=wrong_value)
+        with pytest.raises(BTClibValueError, match="invalid psbt version"):
+            cls.parse(map_.serialize(), psbt_version=wrong_value)
+
+
+def test_an_envelope_is_read_against_magic_bytes_that_are_bytes() -> None:
+    """The one argument of this family that is neither a flag nor a version.
+
+    Compared against the first four octets of the buffer, so a magic of
+    no bytes type is unequal to whatever is there: every envelope was
+    refused, and for the bytes it does carry rather than for the argument
+    that cannot be any.
+    """
+    armor = _ENVELOPE.b64encode()
+    assert ecies.Envelope.b64decode(armor) == _ENVELOPE
+    assert ecies.Envelope.parse(_ENVELOPE.serialize(), magic=b"BIE1") == _ENVELOPE
+
+    for wrong in _WRONG_TYPES:
+        with pytest.raises(BTClibTypeError, match="invalid magic type"):
+            ecies.Envelope.parse(_ENVELOPE.serialize(), magic=wrong)
+        with pytest.raises(BTClibTypeError, match="invalid magic type"):
+            ecies.Envelope.b64decode(armor, magic=wrong)
+
+
+def test_every_json_boundary_is_covered() -> None:
+    """The inventory is a promise only if omission is what fails.
+
+    A `to_dict`/`from_dict` pair added to btclib and forgotten here is
+    the failure this catches: the tests above would go on passing on the
+    classes they were given. The pair is asserted as a pair, a class that
+    writes json and does not read it back being a finding of its own.
+    """
+    covered = {f"{case.cls.__module__}.{case.cls.__qualname__}" for case in _JSON_CASES}
+    assert public_classes_with("from_dict") == covered
+    assert public_classes_with("to_dict") == covered
+
+
+def test_every_decoder_is_covered() -> None:
+    """The same promise for what reads octets and what reads text.
+
+    No exclusion list, which is the state to keep: every decoder in the
+    library takes an argument of a declared type, and refusing what is
+    not of it is a rule with no exception to state.
+    """
+    covered = {
+        f"{cls.__module__}.{cls.__qualname__}.{method}"
+        for _, cls, method in (*_OCTETS_DECODERS, *_TEXT_DECODERS)
+    }
+    found = {
+        f"{name}.{method}"
+        for method in ("parse", "b64decode", "b58decode")
+        for name in public_classes_with(method)
+    }
+    assert found == covered
+
+
+def test_every_codec_that_is_a_function_is_covered() -> None:
+    """And the same promise where the family is a module function.
+
+    The walk that finds the methods finds classes, so these ten would be
+    invisible to it: a `parse` or a `serialize` added to a module of this
+    library is held to nothing until it appears in one of the two tables
+    above.
+
+    What each takes besides the encoding is recorded rather than driven,
+    every one of them being a parameter behind a default -- which is
+    issue #868's census and the line this file stops at.
+    """
+    covered = {
+        f"{function.__module__}.{function.__name__}"
+        for _, function, _ in _MODULE_READERS
+    } | {
+        f"{function.__module__}.{function.__name__}"
+        for _, function, _, _ in _MODULE_WRITERS
+    }
+    found = {}
+    for module_name in (
+        "btclib",
+        *(module.name for module in pkgutil.walk_packages(btclib.__path__, "btclib.")),
+    ):
+        module = import_module(module_name)
+        for method in _FAMILY:
+            function = getattr(module, method, None)
+            if not callable(function) or isinstance(function, type):
+                continue
+            if getattr(function, "__module__", "") != module_name:
+                continue
+            parameters = list(signature(function).parameters)
+            found[f"{module_name}.{method}"] = parameters[1:]
+
+    assert set(found) == covered
+    assert {
+        (name.rsplit(".", 1)[0], name.rsplit(".", 1)[1]): extra
+        for name, extra in found.items()
+        if extra
+    } == _MODULE_EXTRA_ARGUMENTS
+
+
+def test_the_family_takes_no_argument_this_file_does_not_drive() -> None:
+    """What the eight methods take, beyond the object and `check_validity`.
+
+    Read off the signatures rather than listed, which is what makes
+    `_EXTRA_ARGUMENTS` a record instead of a wish: an argument added to
+    any `parse`, `serialize`, `to_dict` or `from_dict` in the library
+    fails here until it is driven above or given a reason of its own.
+
+    The argument this walk does not count is the object's own: the
+    encoding a reader is handed -- `data`, `dict_`, `uri`, `address` --
+    which the tests above drive for every class carrying one, and which a
+    writer does not have at all, the object being what it writes.
+    """
+    found: dict[tuple[str, str], str] = {}
+    for method in _FAMILY:
+        for name in public_classes_with(method):
+            module_name, _, class_name = name.rpartition(".")
+            cls = getattr(import_module(module_name), class_name)
+            parameters = [
+                parameter
+                for parameter in signature(getattr(cls, method)).parameters
+                # `cls` is gone already, a classmethod read off the class
+                # being bound to it; `self` is not, an instance method read
+                # off the class being the plain function
+                if parameter not in ("self", "cls", "check_validity")
+            ]
+            # then the encoding, which is the first argument of a reader
+            # and is not an argument at all for a writer: what a writer
+            # converts is the object it is called on
+            extra = parameters[1:] if method in _READERS else parameters
+            assert len(extra) <= 1, f"{name}.{method} takes {extra}"
+            for parameter in extra:
+                found[name, method] = parameter
+
+    assert found == _EXTRA_ARGUMENTS


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/867.

`tests/serialization_boundary_test.py` is the gate, and it is **not** the
contract `tests/parse_contract_test.py` holds: where the bytes end is a
different question from what type the argument is. The walk that finds
every one of those methods therefore moves to `tests/__init__.py`, where
neither file owns it, and `parse_contract_test.py` calls it too.

## What was found, and fixed

**`from_dict`, the json boundary, had no gate.** All twelve walked the
mapping before asking whether it was one — a `None` left as "not
subscriptable", a `str` as "string indices must be integers" — and a
mapping missing a field left as a `KeyError`, which is neither a
`BTClibException` nor a `ValueError`, so a caller catching either never
caught it. `exceptions.py` lists that gap as
https://github.com/btclib-org/btclib/issues/776's.
`utils.fields_from_json_object` answers both in one line per `from_dict`.

**The arrays those methods walk** are issue #856's "annotation that
accepts the mistake" again: `Sequence[Any]` accepts a `str` and a
`Mapping`, so one input handed where the list of them was meant was as
many inputs as it had characters. `utils.list_from_json_array` asks
first. `Witness.from_dict` was worse than a wrong message: its
constructor reads `stack or ()`, so a `None` stack **was accepted**, as a
witness of no elements.

**Two fields are converted before any constructor sees them** — a block
header's `time` through `datetime.fromisoformat`, a network's `curve`
through a `CURVES` lookup — and both raised from underneath the library.

**What `serialize` takes was accepted whatever it was.**
`Tx.serialize(include_witness)` and `Block.serialize`'s read the flag for
its truth, so a value of no boolean type answered the stripped
serialization — what the transaction id is computed over — where the wire
one was asked for; the line is `built_object_contract_test.py`'s.
`PsbtIn`/`PsbtOut` compare `psbt_version` against 0 alone, so a `None`, a
3 or a string wrote and read a version 2 map and said nothing:
`psbt_utils.assert_valid_psbt_version` is `psbt.py`'s own check moved
down to the module the maps and the psbt share, `PSBT_V0` and `PSBT_V2`
with it — the third entry in `all_test.py`'s `REEXPORTED`, and the same
shape as the second.

**The text decoders and the module-level codecs**: `Psbt.b64decode` and
`ecies.Envelope.b64decode` handed what is neither `str` nor `bytes` to
`base64` or to `.strip`, where `bms.Sig.b64decode` had been fixed for
exactly that (#814); `BIP32KeyData.b58decode` reached the cache in front
of `base58.decode`, which keys on the argument and so refused an
unhashable one for being unhashable; `Bip21.parse` refused a non-`str` as
a *value*; `Envelope.parse`'s `magic` was compared rather than asked;
`descriptors.parse` and `miniscript.parse` asked nothing at all; and
`script.serialize` took a `Sequence[Command]`, which accepts a `str` and
a `bytes` for the reason above.

## What the gate promises

- each case asserts the **valid** call works, so a stale fixture fails
  instead of passing by refusing everything
- **no exemption list** for the decoders: every one takes an argument of
  a declared type, and there is no exception to state
- three completeness walks, so nothing is enumerated by hand: every
  public class with a `to_dict`/`from_dict` pair, every class with a
  decoder, and every module-level member of the family
- and one over the **signatures**: `_EXTRA_ARGUMENTS` records the nine
  arguments these seventy methods take beyond the object and
  `check_validity`, so a tenth fails here until it is driven or given a
  reason. `dsa.Sig.parse`'s `strict` is the one exemption, being a flag
  that decides whether a check runs

Note for the reviewer: `curves.curve._assert_valid_ec`, landed in
https://github.com/btclib-org/btclib/pull/869 an hour before this, asks
the same kind of question with a message of its own ("not a curve");
`utils.assert_type` here is the general spelling for the positions whose
message is "invalid X type". Unifying the two is not attempted here.

Gates run locally: `uv run pytest` (100% coverage, 27644 passed),
`uv run pre-commit run --all-files`, and the sphinx `-W` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Gate the serialization boundary across parse/serialize/to_dict/from_dict, ensuring type-safe input validation and consistent btclib exceptions at JSON, octet, and text boundaries, with tests enforcing coverage of all public serializers/decoders and PSBT helpers refactored to centralize version checks.

Bug Fixes:
- Ensure from_dict handlers for transactions, blocks, PSBTs, witnesses, key origins, scripts, and networks validate mapping and array types and report missing fields via BTClibValueError instead of native exceptions or silent acceptance.
- Fix serialization and parsing of PSBT maps by validating psbt_version against supported versions and refusing non-integer or unsupported values.
- Correct text/base64/base58 decoders (Psbt, ECIES envelope, BIP32KeyData, Bip21, descriptors, miniscript) to validate argument types up front and raise BTClibTypeError for non-string inputs instead of leaking underlying builtin errors.
- Prevent script.serialize from misinterpreting single strings/bytes as sequences of commands by enforcing command-sequence type checks and raising BTClibTypeError for invalid command collections.
- Disallow non-boolean include_witness flags in Tx and Block serialization to avoid computing the wrong transaction/block serialization and txid.

Enhancements:
- Introduce shared utils helpers (assert_type, fields_from_json_object, list_from_json_array) to centralize type gating and JSON structure validation across the library.
- Move PSBT version constants and validation logic into psbt_utils and re-export them from psbt, aligning PSBT maps and views on a single version gate.
- Add public_classes_with discovery helper and comprehensive serialization_boundary_test to automatically cover all public parse/serialize/to_dict/from_dict methods and module-level codecs for input-contract enforcement.

Documentation:
- Update CHANGELOG and HISTORY to document the new serialization boundary gating, PSBT version handling, and breaking changes around stricter type validation and exception types.

Tests:
- Add serialization_boundary_test to systematically exercise type and value contracts for parse/serialize/to_dict/from_dict and module-level codecs, including JSON round-trips, array handling, PSBT versions, ECIES magic, and module-level extras.
- Update parse_contract_test to reuse the shared public_classes_with walk for parser coverage, separating byte-boundary tests from type-boundary tests.
- Extend all_test REEXPORTED checks to cover psbt_utils PSBT_V0/PSBT_V2 re-exports, maintaining module export invariants.
- Adjust bip21_test expectations to match new BTClibTypeError behavior for non-string URIs.