### PR TITLE
Name every gate of the input contract, and stop counting one of them

### DIFF
--- a/tests/built_object_contract_test.py
+++ b/tests/built_object_contract_test.py
@@ -38,15 +38,16 @@ mypy could see it: `Sequence[BIP32Key]` accepts a `str`, and
 key as far as the type goes. One xpub handed where the list was meant was
 111 keys.
 
-A `bool` parameter is not driven here, and the line is
-`musig2._flag`'s: a flag that decides *what is computed* is a kind and not
-a truth, so `KeyGroup(verify=)` refuses a non-bool -- it chooses the
-closing opcode, and a wallet built from a configuration file reading
-"false" would compute every address of the other script. A flag that
-decides only *whether a check runs* -- `check_validity`, and
-`slip132`'s `check_root_xkey` -- is read for its truth, a wrong value
-there running a check or skipping one and never changing an answer.
-`check_validity_test.py` owns that convention.
+A `bool` parameter is driven in `bool_parameter_test.py` rather than here,
+and the line it sorts them by is `musig2._flag`'s: a flag that decides
+*what is computed* is a kind and not a truth, so `KeyGroup(verify=)`
+refuses a non-bool -- it chooses the closing opcode, and a wallet built
+from a configuration file reading "false" would compute every address of
+the other script. A flag that decides only *whether a check runs* --
+`check_validity`, and `slip132`'s `check_root_xkey` -- is read for its
+truth, a wrong value there running a check or skipping one and never
+changing an answer. `check_validity_test.py` owns that convention, and
+`KeyGroup(verify=)` is in the kinds of that census with the rest.
 """
 
 from __future__ import annotations

--- a/tests/check_validity_test.py
+++ b/tests/check_validity_test.py
@@ -5,10 +5,15 @@
 """Tests for the `check_validity` convention.
 
 `check_validity` is keyword-only throughout the package, which is a rule
-about signatures rather than about any one of them: it appears in 91 of
-them and is forwarded by hand from one to the next, so the guard has to be
-the rule itself. A new signature spelling it positionally is what this
-module fails on.
+about signatures rather than about any one of them: it is the flag most of
+them carry, and it is forwarded by hand from one to the next, so the guard
+has to be the rule itself. A new signature spelling it positionally is
+what this module fails on.
+
+How many carry it is not written down here, because a number in prose
+drifts where a walk does not: this file said 91 for as long as the tree
+kept growing past it. `_signatures` is what answers instead, and
+`len(_signatures())` is the count whenever one is wanted.
 
 What the flag *does* when nobody passes it is the other half, and the same
 kind of rule: every default is True, so a caller who says nothing gets the
@@ -119,12 +124,12 @@ def test_check_validity_keyword_still_works() -> None:
 def test_dsa_sig_is_still_a_dataclass() -> None:
     """The three Sig classes trade InitVar for a written-out __init__.
 
-    The InitVar and its __post_init__ are gone -- from all 91 signatures
-    that take the flag, not only these three -- so what the dataclass
+    The InitVar and its __post_init__ are gone -- from every signature
+    that takes the flag, not only these three -- so what the dataclass
     generates around them is all that is left to check, and it must not
     go too. field(kw_only=True) would express the same thing in fewer
     lines and is available now that 3.10 is the floor; it is not used,
-    because using it in three places out of 91 is the inconsistency the
+    because using it in three of the many is the inconsistency the
     written-out constructors removed.
     """
     r = 0x2B698A0F0A4041059B5C617F42B2B90D68F0F27F8B8F1CBA0D7D8F0B4D4B7C1A

--- a/tests/input_validation_test.py
+++ b/tests/input_validation_test.py
@@ -47,7 +47,12 @@ those is the hand-written thing this avoids.
 A **parameter with a default** is never driven: to reach `hf` or
 `network` the arguments before them would have to be valid, which is the
 table this design is built to do without. Those two are gated by hand
-instead, where their own checks live.
+where their own checks live, and the two families of them that are large
+enough to be walked have a file each: `tests/curve_parameter_test.py` for
+every parameter declaring a curve, `tests/bool_parameter_test.py` for
+every `bool` one. Each carries the table this walk avoids, and a walk of
+its own over the parameter it is about, so the table cannot go stale
+quietly.
 
 A **method**, and a function taking a `Tx`, a `Psbt` or a callback, needs
 a valid instance the vocabulary cannot build. That is the part of issue


### PR DESCRIPTION
Three docstrings say where the input contract is driven. Two were written
when there were fewer places to name, and the third had a number that
drifted.

## `input_validation_test.py`

Its "What it does not reach, and why that is not a hole to plug here"
section reads:

> A **parameter with a default** is never driven: to reach `hf` or
> `network` the arguments before them would have to be valid … **Those
> two** are gated by hand instead, where their own checks live.

There are two *files* of them now, each carrying the table that walk exists
to avoid and a walk of its own over the parameter it is about:
`tests/curve_parameter_test.py` (https://github.com/btclib-org/btclib/pull/869)
and `tests/bool_parameter_test.py`
(https://github.com/btclib-org/btclib/pull/871). Saying where a family *is*
reached is the whole job of a paragraph titled that way.

## `built_object_contract_test.py`

It opens its bool paragraph with "A `bool` parameter is **not** driven
here" — true of that file, and it read as *nothing* driving one before
there was a census. It now names where they are driven, and that
`KeyGroup(verify=)` is in the kinds of that census with the rest.

## `check_validity_test.py`

Here the cross-reference was fine and the **number** was not: three places
said the flag appears in **91** signatures, where `_signatures()` — the
walk in that same file — finds **108**.

```shell
python3 -c '
import sys; sys.path.insert(0, ".")
from tests.check_validity_test import _signatures
print(len(_signatures()))'
```

The number goes, and what decided the rule stays: most signatures carry the
flag and each forwards it by hand, which is why the guard has to be the
rule itself rather than a list of names. `len(_signatures())` answers
whenever a count is wanted. A number in prose drifts where a walk does not
— which is the lesson `release_notes_test.py` already holds CHANGELOG.md
and HISTORY.md to, and this is the same defect one directory over.

## Verified

- `uv run pytest`: 27808 passed, coverage 100.00%
- `uv run pre-commit run --all-files`: exit 0
- `sphinx-build -W --keep-going`: build succeeded

No CHANGELOG entry: test prose, nothing a caller sees — as
https://github.com/btclib-org/btclib/pull/866 had none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify test documentation around how input contract parameters and the `check_validity` flag are driven and counted across the codebase.

Enhancements:
- Update input validation tests to name where defaulted curve and bool parameters are exercised and guarded.
- Clarify that bool parameters are validated in dedicated tests and include `KeyGroup(verify=)` in that census of flag-like parameters.
- Remove hard-coded counts of `check_validity` usages from tests in favor of describing the rule qualitatively and relying on `_signatures()` for any needed totals.