### PR TITLE
A json null is not an amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -823,6 +823,21 @@ documented at release-notes length in the first place, and are still in
 
 ### Transactions, blocks and PSBT
 
+- **A json `null` is not an amount** (issue #875).
+  `TxOut.from_dict({"value": null})` built an output of zero satoshi:
+  `valid_sats_amount` reads `None` as zero, for the caller it was written
+  for and with its own reasoning, and `sats_from_btc` inherits it. At the
+  json boundary that value is a field the file has not filled in, and the
+  output it made was legal -- an OP_RETURN pays zero, BIP322's
+  proof-of-funds transactions carry one -- so nothing downstream refused
+  it and what came back said something the file did not.
+
+  The empty string and the word `"null"` were refused already, which is
+  what made this the one worth closing: `null` is the only spelling json
+  itself produces. `valid_sats_amount`'s convention is untouched, and so
+  is `PsbtOut.amount`, where `None` is the field being absent and a psbt
+  output may legitimately declare no amount yet.
+
 - **BIP375's Signer and Transaction Extractor** (#760, following #641).
   `btclib.psbt.silent_payments` is the new module, and it is the half of
   BIP375 that makes the fields worth carrying: a silent payment output
@@ -2549,12 +2564,11 @@ documented at release-notes length in the first place, and are still in
   `taproot.parse(exit_on_op_success=)` is the one that was not a flag at
   all: it chooses between Core's pre-scan and a parse, so the same bytes
   answer `["OP_SUCCESS"]` or `["OP_SUCCESS80", b"v"]` and a value read for
-  its truth silently gave the first. A `bool` now, which is
-  `include_witness` and `KeyGroup(verify=)`'s line.
-  `var_bytes.parse(forbid_zero_size=)` is on the other side of it and
-  stays read for its truth, adding a refusal and changing no answer; the
-  reason is in its docstring rather than only in the test that drives
-  neither.
+  its truth silently gave the first. The census of issue #871 refused it
+  as a kind, and what this adds is the reason beside the flag rather than
+  in a table of them; `var_bytes.parse(forbid_zero_size=)` is on the other
+  side of that line and stays read for its truth, adding a refusal and
+  changing no answer, which its own docstring now says.
 
   `descriptors.parse(network=)` carried a name no network has into the
   `Descriptor`, to be refused by whichever encoder came to use it — a

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,17 +20,24 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
-- **the four module-level codecs refuse four arguments they used to
-  take.** `taproot.parse(script, exit_on_op_success=<not a bool>)` gave
-  Core's pre-scan answer for any truthy value and wants the `bool` it
-  declares; `descriptors.parse(descriptor, <not a network name>)` and
+- **`TxOut.from_dict` refuses a `null` value.** It used to build an output
+  of zero satoshi, `valid_sats_amount` reading `None` as zero for the
+  caller it was written for; a stored dict carrying `{"value": null}` now
+  raises `BTClibValueError` instead of loading as an output that pays
+  nothing. `PsbtOut.amount` is unaffected: there `None` is the field being
+  absent, which a psbt output may legitimately say.
+
+- **the two descriptor parsers refuse three arguments they used to
+  take.** `descriptors.parse(descriptor, <not a network name>)` and
   `miniscript.parse(expression, <not P2WSH or tapscript>)` are refused
   where they used to be carried into the object and refused later, or not
   at all; and `prv_keys` must be a mapping or `None` in both. A caller
   passing values of the declared types is unaffected, and the network
   name is now normalized as everywhere else in the library — `" MainNet
   "` and `"mainnet"` were already one network to the encoders, and the
-  parsed object says so too.
+  parsed object says so too. `taproot.parse`'s `exit_on_op_success` is
+  the bool bullet below's, that being where every flag of the library was
+  classified.
 - **thirty-odd `bool` arguments that used to be accepted are refused.**
   A flag that decides what is computed is a kind and not a truth, so
   `dsa.sign(msg, q, lower_s="no")` — which returned a low-s signature,

--- a/btclib/tx/tx_out.py
+++ b/btclib/tx/tx_out.py
@@ -13,6 +13,7 @@ from typing import Any
 from btclib import var_bytes
 from btclib.alias import BinaryData, Octets, String
 from btclib.amount import btc_from_sats, sats_from_btc, valid_sats_amount
+from btclib.exceptions import BTClibValueError
 from btclib.script import ScriptPubKey, script_from_dict, script_to_dict
 from btclib.utils import (
     assert_no_trailing,
@@ -138,8 +139,24 @@ class TxOut:
     def from_dict(
         cls: type[TxOut], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> TxOut:
-        """Build a TxOut from the dict shape to_dict writes."""
+        """Build a TxOut from the dict shape to_dict writes.
+
+        A `null` value is not an amount here, where `valid_sats_amount`
+        reads `None` as zero for the caller it was written for: a
+        transaction output declares what it pays, so at the json boundary
+        that value is a field the file has not filled in rather than a
+        request for nothing. Unasked, `{"value": null}` built an output of
+        zero satoshi -- legal, an OP_RETURN paying one and BIP322's
+        proof-of-funds transactions carrying one, so nothing downstream
+        refused it and what came back said something the file did not.
+
+        `PsbtOut.amount` is the same value read the other way, and
+        rightly: a psbt output may declare no amount yet, where a
+        transaction output cannot.
+        """
         dict_ = fields_from_json_object(dict_, "transaction output")
+        if dict_["value"] is None:
+            raise BTClibValueError("null transaction output value")
         value = sats_from_btc(dict_["value"])
         script_bin = script_from_dict(dict_["scriptPubKey"])
         network = dict_.get("network", "mainnet")

--- a/tests/serialization_boundary_test.py
+++ b/tests/serialization_boundary_test.py
@@ -383,6 +383,39 @@ def test_the_two_fields_from_dict_converts_itself() -> None:
         Network.from_dict({**network, "curve": "secp256k2"})
 
 
+def test_a_json_null_is_not_an_amount() -> None:
+    """The one field value that arrived through a convention, not a gap.
+
+    `valid_sats_amount` reads `None` as zero, for the caller it was
+    written for and with its own reasoning; at the json boundary the same
+    value is a field the file has not filled in, and it built an output of
+    zero satoshi. Legal -- an OP_RETURN pays one -- so nothing downstream
+    refused it and the transaction that came back said something the file
+    did not.
+
+    The two spellings a hand-edited file is likelier to carry were refused
+    already, which is what made `null` the one worth closing: it is the
+    only one json itself produces.
+    """
+    dict_ = _as_json(_TX.vout[0])
+    assert TxOut.from_dict(dict_).value == 1
+
+    with pytest.raises(BTClibValueError, match="null transaction output value"):
+        TxOut.from_dict({**dict_, "value": None})
+    for wrong in ("", "null"):
+        with pytest.raises(BTClibValueError, match="invalid BTC amount"):
+            TxOut.from_dict({**dict_, "value": wrong})
+
+    # a missing key is the other question, and the gate above answers it
+    with pytest.raises(BTClibValueError, match="missing transaction output field"):
+        TxOut.from_dict({k: v for k, v in dict_.items() if k != "value"})
+
+    # and the psbt output, where None is the field being absent and stays
+    # a value the boundary takes
+    psbt_out = _as_json(_PSBT.outputs[0])
+    assert PsbtOut.from_dict({**psbt_out, "amount": None}).amount is None
+
+
 @pytest.mark.parametrize("label, cls, method", _OCTETS_DECODERS, ids=_OCTETS_IDS)
 def test_the_octets_boundary_refuses_what_is_no_octets(
     label: str, cls: type[Any], method: str


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/875.

The issue asked whether the json boundary reads `null` as zero, as a
caller does, or as no amount. **As no amount**, and
`valid_sats_amount`'s convention is untouched: it reads `None` as zero for
the caller it was written for, with its own reasoning, and nothing about
that changes.

`TxOut.from_dict({"value": null})` built an output of zero satoshi. Legal —
an OP_RETURN pays one, and BIP322's proof-of-funds transactions carry one —
so nothing downstream refused it, and the transaction that came back said
something the file did not. A transaction output declares what it pays, so
at that boundary `null` is a field the file has not filled in.

The two spellings a hand-edited file is likelier to carry were refused
already:

```
{"value": null}    an output of 0 satoshi        -> BTClibValueError now
{"value": ""}      BTClibValueError: invalid BTC amount
{"value": "null"}  BTClibValueError: invalid BTC amount
```

which is what made `null` the one worth closing: it is the only spelling
json itself produces. A **missing** `"value"` key was already
`missing transaction output field: value`, from the gate of
https://github.com/btclib-org/btclib/issues/867, and the test asserts both
so the two answers cannot drift into one.

`PsbtOut.amount` is the same value read the other way and stays that way: a
psbt output may declare no amount yet, where a transaction output cannot.
The test asserts that too.

## One correction to the release notes

HISTORY.md stated one refusal twice. `taproot.parse`'s `exit_on_op_success`
was refused by the flag census of
https://github.com/btclib-org/btclib/issues/871, which landed while
https://github.com/btclib-org/btclib/pull/878 was open, and 878's bullet
took credit for it a second time — the `merge=union` driver those two files
carry is exactly what lets two branches say the same thing without
conflicting, as CLAUDE.md warns. The bullet now claims the three arguments
that are its own and points at the census for the flag; the CHANGELOG entry
says the same.

Gates run locally: `uv run pytest` (100% coverage, 27808 passed),
`uv run pre-commit run --all-files`, and the sphinx `-W` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify JSON boundary handling for transaction outputs so that a null value is treated as an absent amount and refused, while preserving PSBT semantics.

Bug Fixes:
- Make TxOut.from_dict reject a JSON null value for the output amount instead of silently interpreting it as zero satoshi.

Documentation:
- Update CHANGELOG and HISTORY to document the new TxOut.from_dict null-handling behavior and correct the attribution and description of taproot.parse flag semantics.

Tests:
- Add serialization boundary tests covering JSON null, empty string, and missing value for TxOut, and confirming that PsbtOut.amount continues to accept None as an absent amount.