### PR TITLE
An ECIES envelope's four fields are Octets, and coerce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1299,6 +1299,26 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **An ECIES envelope's four fields are `Octets`, and coerce** (issue
+  #874). `magic`, `eph_pub_key`, `ciphertext` and `mac` were declared
+  `bytes` and assigned as they came, the only octet fields in the library
+  with no conversion in their constructor -- `OutPoint.tx_id`,
+  `BlockHeader.merkle_root`, `Witness`'s stack elements and
+  `BIP32KeyData.key` all go through `bytes_from_octets`.
+
+  That made two answers wrong. A value with no `len` left `assert_valid`
+  as a TypeError about a builtin, which is issue #776's shape; and a value
+  *with* one was reported as a **size**, so `Envelope("no", ...)` said
+  "invalid magic size: 2 bytes" where the mistake is that a `str` is not a
+  magic at all. `from_ciphertext` was worse than either, its own
+  concatenation failing first: "unsupported operand type(s) for +".
+
+  A hex string is accepted now, as it is for every other octet parameter,
+  which is what a caller pasting an envelope is likelier to hold.
+
+  The `magic` of `Envelope.parse` and `b64decode` was gated in issue #867
+  and is unchanged: what those two take from a caller was already asked.
+
 - **The `_var` census reaches a measured zero.** Two rounds of the
   suffix had left the question half-answered: every function that spends
   a variable-time primitive is now either suffixed or listed as an

--- a/btclib/ecc/ecies.py
+++ b/btclib/ecc/ecies.py
@@ -146,17 +146,25 @@ class Envelope:
     # see the comment on dsa.Sig.__init__
     def __init__(
         self,
-        magic: bytes,
-        eph_pub_key: bytes,
-        ciphertext: bytes,
-        mac: bytes,
+        magic: Octets,
+        eph_pub_key: Octets,
+        ciphertext: Octets,
+        mac: Octets,
         *,
         check_validity: bool = True,
     ) -> None:
-        object.__setattr__(self, "magic", magic)
-        object.__setattr__(self, "eph_pub_key", eph_pub_key)
-        object.__setattr__(self, "ciphertext", ciphertext)
-        object.__setattr__(self, "mac", mac)
+        # `Octets` and the coercion every other octet field of this
+        # library has in its constructor -- OutPoint's tx_id, a header's
+        # merkle root, a witness element, a bip32 key. These four were
+        # assigned as they came, so a value with no `len` left
+        # `assert_valid` as a TypeError about a builtin, and one with a
+        # `len` was reported as a *size*: a two-character str is not a
+        # two-byte magic, it is not a magic at all. Hex is what a caller
+        # holds as often as bytes, an envelope being copied and pasted
+        object.__setattr__(self, "magic", bytes_from_octets(magic))
+        object.__setattr__(self, "eph_pub_key", bytes_from_octets(eph_pub_key))
+        object.__setattr__(self, "ciphertext", bytes_from_octets(ciphertext))
+        object.__setattr__(self, "mac", bytes_from_octets(mac))
 
         if check_validity:
             self.assert_valid()
@@ -221,12 +229,20 @@ class Envelope:
     def from_ciphertext(
         cls,
         eph_pub_key: Octets,
-        ciphertext: bytes,
+        ciphertext: Octets,
         key_m: Octets,
         *,
-        magic: bytes = MAGIC,
+        magic: Octets = MAGIC,
     ) -> Envelope:
-        """Frame an already-encrypted ciphertext and MAC it under key_m."""
+        """Frame an already-encrypted ciphertext and MAC it under key_m.
+
+        The magic is coerced here and not left to the constructor below,
+        which would take it: this method concatenates before it builds,
+        so a magic that is not bytes failed on the `+` rather than as the
+        argument it is.
+        """
+        magic = bytes_from_octets(magic)
+        ciphertext = bytes_from_octets(ciphertext)
         eph_pub_key = bytes_from_octets(eph_pub_key)
         # the MAC covers the magic and the ephemeral key as well as the
         # ciphertext, so the envelope has to exist before its own MAC does:

--- a/tests/ecc/ecies_test.py
+++ b/tests/ecc/ecies_test.py
@@ -22,13 +22,18 @@ against FIPS-197, and slow. Do not import it from anywhere.
 import base64
 import hashlib
 import string
+from typing import Any
 
 import pytest
 
 from btclib.alias import Point
 from btclib.curves import bytes_from_point, mult, secp256k1
 from btclib.ecc import ecies
-from btclib.exceptions import BTClibRuntimeError, BTClibValueError
+from btclib.exceptions import (
+    BTClibRuntimeError,
+    BTClibTypeError,
+    BTClibValueError,
+)
 
 # --------------------------------------------------------------------------
 # AES-128-CBC with PKCS#7, for this file alone. See the module docstring.
@@ -449,6 +454,50 @@ def test_envelope_round_trips_through_its_serializations() -> None:
     # a hex string is octets too, for both of the octets parameters
     assert envelope.mac_from_key(key_m.hex()) == envelope.mac
     assert ecies.Envelope.parse(envelope.serialize().hex()) == envelope
+
+
+def test_envelope_fields_are_octets_like_every_other_field() -> None:
+    """The four fields coerce and refuse as `Octets` does everywhere else.
+
+    They were declared `bytes` and assigned as they came, which is what
+    made two answers wrong: a value with no `len` left `assert_valid` as a
+    TypeError about a builtin, and a value *with* one was reported as a
+    size -- a two-character str is not a two-byte magic, it is not a magic
+    at all. Every other octet field of the library coerces in its
+    constructor, so a hex string is what a caller may hold here too.
+    """
+    key_m = bytes(range(32))
+    envelope = ecies.Envelope.from_ciphertext(
+        bytes_from_point(mult(42)), bytes(48), key_m
+    )
+    assert (
+        ecies.Envelope(
+            envelope.magic.hex(),
+            envelope.eph_pub_key.hex(),
+            envelope.ciphertext.hex(),
+            envelope.mac.hex(),
+        )
+        == envelope
+    )
+
+    wrong_types: tuple[Any, ...] = (None, 1.5, [1, 2])
+    for wrong in wrong_types:
+        for field in ("magic", "eph_pub_key", "ciphertext", "mac"):
+            fields: dict[str, Any] = {
+                "magic": envelope.magic,
+                "eph_pub_key": envelope.eph_pub_key,
+                "ciphertext": envelope.ciphertext,
+                "mac": envelope.mac,
+            }
+            fields[field] = wrong
+            with pytest.raises(BTClibTypeError, match="invalid octets type"):
+                ecies.Envelope(**fields)
+        # and the factory, which concatenates before it builds: a magic
+        # of no octet type failed on the `+` rather than as an argument
+        with pytest.raises(BTClibTypeError, match="invalid octets type"):
+            ecies.Envelope.from_ciphertext(
+                bytes_from_point(mult(42)), bytes(48), key_m, magic=wrong
+            )
 
 
 def test_envelope_b64decode_tolerates_surrounding_whitespace() -> None:


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/874.

The issue offered two answers — coerce as `Octets`, or refuse as `bytes` —
and this takes the first, because it is what the rest of the library does:
`OutPoint.tx_id`, `BlockHeader.merkle_root`, a `Witness` stack element and
`BIP32KeyData.key` all go through `bytes_from_octets` in their constructor.
These four were the only octet fields with no conversion in front of them,
so this is one class brought back into step rather than a convention gaining
an exception.

## What was wrong, and it was wrong twice

```
Envelope(None, ...)   TypeError: object of type 'NoneType' has no len()
Envelope("no", ...)   BTClibValueError: invalid magic size: 2 bytes
from_ciphertext(magic=None)  TypeError: unsupported operand type(s) for +
```

A value with no `len` left `assert_valid` as a complaint about a builtin,
which is https://github.com/btclib-org/btclib/issues/776's shape. A value
*with* one was reported as a **size** — and that is the worse of the two,
because a two-character `str` is not a two-byte magic, it is not a magic at
all, so the diagnosis names the wrong thing. `from_ciphertext` never
reached either, its own concatenation failing first.

All three are `invalid octets type: <name>` now, and a hex string is
accepted as it is everywhere else — an envelope is copied and pasted, so
text is what a caller holds as often as bytes.

## What is unchanged

`Envelope.parse`'s and `b64decode`'s `magic` argument, gated in
https://github.com/btclib-org/btclib/pull/870: what those two take from a
caller was already asked. `assert_valid` still reports every *size*, which
is what it is for, and now cannot be reached by something that has no size
to report.

The test asserts the hex round trip first, so the case cannot pass by
refusing everything, and drives all four fields plus the factory's magic.

Gates run locally: `uv run pytest` (100% coverage, 27803 passed),
`uv run pre-commit run --all-files`, and the sphinx `-W` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align ECIES Envelope fields with the library-wide Octets convention and ensure type-safe coercion for all inputs.

Bug Fixes:
- Prevent invalid non-octet values for ECIES Envelope fields from causing builtin TypeError or incorrect size errors, instead raising a consistent BTClibTypeError.
- Ensure from_ciphertext validates and coerces magic and ciphertext octets before concatenation, avoiding unsupported operand type errors.

Enhancements:
- Make ECIES Envelope fields (magic, eph_pub_key, ciphertext, mac) accept Octets and coerce them via bytes_from_octets for consistency with other octet fields in the library.

Documentation:
- Document the ECIES Envelope octet coercion behavior and related bug fixes in the changelog.

Tests:
- Add tests verifying hex-string round trips for Envelope fields and that invalid octet types for fields and factory magic raise BTClibTypeError.