### PR TITLE
Speak only octets at the libsecp256k1 boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1351,6 +1351,60 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **The boundary with libsecp256k1 speaks only octets.** btclib held a
+  cffi `CData` in four modules — `curves.curve`, `curves.sec_point`,
+  `to_pub_key` and, briefly, `script.taproot` — and called `keys.parse`,
+  `keys.serialize` and `xonly.parse` to make and unmake it. It did so to
+  avoid parsing one public key twice, and what that was worth turns out
+  to be **0.256 us**: `keys.parse` on the uncompressed serialization,
+  where both coordinates are there to read, against 2.343 on the
+  compressed one, which is a field square root. The uncompressed
+  serialization *is* a parsed key, and nothing has to own its lifetime.
+
+  So `CData` is gone from btclib, and with it every `parse` and
+  `serialize` call: the bindings' own
+  [#161](https://github.com/btclib-org/btclib-secp256k1/issues/161) is
+  where the argument is recorded, and `keys.reserialize` and the
+  widening of every x-only entry point to 32, 33 or 65 octets
+  (btclib-secp256k1#162 and #163) are what it took.
+
+- **What replaces it is not a second validation.** A public key proved a
+  point here and then handed to a call that proves it again lifts one x
+  twice, which is issue #887 read the other way round: the fix is not to
+  carry the first proof, it is not to make it. `to_pub_key._sec_from_pub_key`
+  and `_sec_from_key` are the conversions without the proof, for a caller
+  whose next call is one — `ecc.dsa`'s verification, `ecc.ssa`'s, and
+  `script.taproot`'s tweak — and each translates the `ValueError` that
+  comes back into btclib's own refusal.
+
+  `curves.curve._libsecp256k1_xonly_pubkey_var` goes with them:
+  `ssa.verify` on the octets validates and verifies in the one parse the
+  separate lift was paying for anyway. `_y_even_var` and
+  `_is_x_coordinate_var` ask `keys.reserialize` in place of a parse and a
+  serialization, and `curves.sec_point._sec_from_octets` is the proof
+  `pub_keyinfo_from_pub_key` still makes, being a function that validates
+  and nothing else.
+
+- **One refusal moves, and it is named where it moves to.** Octets of the
+  right size that are no point reach `script.taproot`'s tweak as the
+  public key they were meant to be, and are refused there as an invalid
+  internal public key; `pub_keyinfo_from_key`, which proves them, reports
+  that they are neither kind of key. Every other message is unchanged,
+  and the two spellings of "not an x-coordinate" are held equal by
+  `tests/ecc/ssa_test.py` on both arithmetics, as
+  `tests/curves/curve_test.py` used to hold them.
+
+- Measured on an Apple M5, macOS 26.6, arm64, CPython 3.14.6, median of
+  seven alternating rounds of 4000 calls, against `abfbac22` with the
+  same harness on both trees and each figure normalized by a `mult`
+  control that moved 0.65% between them: `dsa.verify` of an uncompressed
+  key **10.8% faster**, of a compressed key 1.3% slower, of a `Point`
+  2.4% slower — that last one being the argument normalization the
+  octets entry point does and the parsed one skipped — `ssa.verify` 0.8%
+  slower, `taproot.output_pubkey` 1.0% faster, `point_from_octets`
+  unchanged. What was bought is not speed but the boundary; what it cost
+  is inside a couple of percent either way.
+
 - **Public key recovery refuses the key at infinity** (issue #890).
   `dsa.recover_pub_keys_` could report INF as one of the keys it
   recovered, and `recover_pub_key_` could return it: the candidate of step

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -35,14 +35,11 @@ from math import isqrt
 from pathlib import Path
 from typing import Any
 
-from btclib_secp256k1 import CData
-from btclib_secp256k1.keys import parse as libsecp256k1_pubkey_parse
 from btclib_secp256k1.keys import pubkey_combine as libsecp256k1_pubkey_combine
 from btclib_secp256k1.keys import pubkey_tweak_add as libsecp256k1_pubkey_tweak_add
 from btclib_secp256k1.keys import pubkey_tweak_mul as libsecp256k1_pubkey_tweak_mul
-from btclib_secp256k1.keys import serialize as libsecp256k1_pubkey_serialize
+from btclib_secp256k1.keys import reserialize as libsecp256k1_reserialize
 from btclib_secp256k1.mult import mult as libsecp256k1_mult
-from btclib_secp256k1.xonly import parse as libsecp256k1_xonly_parse
 
 from btclib.alias import INF, HashF, Integer, JacPoint, Point
 from btclib.curves.curve_group import (
@@ -496,7 +493,7 @@ def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
     sec = _compressed_sec(x, ec)
     if sec is not None:
         try:
-            libsecp256k1_pubkey_parse(sec)
+            libsecp256k1_reserialize(sec)
         except ValueError:
             return False
         return True
@@ -514,9 +511,9 @@ def _y_even_var(x: int, ec: Curve) -> int:
 
     ec.y_even_var, delegated for secp256k1: the parity a compressed public
     key carries in its prefix is the same tiebreaker, so 0x02 || x names
-    the even-y point and the uncompressed serialization of it hands back
-    the y that was lifted -- 2.9 us against 75. That is 0.5 more than
-    _is_x_coordinate_var above, which is why both exist.
+    the even-y point and `keys.reserialize` asked for the uncompressed
+    form hands back the y that was lifted -- 2.7 us against 75. That is
+    0.3 more than _is_x_coordinate_var above, which is why both exist.
 
     An x the bindings refuse falls through to ec.y_even_var instead of
     raising here, so that the message stays in the one place that has the
@@ -529,42 +526,10 @@ def _y_even_var(x: int, ec: Curve) -> int:
     sec = _compressed_sec(x, ec)
     if sec is not None:
         with contextlib.suppress(ValueError):
-            pubkey = libsecp256k1_pubkey_parse(sec)
-            uncompressed = libsecp256k1_pubkey_serialize(pubkey, compressed=False)
+            uncompressed = libsecp256k1_reserialize(sec, compressed=False)
             return int.from_bytes(uncompressed[ec.p_size + 1 :], "big")
 
     return ec.y_even_var(x)
-
-
-def _libsecp256k1_xonly_pubkey_var(x: int, ec: Curve) -> CData:
-    """Return the x-only key libsecp256k1 parses from x, or refuse x.
-
-    What `_y_even_var` above proves of an x is what xonly_pubkey_parse
-    proves of the same octets: that some point of the curve has it. Where
-    the answer is on its way to a BIP340 verification the parse is the call
-    that has to happen anyway, so it is the whole of the proof rather than
-    a second one standing beside a lift whose y nobody reads -- 2.9 us of a
-    21 us verification, and the lift's serialization with it (issue 887).
-
-    The two refusals are `ec.y_var`'s, and they are spelled out here rather
-    than reached by calling it: this function exists not to take that
-    square root, and on the failing path it is the message that would pay
-    for one.
-
-    For secp256k1, the one curve `_libsecp256k1_serves` admits and so the
-    one that reaches this.
-    """
-    if not 0 <= x < ec.p:
-        err_msg = "x-coordinate not in 0..p-1: "
-        err_msg += f"{hex_string(x)}" if x > HEX_THRESHOLD else f"{x}"
-        raise BTClibValueError(err_msg)
-
-    try:
-        return libsecp256k1_xonly_parse(x.to_bytes(ec.p_size, byteorder="big"))
-    except ValueError as e:
-        err_msg = "invalid x-coordinate: "
-        err_msg += f"{hex_string(x)}" if x > HEX_THRESHOLD else f"{x}"
-        raise BTClibValueError(err_msg) from e
 
 
 def _sec_from_point(Q: Point) -> bytes:

--- a/btclib/curves/sec_point.py
+++ b/btclib/curves/sec_point.py
@@ -6,12 +6,11 @@
 
 import contextlib
 
-from btclib_secp256k1 import CData
-from btclib_secp256k1.keys import parse as libsecp256k1_pubkey_parse
 from btclib_secp256k1.keys import (
     pubkey_from_prvkey as libsecp256k1_pubkey_from_prvkey,
 )
 from btclib_secp256k1.keys import pubkey_tweak_mul as libsecp256k1_pubkey_tweak_mul
+from btclib_secp256k1.keys import reserialize as libsecp256k1_reserialize
 
 from btclib.alias import Integer, Octets, Point
 from btclib.curves.curve import (
@@ -175,32 +174,6 @@ def _mult_sec_var(sec: bytes, m: int, ec: Curve) -> Point:
     return mult(m, point_from_octets(sec, ec), ec)
 
 
-def _sec_and_pubkey_from_octets(
-    pub_key: bytes, ec: Curve
-) -> tuple[bytes, CData | None]:
-    """Return the verified SEC octets, and the parsed key that verified them.
-
-    `_sec_from_octets` below is this with the second half dropped, which
-    is what made a verification pay for the same proof twice: for a
-    compressed key on secp256k1 the proof that the octets are a point *is*
-    ec_pubkey_parse, a field square root, and a caller going on to verify
-    a signature under those octets had libsecp256k1 parse them again --
-    2.35 us of a 22.78 us verification (issue 887). Here the parsed key
-    comes back beside them, for a caller that has somewhere to put it.
-
-    None where nothing parsed it: another curve, the bindings out of
-    reach, or a form that went through `point_from_octets` instead. A
-    caller wanting the key in that case parses the octets itself, which
-    for the uncompressed form is 0.27 us and no square root.
-    """
-    compressed = len(pub_key) == ec.p_size + 1
-    if compressed and _libsecp256k1_serves(ec, None):
-        with contextlib.suppress(ValueError):
-            return pub_key, libsecp256k1_pubkey_parse(pub_key)
-
-    return bytes_from_point(point_from_octets(pub_key, ec), ec, compressed), None
-
-
 def _sec_from_octets(pub_key: bytes, ec: Curve) -> bytes:
     """Return SEC octets of a p-size or 2*p-size length, verified.
 
@@ -210,11 +183,15 @@ def _sec_from_octets(pub_key: bytes, ec: Curve) -> bytes:
     them a point of the curve -- which is the whole of what
     to_pub_key.pub_keyinfo_from_pub_key wants of it.
 
-    For a compressed key on secp256k1 that proof is ec_pubkey_parse and
-    nothing else, 2.4 us against the 4.4 of a round trip that lifts x,
-    re-proves the point it lifted on the curve and serializes it again.
-    It is also the very call libsecp256k1 will make on these bytes if
-    they are on their way to its dsa.verify.
+    For a compressed key on secp256k1 that proof is `keys.reserialize`,
+    which is ec_pubkey_parse and a serialization of what it read back into
+    the form it came in: 2.7 us against the 4.4 of a round trip that lifts
+    x, re-proves the point it lifted on the curve and serializes it again.
+    The parse is also the very call libsecp256k1 will make on these bytes
+    if they are on their way to its dsa.verify -- which is why a caller
+    that is about to make it does not come through here at all, but
+    through `to_pub_key._sec_from_pub_key`, and lets that call be the
+    proof (issue 887).
 
     Anything the bindings refuse falls through to the round trip, and so
     does every 65-byte form: the message that names what is wrong with
@@ -222,8 +199,10 @@ def _sec_from_octets(pub_key: bytes, ec: Curve) -> bytes:
     reason the fallthrough cannot be skipped for a length ec_pubkey_parse
     accepts -- it takes 0x06 and 0x07, point_from_octets only when asked,
     and there is nothing to ask here.
-
-    The parsed key that proof produces is `_sec_and_pubkey_from_octets`
-    above, this being the spelling for a caller with nothing to do with it.
     """
-    return _sec_and_pubkey_from_octets(pub_key, ec)[0]
+    compressed = len(pub_key) == ec.p_size + 1
+    if compressed and _libsecp256k1_serves(ec, None):
+        with contextlib.suppress(ValueError):
+            return libsecp256k1_reserialize(pub_key)
+
+    return bytes_from_point(point_from_octets(pub_key, ec), ec, compressed)

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -61,7 +61,7 @@ from btclib.number_theory import mod_inv, mod_inv_var
 from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.to_pub_key import (
     PubKey,
-    _libsecp256k1_pubkey_from_pub_key,
+    _sec_from_pub_key,
     point_from_pub_key,
 )
 from btclib.utils import (
@@ -983,13 +983,12 @@ def assert_as_valid_(
 
     if _libsecp256k1_serves(sig.ec, hf):
         msg_hash_bytes = bytes_from_octets(msg_hash, 32)
-        # the parsed key, not the octets: validating a public key proves it
-        # a point by parsing it, and for a compressed one that parse is a
-        # field square root -- 2.35 us of a 22.78 us verification, paid
-        # twice when the verification below parsed the same 33 bytes again
-        # (issue 887). `_libsecp256k1_pubkey_from_pub_key` is that same
-        # validation with the parsed key kept
-        pubkey = _libsecp256k1_pubkey_from_pub_key(key)
+        # the octets unproven, because the verification below proves them:
+        # validating a public key is parsing it, for a compressed one a
+        # field square root, and doing it here as well lifts the same x
+        # twice -- 2.35 us of a 22.78 us verification (issue 887). So a
+        # key that is no point leaves through the ValueError caught below
+        sec = _sec_from_pub_key(key)
         # check_validity=False, because assert_valid has just run above --
         # on the Sig handed in, or inside the Sig.parse that made one.
         # What it would run again is the congruence check of r, which is
@@ -1004,9 +1003,15 @@ def assert_as_valid_(
         # and serialized it again for verify to parse what came out, where
         # libsecp256k1 documents sigout == sigin for its own
         # signature_normalize (issue 889)
-        if not libsecp256k1_dsa.verify_(
-            msg_hash_bytes, pubkey, sig_bytes, normalize=True
-        ):
+        try:
+            verified = libsecp256k1_dsa.verify(
+                msg_hash_bytes, sec, sig_bytes, normalize=True
+            )
+        except ValueError as e:
+            # what the octets were not: a point of the curve. Never echoed,
+            # as `to_pub_key` does not echo them either
+            raise BTClibValueError("not a public key") from e
+        if not verified:
             raise BTClibRuntimeError("signature verification failed")
         return
 

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -69,11 +69,11 @@ from btclib.curves.curve import (
     _is_x_coordinate_var,
     _jac_double_mult,
     _libsecp256k1_serves,
-    _libsecp256k1_xonly_pubkey_var,
     _y_even_var,
     mult,
     multi_mult_var,
 )
+from btclib.curves.curve_group import HEX_THRESHOLD
 from btclib.ecc.bip340_nonce import bip340_nonce_
 from btclib.ecc.commit_nonce import commit_entropy_, commit_nonce_, commit_point_
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
@@ -583,6 +583,33 @@ def _assert_commitment_(
             raise BTClibRuntimeError("commitment verification failed")
 
 
+def _invalid_x(x: int) -> str:
+    """Return the message an x that is no x-coordinate is refused with."""
+    err_msg = "invalid x-coordinate: "
+    return err_msg + (f"{hex_string(x)}" if x > HEX_THRESHOLD else f"{x}")
+
+
+def _x_only_bytes(x: int, ec: Curve) -> bytes:
+    """Return the 32 octets of an x, refusing what is no field element.
+
+    The range check `int.to_bytes` cannot make on its own -- an x at or
+    above 2**256 is an OverflowError about a builtin, and one between p
+    and 2**256 is octets libsecp256k1 will refuse -- and the message is
+    `ec.y_var`'s, spelled here rather than reached by calling it: this
+    exists not to take that square root.
+
+    Whether the x is an x-coordinate at all is not asked. What asks is
+    the verification these octets are on their way to, whose parse is
+    that same lift (issue 887); `_invalid_x` is the message for what it
+    refuses.
+    """
+    if not 0 <= x < ec.p:
+        err_msg = "x-coordinate not in 0..p-1: "
+        err_msg += f"{hex_string(x)}" if x > HEX_THRESHOLD else f"{x}"
+        raise BTClibValueError(err_msg)
+    return x.to_bytes(ec.p_size, byteorder="big")
+
+
 def assert_as_valid_(
     msg: Octets,
     Q: BIP340PubKey,
@@ -628,19 +655,23 @@ def assert_as_valid_(
     # issue 169 down the Python path was the 32-byte gate in front of it,
     # never the call itself, and they are verified here now
     if _libsecp256k1_serves(sig.ec, hf):
-        # the x-only key parsed once, where the lift and this parse both
-        # used to run: xonly_pubkey_parse proves x an x-coordinate, which is
-        # what the lift proved, and it is the call the verification makes
-        # anyway -- so what goes is the lift, whose y nothing on this path
-        # reads, and the serialization inside it (issue 887)
-        xonly_pubkey = _libsecp256k1_xonly_pubkey_var(x_Q, sig.ec)
+        # x proved an x-coordinate once, by the verification itself: that
+        # parse is the lift, and validating the key before it would be the
+        # same square root twice (issue 887). So nothing here proves the
+        # key -- what a ValueError from below means is that it was no
+        # point, which is this function's to phrase
+        x_bytes = _x_only_bytes(x_Q, sig.ec)
         # check_validity=False, because assert_valid has just run above --
         # on the Sig handed in, or inside the Sig.parse that made one. What
         # it would run again is the lift of r, which is not free even
         # delegated: 0.14 us against 3.1, of a verification that is 21 in
         # total
         sig_bytes = sig.serialize(check_validity=False)
-        if not libsecp256k1_ssa.verify_(msg, xonly_pubkey, sig_bytes):
+        try:
+            verified = libsecp256k1_ssa.verify(msg, x_bytes, sig_bytes)
+        except ValueError as e:
+            raise BTClibValueError(_invalid_x(x_Q)) from e
+        if not verified:
             raise BTClibRuntimeError("signature verification failed")
         return
 

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 from io import BytesIO
 from typing import cast
 
-from btclib_secp256k1 import CData
 from btclib_secp256k1 import xonly as libsecp256k1_xonly
 
 from btclib import var_bytes
@@ -40,11 +39,7 @@ from btclib.script.op_codes_tapscript import (
 )
 from btclib.script.script import _serialize_bytes_command, _serialize_int_command
 from btclib.to_prv_key import PrvKey, int_from_prv_key
-from btclib.to_pub_key import (
-    Key,
-    _pub_keyinfo_and_pubkey_from_key,
-    point_from_key,
-)
+from btclib.to_pub_key import Key, _sec_from_key, point_from_key
 from btclib.utils import (
     assert_type,
     bytes_from_octets,
@@ -272,19 +267,18 @@ def _output_pubkey_and_internal_key(
         # path, and validating a key is how a point is built, so the same
         # modular square root of the same x was taken twice -- 74 us of the
         # 311 an output key cost there (issue 896). The bindings arm builds
-        # no point of btclib's own: what it keeps instead is the parsed key
-        # the validation made, which `_tweaked_pubkey` tweaks without
-        # parsing the x a second time. `point_from_key` is 6.58 us against
-        # `pub_keyinfo_from_key`'s 3.74, which is a sixth of a 17.3 us
-        # output key added to the path every install takes.
+        # no point of btclib's own and proves nothing either: the tweak
+        # below parses these octets, and that parse is the proof, so a key
+        # that is no point is refused there instead of here (issue 887).
+        # `point_from_key` is 6.58 us against `_sec_from_key`'s 3.74, which
+        # is a sixth of a 17.3 us output key added to the path every
+        # install takes.
         #
         # So each arm reads what it uses, and both read the same spellings:
-        # `compressed=None` accepts the 33-byte and the 65-byte form as
+        # `_sec_from_key` accepts the 33-byte and the 65-byte form as
         # `point_from_key` does, and `[1:33]` is the x-coordinate of either
         if _libsecp256k1_serves(secp256k1, None):
-            (sec, _), pubkey = _pub_keyinfo_and_pubkey_from_key(
-                internal_pubkey, None, None
-            )
+            sec = _sec_from_key(internal_pubkey)
             pub_key = sec[1:33]
             y_even: int | None = None
         else:
@@ -296,19 +290,19 @@ def _output_pubkey_and_internal_key(
             x_P, y_P = point_from_key(internal_pubkey)
             pub_key = x_P.to_bytes(32, "big")
             y_even = y_P if y_P % 2 == 0 else secp256k1.p - y_P
-            pubkey = None
+            sec = None
     else:
         h_str = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
         pub_key = bytes.fromhex(h_str)
         # BIP341's unspendable point is published as an x-only key and
-        # nothing else, so there the lift is the only one there is
+        # nothing else, so there the 32 octets are all there is
         y_even = None
-        pubkey = None
+        sec = None
     if script_tree:
         _, h = tree_helper(script_tree)
     else:
         h = b""
-    q, parity_bit = _tweaked_pubkey(pub_key, h, y_even, pubkey)
+    q, parity_bit = _tweaked_pubkey(pub_key, h, y_even, sec)
     return q, parity_bit, pub_key
 
 
@@ -329,7 +323,7 @@ def output_pubkey(
 
 
 def _tweaked_pubkey(
-    pub_key: bytes, h: bytes, y_even: int | None, pubkey: CData | None
+    pub_key: bytes, h: bytes, y_even: int | None, sec: bytes | None
 ) -> tuple[bytes, int]:
     """Return the x-only key an internal key tweaked by h, and its parity.
 
@@ -344,10 +338,11 @@ def _tweaked_pubkey(
     y_even is the even y-coordinate of pub_key, which `output_pubkey` has
     on the Python path: validating the key is a modular square root of
     this very x, and taking a second one is the redundancy of issue 896.
-    pubkey is the parsed key of the bindings path, where validating is
-    `ec_pubkey_parse` and that parse is the same square root:
-    `xonly.tweak_add_` converts it, which reads the y it is given, where
-    `xonly.tweak_add` parses the 32 octets and lifts the x again.
+    sec is the full public key of the bindings path, uncompressed where
+    the caller had a point to serialize: `xonly.tweak_add` reads the y it
+    is given there, where the 32 x-only octets are a square root to lift
+    -- 4.11 us against 5.92, and the same key either way, `02 || x`,
+    `03 || x` and `04 || x || y` all naming it.
     """
     t = _tap_tweak(pub_key, h)
 
@@ -368,9 +363,7 @@ def _tweaked_pubkey(
     # being the one that asks for a different reason: which form of the
     # internal key is worth building, rather than which arithmetic runs
     if _libsecp256k1_serves(secp256k1, None):
-        if pubkey is None:
-            return libsecp256k1_xonly.tweak_add(pub_key, t)
-        return libsecp256k1_xonly.tweak_add_(pubkey, t)
+        return libsecp256k1_xonly.tweak_add(pub_key if sec is None else sec, t)
 
     P_x = int.from_bytes(pub_key, "big")
     P_y = secp256k1.y_even_var(P_x) if y_even is None else y_even

--- a/btclib/to_pub_key.py
+++ b/btclib/to_pub_key.py
@@ -8,9 +8,6 @@ from __future__ import annotations
 
 import contextlib
 
-from btclib_secp256k1 import CData
-from btclib_secp256k1.keys import parse as libsecp256k1_pubkey_parse
-
 from btclib.alias import Point
 from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, _key_data_from_bip32_key
 from btclib.curves import (
@@ -23,7 +20,7 @@ from btclib.curves import (
     secp256k1,
 )
 from btclib.curves.curve import _assert_valid_ec
-from btclib.curves.sec_point import _sec_and_pubkey_from_octets
+from btclib.curves.sec_point import _sec_from_octets
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
 from btclib.network import (
@@ -231,39 +228,53 @@ def pub_keyinfo_from_key(
     key: Key, network: str | None = None, compressed: bool | None = None
 ) -> PubkeyInfo:
     """Return the pub key tuple (SEC-bytes, network) from a pub/prv key."""
-    return _pub_keyinfo_and_pubkey_from_key(key, network, compressed)[0]
-
-
-def _pub_keyinfo_and_pubkey_from_key(
-    key: Key, network: str | None, compressed: bool | None
-) -> tuple[PubkeyInfo, CData | None]:
-    """Return the pub key tuple, and the parsed key if validating built one.
-
-    The body of `pub_keyinfo_from_key`, as
-    `_pub_keyinfo_and_pubkey_from_pub_key` is the body of
-    `pub_keyinfo_from_pub_key`: one dispatch over the spellings of a key,
-    and two spellings of what to do with the parsed one.
-
-    A private key answers None and there is nothing to keep: its public key
-    is computed and serialized, never parsed. `script.taproot` is the
-    caller, and reads that None as "lift the x-only octets after all".
-    """
     _assert_key_type(key)
     if isinstance(key, PreparedPoint):
-        return _pub_keyinfo_and_pubkey_from_key(key.point, network, compressed)
+        return pub_keyinfo_from_key(key.point, network, compressed)
 
     if isinstance(key, tuple):
-        return _pub_keyinfo_and_pubkey_from_pub_key(key, network, compressed)
+        return pub_keyinfo_from_pub_key(key, network, compressed)
     if isinstance(key, int):
-        return pub_keyinfo_from_prv_key(key, network, compressed), None
+        return pub_keyinfo_from_prv_key(key, network, compressed)
     with contextlib.suppress(BTClibValueError):
-        return _pub_keyinfo_and_pubkey_from_pub_key(key, network, compressed)
+        return pub_keyinfo_from_pub_key(key, network, compressed)
     # it must be a prv_key
     try:
-        return pub_keyinfo_from_prv_key(key, network, compressed), None
+        return pub_keyinfo_from_prv_key(key, network, compressed)
     except BTClibValueError as e:
         err_msg = _err_msg(key, network, compressed)
         raise BTClibValueError(err_msg) from e
+
+
+def _sec_from_key(key: Key) -> bytes:
+    """Return the SEC octets of a public or private key, unproven.
+
+    `_sec_from_pub_key` for a caller that takes both, and the same trade:
+    the octets are not proved a point here, because what they are handed
+    to proves them -- `script.taproot` is the caller, and
+    `xonly.tweak_add` is the parse that would otherwise be the second
+    lift of one x.
+
+    What that costs is which refusal a caller sees for octets of the right
+    size that are no point: `pub_keyinfo_from_key` reads them as a public
+    key, fails to prove one, and tries them as a private key, so the
+    message names both; here the call this feeds refuses them as the
+    public key they were meant to be. Neither is a key, and the second
+    says so more nearly.
+    """
+    _assert_key_type(key)
+    if isinstance(key, PreparedPoint):
+        return _sec_from_key(key.point)
+    if isinstance(key, tuple):
+        return _sec_from_pub_key(key)
+    if isinstance(key, int):
+        return pub_keyinfo_from_prv_key(key)[0]
+    with contextlib.suppress(BTClibValueError):
+        return _sec_from_pub_key(key)
+    try:
+        return pub_keyinfo_from_prv_key(key)[0]
+    except BTClibValueError as e:
+        raise BTClibValueError(_err_msg(key, None, None)) from e
 
 
 def _err_msg(key: Key, network: str | None, compressed: bool | None) -> str:
@@ -282,65 +293,62 @@ def pub_keyinfo_from_pub_key(
     pub_key: PubKey, network: str | None = None, compressed: bool | None = None
 ) -> PubkeyInfo:
     """Return the pub key tuple (SEC-bytes, network) from a public key."""
-    return _pub_keyinfo_and_pubkey_from_pub_key(pub_key, network, compressed)[0]
+    (sec, net), to_prove = _pub_keyinfo_from_pub_key(pub_key, network, compressed)
+    if not to_prove:
+        return sec, net
+    # verify that it is a valid point, which is all there is left to do
+    return _sec_from_octets(sec, network_from_name(net).curve), net
 
 
-def _libsecp256k1_pubkey_from_pub_key(pub_key: PubKey) -> CData:
-    """Return the key as one parsed libsecp256k1 pubkey, however spelled.
+def _sec_from_pub_key(pub_key: PubKey) -> bytes:
+    """Return the SEC octets of a public key, unproven, however spelled.
 
-    `pub_keyinfo_from_pub_key` proves a public key valid and answers the
-    octets, so a caller going on to verify a signature under it had
-    libsecp256k1 parse those octets a second time -- and for a compressed
-    key each parse is a field square root, 2.35 us of a 22.78 us
-    verification (issue 887). This is the same validation with the parsed
-    key kept instead of dropped, which is what `dsa.verify_` takes.
+    `pub_keyinfo_from_pub_key` proves the octets a point of the curve --
+    for a compressed key a field square root -- and a caller going on to
+    verify a signature under them, or to tweak a taproot key with them,
+    hands them to a call whose own parse is that same proof: the two
+    together lift one x twice, which is issue 887.
 
-    Where the validation parsed nothing, the octets it answered are parsed
-    here, and what that costs is the form they are in. The uncompressed
-    octets of `point_from_octets` are 0.26 us, both coordinates being there
-    to read; an xpub or a BIP32KeyData *is* 33 compressed octets with no y
-    anywhere, so its parse is a field square root and nothing here can help
-    it.
+    So this is that conversion with the proof left out, and it is private
+    because the guarantee is the caller's to complete: whatever these
+    octets are handed to is what refuses a key that is no point, and it is
+    the caller that turns the `ValueError` into btclib's own.
 
-    A `Point` is the spelling that looks like the second and is the first,
-    which is why it has a branch of its own: `pub_keyinfo_from_pub_key`
-    answers the compressed form for it -- `compressed=None` means "whatever
-    the key says" and a point says nothing -- so parsing that would lift an
-    x whose y the caller had in hand a line earlier, 3.25 us against 1.24
-    for the uncompressed round trip. It is also the spelling a caller who
-    parses once and keeps the result reaches for, which is what makes it
-    worth the branch.
-
-    No network and no compressed filter, which is what its one caller
-    asks for: a verification takes the key as the key says it is, and the
-    curve it is asked about is the signature's.
+    A `Point` comes back uncompressed, which is the cheap form to parse --
+    0.26 us against the 2.34 of a compressed key, both coordinates being
+    there to read -- where `pub_keyinfo_from_pub_key` answers the
+    compressed one, `compressed=None` meaning "whatever the key says" and
+    a point saying nothing. No network and no compressed filter either,
+    which is what the callers ask for: a verification takes the key as the
+    key says it is, and the curve it is asked about is the signature's.
     """
     if isinstance(pub_key, PreparedPoint):
-        return _libsecp256k1_pubkey_from_pub_key(pub_key.point)
+        return _sec_from_pub_key(pub_key.point)
     if isinstance(pub_key, tuple):
-        # bytes_from_point is the validation this branch skips
-        # `pub_keyinfo_from_pub_key` for: it refuses what is not a point of
-        # the curve, and infinity, which is the whole of what the tuple
-        # branch there does
-        return libsecp256k1_pubkey_parse(bytes_from_point(pub_key, secp256k1, False))
-
-    (sec, _), pubkey = _pub_keyinfo_and_pubkey_from_pub_key(pub_key, None, None)
-    return libsecp256k1_pubkey_parse(sec) if pubkey is None else pubkey
+        # bytes_from_point is btclib's own arithmetic and not a parse: it
+        # refuses what is not a point of the curve, and infinity
+        return bytes_from_point(pub_key, secp256k1, False)
+    return _pub_keyinfo_from_pub_key(pub_key, None, None)[0][0]
 
 
-def _pub_keyinfo_and_pubkey_from_pub_key(
+def _pub_keyinfo_from_pub_key(
     pub_key: PubKey, network: str | None, compressed: bool | None
-) -> tuple[PubkeyInfo, CData | None]:
-    """Return the pub key tuple, and the parsed key if validating built one.
+) -> tuple[PubkeyInfo, bool]:
+    """Return the pub key tuple, and whether it is still to be proved a point.
 
-    The body of `pub_keyinfo_from_pub_key`, which is the spelling for a
-    caller with nothing to do with a parsed key; the two exist as one
-    function so that the dispatch over the spellings of a public key stays
-    written once.
+    The body of `pub_keyinfo_from_pub_key`, and of `_sec_from_pub_key`
+    above: the dispatch over the spellings of a public key stays written
+    once, and the two differ in what they do with the answer.
+
+    True for octets, which arrive unproven and are proved by the public
+    spelling; False for a `Point`, which `bytes_from_point` has just
+    refused if it was not one, and for an extended key, whose 33 octets
+    are validated as a BIP32 key rather than as a point -- neither has a
+    proof left for a caller to make, and neither is one this would add.
     """
     _assert_pub_key_type(pub_key)
     if isinstance(pub_key, PreparedPoint):
-        return _pub_keyinfo_and_pubkey_from_pub_key(pub_key.point, network, compressed)
+        return _pub_keyinfo_from_pub_key(pub_key.point, network, compressed)
     # as in `to_prv_key.prv_keyinfo_from_prv_key`: None means "whatever
     # the key says", and every other spelling of a truth is refused
     if compressed is not None:
@@ -351,11 +359,11 @@ def _pub_keyinfo_and_pubkey_from_pub_key(
     ec = network_from_name(net).curve
 
     if isinstance(pub_key, tuple):
-        return (bytes_from_point(pub_key, ec, compr), net), None
+        return (bytes_from_point(pub_key, ec, compr), net), False
     if isinstance(pub_key, BIP32KeyData):
-        return _pub_keyinfo_from_xpub(pub_key, network, compressed), None
+        return _pub_keyinfo_from_xpub(pub_key, network, compressed), False
     with contextlib.suppress(TypeError, BTClibValueError):
-        return _pub_keyinfo_from_xpub(pub_key, network, compressed), None
+        return _pub_keyinfo_from_xpub(pub_key, network, compressed), False
     # it must be octets, and compressed is a filter on which form they may
     # be in rather than a conversion to it: the size below is required of
     # the input, so octets that pass come back in the form they came in
@@ -370,9 +378,7 @@ def _pub_keyinfo_and_pubkey_from_pub_key(
         # mistake; the chained exception carries the parsing reason
         raise BTClibValueError("not a public key") from e
 
-    # verify that it is a valid point, which is all there is left to do
-    sec, pubkey = _sec_and_pubkey_from_octets(pub_key, ec)
-    return (sec, net), pubkey
+    return (pub_key, net), True
 
 
 def pub_keyinfo_from_prv_key(

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -43,7 +43,6 @@ from btclib.curves.curve import (
     _is_x_coordinate_var,
     _libsecp256k1_multi_mult_,
     _libsecp256k1_serves,
-    _libsecp256k1_xonly_pubkey_var,
     _sec_from_point,
     _tweak_add_var,
     _y_even_var,
@@ -977,7 +976,7 @@ def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
 
     `_libsecp256k1_available` is what `_libsecp256k1_serves` reads on
     every call, so clearing it is the whole package's dispatch and not
-    this module's copy of a predicate. Replacing the five bindings
+    this module's copy of a predicate. Replacing the four bindings
     functions besides is what proves they were not asked anyway: a
     dispatch this does not cover raises here instead of quietly measuring
     the bindings against themselves.
@@ -996,8 +995,7 @@ def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_tweak_add", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_tweak_mul", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_combine", refuse)
-    monkeypatch.setattr(curve, "libsecp256k1_pubkey_parse", refuse)
-    monkeypatch.setattr(curve, "libsecp256k1_pubkey_serialize", refuse)
+    monkeypatch.setattr(curve, "libsecp256k1_reserialize", refuse)
 
 
 @pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
@@ -1225,39 +1223,6 @@ def test_x_coordinate_lift_of_every_other_curve() -> None:
             else:
                 assert _is_x_coordinate_var(x, ec)
                 assert _y_even_var(x, ec) == y_even_var
-
-
-def test_the_xonly_parse_refuses_what_the_lift_refuses_and_in_the_same_words() -> None:
-    """`_libsecp256k1_xonly_pubkey_var` says what `ec.y_var` says (issue 887).
-
-    That function spells `y_var`'s two refusals out rather than reaching
-    them by calling it, and its docstring gives the reason: it exists not to
-    take that modular square root, and on the failing path the message is
-    what would pay for one. The price of the duplication is that an edit to
-    one wording leaves the other behind, and the only thing that would
-    notice is a caller matching on the message -- so the two are held equal
-    here, the class and the whole text.
-
-    Four x, for both messages in both renderings: `ec.p` and above it are
-    the range refusal, `0xDEADBEEF00000000` an x no point of the curve has,
-    and 7 the same refusal below `HEX_THRESHOLD`, where the value renders in
-    decimal rather than as grouped hex -- the other branch of the same
-    conditional in both spellings.
-    """
-    ec = secp256k1
-    for x in (ec.p, ec.p + 1, 0xDEADBEEF00000000, 7):
-        with pytest.raises(BTClibValueError) as delegated:
-            _libsecp256k1_xonly_pubkey_var(x, ec)
-        with pytest.raises(BTClibValueError) as lifted:
-            ec.y_var(x)
-        assert str(delegated.value) == str(lifted.value)
-
-    # and both answer the same y for an x that is one, which is what says
-    # the equality above is about the refusals and not about a function
-    # that refuses everything
-    x_G = ec.G[0]
-    assert _libsecp256k1_xonly_pubkey_var(x_G, ec)
-    assert ec.y_var(x_G) in {ec.G[1], ec.p - ec.G[1]}
 
 
 def test_prepared_point_answers_what_mult_answers() -> None:

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -1673,3 +1673,28 @@ def test_a_prepared_key_stops_the_per_signature_table(
     for _ in range(3):
         assert dsa.verify(msg, prepared, sig)
     assert not builds
+
+
+@pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
+def test_a_key_that_is_no_point_is_refused_by_the_verification_itself(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both arithmetics refuse 33 octets that are no point, in one parse.
+
+    The delegated path does not prove the key before verifying with it:
+    the verification's own parse is that proof, and proving it here as
+    well would lift one x twice (issue 887). So what a bad key raises
+    comes from the bindings and is translated, where the Python path
+    raises it while converting -- the two messages are held equal here,
+    that being the only thing a caller sees of the difference.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    q, _ = dsa.gen_keys(0x1234567890ABCDEF)
+    msg = b"a message"
+    sig = dsa.sign(msg, q)
+
+    for no_point in (b"\x02" + bytes(32), b"\x03" + b"\xff" * 32):
+        with pytest.raises(BTClibValueError, match="not a public key"):
+            dsa.assert_as_valid(msg, no_point, sig)

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -10,7 +10,6 @@ from hashlib import sha256 as hf
 from typing import Any
 
 import pytest
-from btclib_secp256k1 import CData
 from btclib_secp256k1 import ssa as libsecp256k1_ssa
 
 from btclib.alias import INF, Point, String
@@ -411,21 +410,21 @@ def test_a_message_of_any_size_reaches_the_bindings(
     sizes = (0, 1, 17, 31, 32, 33, 100)
     calls: list[tuple[str, int]] = []
     real_sign_custom = libsecp256k1_ssa.sign_custom
-    # `verify_`, the entry point that takes the already-parsed x-only key:
-    # verification hands it the key it validated rather than the octets, so
-    # nothing here parses the same 32 bytes twice (issue 887)
-    real_verify = libsecp256k1_ssa.verify_
+    # `verify` on the octets: proving x an x-coordinate is what that parse
+    # does, so the key is not validated before it and the same 32 bytes
+    # are not parsed twice (issue 887)
+    real_verify = libsecp256k1_ssa.verify
 
     def sign_custom(msg: bytes, prvkey: int, aux: bytes) -> bytes:
         calls.append(("sign_custom", len(msg)))
         return real_sign_custom(msg, prvkey, aux)
 
-    def verify_(msg: bytes, xonly_pubkey: CData, sig: bytes) -> bool:
+    def verify(msg: bytes, pubkey_bytes: bytes, sig: bytes) -> bool:
         calls.append(("verify", len(msg)))
-        return real_verify(msg, xonly_pubkey, sig)
+        return real_verify(msg, pubkey_bytes, sig)
 
     monkeypatch.setattr(libsecp256k1_ssa, "sign_custom", sign_custom)
-    monkeypatch.setattr(libsecp256k1_ssa, "verify_", verify_)
+    monkeypatch.setattr(libsecp256k1_ssa, "verify", verify)
 
     q, x_Q = ssa.gen_keys(0x1234567890ABCDEF)
     for size in sizes:
@@ -1139,3 +1138,36 @@ def test_verification_under_a_prepared_key(monkeypatch: pytest.MonkeyPatch) -> N
             assert ssa.verify(msg, key, sig)
             assert not ssa.verify(b"another message", key, sig)
         no_bindings(monkeypatch)
+
+
+@pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
+def test_a_key_that_is_no_x_coordinate_is_refused_in_the_lift_s_words(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both arithmetics refuse a bad x as `ec.y_var` refuses it.
+
+    The delegated path never lifts the key -- the verification's own parse
+    is that square root (issue 887) -- so the two messages are written in
+    two places and would drift apart unnoticed but for this: what would
+    notice is a caller matching on the text.
+
+    Four x, for both messages in both renderings: `ec.p` and above it are
+    the range refusal, `0xDEADBEEF00000000` an x no point of the curve
+    has, and 7 the same refusal below `HEX_THRESHOLD`, where the value
+    renders in decimal rather than as grouped hex.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    ec = secp256k1
+    q, x_Q = ssa.gen_keys(0x1234567890ABCDEF)
+    msg = b"a message"
+    sig = ssa.sign_(msg, q)
+    assert ssa.verify_(msg, x_Q, sig)
+
+    for x in (ec.p, ec.p + 1, 0xDEADBEEF00000000, 7):
+        with pytest.raises(BTClibValueError) as verified:
+            ssa.assert_as_valid_(msg, x, sig)
+        with pytest.raises(BTClibValueError) as lifted:
+            ec.y_var(x)
+        assert str(verified.value) == str(lifted.value)

--- a/tests/to_pub_key_test.py
+++ b/tests/to_pub_key_test.py
@@ -7,17 +7,23 @@
 from collections.abc import Callable, Sequence
 
 import pytest
-from btclib_secp256k1.keys import serialize as libsecp256k1_pubkey_serialize
 
 from btclib.alias import INF, Point
+from btclib.b58 import wif_from_prv_key
 from btclib.bip32 import BIP32KeyData, derive, rootxprv_from_seed
-from btclib.curves import PreparedPoint, bytes_from_point, mult
+from btclib.curves import (
+    PreparedPoint,
+    bytes_from_point,
+    mult,
+    point_from_octets,
+)
 from btclib.curves.curve import CURVES
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.to_pub_key import (
     Key,
     PubkeyInfo,
-    _libsecp256k1_pubkey_from_pub_key,
+    _sec_from_key,
+    _sec_from_pub_key,
     fingerprint,
     point_from_key,
     point_from_pub_key,
@@ -334,10 +340,10 @@ def test_a_prepared_point_is_a_key_wherever_a_point_is() -> None:
     use for that word, so each answers by asking itself about the point,
     and what proves it is that the two answers are the same object's.
 
-    Both unions, `PubKey` and the wider `Key`, and the private
-    libsecp256k1 parse below them: a prepared point reaching that one is
-    a verification on the delegated path, where the tables it holds are
-    not what answers.
+    Both unions, `PubKey` and the wider `Key`, and the unproven
+    conversion below them: a prepared point reaching that one is a
+    verification on the delegated path, where the tables it holds are not
+    what answers.
     """
     prepared = PreparedPoint(Q)
 
@@ -351,8 +357,9 @@ def test_a_prepared_point_is_a_key_wherever_a_point_is() -> None:
             prepared, "mainnet", compressed
         ) == pub_keyinfo_from_pub_key(Q, "mainnet", compressed)
 
-    parsed = _libsecp256k1_pubkey_from_pub_key(prepared)
-    assert libsecp256k1_pubkey_serialize(parsed) == bytes_from_point(Q)
+    # the uncompressed form, which is what that conversion answers for a
+    # point: the cheap one for whatever call proves it
+    assert _sec_from_pub_key(prepared) == bytes_from_point(Q, compressed=False)
 
     # and a prepared point of another curve is refused where a bare point
     # of it is: preparing validates against its own curve, so what is
@@ -361,3 +368,46 @@ def test_a_prepared_point_is_a_key_wherever_a_point_is() -> None:
     prepared_r1 = PreparedPoint(mult(12, other.G, other), other)
     with pytest.raises(BTClibValueError, match="not a valid public key"):
         point_from_pub_key(prepared_r1)
+
+
+def test_the_unproven_conversion_takes_every_spelling_a_key_has() -> None:
+    """`_sec_from_key` answers what `pub_keyinfo_from_key` answers.
+
+    The same key, which is what has to hold: the octets differ where the
+    form does -- a point comes back uncompressed here, that being the
+    cheap one for the call this feeds, and compressed from the public
+    spelling, which answers "whatever the key says" and a point says
+    nothing -- so the two are compared as the points they name. A private
+    key as an int and as a WIF, a point, a prepared point, an xpub.
+
+    What this one does not do is prove octets a point: it leaves that to
+    the call it feeds, `script.taproot`'s tweak.
+
+    The refusal is the one spelling that differs, and it is named in the
+    docstring: octets of the right size that are no point reach the call
+    below as a public key, where `pub_keyinfo_from_key` reports them as
+    neither kind of key.
+    """
+    q = 0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF
+    wif = wif_from_prv_key(q)
+    xpub = "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy"
+    point = mult(q)
+
+    for key in (q, wif, point, PreparedPoint(point), xpub):
+        assert point_from_octets(_sec_from_key(key)) == point_from_key(key)
+
+    # what is no key in any spelling is refused in the same words, the
+    # fallthrough to the private key being the same one
+    with pytest.raises(BTClibValueError, match="not a private or public key"):
+        _sec_from_key("not a key")
+    with pytest.raises(BTClibValueError, match="not a private or public key"):
+        pub_keyinfo_from_key("not a key")
+
+    # and the one difference, which the docstring names: 33 octets that
+    # are no point come back from here, for the call that feeds them to
+    # refuse, where the public spelling proves them and reports that they
+    # are neither kind of key
+    no_point = b"\x02" + bytes(32)
+    assert _sec_from_key(no_point) == no_point
+    with pytest.raises(BTClibValueError, match="not a private or public key"):
+        pub_keyinfo_from_key(no_point)

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ test = [
 [[package]]
 name = "btclib-secp256k1"
 version = "0.8.0.3"
-source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#97558f6dac4dc4fd4b49002c7c81c8f8c366e3d0" }
+source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#0b7a17a14ce8757577a29bd6be0a0f65bd261b7a" }
 dependencies = [
     { name = "cffi" },
 ]


### PR DESCRIPTION
btclib held a cffi `CData` in four modules — `curves.curve`,
`curves.sec_point`, `to_pub_key` and `script.taproot` — and called
`keys.parse`, `keys.serialize` and `xonly.parse` to make and unmake it.
It did so to avoid parsing one public key twice.

What that is worth is **0.256 us**: `keys.parse` on the uncompressed
serialization, where both coordinates are there to read, against 2.343 on
the compressed one, which is a field square root. **The uncompressed
serialization is a parsed key** — it costs nothing to open, and nothing
has to own its lifetime.

So the type is gone from btclib, and every `parse` and `serialize` call
with it. `git grep CData btclib/` finds one comment about Core's
`CDataStream`.

### It is not replaced by a second validation

A public key proved a point here and then handed to a call that proves it
again lifts one x twice — which is issue #887 read the other way round.
The fix is not to carry the first proof; it is not to make it.
`to_pub_key._sec_from_pub_key` and `_sec_from_key` are the conversions
without the proof, for a caller whose next call *is* one — `ecc.dsa`'s
verification, `ecc.ssa`'s, `script.taproot`'s tweak — and each translates
the `ValueError` that comes back into btclib's own refusal.

`curves.curve._libsecp256k1_xonly_pubkey_var` goes with them:
`ssa.verify` on the octets validates and verifies in the one parse the
separate lift was paying for anyway. `_y_even_var` and
`_is_x_coordinate_var` ask `keys.reserialize` where they asked a parse
and a serialization, and `curves.sec_point._sec_from_octets` stays as the
proof `pub_keyinfo_from_pub_key` makes, being a function that validates
and nothing else.

Upstream took two changes for this, both landed:
[btclib-secp256k1#162](https://github.com/btclib-org/btclib-secp256k1/pull/162)
(`keys.reserialize`) and
[#163](https://github.com/btclib-org/btclib-secp256k1/pull/163) (every
x-only entry point takes 32, 33 or 65 octets, a BIP340 key being an x).
The argument is recorded in
[btclib-secp256k1#161](https://github.com/btclib-org/btclib-secp256k1/issues/161).

### One refusal moves

Octets of the right size that are no point reach `script.taproot`'s tweak
as the public key they were meant to be, and are refused there as an
invalid internal public key; `pub_keyinfo_from_key`, which proves them,
still reports that they are neither kind of key. Every other message is
unchanged, and the two spellings of "not an x-coordinate" are held equal
on both arithmetics by `tests/ecc/ssa_test.py`, as
`tests/curves/curve_test.py` used to hold them.

### Cost

Apple M5, macOS 26.6, arm64, CPython 3.14.6; median of seven alternating
rounds of 4000 calls, the same harness on both trees, each figure
normalized by a `mult` control that moved 0.65% between them:

| | `abfbac22` | here | |
| --- | --- | --- | --- |
| `dsa.verify`, uncompressed key | 21.071 | 18.922 | **−10.8%** |
| `dsa.verify`, compressed key | 20.623 | 21.026 | +1.3% |
| `dsa.verify`, `Point` | 18.022 | 18.571 | +2.4% |
| `ssa.verify`, x-only | 20.595 | 20.887 | +0.8% |
| `taproot.output_pubkey` | 15.844 | 15.784 | −1.0% |
| `point_from_octets` | 3.525 | 3.538 | 0.0% |

The two slower rows are the argument normalization an octets entry point
does and a parsed-key one skipped. What was bought is the boundary, not
speed; what it cost is inside a couple of percent either way.

### Gates

`uv run pytest` at 100.00% over 27842 tests, `pre-commit run --all-files`
clean, `-W` sphinx build. `uv.lock` moves to the bindings' `main` tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove libsecp256k1 CData usage and ensure boundaries pass public keys as raw octets, relying on downstream parses for validation instead of keeping parsed-key state.

Bug Fixes:
- Align error messages between Python and bindings paths so invalid x-coordinates and non-point public keys are refused consistently by signature and taproot verification.

Enhancements:
- Introduce `_sec_from_pub_key` and `_sec_from_key` helpers to convert keys to SEC octets without validating, for callers whose next step performs the proof.
- Refine secp256k1 helper logic to use `keys.reserialize` rather than parse/serialize pairs, simplifying x-coordinate checks and point validation.
- Update DSA and SSA verification to use octet-based libsecp256k1 entry points and delegate key validation to the verification parse, avoiding double lifts of the same x.
- Adjust taproot output key construction to tweak using octets (or full SEC when available) instead of stored parsed pubkeys, keeping all libsecp256k1 interactions byte-based.

Documentation:
- Document the new octet-only libsecp256k1 boundary, the removal of CData usage, and the performance/behavioural implications in the changelog.

Tests:
- Extend and adjust tests to cover the new unproven key conversions, octet-only verification paths, and equality of error messages across Python and binding implementations.
- Update curve and SSA tests to reflect removal of the x-only parsed-key helper and to ensure invalid x-coordinate and non-point key refusals are identical on both paths.

Chores:
- Advance `uv.lock` to the latest btclib-secp256k1 bindings that provide `keys.reserialize` and widened x-only entry points.