### PR TITLE
Lift the taproot internal key once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4527,6 +4527,51 @@ documented at release-notes length in the first place, and are still in
   (issue #892) and keeps the reason, which never rested on the number:
   `mod_inv_var` delegates to `pow(a, -1, m)` now, and the share it derived
   that percentage from is not the share any more.
+- **`taproot.output_pubkey` takes one square root, not two** (issue #896).
+  The internal key was validated by `pub_keyinfo_from_key`, which proves
+  the octets a point by building one and then answers the octets, and
+  `_tweaked_pubkey` lifted the x out of them again to have a point to add
+  `t*G` to — the same x, and on the Python path each lift is a modular
+  square root. `output_pubkey` hands the point's own even y down now, and
+  `_tweaked_pubkey` lifts only for the caller that has none: the x-only
+  octets of `output_pubkey_from_merkle_root`, and BIP341's unspendable
+  point, which is published as an x and nothing else.
+
+  Which of the two roots the key names is its prefix's business and not
+  BIP341's: an `03` internal key validates to the odd-y point where the
+  tweak wants the even one, and that is a subtraction from the root already
+  taken. Counted by wrapping the curve's own `y_var`, one `output_pubkey`
+  takes two roots before and one after.
+
+  **How much of the key is worth building differs between the two arms**,
+  so `output_pubkey` reads the dispatch — the fourth guard in the module,
+  and the only one there that is not about which arithmetic runs. The
+  bindings arm lifts nothing, `xonly_pubkey_tweak_add` carrying its own y,
+  so a point built for it would be computed and dropped: `point_from_key`
+  is 6.58 µs against `pub_keyinfo_from_key`'s 3.74. `output_pubkey` with a
+  compressed key, µs per call: 17.25 with the bindings and 318.3 without on
+  the code this replaces, 17.48 and 236.6 after — a quarter off the Python
+  path and nothing added to the one every install takes.
+
+  **`input_script_sig` read the key a second time**, having called
+  `output_pubkey` for the parity, so the same x was lifted twice again one
+  function further out. `_output_pubkey_and_internal_key` is what the two
+  want between them — the output key, its parity, and the x-only internal
+  key — and `output_pubkey` is that helper with the third answer dropped.
+  Roots per call with the dispatch off, and µs: three and 400.16 before,
+  one and 243.11 after; with the bindings, where the key was read twice and
+  lifted never, 27.46 against 23.39.
+
+  The internal key is read with `compressed=None` and sliced `[1:33]`, so a
+  65-byte SEC key now names the internal key its 33-byte spelling names,
+  where it used to be refused for its length; the Python arm's
+  `point_from_key` accepts the same two forms, so the spellings do not
+  depend on whether the bindings are installed — and, the two callers
+  sharing one reader, no more on which of them is asked. Every other
+  spelling — a `Point`, an xpub, a private key, the compressed octets — is
+  accepted exactly as before, and `output_pubkey_from_merkle_root` still
+  takes 32 bytes and only 32. BIP341's unspendable point is written out
+  once now, where `output_pubkey` and `input_script_sig` each had a copy.
 
 - **`bip32.derive` stops re-decoding the same xprv/xpub on every call**
   (issue #828). `derive` and `derive_from_account` decode their `xkey`

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -39,7 +39,7 @@ from btclib.script.op_codes_tapscript import (
 )
 from btclib.script.script import _serialize_bytes_command, _serialize_int_command
 from btclib.to_prv_key import PrvKey, int_from_prv_key
-from btclib.to_pub_key import Key, pub_keyinfo_from_key
+from btclib.to_pub_key import Key, point_from_key, pub_keyinfo_from_key
 from btclib.utils import (
     assert_type,
     bytes_from_octets,
@@ -239,6 +239,68 @@ def _tap_tweak(pub_key: bytes, h: bytes) -> int:
     return t
 
 
+def _output_pubkey_and_internal_key(
+    internal_pubkey: Key | None, script_tree: TaprootScriptTree | None
+) -> tuple[bytes, int, bytes]:
+    """Return the output key, its parity, and the x-only internal key.
+
+    What `output_pubkey` and `input_script_sig` want between them: the
+    first answers the pair and drops the third, the second needs the
+    internal key beside the parity. Read twice, that key was lifted twice
+    on the Python path -- the same square root of the same x, which is the
+    redundancy issue 896 is about, one function further out -- and 3.74 us
+    of ec_pubkey_parse twice with the bindings.
+
+    Sharing it is also what keeps the two answering for the same spellings
+    of an internal key: a form accepted for the output key and refused for
+    the control block that proves it would be refused one call after being
+    accepted, and one reader cannot drift from another.
+    """
+    if not internal_pubkey and not script_tree:
+        raise BTClibValueError("missing data")
+    if internal_pubkey:
+        # a fourth reading of the dispatch, and the only one in this module
+        # that is not about which arithmetic runs: what differs between the
+        # two arms is *how much of the key is worth building*.
+        #
+        # `_tweaked_pubkey` lifts the x-only key to a point on the Python
+        # path, and validating a key is how a point is built, so the same
+        # modular square root of the same x was taken twice -- 74 us of the
+        # 311 an output key cost there (issue 896). The bindings arm lifts
+        # nothing, xonly_pubkey_tweak_add carrying its own y, so a point
+        # built for it is computed and dropped: `point_from_key` is 6.58 us
+        # against `pub_keyinfo_from_key`'s 3.74, which is a sixth of a
+        # 17.3 us output key added to the path every install takes.
+        #
+        # So each arm reads what it uses, and both read the same spellings:
+        # `compressed=None` accepts the 33-byte and the 65-byte form as
+        # `point_from_key` does, and `[1:33]` is the x-coordinate of either
+        if _libsecp256k1_serves(secp256k1, None):
+            pub_key = pub_keyinfo_from_key(internal_pubkey)[0][1:33]
+            y_even: int | None = None
+        else:
+            # which of the two roots the key names is its prefix's business
+            # and not BIP341's, whose lift wants the even one: an 03 key
+            # validates to the odd-y point, and the even y is then a
+            # subtraction from the root already taken rather than a second
+            # root
+            x_P, y_P = point_from_key(internal_pubkey)
+            pub_key = x_P.to_bytes(32, "big")
+            y_even = y_P if y_P % 2 == 0 else secp256k1.p - y_P
+    else:
+        h_str = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+        pub_key = bytes.fromhex(h_str)
+        # BIP341's unspendable point is published as an x-only key and
+        # nothing else, so there the lift is the only one there is
+        y_even = None
+    if script_tree:
+        _, h = tree_helper(script_tree)
+    else:
+        h = b""
+    q, parity_bit = _tweaked_pubkey(pub_key, h, y_even)
+    return q, parity_bit, pub_key
+
+
 def output_pubkey(
     internal_pubkey: Key | None = None,
     script_tree: TaprootScriptTree | None = None,
@@ -251,25 +313,22 @@ def output_pubkey(
     path only. The parity bit is the tweaked point's, needed by the
     control block and never serialized in the output.
     """
-    if not internal_pubkey and not script_tree:
-        raise BTClibValueError("missing data")
-    if internal_pubkey:
-        pub_key = pub_keyinfo_from_key(internal_pubkey, compressed=True)[0][1:]
-    else:
-        h_str = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
-        pub_key = bytes.fromhex(h_str)
-    if script_tree:
-        _, h = tree_helper(script_tree)
-    else:
-        h = b""
-    return _tweaked_pubkey(pub_key, h)
+    q, parity_bit, _ = _output_pubkey_and_internal_key(internal_pubkey, script_tree)
+    return q, parity_bit
 
 
-def _tweaked_pubkey(pub_key: bytes, h: bytes) -> tuple[bytes, int]:
+def _tweaked_pubkey(pub_key: bytes, h: bytes, y_even: int | None) -> tuple[bytes, int]:
     """Return the x-only key an internal key tweaked by h, and its parity.
 
     The half of BIP341's output key that does not care where h came
     from: a tree the caller built, or the merkle root a psbt carries.
+
+    y_even is the even y-coordinate of pub_key where the caller has it
+    already -- `output_pubkey` validated the internal key by lifting it,
+    and on the Python path that lift is a modular square root of this very
+    x (issue 896) -- and None where it does not, which is a caller holding
+    x-only octets and nothing else. The bindings path reads neither:
+    xonly_pubkey_tweak_add takes the octets and carries its own y.
     """
     t = _tap_tweak(pub_key, h)
 
@@ -281,17 +340,20 @@ def _tweaked_pubkey(pub_key: bytes, h: bytes) -> tuple[bytes, int]:
     # while libsecp256k1 needs no such lift, having the y coordinate as
     # it goes.
     #
-    # The predicate is a constant now that the curve is, and the three
+    # The predicate is a constant now that the curve is, and the four
     # guards in this module keep it rather than saying so: it is the
     # seam the suite closes -- curve._libsecp256k1_available set to
     # False -- to reach the Python arithmetic below, which is the
     # reference implementation the bindings are checked against and not
-    # a path any caller takes. Stated here for all three
+    # a path any caller takes. Stated here for all four, `output_pubkey`'s
+    # being the one that asks for a different reason: which form of the
+    # internal key is worth building, rather than which arithmetic runs
     if _libsecp256k1_serves(secp256k1, None):
         return libsecp256k1_xonly.tweak_add(pub_key, t)
 
     P_x = int.from_bytes(pub_key, "big")
-    Q = secp256k1.add_var((P_x, secp256k1.y_even_var(P_x)), mult(t))
+    P_y = secp256k1.y_even_var(P_x) if y_even is None else y_even
+    Q = secp256k1.add_var((P_x, P_y), mult(t))
     return Q[0].to_bytes(32, "big"), Q[1] % 2
 
 
@@ -313,7 +375,9 @@ def output_pubkey_from_merkle_root(
     reached them in.
     """
     internal_pubkey = bytes_from_octets(internal_pubkey, 32)
-    return _tweaked_pubkey(internal_pubkey, bytes_from_octets(merkle_root))
+    # y_even=None: x-only octets are all this caller has, so the lift is
+    # `_tweaked_pubkey`'s to make
+    return _tweaked_pubkey(internal_pubkey, bytes_from_octets(merkle_root), None)
 
 
 def output_prvkey(
@@ -393,12 +457,14 @@ def input_script_sig(
     last leaf and hand back a control block that proves it, so a leaf
     named from the wrong end is refused rather than answered.
     """
-    parity_bit = output_pubkey(internal_pubkey, script_tree)[1]
-    if internal_pubkey:
-        pub_key_bytes = pub_keyinfo_from_key(internal_pubkey, compressed=True)[0][1:]
-    else:
-        h_str = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
-        pub_key_bytes = bytes.fromhex(h_str)
+    # one read of the internal key for the two things this needs of it: the
+    # parity of the output key it is tweaked into, and the key itself, which
+    # the control block carries. Read twice -- `output_pubkey` and then here
+    # -- it was lifted twice on the Python path, and the unspendable point
+    # was written out twice besides
+    _, parity_bit, pub_key_bytes = _output_pubkey_and_internal_key(
+        internal_pubkey, script_tree
+    )
     leaves = tree_helper(script_tree)[0]
     if not is_integer(script_num):
         raise BTClibTypeError(f"invalid leaf index type: {type(script_num).__name__}")

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -108,6 +108,51 @@ def test_taproot_key_tweaking() -> None:
         assert tweaked_pubkey == mult(tweaked_prvkey)[0].to_bytes(32, "big")
 
 
+def test_one_internal_key_however_it_is_spelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every spelling of an internal key names the same output key (issue 896).
+
+    The 65-byte SEC form is the one that moved: `output_pubkey` read its key
+    through `pub_keyinfo_from_key(..., compressed=True)`, where the flag was
+    a filter as well as a conversion and refused that length, and it reads
+    `compressed=None` now because that is what has the point to hand down.
+    Nothing in this file built an uncompressed key, so the widening had no
+    assertion and statement coverage could not supply one: the same lines
+    run for a 33-byte key.
+
+    `input_script_sig` is asserted beside it because the two take one
+    internal key between them -- it reads the parity of the output key and
+    carries the key itself in the control block -- and they answer for the
+    same spellings by sharing one reader rather than by agreeing. Both
+    arithmetics, because the arms read the key differently: the bindings one
+    wants the octets alone and the Python one the point.
+    """
+    prv_key = 0xC0FFEE
+    point = mult(prv_key)
+    spellings = (
+        point,
+        bytes_from_point(point, compressed=True),
+        bytes_from_point(point, compressed=False),
+    )
+
+    for script_tree in SCRIPT_TREES:
+        expected = output_pubkey(point, script_tree)
+        for key in spellings:
+            assert output_pubkey(key, script_tree) == expected
+            with monkeypatch.context() as no_bindings:
+                no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
+                assert output_pubkey(key, script_tree) == expected
+
+    # and the control block carries the same internal key from any of them,
+    # which is the half a second reader of the key could get wrong
+    for script_tree in SCRIPT_TREES[1:]:
+        assert script_tree is not None  # the None of SCRIPT_TREES is key path only
+        expected_sig = input_script_sig(point, script_tree, 0)
+        for key in spellings:
+            assert input_script_sig(key, script_tree, 0) == expected_sig
+
+
 def test_the_python_tweak_is_the_bindings_tweak(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/896.

`output_pubkey` validated the internal key through `pub_keyinfo_from_key`,
which proves the octets a point by building one and then returns the
octets, and `_tweaked_pubkey` lifted the x back out of them to have a
point to add `t*G` to. The same x, and on the Python path each lift is a
modular square root.

The point's own even y is handed down instead, and `_tweaked_pubkey` lifts
only for a caller that has none: the x-only octets of
`output_pubkey_from_merkle_root`, and BIP341's unspendable point, which is
published as an x and nothing else.

Which of the two roots the key names is its prefix's business and not
BIP341's — an `03` internal key validates to the odd-y point where the
tweak wants the even one — and that is a subtraction from the root already
taken, not a second root. That is the part the change had to keep.

## Measured, `curve._libsecp256k1_available` off

Roots counted by wrapping the curve instance's own `y_var`, so both
spellings the callers use are seen:

| | before | after |
|---|---:|---:|
| square roots per `output_pubkey` | 2 | 1 |
| `output_pubkey` | 311.5 µs | 234.4 µs |
| one square root | 75.0 µs | 75.0 µs |

The bindings path is unchanged and lifts nothing at all:
`secp256k1_xonly_pubkey_tweak_add` carries its own y.

## One input the contract loosens on

The key is read with `point_from_key` rather than
`pub_keyinfo_from_key(..., compressed=True)`, which is what has the point
to hand down. The `compressed=True` there was a filter as well as a
conversion, so a 65-byte SEC key was refused for its length; it now names
the internal key its 33-byte spelling names. Every other spelling — a
`Point`, an xpub, a private key, the compressed octets — is accepted
exactly as before, and the hybrid prefixes stay refused, `point_from_octets`
taking them only when asked.

## Gates

`uv run pytest` 27808 passed at 100.00%; `pre-commit run --files ...`
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Reduce redundant taproot internal key lifting by passing the even y-coordinate into the tweak helper and tightening x-only handling.

Bug Fixes:
- Allow 65-byte SEC taproot internal keys to be interpreted as the same internal key as their 33-byte compressed form instead of rejecting them.

Enhancements:
- Avoid recomputing the taproot internal key point in taproot.output_pubkey by reusing the validated point and only lifting x-only inputs when necessary, improving performance.
- Document the taproot.output_pubkey performance and input-acceptance change in the changelog.