### PR TITLE
Let a caller say a point will come back, and keep its tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4456,6 +4456,51 @@ documented at release-notes length in the first place, and are still in
   stays where it is: the preparation before the loop is the GLV split, the
   four wNAFs and the two tables, and the tables are #893's and #897's to
   memoize rather than this loop's to speed up.
+- **A caller can say that a point will come back, and keep its tables**
+  (issues #893 and #897). Every multiplication table in `curve_group` is
+  memoized on `(point, curve, width)` already, so a repeated point would
+  find its own — what was missing was anyone to say that a point *is*
+  repeated. Only the generator was assumed to be. `curves.PreparedPoint`
+  is where a caller says so, and it answers both halves of that gap with
+  one convention:
+
+    - `PreparedPoint(Q).mult(m)` takes the fixed-base ladder the generator
+    takes, instead of the GLV endomorphism: 142.3 µs a call against
+    551.0, once 9.50 ms has built the per-position tables — 43 positions
+    of 64 points on secp256k1, some 366 KiB. Break-even is 23
+    multiplications of the one point, which is `dh.diffie_hellman`
+    against one counterparty, a taproot internal key tweaked repeatedly,
+    or `pedersen` against a fixed second generator.
+    - `dsa` and `ssa` take one wherever they take a public key, and the
+    key's two GLV halves then get memoized wNAF tables at `_FIXED_POINT_W`
+    instead of tables built at `_DOUBLE_MULT_W` and dropped: 2 tables
+    built per verification become 0, and the verification 609.1 µs
+    against 471.0 for ECDSA, 664.5 against 531.2 for BIP340. Break-even
+    is 22 signatures under the one key. Preparing also parses the key
+    once, which is the other 75.2 µs a pure-Python verifier was
+    repeating.
+
+  **Opt-in, and it will not become automatic.** The tables are per
+  distinct point, so a library that memoized whatever public key arrived
+  would hold a few MB for keys nobody will see again, and would tax the
+  one-shot verifier 3 ms to do it — issue #287, the same bound
+  `_cached_base58_decode` and `pedersen.second_generator` hold. It is the
+  trade `python-ecdsa` documents on its own `VerifyingKey.precompute()`,
+  and it is a method a caller calls there for this reason.
+
+  **It is the Python arithmetic throughout.** On secp256k1 with the
+  bindings in reach a verification is 22.8 µs and libsecp256k1 holds its
+  own tables in its own context, so a prepared point is passed straight
+  through and buys nothing; what it is for is the path that reaches the
+  Python arithmetic — another curve, another hash function, or a
+  deployment without the compiled bindings. Handing one in on the
+  delegated path is not an error and costs nothing.
+
+  The plumbing is that the `fixed` set `_multi_mult_w_NAF_var` already
+  read off `ec._fixed_points` is now passed down to it, so the two
+  verifications can name the key in it;
+  `_double_mult_endomorphism_secp256k1_var` grows it with the
+  endomorphism images as it always did for the generator's.
 
 - **`sign_` stops re-validating the signature libsecp256k1 just made**
   (issue #888). Its bindings path was `Sig.parse(libsecp256k1_dsa.sign(...))`,

--- a/btclib/curves/__init__.py
+++ b/btclib/curves/__init__.py
@@ -18,8 +18,13 @@ curves -- so the anchor is worth stating: `from btclib.curves import mult`,
 `from btclib.ecc import dsa`.
 
 What this package exports is the curve API: a Curve, the catalogue they
-are looked up in, the three scalar multiplications, and the SEC point
-codec. `CURVES` is what makes the catalogue reachable -- `secp256k1` is
+are looked up in, the three scalar multiplications, the SEC point codec,
+and PreparedPoint, which is a point plus a caller's word that it will be
+multiplied again -- the one thing the memoized tables below cannot infer
+and the whole of what stands between a repeated point and the treatment
+the generator gets.
+
+`CURVES` is what makes the catalogue reachable -- `secp256k1` is
 exported by name because nearly every caller wants that one, and every
 other curve is `CURVES["secp256r1"]` -- so exporting the name and not the
 dictionary left the paragraph above naming curves a caller could not get
@@ -84,6 +89,7 @@ materializing the point (issue #127).
 from btclib.curves.curve import (
     CURVES,
     Curve,
+    PreparedPoint,
     double_mult_var,
     mult,
     multi_mult_var,
@@ -101,6 +107,7 @@ __all__ = [
     "CURVES",
     "Curve",
     "CurveGroup",
+    "PreparedPoint",
     "bytes_from_point",
     "bytes_from_prv_key_int",
     "double_mult_var",

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -8,7 +8,9 @@ mult, double_mult_var and multi_mult_var dispatch secp256k1 to the
 libsecp256k1 bindings and answer every other curve -- and the cases
 the bindings cannot express -- with curve_group's arithmetic.
 
-What this module exports is the class, the three multiplications, the
+What this module exports is the class, the three multiplications,
+`PreparedPoint` -- the one way a caller has of saying that a point of
+its own will come back, so that the tables built for it are kept -- the
 catalogue, the four standards it is the union of -- which is where
 btclib.curves keeps them, a standard being a question about a curve and
 not a way of finding one -- and the `*_params2` each of those four is
@@ -27,6 +29,7 @@ from __future__ import annotations
 import contextlib
 import json
 from collections.abc import Sequence
+from dataclasses import dataclass, field
 from hashlib import sha256
 from math import isqrt
 from pathlib import Path
@@ -67,6 +70,7 @@ __all__ = [
     "Brainpool_params2",
     "Curve",
     "NIST_params2",
+    "PreparedPoint",
     "SEC2v1",
     "SEC2v1_params2",
     "SEC2v2",
@@ -663,13 +667,37 @@ def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point
     """Elliptic curve scalar multiplication."""
     _assert_valid_ec(ec)
     m: int = int_from_integer(m_int) % ec.n
+    if Q is not None and Q != ec.G:
+        # hoisted out of the two arms below, which each ran it: the
+        # generator needs none, and every other point needs it on both
+        # paths. Hoisted no further, so that a wrong `ec` is still the
+        # first thing refused
+        ec.require_on_curve(Q)
+    return _mult_checked(m, Q, ec, prepared=False)
 
+
+def _mult_checked(m: int, Q: Point | None, ec: Curve, *, prepared: bool) -> Point:
+    """Return m*Q, the arguments already validated and m already reduced.
+
+    What `mult` and `PreparedPoint.mult` share, so that the dispatch to
+    the bindings is written once: the two differ in one thing, which is
+    the Python arm a point that is not the generator takes.
+
+    `prepared` says the caller has undertaken to multiply this point
+    again -- `PreparedPoint` is where that undertaking is made and where
+    what it costs is written. It sends the point to the same fixed-base
+    ladder the generator runs, whose tables are memoized per point,
+    instead of to the GLV endomorphism, which builds nothing and keeps
+    nothing. On the bindings path it changes nothing at all: libsecp256k1
+    is 22.8 us against the ladder's warm 142.3, so a prepared point is
+    still faster delegated, and the tables are only reached where the
+    bindings decline.
+    """
     # m == 0 is the infinity point, which the bindings reject as a scalar
     if m and _libsecp256k1_serves(ec, None):
         # the generator is ec_pubkey_create, with no point to parse first
         if Q is None or Q == ec.G:
             return libsecp256k1_mult(m)
-        ec.require_on_curve(Q)
         # any other point, infinity excepted: that one is not a pubkey,
         # and m*INF == INF is what the Python path below answers anyway
         if Q[1]:
@@ -683,8 +711,15 @@ def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point
         # so the test is on the point before it is on the curve
         return ec.aff_from_jac_var(_mult_fixed_base(m, ec.GJ, ec, _FIXED_BASE_W))
 
-    ec.require_on_curve(Q)
     QJ = _jac_from_aff(Q)
+
+    if prepared:
+        # the same ladder the generator takes, on the caller's word that
+        # this point is the same on the next call too. No blinding of the
+        # point here, and none is missing: _mult_fixed_base rescales its
+        # accumulator instead, the table it indexes being memoized and
+        # therefore canonical
+        return ec.aff_from_jac_var(_mult_fixed_base(m, QJ, ec, _FIXED_BASE_W))
 
     # what reaches here on secp256k1 is the arguments the bindings decline
     # -- a zero scalar, or infinity -- and, with the dispatch
@@ -716,8 +751,121 @@ def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point
     return ec.aff_from_jac_var(R)
 
 
+@dataclass(frozen=True, init=False)
+class PreparedPoint:
+    """A point whose multiplication tables are kept, because it will come back.
+
+    The tables of `curve_group` are memoized on `(point, curve, width)`
+    already, so a repeated point would find its own: what is missing is
+    anyone to say that a point *is* repeated. Only the generator is
+    assumed to be, and everything else is treated as arriving once --
+    which is right for most callers and wrong for a few, and no
+    measurement can tell which a caller is. This is where a caller says
+    so.
+
+    Two tables answer to it, one per operation:
+
+    - `mult` takes the fixed-base ladder of the generator instead of the
+      GLV endomorphism: 142.3 us a call against 551.0, once 9.50 ms has
+      built the per-position tables -- 43 positions of 64 points on
+      secp256k1, some 366 KiB. Break-even is 23 multiplications of the
+      one point -- `dh.diffie_hellman` against a counterparty, a taproot
+      internal key tweaked repeatedly, `pedersen` against a fixed second
+      generator.
+    - a verification under it -- `dsa` and `ssa` both take one where they
+      take a public key -- memoizes the wNAF tables of the key's two
+      endomorphism halves at `_FIXED_POINT_W` instead of rebuilding them
+      at `_DOUBLE_MULT_W` per signature: 2 tables built per verification
+      become 0, and the verification 609.1 us against 471.0 for ECDSA,
+      664.5 against 531.2 for BIP340. Break-even is 22 signatures under
+      the one key, the first verification costing 3599 us where a bare
+      key's costs 630.
+
+    Both are the Python arithmetic. On secp256k1 with the bindings
+    available neither is reached -- libsecp256k1 verifies in 22.8 us and
+    holds its own tables in its own context -- so what this is for is the
+    Python path: another curve, another hash function, or a deployment
+    without the compiled bindings. Handing one in on the delegated path
+    is not an error and costs nothing; it simply buys nothing.
+
+    Preparing is a caller's word and never inferred, and the memory is
+    why: the tables are per distinct point, so a library that memoized
+    whatever public key arrived would hold a few MB for keys nobody will
+    see again -- issue #287, the bound `_cached_base58_decode` and
+    `pedersen.second_generator` hold too. What bounds it here is that
+    nothing is prepared unless asked, and beyond that the `lru_cache`
+    maxsize the tables live under.
+
+    Nothing is built by the constructor. It parses and validates the
+    point, which is the other half of what a verifier repeats -- 75.2 us
+    of decompression per signature, on the Python path where a
+    compressed key is a field square root -- and leaves the tables to the
+    first multiplication that wants them, because which of the two
+    families above is wanted is a question only that call answers.
+
+    Measured on an Apple M5, macOS 26.6, arm64, CPython 3.14, with
+    `curve._libsecp256k1_available` set to False; best of five
+    alternating rounds of 300 to 800 calls, and the median of seven for
+    the cold rows, each on a freshly derived point so that the tables are
+    built rather than found. A working desktop rather than a quiesced
+    machine: a ratio, not a figure to quote.
+
+    Args:
+        point: the point to prepare, on the curve and not infinity.
+        ec: the curve it belongs to.
+
+    Raises:
+        BTClibValueError: if the point is not on the curve, or is
+            infinity, which has no tables and multiplies to itself.
+    """
+
+    point: Point
+    ec: Curve = secp256k1
+    # the set `_multi_mult_w_NAF_var` reads, complete rather than the
+    # point's own share of it, so that a verification hands it straight
+    # down and nothing on the hot path unions two frozensets per call.
+    # The negation is in it for the reason `Curve.__init__` puts the
+    # generator's there: the GLV split of a point is +-P and +-lambda*P,
+    # and which sign it asks for is the coefficient's business. The two
+    # lambda images are not here, being formed by
+    # _double_mult_endomorphism_secp256k1_var and added by it.
+    # Out of the repr and out of the comparison because it is derived:
+    # two prepared points of the same point and curve are the same
+    # preparation, and a frozenset of Jacobian triples printed beside a
+    # Curve is a screenful saying nothing the point does not
+    fixed: frozenset[JacPoint] = field(init=False, repr=False, compare=False)
+
+    # init=False on the decorator, as `dsa.Sig` has it, and on the
+    # `fixed` field besides: that one is derived rather than passed, and
+    # a field with no default following `ec`, which has one, is a
+    # signature dataclasses refuses to generate and mypy refuses to read
+    def __init__(self, point: Point, ec: Curve = secp256k1) -> None:
+        _assert_valid_ec(ec)
+        ec.require_on_curve(point)
+        # infinity is on the curve and is not a point to prepare: it has
+        # no affine table -- `_signed_odd_multiples_aff` would convert it
+        # -- and m*INF is INF without any of this
+        if not point[1]:
+            raise BTClibValueError("cannot prepare the point at infinity")
+
+        object.__setattr__(self, "point", point)
+        object.__setattr__(self, "ec", ec)
+        PJ = _jac_from_aff(point)
+        object.__setattr__(self, "fixed", ec._fixed_points | {PJ, ec.negate_jac(PJ)})
+
+    def mult(self, m_int: Integer) -> Point:
+        """Return m*point, through the tables this point keeps.
+
+        `curve.mult` with the fixed-base arm taken for this point instead
+        of only for the generator; everything else about the call, the
+        dispatch to the bindings included, is the same.
+        """
+        m: int = int_from_integer(m_int) % self.ec.n
+        return _mult_checked(m, self.point, self.ec, prepared=True)
+
+
 def _double_mult_python(
-    u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: Curve
+    u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: Curve, fixed: frozenset[JacPoint]
 ) -> JacPoint:
     """Return u*HJ + v*QJ in Python, through the endomorphism if there is one.
 
@@ -745,12 +893,17 @@ def _double_mult_python(
     would buy is a fraction of a second, and what it would cost is a
     second copy of the dispatch, one per caller, free to drift. `mult`
     makes the same two comparisons for the same reason.
+
+    `fixed` is the points whose tables are memoized, passed down rather
+    than read off `ec` at the bottom: a verification under a
+    `PreparedPoint` names the key there, and every other caller names
+    `ec._fixed_points`, which is what the bottom used to read for itself.
     """
     if ec == secp256k1:
         return _double_mult_endomorphism_secp256k1_var(
-            u, HJ, v, QJ, ec, _ENDOMORPHISM_W
+            u, HJ, v, QJ, ec, _ENDOMORPHISM_W, fixed
         )
-    return _double_mult_w_NAF_var(u, HJ, v, QJ, ec, _DOUBLE_MULT_W)
+    return _double_mult_w_NAF_var(u, HJ, v, QJ, ec, _DOUBLE_MULT_W, fixed)
 
 
 def double_mult_var(
@@ -773,11 +926,16 @@ def double_mult_var(
 
     HJ = _jac_from_aff(H)
     QJ = _jac_from_aff(Q)
-    R = _double_mult_python(u, HJ, v, QJ, ec)
+    # nothing prepared: this entry point takes two bare points, and a
+    # caller with a point that repeats says so through `PreparedPoint`,
+    # which the verifications take
+    R = _double_mult_python(u, HJ, v, QJ, ec, ec._fixed_points)
     return ec.aff_from_jac_var(R)
 
 
-def _jac_double_mult(u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: Curve) -> JacPoint:
+def _jac_double_mult(
+    u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: Curve, fixed: frozenset[JacPoint]
+) -> JacPoint:
     """Return u*HJ + v*QJ in Jacobian coordinates, delegated where it can be.
 
     double_mult_var for a caller whose equation is written in projective
@@ -806,8 +964,11 @@ def _jac_double_mult(u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: Curve) -> J
     cheapest operand it has.
     """
     if not _libsecp256k1_serves(ec, None):
-        return _double_mult_python(u, HJ, v, QJ, ec)
+        return _double_mult_python(u, HJ, v, QJ, ec, fixed)
 
+    # `fixed` is dropped on this arm and nothing is lost: libsecp256k1
+    # holds its own tables in its own context, and what a caller prepared
+    # here is a table of the Python arithmetic
     R = double_mult_var(u, ec.aff_from_jac_var(HJ), v, ec.aff_from_jac_var(QJ), ec)
     return _jac_from_aff(R)
 

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -1046,9 +1046,14 @@ def _cached_odd_multiples_aff(Q: JacPoint, ec: CurveGroup, w: int) -> list[Point
     same way, `WINDOW_A` of 5 for the variable point against a `WINDOW_G`
     of 15 for the generator, whose table it generates at build time.
 
-    Only the points of `ec._fixed_points` may be handed here: a table
-    memoized on a public key is a table built once, used once and kept
-    for ever.
+    Only a point somebody has said will come back may be handed here:
+    `ec._fixed_points`, or one a caller prepared with
+    `curve.PreparedPoint`. A table memoized on whatever key arrives is a
+    table built once, used once and kept for ever, which is why the
+    preparing is a caller's word and never inferred -- issue #287 is the
+    same bound `_cached_base58_decode` and `pedersen.second_generator`
+    hold. What bounds it when the word is given is this cache's own
+    maxsize, 128 tables of 2^(w-2) points.
     """
     return _odd_multiples_aff(Q, ec, w)
 
@@ -1090,7 +1095,10 @@ def _cached_fixed_base_multiples(
 
     Memoized on (Q, ec, w) because that is what makes it worth building:
     the table is the point's and not the scalar's, so a caller
-    multiplying the generator pays for it once. What it costs to keep is
+    multiplying the generator pays for it once -- and so does a caller
+    multiplying its own point, once it has said with
+    `curve.PreparedPoint` that the point will come back. What it costs
+    to keep is
     2^w points a position -- on secp256k1 at the w=6 `curve.py` passes,
     43 positions of 64 points, some 366 KiB and 9.3 ms to build, which is
     the trade `_mult_fixed_base` measures.
@@ -1133,6 +1141,15 @@ def _mult_fixed_base(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoint:
     applies for the same reason: the point is the curve's generator, the
     same on every call, so its table is built once and kept.
     `curves.mult` is what recognizes that case.
+
+    The reason is the point repeating and not the point being the
+    generator, so `curve.PreparedPoint` reaches here as well, for a
+    caller who has said its own point will come back. Break-even is 23
+    multiplications of that point: 9.50 ms and 366 KiB to build against
+    142.3 us a call warm, where the GLV endomorphism `curves.mult`
+    otherwise runs costs 551.0 with nothing to build. Which is why
+    nothing infers it -- the same measurement, read the other way, is
+    9.5 ms and 366 KiB of pure loss for a point multiplied once.
 
     The accumulator is rescaled where `curves.mult` rescales the point on
     its other arm: the table here is memoized and canonical, so it is the

--- a/btclib/curves/curve_group_2.py
+++ b/btclib/curves/curve_group_2.py
@@ -261,7 +261,13 @@ def _mult_w_NAF_var(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoint:
 
 
 def _double_mult_w_NAF_var(
-    u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: CurveGroup, w: int
+    u: int,
+    HJ: JacPoint,
+    v: int,
+    QJ: JacPoint,
+    ec: CurveGroup,
+    w: int,
+    fixed: frozenset[JacPoint],
 ) -> JacPoint:
     """Double scalar multiplication (u*H + v*Q), interleaved wNAFs.
 
@@ -303,6 +309,12 @@ def _double_mult_w_NAF_var(
     second of the suite and put a branch in the middle of signature
     verification.
 
+    `fixed` is the points whose tables are memoized rather than built
+    here, `_multi_mult_w_NAF_var` says what that buys, and it is the
+    caller's rather than read off `ec` because a caller may have prepared
+    a point of its own: `ec._fixed_points` is what a caller with nothing
+    prepared passes.
+
     The input points are assumed to be on curve, and the u and v
     coefficients are assumed to have been reduced mod n if appropriate
     (e.g. cyclic groups of order n).
@@ -321,7 +333,7 @@ def _double_mult_w_NAF_var(
     # curve names, per call and narrow for one it does not -- and shares
     # the doublings. What this function adds is the pair of messages its
     # own coefficients answer with, and the name the algorithm has
-    return _multi_mult_w_NAF_var([u, v], [HJ, QJ], ec, w, ec._fixed_points)
+    return _multi_mult_w_NAF_var([u, v], [HJ, QJ], ec, w, fixed)
 
 
 def _double_mult_regular_window(
@@ -542,11 +554,17 @@ def _mult_endomorphism_secp256k1_var(
         raise BTClibValueError(f"negative m: {hex(m)}")
 
     m1, P, m2, K = _endomorphism_split_secp256k1(m, Q, ec)
-    return _double_mult_w_NAF_var(m1, P, m2, K, ec, w)
+    return _double_mult_w_NAF_var(m1, P, m2, K, ec, w, ec._fixed_points)
 
 
 def _double_mult_endomorphism_secp256k1_var(
-    u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: CurveGroup, w: int
+    u: int,
+    HJ: JacPoint,
+    v: int,
+    QJ: JacPoint,
+    ec: CurveGroup,
+    w: int,
+    fixed: frozenset[JacPoint],
 ) -> JacPoint:
     """Double scalar multiplication (u*H + v*Q) through the endomorphism.
 
@@ -576,6 +594,13 @@ def _double_mult_endomorphism_secp256k1_var(
     0.82 at w=5, 0.91 at w=6 -- so w=4 and w=5 measure the same and the
     smaller table decides, as it does for `_double_mult_w_NAF_var`.
 
+    `fixed` is `_double_mult_w_NAF_var`'s, and this is the function that
+    grows it: a point named there has its two endomorphism images named
+    too, because they are what actually reaches the interleaved wNAF and
+    they are formed here. So a verification under a `curve.PreparedPoint`
+    memoizes four tables and not one, which is what makes the key's half
+    of the call cost what the generator's costs.
+
     The input points are assumed to be on curve. Either coefficient may be
     zero and either point may be infinity: the interleaved wNAF drops a
     zero half rather than building a table it would never index, and the
@@ -592,9 +617,9 @@ def _double_mult_endomorphism_secp256k1_var(
     # the split of a fixed point is fixed: the halves are +-H and
     # +-lambda*H, determined by H alone and by which of the two signs the
     # coefficient asked for, so both are worth a memoized table whenever H
-    # is one of the points the curve names. The images are formed here and
+    # is one of the points `fixed` names. The images are formed here and
     # nowhere else, which is why they are added here rather than in Curve
-    fixed = ec._fixed_points
+    # or in whatever prepared the point
     if HJ in fixed:
         fixed = fixed | {U1, U2}
     if QJ in fixed:

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -46,7 +46,7 @@ from btclib_secp256k1 import recovery as libsecp256k1_recovery
 
 from btclib import var_bytes
 from btclib.alias import BinaryData, HashF, JacPoint, Octets, Point
-from btclib.curves import Curve, mult, secp256k1
+from btclib.curves import Curve, PreparedPoint, mult, secp256k1
 from btclib.curves.curve import (
     _assert_valid_ec,
     _is_x_coordinate_var,
@@ -848,9 +848,19 @@ def sign_recoverable(
 
 
 def _assert_as_valid_(
-    c: int, QJ: JacPoint, r: int, s: int, ec: Curve, *, lower_s: bool
+    c: int,
+    QJ: JacPoint,
+    r: int,
+    s: int,
+    ec: Curve,
+    fixed: frozenset[JacPoint],
+    *,
+    lower_s: bool,
 ) -> None:
     # Private function for test/dev purposes
+    # `fixed` is the points whose wNAF tables are memoized rather than
+    # rebuilt: `ec._fixed_points` for a caller with a bare key, and the
+    # key's own where `assert_as_valid_` was handed a PreparedPoint
 
     if lower_s and s > ec.n // 2:
         raise BTClibValueError("not a low s")
@@ -866,7 +876,7 @@ def _assert_as_valid_(
     # and on secp256k1 the multiplication is theirs all the same, 28 us
     # against 1.02 ms, which is this whole verification 61 us against
     # 1.10 ms of it
-    KJ = _jac_double_mult(v, QJ, u, ec.GJ, ec)  # 5
+    KJ = _jac_double_mult(v, QJ, u, ec.GJ, ec, fixed)  # 5
 
     # Fail if infinite(K).
     # K = w*(c + r*q)*G is INF whenever c == -r*q (mod n)
@@ -1004,8 +1014,12 @@ def assert_as_valid_(
     c = challenge_(msg_hash, sig.ec, hf)  # 2, 3
     Q = point_from_pub_key(key, sig.ec)
     QJ = Q[0], Q[1], 1
+    # the key's own memoized tables where the caller prepared it, the
+    # curve's alone where it did not: 471.0 us against 609.1 under one
+    # key, and `curves.PreparedPoint` is where the trade is written
+    fixed = key.fixed if isinstance(key, PreparedPoint) else sig.ec._fixed_points
     # second part delegated to helper function
-    _assert_as_valid_(c, QJ, sig.r, sig.s, sig.ec, lower_s=False)
+    _assert_as_valid_(c, QJ, sig.r, sig.s, sig.ec, fixed, lower_s=False)
 
 
 def assert_as_valid(
@@ -1438,7 +1452,7 @@ def _recover_pub_key_(
     # back is _jac_from_aff, i.e. z == 1, where the wNAF answered whatever
     # representative its ladder reached. Every caller converts with
     # aff_from_jac_var, which is what a Jacobian coordinate is for
-    QJ = _jac_double_mult(r1s, KJ, r1e, ec.GJ, ec)  # 1.6.1
+    QJ = _jac_double_mult(r1s, KJ, r1e, ec.GJ, ec, ec._fixed_points)  # 1.6.1
 
     # INF is no public key, and step 1.6.2 does not refuse it: with Q at
     # infinity the K' that verification recomputes is the lift itself, so
@@ -1473,8 +1487,10 @@ def _recover_pub_key_(
 
     # lower_s=False, the rule having been asked at the top of this function
     # for every candidate: what is left here is the step itself, and
-    # nothing about the form of the signature
-    _assert_as_valid_(c, QJ, r, s, ec, lower_s=False)  # 1.6.2
+    # nothing about the form of the signature. Nothing prepared either --
+    # recovery answers a key rather than being handed one, so there is no
+    # point anybody has said will come back
+    _assert_as_valid_(c, QJ, r, s, ec, ec._fixed_points, lower_s=False)  # 1.6.2
     return QJ
 
 

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -63,7 +63,7 @@ from btclib_secp256k1 import ssa as libsecp256k1_ssa
 
 from btclib.alias import BinaryData, HashF, Integer, JacPoint, Octets, Point
 from btclib.bip32 import BIP32Key
-from btclib.curves import Curve, secp256k1
+from btclib.curves import Curve, PreparedPoint, secp256k1
 from btclib.curves.curve import (
     _assert_valid_ec,
     _is_x_coordinate_var,
@@ -234,7 +234,7 @@ class Sig:
 # 33 or 65 bytes or hex-string
 # BIP32Key as dict or String
 # tuple Point
-BIP340PubKey = Integer | Octets | BIP32Key | Point
+BIP340PubKey = Integer | Octets | BIP32Key | Point | PreparedPoint
 
 
 def _x_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve) -> int:
@@ -530,8 +530,12 @@ def sign(
     return sign_(msg_hash, prv_key, aux, ec, hf, commit_hash=reduce_to_hlen(commit, hf))
 
 
-def _assert_as_valid_(c: int, QJ: JacPoint, r: int, s: int, ec: Curve) -> None:
+def _assert_as_valid_(
+    c: int, QJ: JacPoint, r: int, s: int, ec: Curve, fixed: frozenset[JacPoint]
+) -> None:
     # Private function for test/dev purposes
+    # `fixed` is dsa._assert_as_valid_'s: the points whose wNAF tables
+    # are memoized, the key's among them where the caller prepared it
     # It raises Errors, while verify should always return True or False
 
     # Let K = sG - eQ.
@@ -543,7 +547,7 @@ def _assert_as_valid_(c: int, QJ: JacPoint, r: int, s: int, ec: Curve) -> None:
     # multiplication is still theirs, 28 us against 1.02 ms. This whole
     # verification is then 38 us against 1.17 ms, the two lifts around it
     # -- the r of the signature and the x-only key -- being theirs as well
-    KJ = _jac_double_mult(ec.n - c, QJ, s, ec.GJ, ec)
+    KJ = _jac_double_mult(ec.n - c, QJ, s, ec.GJ, ec, fixed)
 
     # The following check is prescribed by BIP340 but it is useless:
     # if moved after 'Fail if x_K ≠ r' it would never be executed
@@ -643,9 +647,15 @@ def assert_as_valid_(
     # the lift the branch above does not need, and the validation of x_Q
     # with it: `_x_from_bip340pub_key` reads the key and proves nothing
     y_Q = _y_even_var(x_Q, sig.ec)
+    # the key's own memoized tables where the caller prepared it, as in
+    # `dsa.assert_as_valid_`: 531.2 us against 664.5 under one key. The
+    # negation is in that set too, which is what makes it answer here --
+    # a prepared point of odd y is this same key, and the lift above is
+    # the one of the two BIP340 names
+    fixed = Q.fixed if isinstance(Q, PreparedPoint) else sig.ec._fixed_points
     # Let c = int(hf(bytes(r) || bytes(Q) || msg)) mod n.
     c = challenge_(msg, x_Q, sig.r, sig.ec, hf)
-    _assert_as_valid_(c, (x_Q, y_Q, 1), sig.r, sig.s, sig.ec)
+    _assert_as_valid_(c, (x_Q, y_Q, 1), sig.r, sig.s, sig.ec, fixed)
 
 
 def assert_as_valid(
@@ -745,7 +755,7 @@ def _recover_pub_key_(c: int, r: int, s: int, ec: Curve) -> int:
     # 109 for this function. Which is also why this stays private, with no
     # public spelling above it: BIP340 has no recovery flag to carry the
     # candidate, x-only keys leaving nothing for one to disambiguate
-    QJ = _jac_double_mult(ec.n - e1, KJ, e1 * s, ec.GJ, ec)
+    QJ = _jac_double_mult(ec.n - e1, KJ, e1 * s, ec.GJ, ec, ec._fixed_points)
     # QJ = e1*(s*G - K) is INF whenever r is the x of s*G, y even, and
     # that answer comes back from the bindings too: a libsecp256k1 pubkey
     # is never the identity, so the sum is recognized from the coordinates

--- a/btclib/to_pub_key.py
+++ b/btclib/to_pub_key.py
@@ -15,6 +15,7 @@ from btclib.alias import Point
 from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, _key_data_from_bip32_key
 from btclib.curves import (
     Curve,
+    PreparedPoint,
     bytes_from_point,
     bytes_from_prv_key_int,
     mult,
@@ -47,18 +48,38 @@ __all__ = [
 ]
 
 # public key inputs:
-# elliptic curve point as Union[Octets, BIP32Key, Point]
-PubKey = bytes | str | BIP32KeyData | Point
+# elliptic curve point as Union[Octets, BIP32Key, Point, PreparedPoint]
+PubKey = bytes | str | BIP32KeyData | Point | PreparedPoint
 
 # public or private key input,
 # usable wherever a PubKey is logically expected
-Key = int | bytes | str | BIP32KeyData | Point
+Key = int | bytes | str | BIP32KeyData | Point | PreparedPoint
 
 # the two unions at run time, with the buffers bytes_from_octets accepts
 # beside bytes. An int is in one and not the other on purpose: in this
 # library an int is a private key, and never a public one
-_PUB_KEY_TYPES = (bytes, bytearray, memoryview, str, BIP32KeyData, tuple)
+_PUB_KEY_TYPES = (bytes, bytearray, memoryview, str, BIP32KeyData, tuple, PreparedPoint)
 _KEY_TYPES = (int, *_PUB_KEY_TYPES)
+
+
+# **A prepared point is read as the point it holds, everywhere below.**
+# `curves.PreparedPoint` is a `Point` plus a caller's word that it will
+# be multiplied again, and the word is the whole of the difference: an
+# address, a fingerprint and a SEC encoding are the point's, so each
+# converter answers a prepared point by asking itself about `.point`.
+# What is *not* the point's is the memoized tables, and
+# `dsa.assert_as_valid_` and `ssa.assert_as_valid_` are the two places
+# that read those, off the object and not through here.
+#
+# Spelled as five one-line recursions rather than as one unwrapping
+# helper, and the types are why: a helper would have to answer the union
+# it was given minus PreparedPoint, which is a different union per
+# converter and two overloads to keep in step, where re-asking the same
+# function is exactly as narrow as the function already is.
+#
+# Nothing compares a curve on the way through: a prepared point of
+# another curve fails the `is_on_curve` its tuple then faces, exactly as
+# a bare `Point` of that curve does and with the same message.
 
 
 def _assert_pub_key_type(pub_key: PubKey) -> None:
@@ -124,6 +145,8 @@ def point_from_key(key: Key, ec: Curve = secp256k1) -> Point:
     # "Curve mismatch" for what is a caller's own mistake
     _assert_valid_ec(ec)
     _assert_key_type(key)
+    if isinstance(key, PreparedPoint):
+        return point_from_key(key.point, ec)
 
     if isinstance(key, tuple):
         return point_from_pub_key(key, ec)
@@ -146,6 +169,8 @@ def point_from_pub_key(pub_key: PubKey, ec: Curve = secp256k1) -> Point:
     """Return an elliptic curve point tuple from a public key."""
     _assert_valid_ec(ec)
     _assert_pub_key_type(pub_key)
+    if isinstance(pub_key, PreparedPoint):
+        return point_from_pub_key(pub_key.point, ec)
 
     if isinstance(pub_key, tuple):
         if ec.is_on_curve(pub_key) and pub_key[1] != 0:
@@ -207,6 +232,8 @@ def pub_keyinfo_from_key(
 ) -> PubkeyInfo:
     """Return the pub key tuple (SEC-bytes, network) from a pub/prv key."""
     _assert_key_type(key)
+    if isinstance(key, PreparedPoint):
+        return pub_keyinfo_from_key(key.point, network, compressed)
 
     if isinstance(key, tuple):
         return pub_keyinfo_from_pub_key(key, network, compressed)
@@ -271,6 +298,8 @@ def _libsecp256k1_pubkey_from_pub_key(pub_key: PubKey) -> CData:
     asks for: a verification takes the key as the key says it is, and the
     curve it is asked about is the signature's.
     """
+    if isinstance(pub_key, PreparedPoint):
+        return _libsecp256k1_pubkey_from_pub_key(pub_key.point)
     if isinstance(pub_key, tuple):
         # bytes_from_point is the validation this branch skips
         # `pub_keyinfo_from_pub_key` for: it refuses what is not a point of
@@ -293,6 +322,8 @@ def _pub_keyinfo_and_pubkey_from_pub_key(
     written once.
     """
     _assert_pub_key_type(pub_key)
+    if isinstance(pub_key, PreparedPoint):
+        return _pub_keyinfo_and_pubkey_from_pub_key(pub_key.point, network, compressed)
     # as in `to_prv_key.prv_keyinfo_from_prv_key`: None means "whatever
     # the key says", and every other spelling of a truth is refused
     if compressed is not None:

--- a/btclib/wallet/key_wallet.py
+++ b/btclib/wallet/key_wallet.py
@@ -61,6 +61,7 @@ from btclib.bip32.der_path import (
     str_from_der_path,
 )
 from btclib.bip44 import _ADDRESS_FROM_SCRIPT_TYPE, _script_type_from_purpose
+from btclib.curves import PreparedPoint
 from btclib.ecc import bms
 from btclib.exceptions import BTClibValueError
 from btclib.network import network_from_xkeyversion
@@ -105,10 +106,13 @@ def _checked_script_type(script_type: str) -> BIP44ScriptType:
 def _wif_if_private(key: Key, network: str) -> str:
     """Return the WIF of a private key, or "" for a public one.
 
-    Two of the five spellings `to_pub_key.Key` admits say which they are
-    by their type, and are taken first because the ambiguous test below
+    Two of the spellings `to_pub_key.Key` admits say which they are by
+    their type, and are taken first because the ambiguous test below
     cannot be asked of them: an int is a scalar, so it is a private key,
-    and a point is a pair of coordinates, so it is a public one.
+    and a point is a pair of coordinates, so it is a public one -- a
+    `PreparedPoint` with it, that being a point and a caller's word about
+    how often it will be multiplied, which says nothing about who can
+    sign.
 
     The rest -- octets, a WIF or an extended key -- are told apart in the
     order `to_pub_key.pub_keyinfo_from_key` tells them apart, public
@@ -120,7 +124,7 @@ def _wif_if_private(key: Key, network: str) -> str:
     """
     if isinstance(key, int):
         return b58.wif_from_prv_key(key, network)
-    if isinstance(key, tuple):
+    if isinstance(key, (tuple, PreparedPoint)):
         return ""
 
     with contextlib.suppress(BTClibValueError):

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -341,6 +341,7 @@ def test_ec_exports_the_curve_api_not_the_benchmark() -> None:
         "CURVES",
         "Curve",
         "CurveGroup",
+        "PreparedPoint",
         "bytes_from_point",
         "bytes_from_prv_key_int",
         "double_mult_var",

--- a/tests/curve_parameter_test.py
+++ b/tests/curve_parameter_test.py
@@ -76,6 +76,7 @@ from btclib.bip32.bip32 import BIP32KeyData, rootxprv_from_seed, xpub_from_xprv
 from btclib.curves import CurveGroup, secp256k1
 from btclib.curves.curve import (
     Curve,
+    PreparedPoint,
     double_mult_var,
     mult,
     multi_mult_var,
@@ -158,6 +159,14 @@ class _Case:
 
 _CASES = (
     _Case("btclib.curves.curve.mult", mult, {"m_int": _PRV_KEY, "Q": _PUB_KEY}),
+    # the constructor, `point` being what it calls the argument the
+    # multiplications call Q: the guard runs before the point is looked
+    # at, as everywhere else here
+    _Case(
+        "btclib.curves.curve.PreparedPoint.__init__",
+        PreparedPoint,
+        {"point": _PUB_KEY},
+    ),
     _Case(
         "btclib.curves.curve.double_mult_var",
         double_mult_var,

--- a/tests/curves/curve_group_2_test.py
+++ b/tests/curves/curve_group_2_test.py
@@ -221,17 +221,19 @@ def test_double_mult_w_NAF() -> None:
             for u in range(ec.n):
                 for v in range(ec.n):
                     expected = _double_mult_var(u, HJ, v, QJ, ec)
-                    got = _double_mult_w_NAF_var(u, HJ, v, QJ, ec, w)
+                    got = _double_mult_w_NAF_var(u, HJ, v, QJ, ec, w, ec._fixed_points)
                     assert ec.is_jac_equal(got, expected), (u, v, w)
 
     ec = secp256k1
-    assert ec.is_jac_equal(_double_mult_w_NAF_var(0, ec.GJ, 0, ec.GJ, ec, w=4), INFJ)
+    assert ec.is_jac_equal(
+        _double_mult_w_NAF_var(0, ec.GJ, 0, ec.GJ, ec, 4, ec._fixed_points), INFJ
+    )
     with pytest.raises(BTClibValueError, match="negative first coefficient: "):
-        _double_mult_w_NAF_var(-1, ec.GJ, 1, ec.GJ, ec, w=4)
+        _double_mult_w_NAF_var(-1, ec.GJ, 1, ec.GJ, ec, 4, ec._fixed_points)
     with pytest.raises(BTClibValueError, match="negative second coefficient: "):
-        _double_mult_w_NAF_var(1, ec.GJ, -1, ec.GJ, ec, w=4)
+        _double_mult_w_NAF_var(1, ec.GJ, -1, ec.GJ, ec, 4, ec._fixed_points)
     with pytest.raises(BTClibValueError, match="non positive w: "):
-        _double_mult_w_NAF_var(1, ec.GJ, 1, ec.GJ, ec, 0)
+        _double_mult_w_NAF_var(1, ec.GJ, 1, ec.GJ, ec, 0, ec._fixed_points)
 
 
 def test_double_mult_endomorphism_secp256k1() -> None:
@@ -254,7 +256,9 @@ def test_double_mult_endomorphism_secp256k1() -> None:
     QJ = _mult(3, ec.GJ, ec)
 
     def dm(u: int, v: int, H: JacPoint, Q: JacPoint, w: int = 4) -> JacPoint:
-        return _double_mult_endomorphism_secp256k1_var(u, H, v, Q, ec, w)
+        return _double_mult_endomorphism_secp256k1_var(
+            u, H, v, Q, ec, w, ec._fixed_points
+        )
 
     pairs = [
         (0, 0),

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -8,7 +8,7 @@ import copy
 import itertools
 from functools import partial
 from hashlib import sha256, sha512
-from math import isqrt, sqrt
+from math import ceil, isqrt, sqrt
 
 import pytest
 
@@ -16,11 +16,15 @@ from btclib.alias import INF, INFJ, Integer, JacPoint, Point
 from btclib.curves import (
     Curve,
     CurveGroup,
+    PreparedPoint,
     bytes_from_point,
     # the module, not only the names in it: `_libsecp256k1_available` is a
     # module attribute, and switching it off is how no_bindings below
     # reaches the Python arithmetic underneath
     curve,
+    # the module as well, for the same reason `curve` is imported as one:
+    # the table builder a memoization test counts is patched on it
+    curve_group,
     double_mult_var,
     mult,
     multi_mult_var,
@@ -1214,3 +1218,112 @@ def test_the_xonly_parse_refuses_what_the_lift_refuses_and_in_the_same_words() -
     x_G = ec.G[0]
     assert _libsecp256k1_xonly_pubkey_var(x_G, ec)
     assert ec.y_var(x_G) in {ec.G[1], ec.p - ec.G[1]}
+
+
+def test_prepared_point_answers_what_mult_answers() -> None:
+    """A prepared point is a faster arm, not a second arithmetic.
+
+    Which is the whole of what may be asserted about it: the tables are a
+    memoization, so the only observable difference between `mult(m, Q)`
+    and `PreparedPoint(Q).mult(m)` is how long it took, and a test that
+    measured that would be measuring the machine. So the two are held
+    equal, over every curve the suite has and a spread of scalars that
+    reaches both ends of each -- 0 and n-1 included, the parity
+    correction of `_mult_fixed_base` being where a fixed-base ladder
+    differs from every other one.
+
+    The generator among the points on purpose: preparing G is asking for
+    what `mult` does for it anyway, and it must not become a second
+    answer.
+    """
+    for name, ec in all_curves.items():
+        points = [ec.G, mult(2, ec.G, ec), mult(ec.n - 1, ec.G, ec)]
+        scalars = [0, 1, 2, ec.n - 2, ec.n - 1, ec.n, ec.n + 1]
+        for Q in points:
+            prepared = PreparedPoint(Q, ec)
+            assert prepared.point == Q
+            assert prepared.ec == ec
+            for m in scalars:
+                assert prepared.mult(m) == mult(m, Q, ec), (name, Q, m)
+
+
+def test_prepared_point_answers_the_python_arithmetic_too(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same equality with the dispatch off, which is the point of it.
+
+    `PreparedPoint` exists for the Python path -- on secp256k1 with the
+    bindings in reach the ladder is not even the faster arm -- so the
+    delegated agreement above is the arm that matters least here. This is
+    the other one, and it is the one where the fixed-base tables are
+    actually built and indexed.
+    """
+    no_bindings(monkeypatch)
+    ec = secp256k1
+    Q = mult(0xDEADBEEF, ec.G, ec)
+    prepared = PreparedPoint(Q, ec)
+    for m in (0, 1, 2, 0xC0FFEE, ec.n - 1):
+        assert prepared.mult(m) == mult(m, Q, ec)
+
+
+def test_prepared_point_refuses_a_point_with_no_tables() -> None:
+    """Infinity and a point of no curve, the two the constructor is for.
+
+    Infinity is on the curve and would pass `require_on_curve`, so it is
+    refused by name: it has no affine odd multiples to tabulate, and
+    m*INF is INF without any of this. A point off the curve is the
+    ordinary refusal, and it happens here rather than at the first
+    multiplication, which is what preparing is -- validating once so that
+    nothing after it has to.
+    """
+    with pytest.raises(BTClibValueError, match="cannot prepare the point at infinity"):
+        PreparedPoint(INF)
+    with pytest.raises(BTClibValueError, match="point not on curve"):
+        PreparedPoint((secp256k1.G[0], secp256k1.G[1] + 1))
+    # a point of another curve is that same refusal, and it is why
+    # `to_pub_key._unwrapped` needs no curve comparison of its own
+    with pytest.raises(BTClibValueError, match="point not on curve"):
+        PreparedPoint(secp256k1.G, CURVES["secp256r1"])
+
+
+def test_a_prepared_point_builds_its_tables_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The memoization is the feature, so it is what is asserted.
+
+    Counted at `_signed_odd_multiples_aff`, which is what
+    `_cached_fixed_base_multiples` calls once per digit position: the
+    first multiplication of a prepared point builds every position, and
+    no later one builds anything. Where the unprepared `mult` goes
+    instead -- the GLV endomorphism -- it builds a table on every call
+    and keeps none, which is the asymmetry this whole object is about.
+
+    A fresh point per case, since the caches are module-wide and a point
+    the suite has already prepared would find its tables built.
+    """
+    no_bindings(monkeypatch)
+    ec = secp256k1
+    builds = []
+    built = curve_group._signed_odd_multiples_aff
+
+    def counting(Q: JacPoint, group: CurveGroup, w: int) -> list[Point]:
+        builds.append(Q)
+        return built(Q, group, w)
+
+    monkeypatch.setattr(curve_group, "_signed_odd_multiples_aff", counting)
+
+    prepared = PreparedPoint(mult(0x5EED0001, ec.G, ec), ec)
+    # deriving the point above is a multiplication of the generator, and
+    # on a worker that has not made one yet that is G's own tables being
+    # built: the count starts after it
+    builds.clear()
+    prepared.mult(3)
+    first = len(builds)
+    # every digit position of the scalar, and the measurement in
+    # `_cached_fixed_base_multiples` says how many that is
+    assert first == ceil(ec.scalar_len / curve._FIXED_BASE_W)
+
+    builds.clear()
+    for m in (5, 7, 11):
+        prepared.mult(m)
+    assert not builds

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -12,24 +12,26 @@ import pytest
 from btclib_secp256k1 import dsa as libsecp256k1_dsa
 from btclib_secp256k1 import recovery as libsecp256k1_recovery
 
-from btclib.alias import INF, Point
+from btclib.alias import INF, JacPoint, Point
 from btclib.curves import (
     Curve,
+    PreparedPoint,
     bytes_from_point,
     curve,
+    curve_group,
     double_mult_var,
     mult,
     point_from_octets,
     secp256k1,
 )
 from btclib.curves.curve import CURVES
-from btclib.curves.curve_group import _mult
+from btclib.curves.curve_group import CurveGroup, _mult
 from btclib.ecc import dsa
 from btclib.ecc.rfc6979_nonce import challenge_
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
 from btclib.hashes import reduce_to_hlen
 from btclib.number_theory import mod_inv_var
-from btclib.to_pub_key import pub_keyinfo_from_prv_key
+from btclib.to_pub_key import pub_keyinfo_from_prv_key, pub_keyinfo_from_pub_key
 from tests import load, vector_id
 from tests.curves.curve_test import low_card_curves, no_bindings, secp256k1_bis
 from tests.to_key_test import Q as pub_key_point
@@ -252,7 +254,9 @@ def _step_1_6_1(c: int, r: int, s: int, ec: Curve) -> list[Point | None]:
 def _verifies(c: int, Q: Point, r: int, s: int, ec: Curve) -> bool:
     """Answer whether Q verifies (r, s), which is step 1.6.2 as a boolean."""
     try:
-        dsa._assert_as_valid_(c, (Q[0], Q[1], 1), r, s, ec, lower_s=False)
+        dsa._assert_as_valid_(
+            c, (Q[0], Q[1], 1), r, s, ec, ec._fixed_points, lower_s=False
+        )
     except (BTClibValueError, BTClibRuntimeError):
         return False
     return True
@@ -285,7 +289,9 @@ def test_low_cardinality(name: str) -> None:
                     assert ec == sig.ec
                     # valid signature must pass verification, and here even
                     # under the strict rule: every s above was normalized
-                    dsa._assert_as_valid_(e, QJ, r, s, ec, lower_s=lower_s)
+                    dsa._assert_as_valid_(
+                        e, QJ, r, s, ec, ec._fixed_points, lower_s=lower_s
+                    )
 
                     jac_keys = dsa._recover_pub_keys_(e, r, s, ec, lower_s=lower_s)
                     Qs = [ec.aff_from_jac_var(key) for key in jac_keys]
@@ -485,7 +491,7 @@ def test_forge_hash_sig() -> None:
     s = r * u2inv % ec.n
     s = ec.n - s if s > ec.n / 2 else s
     e = s * u1 % ec.n
-    dsa._assert_as_valid_(e, (Q[0], Q[1], 1), r, s, lower_s=True, ec=ec)
+    dsa._assert_as_valid_(e, (Q[0], Q[1], 1), r, s, ec, ec._fixed_points, lower_s=True)
 
     # pick u1 and u2 at will
     u1 = 1234567890
@@ -496,7 +502,7 @@ def test_forge_hash_sig() -> None:
     s = r * u2inv % ec.n
     s = ec.n - s if s > ec.n / 2 else s
     e = s * u1 % ec.n
-    dsa._assert_as_valid_(e, (Q[0], Q[1], 1), r, s, lower_s=True, ec=ec)
+    dsa._assert_as_valid_(e, (Q[0], Q[1], 1), r, s, ec, ec._fixed_points, lower_s=True)
 
 
 def test_sign_input_type() -> None:
@@ -1006,7 +1012,15 @@ def test_the_low_s_rule_is_asked_for_and_not_assumed(
 
     # and every private spelling refuses it when told to
     with pytest.raises(BTClibValueError, match=err_msg):
-        dsa._assert_as_valid_(c, QJ, malleated.r, malleated.s, secp256k1, lower_s=True)
+        dsa._assert_as_valid_(
+            c,
+            QJ,
+            malleated.r,
+            malleated.s,
+            secp256k1,
+            secp256k1._fixed_points,
+            lower_s=True,
+        )
     with pytest.raises(BTClibValueError, match=err_msg):
         dsa._libsecp256k1_recover_point_(key_id ^ 1, msg_hash, malleated, lower_s=True)
     with pytest.raises(BTClibValueError, match=err_msg):
@@ -1024,7 +1038,9 @@ def test_the_low_s_rule_is_asked_for_and_not_assumed(
     # the signature as signed passes the strict rule on both paths, which
     # is what says the refusals above are about the malleation and not
     # about the arguments being threaded wrongly
-    dsa._assert_as_valid_(c, QJ, sig.r, sig.s, secp256k1, lower_s=True)
+    dsa._assert_as_valid_(
+        c, QJ, sig.r, sig.s, secp256k1, secp256k1._fixed_points, lower_s=True
+    )
     assert dsa._libsecp256k1_recover_point_(key_id, msg_hash, sig, lower_s=True) == Q
     with monkeypatch.context() as no_bindings:
         no_bindings.setattr(dsa, "_libsecp256k1_serves", lambda *_: False)
@@ -1479,7 +1495,9 @@ def test_verify_infinity_point() -> None:
     ec = CURVES["secp256k1"]
     err_msg = r"invalid \(INF\) key"
     with pytest.raises(BTClibRuntimeError, match=err_msg):
-        dsa._assert_as_valid_(ec.n - 1, ec.GJ, 1, 1, ec, lower_s=False)
+        dsa._assert_as_valid_(
+            ec.n - 1, ec.GJ, 1, 1, ec, ec._fixed_points, lower_s=False
+        )
 
 
 def test_verify_with_another_hash_function_on_both_arithmetics(
@@ -1512,7 +1530,9 @@ def test_verify_with_another_hash_function_on_both_arithmetics(
         assert not dsa.verify(b"another message", Q, sig, hf=sha512)
         # K = u*G + v*Q is INF for Q = G, r = s = 1 and c = n-1
         with pytest.raises(BTClibRuntimeError, match=r"invalid \(INF\) key"):
-            dsa._assert_as_valid_(ec.n - 1, ec.GJ, 1, 1, ec, lower_s=False)
+            dsa._assert_as_valid_(
+                ec.n - 1, ec.GJ, 1, 1, ec, ec._fixed_points, lower_s=False
+            )
 
     checks()
     no_bindings(monkeypatch)
@@ -1573,3 +1593,83 @@ def test_a_bad_hf_raises_rather_than_answering_about_the_signature() -> None:
     # and through the un-underscored spellings, which reduce first
     with pytest.raises(BTClibTypeError, match=err_msg):
         dsa.verify(msg, Q, sig, sha256())  # type: ignore[arg-type]
+
+
+def test_verification_under_a_prepared_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A prepared key verifies what the bare key verifies, and no more.
+
+    `PreparedPoint` is a memoization the caller opted into, so it must be
+    invisible in the answer: the same signatures pass, the same ones
+    fail, and the refusals keep their class. Asserted on both arithmetics
+    -- the delegated one, where the object buys nothing and must
+    therefore cost nothing either, and the Python one, which is what it
+    is for.
+    """
+    prv_key = 0xC28FCA386C7A227600B2FE50B7CAE11EC86D3BF1FBE471BE89827E19D72AA1D
+    _, Q = dsa.gen_keys(prv_key)
+    prepared = PreparedPoint(Q)
+    msg = b"Satoshi Nakamoto"
+    sig = dsa.sign(msg, prv_key)
+
+    for _ in range(2):
+        dsa.assert_as_valid(msg, prepared, sig)
+        assert dsa.verify(msg, prepared, sig)
+        assert not dsa.verify(b"another message", prepared, sig)
+        # the wrong key, prepared, is still the wrong key
+        assert not dsa.verify(msg, PreparedPoint(dsa.gen_keys(prv_key + 1)[1]), sig)
+        # and it is a public key wherever one is read, the tables being
+        # the only thing about it that is not the point's
+        assert pub_keyinfo_from_pub_key(prepared) == pub_keyinfo_from_pub_key(Q)
+        no_bindings(monkeypatch)
+
+
+def test_a_prepared_key_stops_the_per_signature_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The 2 tables a verification rebuilds per signature become 0.
+
+    This is issue #893 itself, and it is asserted as a count rather than
+    as a duration: what a prepared key buys is that the wNAF tables of
+    the key's two GLV halves are memoized instead of built and dropped,
+    and the tables built per call is the thing that changes. A time would
+    measure the machine.
+
+    `_odd_multiples` is where a table that is *not* memoized is built --
+    `_multi_mult_w_NAF_var` sends a fixed point to
+    `_cached_odd_multiples_aff` instead -- so counting calls to it counts
+    exactly what the preparing removes. Two per verification: the key's
+    two halves, the generator's two being fixed already.
+    """
+    no_bindings(monkeypatch)
+    prv_key = 0xB6B7E2CA8E31CE45C1D2C0E1E0C5D62F0E52B1E8C8B5A4A9D3E2F1C0B9A8D7E6
+    _, Q = dsa.gen_keys(prv_key)
+    msg = b"Satoshi Nakamoto"
+    sig = dsa.sign(msg, prv_key)
+
+    builds = []
+    built = curve_group._odd_multiples
+
+    def counting(point: JacPoint, ec: CurveGroup, w: int) -> list[JacPoint]:
+        builds.append(point)
+        return built(point, ec, w)
+
+    monkeypatch.setattr(curve_group, "_odd_multiples", counting)
+
+    # one verification first, and the count taken after it: the
+    # generator's own two tables are memoized as well, so on a worker
+    # that has verified nothing yet they are built here once and would
+    # be counted as the key's
+    assert dsa.verify(msg, Q, sig)
+    builds.clear()
+    for _ in range(3):
+        assert dsa.verify(msg, Q, sig)
+    assert len(builds) == 6
+
+    prepared = PreparedPoint(Q)
+    # the same warm-up on the other arm, filling the key's two wide
+    # tables, which is what the break-even in `PreparedPoint` prices
+    assert dsa.verify(msg, prepared, sig)
+    builds.clear()
+    for _ in range(3):
+        assert dsa.verify(msg, prepared, sig)
+    assert not builds

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -16,6 +16,7 @@ from btclib_secp256k1 import ssa as libsecp256k1_ssa
 from btclib.alias import INF, Point, String
 from btclib.bip32 import BIP32KeyData
 from btclib.curves import (
+    PreparedPoint,
     bytes_from_point,
     curve_group,
     double_mult_var,
@@ -346,9 +347,9 @@ def test_low_cardinality() -> None:
                             ssa._recover_pub_key_(e, r, s, ec)
 
                         # if e == 0 then the sig is always valid
-                        ssa._assert_as_valid_(e, QJ, r, s, ec)
+                        ssa._assert_as_valid_(e, QJ, r, s, ec, ec._fixed_points)
                         #  for all {q, Q}
-                        ssa._assert_as_valid_(e, ec.GJ, r, s, ec)
+                        ssa._assert_as_valid_(e, ec.GJ, r, s, ec, ec._fixed_points)
                     else:
                         sig = ssa._sign_(e, q_fixed, k_fixed, r, ec)
                         # recover pub_key
@@ -356,13 +357,15 @@ def test_low_cardinality() -> None:
 
                         assert ssa.Sig(r, s, ec) == sig
                         # valid signature must validate
-                        ssa._assert_as_valid_(e, QJ, r, s, ec)
+                        ssa._assert_as_valid_(e, QJ, r, s, ec, ec._fixed_points)
                         # invalid signature must raise
                         err_msg = r"y_K is odd|INF has no y-coordinate|signature verification failed"
                         with pytest.raises(
                             (BTClibRuntimeError, BTClibValueError), match=err_msg
                         ):
-                            ssa._assert_as_valid_(e, QJ, r, (s - 1) % ec.n, ec)
+                            ssa._assert_as_valid_(
+                                e, QJ, r, (s - 1) % ec.n, ec, ec._fixed_points
+                            )
 
 
 def test_assert_as_valid_rejects_the_odd_y_twin_of_a_correct_k() -> None:
@@ -384,7 +387,7 @@ def test_assert_as_valid_rejects_the_odd_y_twin_of_a_correct_k() -> None:
 
     s_prime = (ec.n - k + e * q) % ec.n
     with pytest.raises(BTClibRuntimeError, match="y_K is odd"):
-        ssa._assert_as_valid_(e, QJ, r, s_prime, ec)
+        ssa._assert_as_valid_(e, QJ, r, s_prime, ec, ec._fixed_points)
 
 
 def test_a_message_of_any_size_reaches_the_bindings(
@@ -1109,3 +1112,30 @@ def test_a_bad_hf_raises_rather_than_answering_about_the_signature() -> None:
                 [sig] * size,
                 hf(),  # type: ignore[arg-type]
             )
+
+
+def test_verification_under_a_prepared_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BIP340 takes a prepared key too, and both lifts of it are the key.
+
+    An x-only key names two points and BIP340 means the even-y one, so a
+    caller preparing the odd-y twin has prepared this same key: the
+    verification lifts as it always did, and the tables answer because
+    `PreparedPoint` puts the negation in its set beside the point --
+    which is the reason `Curve.__init__` puts the generator's there.
+
+    So the assertion is that all three spellings verify the same
+    signature and agree with each other, on both arithmetics.
+    """
+    prv_key = 0xC28FCA386C7A227600B2FE50B7CAE11EC86D3BF1FBE471BE89827E19D72AA1D
+    _, x_Q = ssa.gen_keys(prv_key)
+    msg = b"Satoshi Nakamoto"
+    sig = ssa.sign(msg, prv_key)
+
+    even = ssa.point_from_bip340pub_key(x_Q)
+    odd = even[0], secp256k1.p - even[1]
+    for _ in range(2):
+        for key in (x_Q, PreparedPoint(even), PreparedPoint(odd)):
+            ssa.assert_as_valid(msg, key, sig)
+            assert ssa.verify(msg, key, sig)
+            assert not ssa.verify(b"another message", key, sig)
+        no_bindings(monkeypatch)

--- a/tests/to_pub_key_test.py
+++ b/tests/to_pub_key_test.py
@@ -7,15 +7,17 @@
 from collections.abc import Callable, Sequence
 
 import pytest
+from btclib_secp256k1.keys import serialize as libsecp256k1_pubkey_serialize
 
 from btclib.alias import INF, Point
 from btclib.bip32 import BIP32KeyData, derive, rootxprv_from_seed
-from btclib.curves import bytes_from_point
+from btclib.curves import PreparedPoint, bytes_from_point, mult
 from btclib.curves.curve import CURVES
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.to_pub_key import (
     Key,
     PubkeyInfo,
+    _libsecp256k1_pubkey_from_pub_key,
     fingerprint,
     point_from_key,
     point_from_pub_key,
@@ -322,3 +324,40 @@ def test_no_key_material_in_exceptions() -> None:
     with pytest.raises(BTClibValueError) as excinfo:
         point_from_pub_key(xprv_data.key)
     assert xprv_data.key.hex() not in str(excinfo.value)
+
+
+def test_a_prepared_point_is_a_key_wherever_a_point_is() -> None:
+    """The four converters answer a prepared point as they answer its point.
+
+    `curves.PreparedPoint` carries a caller's word about how often the
+    point will be multiplied, and nothing else: no converter here has a
+    use for that word, so each answers by asking itself about the point,
+    and what proves it is that the two answers are the same object's.
+
+    Both unions, `PubKey` and the wider `Key`, and the private
+    libsecp256k1 parse below them: a prepared point reaching that one is
+    a verification on the delegated path, where the tables it holds are
+    not what answers.
+    """
+    prepared = PreparedPoint(Q)
+
+    assert point_from_pub_key(prepared) == point_from_pub_key(Q)
+    assert point_from_key(prepared) == point_from_key(Q)
+    assert pub_keyinfo_from_pub_key(prepared) == pub_keyinfo_from_pub_key(Q)
+    assert pub_keyinfo_from_key(prepared) == pub_keyinfo_from_key(Q)
+    assert fingerprint(prepared) == fingerprint(Q)
+    for compressed in (True, False):
+        assert pub_keyinfo_from_pub_key(
+            prepared, "mainnet", compressed
+        ) == pub_keyinfo_from_pub_key(Q, "mainnet", compressed)
+
+    parsed = _libsecp256k1_pubkey_from_pub_key(prepared)
+    assert libsecp256k1_pubkey_serialize(parsed) == bytes_from_point(Q)
+
+    # and a prepared point of another curve is refused where a bare point
+    # of it is: preparing validates against its own curve, so what is
+    # asked here is the second one
+    other = CURVES["secp256r1"]
+    prepared_r1 = PreparedPoint(mult(12, other.G, other), other)
+    with pytest.raises(BTClibValueError, match="not a valid public key"):
+        point_from_pub_key(prepared_r1)


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/893 and
https://github.com/btclib-org/btclib/issues/897, which are one design
question asked twice. Both issues parked on it, and the shape chosen is
the holder object of the two they list — `PubkeyTweakChain`'s shape, on
the arithmetic side.

## The gap

Every multiplication table in `curve_group` is memoized on
`(point, curve, width)` already, so a repeated point would find its own.
What was missing was anyone to *say* that a point is repeated: only the
generator was assumed to be, and everything else was treated as arriving
once. `curves.PreparedPoint` is where a caller says otherwise.

```python
from btclib.curves import PreparedPoint

P = PreparedPoint(Q)          # parsed and validated once
for m in scalars:
    P.mult(m)                 # ISS897: the generator's fixed-base ladder

K = PreparedPoint(pub_key_point)
for msg, sig in signatures:
    dsa.assert_as_valid(msg, K, sig)   # ISS893: the key's wNAF tables kept
```

## What it buys

| | before | after | |
| --- | ---: | ---: | ---: |
| `mult`, one point repeated | 551.0 µs | 142.3 µs | 3.87x |
| ECDSA verification, one key | 609.1 µs | 471.0 µs | 1.30x |
| BIP340 verification, one key | 664.5 µs | 531.2 µs | 1.25x |
| tables built per verification | 2 | 0 | |

Break-even is 23 multiplications of the one point (9.50 ms and 366 KiB
of per-position tables) and 22 signatures under the one key. Preparing
also parses the key once, which is the other 75.2 µs a pure-Python
verifier was repeating — https://github.com/btclib-org/btclib/issues/893's
second half, on the path https://github.com/btclib-org/btclib/pull/902
could not reach.

Measured on an Apple M5, macOS 26.6, arm64, CPython 3.14, bindings
switched off; best of five alternating rounds, with a case neither arm
touches as the noise detector (1.00x). The ratios reproduce after the
rebase onto https://github.com/btclib-org/btclib/pull/907; the absolute
figures drift with the machine, and the docstrings say so.

## Two things it deliberately is not

**Not automatic, and not on a path to becoming so.** The tables are per
distinct point, so memoizing whatever public key arrived would hold a few
MB for keys nobody will see again and tax the one-shot verifier 3 ms to
do it — https://github.com/btclib-org/btclib/issues/287, the same bound
`_cached_base58_decode` and `pedersen.second_generator` hold. It is the
trade `python-ecdsa` documents on its own `VerifyingKey.precompute()`.

**Not the bindings path.** libsecp256k1 verifies in 22.8 µs and holds its
own tables in its own context, so a prepared point is passed straight
through there and buys nothing. What this is for is the Python
arithmetic: another curve, another hash function, or a deployment without
the compiled bindings. Handing one in on the delegated path is not an
error and costs nothing.

## How it is wired

The `fixed` set that `_multi_mult_w_NAF_var` used to read off
`ec._fixed_points` is now passed down to it, so the two verifications can
name the key in it; `_double_mult_endomorphism_secp256k1_var` grows it
with the endomorphism images exactly as it always did for the
generator's, which is why a prepared key memoizes four tables and not
one. `mult` and `PreparedPoint.mult` share `_mult_checked`, so the
dispatch to the bindings stays written once.

`PubKey`, `Key` and `BIP340PubKey` gain the type, and each converter in
`to_pub_key` answers a prepared point by asking itself about its
`.point`: the tables are the only thing about it that is not the point's.

## Gates

`uv run pytest` (100.00% coverage), `pre-commit run --all-files` and the
`sphinx-build -W` docs job all pass by exit code, before and after the
rebase. New tests assert the *mechanism* rather than a duration: the
tables built per verification going 2 → 0, the fixed-base tables built
once and never again, and a prepared point agreeing with the bare one
over every curve in the suite on both arithmetics — including the odd-y
BIP340 twin, which the negation in the set is there for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce PreparedPoint as an opt-in mechanism for callers to mark reusable elliptic-curve points so their multiplication tables are memoized and reused across operations, improving performance of Python-based scalar multiplications and signature verification without affecting libsecp256k1 paths.

New Features:
- Expose PreparedPoint in the curves API as a reusable point wrapper with a dedicated mult method that leverages fixed-base tables for repeated scalar multiplications.
- Allow ECDSA and BIP340 verification functions to accept PreparedPoint keys and reuse memoized wNAF tables for repeated verifications under the same public key.
- Extend key/public-key conversion utilities and wallet code so PreparedPoint is treated transparently as a public key wherever a point is accepted.

Enhancements:
- Refactor scalar and double-scalar multiplication plumbing to pass through fixed-point sets explicitly, enabling prepared keys to contribute their memoized tables.
- Clarify and document the caching strategy for fixed-base and wNAF tables, including bounds and the opt-in nature of table memoization.
- Update curve and package exports to include PreparedPoint as part of the public curve API.

Documentation:
- Document PreparedPoint usage, performance characteristics, and design rationale in the changelog, including trade-offs and the opt-in nature of table memoization.

Tests:
- Add tests ensuring PreparedPoint multiplications match standard mult results on both libsecp256k1 and pure-Python arithmetic paths.
- Add tests verifying that PreparedPoint keys behave identically to bare points in ECDSA and BIP340 verification, including table-build count assertions for the memoization behavior.
- Extend tests for public-key conversion and wallet utilities to cover PreparedPoint inputs and curve-mismatch handling.