### PR TITLE
Hand the bindings the point in the form they read, not the one they lift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1351,6 +1351,22 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **Two calls handed libsecp256k1 the expensive serialization of a point
+  they were holding.** `ecc.dh.diffie_hellman` and
+  `ecc.ellswift.encode_var` each have a `Point` and serialize it for the
+  bindings, and `bytes_from_point` writes the compressed form unless told
+  otherwise -- so what crossed was 33 octets that libsecp256k1 opens with
+  a field square root, where the 65 it could have been handed are read.
+  Both write the uncompressed form now: `pubkey_tweak_mul` **12.63 us
+  against 14.73**, `ellswift.encode` **13.06 against 15.11**, and the 32
+  octets more cost 0.09 us to write.
+
+  There is nothing to choose here, which is what makes it worth writing
+  down: a caller serializing a point *for* the bindings has no reason to
+  compress it, and `curves.curve._sec_from_point` -- the one the
+  arithmetic uses -- has said so in its docstring since it was written.
+  These two predate it and were never revisited.
+
 - **Validating a public key answers a verdict, not a serialization.**
   The octets-only boundary below validated with `keys.reserialize`, which
   is `secp256k1_ec_pubkey_parse` and a serialization of what it read back

--- a/btclib/ecc/dh.py
+++ b/btclib/ecc/dh.py
@@ -106,7 +106,13 @@ def diffie_hellman(
     # they have no serialization for either. Both are the Python path's
     # to answer, and it answers them below
     if d and _libsecp256k1_serves(ec, None):
-        sec = libsecp256k1_keys.pubkey_tweak_mul(bytes_from_point(QV, ec), d)
+        # uncompressed, which is the cheap form to hand over: parsing 65
+        # octets reads both coordinates where 33 are a field square root,
+        # and the point is here to be written either way -- 12.6 us
+        # against 14.7 for the multiplication that follows
+        sec = libsecp256k1_keys.pubkey_tweak_mul(
+            bytes_from_point(QV, ec, compressed=False), d
+        )
         return ansi_x9_63_kdf(sec[1:], size, hf, shared_info)
 
     shared_secret_point = mult(dU, QV, ec)

--- a/btclib/ecc/ellswift.py
+++ b/btclib/ecc/ellswift.py
@@ -293,7 +293,10 @@ def encode_var(pub_key: PubKey, ec: Curve = secp256k1) -> bytes:
     Q = point_from_pub_key(pub_key, ec)
 
     if _libsecp256k1_serves(ec, None):
-        return libsecp256k1_ellswift.encode(bytes_from_point(Q, ec))
+        # uncompressed, as in `dh.diffie_hellman`: the encoding parses
+        # what it is handed, and 65 octets are read where 33 are lifted --
+        # 13.1 us against 15.1
+        return libsecp256k1_ellswift.encode(bytes_from_point(Q, ec, compressed=False))
 
     _constants(ec)
     return _ell_from_point(Q, ec)


### PR DESCRIPTION
`ecc.dh.diffie_hellman` and `ecc.ellswift.encode_var` each hold a `Point`
and serialize it for libsecp256k1. `bytes_from_point` writes the
compressed form unless told otherwise, so what crossed was 33 octets that
the bindings open with a **field square root** — where the 65 they could
have been handed are read.

| | compressed | uncompressed |
| --- | --- | --- |
| `keys.pubkey_tweak_mul` | 14.729 us | **12.634** |
| `ellswift.encode` | 15.114 us | **13.061** |

The 32 octets more cost 0.09 us to write. There is nothing to trade here,
which is what makes it worth writing down rather than just doing: a
caller serializing a point *for* the bindings has no reason to compress
it, and `curves.curve._sec_from_point` — the one the delegated arithmetic
uses — has said exactly that in its docstring since it was written. These
two predate it and were never revisited.

Found by walking every contact point with the bindings and asking not
"how many crossings" but "in which form": the other two answers of that
walk are ECDSA's DER, which is a separate issue, and BIP32's offset,
which is bytes read into an int for a range check and written back out.

Median of seven alternating rounds of 20000 calls, Apple M5, macOS 26.6,
arm64, CPython 3.14.6, `mult` control within 0.5%.

`uv run pytest` at 100.00%, `pre-commit run --all-files` clean, `-W`
sphinx build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize libsecp256k1 integration by passing points in uncompressed form where they are parsed as such.

Enhancements:
- Use uncompressed point serialization for Diffie-Hellman pubkey tweak multiplication to avoid unnecessary compressed parsing overhead.
- Use uncompressed point serialization for EllSwift variable encoding to remove the cost of decompressing points in the bindings.

Documentation:
- Update changelog to document the switch to uncompressed point serialization for libsecp256k1-backed operations and its performance impact.