### PR TITLE
Leave BIP32's offset in the octets the hash wrote it in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1351,6 +1351,22 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **BIP32's offset stays the octets the hash left.** `_pub_key_offset`
+  read the hmac's left half into an integer, compared it with the group
+  order, and handed it to `keys.pubkey_tweak_add` — which writes it back
+  into the same 32 octets, `scalar` being what every bindings entry point
+  takes a tweak through. `pub_key_derivation_tweaks` wrote them a second
+  time, its answer being octets too.
+
+  Big-endian bytes of one width compare as the numbers they spell, so the
+  range check is made where the hash left the value and nothing reads an
+  integer out of it. **0.10 us a level**, and 0.17 in the tweaks, which
+  is 0.4 to 1.1% of a derivation depending on how deep the path is;
+  measured against `9bf27eb1` with a `b58decode` control that moved 0.2%.
+  The private half already worked this way for its key -- "so that no
+  arithmetic on the secret happens here" -- and this is the same
+  reasoning about the tweak beside it.
+
 - **Two calls handed libsecp256k1 the expensive serialization of a point
   they were holding.** `ecc.dh.diffie_hellman` and
   `ecc.ellswift.encode_var` each have a `Point` and serialize it for the

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -559,6 +559,14 @@ class _BIP32KeyData:
         return self.key[0] == 0
 
 
+# the group order as the 32 octets a scalar is written in: big-endian
+# bytes of one width compare as the numbers they spell, so the range
+# check BIP32 makes of the hmac's left half is made where the hash left
+# it, and neither the check nor the tweak that follows reads an integer
+# out of it
+_N_BYTES = secp256k1.n.to_bytes(secp256k1.n_size, byteorder="big")
+
+
 def _invalid_child(index: int, reason: str) -> BTClibValueError:
     """Return the error for a child BIP32 declares invalid.
 
@@ -586,8 +594,8 @@ def __prv_key_derivation(xkey: _BIP32KeyData, index: int, pub_key: bytes) -> Non
     )
     xb += index.to_bytes(4, byteorder="big", signed=False)
     hmac_ = hmac.new(xkey.chain_code, xb, "sha512").digest()
-    offset = int.from_bytes(hmac_[:32], byteorder="big", signed=False)
-    if offset >= secp256k1.n:
+    offset = hmac_[:32]
+    if offset >= _N_BYTES:
         raise _invalid_child(index, "the hmac left half is not a valid scalar")
 
     # the sum of two scalars, one of them the parent private key:
@@ -616,7 +624,7 @@ def __prv_key_derivation(xkey: _BIP32KeyData, index: int, pub_key: bytes) -> Non
     xkey.key = b"\x00" + key
 
 
-def _pub_key_offset(chain_code: bytes, key: bytes, index: int) -> tuple[int, bytes]:
+def _pub_key_offset(chain_code: bytes, key: bytes, index: int) -> tuple[bytes, bytes]:
     """Return what an unhardened index adds, and the child chain code.
 
     The scalar alone, without the point it is added to: BIP32 derives a
@@ -624,11 +632,16 @@ def _pub_key_offset(chain_code: bytes, key: bytes, index: int) -> tuple[int, byt
     a caller which is not deriving a key of its own needs --
     `pub_key_derivation_tweaks` below, and through it the MuSig2
     aggregate keys of BIP328, which have no private key to derive with.
+
+    The 32 octets of the hmac's left half, not the integer they spell:
+    what reads them is `keys.pubkey_tweak_add`, which takes octets, and
+    what `pub_key_derivation_tweaks` answers is octets too, so an integer
+    here would be read out of the hash and written straight back.
     """
     xb = key + index.to_bytes(4, byteorder="big", signed=False)
     hmac_ = hmac.new(chain_code, xb, "sha512").digest()
-    offset = int.from_bytes(hmac_[:32], byteorder="big", signed=False)
-    if offset >= secp256k1.n:
+    offset = hmac_[:32]
+    if offset >= _N_BYTES:
         raise _invalid_child(index, "the hmac left half is not a valid scalar")
     return offset, hmac_[32:]
 
@@ -683,7 +696,7 @@ def pub_key_derivation_tweaks(
     tweaks: list[bytes] = []
     for index in indexes:
         offset, code = _pub_key_offset(code, key, index)
-        tweaks.append(offset.to_bytes(32, byteorder="big"))
+        tweaks.append(offset)
         key = chain.tweak_add(offset, compressed=True)
     return tweaks
 


### PR DESCRIPTION
`_pub_key_offset` read the hmac's left half into an integer, compared it
with the group order, and handed it to `keys.pubkey_tweak_add` — which
writes it back into the same 32 octets, `scalar` being what every
bindings entry point takes a tweak through. `pub_key_derivation_tweaks`
wrote them a second time, its own answer being octets.

Big-endian bytes of one width compare as the numbers they spell, so the
range check is made where the hash left the value, and neither it nor the
tweak that follows reads an integer out of it.

**0.10 us a level**, and 0.17 in the tweaks, which is 0.4 to 1.1% of a
derivation depending on how deep the path is — median of seven
alternating rounds of 2000 calls against `9bf27eb1`, with a `b58decode`
control that moved 0.2%. Small, and the reason to write it is as much
that the round trip was through a value nothing reads: the private half
already worked this way for its key, "so that no arithmetic on the secret
happens here", and this is the same reasoning about the tweak beside it.

Found by walking every contact point with the bindings and asking in
which *form* each value crosses — the third answer of that walk, after
[#921](https://github.com/btclib-org/btclib/pull/921) and
[#922](https://github.com/btclib-org/btclib/issues/922).

`uv run pytest` at 100.00%, `pre-commit run --all-files` clean, `-W`
sphinx build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Avoid unnecessary integer conversions in BIP32 public key derivation by keeping HMAC-derived offsets as raw 32-byte values and aligning the range check and tweak handling with this byte representation.

Enhancements:
- Reuse a precomputed byte representation of the secp256k1 group order for scalar range checks in both private and public key derivation paths.
- Streamline `pub_key_derivation_tweaks` and `_pub_key_offset` to operate directly on HMAC output bytes rather than converting to and from integers, improving performance and consistency with the private key path.

Documentation:
- Document the BIP32 offset representation and the associated performance and security reasoning in the changelog.