### PR TITLE
A kind is not read for its truth, and every flag says which it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2556,6 +2556,60 @@ documented at release-notes length in the first place, and are still in
   public key" are the caller's diagnosis rather than a type report; and
   the 33 guards built on `is_integer` are the integer policy
   `tests/integer_policy_test.py` owns, a bool being an int.
+- **Every `bool` parameter of the library is a kind or a truth, and the
+  kinds refuse what is not one** (issue #868, second half). CONTRIBUTING.md
+  has drawn the line since `KeyGroup(verify=)`: a flag that decides *what
+  is computed* is a kind, `musig2._flag`'s reasoning being that a kind
+  written down and read back arrives as whatever it was written as and
+  `"false"` is true; a flag that decides only *whether a check runs* is
+  read for its truth. Applying it meant the census, and the census is
+  `tests/bool_parameter_test.py`: seventy-eight `bool` parameters besides
+  `check_validity`, fifty-three of them kinds and twenty-five truths, with
+  every one of the seventy-eight in one of the two tables or the run is
+  red.
+
+  What was open were the two the issue names, and thirty-odd more of the
+  same shape:
+
+  ```text
+  dsa.sign(msg, q, lower_s="no")        -> a low-s signature, "no" being true
+  pub_keyinfo_from_prv_key(q, "no")     -> the compressed key, and its address
+  ```
+
+  `compressed` chooses which public key is computed and therefore which
+  address, `lower_s` which of the two signatures comes back, `grind`
+  whether the nonce is searched until r is short. The script engine's
+  `segwit` says which digest a signature commits to and which script code
+  it is checked against — a consensus answer, in five signatures — beside
+  `const_scriptcode`, `skip_execution` and `exit_on_op_success`. Then
+  `signed`, `include_witness` and `unsigned_template` at the psbt
+  boundary, `shuffle_inp` and `shuffle_out` in both `join`s, `legacy` in
+  BIP322's two verifications, `sort`, `pad`, `shuffle`, `to_be_hashed`,
+  `extendable`, `lexicographic_sorting`, `emulators`, `musig2`, `active`
+  and `internal`. Each refuses a non-bool with a `BTClibTypeError` now,
+  through `utils.assert_type`, which is the library's one spelling of that
+  refusal: thirty new guards and no thirty-first message shape.
+
+  The check sits where the flag is first read, which is fewer places than
+  there are parameters: `b58.p2pkh`, `ScriptPubKey.p2pkh` and the rest
+  reach one of the four `compressed` checks, `dsa.sign` and
+  `anti_exfil_sign` reach `sign_`'s, and `verify_script` reaches
+  `prepare_script`'s. `b58.wif_from_prv_key` is the one that had to ask for
+  itself: it calls `prv_keyinfo_from_prv_key` without the flag and reads
+  the caller's own afterwards.
+
+  The truths are the other half of the census and they stay read for their
+  truth, each with the reason in the table: `check_validity` (whose own
+  file holds it), `check_root_xkey`, `verify_checksum`, `strict`,
+  `bip380_enforced`, `forbid_zero_size`, `allow_partial`, `check_amounts`,
+  `verify_network`, `branches_0_1_only`, `hybrid`, `power_of_two`,
+  `order_check`, `weakness_check`, the four `enforce_same_*`,
+  `unsigned_template` on `Tx.assert_valid`, and the engine's `final` and
+  `verified`. What makes the classification checkable rather than asserted
+  is that a truth is *driven* too: it is called with `"no"`, `0` and `1` on
+  a fixture its `True` accepts, and all three go through. A truth that
+  starts refusing fails that test, and the entry has to move to the kinds
+  rather than the test being edited.
 
 - **The input contract reaches `ec`, which had no check anywhere** (issue
   #868). The census of parameters behind a default put it fourth by

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -894,6 +894,17 @@ only *whether a check runs* is read for its truth: `check_validity` and
 `slip132`'s `check_root_xkey` either run a check or skip one, and neither
 changes an answer. `tests/check_validity_test.py` owns that convention.
 
+**Which of the two a flag is, is written down for every one of them.**
+`tests/bool_parameter_test.py` is the census: two tables, a kind driven
+until it refuses `"no"`, `0` and `1`, a truth driven until it accepts all
+three, and a walk that fails on a `bool` parameter in neither table. So a
+flag added anywhere is a decision somebody makes rather than one the
+default makes for them — and `0` and `1` are in that vocabulary because
+`bool` is a subclass of `int`, which is what leaves `isinstance(value,
+int)` no check at all here. `utils.assert_type` is the refusal, and
+`check_validity` is the one name subtracted by the walk, its own file
+holding it.
+
 Four shapes were what the second gate found when it was written, and they
 are worth knowing because each is a way of being handed an argument
 without looking at it: a **sequence parameter** walked before it is

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,25 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **thirty-odd `bool` arguments that used to be accepted are refused.**
+  A flag that decides what is computed is a kind and not a truth, so
+  `dsa.sign(msg, q, lower_s="no")` — which returned a low-s signature,
+  `"no"` being true — and `pub_keyinfo_from_prv_key(q, compressed="no")`
+  — which returned the compressed key, and with it a different address —
+  raise `BTClibTypeError` now. So do `compressed` in the nine other
+  signatures that carry it, `grind`, the script engine's `segwit`,
+  `const_scriptcode`, `skip_execution` and `exit_on_op_success`, `signed`,
+  `include_witness` and `unsigned_template` at the psbt boundary,
+  `shuffle_inp` and `shuffle_out`, BIP322's `legacy`, `sort`, `pad`,
+  `shuffle`, `to_be_hashed`, `extendable`, `lexicographic_sorting`,
+  `emulators`, `musig2`, `active` and `internal`. A caller passing a
+  `bool` is unaffected, and mypy already refused every one of these calls;
+  `0` and `1` are refused too, `bool` being a subclass of `int` and that
+  being what made the type check no check at all. The flags that decide
+  only whether a check runs — `check_validity`, `check_root_xkey`,
+  `verify_checksum`, `strict`, `bip380_enforced` and the rest, listed in
+  `tests/bool_parameter_test.py` — are still read for their truth.
+
 - **the serialization boundary refuses what it used to take, and reports
   through the exception contract.** A `from_dict` handed a mapping
   without a field raises `BTClibValueError` where it raised a bare

--- a/btclib/b32.py
+++ b/btclib/b32.py
@@ -60,7 +60,7 @@ from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, sha256
 from btclib.network import NETWORKS, network_from_key_value, network_from_name
 from btclib.to_pub_key import Key, pub_keyinfo_from_key
-from btclib.utils import bytes_from_octets, str_from_string
+from btclib.utils import assert_type, bytes_from_octets, str_from_string
 
 __all__ = [
     "address_from_witness",
@@ -90,6 +90,8 @@ def power_of_2_base_conversion(
     data: Iterable[int], from_bits: int, to_bits: int, pad: bool = True
 ) -> list[int]:
     """Convert a power-of-two digit sequence to another power-of-two base."""
+    assert_type(pad, bool, "pad")
+
     acc = 0
     bits = 0
     ret = []

--- a/btclib/b58.py
+++ b/btclib/b58.py
@@ -27,7 +27,7 @@ from btclib.hashes import hash160, sha256
 from btclib.network import network_from_key_value, network_from_name
 from btclib.to_prv_key import PrvKey, prv_keyinfo_from_prv_key
 from btclib.to_pub_key import Key, pub_keyinfo_from_key
-from btclib.utils import bytes_from_octets
+from btclib.utils import assert_type, bytes_from_octets
 
 __all__ = [
     "address_from_h160",
@@ -44,6 +44,11 @@ def wif_from_prv_key(
     prv_key: PrvKey, network: str | None = None, compressed: bool | None = None
 ) -> str:
     """Return the WIF encoding of a private key."""
+    # asked here rather than passed down: `prv_keyinfo_from_prv_key` is
+    # called without it, so what the key says is what comes back and this
+    # is where a caller's own choice is read
+    if compressed is not None:
+        assert_type(compressed, bool, "compressed")
     q, net, compr = prv_keyinfo_from_prv_key(prv_key)
 
     # the private key might provide network and compressed information

--- a/btclib/bip322.py
+++ b/btclib/bip322.py
@@ -111,7 +111,7 @@ from btclib.script.taproot import output_prvkey_from_merkle_root, output_pubkey
 from btclib.script.witness import Witness
 from btclib.to_prv_key import PrvKey, prv_keyinfo_from_prv_key
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
-from btclib.utils import bytes_from_octets, str_from_string
+from btclib.utils import assert_type, bytes_from_octets, str_from_string
 
 __all__ = [
     "FULL",
@@ -491,6 +491,10 @@ def assert_as_valid(
     Raises `InconclusiveError` for a signature that is not invalid and
     cannot be judged valid; see the module docstring for that state.
     """
+    # which of the two verifications runs, a BMS signature over the message
+    # or BIP322's own, so it is a kind and `verify` inherits the check
+    assert_type(legacy, bool, "legacy")
+
     script_pub_key = ScriptPubKey.from_address(addr).script
 
     if legacy and isinstance(sig, (str, bytes)) and _is_bms(sig):

--- a/btclib/core_import.py
+++ b/btclib/core_import.py
@@ -75,7 +75,7 @@ from typing import Any
 
 from btclib.descriptors import Descriptor, add_checksum, parse
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
-from btclib.utils import is_integer
+from btclib.utils import assert_type, is_integer
 
 __all__ = [
     "DEFAULT_RANGE",
@@ -246,6 +246,11 @@ def import_request(
     `label` names the address, and Core allows one only for a single
     unranged receiving descriptor: not for change, and not for a range.
     """
+    # both are fields of the request Core is handed, so a truth read for
+    # its truth would import the other kind of descriptor
+    assert_type(internal, bool, "internal")
+    assert_type(active, bool, "active")
+
     text = add_checksum(descriptor if isinstance(descriptor, str) else str(descriptor))
     is_ranged = _is_ranged(descriptor)
 

--- a/btclib/curves/sec_point.py
+++ b/btclib/curves/sec_point.py
@@ -21,7 +21,7 @@ from btclib.curves.curve import (
     secp256k1,
 )
 from btclib.exceptions import BTClibValueError
-from btclib.utils import bytes_from_octets, hex_string, int_from_integer
+from btclib.utils import assert_type, bytes_from_octets, hex_string, int_from_integer
 
 __all__ = [
     "bytes_from_point",
@@ -37,6 +37,7 @@ def bytes_from_point(Q: Point, ec: Curve = secp256k1, compressed: bool = True) -
     octet sequence, according to SEC 1 v.2, section 2.3.3.
     """
     _assert_valid_ec(ec)
+    assert_type(compressed, bool, "compressed")
     # check that Q is a point and that is on curve
     ec.require_on_curve(Q)
 
@@ -69,6 +70,8 @@ def bytes_from_prv_key_int(
     uncompressed one (issue #459).
     """
     _assert_valid_ec(ec)
+    # before the bindings, which take it as the C bool they serialize with
+    assert_type(compressed, bool, "compressed")
     q = int_from_integer(prv_key_int) % ec.n
 
     # q == 0 is the infinity point, which the bindings reject as a scalar

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -61,7 +61,12 @@ from btclib.hashes import _assert_valid_hf, reduce_to_hlen
 from btclib.number_theory import mod_inv, mod_inv_var
 from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.to_pub_key import PubKey, point_from_pub_key, pub_keyinfo_from_pub_key
-from btclib.utils import bytes_from_octets, bytesio_from_binarydata, hex_string
+from btclib.utils import (
+    assert_type,
+    bytes_from_octets,
+    bytesio_from_binarydata,
+    hex_string,
+)
 
 __all__ = [
     "Sig",
@@ -546,6 +551,12 @@ def sign_(
     derivation is where half of the scheme's security is.
     """
     # the message msg_hash: a hf_len array
+    # both flags decide which signature comes back -- lower_s which of the
+    # two s values, grind whether the nonce is searched for a low r -- so
+    # both are kinds and neither is read for its truth
+    assert_type(lower_s, bool, "lower_s")
+    assert_type(grind, bool, "grind")
+
     hf_len = hf().digest_size
     msg_hash = bytes_from_octets(msg_hash, hf_len)
 
@@ -731,6 +742,8 @@ def sign_recoverable_(
     nothing.
     """
     # the message msg_hash: a hf_len array
+    assert_type(lower_s, bool, "lower_s")
+
     hf_len = hf().digest_size
     msg_hash = bytes_from_octets(msg_hash, hf_len)
 

--- a/btclib/hwi.py
+++ b/btclib/hwi.py
@@ -113,7 +113,7 @@ from btclib.exceptions import BTClibValueError, SignerError, SignerNotFoundError
 from btclib.network import NETWORKS
 from btclib.psbt.psbt import Psbt
 from btclib.psbt_signer import SignerCapabilities
-from btclib.utils import bytes_from_octets, is_integer
+from btclib.utils import assert_type, bytes_from_octets, is_integer
 
 __all__ = [
     "DEFAULT_EXECUTABLE",
@@ -425,6 +425,7 @@ def enumerate_devices(
     a device with no secure element and no owner, and enumerating one
     without being asked would make a test fixture look like a signer.
     """
+    assert_type(emulators, bool, "emulators")
     argv = [*_executable(executable), *_chain_args(network), "enumerate"]
     if emulators:
         argv.insert(-1, "--emulators")
@@ -479,6 +480,7 @@ class HwiSigner:
     ) -> None:
         if network not in NETWORKS:
             raise BTClibValueError(f"unknown network: {network}")
+        assert_type(emulators, bool, "emulators")
         self.executable = _executable(executable)
         self.network = network
         self.timeout = timeout

--- a/btclib/mnemonic/entropy.py
+++ b/btclib/mnemonic/entropy.py
@@ -23,7 +23,7 @@ from hashlib import sha512
 
 from btclib.alias import Octets
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.utils import bytes_from_octets, is_integer
+from btclib.utils import assert_type, bytes_from_octets, is_integer
 
 __all__ = [
     "BinStr",
@@ -388,6 +388,7 @@ def bin_str_entropy_from_rolls(
     if not is_integer(dice_sides):
         err_msg = f"invalid dice base type: {type(dice_sides).__name__}"
         raise BTClibTypeError(err_msg)
+    assert_type(shuffle, bool, "shuffle")
     if dice_sides < 2:
         raise BTClibValueError(f"invalid dice base: {dice_sides}, must be >= 2")
     bits_per_roll = _bits_per_digit(dice_sides)
@@ -432,6 +433,8 @@ def bin_str_entropy_from_random(
     - XOR-ed with CSPRNG system entropy
     - possibly hashed (if requested)
     """
+    assert_type(to_be_hashed, bool, "to_be_hashed")
+
     if entropy is None or not entropy:
         i = secrets.randbits(bits)
     else:

--- a/btclib/mnemonic/slip39.py
+++ b/btclib/mnemonic/slip39.py
@@ -69,7 +69,7 @@ from btclib.mnemonic.mnemonic import (
     mnemonic_from_indexes,
 )
 from btclib.network import network_from_name
-from btclib.utils import bytes_from_octets
+from btclib.utils import assert_type, bytes_from_octets
 
 __all__ = [
     "Share",
@@ -595,6 +595,7 @@ def mnemonics_from_master_secret(
     is the same bytes through another name); anything weaker substituted
     here is a secret an attacker can reproduce.
     """
+    assert_type(extendable, bool, "extendable")
     _assert_valid_passphrase(passphrase)
     secret = bytes_from_octets(master_secret)
     _assert_valid_length(len(secret), "master secret")

--- a/btclib/psbt/musig2.py
+++ b/btclib/psbt/musig2.py
@@ -78,7 +78,7 @@ from btclib.psbt.psbt_utils import (
 )
 from btclib.script import type_and_payload
 from btclib.to_prv_key import PrvKey
-from btclib.utils import bytes_from_octets
+from btclib.utils import assert_type, bytes_from_octets
 
 __all__ = [
     "add_participant_pub_keys",
@@ -109,6 +109,9 @@ def add_participant_pub_keys(
     and as BIP373 requires whenever sorting was used at all: the order is
     part of the key, so it is stored in the order it was aggregated in.
     """
+    # the order is part of the aggregate key, so this decides which key
+    # the participants are filed under
+    assert_type(sort, bool, "sort")
     keys = musig2.key_sort(participant_pub_keys) if sort else participant_pub_keys
     aggregate_pub_key = bytes_from_point(musig2.key_agg(keys).Q, secp256k1)
     psbt_map.musig2_participant_pub_keys[aggregate_pub_key] = [

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -3444,6 +3444,9 @@ def join(
     building a proof of funds this way sets the field on the result,
     where what it names is a transaction that exists.
     """
+    assert_type(shuffle_inp, bool, "shuffle_inp")
+    assert_type(shuffle_out, bool, "shuffle_out")
+
     _ensure_consistency(psbts)
     psbts = deepcopy(list(psbts))
 

--- a/btclib/psbt/psbt_utils.py
+++ b/btclib/psbt/psbt_utils.py
@@ -23,6 +23,7 @@ from btclib.script.sig_hash import DEFAULT, SIG_HASH_TYPES
 from btclib.script.taproot import assert_valid_control_block
 from btclib.tx import Tx
 from btclib.utils import (
+    assert_type,
     bytes_from_octets,
     bytesio_from_binarydata,
     fields_from_json_object,
@@ -227,6 +228,7 @@ def deserialize_sized_int(
     version as signed too, and `btclib.psbt.psbt` reads it unsigned,
     with the reason at the two sites that do.
     """
+    assert_type(signed, bool, "signed")
     if len(k) != 1:
         err_msg = f"invalid {type_} key length: {len(k)}"
         raise BTClibValueError(err_msg)
@@ -265,6 +267,7 @@ def serialize_sized_int(
     type_: bytes, value: int, size: int, *, signed: bool = False
 ) -> bytes:
     """Return the binary representation of a fixed-size integer field."""
+    assert_type(signed, bool, "signed")
     return serialize_bytes(
         type_, value.to_bytes(size, byteorder="little", signed=signed)
     )
@@ -835,6 +838,11 @@ def deserialize_tx(
     -- to be refused for its size, not for having no inputs, which is true
     of it but not the fault.
     """
+    # None is a declared value for include_witness -- "either encoding" --
+    # and every other non-bool decides which one is accepted
+    if include_witness is not None:
+        assert_type(include_witness, bool, "include_witness")
+    assert_type(unsigned_template, bool, "unsigned_template")
     if len(k) != 1:
         err_msg = f"invalid {type_} key length: {len(k)}"
         raise BTClibValueError(err_msg)

--- a/btclib/psbt_signer.py
+++ b/btclib/psbt_signer.py
@@ -65,7 +65,7 @@ from btclib.psbt.psbt import Psbt, assert_signatures_only, combine, sign
 from btclib.script.taproot import output_prvkey_from_merkle_root
 from btclib.to_prv_key import prv_keyinfo_from_prv_key
 from btclib.to_pub_key import fingerprint, pub_keyinfo_from_key
-from btclib.utils import bytes_from_octets
+from btclib.utils import assert_type, bytes_from_octets
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -536,6 +536,7 @@ class SoftwareSigner:
         # inside, rather than a branch at every use. The round trip is
         # also what refuses a key that is no key, at construction rather
         # than at the first question asked
+        assert_type(musig2, bool, "musig2")
         key = _b58_text(xkey)
         self._musig2 = musig2
         self._fingerprint = fingerprint(key)
@@ -588,6 +589,9 @@ class SoftwareSigner:
         """
         if not accounts:
             raise BTClibValueError("no account: the signer would hold no key")
+        # this factory writes the fields rather than calling __init__, so
+        # the flag is asked for here as well
+        assert_type(musig2, bool, "musig2")
         signer = cls.__new__(cls)
         signer._musig2 = musig2
         signer._fingerprint = bytes_from_octets(master_fingerprint, 4)

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -148,6 +148,7 @@ def check_pub_key(pub_key: bytes, segwit: bool, flags: ScriptFlag) -> bool:
     for a hybrid 0x06/0x07 prefix, WITNESS_PUBKEYTYPE for an
     uncompressed key in a segwit script.
     """
+    assert_type(segwit, bool, "segwit")
     if not pub_key:
         return False
     if pub_key[0] in {4, 6, 7}:
@@ -218,6 +219,9 @@ def calculate_script_code(
     that is where Core does it, and doing it here as well would elide
     them before FindAndDelete rather than after.
     """
+    assert_type(const_scriptcode, bool, "const_scriptcode")
+    assert_type(segwit, bool, "segwit")
+
     script_code = script_bytes[codesep_offset:]
 
     if not segwit:
@@ -268,6 +272,7 @@ def op_checksig(
     because this is where the last byte of a stack element is known to
     be a hash type at all.
     """
+    assert_type(segwit, bool, "segwit")
     if not signature:
         return False
     try:
@@ -430,6 +435,9 @@ def prepare_script(script: ScriptList, flags: ScriptFlag, segwit: bool) -> None:
     Only legacy: BIP143 keeps the op code meaningful in segwit v0, so
     the pre-segwit script code is the one the flag freezes.
     """
+    # `verify_script` reaches this before it reads its own `segwit`, so
+    # this is where the flag of a whole script evaluation is asked for
+    assert_type(segwit, bool, "segwit")
     if (
         "OP_CODESEPARATOR" in script
         and ScriptFlag.CONST_SCRIPTCODE in flags

--- a/btclib/script/engine/script_op_codes.py
+++ b/btclib/script/engine/script_op_codes.py
@@ -32,7 +32,7 @@ from btclib.hashes import hash160, hash256, ripemd160, sha1, sha256
 from btclib.script.engine.flags import ScriptFlag
 from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE, MAX_STACK_SIZE
 from btclib.tx.tx import Tx
-from btclib.utils import decode_num, encode_num
+from btclib.utils import assert_type, decode_num, encode_num
 
 __all__ = [
     "ScriptOp",
@@ -213,6 +213,7 @@ def read_push_data(
     measure. Core defers it the same way, by scanning for OP_SUCCESSx
     before it executes anything at all.
     """
+    assert_type(skip_execution, bool, "skip_execution")
     if op_code < 76:
         data_length = op_code
     else:

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -683,6 +683,8 @@ class ScriptPubKey(Script):
 
         https://github.com/bitcoin/bips/blob/master/bip-0067.mediawiki
         """
+        assert_type(lexicographic_sorting, bool, "lexicographic_sorting")
+
         n = len(keys)
         if not 0 < n < 17:
             raise BTClibValueError(f"invalid n in m-of-n: {n}")

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -143,6 +143,8 @@ def parse(stream: BinaryData, exit_on_op_success: bool = False) -> ScriptList:
     520 bytes is refused only by a parse that meets no OP_SUCCESSx,
     one anywhere making the script valid.
     """
+    assert_type(exit_on_op_success, bool, "exit_on_op_success")
+
     s = bytesio_from_binarydata(stream)
     r: ScriptList = []  # initialize the result list
     invalid_element_size = False

--- a/btclib/to_prv_key.py
+++ b/btclib/to_prv_key.py
@@ -23,7 +23,7 @@ from btclib.network import (
     network_from_xkeyversion,
     xprvversions_from_network,
 )
-from btclib.utils import bytes_from_octets
+from btclib.utils import assert_type, bytes_from_octets
 
 __all__ = [
     "PrvKey",
@@ -334,6 +334,10 @@ def prv_keyinfo_from_prv_key(
     -- fill in.
     """
     _assert_prv_key_type(prv_key)
+    # None is a declared value here and means "whatever the key says", so
+    # it is the one non-bool this position takes
+    if compressed is not None:
+        assert_type(compressed, bool, "compressed")
 
     compr = True if compressed is None else compressed
     net = "mainnet" if network is None else network

--- a/btclib/to_pub_key.py
+++ b/btclib/to_pub_key.py
@@ -29,7 +29,7 @@ from btclib.network import (
     xpubversions_from_network,
 )
 from btclib.to_prv_key import PrvKey, prv_keyinfo_from_prv_key
-from btclib.utils import bytes_from_octets
+from btclib.utils import assert_type, bytes_from_octets
 
 __all__ = [
     "Key",
@@ -236,6 +236,10 @@ def pub_keyinfo_from_pub_key(
 ) -> PubkeyInfo:
     """Return the pub key tuple (SEC-bytes, network) from a public key."""
     _assert_pub_key_type(pub_key)
+    # as in `to_prv_key.prv_keyinfo_from_prv_key`: None means "whatever
+    # the key says", and every other spelling of a truth is refused
+    if compressed is not None:
+        assert_type(compressed, bool, "compressed")
 
     compr = True if compressed is None else compressed
     net = "mainnet" if network is None else network

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -495,6 +495,9 @@ def join(
     order the merge ran in. Summing two payments into one output is the
     caller's to do before signing.
     """
+    assert_type(shuffle_inp, bool, "shuffle_inp")
+    assert_type(shuffle_out, bool, "shuffle_out")
+
     version = max(tx.version for tx in txs)
     if enforce_same_version and any(tx.version != version for tx in txs):
         raise BTClibValueError("Version numbers are not the same")

--- a/tests/bool_parameter_test.py
+++ b/tests/bool_parameter_test.py
@@ -1,0 +1,977 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Every `bool` parameter of the library, classified and held to its class.
+
+CONTRIBUTING.md's "A `bool` parameter is a kind or a truth, and only the
+first is type-checked", which is `musig2._flag`'s reasoning: a kind
+written down and read back -- json, a configuration file, a coordinator's
+message -- arrives as whatever it was written as, and `"false"` is true.
+Issue #868 asked for the census this file is.
+
+## The line, and the shape that makes it decidable
+
+A **truth** only decides whether the call refuses: `check_validity=False`
+says do not check now, and the object handed back is the same one. So a
+value read for its truth runs a check or skips one and changes no answer,
+which is why nothing is refused there.
+
+A **kind** decides what a non-refusing call computes, returns or writes.
+`"no"` is true, so a kind read for its truth quietly computes the other
+answer -- the other signature, the other address, the other script code --
+and that is what the refusal is for.
+
+The two tests below are that line, one each:
+
+- a kind refuses `"no"`, `0`, `1` and (where the annotation does not
+  declare it) `None`, with a `BTClibTypeError`
+- a truth **accepts** them, on a fixture the flag's `True` accepts. It is
+  the ratchet `input_validation_test._ANSWERS_FALSE` is: a truth that
+  starts refusing fails here, and the entry has to move rather than the
+  test being edited
+
+## What the census found
+
+Every kind below was ungated when this file was written, `include_witness`
+excepted -- `Block.serialize` and `Tx.serialize` were gated with
+`utils.assert_type` as the serialization boundary was -- and so were
+`musig2.apply_tweak`'s `is_xonly`, which `_flag` refuses, and
+`KeyGroup(verify=)`. The two the issue names are the sharpest:
+
+```text
+dsa.sign(msg, q, lower_s="no")        -> a low-s signature, "no" being true
+pub_keyinfo_from_prv_key(q, "no")     -> the compressed key, and its address
+```
+
+## The walk, and the one name it subtracts
+
+`_bool_parameters` reads every public function of the package and every
+`bool`-annotated parameter of one, so a flag added anywhere is either in a
+table here or the run is red -- there is no third table, and that is the
+state to keep.
+
+`check_validity` is subtracted by name, with one reason for its many
+signatures: it is a convention rather than a parameter, and
+`check_validity_test.py` owns it, holding every class to the same two
+answers. Being a truth is what that file is about.
+
+## Where a fixture is not what it looks like
+
+The engine's five and `read_push_data` take the interpreter's own state,
+and what they are handed here is the smallest *valid* call of each: an
+empty signature is a False `op_checksig` answers rather than raises, an
+empty script is a script code of nothing, and OP_1 is a script that leaves
+a true stack. `hwi.enumerate_devices` runs a command line, so its stand-in
+is `python -c "print('[]')"` -- a device list of none, which is what an
+`emulators` of the wrong type must be refused in front of.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from dataclasses import dataclass, field
+from hashlib import sha256
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from btclib import b32, b58, bip322, core_import, slip132, var_bytes
+from btclib.bip32.bip32 import (
+    derive,
+    derive_from_account,
+    rootxprv_from_seed,
+    xpub_from_xprv,
+)
+from btclib.bip32.der_path import (
+    hardenings_from_der_path,
+    indexes_from_der_path,
+    int_from_index_str,
+)
+from btclib.block.block import Block
+from btclib.curves.curve import Curve, SEC2v1_params2
+from btclib.curves.sec_point import (
+    bytes_from_point,
+    bytes_from_prv_key_int,
+    point_from_octets,
+)
+from btclib.descriptors.descriptors import parse as descriptor_from_string
+from btclib.ecc import bms, dsa, musig2
+from btclib.exceptions import BTClibTypeError
+from btclib.fetch.bitcoin_core import BitcoinCoreFetcher
+from btclib.hwi import HwiSigner, enumerate_devices
+from btclib.mnemonic import bip39, slip39
+from btclib.mnemonic.entropy import (
+    bin_str_entropy_from_random,
+    bin_str_entropy_from_rolls,
+)
+from btclib.mnemonic.mnemonic import WordLists
+from btclib.psbt import musig2 as psbt_musig2
+from btclib.psbt.psbt import Psbt, assert_signed
+from btclib.psbt.psbt import join as psbt_join
+from btclib.psbt.psbt_in import PsbtIn
+from btclib.psbt.psbt_utils import (
+    deserialize_sized_int,
+    deserialize_tx,
+    serialize_sized_int,
+)
+from btclib.psbt_signer import SoftwareSigner
+from btclib.script.engine import script as engine
+from btclib.script.engine import script_op_codes, verify_transaction
+from btclib.script.engine.flags import NO_FLAGS, ScriptFlag
+from btclib.script.script import serialize as serialize_script
+from btclib.script.script_pub_key import ScriptPubKey
+from btclib.script.taproot import parse as taproot_parse
+from btclib.to_prv_key import prv_keyinfo_from_prv_key
+from btclib.to_pub_key import (
+    pub_keyinfo_from_key,
+    pub_keyinfo_from_prv_key,
+    pub_keyinfo_from_pub_key,
+)
+from btclib.tx.out_point import OutPoint
+from btclib.tx.tx import Tx
+from btclib.tx.tx import join as tx_join
+from btclib.tx.tx_in import TxIn
+from btclib.tx.tx_out import TxOut
+from btclib.wallet.script_wallet import KeyGroup
+from tests.fetch.bitcoin_core_test import client
+from tests.psbt import psbt_cases
+
+
+def _is_signed(psbt: Psbt) -> bool:
+    """Return whether every input of the psbt is signed through."""
+    try:
+        assert_signed(psbt)
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+_LIBRARY = Path(__file__).parents[1] / "btclib"
+
+# `check_validity` is the one name the walk subtracts, and this is the
+# reason it may: it is a convention over many signatures rather than a
+# parameter of one, and `check_validity_test.py` is the file that holds
+# every class to it -- being a truth is what that whole file is about
+_OWNED_BY_ITS_OWN_FILE = "check_validity"
+
+# a value of no bool type: a truthy string, and the two integers `bool`
+# inherits from. Every one of them is a call mypy refuses
+_WRONG_TYPES: tuple[Any, ...] = ("no", 0, 1)
+
+_PRV_KEY = 0xC28FCA386C7A227600B2FE50B7CAE11EC86D3BF1FBE471BE89827E19D72AA1D
+_PUB_KEY = dsa.gen_keys(_PRV_KEY)[1]
+_SEC = bytes_from_point(_PUB_KEY)
+_SEC_2 = bytes_from_prv_key_int(_PRV_KEY + 1)
+_MSG = b"Satoshi Nakamoto"
+_MSG_HASH = sha256(_MSG).digest()
+_DER_SIG = dsa.sign(_MSG, _PRV_KEY).serialize()
+
+_ROOT_XPRV = rootxprv_from_seed("00" * 32)
+_ACCOUNT_XPRV = derive(_ROOT_XPRV, "m/44h/0h/0h")
+
+# the cheapest catalogued curve, and the point of it is that both
+# construction-time checks pass on it: a low-cardinality one is MOV-weak,
+# which is what `weakness_check=True` is there to refuse
+_SMALL_CURVE = dict(
+    zip(
+        ("p", "a", "b", "G", "n", "cofactor"),
+        SEC2v1_params2["secp112r1"][:6],
+        strict=True,
+    )
+)
+_XPUB = xpub_from_xprv(_ROOT_XPRV)
+_DESCRIPTOR = descriptor_from_string(f"wpkh({_XPUB}/0/*)")
+_ADDRESS = b58.p2pkh(_PUB_KEY)
+_BIP322_SIG = bip322.sign(_MSG, _PRV_KEY, _ADDRESS)
+
+# a transaction with an input, which is what the engine and the psbt
+# boundary both refuse to work without
+_TX = Tx(vin=[TxIn(OutPoint(b"\x00" * 32, 0))], vout=[TxOut(1000, b"\x51")])
+# a second one spending another outpoint: what `join` refuses is two
+# transactions with an input in common, so one twice is no fixture
+_TX_2 = Tx(vin=[TxIn(OutPoint(b"\x11" * 32, 1))], vout=[TxOut(900, b"\x51")])
+_PSBTS = [Psbt.from_tx(_TX), Psbt.from_tx(_TX_2)]
+_TX_BYTES = _TX.serialize(include_witness=False, check_validity=False)
+# OP_1 as the output being spent: a script anyone can satisfy, so the one
+# verification below is about `check_amounts` and not about a signature
+_PREVOUTS = [TxOut(2000, b"\x51")]
+
+_BLOCK = Block.parse(
+    (Path(__file__).parent / "block" / "_data" / "block_1.bin").read_bytes()
+)
+
+# the first BIP174 vector that is signed through, which is what makes
+# `allow_partial` a flag both of whose values accept it
+_SIGNED_PSBT = next(
+    psbt
+    for psbt in (
+        Psbt.b64decode(case["encoded psbt"])
+        for case in psbt_cases("bip174_test_vectors.json", "valid psbts")
+    )
+    if _is_signed(psbt)
+)
+
+# a device that answers HWI's own shape and needs no device: the flag is
+# read in front of the command line, which is where it has to be
+_STAND_IN = [sys.executable, "-c", "print('[]')"]
+
+_KEY_AGG = musig2.key_agg([_SEC, _SEC_2])
+
+
+@dataclass(frozen=True)
+class _Case:
+    """One `bool` parameter, and a call of its function that works."""
+
+    dotted: str
+    flag: str
+    function: Any
+    # every argument but the flag, by keyword
+    args: dict[str, Any] = field(default_factory=dict)
+    # the flag value the working call is made with: `True` unless the
+    # fixture is one only `False` accepts
+    valid: bool = True
+    # `bool | None` declares None, so it is not a wrong value there. Read
+    # off the annotation, not an exemption from anything
+    optional: bool = False
+    # a truth's classification, which is prose because it is a judgement:
+    # what the flag turns on, and what it therefore cannot change
+    reason: str = ""
+
+
+_KINDS = (
+    # `compressed` chooses which public key is computed, and therefore
+    # which address: eleven parameters, four checks, the rest reaching one
+    # of those four
+    _Case(
+        "btclib.curves.sec_point.bytes_from_point",
+        "compressed",
+        bytes_from_point,
+        {"Q": _PUB_KEY},
+    ),
+    _Case(
+        "btclib.curves.sec_point.bytes_from_prv_key_int",
+        "compressed",
+        bytes_from_prv_key_int,
+        {"prv_key_int": _PRV_KEY},
+    ),
+    _Case(
+        "btclib.to_prv_key.prv_keyinfo_from_prv_key",
+        "compressed",
+        prv_keyinfo_from_prv_key,
+        {"prv_key": _PRV_KEY},
+        optional=True,
+    ),
+    _Case(
+        "btclib.to_pub_key.pub_keyinfo_from_key",
+        "compressed",
+        pub_keyinfo_from_key,
+        {"key": _SEC},
+        optional=True,
+    ),
+    _Case(
+        "btclib.to_pub_key.pub_keyinfo_from_pub_key",
+        "compressed",
+        pub_keyinfo_from_pub_key,
+        {"pub_key": _SEC},
+        optional=True,
+    ),
+    _Case(
+        "btclib.to_pub_key.pub_keyinfo_from_prv_key",
+        "compressed",
+        pub_keyinfo_from_prv_key,
+        {"prv_key": _PRV_KEY},
+        optional=True,
+    ),
+    _Case(
+        "btclib.b58.wif_from_prv_key",
+        "compressed",
+        b58.wif_from_prv_key,
+        {"prv_key": _PRV_KEY},
+        optional=True,
+    ),
+    _Case("btclib.b58.p2pkh", "compressed", b58.p2pkh, {"key": _SEC}, optional=True),
+    _Case(
+        "btclib.ecc.bms.gen_keys",
+        "compressed",
+        bms.gen_keys,
+        {"prv_key": _PRV_KEY},
+        optional=True,
+    ),
+    _Case(
+        "btclib.script.script_pub_key.ScriptPubKey.p2pkh",
+        "compressed",
+        ScriptPubKey.p2pkh,
+        {"key": _SEC},
+        optional=True,
+    ),
+    _Case(
+        "btclib.script.script_pub_key.ScriptPubKey.p2ms",
+        "compressed",
+        ScriptPubKey.p2ms,
+        {"m": 1, "keys": [_SEC, _SEC_2]},
+        optional=True,
+    ),
+    _Case(
+        "btclib.script.script_pub_key.ScriptPubKey.p2ms",
+        "lexicographic_sorting",
+        ScriptPubKey.p2ms,
+        {"m": 1, "keys": [_SEC, _SEC_2]},
+    ),
+    # `lower_s` chooses which of the two signatures is returned, `grind`
+    # whether the nonce is searched until r is short
+    _Case(
+        "btclib.ecc.dsa.sign_",
+        "lower_s",
+        dsa.sign_,
+        {"msg_hash": _MSG_HASH, "prv_key": _PRV_KEY},
+    ),
+    _Case(
+        "btclib.ecc.dsa.sign", "lower_s", dsa.sign, {"msg": _MSG, "prv_key": _PRV_KEY}
+    ),
+    _Case(
+        "btclib.ecc.dsa.sign_recoverable_",
+        "lower_s",
+        dsa.sign_recoverable_,
+        {"msg_hash": _MSG_HASH, "prv_key": _PRV_KEY},
+    ),
+    _Case(
+        "btclib.ecc.dsa.sign_recoverable",
+        "lower_s",
+        dsa.sign_recoverable,
+        {"msg": _MSG, "prv_key": _PRV_KEY},
+    ),
+    _Case(
+        "btclib.ecc.dsa.anti_exfil_sign",
+        "lower_s",
+        dsa.anti_exfil_sign,
+        {"msg_hash": _MSG_HASH, "prv_key": _PRV_KEY, "rho": _MSG_HASH},
+    ),
+    _Case(
+        "btclib.ecc.dsa.sign_",
+        "grind",
+        dsa.sign_,
+        {"msg_hash": _MSG_HASH, "prv_key": _PRV_KEY},
+    ),
+    _Case("btclib.ecc.dsa.sign", "grind", dsa.sign, {"msg": _MSG, "prv_key": _PRV_KEY}),
+    # the script engine: `segwit` says which digest a signature commits
+    # to and which script code it is checked against, so it is a
+    # consensus answer and not a check
+    _Case(
+        "btclib.script.engine.script.check_pub_key",
+        "segwit",
+        engine.check_pub_key,
+        {"pub_key": _SEC, "flags": NO_FLAGS},
+    ),
+    _Case(
+        "btclib.script.engine.script.calculate_script_code",
+        "segwit",
+        engine.calculate_script_code,
+        {
+            "script_bytes": b"",
+            "codesep_offset": 0,
+            "signatures": [],
+            "const_scriptcode": False,
+        },
+    ),
+    _Case(
+        "btclib.script.engine.script.calculate_script_code",
+        "const_scriptcode",
+        engine.calculate_script_code,
+        {"script_bytes": b"", "codesep_offset": 0, "signatures": [], "segwit": True},
+        valid=False,
+    ),
+    _Case(
+        "btclib.script.engine.script.op_checksig",
+        "segwit",
+        engine.op_checksig,
+        {
+            "signature": b"",
+            "signatures": [],
+            "pub_key": _SEC,
+            "script_bytes": b"",
+            "codesep_offset": 0,
+            "prevout_value": 0,
+            "tx": _TX,
+            "i": 0,
+            "flags": NO_FLAGS,
+        },
+    ),
+    _Case(
+        "btclib.script.engine.script.prepare_script",
+        "segwit",
+        engine.prepare_script,
+        {"script": [], "flags": NO_FLAGS},
+    ),
+    _Case(
+        "btclib.script.engine.script.verify_script",
+        "segwit",
+        engine.verify_script,
+        {
+            "script_bytes": b"\x51",
+            "stack": [],
+            "prevout_value": 0,
+            "tx": _TX,
+            "i": 0,
+            "flags": NO_FLAGS,
+        },
+        valid=False,
+    ),
+    _Case(
+        "btclib.script.engine.script_op_codes.read_push_data",
+        "skip_execution",
+        script_op_codes.read_push_data,
+        {
+            "op_code": 1,
+            "s": BytesIO(b"\x01"),
+            "stack": [],
+            "flags": NO_FLAGS,
+            "serialize": serialize_script,
+        },
+    ),
+    _Case(
+        "btclib.script.taproot.parse",
+        "exit_on_op_success",
+        taproot_parse,
+        {"stream": b"\x51"},
+    ),
+    # the psbt boundary: which integer encoding, and which transaction
+    _Case(
+        "btclib.psbt.psbt_utils.deserialize_sized_int",
+        "signed",
+        deserialize_sized_int,
+        {"k": b"\x00", "v": b"\x01\x00\x00\x00", "type_": "field", "size": 4},
+        valid=False,
+    ),
+    _Case(
+        "btclib.psbt.psbt_utils.serialize_sized_int",
+        "signed",
+        serialize_sized_int,
+        {"type_": b"\x00", "value": 1, "size": 4},
+        valid=False,
+    ),
+    _Case(
+        "btclib.psbt.psbt_utils.deserialize_tx",
+        "include_witness",
+        deserialize_tx,
+        {"k": b"\x00", "v": _TX_BYTES, "type_": "field"},
+        valid=False,
+        optional=True,
+    ),
+    _Case(
+        "btclib.psbt.psbt_utils.deserialize_tx",
+        "unsigned_template",
+        deserialize_tx,
+        {"k": b"\x00", "v": _TX_BYTES, "type_": "field", "include_witness": False},
+        valid=False,
+    ),
+    _Case(
+        "btclib.block.block.Block.serialize",
+        "include_witness",
+        _BLOCK.serialize,
+        {},
+    ),
+    _Case("btclib.tx.tx.Tx.serialize", "include_witness", _TX.serialize, {}),
+    _Case(
+        "btclib.b32.power_of_2_base_conversion",
+        "pad",
+        b32.power_of_2_base_conversion,
+        {"data": [1, 2, 3], "from_bits": 8, "to_bits": 5},
+    ),
+    _Case(
+        "btclib.psbt.musig2.add_participant_pub_keys",
+        "sort",
+        psbt_musig2.add_participant_pub_keys,
+        {"psbt_map": PsbtIn(), "participant_pub_keys": [_SEC, _SEC_2]},
+        valid=False,
+    ),
+    _Case(
+        "btclib.mnemonic.entropy.bin_str_entropy_from_rolls",
+        "shuffle",
+        bin_str_entropy_from_rolls,
+        {"bits": 8, "dice_sides": 6, "rolls": [1, 2, 3, 4, 5, 6, 1, 2]},
+    ),
+    _Case(
+        "btclib.mnemonic.entropy.bin_str_entropy_from_random",
+        "to_be_hashed",
+        bin_str_entropy_from_random,
+        {"bits": 128},
+    ),
+    _Case(
+        "btclib.psbt.psbt.join",
+        "shuffle_inp",
+        psbt_join,
+        {
+            "psbts": _PSBTS,
+            "enforce_same_tx_version": True,
+            "enforce_same_tx_lock_time": True,
+            "shuffle_out": False,
+        },
+        valid=False,
+    ),
+    _Case(
+        "btclib.psbt.psbt.join",
+        "shuffle_out",
+        psbt_join,
+        {
+            "psbts": _PSBTS,
+            "enforce_same_tx_version": True,
+            "enforce_same_tx_lock_time": True,
+            "shuffle_inp": False,
+        },
+        valid=False,
+    ),
+    _Case(
+        "btclib.tx.tx.join",
+        "shuffle_inp",
+        tx_join,
+        {
+            "txs": [_TX, _TX_2],
+            "enforce_same_version": True,
+            "enforce_same_lock_time": True,
+            "shuffle_out": False,
+        },
+        valid=False,
+    ),
+    _Case(
+        "btclib.tx.tx.join",
+        "shuffle_out",
+        tx_join,
+        {
+            "txs": [_TX, _TX_2],
+            "enforce_same_version": True,
+            "enforce_same_lock_time": True,
+            "shuffle_inp": False,
+        },
+        valid=False,
+    ),
+    # which verification runs: a BMS signature over the message, or
+    # BIP322's own
+    _Case(
+        "btclib.bip322.assert_as_valid",
+        "legacy",
+        bip322.assert_as_valid,
+        {"msg": _MSG, "addr": _ADDRESS, "sig": _BIP322_SIG},
+    ),
+    _Case(
+        "btclib.bip322.verify",
+        "legacy",
+        bip322.verify,
+        {"msg": _MSG, "addr": _ADDRESS, "sig": _BIP322_SIG},
+    ),
+    _Case(
+        "btclib.hwi.enumerate_devices",
+        "emulators",
+        enumerate_devices,
+        {"executable": _STAND_IN},
+        valid=False,
+    ),
+    _Case(
+        "btclib.hwi.HwiSigner.__init__",
+        "emulators",
+        HwiSigner,
+        {"fingerprint": "00" * 4, "executable": _STAND_IN},
+        valid=False,
+    ),
+    _Case(
+        "btclib.psbt_signer.SoftwareSigner.__init__",
+        "musig2",
+        SoftwareSigner,
+        {"xkey": _ROOT_XPRV},
+        valid=False,
+    ),
+    _Case(
+        "btclib.psbt_signer.SoftwareSigner.from_accounts",
+        "musig2",
+        SoftwareSigner.from_accounts,
+        {"master_fingerprint": "00" * 4, "accounts": {"m/0h": _XPUB}},
+        valid=False,
+    ),
+    _Case(
+        "btclib.core_import.import_request",
+        "internal",
+        core_import.import_request,
+        {"descriptor": _DESCRIPTOR, "timestamp": 0},
+        valid=False,
+    ),
+    _Case(
+        "btclib.core_import.import_request",
+        "active",
+        core_import.import_request,
+        {"descriptor": _DESCRIPTOR, "timestamp": 0},
+    ),
+    _Case(
+        "btclib.core_import.account_import_requests",
+        "active",
+        core_import.account_import_requests,
+        {"receive": _DESCRIPTOR, "change": _DESCRIPTOR, "timestamp": 0},
+    ),
+    _Case(
+        "btclib.mnemonic.slip39.mnemonics_from_master_secret",
+        "extendable",
+        slip39.mnemonics_from_master_secret,
+        {"master_secret": "00" * 16},
+    ),
+    _Case(
+        "btclib.ecc.musig2.apply_tweak",
+        "is_xonly",
+        musig2.apply_tweak,
+        {"key_agg_ctx": _KEY_AGG, "tweak": b"\x01" * 32},
+    ),
+    _Case(
+        "btclib.wallet.script_wallet.KeyGroup.__init__",
+        "verify",
+        KeyGroup,
+        {"threshold": 2, "keys": [_XPUB, _XPUB]},
+        valid=False,
+    ),
+)
+
+_TRUTHS = (
+    _Case(
+        "btclib.slip132.p2pkh_xkey",
+        "check_root_xkey",
+        slip132.p2pkh_xkey,
+        {"xkey": _ROOT_XPRV},
+        reason="whether the xkey is required to be a root one",
+    ),
+    _Case(
+        "btclib.slip132.p2wpkh_xkey",
+        "check_root_xkey",
+        slip132.p2wpkh_xkey,
+        {"xkey": _ROOT_XPRV},
+        reason="whether the xkey is required to be a root one",
+    ),
+    _Case(
+        "btclib.slip132.p2wpkh_p2sh_xkey",
+        "check_root_xkey",
+        slip132.p2wpkh_p2sh_xkey,
+        {"xkey": _ROOT_XPRV},
+        reason="whether the xkey is required to be a root one",
+    ),
+    _Case(
+        "btclib.mnemonic.bip39.seed_from_mnemonic",
+        "verify_checksum",
+        bip39.seed_from_mnemonic,
+        {"mnemonic": "abandon " * 11 + "about", "passphrase": ""},
+        reason="whether the mnemonic's checksum is checked; the seed is the"
+        " same either way, being a PBKDF2 of the words",
+    ),
+    _Case(
+        "btclib.mnemonic.bip39.mxprv_from_mnemonic",
+        "verify_checksum",
+        bip39.mxprv_from_mnemonic,
+        {"mnemonic": "abandon " * 11 + "about"},
+        reason="whether the mnemonic's checksum is checked",
+    ),
+    _Case(
+        "btclib.curves.curve.Curve.__init__",
+        "weakness_check",
+        Curve,
+        _SMALL_CURVE,
+        reason="whether the embedding degree is derived; a construction-time"
+        " check, and no parameter of the curve built",
+    ),
+    _Case(
+        "btclib.curves.curve.Curve.__init__",
+        "order_check",
+        Curve,
+        _SMALL_CURVE,
+        reason="whether n*G is verified to be the point at infinity",
+    ),
+    _Case(
+        "btclib.bip32.der_path.int_from_index_str",
+        "bip380_enforced",
+        int_from_index_str,
+        {"s": "0"},
+        reason="whether BIP380's spelling rules are enforced; an index both"
+        " accept is the same integer",
+    ),
+    _Case(
+        "btclib.bip32.der_path.indexes_from_der_path",
+        "bip380_enforced",
+        indexes_from_der_path,
+        {"der_path": "0/1"},
+        reason="whether BIP380's spelling rules are enforced",
+    ),
+    _Case(
+        "btclib.bip32.der_path.hardenings_from_der_path",
+        "bip380_enforced",
+        hardenings_from_der_path,
+        {"der_path": "0/1"},
+        reason="whether BIP380's spelling rules are enforced",
+    ),
+    _Case(
+        "btclib.ecc.dsa.Sig.parse",
+        "strict",
+        dsa.Sig.parse,
+        {"data": _DER_SIG},
+        reason="whether trailing bytes after the DER sequence are refused;"
+        " the signature parsed out of what both accept is one signature",
+    ),
+    _Case(
+        "btclib.psbt.psbt.assert_signed",
+        "allow_partial",
+        assert_signed,
+        {"psbt": _SIGNED_PSBT},
+        reason="whether an input still unsigned is allowed",
+    ),
+    _Case(
+        "btclib.var_bytes.parse",
+        "forbid_zero_size",
+        var_bytes.parse,
+        {"stream": b"\x01\x00"},
+        reason="whether a zero-size field is refused",
+    ),
+    _Case(
+        "btclib.tx.tx.join",
+        "enforce_same_version",
+        tx_join,
+        {
+            "txs": [_TX, _TX_2],
+            "enforce_same_lock_time": True,
+            "shuffle_inp": False,
+            "shuffle_out": False,
+        },
+        reason="whether a version the others do not share is refused; the"
+        " joined transaction takes the highest either way",
+    ),
+    _Case(
+        "btclib.tx.tx.join",
+        "enforce_same_lock_time",
+        tx_join,
+        {
+            "txs": [_TX, _TX_2],
+            "enforce_same_version": True,
+            "shuffle_inp": False,
+            "shuffle_out": False,
+        },
+        reason="whether a lock time the others do not share is refused",
+    ),
+    _Case(
+        "btclib.psbt.psbt.join",
+        "enforce_same_tx_version",
+        psbt_join,
+        {
+            "psbts": _PSBTS,
+            "enforce_same_tx_lock_time": True,
+            "shuffle_inp": False,
+            "shuffle_out": False,
+        },
+        reason="whether a transaction version the others do not share is refused",
+    ),
+    _Case(
+        "btclib.psbt.psbt.join",
+        "enforce_same_tx_lock_time",
+        psbt_join,
+        {
+            "psbts": _PSBTS,
+            "enforce_same_tx_version": True,
+            "shuffle_inp": False,
+            "shuffle_out": False,
+        },
+        reason="whether a lock time the others do not share is refused",
+    ),
+    _Case(
+        "btclib.script.engine.__init__.verify_transaction",
+        "check_amounts",
+        verify_transaction,
+        {"prevouts": _PREVOUTS, "tx": _TX},
+        reason="whether the outputs are required to be worth no more than"
+        " the inputs; the scripts run either way",
+    ),
+    _Case(
+        "btclib.fetch.bitcoin_core.BitcoinCoreFetcher.__init__",
+        "verify_network",
+        BitcoinCoreFetcher,
+        {"client": client()},
+        reason="whether the node is asked which chain it serves; a check,"
+        " and the one the fetcher makes before its first fetch",
+    ),
+    _Case(
+        "btclib.bip32.bip32.derive_from_account",
+        "branches_0_1_only",
+        derive_from_account,
+        {"mxkey": _ACCOUNT_XPRV, "branch": 0, "address_index": 0},
+        reason="whether a branch other than 0 and 1 is refused; the key"
+        " derived at a branch both accept is the same key",
+    ),
+    _Case(
+        "btclib.curves.sec_point.point_from_octets",
+        "hybrid",
+        point_from_octets,
+        {"pub_key": _SEC},
+        reason="whether the 0x06 and 0x07 prefixes are accepted; the point"
+        " read out of octets both accept is the same point",
+    ),
+    _Case(
+        "btclib.mnemonic.mnemonic.WordLists.__init__",
+        "power_of_two",
+        WordLists,
+        {},
+        reason="whether a word list whose length is not a power of two is"
+        " refused, which is what Electrum's 1626 words need off",
+    ),
+    _Case(
+        "btclib.tx.tx.Tx.assert_valid",
+        "unsigned_template",
+        _TX.assert_valid,
+        {},
+        reason="whether the inputs are required to carry no signature,"
+        " which is a rule about a template and not a field of the tx",
+    ),
+    _Case(
+        "btclib.script.engine.script.verify_script",
+        "final",
+        engine.verify_script,
+        {
+            "script_bytes": b"\x51",
+            "stack": [],
+            "prevout_value": 0,
+            "tx": _TX,
+            "i": 0,
+            "flags": NO_FLAGS,
+            "segwit": False,
+        },
+        reason="whether the script is required to end on a true stack,"
+        " which is the caller saying no script runs after this one",
+    ),
+    _Case(
+        "btclib.script.engine.script.assert_nullfail",
+        "verified",
+        engine.assert_nullfail,
+        {
+            "flags": ScriptFlag.NULLFAIL,
+            "signatures": [b""],
+            "op": "OP_CHECKSIG",
+        },
+        reason="whether the NULLFAIL refusal fires, an empty signature"
+        " being what it demands of a check that failed",
+    ),
+)
+
+_KIND_IDS = tuple(f"{case.dotted}({case.flag})" for case in _KINDS)
+_TRUTH_IDS = tuple(f"{case.dotted}({case.flag})" for case in _TRUTHS)
+
+
+def _flags_of(function: ast.FunctionDef) -> set[str]:
+    """Return the `bool`-annotated parameters of one public function."""
+    if function.name.startswith("_") and not function.name.startswith("__"):
+        return set()
+    if any(ast.unparse(d) == "overload" for d in function.decorator_list):
+        return set()
+    arguments = [
+        *function.args.posonlyargs,
+        *function.args.args,
+        *function.args.kwonlyargs,
+    ]
+    return {
+        argument.arg
+        for argument in arguments
+        if argument.annotation is not None
+        and ast.unparse(argument.annotation) in {"bool", "bool | None"}
+        and argument.arg != _OWNED_BY_ITS_OWN_FILE
+    }
+
+
+def _bool_parameters() -> set[tuple[str, str]]:
+    """Return every (function, `bool` parameter) pair of the public API.
+
+    Keyed on the annotation, `bool` and `bool | None`: what a flag is
+    called says nothing, and `include_witness` is spelled both ways.
+
+    A method counts and a private function does not, as in
+    `curve_parameter_test.py`; an `@overload` stub is not a function to
+    drive; and a function nested in another is a closure rather than API --
+    `Miniscript.to_script`'s `up` takes a `verify` that no caller can pass.
+    """
+    found: set[tuple[str, str]] = set()
+
+    def walk(node: ast.Module | ast.ClassDef, module: str, prefix: str) -> None:
+        for child in node.body:
+            if isinstance(child, ast.ClassDef):
+                walk(child, module, f"{prefix}{child.name}.")
+            elif isinstance(child, ast.FunctionDef):
+                dotted = f"{module}.{prefix}{child.name}"
+                found.update((dotted, flag) for flag in _flags_of(child))
+
+    for path in sorted(_LIBRARY.rglob("*.py")):
+        module = ".".join(path.relative_to(_LIBRARY.parent).with_suffix("").parts)
+        walk(ast.parse(path.read_text(encoding="utf-8")), module, "")
+    return found
+
+
+@pytest.mark.parametrize("case", [*_KINDS, *_TRUTHS], ids=[*_KIND_IDS, *_TRUTH_IDS])
+def test_the_call_works(case: _Case) -> None:
+    """The fixture is valid, which is what makes a refusal below a finding.
+
+    Without this a case whose arguments had gone stale would pass every
+    test in the file by refusing everything it is handed.
+    """
+    case.function(**case.args, **{case.flag: case.valid})
+
+
+@pytest.mark.parametrize("case", _KINDS, ids=_KIND_IDS)
+def test_a_kind_refuses_a_non_bool(case: _Case) -> None:
+    """A kind decides what is computed, so it is not read for its truth.
+
+    `"no"` is the value that makes the point -- it is true, so the flag
+    would be on -- and `0` and `1` are the two `bool` inherits from, which
+    is what makes `isinstance(value, int)` no check at all here.
+    """
+    wrong = _WRONG_TYPES if case.optional else (*_WRONG_TYPES, None)
+    for value in wrong:
+        with pytest.raises(BTClibTypeError, match=f"invalid {case.flag} type"):
+            case.function(**case.args, **{case.flag: value})
+
+
+@pytest.mark.parametrize("case", _TRUTHS, ids=_TRUTH_IDS)
+def test_a_truth_is_read_for_its_truth(case: _Case) -> None:
+    """The other half of the line, and the ratchet under this file.
+
+    A truth turns a check on or off and changes no answer, so a value of
+    another type is read for whether it is true and refused by nothing.
+    An entry that starts refusing fails here rather than passing quietly:
+    the fix is to move it to `_KINDS`, which is a decision about the
+    parameter and not about this test.
+    """
+    for value in _WRONG_TYPES:
+        case.function(**case.args, **{case.flag: value})
+
+
+def test_every_bool_parameter_is_classified() -> None:
+    """No third table: a flag is a kind or a truth, and the walk says so.
+
+    A parameter added anywhere under `btclib/` fails here until somebody
+    decides which of the two it is -- which is the decision this file
+    exists to keep from being made by default.
+    """
+    classified = {(case.dotted, case.flag) for case in (*_KINDS, *_TRUTHS)}
+    found = _bool_parameters()
+    assert classified == found, (
+        f"unclassified: {sorted(found - classified)};"
+        f" gone from the tree: {sorted(classified - found)}"
+    )
+
+
+def test_the_walk_reaches_what_it_claims() -> None:
+    """The shapes it must find, and the four it must not.
+
+    A walk that found nothing would pass the test above.
+    """
+    found = _bool_parameters()
+    # a defaulted flag, a required one, an optional annotation, a method
+    assert ("btclib.ecc.dsa.sign", "lower_s") in found
+    assert ("btclib.tx.tx.join", "shuffle_inp") in found
+    assert ("btclib.b58.p2pkh", "compressed") in found
+    assert ("btclib.tx.tx.Tx.serialize", "include_witness") in found
+
+    # the convention with a file of its own
+    assert not [pair for pair in found if pair[1] == "check_validity"]
+    # a private function, a closure, and a parameter of another type
+    assert ("btclib.ecc.musig2._flag", "is_xonly") not in found
+    assert ("btclib.descriptors.miniscript.up", "verify") not in found
+    assert ("btclib.hashes.reduce_to_hlen", "hf") not in found


### PR DESCRIPTION
The second half of https://github.com/btclib-org/btclib/issues/868, whose
first half is https://github.com/btclib-org/btclib/pull/869: applying
CONTRIBUTING.md's kind-or-truth line to every `bool` parameter of the
library, which meant the census first.

## The line, made decidable

A **kind** decides what a non-refusing call computes, returns or writes. A
**truth** decides only whether the call refuses, so a value read for its
truth runs a check or skips one and changes no answer. That is the shape
the census is sorted by, and both halves of it are driven rather than
asserted.

Seventy-eight `bool` parameters besides `check_validity`: **fifty-three
kinds and twenty-five truths.**

## What was open

The two the issue names, and thirty-odd more of the same shape:

```text
dsa.sign(msg, q, lower_s="no")        -> a low-s signature, "no" being true
pub_keyinfo_from_prv_key(q, "no")     -> the compressed key, and its address
```

`compressed` chooses which public key is computed and therefore which
address; `lower_s` which of the two signatures comes back; `grind` whether
the nonce is searched until r is short. The script engine's `segwit` says
which digest a signature commits to and which script code it is checked
against — a consensus answer, in five signatures — beside
`const_scriptcode`, `skip_execution` and `exit_on_op_success`. Then
`signed`, `include_witness` and `unsigned_template` at the psbt boundary,
`shuffle_inp` and `shuffle_out` in both `join`s, BIP322's `legacy`, and
`sort`, `pad`, `shuffle`, `to_be_hashed`, `extendable`,
`lexicographic_sorting`, `emulators`, `musig2`, `active`, `internal`.

`0` and `1` are refused too, and that is not pedantry: `bool` is a subclass
of `int`, which is what leaves `isinstance(value, int)` no check at all
here — the same reason `utils.is_integer` exists for the other direction.

## The refusal

`utils.assert_type`, which since
https://github.com/btclib-org/btclib/pull/877 is the library's one
spelling of that refusal: thirty new guards and no thirty-first message
shape. One Python call, one to three times in a call that is microseconds
— a trivial script verification is 9 us and makes three of them.

It sits where the flag is **first read**, which is fewer places than there
are parameters: `b58.p2pkh`, `ScriptPubKey.p2pkh` and the rest reach one of
the four `compressed` checks, `dsa.sign` and `anti_exfil_sign` reach
`sign_`'s, `verify_script` reaches `prepare_script`'s.
`b58.wif_from_prv_key` is the one that had to ask for itself: it calls
`prv_keyinfo_from_prv_key` *without* the flag and reads the caller's own
afterwards.

## The gate

`tests/bool_parameter_test.py`, two tables and no third:

- a **kind** is driven until it refuses `"no"`, `0`, `1` — and `None` where
  the annotation does not declare it
- a **truth** is driven until it *accepts* all three, on a fixture its
  `True` accepts. This is what keeps the classification honest rather than
  self-serving: a truth that starts refusing fails here, and the entry has
  to move to the kinds rather than the test being edited. It is
  `input_validation_test._ANSWERS_FALSE`'s ratchet.
- a **walk** over every public function's `bool` parameters fails on one in
  neither table, so a flag added anywhere is a decision somebody makes
  rather than one the default makes for them

`check_validity` is the one name the walk subtracts, with one reason for
its many signatures: `check_validity_test.py` owns that convention, and
being a truth is what that whole file is about.

The truths, each with its reason in the table: `check_root_xkey`,
`verify_checksum`, `strict`, `bip380_enforced`, `forbid_zero_size`,
`allow_partial`, `check_amounts`, `verify_network`, `branches_0_1_only`,
`hybrid`, `power_of_two`, `order_check`, `weakness_check`, the four
`enforce_same_*`, `unsigned_template` on `Tx.assert_valid`, and the
engine's `final` and `verified`.

## Fixtures worth a word

The engine's five and `read_push_data` take the interpreter's own state,
and what they get is the smallest **valid** call of each: an empty
signature is a False `op_checksig` answers rather than raises, an empty
script is a script code of nothing, OP_1 is a script that leaves a true
stack. `hwi.enumerate_devices` runs a command line, so its stand-in is
`python -c "print('[]')"` — a device list of none, which is what an
`emulators` of the wrong type has to be refused in front of. And
`Curve(weakness_check=)` is driven on `secp112r1`'s catalogued parameters,
not on a low-cardinality curve: those are MOV-weak, which is exactly what
`True` refuses.

## Breaking

Thirty-odd arguments that used to be accepted now raise a
`BTClibTypeError`. A caller passing a `bool` is unaffected, and mypy
already refused every one of these calls. HISTORY.md carries the bullet,
CHANGELOG.md the detail.

## Verified

- `uv run pytest`: 27802 passed, coverage 100.00%
- `uv run pre-commit run --all-files`: exit 0
- `sphinx-build -W --keep-going`: build succeeded

Closes https://github.com/btclib-org/btclib/issues/868

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Classify all public bool parameters as either kind or truth and enforce consistent validation and documentation around them.

Enhancements:
- Add centralized type-checking for kind-style bool flags using utils.assert_type across cryptographic, script, PSBT, transaction, mnemonic, HWI, and wallet APIs.
- Introduce a comprehensive tests/bool_parameter_test.py census that verifies each bool parameter’s classification and behavior and ensures new flags are explicitly categorized.
- Document the kind/truth convention, its census, and enforcement in CONTRIBUTING.md, CHANGELOG.md, and HISTORY.md, including the breaking nature of rejecting non-bool values.

Documentation:
- Expand CONTRIBUTING.md, CHANGELOG.md, and HISTORY.md to describe the kind vs truth bool convention, the census, and the impact on the public API.

Tests:
- Add bool_parameter_test.py to exhaustively test all public bool parameters, their classification as kind or truth, and their handling of non-bool inputs.
