### PR TITLE
fix(slip39): default entropy_source to None to avoid function default import evaluation (#671)

### DIFF
--- a/btclib/mnemonic/slip39.py
+++ b/btclib/mnemonic/slip39.py
@@ -576,7 +576,7 @@ def mnemonics_from_master_secret(
     passphrase: str = "",
     iteration_exponent: int = 1,
     extendable: bool = True,
-    entropy_source: Callable[[int], bytes] = os.urandom,
+    entropy_source: Callable[[int], bytes] | None = None,
 ) -> list[list[Mnemonic]]:
     """Return the SLIP-0039 shares of a master secret, grouped.
 
@@ -595,6 +595,8 @@ def mnemonics_from_master_secret(
     is the same bytes through another name); anything weaker substituted
     here is a secret an attacker can reproduce.
     """
+    if entropy_source is None:
+        entropy_source = os.urandom
     assert_type(extendable, bool, "extendable")
     _assert_valid_passphrase(passphrase)
     secret = bytes_from_octets(master_secret)

--- a/tests/mnemonic/slip39_test.py
+++ b/tests/mnemonic/slip39_test.py
@@ -319,3 +319,14 @@ def test_invalid_threshold(groups: list[tuple[int, int]], group_threshold: int) 
         slip39.mnemonics_from_master_secret(
             bytes(16), groups=groups, group_threshold=group_threshold
         )
+
+
+def test_mnemonics_from_master_secret_none_entropy_source() -> None:
+    """Verify that entropy_source=None defaults to fresh os.urandom entropy."""
+    shares1 = slip39.mnemonics_from_master_secret(bytes(16), entropy_source=None)
+    shares2 = slip39.mnemonics_from_master_secret(bytes(16), entropy_source=None)
+    assert len(shares1) == 1 and len(shares1[0]) == 1
+    assert len(shares2) == 1 and len(shares2[0]) == 1
+    # Fresh entropy_source should generate distinct shares across calls
+    assert shares1 != shares2
+


### PR DESCRIPTION
### Summary of Changes
Fixes #671.

In `btclib/mnemonic/slip39.py`, `mnemonics_from_master_secret` previously declared `entropy_source: Callable[[int], bytes] = os.urandom` as a default parameter value, causing function reference evaluation at module import time.

### State-of-the-Art Fix
1. Updated `entropy_source` parameter default to `Callable[[int], bytes] | None = None`.
2. Initialized `if entropy_source is None: entropy_source = os.urandom` inside the function body at runtime.
3. Aligns `slip39.py` with the rest of `btclib`'s codebase type contracts (where optional `Callable` parameters default to `None`).
4. Added regression test `test_mnemonics_from_master_secret_none_entropy_source` in `tests/mnemonic/slip39_test.py`.

### Testing
- `pytest tests/mnemonic/slip39_test.py`: Passed cleanly (**81 passed**).
- `ruff check`: All checks passed.
