### PR TITLE
Ask the four module codecs' own arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2521,6 +2521,36 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **The four codecs that are module functions ask their own arguments
+  too** (issue #872). The gate of issue #867 recorded the six they take
+  besides the encoding and asked none of them, that being issue #868's
+  census; five were measured and four were taking anything.
+
+  `taproot.parse(exit_on_op_success=)` is the one that was not a flag at
+  all: it chooses between Core's pre-scan and a parse, so the same bytes
+  answer `["OP_SUCCESS"]` or `["OP_SUCCESS80", b"v"]` and a value read for
+  its truth silently gave the first. A `bool` now, which is
+  `include_witness` and `KeyGroup(verify=)`'s line.
+  `var_bytes.parse(forbid_zero_size=)` is on the other side of it and
+  stays read for its truth, adding a refusal and changing no answer; the
+  reason is in its docstring rather than only in the test that drives
+  neither.
+
+  `descriptors.parse(network=)` carried a name no network has into the
+  `Descriptor`, to be refused by whichever encoder came to use it — a
+  complaint about a key or an address, one call after the argument that
+  was wrong. It goes through `_validated_network_name` now, so the name
+  is also normalized to what `network_from_name` answers to.
+  `miniscript.parse(context=)` was worse than late: every rule reads the
+  context by asking whether it is `TAPSCRIPT`, so a third value was the
+  p2wsh one silently, and an expression was type-checked and sized under
+  rules it was not offered to. One of BIP379's two now, refused by
+  `_assert_valid_context`.
+
+  `prv_keys` is a `Mapping` or `None` in both parsers, where a list of
+  pairs answered "not found" for every key: asked in one call rather than
+  a branch, `None` being the other type the annotation declares.
+
 - **One spelling for the type refusal, over 22 guards** (issue #876).
   `utils.assert_type` arrived with the serialization boundary's gate
   (issue #867) and the rest of the library was still composing the same

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,18 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **the four module-level codecs refuse four arguments they used to
+  take.** `taproot.parse(script, exit_on_op_success=<not a bool>)` gave
+  Core's pre-scan answer for any truthy value and wants the `bool` it
+  declares; `descriptors.parse(descriptor, <not a network name>)` and
+  `miniscript.parse(expression, <not P2WSH or tapscript>)` are refused
+  where they used to be carried into the object and refused later, or not
+  at all; and `prv_keys` must be a mapping or `None` in both. A caller
+  passing values of the declared types is unaffected, and the network
+  name is now normalized as everywhere else in the library — `" MainNet
+  "` and `"mainnet"` were already one network to the encoders, and the
+  parsed object says so too.
+
 - **the serialization boundary refuses what it used to take, and reports
   through the exception contract.** A `from_dict` handed a mapping
   without a field raises `BTClibValueError` where it raised a bare

--- a/btclib/descriptors/descriptors.py
+++ b/btclib/descriptors/descriptors.py
@@ -184,7 +184,11 @@ from btclib.descriptors.miniscript import from_script as _miniscript_from_script
 from btclib.descriptors.miniscript import parse as _parse_miniscript
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
-from btclib.network import NETWORKS, network_from_xkeyversion
+from btclib.network import (
+    NETWORKS,
+    _validated_network_name,
+    network_from_xkeyversion,
+)
 from btclib.psbt.psbt import Psbt
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.psbt.psbt_out import PsbtOut
@@ -2257,8 +2261,24 @@ def parse(
     `strip_checksum` untouched and left as an AttributeError about
     `partition`, or as a TypeError about mixing bytes and str -- neither
     of them a word about the descriptor that was passed.
+
+    The network is asked for here rather than where a script is finally
+    written: a name no network has was carried into the Descriptor and
+    refused by the encoder that came to use it, which is a complaint
+    about a key or an address, one call later than the argument that was
+    wrong. Normalized as well, so that what the object holds is the name
+    `network_from_name` would answer to.
+
+    `prv_keys` is a mapping, and what is not one was walked anyway: the
+    lookups below are `in` and `[]`, so a list of pairs answered "not
+    found" for every key rather than saying it is not a mapping. `None`
+    is asked for with it, that being the other type the annotation
+    declares -- and one call rather than a branch, which is what keeps
+    the two spellings of "a declared type" in one place.
     """
     assert_type(descriptor, str, "descriptor")
+    network = _validated_network_name(network)
+    assert_type(prv_keys, (Mapping, type(None)), "prv_keys")
 
     if prv_keys is None:
         prv_keys = {}

--- a/btclib/descriptors/miniscript.py
+++ b/btclib/descriptors/miniscript.py
@@ -198,6 +198,23 @@ _ARITY = {
 _NUMBER = re.compile(r"[0-9]+")
 
 
+def _assert_valid_context(context: str) -> None:
+    """Refuse a spend context that is not one of BIP379's two.
+
+    Every rule below reads the context by asking whether it is
+    `TAPSCRIPT`, so a third value is not an unknown context: it is the
+    p2wsh one, silently, and the expression is type-checked and sized
+    under rules it was not offered to. A function rather than two lines
+    at the one caller, so that `parse` keeps the branch count ruff's
+    C901 allows it.
+    """
+    assert_type(context, str, "context")
+    if context not in {P2WSH, TAPSCRIPT}:
+        err_msg = f"unknown spend context: '{context}'"
+        err_msg += f"; it must be one of {sorted((P2WSH, TAPSCRIPT))}"
+        raise BTClibValueError(err_msg)
+
+
 def _t(properties: str) -> frozenset[str]:
     """Return a set of type properties, one character each."""
     return frozenset(properties)
@@ -2052,8 +2069,16 @@ def parse(
     A `str`, a BIP379 expression being text, and refused as a type for
     the reason `descriptors.parse` gives: what was neither reached the
     slicing below and left as "object of type X has no len()".
+
+    The context is one of the two BIP379 has, and `prv_keys` a mapping
+    or `None`, as `descriptors.parse` asks for the same pair: a context
+    no fragment table knows was compared against `TAPSCRIPT`, found
+    unequal, and every rule then read as the p2wsh one, so an expression
+    was type-checked under a context that does not exist.
     """
     assert_type(expression, str, "miniscript")
+    _assert_valid_context(context)
+    assert_type(prv_keys, (Mapping, type(None)), "prv_keys")
 
     if prv_keys is None:
         prv_keys = {}

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -142,7 +142,15 @@ def parse(stream: BinaryData, exit_on_op_success: bool = False) -> ScriptList:
     marker ["OP_SUCCESS"], which is Core's pre-scan. An element over
     520 bytes is refused only by a parse that meets no OP_SUCCESSx,
     one anywhere making the script valid.
+
+    A `bool` and nothing else, which is the line
+    `tests/built_object_contract_test.py` draws: this flag decides *what
+    is computed* rather than whether a check runs, so a value read for
+    its truth answered the pre-scan's marker where the commands were
+    asked for -- two different readings of the same bytes.
     """
+    assert_type(exit_on_op_success, bool, "exit_on_op_success")
+
     s = bytesio_from_binarydata(stream)
     r: ScriptList = []  # initialize the result list
     invalid_element_size = False

--- a/btclib/var_bytes.py
+++ b/btclib/var_bytes.py
@@ -16,7 +16,15 @@ __all__ = [
 
 
 def parse(stream: BinaryData, forbid_zero_size: bool = False) -> bytes:
-    """Return the variable-length octets read from a stream."""
+    """Return the variable-length octets read from a stream.
+
+    `forbid_zero_size` is read for its truth and not asked for its type,
+    which is the convention `check_validity` is read under: it decides
+    only *whether a check runs*, so no value of it changes the octets
+    this answers with -- where `taproot.parse`'s `exit_on_op_success`
+    decides which of two answers is computed and is therefore refused
+    unless it is a bool.
+    """
     stream = bytesio_from_binarydata(stream)
     i = var_int.parse(stream)
     if forbid_zero_size and i == 0:

--- a/tests/serialization_boundary_test.py
+++ b/tests/serialization_boundary_test.py
@@ -85,6 +85,10 @@ _WRONG_TYPES: tuple[Any, ...] = (None, 1.5, [1, 2])
 # rather than the argument
 _NOT_AN_ARRAY: tuple[Any, ...] = (*_WRONG_TYPES, "ab", {"a": 1})
 
+# and the same list where `None` is a type the position declares, which is
+# a statement about the signature rather than an exemption from the rule
+_NOT_NONE: tuple[Any, ...] = tuple(w for w in _WRONG_TYPES if w is not None)
+
 _TX_ID = "01" * 32
 
 _TX = Tx(1, 0x12345678, [TxIn(OutPoint(_TX_ID, 0), b"", 0xFFFFFFFF)], [TxOut(1, b"")])
@@ -250,11 +254,11 @@ _MODULE_WRITERS = (
 
 _MODULE_WRITER_IDS = tuple(label for label, _, _, _ in _MODULE_WRITERS)
 
-# what those ten take besides the thing they convert. Every one of them
-# is a parameter behind a default, which is issue #868's census and not
-# this file's: `max_size` and `context` are asked where they are read,
-# `forbid_zero_size` and `exit_on_op_success` are flags, and `network`
-# and `prv_keys` are the descriptor family's own inputs
+# what those ten take besides the thing they convert, and what drives
+# each: five of the six were ungated when this file was written and issue
+# #872 is where they were measured. `forbid_zero_size` is the one that is
+# driven by nothing, being a flag that decides whether a check runs and
+# therefore read for its truth, as `check_validity` is
 _MODULE_EXTRA_ARGUMENTS = {
     ("btclib.var_int", "parse"): ["max_size"],
     ("btclib.var_bytes", "parse"): ["forbid_zero_size"],
@@ -507,6 +511,85 @@ def test_an_envelope_is_read_against_magic_bytes_that_are_bytes() -> None:
             ecies.Envelope.parse(_ENVELOPE.serialize(), magic=wrong)
         with pytest.raises(BTClibTypeError, match="invalid magic type"):
             ecies.Envelope.b64decode(armor, magic=wrong)
+
+
+def test_a_tapscript_says_which_answer_it_is_asked_for() -> None:
+    """`exit_on_op_success` decides what is computed, so it is a bool.
+
+    Core's pre-scan and a parse are two readings of the same bytes, and
+    the flag chooses between them: read for its truth, a value of no
+    boolean type answered the marker where the commands were asked for.
+    """
+    script_bytes = bytes([0x50, 0x76])  # OP_SUCCESS80, then one byte
+    assert taproot.parse(script_bytes) == ["OP_SUCCESS80", b"v"]
+    assert taproot.parse(script_bytes, exit_on_op_success=True) == ["OP_SUCCESS"]
+
+    for wrong in (*_WRONG_TYPES, 0, 1):
+        with pytest.raises(BTClibTypeError, match="invalid exit_on_op_success type"):
+            taproot.parse(script_bytes, exit_on_op_success=wrong)
+
+
+def test_a_var_bytes_flag_is_read_for_its_truth() -> None:
+    """And the one on the other side of that line, which stays there.
+
+    `forbid_zero_size` adds a refusal and changes no answer, so it is
+    read as `check_validity` is: what it must not do is refuse a value
+    of its own, which would make the two conventions one.
+    """
+    assert var_bytes.parse(b"\x01\x02") == b"\x02"
+    for wrong in _WRONG_TYPES:
+        assert var_bytes.parse(b"\x01\x02", forbid_zero_size=wrong) == b"\x02"
+
+
+def test_a_descriptor_is_parsed_for_a_network_that_exists() -> None:
+    """The two arguments `descriptors.parse` takes besides the text.
+
+    A name no network has was carried into the `Descriptor` and refused
+    by whichever encoder came to use it, one call later than the argument
+    that was wrong; `prv_keys` was walked with `in` and `[]`, so a list
+    of pairs answered "not found" for every key rather than saying it is
+    not a mapping. `None` is a type it declares, so it is asserted to
+    work rather than driven -- a statement about the signature, and the
+    one `built_object_contract_test.py` records as `optional`.
+    """
+    descriptor = f"pk({pub_keyinfo_from_prv_key(1)[0].hex()})"
+    assert descriptors.parse(descriptor, "testnet").network == "testnet"
+    assert descriptors.parse(descriptor, prv_keys={}).network == "mainnet"
+    assert descriptors.parse(descriptor, prv_keys=None).network == "mainnet"
+    # and normalized, which is what going through the library's own
+    # question buys beyond refusing what is not one
+    assert descriptors.parse(descriptor, " TestNet ").network == "testnet"
+
+    for wrong in _WRONG_TYPES:
+        with pytest.raises(BTClibTypeError, match="not a network name"):
+            descriptors.parse(descriptor, wrong)
+    for wrong in _NOT_NONE:
+        with pytest.raises(BTClibTypeError, match="invalid prv_keys type"):
+            descriptors.parse(descriptor, prv_keys=wrong)
+    with pytest.raises(BTClibValueError, match="unknown network"):
+        descriptors.parse(descriptor, "mainet")
+
+
+def test_a_miniscript_is_parsed_in_a_context_that_exists() -> None:
+    """The same pair for the miniscript parser, its own first argument.
+
+    Every rule reads the context by asking whether it is `TAPSCRIPT`, so
+    a third value was the p2wsh one silently: the expression was
+    type-checked and sized under rules it was not offered to.
+    """
+    expression = f"pk({pub_keyinfo_from_prv_key(1)[0].hex()})"
+    for context in (miniscript.P2WSH, miniscript.TAPSCRIPT):
+        assert miniscript.parse(expression, context).context == context
+    assert miniscript.parse(expression, prv_keys=None).context == miniscript.P2WSH
+
+    for wrong in _WRONG_TYPES:
+        with pytest.raises(BTClibTypeError, match="invalid context type"):
+            miniscript.parse(expression, wrong)
+    for wrong in _NOT_NONE:
+        with pytest.raises(BTClibTypeError, match="invalid prv_keys type"):
+            miniscript.parse(expression, prv_keys=wrong)
+    with pytest.raises(BTClibValueError, match="unknown spend context"):
+        miniscript.parse(expression, "P2SH")
 
 
 def test_every_json_boundary_is_covered() -> None:


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/872.

The gate of https://github.com/btclib-org/btclib/issues/867 recorded the
six arguments the family's module-level codecs take besides the encoding —
`tests/serialization_boundary_test.py`'s `_MODULE_EXTRA_ARGUMENTS` — and
drove none of them, that being
https://github.com/btclib-org/btclib/issues/868's census. Five were
measured; four were taking anything.

## `exit_on_op_success` was not a flag

It chooses between Core's pre-scan and a parse, so the same bytes have two
answers:

```
taproot.parse(sc)                            -> ['OP_SUCCESS80', b'v']
taproot.parse(sc, exit_on_op_success=True)   -> ['OP_SUCCESS']
taproot.parse(sc, exit_on_op_success=1.5)    -> ['OP_SUCCESS']
```

A `bool` now, which is the line PR
https://github.com/btclib-org/btclib/pull/863 drew for
`KeyGroup(verify=)` and PR 870 applied to `Tx.serialize(include_witness)`:
a flag that decides *what is computed* is a kind and not a truth.

**`var_bytes.parse(forbid_zero_size=)` is on the other side of that line
and stays there**, adding a refusal and changing no answer, exactly as
`check_validity` does. What changed is that the reason is now in its
docstring instead of living only in the test that drives neither of them —
and the test asserts that it keeps accepting what it is handed, so the two
conventions cannot quietly become one.

## The descriptor parsers

`descriptors.parse(network=)` carried a name no network has into the
`Descriptor`, to be refused later by whichever encoder came to use it — a
complaint about a key or an address, one call after the argument that was
wrong. It goes through `network._validated_network_name` now, the question
the rest of the library asks, which also **normalizes** it: `" TestNet "`
and `"testnet"` were already one network to the encoders, and the parsed
object says so too.

`miniscript.parse(context=)` was worse than late. Every rule reads the
context by asking whether it is `TAPSCRIPT`, so a third value was the p2wsh
one *silently*: the expression was type-checked and sized under rules it
was not offered to. One of BIP379's two now, refused by
`_assert_valid_context` — a function and not two lines at the one caller,
because `parse` has no branch to spare under ruff's C901.

`prv_keys` is a `Mapping` or `None` in both parsers, where a list of pairs
answered "not found" for every key. Asked in one call —
`assert_type(prv_keys, (Mapping, type(None)), "prv_keys")` — rather than a
branch, for the same C901 reason and because `None` *is* one of the types
the annotation declares, which is how `built_object_contract_test.py`
records an optional position.

## Tests

Four in `tests/serialization_boundary_test.py`, beside the record they make
honest. Each asserts the valid calls first — both contexts, both networks,
the normalization — so a fixture that went stale fails instead of passing
by refusing everything.

Gates run locally: `uv run pytest` (100% coverage, 27648 passed),
`uv run pre-commit run --all-files`, and the sphinx `-W` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten argument validation for four module-level codecs and document the behavior, ensuring descriptor and miniscript parsers and taproot/var_bytes codecs consistently enforce their declared input contracts.

Bug Fixes:
- Validate descriptor network names eagerly and normalize them, preventing invalid or mistyped networks from propagating into parsed Descriptor objects.
- Enforce miniscript spend context to BIP379’s two valid values and validate private key mappings, avoiding silent misuse of unsupported contexts or non-mapping key containers.
- Require a boolean for taproot.parse’s exit_on_op_success flag so non-boolean truthy values no longer alter which script interpretation is returned.

Enhancements:
- Clarify var_bytes.parse forbid_zero_size semantics in its docstring while keeping it a truth-tested flag that does not alter return values.
- Align descriptors.parse and miniscript.parse type checking for prv_keys and context/network parameters using shared validation utilities.
- Update documentation (CHANGELOG and HISTORY) to describe the stricter codec argument validation and its breaking implications.

Tests:
- Add boundary tests that drive all extra arguments for the four module-level codecs, covering valid and invalid types, network normalization, and miniscript contexts.