### PR TITLE
Trust the signature libsecp256k1 just made, and say why a verifier does not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4337,6 +4337,63 @@ documented at release-notes length in the first place, and are still in
 
 ### Performance
 
+- **`sign_` stops re-validating the signature libsecp256k1 just made**
+  (issue #888). Its bindings path was `Sig.parse(libsecp256k1_dsa.sign(...))`,
+  and `Sig.parse` validates by default: r and s in 1..n-1, and r congruent
+  to a valid x-coordinate — which is another `ec_pubkey_parse`, of
+  `0x02 || r`. The values being checked are the ones
+  `secp256k1_ecdsa_sign` has just computed, r being the x-coordinate of
+  the nonce point reduced mod n and s a scalar beside it: neither can be
+  out of range, and an r it produced cannot fail a congruence it was built
+  from. So the parse is asked for with `check_validity=False`, and the
+  provenance is the argument for it; `sign_recoverable_`'s bindings path
+  builds its `Sig` the same way, for the same reason.
+
+  Grinding paid it per attempt, `_grind_low_r` building a whole `Sig` to
+  read `sig.r` off it, so the figure that means anything is per attempt:
+  `Sig.parse` 4.05 µs against 1.25 with the flag off, 2.8 µs an attempt.
+  How many attempts there are is a property of the key and the message —
+  `_grind_low_r` walks Core's sequence until r is low — so a grinding
+  figure carries its attempt count, as a recovery's carries its population:
+
+  | attempts | before | after |
+  | --- | ---: | ---: |
+  | 1 | 16.99 | 14.22 |
+  | 2 | 33.94 | 28.15 |
+  | 8 | 132.76 | 110.53 |
+
+  **The Python path is the more expensive one to have left it on**, and
+  `_sign_recoverable_` builds its `Sig` with the flag off too. There the
+  provenance is btclib's own arithmetic rather than libsecp256k1's: `r ==
+  0` and `s == 0` are that function's two refusals, so both scalars are in
+  1..n-1 by the time the `Sig` is built, and r is x_K reduced mod n for a
+  K it multiplied itself. What the validation would ask about the
+  congruence is what r was built from — and with the dispatch off that
+  question is `_is_x_coordinate_var`'s Legendre symbol in Python, 13.57 µs
+  of a signature: `sign_(grind=False)` 175.4 against 161.2, and grinding
+  350.4 against 322.9 over this fixture's two attempts, which is 110 µs
+  over the eight another fixture takes.
+
+  Reading r off the DER and building one `Sig` after the loop settles is
+  measured and not taken: on the bindings path it saves the object of each
+  discarded attempt, 1.25 µs against 0.53 for a read of r alone, so 0.7 µs
+  an attempt — 5% of an eight-attempt signature — and it costs a second DER
+  reader beside `Sig.parse` with no validation in it. It is not what the
+  Python path needed either: there is no DER there, and the per-attempt cost
+  was the validation rather than the object.
+
+  **The verification side keeps its second pass, and now says why.**
+  `assert_as_valid_` validates a `Sig` it is handed, and that is not the
+  same redundancy: the class is frozen, so an instance that validated
+  stays valid, but `check_validity=False` is a spelling the library itself
+  uses and `object.__setattr__` reaches past frozen — which the suite does
+  on purpose. `verify_`'s contract of answering a boolean rests on the
+  check: `Sig(-1, 5, check_validity=False)` reaches `_serialize_scalar`,
+  where `to_bytes(..., signed=False)` raises `OverflowError`, an
+  `ArithmeticError` and so not in the tuple `verify_` catches.
+  `test_a_sig_that_never_validated_answers_false_and_does_not_raise` is
+  that reason as a test, both ways in.
+
 - **`bip32.derive` stops re-decoding the same xprv/xpub on every call**
   (issue #828). `derive` and `derive_from_account` decode their `xkey`
   argument through `BIP32KeyData.b58decode` fresh each time, so a

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -431,7 +431,19 @@ def _sign_recoverable_(
         # libsecp256k1 has the same `*recid ^= 1` beside the same negation
         key_id ^= 1
 
-    return Sig(r, s, ec), key_id
+    # check_validity=False, and the provenance is again the argument
+    # (issue 888), one implementation over: r == 0 and s == 0 are the two
+    # refusals this function makes above, so both scalars are in 1..n-1 by
+    # the time they get here, and r is x_K reduced mod n for a K this
+    # function multiplied -- the congruence a validation would ask about is
+    # what r was built from.
+    #
+    # It is the more expensive of the two paths to leave it on. With the
+    # dispatch off that congruence is `_is_x_coordinate_var`'s Legendre
+    # symbol in Python, 13.30 us of the 177.8 a signature costs, and
+    # `_grind_low_r` pays it once per attempt -- 110 us of a 1440 us
+    # grinding signature over eight of them
+    return Sig(r, s, ec, check_validity=False), key_id
 
 
 def _sign_(c: int, q: int, nonce: int, lower_s: bool, ec: Curve) -> Sig:
@@ -612,9 +624,31 @@ def sign_(
         and lower_s
         and commit_hash is None
     ):
+        # check_validity=False, and here the provenance is the argument
+        # (issue 888): what `Sig.parse` would validate is r in 1..n-1, s in
+        # 1..n-1 and r congruent to a valid x-coordinate, of the very values
+        # secp256k1_ecdsa_sign has just computed -- r is the x of the nonce
+        # point reduced mod n and s is a scalar beside it, so neither can be
+        # out of range and an r it produced cannot fail a congruence it was
+        # built from. The congruence is another ec_pubkey_parse, of
+        # 0x02 || r, and grinding pays the whole check once per attempt:
+        # 4.05 us against 1.25 for the parse alone, so 2.8 us an attempt.
+        # Per attempt and not per signature, because how many attempts
+        # there are is a property of the key and the message rather than of
+        # the machine -- `_grind_low_r` walks Core's sequence until r is low
+        # -- and a grinding figure without its attempt count says nothing:
+        # one attempt is 16.99 us against 14.22, eight are 132.76 against
+        # 110.53.
+        #
+        # Reading r off the DER instead, and building one Sig after the loop
+        # settles, was measured and not taken: it saves the object of each
+        # discarded attempt, 1.25 us against 0.53 for a read of r alone, so
+        # 0.7 us an attempt, and it costs a second DER reader beside
+        # `Sig.parse` with no validation in it
         return _grind_low_r(
             lambda counter: Sig.parse(
-                libsecp256k1_dsa.sign(msg_hash, q, _grind_entropy(counter))
+                libsecp256k1_dsa.sign(msg_hash, q, _grind_entropy(counter)),
+                check_validity=False,
             ),
             grind,
             ec,
@@ -776,7 +810,9 @@ def sign_recoverable_(
         n_size = ec.n_size
         r = int.from_bytes(sig_bytes[:n_size], byteorder="big", signed=False)
         s = int.from_bytes(sig_bytes[n_size:], byteorder="big", signed=False)
-        return Sig(r, s, ec), key_id
+        # check_validity=False for `sign_`'s reason above: these are the
+        # values secp256k1_ecdsa_sign_recoverable has just computed
+        return Sig(r, s, ec, check_validity=False), key_id
 
     # the challenge
     c = challenge_(msg_hash, ec, hf)  # 4, 5
@@ -909,6 +945,18 @@ def assert_as_valid_(
     # is not just an annotation: the helpers called below reject a WIF
     # and an xprv too, which a PubKey annotation cannot rule out, both
     # being strings
+    # a `Sig` handed in is validated again, and this is not the redundancy
+    # it looks like (issue 888). The class is frozen, so an instance that
+    # validated at construction stays valid -- but `check_validity=False`
+    # says "not checked yet" and is a spelling the library itself uses
+    # (`sign_` above, for values libsecp256k1 has just computed), and
+    # `object.__setattr__` reaches past frozen, which the suite does on
+    # purpose. What rests on this call is `verify_`'s contract of answering
+    # a boolean: `Sig(-1, 5, check_validity=False)` reaches
+    # `_serialize_scalar` below, where `to_bytes(..., signed=False)` raises
+    # OverflowError -- an ArithmeticError, so not in the (ValueError,
+    # BTClibRuntimeError) `verify_` catches, and it would leave through a
+    # function whose whole answer is True or False
     if isinstance(sig, Sig):
         sig.assert_valid()
     else:

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -817,6 +817,38 @@ def test_core_grinds_the_same_signatures(
     assert sig.serialize() == libsecp256k1_dsa.sign(sig_hash, prv_key, ndata)
 
 
+def test_a_sig_that_never_validated_answers_false_and_does_not_raise() -> None:
+    """Why `assert_as_valid_` validates a `Sig` it was handed (issue 888).
+
+    The class is frozen, so an instance that validated at construction
+    stays valid, and the second pass looks redundant. What makes it not is
+    the two ways an unvalidated instance is reachable: `check_validity=False`,
+    which the library itself passes for values libsecp256k1 has just
+    computed, and `object.__setattr__`, which reaches past frozen as
+    `tests/bip32/bip32_test.py::test_assert_valid2` does on purpose.
+
+    Both of those reach `_serialize_scalar`, where `to_bytes(...,
+    signed=False)` raises OverflowError for a negative r -- an
+    ArithmeticError, so not in the `(ValueError, BTClibRuntimeError)` tuple
+    `verify_` catches. Drop the validation and a function whose whole answer
+    is True or False raises instead, which is the rule issue #814 states.
+    """
+    _, Q = dsa.gen_keys(prv_key_int)
+    msg_hash = reduce_to_hlen(b"Satoshi Nakamoto")
+
+    unvalidated = dsa.Sig(-1, 5, check_validity=False)
+    assert not dsa.verify_(msg_hash, Q, unvalidated)
+    with pytest.raises(BTClibValueError, match="scalar r not in 1..n-1"):
+        dsa.assert_as_valid_(msg_hash, Q, unvalidated)
+
+    # and the same for an instance that validated and was rewritten after
+    corrupted = dsa.sign_(msg_hash, prv_key_int)
+    object.__setattr__(corrupted, "r", -1)
+    assert not dsa.verify_(msg_hash, Q, corrupted)
+    with pytest.raises(BTClibValueError, match="scalar r not in 1..n-1"):
+        dsa.assert_as_valid_(msg_hash, Q, corrupted)
+
+
 def _recovered(key_id: int, msg: bytes, sig: dsa.Sig) -> Point | None:
     """Return the recovered key, None for a candidate recovering nothing."""
     try:


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/888 — both halves, and
both paths: the issue's 2026-08-14 comment adds the pure-Python one, which
the first version of this PR did not touch.

## The signing half: provenance

`sign_`'s bindings path was `Sig.parse(libsecp256k1_dsa.sign(...))`, and
`Sig.parse` validates by default: r and s in 1..n-1, and r congruent to a
valid x-coordinate — the last being another `ec_pubkey_parse`, of
`0x02 || r`. What it checks are the values `secp256k1_ecdsa_sign` has just
computed: r is the x-coordinate of the nonce point reduced mod n, s is a
scalar beside it, so neither can be out of range, and an r it produced
cannot fail a congruence it was built from. `check_validity=False`, with
the provenance as the argument.

| µs per call, bindings path | before | after |
|---|---:|---:|
| `Sig.parse(der)` / with the flag off | 4.07 | 1.27 |
| `sign_(grind=False)` | 17.12 | 14.44 |
| `sign_()`, grinding, one fixture | 33.81 | 28.65 |

**And the Python path, which is the more expensive one to have left it
on.** `_sign_recoverable_` builds its `Sig` with the flag off too, and
there the provenance is btclib's own arithmetic: `r == 0` and `s == 0` are
that function's two refusals, so both scalars are in 1..n-1 by the time the
`Sig` is built, and r is x_K reduced mod n for a K it multiplied itself —
the congruence a validation would ask about is what r was built from. With
the dispatch off that congruence is `_is_x_coordinate_var`'s Legendre
symbol in Python, not a 2.35 µs parse:

| µs per call, `curve._libsecp256k1_available` off | before | after |
|---|---:|---:|
| `sign_(grind=False)` | 175.4 | 161.2 |
| `sign_()`, grinding, two attempts | 350.4 | 322.9 |
| the r congruence alone | 13.57 | — |

Two attempts here; the issue's fixture takes eight, which is the 110 µs it
measures. A grinding figure carries its attempt count for that reason.

**Measured and not taken**, and recorded in the comment: reading r off the
DER and building one `Sig` after the loop settles. On the bindings path it
saves the object of each discarded attempt — 0.7 µs of a 34 µs grinding
signature — for a second DER reader beside `Sig.parse` with no validation
in it. And it is not what the Python path needed either: there is no DER
there, and the per-attempt cost was the validation rather than the object,
which `check_validity=False` removes without a new parser.

## The verification half: the check stays, and says why

`assert_as_valid_` validates a `Sig` it was handed, and the issue asked for
a decision rather than a deletion. The decision is to keep it, and the
reason is not stylistic — measured with `assert_valid` stubbed out:

```
Sig(-1, 5, check_validity=False)   -> verify_ raised OverflowError
the same via object.__setattr__    -> verify_ raised OverflowError
```

`Sig` **is** already frozen, so an instance that validated at construction
stays valid; what makes an unvalidated one reachable is
`check_validity=False` — a spelling the library itself now uses in two more
places, one paragraph up — and `object.__setattr__`, which the suite uses
on purpose. Either reaches `_serialize_scalar`, where
`to_bytes(..., signed=False)` raises `OverflowError`: an `ArithmeticError`,
so not in the `(ValueError, BTClibRuntimeError)` tuple `verify_` catches,
and it would leave through a function whose whole answer is `True` or
`False` — issue #814's rule.

So the comment there stops reading as a redundancy and states that, and
`test_a_sig_that_never_validated_answers_false_and_does_not_raise` pins it
both ways in. A future reader who wants the 2.35 µs has to make that test
fail first.

## Gates

`uv run pytest` 27809 passed at 100.00%; `pre-commit run --files ...`
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)