### PR TITLE
Cross the boundary with the two scalars a signature is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1351,6 +1351,41 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **An ECDSA signature crosses the boundary as the two scalars it is**
+  (issue #922). It crossed as DER at both ends: `assert_as_valid_` wrote
+  the ASN.1 structure for a call whose first act is `parse_der`, and
+  `sign_` read one back that libsecp256k1 had just written -- once per
+  attempt under low-r grinding, where the loop parses what it may throw
+  away. `dsa.sign` and `dsa.verify` take a `compact` flag now
+  (btclib-secp256k1#168), so what crosses is `r || s`: writing it is 0.08
+  us against 0.71, reading it 0.32 against 1.25.
+
+  **`dsa.sign` 14.08 us against 15.35, `sign_` without grinding 13.61
+  against 14.91, `dsa.verify` 20.79 against 21.54** -- 7.7% and 2.9% of a
+  signature and a verification, normalized by a `mult` control that moved
+  0.6%, median of seven alternating rounds of 4000 calls on the machine
+  the entries above name.
+
+  `_compact` and `_sig_from_compact` are the two conversions, written
+  once: `sign_recoverable` read r and s by hand and
+  `_libsecp256k1_recover_sec_` wrote them by hand, both of them because
+  the recoverable entry points have always spoken in the compact form --
+  that path made this decision long ago, and the plain one had not. Its
+  own figure is unchanged, which is what says the helpers cost nothing.
+
+  What still crosses as DER is the wire: `script.engine` hands
+  libsecp256k1 the signature the script carries, unparsed, and
+  re-encoding consensus data would be a second opinion about what the
+  transaction says. `Sig.serialize` and `Sig.parse` are unchanged, and
+  are still what a caller reading or writing a signature gets.
+
+- **A comment named a function that had gone private.**
+  `ecc.ssa._x_from_bip340pub_key` cited `libsecp256k1_ssa.verify_`, which
+  is `_verify_` since btclib-secp256k1#165 and is not what btclib calls
+  anyway: `verify` on the octets is, since #915. The reasoning the
+  comment gives is unchanged and correct; only the name it hangs on had
+  moved.
+
 - **BIP32's offset stays the octets the hash left.** `_pub_key_offset`
   read the hmac's left half into an integer, compared it with the group
   order, and handed it to `keys.pubkey_tweak_add` — which writes it back

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -354,6 +354,33 @@ class Sig:
         return cls(r, s, ec, check_validity=check_validity)
 
 
+def _compact(sig: Sig) -> bytes:
+    """Return r || s, the 64 octets libsecp256k1 takes a signature in.
+
+    A signature is two scalars, and this is them: `Sig.serialize` writes
+    the DER the wire carries, which the bindings would take apart again --
+    0.71 us to write and 1.25 to read back, against 0.08 and 0.32 here
+    (issue 922). Nothing is validated, the caller having a `Sig` whose
+    `assert_valid` has run or whose values libsecp256k1 has just computed.
+    """
+    n_size = sig.ec.n_size
+    out = sig.r.to_bytes(n_size, byteorder="big", signed=False)
+    return out + sig.s.to_bytes(n_size, byteorder="big", signed=False)
+
+
+def _sig_from_compact(compact: bytes, ec: Curve) -> Sig:
+    """Return the Sig of 64 octets libsecp256k1 has just written.
+
+    The inverse of `_compact` above, and unvalidated for the same reason:
+    r and s are what secp256k1_ecdsa_sign computed, so `check_validity`
+    would ask the library to prove its own output (issue 888).
+    """
+    n_size = ec.n_size
+    r = int.from_bytes(compact[:n_size], byteorder="big", signed=False)
+    s = int.from_bytes(compact[n_size:], byteorder="big", signed=False)
+    return Sig(r, s, ec, check_validity=False)
+
+
 def gen_keys(prv_key: PrvKey | None = None, ec: Curve = secp256k1) -> tuple[int, Point]:
     """Return a private/public (int, Point) key-pair."""
     # here rather than in the branch below that reads n off the curve: a
@@ -643,15 +670,20 @@ def sign_(
         # one attempt is 16.99 us against 14.22, eight are 132.76 against
         # 110.53.
         #
-        # Reading r off the DER instead, and building one Sig after the loop
-        # settles, was measured and not taken: it saves the object of each
-        # discarded attempt, 1.25 us against 0.53 for a read of r alone, so
-        # 0.7 us an attempt, and it costs a second DER reader beside
-        # `Sig.parse` with no validation in it
+        # The compact form, r || s, and not the DER `sign` answers by
+        # default: a signature is two scalars, and the DER would be
+        # written by libsecp256k1 and taken apart again here -- 1.25 us to
+        # read against the 0.32 of `_sig_from_compact` (issue 922), once
+        # per attempt. What that also settles is the question the previous
+        # paragraph left open: reading r alone and building one Sig after
+        # the loop is now worth 0.32 us an attempt rather than 0.7, and it
+        # would still cost a second reader beside this one
         return _grind_low_r(
-            lambda counter: Sig.parse(
-                libsecp256k1_dsa.sign(msg_hash, q, _grind_entropy(counter)),
-                check_validity=False,
+            lambda counter: _sig_from_compact(
+                libsecp256k1_dsa.sign(
+                    msg_hash, q, _grind_entropy(counter), compact=True
+                ),
+                ec,
             ),
             grind,
             ec,
@@ -810,12 +842,10 @@ def sign_recoverable_(
         # encoding sign_ parses would have to be taken apart again, the
         # key_id being what this call is made for
         sig_bytes, key_id = libsecp256k1_recovery.sign(msg_hash, q)
-        n_size = ec.n_size
-        r = int.from_bytes(sig_bytes[:n_size], byteorder="big", signed=False)
-        s = int.from_bytes(sig_bytes[n_size:], byteorder="big", signed=False)
-        # check_validity=False for `sign_`'s reason above: these are the
-        # values secp256k1_ecdsa_sign_recoverable has just computed
-        return Sig(r, s, ec, check_validity=False), key_id
+        # `_sig_from_compact` for `sign_`'s reason, stated there: these
+        # are the values secp256k1_ecdsa_sign_recoverable has just
+        # computed, and nothing here proves the library its own output
+        return _sig_from_compact(sig_bytes, ec), key_id
 
     # the challenge
     c = challenge_(msg_hash, ec, hf)  # 4, 5
@@ -989,12 +1019,15 @@ def assert_as_valid_(
         # twice -- 2.35 us of a 22.78 us verification (issue 887). So a
         # key that is no point leaves through the ValueError caught below
         sec = _sec_from_pub_key(key)
-        # check_validity=False, because assert_valid has just run above --
-        # on the Sig handed in, or inside the Sig.parse that made one.
-        # What it would run again is the congruence check of r, which is
-        # not free even delegated: 0.54 us against 3.1, of a verification
-        # that is 22 in total
-        sig_bytes = sig.serialize(check_validity=False)
+        # the compact form, which is the signature: `Sig.serialize` would
+        # write the DER the wire carries for a call whose first act is to
+        # take it apart again, 0.71 us against 0.08 (issue 922). It also
+        # validated, and assert_valid has just run above -- on the Sig
+        # handed in, or inside the Sig.parse that made one -- so what that
+        # would run again is the congruence check of r, not free even
+        # delegated: 0.54 us against 3.1, of a verification that is 22 in
+        # total
+        sig_bytes = _compact(sig)
         # normalize=True, because libsecp256k1 rejects what is not in the
         # lower-s form and which form a signature is in was the signer's
         # choice: normalizing is right where refusing would not be. Asked
@@ -1005,7 +1038,7 @@ def assert_as_valid_(
         # signature_normalize (issue 889)
         try:
             verified = libsecp256k1_dsa.verify(
-                msg_hash_bytes, sec, sig_bytes, normalize=True
+                msg_hash_bytes, sec, sig_bytes, normalize=True, compact=True
             )
         except ValueError as e:
             # what the octets were not: a point of the curve. Never echoed,
@@ -1529,9 +1562,7 @@ def _libsecp256k1_recover_sec_(
     if lower_s and sig.s > sig.ec.n // 2:
         raise BTClibValueError("not a low s")
 
-    n_size = sig.ec.n_size
-    compact = sig.r.to_bytes(n_size, byteorder="big", signed=False)
-    compact += sig.s.to_bytes(n_size, byteorder="big", signed=False)
+    compact = _compact(sig)
     try:
         # the serialization asked for, rather than the compressed default
         # undone by a parse: the rf <= 30 case of a message signature

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -243,8 +243,9 @@ def _x_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve) -> int:
     The dispatch over the spellings, without the lift that
     `point_from_bip340pub_key` puts on top of it: what an x-only key is
     unlifted is an x, and a verification through the bindings has no use
-    for the y -- `libsecp256k1_ssa.verify_` takes the x-only key, and
-    proving x an x-coordinate is what parsing it does anyway (issue 887).
+    for the y -- `libsecp256k1_ssa.verify` takes the x-only octets, and
+    proving x an x-coordinate is what parsing them does anyway (issue
+    887).
 
     So the x that comes back here is not proved to be an x-coordinate of
     anything: it is validated as far as its spelling goes, and whoever

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ test = [
 [[package]]
 name = "btclib-secp256k1"
 version = "0.8.0.3"
-source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#2f0265b9d1046df86f6005636767eef215a1d627" }
+source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#8d6f248ec44635dde1514f897f035e9f95aefbdd" }
 dependencies = [
     { name = "cffi" },
 ]


### PR DESCRIPTION
Closes #922.

An ECDSA signature crossed as DER at both ends: `assert_as_valid_` wrote
the ASN.1 structure for a call whose first act is `parse_der`, and
`sign_` read one back that libsecp256k1 had just written — **once per
attempt** under low-r grinding, where the loop parses what it may throw
away.

`dsa.sign` and `dsa.verify` take a `compact` flag since
[btclib-secp256k1#168](https://github.com/btclib-org/btclib-secp256k1/pull/168),
so what crosses is `r || s`: writing it is 0.08 us against 0.71, reading
it 0.32 against 1.25.

| | DER | compact | |
| --- | --- | --- | --- |
| `dsa.sign` | 15.345 us | **14.077** | −8.3% |
| `dsa.sign_`, no grinding | 14.914 | **13.605** | −8.8% |
| `dsa.verify` | 21.541 | **20.792** | −3.5% |
| `dsa.sign_recoverable` | 13.914 | 13.878 | — |

Median of seven alternating rounds of 4000 calls, `mult` control within
0.6%, so 7.7% and 2.9% normalized.

`_compact` and `_sig_from_compact` are the two conversions, written once:
`sign_recoverable` read r and s by hand and `_libsecp256k1_recover_sec_`
wrote them by hand, both because the recoverable entry points have always
spoken in the compact form — that path made this decision long ago and
the plain one had not. Its own figure is unchanged, which is what says
the helpers cost nothing.

**What still crosses as DER is the wire.** `script.engine` hands
libsecp256k1 the signature the script carries, unparsed: re-encoding
consensus data would be a second opinion about what the transaction says.
`Sig.serialize` and `Sig.parse` are unchanged and are still what a caller
reading or writing a signature gets — #911 is where whether *those*
should be delegated is asked, and this PR does not answer it.

### Two smaller things, from the same audit

- `ecc.ssa._x_from_bip340pub_key` cited `libsecp256k1_ssa.verify_`, which
  has been `_verify_` since
  [btclib-secp256k1#165](https://github.com/btclib-org/btclib-secp256k1/pull/165)
  and is not what btclib calls anyway — `verify` on the octets is, since
  #915. The reasoning is unchanged; the name it hung on had moved.
- `uv.lock` moves to the bindings' `main` tip (8d6f248), which is where
  the `compact` flag is.

`uv run pytest` at 100.00% over 27842 tests, `pre-commit run --all-files`
clean, `-W` sphinx build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Pass ECDSA signatures across the libsecp256k1 boundary in compact r||s form instead of DER to reduce overhead while keeping on-wire DER unchanged.

Enhancements:
- Introduce helper functions to convert Sig objects to and from the 64-byte compact r||s representation shared with libsecp256k1.
- Update internal ECDSA signing, verification, and key recovery paths to use the compact signature form at the binding boundary, avoiding redundant DER encoding/decoding.
- Clarify SSA documentation comments to reference the current libsecp256k1 verification API correctly.

Documentation:
- Document the switch to compact ECDSA signatures at the libsecp256k1 boundary and its performance impact in the changelog.

Chores:
- Refresh the uv.lock file to align with bindings that expose the compact signature flag.