### PR TITLE
Recover one candidate with one multiplication, and refuse the INF key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1338,6 +1338,28 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **Public key recovery refuses the key at infinity** (issue #890).
+  `dsa.recover_pub_keys_` could report INF as one of the keys it
+  recovered, and `recover_pub_key_` could return it: the candidate of step
+  1.6.1 is `r^-1*(s*K - c*G)`, which is the point at infinity whenever
+  `s*K == c*G`, and step 1.6.2's verification does not refuse it. With Q
+  at infinity the `K'` that verification recomputes is the lift itself, so
+  the congruence `x_K % n == r` passes and the candidate is kept — and
+  what the caller then reads is `(5, 0)`, btclib's sentinel for infinity
+  and no public key at all. `_recover_pub_key_` tests the candidate now,
+  as `ssa._recover_pub_key_` always has, and the enumeration drops it as
+  it drops every other candidate that is not a key.
+
+  No signature anybody made reaches it: `s*K == c*G` takes an `r` and an
+  `s` chosen against the challenge, which is what
+  `tests/ecc/dsa_test.py::test_the_recovered_key_can_be_infinity_and_is_refused`
+  builds — `s = 1` and `r` the x-coordinate of `c*G`, through the public
+  spelling. The bindings path could not produce it either way, a
+  libsecp256k1 public key being a point of the curve. What the fix
+  changes for a caller is that a recovered list is one key shorter where
+  the INF used to be in it, so an index into that list is a key_id there
+  too — which is what the list is read for.
+
 - **An ECIES envelope's four fields are `Octets`, and coerce** (issue
   #874). `magic`, `eph_pub_key`, `ciphertext` and `mac` were declared
   `bytes` and assigned as they came, the only octet fields in the library
@@ -4336,6 +4358,60 @@ documented at release-notes length in the first place, and are still in
   multiplication is Python's, an inverse being 8.8 us of 1148.
 
 ### Performance
+
+- **ECDSA recovery is one double multiplication per candidate, not two**
+  (issues #890, #891, #895). `_recover_pub_key_` built the candidate with
+  the double multiplication of step 1.6.1 and then verified it with a
+  second one of the same size, step 1.6.2 — half of the elliptic-curve
+  work of a recovery, spent on an identity the line above established.
+  Substituting the candidate into the verification gives `K' = K`
+  identically, for every r and s, and what the step then asks — `x_K % n
+  == r` — holds by construction where `x_K` is `r + j*n` with `r < n`. So
+  on a curve of prime order the step is two comparisons: the infinity test
+  above, which the verification never made, and a screen on `x_K`.
+
+  That screen is the second half. `x_K = r + j*n` was reduced `% p`, so a
+  candidate whose x-coordinate overflowed the field was carried into a
+  Python square root and a double multiplication before 1.6.2 refused it
+  — and it always refuses it, the congruence then needing `m*p ≡ 0 mod n`.
+  It is compared against `p` instead, which is the screen libsecp256k1
+  imposes on its own side (`r < p - n` for `j = 1`) and the reason the
+  bindings arm can say the key it gets back is right by construction. The
+  comparison sits above the per-candidate precomputation, for the reason
+  the low-s rule sits above the whole of it: it reads `key_id`, `r` and the
+  curve and nothing the arithmetic produces, so a candidate it refuses pays
+  neither a modular inverse nor a lift — 9.45 µs down to 0.29, and on
+  secp256k1 that is two of the four candidates of every signature. The
+  bindings arm of `recover_pub_keys_` asks the same question before
+  crossing at all: recid 2 and 3 need `r + n < p`, some 2^-127 of
+  signatures, so it is two `recover` calls rather than four for every
+  signature anybody made.
+
+  Above cofactor 1 nothing changes. There a lift need not land in the
+  prime-order subgroup, the scalars are reduced modulo `n` and the
+  reduction is then not a no-op, so `K' = K` does not hold and the
+  verification is doing real work — secp112r2, cofactor 4, answers four
+  keys of ten candidates. The guard is the curve's for that reason and not
+  the caller's.
+
+  Measured on this machine, the mean over 40 random keys, µs per call,
+  before against after: `recover_pub_keys_` on the pure-Python path 3745
+  against 1381, `bms.verify` 1306 against 739, `recover_pub_key` 1272
+  against 694, and the enumeration with the arithmetic delegated 347
+  against 107. The bindings path pays none of this — it never reaches the
+  function — and its own enumeration moves 43.3 to 42.1, two crossings
+  whose answer was a range test.
+
+  Four figures in the same comments are re-measured while they are being
+  rewritten (issue #898): each was 1.7x to 2.1x what the call now costs,
+  the Python arithmetic under them having got faster after they were
+  written. A recovery's figure carries the population it was measured over
+  now, which a signature's does not need: what the enumeration costs
+  depends on how many of its candidates lift. `_recover_pub_keys_`'s own
+  comment drops the "19%" it priced the un-hoisted precomputation at
+  (issue #892) and keeps the reason, which never rested on the number:
+  `mod_inv_var` delegates to `pow(a, -1, m)` now, and the share it derived
+  that percentage from is not the share any more.
 
 - **`bip32.derive` stops re-decoding the same xprv/xpub on every call**
   (issue #828). `derive` and `derive_from_account` decode their `xkey`

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,17 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **`dsa.recover_pub_key_` reports a key_id outside 0..3 as a
+  `BTClibValueError`.** It raised `BTClibRuntimeError` — "signature
+  verification failed" — for a key_id whose `x_K = r + j*n` is no field
+  element, that being the verification refusing it a double multiplication
+  later; the screen that now refuses it says so as a value error, so an
+  `except BTClibRuntimeError` written against key_id 4 catches nothing.
+  `recover_pub_keys_` is unaffected, suppressing both classes as it always
+  did, and so is every key_id a signature can name. `recover_pub_keys_`
+  also stops reporting the point at infinity as a recovered key, which
+  CHANGELOG.md has.
+
 - **`TxOut.from_dict` refuses a `null` value.** It used to build an output
   of zero satoshi, `valid_sats_amount` reading `None` as zero for the
   caller it was written for; a stored dict carrying `{"value": null}` now

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -394,8 +394,8 @@ def assert_as_valid(msg: Octets, addr: String, sig: Sig | String) -> None:
     # signature is valid only if the provided address is matched, and an
     # address is a hash of the sec octets: no point is built here, the
     # bindings answering the octets themselves -- which is the mod_inv_var of
-    # an affine conversion not paid either. `verify` is 25 us against 2782,
-    # the mean over 40 random keys, of which some 20 are the recovery
+    # an affine conversion not paid either. `verify` is 25 us against 739,
+    # the mean over 40 random keys, of which some 16 are the recovery
     # itself and 2.4 the r-congruence check of the Sig validation above
     if _libsecp256k1_serves(secp256k1, None):
         pub_key = _libsecp256k1_recover_sec_(

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -1190,23 +1190,21 @@ def _recover_pub_keys_(
     # order key_id numbers them in, so range() is the loop.
     #
     # It costs a mod_inv_var per candidate rather than hoisting the
-    # precomputation out of the loop, and delegating the double_mult_var below
-    # is what made that measurable: 41 us of the 214 a candidate takes on
-    # secp256k1 with the dispatch off, where the same 41 sat inside 2215.
-    # Still not hoisted, because the plural is `_recover_pub_key_` over a
-    # range of key_ids and nothing else -- issue 183 was the two
-    # disagreeing while each held its own copy of this arithmetic -- so the
-    # paths that reach this loop pay 19% for the singular staying the only
-    # place the arithmetic is written.
+    # precomputation out of the loop. Not hoisted, because the plural is
+    # `_recover_pub_key_` over a range of key_ids and nothing else: issue
+    # 183 was the two implementations disagreeing while each held its own
+    # copy of this arithmetic, so the singular stays the only place the
+    # arithmetic is written.
     keys: list[JacPoint] = []
     for key_id in range(2 * (ec.cofactor + 1)):
-        # a candidate can fail either half of step 1.6: x_K may not be on
-        # the curve at all -- r = K[0] % ec.n, so when ec.n < K[0] < ec.p,
-        # likely for cofactor > 1, it is x_K = r + ec.n that is -- or the
-        # key it yields may not verify the signature. Both mean "not this
-        # one", not "no key", so the list is dense and shorter than the
-        # range: it is what a caller indexes to name a key_id, which is
-        # only that key_id when no earlier candidate dropped out
+        # a candidate can fail any of the three refusals of step 1.6:
+        # x_K = r + j*ec.n may be no field element -- which is most of
+        # them, r + ec.n < ec.p being some 2^-127 of signatures on
+        # secp256k1 -- or no x-coordinate of the curve, or the key it
+        # yields may be INF. All three mean "not this one", not "no key",
+        # so the list is dense and shorter than the range: it is what a
+        # caller indexes to name a key_id, which is only that key_id when
+        # no earlier candidate dropped out
         with contextlib.suppress(BTClibValueError, BTClibRuntimeError):
             keys.append(_recover_pub_key_(key_id, c, r, s, ec, lower_s=lower_s))
     return keys
@@ -1232,15 +1230,22 @@ def recover_pub_keys_(
 
     # the enumeration is btclib's loop and not a function libsecp256k1
     # has, but each candidate in it is a recid the bindings answer for, so
-    # what runs here is four `recover` calls: 83 us against 854 (issue
-    # 286). A recid is two bits, i.e. every candidate a curve of cofactor
-    # 1 has, and _libsecp256k1_serves admits no other curve --
-    # secp256k1's cofactor is 1, so `range(4)` here is the
+    # what runs here is a `recover` call per candidate: 42 us against 1381
+    # (issue 286). A recid is two bits, i.e. every candidate a curve of
+    # cofactor 1 has, and _libsecp256k1_serves admits no other curve --
+    # secp256k1's cofactor is 1, so the range below is the
     # `range(2 * (ec.cofactor + 1))` of the Python enumeration above, in
     # the same order, key_id by key_id
     if _libsecp256k1_serves(sig.ec, hf):
         keys: list[Point] = []
-        for key_id in range(4):
+        # and it is two candidates rather than four for every signature
+        # anybody made: recid 2 and 3 are j = 1, i.e. x_K = r + ec.n, which
+        # needs r + ec.n < ec.p -- some 2^-127 of signatures on secp256k1.
+        # The same screen `_recover_pub_key_` applies on the other side,
+        # and the one libsecp256k1 applies on its own: what is skipped is a
+        # crossing whose answer is a refusal on that very range test, so
+        # the candidates that survive are unchanged
+        for key_id in range(4 if sig.r + sig.ec.n < sig.ec.p else 2):
             # a candidate that recovers nothing is dropped rather than
             # reported, as in _recover_pub_keys_: the bindings' refusal
             # arrives as the BTClibValueError _libsecp256k1_recover_sec_
@@ -1273,12 +1278,28 @@ def recover_pub_keys(msg: Octets, sig: Sig | Octets, hf: HashF = sha256) -> list
 def _recover_pub_key_(
     key_id: int, c: int, r: int, s: int, ec: Curve, *, lower_s: bool
 ) -> JacPoint:
-    # Private function provided for testing purposes only.
+    # Private function provided for testing purposes only: r and s are
+    # assumed in 1..n-1, which is what every caller's Sig validation
+    # establishes and what the two shortcuts below rest on.
 
-    # precomputations
-    r_1 = mod_inv_var(r, ec.n)
-    r1s = r_1 * s % ec.n
-    r1e = -r_1 * c % ec.n
+    # the low-s rule first, where `_libsecp256k1_recover_sec_` also asks
+    # it: it is a property of the signature and not of the candidate, so
+    # every key_id answers it the same way and none of the arithmetic
+    # below is needed to say so
+    if lower_s and s > ec.n // 2:
+        raise BTClibValueError("not a low s")
+
+    # whether step 1.6.2 has anything left to check, which is a property
+    # of the curve and not of the signature (issue 890). With cofactor 1
+    # the curve has ec.n points and every one of them is a multiple of G,
+    # so the scalars below -- reduced modulo ec.n, as scalars are -- act on
+    # a lifted K the way SEC 1's arithmetic says they do, and the two
+    # comparisons this enables are argued for where they are made. Above 1
+    # a lift need not land in the prime-order subgroup, the reduction is
+    # then not a no-op, and the verification is doing real work: secp112r2
+    # has cofactor 4, and its recovery answers four keys of ten candidates
+    prime_order = ec.cofactor == 1
+
     # r is x_K reduced mod n, so it does not determine x_K:
     # if ec.n < K[0] < ec.p (likely when cofactor ec.cofactor > 1)
     # then both x_K=r and x_K=r+ec.n must be tested
@@ -1294,7 +1315,38 @@ def _recover_pub_key_(
     # cannot name a candidate that failed -- but a key_id arrives from
     # outside too, in the recovery flag of a message signature
     j = key_id >> 1  # allow for key_id in [0, 7]
-    x_K = (r + j * ec.n) % ec.p  # 1.1
+    x_K = r + j * ec.n  # 1.1
+
+    if prime_order:
+        # screened rather than reduced, which is the screen libsecp256k1
+        # imposes on its own side -- `recover_pub_key_`'s comment states
+        # it, "the bindings require r < ec.p - ec.n for j = 1" -- and half
+        # of what leaves step 1.6.2 a comparison. A `% ec.p` answers
+        # x_K = r + j*ec.n - m*ec.p for some m >= 1 instead, and no such
+        # candidate can pass 1.6.2: that step asks x_K % ec.n == r, which
+        # would need m*ec.p ≡ 0 mod ec.n, and ec.n divides neither ec.p
+        # nor an m this small. So a wrapped x_K is refused here by one
+        # comparison, where the reduction spent a Python square root and a
+        # double multiplication to refuse it -- the trade
+        # `_is_x_coordinate_var`'s docstring exists not to make, reached by
+        # a caller who could have skipped the question (issue 891).
+        #
+        # A negative x_K is the same refusal: nothing outside 0..p-1 is a
+        # field element, and a key_id below zero is what reaches it
+        if not 0 <= x_K < ec.p:
+            err_msg = f"invalid key_id ({key_id}): x_K is not a field element"
+            raise BTClibValueError(err_msg)
+    else:
+        x_K %= ec.p
+
+    # the precomputations, below the screen and not above it: a
+    # candidate the comparison refuses has no use for them, and on
+    # secp256k1 that is key_id 2 and 3 of every signature anybody made
+    # -- which is the reason the low-s rule is asked first, one line of
+    # arithmetic further up
+    r_1 = mod_inv_var(r, ec.n)
+    r1s = r_1 * s % ec.n
+    r1e = -r_1 * c % ec.n
 
     # even root first for Bitcoin Core compatibility
     i = key_id & 0b01
@@ -1307,20 +1359,58 @@ def _recover_pub_key_(
     KJ = x_K, y_K, 1  # 1.2, 1.3, and 1.4
     # 1.5 has been performed in the recover_pub_keys calling function
     #
-    # delegated as the double_mult_var of _assert_as_valid_ below it is: this
-    # is the Python path of recovery -- the named candidate goes to
-    # secp256k1_ecdsa_recover instead, and the enumeration has no
-    # counterpart to go to at all -- but the arithmetic under it is
-    # libsecp256k1's for secp256k1 all the same, as the lift above is:
-    # 2215 us against 214 for the whole of this function, and 6800 against
-    # 850 for the enumeration that runs it once per candidate.
+    # delegated as the lift above is: this is the Python path of recovery
+    # -- the named candidate goes to secp256k1_ecdsa_recover instead, and
+    # the enumeration has no counterpart to go to at all -- but the
+    # arithmetic under it is libsecp256k1's for secp256k1 all the same:
+    # 708 us against 49 for the whole of this function, and 1347 against
+    # 107 for the enumeration that runs it once per candidate.
+    # The mean over 40 random keys, and a recovery needs the population
+    # stated where a signature does not: what the enumeration costs
+    # depends on how many of its candidates lift, which is a property of
+    # the signature and not of the machine.
     #
     # It is the same point either way and not the same triple: what comes
     # back is _jac_from_aff, i.e. z == 1, where the wNAF answered whatever
     # representative its ladder reached. Every caller converts with
     # aff_from_jac_var, which is what a Jacobian coordinate is for
     QJ = _jac_double_mult(r1s, KJ, r1e, ec.GJ, ec)  # 1.6.1
-    _assert_as_valid_(c, QJ, r, s, ec, lower_s=lower_s)  # 1.6.2
+
+    # INF is no public key, and step 1.6.2 does not refuse it: with Q at
+    # infinity the K' that verification recomputes is the lift itself, so
+    # the congruence holds and the INF was reported as a recovered key,
+    # (5, 0) once converted -- btclib's sentinel for infinity and no key
+    # at all. Q is INF whenever s*K == c*G, which is no signature anybody
+    # made and is a `Sig` a caller may still hand in.
+    # `ssa._recover_pub_key_` has always tested its own, for this reason
+    if QJ[2] == 0:
+        err_msg = "invalid (INF) key"
+        raise BTClibRuntimeError(err_msg)
+
+    if prime_order:
+        # and step 1.6.2 has nothing else left to ask. Verification
+        # recomputes K' = s^-1*(c*G + r*Q); substituting the Q that 1.6.1
+        # has just built, r^-1*(s*K - c*G), gives K' = K identically, for
+        # every r and s. What the step then asks is x_K % ec.n == r, and
+        # x_K is r + j*ec.n with r < ec.n, so that holds by construction as
+        # well -- the screen above being what rules out the x_K that is
+        # neither, and the infinity test above the degenerate answer.
+        #
+        # secp256k1_ecdsa_recover makes no verification pass either, and
+        # `_libsecp256k1_recover_sec_`'s comment below is where that
+        # argument is written out: this is the arm it did not cover. What
+        # the multiplication also bought was a cross-check of 1.6.1 --
+        # issue 183 was the two implementations disagreeing while each held
+        # its own copy of this arithmetic -- and that guarantee is the
+        # suite's now, where it already lives: the bindings are the
+        # authority this path is held against, candidate by candidate and
+        # key_id by key_id (issue 890)
+        return QJ
+
+    # lower_s=False, the rule having been asked at the top of this function
+    # for every candidate: what is left here is the step itself, and
+    # nothing about the form of the signature
+    _assert_as_valid_(c, QJ, r, s, ec, lower_s=False)  # 1.6.2
     return QJ
 
 
@@ -1331,16 +1421,19 @@ def _libsecp256k1_recover_sec_(
     # already, and hands in a 32-byte msg_hash and a key_id in [0, 3].
     #
     # secp256k1_ecdsa_recover is step 1.6 of SEC 1 v.2 section 4.1.6 for
-    # the one named candidate: 19 us here against the two milliseconds of
-    # the Python path, which is `recover_pub_key` 22 us against 2330 once
-    # the Sig validation both of them pay is counted in. It answers sec
-    # octets rather than a point, which is what an address wants, so bms
-    # hashes these very bytes and never builds a point.
+    # the one named candidate: 16 us here against the 708 of the Python
+    # path, which is `recover_pub_key` 22 us against 694 once the Sig
+    # validation both of them pay is counted in, the mean over 40 random
+    # keys. It answers sec octets rather than a point, which is what an
+    # address wants, so bms hashes these very bytes and never builds a
+    # point.
     #
     # Step 1.6.2 -- that the recovered key verifies the signature -- is
     # not skipped by delegating: the key returned satisfies the signature
     # equation by construction, and a candidate whose x-coordinate is not
-    # on the curve is the failure caught below.
+    # on the curve is the failure caught below. Which is the argument
+    # `_recover_pub_key_` makes on its own side now, the screen there
+    # being what the bindings impose here.
     #
     # The lower-s rule is checked here and not there, and only when asked
     # for: the recoverable parser takes any s in [1, n-1], as it must, a
@@ -1423,10 +1516,9 @@ def recover_pub_key_(
     # candidate a curve of cofactor 1 has; _recover_pub_key_ below reads a
     # key_id up to 7 as j up to 3, and no j above 1 is reachable on
     # secp256k1 anyway -- x_K = r + 2*ec.n exceeds ec.p for every r.
-    # Where both answer, they answer the same: the bindings require
-    # r < ec.p - ec.n for j = 1, and the % ec.p of the Python path leaves
-    # x_K = r + ec.n - ec.p otherwise, which fails step 1.6.2 for every r
-    # -- passing it would need ec.p ≡ 0 mod ec.n
+    # Where both answer, they answer the same, and now by the same test:
+    # the bindings require r < ec.p - ec.n for j = 1, and that is the
+    # screen the Python path applies to its own x_K
     if _libsecp256k1_serves(sig.ec, hf) and 0 <= key_id <= 3:
         return _libsecp256k1_recover_point_(key_id, msg_hash, sig, lower_s=False)
 

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -217,6 +217,47 @@ def test_gec() -> None:
     assert dsa.verify(msg, QU, sig, hf)
 
 
+def _step_1_6_1(c: int, r: int, s: int, ec: Curve) -> list[Point | None]:
+    """Return SEC 1 v.2 step 1.6.1's candidate per key_id, None where none.
+
+    The step written out with the curve's affine arithmetic, as the
+    independent opinion `_recover_pub_key_` is held against: a candidate is
+    r^-1*(s*K - c*G) over the lift of x_K = r + j*ec.n, and None where that
+    x_K is no field element, or no x-coordinate of the curve, or where the
+    sum is INF. On a curve of prime order those three are the whole of what
+    step 1.6 refuses, which is what issue 890 turns on, so this list less
+    its Nones is what the enumeration has to answer.
+    """
+    candidates: list[Point | None] = []
+    r_1 = mod_inv_var(r, ec.n)
+    for key_id in range(2 * (ec.cofactor + 1)):
+        x_K = r + (key_id >> 1) * ec.n
+        if ec.cofactor == 1:
+            if x_K >= ec.p:  # the screen, where the implementation screens
+                candidates.append(None)
+                continue
+        else:  # and the reduction where it reduces
+            x_K %= ec.p
+        try:
+            y = ec.y_even_var(x_K)
+        except BTClibValueError:
+            candidates.append(None)
+            continue
+        K = x_K, ec.p - y if key_id & 0b01 else y
+        Q = ec.add_var(mult(r_1 * s % ec.n, K, ec), mult(-r_1 * c % ec.n, ec.G, ec))
+        candidates.append(None if Q == INF else Q)
+    return candidates
+
+
+def _verifies(c: int, Q: Point, r: int, s: int, ec: Curve) -> bool:
+    """Answer whether Q verifies (r, s), which is step 1.6.2 as a boolean."""
+    try:
+        dsa._assert_as_valid_(c, (Q[0], Q[1], 1), r, s, ec, lower_s=False)
+    except (BTClibValueError, BTClibRuntimeError):
+        return False
+    return True
+
+
 @pytest.mark.parametrize("name", list(low_card_curves))
 def test_low_cardinality(name: str) -> None:
     """Exercise every low-cardinality curve in its own exhaustive test case."""
@@ -249,7 +290,23 @@ def test_low_cardinality(name: str) -> None:
                     jac_keys = dsa._recover_pub_keys_(e, r, s, ec, lower_s=lower_s)
                     Qs = [ec.aff_from_jac_var(key) for key in jac_keys]
                     assert ec.aff_from_jac_var(QJ) in Qs
-                    assert len(jac_keys) in {2, 4}
+                    # every key it answers is a key, where the INF the list
+                    # used to carry is none: with Q at infinity the
+                    # verification of step 1.6.2 passes vacuously, so the
+                    # pair can be a single key and the count is not the
+                    # assertion (issue 890)
+                    assert INF not in Qs
+                    # and the list is exactly step 1.6.1's candidates, less
+                    # what step 1.6 refuses: on a curve of prime order that
+                    # is the screen and the infinity test alone, and above
+                    # cofactor 1 the verification as well, a lift there
+                    # landing outside the prime-order subgroup
+                    candidates = [Q_ for Q_ in _step_1_6_1(e, r, s, ec) if Q_]
+                    if ec.cofactor > 1:
+                        candidates = [
+                            Q_ for Q_ in candidates if _verifies(e, Q_, r, s, ec)
+                        ]
+                    assert Qs == candidates
 
 
 def test_pub_key_recovery() -> None:
@@ -1051,7 +1108,11 @@ def test_the_enumeration_asks_for_the_j_one_candidates(
     equation by construction. What it pins is that the four `recover` calls
     ask for the same candidates as the Python loop, in the same order, and
     drop the same ones -- on the two key_ids the bindings and the Python
-    path arrive at differently, `recid & 2` against `(r + j*ec.n) % ec.p`.
+    path arrive at differently, `recid & 2` against the screen on
+    x_K = r + j*ec.n. Both r are small enough for that screen to admit the
+    j = 1 pair, which is the point of fabricating one: no signature has an
+    r that low, and the screen is the whole of what the two paths have to
+    agree about there (issue 891).
     """
     msg_hash = reduce_to_hlen(b"Satoshi Nakamoto")
     sig = dsa.Sig(r, 12345)
@@ -1068,6 +1129,47 @@ def test_the_enumeration_asks_for_the_j_one_candidates(
         assert dsa.recover_pub_keys_(msg_hash, sig) == keys
         no_bindings(patch)
         assert dsa.recover_pub_keys_(msg_hash, sig) == keys
+
+
+def test_the_recovered_key_can_be_infinity_and_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Q = r^-1*(s*K - c*G) is INF whenever s*K == c*G, and INF is no key.
+
+    Step 1.6.2's verification does not catch it, which is why the infinity
+    test that replaced it is not a shortcut's price but its gain (issue
+    890): with Q at infinity the recomputed K' is the lift itself, so the
+    congruence x_K % ec.n == r passes and the enumeration reported the INF
+    as a recovered key -- (5, 0) once converted, which is btclib's sentinel
+    for infinity and no public key at all. `ssa._recover_pub_key_` has
+    always refused its own, for this same reason.
+
+    Reached through the public spelling and not the private one: with s = 1
+    the condition is K == c*G, so r is that point's x-coordinate and the
+    key_id its parity. sha512 is what sends the recovery down the Python
+    path on secp256k1 -- the bindings cannot answer INF, a libsecp256k1
+    public key being a point of the curve -- and the fully Python
+    arithmetic under it answers the same, as it does for BIP340.
+    """
+    ec = secp256k1
+    msg_hash = reduce_to_hlen(b"Satoshi Nakamoto", sha512)
+    c = challenge_(msg_hash, ec, sha512)
+    K = mult(c, ec.G, ec)
+    sig = dsa.Sig(K[0], 1)
+    key_id = K[1] & 0b01
+
+    err_msg = r"invalid \(INF\) key"
+    with pytest.raises(BTClibRuntimeError, match=err_msg):
+        dsa.recover_pub_key_(key_id, msg_hash, sig, sha512)
+    keys = dsa.recover_pub_keys_(msg_hash, sig, sha512)
+    assert keys
+    assert INF not in keys
+
+    with monkeypatch.context() as patch:
+        no_bindings(patch)
+        with pytest.raises(BTClibRuntimeError, match=err_msg):
+            dsa.recover_pub_key_(key_id, msg_hash, sig, sha512)
+        assert dsa.recover_pub_keys_(msg_hash, sig, sha512) == keys
 
 
 def _search_key_id(msg: bytes, sig: dsa.Sig, Q: Point) -> int:
@@ -1186,13 +1288,12 @@ def test_recover_pub_key_dispatches_to_the_bindings_for_0_to_3_only() -> None:
     """The bindings take a recovery id of 0, 1, 2 or 3, and nothing wider.
 
     A key_id outside that range has to reach the Python path instead,
-    which answers in its own words rather than the bindings': recovering
-    a candidate that does not verify (public key recovery failed) or
-    finding no candidate at all congruent to r (signature verification
-    failed) -- neither of them the bindings' own "the recovery id must
-    be 0, 1, 2, or 3", which is what a widened or narrowed guard sends a
-    boundary value to instead. Four key_ids, one per boundary the six
-    ways this guard survived moved.
+    which answers in its own words rather than the bindings': its own
+    screen on x_K = r + j*ec.n, which is no field element for a j of -1
+    or 2 (issue 891) -- not the bindings' "the recovery id must be 0, 1,
+    2, or 3", which is what a widened or narrowed guard sends a boundary
+    value to instead. Four key_ids, one per boundary the six ways this
+    guard survived moved.
     """
     q = 0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCD
     # grind=False: this signature is the fixture, chosen for the four
@@ -1201,10 +1302,10 @@ def test_recover_pub_key_dispatches_to_the_bindings_for_0_to_3_only() -> None:
     msg_hash = b"\x00" * 32
 
     cases = {
-        -1: (BTClibRuntimeError, "signature verification failed"),
+        -1: (BTClibValueError, r"invalid key_id \(-1\)"),
         2: (BTClibValueError, "public key recovery failed"),
         3: (BTClibValueError, "public key recovery failed"),
-        4: (BTClibRuntimeError, "signature verification failed"),
+        4: (BTClibValueError, r"invalid key_id \(4\)"),
     }
     for key_id, (exc, err_msg) in cases.items():
         with pytest.raises(exc, match=err_msg):


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/890,
https://github.com/btclib-org/btclib/issues/891,
https://github.com/btclib-org/btclib/issues/892 and
https://github.com/btclib-org/btclib/issues/898.

**On the split**, since it moved while this was being written:
https://github.com/btclib-org/btclib/issues/895 is closed as a duplicate,
and #890 and #891 are the two halves — 1.6.2 in one, the unreachable
candidates in the other — with the joint argument in
[#890's comment](https://github.com/btclib-org/btclib/issues/890#issuecomment-5296410894).
This PR is that joint change, in the order that comment requires: the
screen first, and 1.6.2 only becomes a comparison behind it. The commit
message still carries a `Closes #895` trailer; it is the same change and
the issue is already closed.

The two halves confirm each other. Independently of the issues, taking
1.6.2 out with no screen turned the suite red on secp112r2 and on the two
cofactor-2 low-cardinality curves — which is #890's comment arriving as a
test failure — and the screen is what makes the removal sound.

## The defect found on the way, which is the reason to read this twice

**`recover_pub_keys_` could report the point at infinity as a recovered
key.** The candidate of step 1.6.1 is `r^-1*(s*K - c*G)`, INF whenever
`s*K == c*G`, and step 1.6.2 does not refuse it: with Q at infinity the
`K'` that verification recomputes *is* the lift, so the congruence
`x_K % n == r` passes and the candidate is kept. What the caller reads back
is `(5, 0)` — btclib's sentinel for infinity, and no public key.

So the infinity test that replaces the verification is not the shortcut's
price but its gain. `ssa._recover_pub_key_` has always had it, for this
same reason and with this same message.
`test_the_recovered_key_can_be_infinity_and_is_refused` reaches it through
the public spelling: `s = 1` and `r` the x-coordinate of `c*G`, with sha512
to stay on the Python path.

## The two comparisons that replace the multiplication

Substituting 1.6.1's Q into the verification gives `K' = K` identically,
for every r and s; the congruence then holds by construction where `x_K` is
`r + j*n` with `r < n`. What is left is the degenerate answer above, and
the `x_K` that is not `r + j*n`:

- **the screen** (#891). `x_K` was reduced `% p`, so a candidate whose
  x-coordinate overflows the field was not skipped but *changed*: the
  wrapped `r + n - p` is an x-coordinate about half the time, and then it
  paid a Python square root and a full 1.6.1 double multiplication before
  1.6.2 refused it. Compared against `p` instead, which is what
  libsecp256k1 imposes on its own side (`r < p - n` for `j = 1`) and the
  reason its arm can say the key comes back right by construction. The
  bindings arm — the half of #891 that does not follow from the Python
  change — asks the same question before crossing at all: recid 2 and 3
  need `r + n < p`, so it is two `recover` calls rather than four for every
  signature anybody made.
- **the cofactor guard** (#890). Above cofactor 1 a lift need not land in
  the prime-order subgroup; the scalars are reduced mod `n` and the
  reduction is then not a no-op, so `K' = K` does not hold and the
  verification is doing real work. secp112r2, cofactor 4, answers four keys
  of ten candidates. Nothing changes there — neither the screen nor the
  shortcut applies.

## Test

`test_low_cardinality` no longer asserts `len(jac_keys) in {2, 4}` — a
count that was two partly *because* the INF was in the list. It asserts the
exact list against `_step_1_6_1`, step 1.6.1 written out with the curve's
affine arithmetic, less what step 1.6 refuses: the screen and the infinity
test on a curve of prime order, the verification as well above cofactor 1.
It is a stronger assertion than the count, and it is the one that would
have caught the INF.

## Measured, this machine, mean over 40 random keys, µs per call

| | before | after |
|---|---:|---:|
| `recover_pub_keys_`, pure Python | 3745 | 1381 |
| `bms.verify`, pure Python | 1306 | 739 |
| `recover_pub_key`, pure Python | 1272 | 694 |
| the enumeration, arithmetic delegated | 347 | 107 |
| `recover_pub_keys_`, bindings | 43.3 | 42.1 |

Four figures in the same comments were 1.7x to 2.1x what the calls cost
(#898) — the Python arithmetic under them got faster after they were
written — and are re-measured with the population named, which a recovery's
figure needs and a signature's does not. `_recover_pub_keys_` drops the
"19%" it priced the un-hoisted precomputation at (#892), which is the fifth
stale figure and the one with its own cause: `mod_inv_var` delegates to
`pow(a, -1, m)` now, so the share that percentage came from is not the
share. The reason it was arguing for never rested on the number, and stays.

## Gates

`uv run pytest` 27809 passed at 100.00%; `pre-commit run --files ...`
clean; the sphinx `-W` build passes. Rebased on `main` at 7d20ec16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)