### PR TITLE
One spelling for the type refusal: 22 guards become utils.assert_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2521,6 +2521,42 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **One spelling for the type refusal, over 22 guards** (issue #876).
+  `utils.assert_type` arrived with the serialization boundary's gate
+  (issue #867) and the rest of the library was still composing the same
+  message by hand: 26 guards whose test is a bare `not isinstance(...)`
+  and whose body raises a `BTClibTypeError` reading `invalid <what> type:
+  <type name>`, in `bip32/`, `block/`, `curves/`, `descriptors/`, `ecc/`,
+  `psbt/`, `script/`, `wallet/`, `network.py` and `utils.py` itself. 22 of
+  them are that one call now, with every message unchanged -- the tests
+  that match on them are the evidence.
+
+  What it buys is not the lines: **thirteen `# type: ignore[unreachable]`
+  suppressions go away**, seven of the twenty in the package remaining.
+  Each existed because the parameter is annotated, so mypy proves the
+  branch dead while the check is precisely what a caller who has not run
+  mypy needs; `assert_type` takes `Any`, so the question lives where it is
+  reachable and no call site has to say so.
+
+  It costs one Python call: 33 ns against 21 inline, measured as the
+  median of seven alternating rounds of 200k with an empty body as the
+  noise detector. `curves.curve._assert_valid_ec` is where that was worth
+  checking rather than assuming, its docstring having measured its own
+  cost: two guards in the 17.7 us of a signature and three in the 48.3 us
+  of a five-level BIP32 derivation, so 74 and 112 ns of them. The
+  docstring carries the re-measured figures.
+
+  Four of the 26 keep their own spelling, and the reason is in each: the
+  three coercions -- `bytes_from_octets`, `str_from_string`,
+  `base58.decode` -- refuse as the `else` of a conversion rather than as a
+  guard in front of one, and `satisfaction_sizer`'s `keys` is half of a
+  two-part question whose other half is a positive `isinstance`, which
+  this helper cannot express. `hashes._assert_valid_hf` asks `callable`
+  and not a type; the key converters' "not a private key" and "not a
+  public key" are the caller's diagnosis rather than a type report; and
+  the 33 guards built on `is_integer` are the integer policy
+  `tests/integer_policy_test.py` owns, a bool being an int.
+
 - **The input contract reaches `ec`, which had no check anywhere** (issue
   #868). The census of parameters behind a default put it fourth by
   frequency and first by exposure: `hf` and `network` are gated where their

--- a/btclib/bip32/der_path.py
+++ b/btclib/bip32/der_path.py
@@ -25,7 +25,7 @@ from collections.abc import Iterable, Sequence
 
 from btclib.alias import Octets
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.utils import is_integer
+from btclib.utils import assert_type, is_integer
 
 __all__ = [
     "DerPath",
@@ -236,12 +236,10 @@ def _indexes_from_der_path(der_path: Sequence[int] | int | bytes) -> list[int]:
             for n in range(0, len(der_path), 4)
         ]
 
-    if not isinstance(der_path, Iterable):
-        # what is left went to `list()` untouched, which answers a float
-        # with "'float' object is not iterable" -- a complaint about
-        # iteration, from underneath the library, about a path
-        err_msg = f"invalid derivation path type: {type(der_path).__name__}"  # type: ignore[unreachable]
-        raise BTClibTypeError(err_msg)
+    # what is left went to `list()` untouched, which answers a float with
+    # "'float' object is not iterable" -- a complaint about iteration, from
+    # underneath the library, about a path
+    assert_type(der_path, Iterable, "derivation path")
 
     # an iterable of int, and of int alone: int() here would coerce a bool
     # into the index one, where the annotation already says Sequence[int]

--- a/btclib/block/block_context.py
+++ b/btclib/block/block_context.py
@@ -33,7 +33,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.utils import is_integer
+from btclib.utils import assert_type, is_integer
 
 __all__ = [
     "BIP34_HEIGHT",
@@ -117,9 +117,7 @@ class BlockContext:
             if value < 0:
                 raise BTClibValueError(f"invalid {key}: {value}")
 
-        if not isinstance(self.now, datetime):
-            err_msg = f"invalid now type: {type(self.now).__name__}"  # type: ignore[unreachable]
-            raise BTClibTypeError(err_msg)
+        assert_type(self.now, datetime, "now")
 
         # a naive datetime has no instant attached to it: timestamp() would
         # read it as local time, so the same block would be too far in the

--- a/btclib/block/block_header.py
+++ b/btclib/block/block_header.py
@@ -305,8 +305,7 @@ class BlockHeader:
         # the type before the time zone: `.tzinfo` on anything else is an
         # AttributeError, which is neither a ValueError nor a TypeError
         # and so is caught by nothing this library tells a caller to catch
-        if not isinstance(now, datetime):
-            raise BTClibTypeError(f"invalid current time type: {type(now).__name__}")
+        assert_type(now, datetime, "current time")
         if now.tzinfo is None or now.tzinfo.utcoffset(now) is None:
             raise BTClibValueError(f"naive current time (no time zone): {now}")
 
@@ -343,11 +342,7 @@ class BlockHeader:
                 err_msg = f"invalid {key} type: {type(value).__name__}"
                 raise BTClibTypeError(err_msg)
 
-        if not isinstance(self.time, datetime):
-            # unreachable to mypy, the field being annotated: the caller
-            # this is here for is the one mypy never sees
-            err_msg = f"invalid timestamp type: {type(self.time).__name__}"  # type: ignore[unreachable]
-            raise BTClibTypeError(err_msg)
+        assert_type(self.time, datetime, "timestamp")
 
     def assert_valid(self) -> None:
         """Refuse a header the eighty bytes could not hold.

--- a/btclib/block/merkle_proof.py
+++ b/btclib/block/merkle_proof.py
@@ -35,7 +35,7 @@ from btclib.exceptions import (
 )
 from btclib.hashes import hash256, merkle_root_from_branch
 from btclib.tx import Tx
-from btclib.utils import bytes_from_octets
+from btclib.utils import assert_type, bytes_from_octets
 
 __all__ = [
     "assert_as_valid",
@@ -91,8 +91,7 @@ def assert_as_valid(
     # the branch before it is walked: what is not a sequence went to the
     # comprehension below untouched, so a None left it as "not iterable"
     # -- a complaint about iteration and not about a branch (issue #814)
-    if not isinstance(branch, Sequence):
-        raise BTClibTypeError(f"invalid branch type: {type(branch).__name__}")
+    assert_type(branch, Sequence, "branch")
 
     root = bytes_from_octets(merkle_root, 32)
     computed = merkle_root_from_branch(

--- a/btclib/block/mining.py
+++ b/btclib/block/mining.py
@@ -30,7 +30,7 @@ from btclib.block.block import merkle_root_and_mutated_from_transactions
 from btclib.block.block_header import BlockHeader
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.tx import Tx
-from btclib.utils import is_integer
+from btclib.utils import assert_type, is_integer
 
 __all__ = [
     "NONCE_SPACE",
@@ -106,8 +106,7 @@ def mine(header: BlockHeader, max_tries: int = 1 << 20) -> BlockHeader | None:
     # anything else, from the standard library and about a call the caller
     # never made; `max_tries < 1` is a bare TypeError about the operands,
     # and a float passes it to fail at `range` a few lines down
-    if not isinstance(header, BlockHeader):
-        raise BTClibTypeError(f"invalid header type: {type(header).__name__}")
+    assert_type(header, BlockHeader, "header")
     if not is_integer(max_tries):
         raise BTClibTypeError(f"invalid max_tries type: {type(max_tries).__name__}")
     if max_tries < 1:

--- a/btclib/block/proof_of_work.py
+++ b/btclib/block/proof_of_work.py
@@ -32,7 +32,7 @@ from datetime import datetime
 
 from btclib.alias import Octets
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.utils import bytes_from_octets, is_integer
+from btclib.utils import assert_type, bytes_from_octets, is_integer
 
 __all__ = [
     "DIFFICULTY_ADJUSTMENT_INTERVAL",
@@ -264,8 +264,7 @@ def next_bits(
         ("first block time", first_block_time),
         ("last block time", last_block_time),
     ):
-        if not isinstance(value, datetime):
-            raise BTClibTypeError(f"invalid {name} type: {type(value).__name__}")
+        assert_type(value, datetime, name)
 
     # the difference of two datetimes, not two timestamp() calls: aware
     # or naive, the subtraction is the same number of seconds, so the

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -54,9 +54,9 @@ from btclib.curves.curve_group_2 import (
     _double_mult_w_NAF_var,
     _mult_endomorphism_secp256k1,
 )
-from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.exceptions import BTClibValueError
 from btclib.number_theory import legendre_symbol_var
-from btclib.utils import hex_string, int_from_integer
+from btclib.utils import assert_type, hex_string, int_from_integer
 
 __all__ = [
     "CURVES",
@@ -321,20 +321,22 @@ def _assert_valid_ec(ec: Curve) -> None:
     every multiplication below reduces its scalar mod n, so a CurveGroup
     would pass a group check and fail on a field it has not got.
 
-    `isinstance` and not a field lookup, the way
-    `hashes._assert_valid_hf` asks `callable` rather than making a digest:
-    an ec is an object of the library's own making, with no conversion
-    from anything else the way a network name has one, so the type is the
-    whole of the question.
+    A type and not a field lookup, the way `hashes._assert_valid_hf` asks
+    `callable` rather than making a digest: an ec is an object of the
+    library's own making, with no conversion from anything else the way a
+    network name has one, so the type is the whole of the question. That
+    is what makes it `utils.assert_type`'s, which is the one spelling of
+    the refusal for the whole library.
 
-    22 ns, asked where each public function first reads the parameter,
-    which is one to four times in what a caller calls one operation: 45 ns
-    of the 17.5 us of a signature, 88 of the 39.2 of a verification, and
-    two guards in the 39.1 us of a five-level BIP32 derivation.
+    37 ns through that call, asked where each public function first reads
+    the parameter, which is one to three times in what a caller calls one
+    operation: two guards in the 17.7 us of a signature, three in the
+    48.3 us of a five-level BIP32 derivation. A wall clock is a number
+    that drifts, so `timeit` over the guard and over `dsa.sign` is what
+    says whether these still hold; what they are here for is the decision
+    to ask once per parameter rather than once per function.
     """
-    if not isinstance(ec, Curve):
-        err_msg = f"invalid ec type: {type(ec).__name__}"  # type: ignore[unreachable]
-        raise BTClibTypeError(err_msg)
+    assert_type(ec, Curve, "ec")
 
 
 datadir = Path(__file__).parent / "_data"

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -22,7 +22,7 @@ from math import ceil
 from btclib.alias import INF, INFJ, Integer, JacPoint, Point
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.number_theory import mod_inv_batch_var, mod_inv_var, mod_sqrt_var
-from btclib.utils import hex_string, int_from_integer
+from btclib.utils import assert_type, hex_string, int_from_integer
 
 __all__ = [
     "BOS_COSTER_THRESHOLD",
@@ -660,8 +660,7 @@ class CurveGroup:
         """Return True if the point is on the curve."""
         # the type before the length: `len` of what is not sized is a
         # TypeError about a builtin, where a Point is what this asks for
-        if not isinstance(Q, tuple):
-            raise BTClibTypeError(f"invalid point type: {type(Q).__name__}")
+        assert_type(Q, tuple, "point")
         if len(Q) != 2:
             raise BTClibValueError("point must be a tuple[int, int]")
         if Q[1] == 0:  # Infinity point in affine coordinates
@@ -715,9 +714,7 @@ def _assert_valid_ec(ec: CurveGroup) -> None:
     the group check would pass an ec that the multiplication then reads a
     missing field off.
     """
-    if not isinstance(ec, CurveGroup):
-        err_msg = f"invalid ec type: {type(ec).__name__}"  # type: ignore[unreachable]
-        raise BTClibTypeError(err_msg)
+    assert_type(ec, CurveGroup, "ec")
 
 
 def _mult_recursive_aff_var(m: int, Q: Point, ec: CurveGroup) -> Point:

--- a/btclib/ecc/musig2.py
+++ b/btclib/ecc/musig2.py
@@ -83,13 +83,12 @@ from btclib.curves.sec_point import (
 from btclib.ecc import ssa
 from btclib.exceptions import (
     BTClibRuntimeError,
-    BTClibTypeError,
     BTClibValueError,
     InvalidContributionError,
 )
 from btclib.hashes import tagged_hash
 from btclib.to_prv_key import PrvKey, int_from_prv_key
-from btclib.utils import bytes_from_octets
+from btclib.utils import assert_type, bytes_from_octets
 
 __all__ = [
     "KeyAggContext",
@@ -203,9 +202,7 @@ def _flag(is_xonly: bool) -> bool:
     keys the group signs under, so a value read for its truth would put
     half the signers on the other key rather than raise.
     """
-    if not isinstance(is_xonly, bool):
-        err_msg = f"invalid is_xonly type: {type(is_xonly).__name__}"  # type: ignore[unreachable]
-        raise BTClibTypeError(err_msg)
+    assert_type(is_xonly, bool, "is_xonly")
     return is_xonly
 
 

--- a/btclib/ecc/pedersen.py
+++ b/btclib/ecc/pedersen.py
@@ -30,8 +30,8 @@ from hashlib import sha256
 from btclib.alias import HashF, Point
 from btclib.curves import Curve, bytes_from_point, double_mult_var, secp256k1
 from btclib.curves.curve import _assert_valid_ec
-from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
-from btclib.utils import int_from_bits
+from btclib.exceptions import BTClibRuntimeError, BTClibValueError
+from btclib.utils import assert_type, int_from_bits
 
 __all__ = [
     "assert_as_valid",
@@ -122,9 +122,7 @@ def assert_as_valid(
     #814). `is_on_curve` is deliberately not asked -- that would refuse a
     wrong value too.
     """
-    if not isinstance(commitment, tuple):
-        err_msg = f"invalid commitment type: {type(commitment).__name__}"  # type: ignore[unreachable]
-        raise BTClibTypeError(err_msg)
+    assert_type(commitment, tuple, "commitment")
 
     if commitment != commit(r, v, ec, hf):
         raise BTClibRuntimeError("commitment verification failed")

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -82,6 +82,7 @@ from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.to_pub_key import point_from_pub_key
 from btclib.utils import (
     assert_no_trailing,
+    assert_type,
     bytes_from_octets,
     bytesio_from_binarydata,
     hex_string,
@@ -751,8 +752,7 @@ def _assert_batch_sequences(
     for their own values.
     """
     for value, what in ((msgs, "msgs"), (Qs, "Qs"), (sigs, "sigs")):
-        if not isinstance(value, Sequence):
-            raise BTClibTypeError(f"invalid {what} type: {type(value).__name__}")
+        assert_type(value, Sequence, what)
 
 
 def assert_batch_as_valid_(

--- a/btclib/network.py
+++ b/btclib/network.py
@@ -290,9 +290,7 @@ class Network:
         # there is. The bytes() calls below are the same guard for the
         # bytes fields, TypeError being what they raise for a field
         # rebound to something else
-        if not isinstance(self.hrp, str):
-            err_msg = f"invalid hrp type: {type(self.hrp).__name__}"  # type: ignore[unreachable]
-            raise BTClibTypeError(err_msg)
+        assert_type(self.hrp, str, "hrp")
 
         # NetworkType is a Literal, which is a mypy fact and not a runtime
         # one: from_dict takes whatever the json says, so this is the only

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -93,6 +93,7 @@ from btclib.tx import Tx, TxIn, TxOut
 from btclib.tx.limits import MAX_TX_IN_COUNT, MAX_TX_OUT_COUNT
 from btclib.utils import (
     assert_no_trailing,
+    assert_type,
     bytes_from_octets,
     bytesio_from_binarydata,
     fields_from_json_object,
@@ -2775,9 +2776,7 @@ def _assert_psbt_pair(request: Psbt, returned: Psbt) -> None:
     as an AttributeError about a field name.
     """
     for psbt, what in ((request, "request"), (returned, "returned")):
-        if not isinstance(psbt, Psbt):
-            err_msg = f"invalid {what} type: {type(psbt).__name__}"  # type: ignore[unreachable]
-            raise BTClibTypeError(err_msg)
+        assert_type(psbt, Psbt, what)
 
 
 def assert_signatures_only(request: Psbt, returned: Psbt) -> None:

--- a/btclib/psbt/psbt_size.py
+++ b/btclib/psbt/psbt_size.py
@@ -55,6 +55,7 @@ from btclib.hashes import hash160
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.script import serialize, type_and_payload
 from btclib.tx import TxIn
+from btclib.utils import assert_type
 
 __all__ = [
     "COMPRESSED_PUB_KEY_SIZE",
@@ -238,12 +239,8 @@ def _assert_input_types(psbt_in: PsbtIn, tx_in: TxIn) -> None:
     allows it, `descriptors` importing this module and nothing here
     importing back.
     """
-    if not isinstance(psbt_in, PsbtIn):
-        err_msg = f"invalid psbt_in type: {type(psbt_in).__name__}"  # type: ignore[unreachable]
-        raise BTClibTypeError(err_msg)
-    if not isinstance(tx_in, TxIn):
-        err_msg = f"invalid tx_in type: {type(tx_in).__name__}"  # type: ignore[unreachable]
-        raise BTClibTypeError(err_msg)
+    assert_type(psbt_in, PsbtIn, "psbt_in")
+    assert_type(tx_in, TxIn, "tx_in")
 
 
 def _assert_arguments(

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -14,7 +14,6 @@ from btclib.alias import ScriptList
 from btclib.ecc.dsa import Sig
 from btclib.exceptions import (
     BTClibRuntimeError,
-    BTClibTypeError,
     BTClibValueError,
     ScriptError,
 )
@@ -37,7 +36,7 @@ from btclib.script.script import (
 from btclib.script.script import serialize as serialize_script
 from btclib.script.sig_hash import SIG_HASH_TYPES, PrecomputedTxData
 from btclib.tx.tx import Tx
-from btclib.utils import bytesio_from_binarydata, encode_num
+from btclib.utils import assert_type, bytesio_from_binarydata, encode_num
 
 __all__ = [
     "DISABLED_OP_CODES",
@@ -72,8 +71,7 @@ def _assert_bytes_arguments(**arguments: object) -> None:
     out names the one that was wrong.
     """
     for what, value in arguments.items():
-        if not isinstance(value, bytes):
-            raise BTClibTypeError(f"invalid {what} type: {type(value).__name__}")
+        assert_type(value, bytes, what)
 
 
 def dsa_verify(msg_hash: bytes, pub_key: bytes, sig: bytes) -> bool:

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -22,13 +22,13 @@ from dataclasses import dataclass
 from btclib import b32, b58, var_bytes
 from btclib.alias import Octets, ScriptList, ScriptType, String, TaprootScriptTree
 from btclib.curves import point_from_octets
-from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, sha256
 from btclib.network import NETWORKS, network_type_from_network
 from btclib.script.script import Script, op_int, serialize
 from btclib.script.taproot import output_pubkey
 from btclib.to_pub_key import Key, pub_keyinfo_from_key
-from btclib.utils import bytes_from_octets, bytesio_from_binarydata
+from btclib.utils import assert_type, bytes_from_octets, bytesio_from_binarydata
 
 __all__ = [
     "ScriptPubKey",
@@ -839,9 +839,7 @@ def _script_from(script_pub_key: Octets | ScriptPubKey) -> bytes:
     # unreachable to mypy, the annotation having no fourth case, and the
     # whole point to a caller who is not running it: `Octets` is honoured
     # inside btclib and nowhere else
-    if not isinstance(script_pub_key, str):
-        err_msg = f"invalid script_pub_key type: {type(script_pub_key).__name__}"  # type: ignore[unreachable]
-        raise BTClibTypeError(err_msg)
+    assert_type(script_pub_key, str, "script_pub_key")
     if not script_pub_key:
         err_msg = "empty script_pub_key: a script with no address renders as ''"
         raise BTClibValueError(err_msg)

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -40,7 +40,12 @@ from btclib.script.op_codes_tapscript import (
 from btclib.script.script import _serialize_bytes_command, _serialize_int_command
 from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.to_pub_key import Key, pub_keyinfo_from_key
-from btclib.utils import bytes_from_octets, bytesio_from_binarydata, is_integer
+from btclib.utils import (
+    assert_type,
+    bytes_from_octets,
+    bytesio_from_binarydata,
+    is_integer,
+)
 
 __all__ = [
     "MAX_TREE_DEPTH",
@@ -79,11 +84,10 @@ def serialize(script: ScriptList) -> bytes:
     by exactly one bytes command, appended raw -- what follows an
     OP_SUCCESS need not be a script, so it round-trips unparsed.
     """
-    if not isinstance(script, list):
-        # what is not a list reached the reversal and the `pop` below
-        # untouched, so a None was "not subscriptable" and a str was a
-        # str with no `pop` -- neither of them a word about the script
-        raise BTClibTypeError(f"invalid tapscript type: {type(script).__name__}")
+    # what is not a list reached the reversal and the `pop` below
+    # untouched, so a None was "not subscriptable" and a str was a str with
+    # no `pop` -- neither of them a word about the script
+    assert_type(script, list, "tapscript")
 
     r: list[bytes] = []
     script = script[::-1]

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -363,9 +363,7 @@ def fields_from_json_object(dict_: Any, what: str) -> Mapping[str, Any]:
     `assert_type` takes one: the check is here for the caller mypy did
     not read.
     """
-    if not isinstance(dict_, Mapping):
-        err_msg = f"invalid {what} dict type: {type(dict_).__name__}"
-        raise BTClibTypeError(err_msg)
+    assert_type(dict_, Mapping, f"{what} dict")
     return _JsonObject(what, dict_)
 
 

--- a/btclib/wallet/script_wallet.py
+++ b/btclib/wallet/script_wallet.py
@@ -156,7 +156,7 @@ from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE, MAX_SCRIPT_SIZE
 from btclib.script.script import op_int, serialize
 from btclib.script.script_pub_key import ScriptPubKey
 from btclib.to_pub_key import fingerprint, pub_keyinfo_from_key
-from btclib.utils import is_integer
+from btclib.utils import assert_type, is_integer
 from btclib.wallet.wallet import RangedWallet
 
 __all__ = [
@@ -321,9 +321,7 @@ def _assert_group_arguments(
         raise BTClibTypeError(f"invalid keys type: {type(keys).__name__}")
     if origins is not None and not isinstance(origins, Sequence):
         raise BTClibTypeError(f"invalid origins type: {type(origins).__name__}")
-    if not isinstance(verify, bool):
-        err_msg = f"invalid verify type: {type(verify).__name__}"  # type: ignore[unreachable]
-        raise BTClibTypeError(err_msg)
+    assert_type(verify, bool, "verify")
 
 
 def _assert_origin_types(origins: tuple[BIP32KeyOrigin | None, ...]) -> None:


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/876.

Successor to https://github.com/btclib-org/btclib/pull/870, which added
`utils.assert_type` for the nine arguments the serialization boundary takes
besides the object, and left the rest of the library spelling the same
refusal by hand.

## The census, and what converts

26 guards in `btclib/` have a bare `not isinstance(...)` test and a body
that raises a `BTClibTypeError` reading `invalid <what> type: <type name>`
— exactly what `assert_type` composes. The issue has the AST command that
finds them. **22 are that one call now**, across `bip32/`, `block/`,
`curves/`, `descriptors/`, `ecc/`, `psbt/`, `script/`, `wallet/`,
`network.py` and `utils.py`, and every message is unchanged: the tests that
match on them are the evidence.

## What it buys

**Thirteen `# type: ignore[unreachable]` suppressions go away**, seven of
the twenty in the package remaining. Each existed for the same reason: the
parameter is annotated, so mypy proves the branch dead, while the check is
precisely what a caller who has not run mypy needs. `assert_type` takes
`Any`, so the question lives in a function where it is reachable and no
call site has to suppress anything.

## What it costs, measured

One Python call: **33 ns against 21 inline**, median of seven alternating
rounds of 200k calls with an empty body as the noise detector (16.6 ns), so
+12 ns per check.

`curves.curve._assert_valid_ec` is the one place that was worth measuring
rather than assuming, its own docstring having measured its own cost. The
guard costs 37 ns through the call, and the counts are dynamic
(`sys.setprofile` over the two guard names): two guards in the 17.7 us of a
signature, three in the 48.3 us of a five-level BIP32 derivation — 74 and
112 ns of them. The docstring carries the re-measured figures, the two it
carried that this machine does not reproduce having gone rather than been
copied forward.

## What keeps its own spelling, and why

- the three coercions — `bytes_from_octets`, `str_from_string`,
  `base58.decode` — refuse as the `else` of a conversion rather than as a
  guard in front of one
- `satisfaction_sizer`'s `keys` is half of a two-part question whose other
  half is a positive `isinstance`, which this helper cannot express;
  `script.serialize` and `KeyGroup` ask the same pair the same way
- `hashes._assert_valid_hf` asks `callable`, there being no class a hash
  function is an instance of
- `to_prv_key`'s "not a private key" and `to_pub_key`'s two are the
  caller's diagnosis, the converters trying formats in turn
- the 33 guards built on `is_integer` are the integer policy
  `tests/integer_policy_test.py` owns, a bool being an int

Gates run locally: `uv run pytest` (100% coverage, 27644 passed),
`uv run pre-commit run --all-files`, and the sphinx `-W` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Unify runtime type checks across the library by routing existing guards through utils.assert_type while preserving error messages and documented behavior.

Enhancements:
- Replace numerous hand-written isinstance/BTClibTypeError guards with utils.assert_type in core modules (bip32, block, curves, descriptors, ecc, psbt, script, wallet, network, utils).
- Update curve validation and documentation in btclib.curves.curve to reflect the centralized type-checking helper and refreshed performance measurements.
- Simplify several internal argument validation helpers to rely on the shared type assertion utility instead of bespoke checks.

Documentation:
- Document the standardized type-refusal mechanism and its scope in the CHANGELOG, including performance and rationale notes.