### PR TITLE
Say once why the bindings' ecdh.shared_secret has no caller here

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4442,6 +4442,29 @@ documented at release-notes length in the first place, and are still in
 
 ### Documentation and the website
 
+- **Why the bindings' `ecdh.shared_secret` has no caller here is now
+  written in one place** (issue #909). It multiplies and hashes in one
+  call, and the hash is SHA256 of the compressed shared point with no way
+  to change it — libsecp256k1 takes it as a C callback. Both sides
+  carried a paragraph saying so, and neither said whether it held for
+  every caller or only for the one it was written under.
+
+  `ecc.dh`'s module docstring now has the verdict over all four
+  ECDH-shaped computations in the tree: `diffie_hellman` derives through
+  SEC 1's ANSI-X9.63-KDF under the caller's hash function,
+  `ecc.ecies.derive_keys` through sha512 cut three ways,
+  `silent_payments.shared_secret` answers the point itself because BIP352
+  tags it with a counter afterwards, and `ecc.ellswift.xdh` is the
+  exception that proves it — BIP324 defines the hash, so that one is
+  delegated whole. What is delegated in the other three is the
+  multiplication, `keys.pubkey_tweak_mul` being that same C call in
+  constant time.
+
+  A shared secret is a protocol's own derivation, and only a protocol
+  that agrees with libsecp256k1's default can hand the whole of it over.
+  `ecies` and `silent_payments` point at that paragraph rather than
+  restating it.
+
 - **`psbt.silent_payments` said its `k` follows an order it does not
   follow.** The module docstring described the BIP375 prose -- codes
   sorted lexicographically by spend key -- and named `_ordered_sp_outputs`

--- a/btclib/ecc/dh.py
+++ b/btclib/ecc/dh.py
@@ -10,6 +10,31 @@ derive symmetric keying data from it through a key derivation
 function. The curve and the KDF are the two things the parties must
 agree on beforehand; ansi_x9_63_kdf is SEC 1's KDF, and
 diffie_hellman is the agreement built on it.
+
+**Why `ecdh.shared_secret` of the bindings has no caller in btclib, and
+this is the place that says so** (issue 909). That function multiplies
+and hashes in one call, and the hash is SHA256 of the compressed shared
+point with no way to change it: libsecp256k1 takes it as a C callback, so
+exposing it would mean calling back into python from the middle of the
+computation. Every ECDH-shaped computation here derives differently, so
+what is delegated is the multiplication -- `keys.pubkey_tweak_mul`, which
+is that same C multiplication, in constant time -- and the derivation
+stays in python:
+
+- `diffie_hellman` below runs SEC 1's ANSI-X9.63-KDF over the
+  x-coordinate, under the hash function the caller passed;
+- `ecc.ecies.derive_keys` hashes the *compressed point* with sha512 and
+  cuts the 64 bytes three ways, which is BIE1's shape and not this one;
+- `silent_payments.shared_secret` answers the point itself: BIP352 tags
+  it with a counter afterwards, and a BIP375 psbt carries it as a point;
+- `ecc.ellswift.xdh` is the exception that proves the rule. BIP324
+  defines the hash, libsecp256k1 implements that definition, and it is
+  delegated whole -- `ellswift.xdh` is one call there.
+
+So the verdict is not that the function is wrong: it is that a shared
+secret is a protocol's own derivation, and only a protocol agreeing with
+libsecp256k1's default can hand the whole of it over. Three of the four
+here do not, and the fourth already does.
 """
 
 from __future__ import annotations
@@ -96,7 +121,8 @@ def diffie_hellman(
 
     `ecdh.shared_secret` of the bindings is a different function and not
     a substitute: it hashes the compressed shared point with SHA256,
-    libsecp256k1's default, where this derives through ANSI-X9.63-KDF.
+    where this derives through ANSI-X9.63-KDF. The module docstring above
+    has that verdict for all four of btclib's ECDH-shaped computations.
     """
     _assert_valid_ec(ec)
     d = dU % ec.n

--- a/btclib/ecc/ecies.py
+++ b/btclib/ecc/ecies.py
@@ -117,6 +117,11 @@ def derive_keys(prv_key: PrvKey, pub_key: PubKey) -> tuple[bytes, bytes, bytes]:
     with its own private key and the ephemeral public key from the
     envelope.
 
+    The multiplication is delegated and the derivation is not, which is
+    :mod:`btclib.ecc.dh`'s verdict for every ECDH-shaped computation here:
+    `ecdh.shared_secret` of the bindings hashes with SHA256 and BIE1 wants
+    sha512 cut three ways.
+
     No infinity check on the shared point, unlike
     :func:`btclib.ecc.dh.diffie_hellman`, which takes a bare int: the
     scalars that could produce one are exactly those `int_from_prv_key`

--- a/btclib/silent_payments.py
+++ b/btclib/silent_payments.py
@@ -530,7 +530,11 @@ def shared_secret(scalar: PrvKey, point: PubKey) -> Point:
 
     The public key stays octets rather than becoming a point: nothing here
     reads a coordinate of it, and `_mult_sec_var` is that multiplication
-    without the round trip through one.
+    without the round trip through one. The point itself is the answer,
+    which is why `ecdh.shared_secret` of the bindings is no substitute --
+    it hashes, and BIP352 tags this point with a counter of its own;
+    :mod:`btclib.ecc.dh` has that verdict for all four of the library's
+    ECDH-shaped computations.
     """
     sec = pub_keyinfo_from_pub_key(point)[0]
     return _mult_sec_var(sec, int_from_prv_key(scalar), secp256k1)


### PR DESCRIPTION
Closes #909.

`ecdh.shared_secret` multiplies and hashes in one call, and the hash is
SHA256 of the compressed shared point with no way to change it —
libsecp256k1 takes it as a C callback, so exposing it would mean calling
back into python from the middle of the computation. Both sides carried a
paragraph saying so, and neither said whether it held for **every** caller
or only for the one it was written under.

The issue asked for that verdict re-derived over every ECDH-shaped
computation in the tree, and written where it can be found. `ecc.dh`'s
module docstring is that place:

- `diffie_hellman` derives through SEC 1's ANSI-X9.63-KDF, under the hash
  function the caller passed;
- `ecc.ecies.derive_keys` hashes the compressed point with sha512 and
  cuts the 64 bytes three ways, which is BIE1's shape;
- `silent_payments.shared_secret` answers the point itself: BIP352 tags
  it with a counter afterwards, and a BIP375 psbt carries it as a point;
- `ecc.ellswift.xdh` is the exception that proves the rule — BIP324
  defines the hash, libsecp256k1 implements that definition, and it is
  delegated whole.

So a shared secret is a protocol's own derivation, and only a protocol
that agrees with libsecp256k1's default can hand the whole of it over:
three of the four do not, and the fourth already does. What is delegated
in the three is the multiplication, `keys.pubkey_tweak_mul` being that
same C call in constant time.

`ecies` and `silent_payments` gain a sentence pointing at that paragraph
rather than restating it; `diffie_hellman`'s own keeps the one-line
reason and points there for the other three.

Prose only — no code changes, and the suite is unchanged at 27842 tests
and 100.00%. `pre-commit run --all-files` clean, `-W` sphinx build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document why the libsecp256k1 bindings’ ecdh.shared_secret helper is not used by btclib and centralize that explanation in the ECDH documentation.

Documentation:
- Expand btclib.ecc.dh module docstring to describe the behavior of all four ECDH-shaped computations and their relationship to the bindings’ ecdh.shared_secret.
- Update ecies and silent_payments documentation to reference the centralized ECDH explanation instead of restating it.
- Add a changelog entry detailing the rationale for not calling the bindings’ ecdh.shared_secret and where that reasoning is documented.