### PR TITLE
dsa's strict stays a truth, and says which direction its accident goes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4146,6 +4146,22 @@ documented at release-notes length in the first place, and are still in
 
 ### Documentation and the website
 
+- **`dsa.Sig.parse`'s `strict` says which direction each accident goes**
+  (issue #873). The flag stays read for its truth, which is what
+  `bool_parameter_test.py` classifies it as and what the line
+  CONTRIBUTING.md draws asks: it decides whether the call refuses, and the
+  signature parsed out of an encoding both readings accept is one
+  signature. What was not written down is that its two accidents are not
+  symmetric -- `"false"` out of a configuration file is truthy and
+  therefore strict, while a `None` from a lookup that found nothing is the
+  lax one, so it is the safe-looking accident that costs something. The
+  docstring says so, and says to pass `True` rather than whatever a table
+  answered.
+
+  The census entry is sharpened with it: it named trailing bytes where the
+  flag gates the whole of Bitcoin Core's `IsValidSignatureEncoding`,
+  non-minimal scalars included.
+
 - **The README says what a `_var` name means**, in the section on where
   constant time ends. The convention decides which of two spellings a
   caller reaches for — `mod_inv` blinds its operand where `mod_inv_var`

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -282,12 +282,24 @@ class Sig:
         Deserialize a strict ASN.1 DER representation of an ECDSA
         signature.
 
-        strict says whether the encoding must be the canonical one,
-        covering what comes *after* the sequence as well as what is in
-        it: a byte too many is not a DER signature either. What it does
+        strict says whether the encoding must be the canonical one, which
+        is Bitcoin Core's `IsValidSignatureEncoding` and covers what comes
+        *after* the sequence as well as what is in it: a byte too many is
+        not a DER signature either, and neither is a scalar written with a
+        leading zero it does not need or without one it does. What it does
         not cover, and what a caller has to strip, is a sighash type byte
         -- a script signature and a psbt partial signature both carry one,
         and neither is a bare DER encoding.
+
+        It is read for its truth and not asked for its type, which is the
+        classification `tests/bool_parameter_test.py` records: the flag
+        decides whether the call refuses, and the signature parsed out of
+        an encoding both readings accept is one signature. Worth knowing
+        which direction each accident goes, though, because they are not
+        symmetric: `"false"` out of a configuration file is truthy and
+        therefore strict, while a `None` from a lookup that found nothing
+        is the lax one -- so a caller who means the canonical encoding
+        should pass `True` rather than whatever a table answered.
         """
         stream = bytesio_from_binarydata(data)
         ec = secp256k1

--- a/tests/bool_parameter_test.py
+++ b/tests/bool_parameter_test.py
@@ -709,8 +709,9 @@ _TRUTHS = (
         "strict",
         dsa.Sig.parse,
         {"data": _DER_SIG},
-        reason="whether trailing bytes after the DER sequence are refused;"
-        " the signature parsed out of what both accept is one signature",
+        reason="whether the encoding must be Bitcoin Core's canonical one,"
+        " trailing bytes and non-minimal scalars alike; the signature"
+        " parsed out of what both readings accept is one signature",
     ),
     _Case(
         "btclib.psbt.psbt.assert_signed",

--- a/tests/serialization_boundary_test.py
+++ b/tests/serialization_boundary_test.py
@@ -41,7 +41,9 @@ it is driven.
 decides whether a check runs rather than what is computed, so it is read
 for its truth, and `check_validity_test.py` owns that convention.
 `dsa.Sig.parse`'s `strict` is the same kind of flag and the same
-exemption, recorded below beside the arguments that are not.
+exemption, recorded below beside the arguments that are not --
+`bool_parameter_test.py` is where that classification is decided, for
+every flag in the library and with the reason for each.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/873.

**The issue asked whether `strict` is a kind or a truth, and the answer is
the one the tree already records: a truth.** No behaviour changes here.

`tests/bool_parameter_test.py` classifies every `bool` parameter in the
library and holds each to its class in both directions — a kind refuses
`"no"`, `0`, `1`; a truth **accepts** them, and "a truth that starts
refusing fails here, and the entry has to move rather than the test being
edited". `strict` is in `_TRUTHS`, and the line CONTRIBUTING.md draws is
about what a non-refusing call *computes*: `strict` computes nothing
different. It decides whether the call refuses, and the signature parsed
out of an encoding both readings accept is one signature.

## What the issue found that was worth writing down

The two accidents are not symmetric, which no comment said:

```
strict=True   refuses 3006020180020180
strict=False  parses it, r = 128
strict=None   parses it            <- a lookup that found nothing
strict="no"   refuses it           <- a configuration file reading "false"
```

So the safe-looking accident — text out of a file, which is truthy — lands
on the strict side, and the one that costs something is `None`. The
docstring says it now, and says to pass `True` rather than whatever a table
answered.

## The two other corrections

The census entry gave as its reason "whether trailing bytes after the DER
sequence are refused", which is one of the rules the flag gates: it gates
the whole of Bitcoin Core's `IsValidSignatureEncoding`, non-minimal and
negative-looking scalars included — which is what the measurement above
exercises, `3006020180020180` having no trailing byte at all.

And `tests/serialization_boundary_test.py`, which records `strict` as the
serialization family's one exemption, now points at the census that decides
the classification rather than stating it a second time.

Gates run locally: `uv run pytest` (27802 passed),
`uv run pre-commit run --all-files`, and the sphinx `-W` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify the meaning and behavior of the `strict` flag in ECDSA signature parsing and align its documentation and tests with the library-wide boolean parameter conventions.

Enhancements:
- Sharpen internal descriptions of the `strict` flag to emphasize that it gates full canonical encoding checks rather than only trailing bytes.

Documentation:
- Expand `dsa.Sig.parse` docstring to describe `strict` as a truth-valued flag, its relationship to Bitcoin Core's `IsValidSignatureEncoding`, and how different accidental inputs (`None`, "false") are treated.
- Update CHANGELOG to document the clarified behavior, classification, and recommended usage of the `strict` parameter.

Tests:
- Refine `bool_parameter_test.py`'s reason text for the `strict` flag to reference canonical encoding rules including trailing bytes and non-minimal scalars.
- Adjust `serialization_boundary_test.py` to delegate `strict`'s classification to the boolean parameter census and describe where that classification is decided.