### PR TITLE
Ask the bindings the two x-only questions, and sum the terms once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4600,6 +4600,66 @@ documented at release-notes length in the first place, and are still in
 
 ### Performance
 
+- **A multi-scalar multiplication sums its terms once, not once per
+  term** (issue #917). `_libsecp256k1_multi_mult_` multiplied a term,
+  combined it into a running total, and did that again for the next one,
+  so a sum of n points crossed the boundary with n-1 combines and n-1
+  serializations of a partial total nothing outside the loop wanted. The
+  running total was there for one reason: an intermediate sum at infinity
+  has no serialization, libsecp256k1 answering 0 both for a point it
+  could not read and for a total at infinity, and comparing the
+  coordinates of a total this side held was the only way of telling the
+  two apart. `keys.pubkey_sum` (btclib-secp256k1#171) tells them apart on
+  the other side — the unreadable key raises through the illegal
+  callback, so a `None` back is the infinity and nothing else — and the
+  loop becomes the terms and one sum.
+
+  Measured on this tree, alternating rounds with the terms alone as the
+  control — which is the noise detector, being what neither shape
+  changes:
+
+  | terms | combine per term | one `pubkey_sum` | control (terms only) |
+  | --- | --- | --- | --- |
+  | 2 | 14.57 µs | 14.51 µs | 10.42 µs |
+  | 3 | 24.16 µs | 20.37 µs | 15.77 µs |
+  | 8 | 71.08 µs | 48.72 µs | 42.28 µs |
+  | 20 | 186.86 µs | 118.68 µs | 107.50 µs |
+  | 64 | 612.94 µs | 376.80 µs | 348.46 µs |
+
+  Two terms — `double_mult_var`, and the shape most callers have — are
+  unchanged: one combine either way, and now no comparison. End to end at
+  the caller the issue names, `musig2.key_agg`: five keys 94.05 µs
+  against 105.70, twenty 388.92 against 456.74, sixty-four 1247.33
+  against 1481.49.
+
+  What this does not do is keep the terms beyond the boundary as well,
+  which is the remaining third and needs a multi-multiplication entry
+  point in the bindings rather than a composition here; the issue stays
+  open on that half.
+
+- **Two questions about an x coordinate are asked as x-only questions**
+  (issue #927). `curves.curve._compressed_sec` wrote `0x02 || x` so that
+  `_is_x_coordinate_var` and `_y_even_var` could reach libsecp256k1
+  through the public-key API, there being no x-only call to reach it
+  through: the caller held an x, and what crossed was a compressed public
+  key built to be discarded, carrying a parity nobody chose.
+  `xonly.pubkey_verify` and `xonly.to_pubkey` (btclib-secp256k1#171) are
+  those calls, and the concatenation is theirs now — libsecp256k1
+  converts a point to an x-only key and has nothing the other way, so the
+  lift is a rule and belongs where the other x-only rules are.
+  `_compressed_sec` becomes `_x_octets`, which is the guard and the
+  encoding without the key around them.
+
+  No answer changes: the same x is refused by all three spellings, which
+  `curves` already asserts, and `to_pubkey` raises for an x that is no
+  x-coordinate, which is the one thing `_y_even_var` was already falling
+  through on. Nor is it a speed change, and it was measured before being
+  taken: 2.44 µs against 2.37 for the verdict and 3.61 against 3.44 for
+  the lift, the same C work through a different door. `_y_even_var`'s
+  recorded figures are corrected to what reproduces while there — 3.6 µs
+  against `ec.y_even_var`'s 73, and 1.2 more than the verdict rather than
+  the 0.3 that was written, a gap the old spelling measures the same.
+
 - **A point plus a multiple of the generator is one call to the bindings,
   wherever it is written.** BIP32's public derivation, BIP341's output
   key, the outputs and labels of BIP352 and the point a sign-to-contract

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -35,12 +35,12 @@ from math import isqrt
 from pathlib import Path
 from typing import Any
 
-from btclib_secp256k1.keys import pubkey_combine as libsecp256k1_pubkey_combine
+from btclib_secp256k1.keys import pubkey_sum as libsecp256k1_pubkey_sum
 from btclib_secp256k1.keys import pubkey_tweak_add as libsecp256k1_pubkey_tweak_add
 from btclib_secp256k1.keys import pubkey_tweak_mul as libsecp256k1_pubkey_tweak_mul
-from btclib_secp256k1.keys import pubkey_verify as libsecp256k1_pubkey_verify
-from btclib_secp256k1.keys import reserialize as libsecp256k1_reserialize
 from btclib_secp256k1.mult import mult as libsecp256k1_mult
+from btclib_secp256k1.xonly import pubkey_verify as libsecp256k1_xonly_pubkey_verify
+from btclib_secp256k1.xonly import to_pubkey as libsecp256k1_xonly_to_pubkey
 
 from btclib.alias import INF, HashF, Integer, JacPoint, Point
 from btclib.curves.curve_group import (
@@ -458,19 +458,27 @@ def _libsecp256k1_serves(ec: Curve, hf: HashF | None) -> bool:
     return hf is None or hf is sha256
 
 
-def _compressed_sec(x: int, ec: Curve) -> bytes | None:
-    """Return 0x02 || x for the bindings to parse, None if they cannot.
+def _x_octets(x: int, ec: Curve) -> bytes | None:
+    """Return x as the octets the bindings read, None if they cannot.
 
-    The two functions below ask libsecp256k1 the one question a compressed
-    public key is -- "this x, and the y that goes with it" -- and this is
-    the argument they ask it with, plus the conditions under which there
-    is one: the curve has to be secp256k1, and x has to be a field
-    element, ec_pubkey_parse taking no x-coordinate at or above ec.p and
+    The two functions below ask libsecp256k1 about an x coordinate, and
+    this is the argument they ask with, plus the conditions under which
+    there is one: the curve has to be secp256k1, and x has to be a field
+    element, `xonly` taking no x-coordinate at or above ec.p and
     x.to_bytes raising OverflowError rather than answering for one.
+
+    An x-only key and nothing built around it. What crosses used to be
+    0x02 || x, a compressed public key assembled here so that the
+    question could be put through the public-key API, there being no
+    x-only call to put it through; `xonly.pubkey_verify` and
+    `xonly.to_pubkey` are those calls, and the concatenation is theirs
+    now -- libsecp256k1 converting a point to an x-only key and offering
+    nothing the other way, so the lift is a rule and belongs where the
+    other x-only rules are.
     """
     if not _libsecp256k1_serves(ec, None) or not 0 <= x < ec.p:
         return None
-    return b"\x02" + x.to_bytes(ec.p_size, "big")
+    return x.to_bytes(ec.p_size, "big")
 
 
 def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
@@ -479,11 +487,12 @@ def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
     Existence and nothing else, which is what a caller with no use for
     the y has to ask, and it is a question the Legendre symbol answers
     without ever forming a root: 14 us on secp256k1 against the 75 of
-    ec.y, and `keys.pubkey_verify` answers the same of the compressed key
-    0x02 || x in 2.4, being ec_pubkey_parse and a verdict -- the same
+    ec.y, and `xonly.pubkey_verify` answers the same of the x alone in
+    2.4, being secp256k1_xonly_pubkey_parse and a verdict -- the same
     answer three ways, all three refusing the same x. It is
-    libsecp256k1's own shape, `secp256k1_ge_x_on_curve_var` being
-    `secp256k1_fe_is_square_var` of x^3 + ax + b and nothing else.
+    libsecp256k1's own shape,
+    `secp256k1_ge_x_on_curve_var` being `secp256k1_fe_is_square_var` of
+    x^3 + ax + b and nothing else.
 
     A bool rather than an exception, because the value that names itself
     in an error message is the caller's and not this x: dsa.Sig's
@@ -492,9 +501,9 @@ def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
     of the field elements are not x-coordinates, and the symbol costs the
     same for those as for the others.
     """
-    sec = _compressed_sec(x, ec)
-    if sec is not None:
-        return libsecp256k1_pubkey_verify(sec)
+    octets = _x_octets(x, ec)
+    if octets is not None:
+        return libsecp256k1_xonly_pubkey_verify(octets)
 
     if not 0 <= x < ec.p:
         return False
@@ -507,11 +516,11 @@ def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
 def _y_even_var(x: int, ec: Curve) -> int:
     """Return the even y-coordinate associated to x.
 
-    ec.y_even_var, delegated for secp256k1: the parity a compressed public
-    key carries in its prefix is the same tiebreaker, so 0x02 || x names
-    the even-y point and `keys.reserialize` asked for the uncompressed
-    form hands back the y that was lifted -- 2.7 us against 75. That is
-    0.3 more than _is_x_coordinate_var above, which is why both exist.
+    ec.y_even_var, delegated for secp256k1: the even y is the one an
+    x-only key names, so `xonly.to_pubkey` asked for the uncompressed
+    form hands back the y that was lifted -- 3.6 us against 73. That is
+    1.2 more than _is_x_coordinate_var above, which is why both exist:
+    finding the root is what the verdict does not do.
 
     An x the bindings refuse falls through to ec.y_even_var instead of
     raising here, so that the message stays in the one place that has the
@@ -519,12 +528,13 @@ def _y_even_var(x: int, ec: Curve) -> int:
     the callers of this function wrap that message rather than restating
     it. The fallthrough pays the Python square root on a path whose
     answer is an exception, which is the trade _is_x_coordinate_var exists
-    not to make.
+    not to make. `to_pubkey` raises for one thing only -- an x that is no
+    x-coordinate -- which is the one thing this falls through on.
     """
-    sec = _compressed_sec(x, ec)
-    if sec is not None:
+    octets = _x_octets(x, ec)
+    if octets is not None:
         with contextlib.suppress(ValueError):
-            uncompressed = libsecp256k1_reserialize(sec, compressed=False)
+            uncompressed = libsecp256k1_xonly_to_pubkey(octets, compressed=False)
             return int.from_bytes(uncompressed[ec.p_size + 1 :], "big")
 
     return ec.y_even_var(x)
@@ -570,29 +580,31 @@ def _libsecp256k1_multi_mult_(
     answer for: u*H + v*Q with v*Q == -u*H, and v = n - u with Q == H is
     the one-line case of it.
 
-    That sum is recognized from the coordinates, same x and different y,
-    rather than caught from the combine that fails on it, so that a
-    ValueError raised in here still means what it says instead of
-    doubling as a value. Its price is one combine per term rather than
-    one for all of them, a running total being what has an x to compare:
-    measured on eight terms 112 us against 97, and on sixty-four 925
-    against 774, where the Python arithmetic below takes 2.4 ms and 15 ms.
-    Two terms, which is double_mult_var and the shape most callers have, pay
-    nothing at all: one combine either way.
+    `keys.pubkey_sum` is what answers it, being `pubkey_combine` with that
+    one sum answered rather than refused: libsecp256k1 reports 0 both for
+    a key it could not read and for a total at infinity, and the first
+    raises through the illegal callback, so a None back from here is the
+    infinity and nothing else. What that replaces is a combine per term
+    with a running total this side compared coordinates on, the only way
+    of telling the two zeros apart while the sum was assembled here.
+    Terms first, then one sum, which is worth about a third of the call
+    from eight terms up. Two terms -- double_mult_var, and the shape most
+    callers have -- pay nothing either way: one combine, and now no
+    comparison. The measurement per term count is in the CHANGELOG entry
+    that made the change, which is where a figure belongs: an entry is
+    read as the history of a release and this is read as a statement
+    about the code as it stands.
+
+    At least one term, `pubkey_sum` refusing an empty sequence as
+    `pubkey_combine` does. That is no narrowing of what the callers below
+    reach: fewer than two terms is not a multi_mult_var, and the two other
+    entry points hand over one and two.
     """
-    x_slice = slice(1, secp256k1.p_size + 1)
-    total: bytes | None = None
-    for m, sec in zip(scalars, secs, strict=True):
-        term = libsecp256k1_pubkey_tweak_mul(sec, m, False)
-        if total is None:  # nothing yet, or infinity, and INF + P is P
-            total = term
-        elif total != term and total[x_slice] == term[x_slice]:
-            # same x, different y, i.e. P + (-P): infinity. Equal octets
-            # instead are P + P, which combine doubles like any other sum
-            total = None
-        else:
-            total = libsecp256k1_pubkey_combine([total, term], False)
-    return total
+    terms = [
+        libsecp256k1_pubkey_tweak_mul(sec, m, False)
+        for m, sec in zip(scalars, secs, strict=True)
+    ]
+    return libsecp256k1_pubkey_sum(terms, False)
 
 
 def _point_from_sec(sec: bytes) -> Point:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,13 @@ dependencies = [
     # 0.8.0.3 for `xonly.tweak_add_` (btclib-secp256k1#158), which
     # `script.taproot` calls: it tweaks the parsed internal key, where
     # `xonly.tweak_add` parses the x again and that parse is a field square
-    # root. The version is not on PyPI yet -- `[tool.uv.sources]` below is
-    # what resolves it here -- so this floor is also what stops a release
-    # going out against a bindings that cannot serve it
+    # root. The same version for `keys.pubkey_sum`, `xonly.pubkey_verify`
+    # and `xonly.to_pubkey` (btclib-secp256k1#171), which `curves.curve`
+    # calls -- one sum instead of a combine per term, and the two
+    # questions about an x asked as x-only questions. The version is not
+    # on PyPI yet -- `[tool.uv.sources]` below is what resolves it here --
+    # so this floor is also what stops a release going out against a
+    # bindings that cannot serve it
     "btclib_secp256k1>=0.8.0.3",
     "bitcoin-core-rpc>=2026.8.13",
 ]

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -976,8 +976,8 @@ def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
 
     `_libsecp256k1_available` is what `_libsecp256k1_serves` reads on
     every call, so clearing it is the whole package's dispatch and not
-    this module's copy of a predicate. Replacing the four bindings
-    functions besides is what proves they were not asked anyway: a
+    this module's copy of a predicate. Replacing every bindings function
+    the module imports is what proves they were not asked anyway: a
     dispatch this does not cover raises here instead of quietly measuring
     the bindings against themselves.
     """
@@ -994,8 +994,9 @@ def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(curve, "libsecp256k1_mult", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_tweak_add", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_tweak_mul", refuse)
-    monkeypatch.setattr(curve, "libsecp256k1_pubkey_combine", refuse)
-    monkeypatch.setattr(curve, "libsecp256k1_reserialize", refuse)
+    monkeypatch.setattr(curve, "libsecp256k1_pubkey_sum", refuse)
+    monkeypatch.setattr(curve, "libsecp256k1_xonly_pubkey_verify", refuse)
+    monkeypatch.setattr(curve, "libsecp256k1_xonly_to_pubkey", refuse)
 
 
 @pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ test = [
 [[package]]
 name = "btclib-secp256k1"
 version = "0.8.0.3"
-source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#8d6f248ec44635dde1514f897f035e9f95aefbdd" }
+source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#8ee6b2cf9b96f65ae88db2f4833f207a0e79c517" }
 dependencies = [
     { name = "cffi" },
 ]


### PR DESCRIPTION
Two issues, one PR: both consume entry points
[btclib-secp256k1#171](https://github.com/btclib-org/btclib-secp256k1/pull/171)
added, both are in `curves/curve.py`, and both need the same lock bump —
`8d6f248e` → `8ee6b2cf`, still `0.8.0.3`, which is unreleased upstream so
the floor in `pyproject.toml` stays what it was and gains the three names
it is now also for.

## One sum instead of a combine per term (issue #917)

`_libsecp256k1_multi_mult_` multiplied a term, combined it into a running
total, and did that again for the next one, so a sum of n points crossed
the boundary with n-1 combines and n-1 serializations of a partial total
nothing outside the loop wanted. The running total was there for one
reason, and the docstring said so: an intermediate sum at infinity has no
serialization, libsecp256k1 answers 0 both for a point it could not read
and for a total at infinity, and comparing the coordinates of a total
held on this side was the only way of telling the two apart.

`keys.pubkey_sum` tells them apart on the other side — the unreadable key
is reported through the illegal callback and raises — so a `None` back
means infinity and nothing else, and the loop becomes the terms and one
sum.

Measured on this tree, alternating rounds, minimum of seven, with the
terms alone as the control so a difference in *it* would be the noise
floor:

| terms | combine per term | one `pubkey_sum` | control (terms only) |
| --- | --- | --- | --- |
| 2 | 14.57 µs | 14.51 µs | 10.42 µs |
| 3 | 24.16 µs | 20.37 µs | 15.77 µs |
| 8 | 71.08 µs | 48.72 µs | 42.28 µs |
| 20 | 186.86 µs | 118.68 µs | 107.50 µs |
| 64 | 612.94 µs | 376.80 µs | 348.46 µs |

Two terms — `double_mult_var`, and the shape most callers have — are
unchanged, one combine either way and now no comparison. End to end at
the caller the issue names, `musig2.key_agg`, the two sums alternating in
one process: 5 keys 94.05 µs against 105.70, 20 keys 388.92 against
456.74, 64 keys 1247.33 against 1481.49.

**#917 stays open**, per its own comment: this is the `pubkey_sum` half,
which is about two thirds of what is available. The remaining third is
the terms never crossing at all, which needs a multi-multiplication entry
point in the bindings rather than a composition here, and that is a
design question over there.

## Two questions about an x, asked as x-only questions (issue #927)

`_compressed_sec` wrote `0x02 || x` so that `_is_x_coordinate_var` and
`_y_even_var` could reach libsecp256k1 through the public-key API, there
being no x-only call to reach it through: the caller held an x, and what
crossed was a compressed public key built to be discarded, carrying a
parity nobody chose. `xonly.pubkey_verify` and `xonly.to_pubkey` are
those calls, and the concatenation is theirs now — libsecp256k1 converts
a point to an x-only key and has nothing the other way, so the lift is a
rule and belongs where the other x-only rules are. What is left here is
`_x_octets`: the guard and the encoding, without the key around them.

Measured before being taken, as the issue asks, and it is the wash it
predicted — the same C work through a different door:

| | `0x02 ‖ x` through `keys` | x through `xonly` |
| --- | --- | --- |
| `_is_x_coordinate_var` | 2.37 µs | 2.44 µs |
| `_y_even_var` | 3.44 µs | 3.61 µs |

No answer changes: the same x is refused by all three spellings, which
`curves` already asserts, and `to_pubkey` raises for an x that is no
x-coordinate, which is the one thing `_y_even_var` already fell through
on. `curve_test.no_bindings` patches the two new names in place of the
two that are gone, so a dispatch it does not cover still raises rather
than quietly measuring the bindings against themselves.

**One correction while in there.** `_y_even_var`'s docstring recorded 2.7
µs and "0.3 more than `_is_x_coordinate_var`". Neither reproduces on this
machine, and not because of this change — the old spelling measures the
same 3.4 µs, against `ec.y_even_var`'s 73 (the recorded 75). The
docstring now says 3.6 against 73, and 1.2 more than the verdict.

Local gates: `pre-commit run --all-files` green, `pytest` green (27842
passed, coverage 100%), `sphinx-build -W` green.

Closes https://github.com/btclib-org/btclib/issues/927
Part of https://github.com/btclib-org/btclib/issues/917

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve secp256k1-backed curve operations by delegating multi-scalar point sums and x-coordinate queries to new bindings entry points for better performance and clearer semantics.

Enhancements:
- Use `pubkey_sum` for multi-scalar multiplication to perform a single aggregate sum across terms instead of per-term combines, reducing crossing overhead while preserving behavior for infinity results.
- Route x-coordinate existence and even-y queries through x-only bindings (`xonly.pubkey_verify`/`xonly.to_pubkey`) via a new `_x_octets` helper, avoiding ad‑hoc compressed key construction and keeping the lifting rule in the x-only layer.
- Tighten the `no_bindings` test fixture to replace all imported bindings functions, ensuring curve code paths are properly exercised without accidentally calling the C bindings.

Build:
- Extend the minimum `btclib_secp256k1` version requirement to 0.8.0.3 to rely on new `pubkey_sum` and x-only APIs needed by curve operations.

Documentation:
- Document the performance change for multi-scalar summation and the switch to x-only queries in the changelog, including updated micro-benchmarks and corrected timing figures for `_y_even_var`.

Tests:
- Update curve tests to monkeypatch the new bindings functions used by `curves.curve`, keeping the `no_bindings` variant consistent with the module’s imports.