### PR TITLE
Validate a public key with a verdict, not with a serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1351,6 +1351,31 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **Validating a public key answers a verdict, not a serialization.**
+  The octets-only boundary below validated with `keys.reserialize`, which
+  is `secp256k1_ec_pubkey_parse` and a serialization of what it read back
+  into the form it came in — so `pub_keyinfo_from_pub_key` was paying
+  0.37 us to be handed the octets it had passed in. Profiling a
+  verification showed it exactly: the parse count unchanged and 40 000
+  serializations added over 40 000 calls, which was the whole of that
+  entry's cost on the rows where it had one.
+
+  `keys.pubkey_verify` is that parse with nothing kept
+  (btclib-secp256k1#164, and #166 folded it into `parse`'s own body), and
+  it is what `curves.sec_point._sec_from_octets` and
+  `curves.curve._is_x_coordinate_var` now ask. The second of the two
+  wanted a bool all along and had a `try`/`except` around a call that
+  built one. `_y_even_var` keeps `reserialize`: what it reads is the y in
+  the octets that come back.
+
+  Measured as the entry below, both trees against the same bindings
+  commit, control within 0.6%: `dsa.verify` **4.0 to 5.1% faster** across
+  the three spellings of a key, `ssa.verify` **6.0%**, taproot and
+  `point_from_octets` unchanged. Composed with the entry below, which is
+  the other half of the same measurement, every one of those is now
+  faster than it was before the boundary was moved — the uncompressed
+  key by 13.8%, the others between 1.3 and 2.9.
+
 - **The boundary with libsecp256k1 speaks only octets.** btclib held a
   cffi `CData` in four modules — `curves.curve`, `curves.sec_point`,
   `to_pub_key` and, briefly, `script.taproot` — and called `keys.parse`,

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -38,6 +38,7 @@ from typing import Any
 from btclib_secp256k1.keys import pubkey_combine as libsecp256k1_pubkey_combine
 from btclib_secp256k1.keys import pubkey_tweak_add as libsecp256k1_pubkey_tweak_add
 from btclib_secp256k1.keys import pubkey_tweak_mul as libsecp256k1_pubkey_tweak_mul
+from btclib_secp256k1.keys import pubkey_verify as libsecp256k1_pubkey_verify
 from btclib_secp256k1.keys import reserialize as libsecp256k1_reserialize
 from btclib_secp256k1.mult import mult as libsecp256k1_mult
 
@@ -478,10 +479,11 @@ def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
     Existence and nothing else, which is what a caller with no use for
     the y has to ask, and it is a question the Legendre symbol answers
     without ever forming a root: 14 us on secp256k1 against the 75 of
-    ec.y, and ec_pubkey_parse answers the same of the compressed key
-    0x02 || x in 2.4 -- the same answer three ways, all three refusing
-    the same x. It is libsecp256k1's own shape, `secp256k1_ge_x_on_curve_var`
-    being `secp256k1_fe_is_square_var` of x^3 + ax + b and nothing else.
+    ec.y, and `keys.pubkey_verify` answers the same of the compressed key
+    0x02 || x in 2.4, being ec_pubkey_parse and a verdict -- the same
+    answer three ways, all three refusing the same x. It is
+    libsecp256k1's own shape, `secp256k1_ge_x_on_curve_var` being
+    `secp256k1_fe_is_square_var` of x^3 + ax + b and nothing else.
 
     A bool rather than an exception, because the value that names itself
     in an error message is the caller's and not this x: dsa.Sig's
@@ -492,11 +494,7 @@ def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
     """
     sec = _compressed_sec(x, ec)
     if sec is not None:
-        try:
-            libsecp256k1_reserialize(sec)
-        except ValueError:
-            return False
-        return True
+        return libsecp256k1_pubkey_verify(sec)
 
     if not 0 <= x < ec.p:
         return False

--- a/btclib/curves/sec_point.py
+++ b/btclib/curves/sec_point.py
@@ -10,7 +10,7 @@ from btclib_secp256k1.keys import (
     pubkey_from_prvkey as libsecp256k1_pubkey_from_prvkey,
 )
 from btclib_secp256k1.keys import pubkey_tweak_mul as libsecp256k1_pubkey_tweak_mul
-from btclib_secp256k1.keys import reserialize as libsecp256k1_reserialize
+from btclib_secp256k1.keys import pubkey_verify as libsecp256k1_pubkey_verify
 
 from btclib.alias import Integer, Octets, Point
 from btclib.curves.curve import (
@@ -183,15 +183,16 @@ def _sec_from_octets(pub_key: bytes, ec: Curve) -> bytes:
     them a point of the curve -- which is the whole of what
     to_pub_key.pub_keyinfo_from_pub_key wants of it.
 
-    For a compressed key on secp256k1 that proof is `keys.reserialize`,
-    which is ec_pubkey_parse and a serialization of what it read back into
-    the form it came in: 2.7 us against the 4.4 of a round trip that lifts
-    x, re-proves the point it lifted on the curve and serializes it again.
-    The parse is also the very call libsecp256k1 will make on these bytes
-    if they are on their way to its dsa.verify -- which is why a caller
-    that is about to make it does not come through here at all, but
-    through `to_pub_key._sec_from_pub_key`, and lets that call be the
-    proof (issue 887).
+    For a compressed key on secp256k1 that proof is `keys.pubkey_verify`,
+    which is ec_pubkey_parse and a verdict: 2.4 us against the 4.4 of a
+    round trip that lifts x, re-proves the point it lifted on the curve
+    and serializes it again -- and against the 2.7 of `keys.reserialize`,
+    which answers the octets this already has. The parse is also the very
+    call libsecp256k1 will make on these bytes if they are on their way to
+    its dsa.verify -- which is why a caller that is about to make it does
+    not come through here at all, but through
+    `to_pub_key._sec_from_pub_key`, and lets that call be the proof
+    (issue 887).
 
     Anything the bindings refuse falls through to the round trip, and so
     does every 65-byte form: the message that names what is wrong with
@@ -201,8 +202,11 @@ def _sec_from_octets(pub_key: bytes, ec: Curve) -> bytes:
     and there is nothing to ask here.
     """
     compressed = len(pub_key) == ec.p_size + 1
-    if compressed and _libsecp256k1_serves(ec, None):
-        with contextlib.suppress(ValueError):
-            return libsecp256k1_reserialize(pub_key)
+    if (
+        compressed
+        and _libsecp256k1_serves(ec, None)
+        and libsecp256k1_pubkey_verify(pub_key)
+    ):
+        return pub_key
 
     return bytes_from_point(point_from_octets(pub_key, ec), ec, compressed)

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ test = [
 [[package]]
 name = "btclib-secp256k1"
 version = "0.8.0.3"
-source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#0b7a17a14ce8757577a29bd6be0a0f65bd261b7a" }
+source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#2f0265b9d1046df86f6005636767eef215a1d627" }
 dependencies = [
     { name = "cffi" },
 ]


### PR DESCRIPTION
The octets-only boundary (#915) validated with `keys.reserialize`, which
is `secp256k1_ec_pubkey_parse` **and a serialization** of what it read,
back into the form it came in. So `pub_keyinfo_from_pub_key` was paying
0.37 us to be handed the octets it had passed in.

Profiling a verification on either side of #915 said it exactly: the
parse count unchanged at 60 000 over 40 000 calls, and **40 000
serializations added**. That was the whole of the cost that PR carried on
the rows where it had one — the +1.3%, +3.2% and +5.0% in its own table.

`keys.pubkey_verify` is that parse with nothing kept
([btclib-secp256k1#164](https://github.com/btclib-org/btclib-secp256k1/pull/164),
and #166 folded it into `parse`'s own body upstream), and it is what
`curves.sec_point._sec_from_octets` and `curves.curve._is_x_coordinate_var`
now ask. The second wanted a bool all along, and had a `try`/`except`
around a call that built an object to get one. `_y_even_var` keeps
`reserialize`: what it reads is the y in the octets that come back.

### Measured

Both trees against the same bindings commit (2f0265b), median of seven
alternating rounds of 4000 calls, control within 0.6%:

| | `main` | here | |
| --- | --- | --- | --- |
| `dsa.verify`, compressed | 22.900 | 21.969 | −4.1% |
| `dsa.verify`, uncompressed | 20.749 | 19.926 | −4.0% |
| `dsa.verify`, `Point` | 20.401 | 19.364 | −5.1% |
| `ssa.verify`, x-only | 22.290 | 20.960 | −6.0% |
| `taproot.output_pubkey` | 17.611 | 17.753 | +0.8% |
| `point_from_octets` | 4.142 | 4.116 | −0.6% |

Composed with #915's own table, which is the other half of the same
question, every row is now faster than before the boundary moved: the
uncompressed key by 13.8%, the others between 1.3 and 2.9%. Taproot is
unchanged and does not come through this path at all — the two figures
overlap in their spread.

The two comparisons cannot be collapsed into one measurement, and this is
the reason: **the pre-#915 tree no longer runs against the current
bindings.** `dsa.verify_` is private now (`_verify_`, upstream #165), and
that tree calls it. #915 is what keeps btclib building against the
bindings' `main`.

### Gates

`uv run pytest` at 100.00% over 27842 tests, `pre-commit run --all-files`
clean, `-W` sphinx build. `uv.lock` moves to the bindings' `main` tip,
which carries #164, #165 and #166 — the suite passes against it unchanged
apart from this entry, the whole `foo_` → `_foo_` rename touching nothing
here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Validate secp256k1 public keys using libsecp256k1’s verdict-only pubkey verification instead of round-tripping serializations, improving key handling performance without changing behavior.

Enhancements:
- Use libsecp256k1 pubkey_verify in sec_point._sec_from_octets to accept already-valid compressed public keys without reserialization.
- Simplify curve._is_x_coordinate_var to call pubkey_verify directly for x-only keys, replacing exception-based control flow with a boolean verdict.

Build:
- Update the uv.lock file to track the latest btclib_secp256k1 bindings that provide pubkey_verify and related changes.

Documentation:
- Extend the changelog with an entry explaining the switch from reserialize to pubkey_verify for public key validation and the measured performance gains across signature verification paths.