### PR TITLE
Build the batch terms as octets, and say what the batch costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4600,6 +4600,78 @@ documented at release-notes length in the first place, and are still in
 
 ### Performance
 
+- **BIP340 batch verification stops lifting two points a signature**
+  (issue #919). `assert_batch_as_valid_` built each term as a `Point` —
+  `_y_even_var` of `r`, and the lift inside
+  `point_from_bip340pub_key` — whose coordinates the multiplication then
+  wrote straight back out as 65 octets and parsed again. Neither lift is
+  needed for the arithmetic: both terms are the even-y point an x names,
+  which is `0x02 || x`, octets libsecp256k1 lifts itself inside the
+  multiplication that wants the point anyway.
+  `curves.curve._multi_mult_x_only_var` is the two arms — octets where
+  the bindings answer, points where the Python arithmetic does, which is
+  what its terms have to be. It sits beside `_sum_var` and
+  `_libsecp256k1_multi_mult_` rather than in `ecc.ssa`, the
+  concatenation being an x-only rule like the ones `_x_octets` serves:
+  the difference is the door, `pubkey_tweak_mul` reading a public key
+  and libsecp256k1 having no x-only multiplication to hand a bare x to.
+
+  | signatures | two lifts | compressed octets |
+  | --- | --- | --- |
+  | 2 | 89.3 µs | 78.1 µs |
+  | 16 | 681.3 µs | 592.6 µs |
+  | 64 | 2700.3 µs | 2353.2 µs |
+
+ About two thirds of that is `r` alone, whose
+  lift bought least of all: `sig.assert_valid` proves it an x-coordinate
+  above the loop, so the y it found was read for nothing.
+
+  Neither lift was validating anything the multiplication does not.
+  `r` is proved above; a key is proved by the parse, which is that same
+  square root (issue #887, and `assert_as_valid_` has taken this shape
+  since). What the accepting path no longer pays, the refusing path
+  does: which term the bindings could not read is found by asking, and
+  the message is `ec.y_var`'s, the same one the lift raised — a new test
+  pins the two spellings together over the same four x the
+  single-signature twin uses.
+
+- **`ssa.assert_batch_as_valid_` says what it costs, and it is not what
+  the name suggests** (issue #913). It was documented as "cheaper than
+  one verification per signature", which is false on secp256k1 with
+  sha256 and was never measured. Against n delegated `verify_` calls:
+
+  | n | batch | n × `verify_` | per sig, batch | per sig, one by one |
+  | --- | --- | --- | --- | --- |
+  | 2 | 78.1 µs | 36.6 µs | 39.03 | 18.28 |
+  | 4 | 152.3 µs | 73.0 µs | 38.07 | 18.25 |
+  | 8 | 299.5 µs | 146.1 µs | 37.44 | 18.26 |
+  | 16 | 592.6 µs | 291.9 µs | 37.04 | 18.25 |
+  | 64 | 2353.2 µs | 1176.1 µs | 36.77 | 18.38 |
+  | 256 | 9389.9 µs | 4807.3 µs | 36.68 | 18.78 |
+
+  Flat in n on both sides, so there is no crossover to find.
+  libsecp256k1 has no batch verification to delegate to, checked at
+  `687155df` upstream and at the tip of
+  secp256k1-zkp, whose half-aggregation is a different construction, so
+  what the batch saves in multiplications it spends on a Python term per
+  signature against a whole verification that is one C call.
+
+  It stays, and now says why. On the arithmetic it was written for —
+  every other curve, every other hash function, the bindings switched
+  off — the equation is one multi-scalar multiplication where n
+  verifications are n double multiplications, and it overtakes them
+  between four signatures and eight:
+
+  | n | batch (Python) | n × `verify_` (Python) |
+  | --- | --- | --- |
+  | 2 | 1585.5 µs | 1297.9 µs |
+  | 4 | 2716.1 µs | 2627.9 µs |
+  | 8 | 4916.4 µs | 5235.3 µs |
+  | 16 | 9250.0 µs | 10493.9 µs |
+
+  That, and its being BIP340's own algorithm and the reference the
+  delegated path is read against.
+
 - **A multi-scalar multiplication sums its terms once, not once per
   term** (issue #917). `_libsecp256k1_multi_mult_` multiplied a term,
   combined it into a running total, and did that again for the next one,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4600,6 +4600,66 @@ documented at release-notes length in the first place, and are still in
 
 ### Performance
 
+- **A multi-scalar multiplication sums its terms once, not once per
+  term** (issue #917). `_libsecp256k1_multi_mult_` multiplied a term,
+  combined it into a running total, and did that again for the next one,
+  so a sum of n points crossed the boundary with n-1 combines and n-1
+  serializations of a partial total nothing outside the loop wanted. The
+  running total was there for one reason: an intermediate sum at infinity
+  has no serialization, libsecp256k1 answering 0 both for a point it
+  could not read and for a total at infinity, and comparing the
+  coordinates of a total this side held was the only way of telling the
+  two apart. `keys.pubkey_sum` (btclib-secp256k1#171) tells them apart on
+  the other side — the unreadable key raises through the illegal
+  callback, so a `None` back is the infinity and nothing else — and the
+  loop becomes the terms and one sum.
+
+  Measured on this tree, alternating rounds with the terms alone as the
+  control — which is the noise detector, being what neither shape
+  changes:
+
+  | terms | combine per term | one `pubkey_sum` | control (terms only) |
+  | --- | --- | --- | --- |
+  | 2 | 14.57 µs | 14.51 µs | 10.42 µs |
+  | 3 | 24.16 µs | 20.37 µs | 15.77 µs |
+  | 8 | 71.08 µs | 48.72 µs | 42.28 µs |
+  | 20 | 186.86 µs | 118.68 µs | 107.50 µs |
+  | 64 | 612.94 µs | 376.80 µs | 348.46 µs |
+
+  Two terms — `double_mult_var`, and the shape most callers have — are
+  unchanged: one combine either way, and now no comparison. End to end at
+  the caller the issue names, `musig2.key_agg`: five keys 94.05 µs
+  against 105.70, twenty 388.92 against 456.74, sixty-four 1247.33
+  against 1481.49.
+
+  What this does not do is keep the terms beyond the boundary as well,
+  which is the remaining third and needs a multi-multiplication entry
+  point in the bindings rather than a composition here; the issue stays
+  open on that half.
+
+- **Two questions about an x coordinate are asked as x-only questions**
+  (issue #927). `curves.curve._compressed_sec` wrote `0x02 || x` so that
+  `_is_x_coordinate_var` and `_y_even_var` could reach libsecp256k1
+  through the public-key API, there being no x-only call to reach it
+  through: the caller held an x, and what crossed was a compressed public
+  key built to be discarded, carrying a parity nobody chose.
+  `xonly.pubkey_verify` and `xonly.to_pubkey` (btclib-secp256k1#171) are
+  those calls, and the concatenation is theirs now — libsecp256k1
+  converts a point to an x-only key and has nothing the other way, so the
+  lift is a rule and belongs where the other x-only rules are.
+  `_compressed_sec` becomes `_x_octets`, which is the guard and the
+  encoding without the key around them.
+
+  No answer changes: the same x is refused by all three spellings, which
+  `curves` already asserts, and `to_pubkey` raises for an x that is no
+  x-coordinate, which is the one thing `_y_even_var` was already falling
+  through on. Nor is it a speed change, and it was measured before being
+  taken: 2.44 µs against 2.37 for the verdict and 3.61 against 3.44 for
+  the lift, the same C work through a different door. `_y_even_var`'s
+  recorded figures are corrected to what reproduces while there — 3.6 µs
+  against `ec.y_even_var`'s 73, and 1.2 more than the verdict rather than
+  the 0.3 that was written, a gap the old spelling measures the same.
+
 - **A point plus a multiple of the generator is one call to the bindings,
   wherever it is written.** BIP32's public derivation, BIP341's output
   key, the outputs and labels of BIP352 and the point a sign-to-contract

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -607,6 +607,59 @@ def _libsecp256k1_multi_mult_(
     return libsecp256k1_pubkey_sum(terms, False)
 
 
+def _multi_mult_x_only_var(
+    scalars: Sequence[int], x_coords: Sequence[int], ec: Curve
+) -> Point:
+    """Return sum(scalars[i]*P_i), each P_i the even-y point of an x.
+
+    The terms of BIP340's batch verification, which is the one caller and
+    the one place in btclib that hands the bindings many scalars at once,
+    libsecp256k1 exposing no batch verification of its own.
+
+    The two arms differ in what they need of a term. `0x02 || x` is the
+    even-y point an x-only key names, and the bindings lift it inside the
+    multiplication that wants the point anyway; the Python arithmetic
+    takes a `Point`, so there the lift is the work and is paid here. That
+    is why this takes x-coordinates rather than points, and why the
+    concatenation is written here rather than left to `xonly.to_pubkey`:
+    what the octets are on their way to is `pubkey_tweak_mul`, which
+    reads a public key, and libsecp256k1 has no x-only multiplication to
+    hand them to instead. It is the same rule `_x_octets` above serves,
+    reached through the one door that exists for it.
+
+    `_libsecp256k1_multi_mult_` and not the public `multi_mult_var`, that
+    one taking points -- which is the form the lift would have to build
+    and the multiplication would then write straight back out. Sixteen
+    signatures end to end, i.e. the thirty-two terms: 592.6 us against
+    681.3 with both terms lifted by the caller.
+
+    Every scalar is required to be in 1..n-1 and every x to be an
+    x-coordinate. The caller is what holds to that -- ssa's rand is drawn
+    in that range, its challenge is refused at zero, n is prime -- so
+    what is left for the bindings to refuse is a term they cannot read,
+    and finding which is the lift the accepting path does not pay. Issue
+    622 made that trade the other way round in `Sig.assert_valid`, and it
+    is the same one: the refusing path can afford a square root. The
+    message is `ec.y_var`'s, from the lift itself rather than restated.
+    """
+    if _libsecp256k1_serves(ec, None):
+        secs = [b"\x02" + x.to_bytes(ec.p_size, "big") for x in x_coords]
+        try:
+            total = _libsecp256k1_multi_mult_(scalars, secs)
+        except ValueError:
+            for x in x_coords:
+                _y_even_var(x, ec)
+            # the loop above raises, every ValueError from the bindings
+            # here being a term they could not read: the pragma is the
+            # one borromean and bms carry, for a line the arithmetic
+            # rules out
+            raise  # pragma: no cover
+        return INF if total is None else _point_from_sec(total)
+
+    points = [(x, _y_even_var(x, ec)) for x in x_coords]
+    return multi_mult_var(scalars, points, ec)
+
+
 def _point_from_sec(sec: bytes) -> Point:
     """Return the point of an uncompressed 0x04 || x || y serialization.
 
@@ -1003,9 +1056,15 @@ def multi_mult_var(
 
     Interleaved wNAF on few scalars, Bos-Coster on many: curve_group's
     _multi_mult_var dispatches on the count, at the size the two measure the
-    same. On secp256k1 the bindings serve the whole sum instead, and this
-    is the one caller that hands them many scalars at once -- libsecp256k1
-    exposing no batch verification, ssa's is built on this.
+    same. On secp256k1 the bindings serve the whole sum instead.
+
+    ssa's batch verification is what hands many scalars over at once,
+    libsecp256k1 exposing no batch verification of its own, and it is the
+    Python arm of that sum which arrives here: the delegated arm reaches
+    `_libsecp256k1_multi_mult_` below with its terms as octets, this
+    signature taking points and a point being what its terms would have
+    to be lifted into for the multiplication to write them straight back
+    out.
     """
     _assert_valid_ec(ec)
     if len(scalars) != len(points):

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -35,12 +35,12 @@ from math import isqrt
 from pathlib import Path
 from typing import Any
 
-from btclib_secp256k1.keys import pubkey_combine as libsecp256k1_pubkey_combine
+from btclib_secp256k1.keys import pubkey_sum as libsecp256k1_pubkey_sum
 from btclib_secp256k1.keys import pubkey_tweak_add as libsecp256k1_pubkey_tweak_add
 from btclib_secp256k1.keys import pubkey_tweak_mul as libsecp256k1_pubkey_tweak_mul
-from btclib_secp256k1.keys import pubkey_verify as libsecp256k1_pubkey_verify
-from btclib_secp256k1.keys import reserialize as libsecp256k1_reserialize
 from btclib_secp256k1.mult import mult as libsecp256k1_mult
+from btclib_secp256k1.xonly import pubkey_verify as libsecp256k1_xonly_pubkey_verify
+from btclib_secp256k1.xonly import to_pubkey as libsecp256k1_xonly_to_pubkey
 
 from btclib.alias import INF, HashF, Integer, JacPoint, Point
 from btclib.curves.curve_group import (
@@ -458,19 +458,27 @@ def _libsecp256k1_serves(ec: Curve, hf: HashF | None) -> bool:
     return hf is None or hf is sha256
 
 
-def _compressed_sec(x: int, ec: Curve) -> bytes | None:
-    """Return 0x02 || x for the bindings to parse, None if they cannot.
+def _x_octets(x: int, ec: Curve) -> bytes | None:
+    """Return x as the octets the bindings read, None if they cannot.
 
-    The two functions below ask libsecp256k1 the one question a compressed
-    public key is -- "this x, and the y that goes with it" -- and this is
-    the argument they ask it with, plus the conditions under which there
-    is one: the curve has to be secp256k1, and x has to be a field
-    element, ec_pubkey_parse taking no x-coordinate at or above ec.p and
+    The two functions below ask libsecp256k1 about an x coordinate, and
+    this is the argument they ask with, plus the conditions under which
+    there is one: the curve has to be secp256k1, and x has to be a field
+    element, `xonly` taking no x-coordinate at or above ec.p and
     x.to_bytes raising OverflowError rather than answering for one.
+
+    An x-only key and nothing built around it. What crosses used to be
+    0x02 || x, a compressed public key assembled here so that the
+    question could be put through the public-key API, there being no
+    x-only call to put it through; `xonly.pubkey_verify` and
+    `xonly.to_pubkey` are those calls, and the concatenation is theirs
+    now -- libsecp256k1 converting a point to an x-only key and offering
+    nothing the other way, so the lift is a rule and belongs where the
+    other x-only rules are.
     """
     if not _libsecp256k1_serves(ec, None) or not 0 <= x < ec.p:
         return None
-    return b"\x02" + x.to_bytes(ec.p_size, "big")
+    return x.to_bytes(ec.p_size, "big")
 
 
 def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
@@ -479,11 +487,12 @@ def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
     Existence and nothing else, which is what a caller with no use for
     the y has to ask, and it is a question the Legendre symbol answers
     without ever forming a root: 14 us on secp256k1 against the 75 of
-    ec.y, and `keys.pubkey_verify` answers the same of the compressed key
-    0x02 || x in 2.4, being ec_pubkey_parse and a verdict -- the same
+    ec.y, and `xonly.pubkey_verify` answers the same of the x alone in
+    2.4, being secp256k1_xonly_pubkey_parse and a verdict -- the same
     answer three ways, all three refusing the same x. It is
-    libsecp256k1's own shape, `secp256k1_ge_x_on_curve_var` being
-    `secp256k1_fe_is_square_var` of x^3 + ax + b and nothing else.
+    libsecp256k1's own shape,
+    `secp256k1_ge_x_on_curve_var` being `secp256k1_fe_is_square_var` of
+    x^3 + ax + b and nothing else.
 
     A bool rather than an exception, because the value that names itself
     in an error message is the caller's and not this x: dsa.Sig's
@@ -492,9 +501,9 @@ def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
     of the field elements are not x-coordinates, and the symbol costs the
     same for those as for the others.
     """
-    sec = _compressed_sec(x, ec)
-    if sec is not None:
-        return libsecp256k1_pubkey_verify(sec)
+    octets = _x_octets(x, ec)
+    if octets is not None:
+        return libsecp256k1_xonly_pubkey_verify(octets)
 
     if not 0 <= x < ec.p:
         return False
@@ -507,11 +516,11 @@ def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
 def _y_even_var(x: int, ec: Curve) -> int:
     """Return the even y-coordinate associated to x.
 
-    ec.y_even_var, delegated for secp256k1: the parity a compressed public
-    key carries in its prefix is the same tiebreaker, so 0x02 || x names
-    the even-y point and `keys.reserialize` asked for the uncompressed
-    form hands back the y that was lifted -- 2.7 us against 75. That is
-    0.3 more than _is_x_coordinate_var above, which is why both exist.
+    ec.y_even_var, delegated for secp256k1: the even y is the one an
+    x-only key names, so `xonly.to_pubkey` asked for the uncompressed
+    form hands back the y that was lifted -- 3.6 us against 73. That is
+    1.2 more than _is_x_coordinate_var above, which is why both exist:
+    finding the root is what the verdict does not do.
 
     An x the bindings refuse falls through to ec.y_even_var instead of
     raising here, so that the message stays in the one place that has the
@@ -519,12 +528,13 @@ def _y_even_var(x: int, ec: Curve) -> int:
     the callers of this function wrap that message rather than restating
     it. The fallthrough pays the Python square root on a path whose
     answer is an exception, which is the trade _is_x_coordinate_var exists
-    not to make.
+    not to make. `to_pubkey` raises for one thing only -- an x that is no
+    x-coordinate -- which is the one thing this falls through on.
     """
-    sec = _compressed_sec(x, ec)
-    if sec is not None:
+    octets = _x_octets(x, ec)
+    if octets is not None:
         with contextlib.suppress(ValueError):
-            uncompressed = libsecp256k1_reserialize(sec, compressed=False)
+            uncompressed = libsecp256k1_xonly_to_pubkey(octets, compressed=False)
             return int.from_bytes(uncompressed[ec.p_size + 1 :], "big")
 
     return ec.y_even_var(x)
@@ -570,29 +580,31 @@ def _libsecp256k1_multi_mult_(
     answer for: u*H + v*Q with v*Q == -u*H, and v = n - u with Q == H is
     the one-line case of it.
 
-    That sum is recognized from the coordinates, same x and different y,
-    rather than caught from the combine that fails on it, so that a
-    ValueError raised in here still means what it says instead of
-    doubling as a value. Its price is one combine per term rather than
-    one for all of them, a running total being what has an x to compare:
-    measured on eight terms 112 us against 97, and on sixty-four 925
-    against 774, where the Python arithmetic below takes 2.4 ms and 15 ms.
-    Two terms, which is double_mult_var and the shape most callers have, pay
-    nothing at all: one combine either way.
+    `keys.pubkey_sum` is what answers it, being `pubkey_combine` with that
+    one sum answered rather than refused: libsecp256k1 reports 0 both for
+    a key it could not read and for a total at infinity, and the first
+    raises through the illegal callback, so a None back from here is the
+    infinity and nothing else. What that replaces is a combine per term
+    with a running total this side compared coordinates on, the only way
+    of telling the two zeros apart while the sum was assembled here.
+    Terms first, then one sum, which is worth about a third of the call
+    from eight terms up. Two terms -- double_mult_var, and the shape most
+    callers have -- pay nothing either way: one combine, and now no
+    comparison. The measurement per term count is in the CHANGELOG entry
+    that made the change, which is where a figure belongs: an entry is
+    read as the history of a release and this is read as a statement
+    about the code as it stands.
+
+    At least one term, `pubkey_sum` refusing an empty sequence as
+    `pubkey_combine` does. That is no narrowing of what the callers below
+    reach: fewer than two terms is not a multi_mult_var, and the two other
+    entry points hand over one and two.
     """
-    x_slice = slice(1, secp256k1.p_size + 1)
-    total: bytes | None = None
-    for m, sec in zip(scalars, secs, strict=True):
-        term = libsecp256k1_pubkey_tweak_mul(sec, m, False)
-        if total is None:  # nothing yet, or infinity, and INF + P is P
-            total = term
-        elif total != term and total[x_slice] == term[x_slice]:
-            # same x, different y, i.e. P + (-P): infinity. Equal octets
-            # instead are P + P, which combine doubles like any other sum
-            total = None
-        else:
-            total = libsecp256k1_pubkey_combine([total, term], False)
-    return total
+    terms = [
+        libsecp256k1_pubkey_tweak_mul(sec, m, False)
+        for m, sec in zip(scalars, secs, strict=True)
+    ]
+    return libsecp256k1_pubkey_sum(terms, False)
 
 
 def _point_from_sec(sec: bytes) -> Point:

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -69,9 +69,9 @@ from btclib.curves.curve import (
     _is_x_coordinate_var,
     _jac_double_mult,
     _libsecp256k1_serves,
+    _multi_mult_x_only_var,
     _y_even_var,
     mult,
-    multi_mult_var,
 )
 from btclib.curves.curve_group import HEX_THRESHOLD
 from btclib.ecc.bip340_nonce import bip340_nonce_
@@ -831,10 +831,43 @@ def assert_batch_as_valid_(
     """Refuse an invalid signature in a batch of prepared messages.
 
     BIP340's batch verification: one multi-scalar equation over
-    random coefficients, cheaper than one verification per signature
-    -- and which signature failed is not in the answer, only that one
-    did. Messages enter as they are; every signature must share one
-    curve.
+    random coefficients -- and which signature failed is not in the
+    answer, only that one did. Messages enter as they are; every
+    signature must share one curve.
+
+    **It is not the fast way to verify n signatures of secp256k1.**
+    Measured against n delegated `verify_` calls, the batch is about 37 us
+    a signature and a `verify_` about 18, both flat in n, so there is no
+    crossover at any batch size. libsecp256k1 has no batch verification to
+    delegate to, checked at 687155df upstream and at the tip of
+    secp256k1-zkp, whose half-aggregation is a different construction; so
+    what the batch saves in multiplications it spends on a Python term per
+    signature, against a whole verification that is one C call.
+
+    Where it does win is the arithmetic it was written for. With the
+    bindings switched off -- every other curve, and every other hash
+    function -- the equation is one multi-scalar multiplication where n
+    verifications are n double multiplications, and it overtakes them
+    between four signatures and eight. That is the reason it stays, beside
+    its being BIP340's own algorithm and the reference the delegated path
+    is read against. Both measurements per batch size are in the CHANGELOG
+    entry that took them, an entry being read as the history of a release
+    where this is read as a statement about the code as it stands.
+
+    **Which leaves the question of why secp256k1 runs the equation at
+    all, rather than a loop of `verify_`.** That loop would be twice as
+    fast and would say *which* signature failed, where this says only
+    that one did, so it is not obviously the wrong answer -- and it is
+    not taken. What a caller asks of this function is BIP340 batch
+    verification: one equation over random coefficients, the construction
+    with the security argument the BIP makes, and the thing an
+    implementation is compared against. A dispatch that answered it with
+    n independent verifications would answer the same *verdict* by a
+    different computation, and would leave nothing running the equation
+    on the curve where the equation is checkable against libsecp256k1 --
+    which is what `test_batch_validation_on_the_python_path` uses it for.
+    A caller who wants n verifications has `verify_` and a loop, and the
+    figures above are here so that the choice is an informed one.
 
     Every signature is asked whether it is one, this being a public
     function handed objects somebody else built: the equation below is
@@ -881,14 +914,21 @@ def assert_batch_as_valid_(
         sig.assert_valid()
     t = 0
     scalars: list[int] = []
-    points: list[Point] = []
+    x_coords: list[int] = []
     for i, (msg, Q, sig) in enumerate(zip(msgs, Qs, sigs, strict=True)):
         # any size, as in sign_ and assert_as_valid_
         msg = bytes_from_octets(msg)  # noqa: PLW2901
 
-        K = sig.r, _y_even_var(sig.r, ec)
-
-        x_Q, y_Q = point_from_bip340pub_key(Q, ec)
+        # the x of each term and no lift, both terms being the even-y
+        # point an x names: r has been proved an x-coordinate by
+        # `sig.assert_valid` above, and x_Q is proved by the
+        # multiplication these terms are on their way to, whose parse is
+        # that same lift -- `assert_as_valid_` takes the shape for the
+        # same reason (issue 887). The range is still this side's to
+        # refuse, `challenge_` writing x_Q into its preimage and
+        # answering an OverflowError for what is no field element
+        x_Q = _x_from_bip340pub_key(Q, ec)
+        _x_only_bytes(x_Q, ec)
 
         c = challenge_(msg, x_Q, sig.r, ec, hf)
 
@@ -899,24 +939,12 @@ def assert_batch_as_valid_(
         # run of the batch verification algorithm
         rand = 1 if i == 0 else 1 + secrets.randbelow(ec.n - 1)
         scalars.append(rand)
-        points.append(K)
+        x_coords.append(sig.r)
         scalars.append(rand * c % ec.n)
-        points.append((x_Q, y_Q))
+        x_coords.append(x_Q)
         t += rand * sig.s
 
-    # the public mult and multi_mult_var, in affine coordinates, rather than
-    # the Jacobian functions of curve_group underneath them and an
-    # equality of projective coordinates: those two are where the
-    # libsecp256k1 dispatch lives, and this sum is the one place in btclib
-    # that hands the bindings many scalars at once, libsecp256k1 exposing
-    # no batch verification of its own. Four signatures, i.e. the eight
-    # terms above: 2.4 ms of Python arithmetic against 122 us, and
-    # assert_batch_as_valid_ as a whole 3.4 ms against 158 us -- what is
-    # left being two lifts and a challenge per signature, some 9 us of
-    # which the lifts are libsecp256k1's. The two affine
-    # conversions the equality costs on every other curve are one modular
-    # inversion each, next to a multi_mult_var of all the terms
-    if mult(t, ec=ec) != multi_mult_var(scalars, points, ec):
+    if mult(t, ec=ec) != _multi_mult_x_only_var(scalars, x_coords, ec):
         raise BTClibRuntimeError("signature verification failed")
     return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,13 @@ dependencies = [
     # 0.8.0.3 for `xonly.tweak_add_` (btclib-secp256k1#158), which
     # `script.taproot` calls: it tweaks the parsed internal key, where
     # `xonly.tweak_add` parses the x again and that parse is a field square
-    # root. The version is not on PyPI yet -- `[tool.uv.sources]` below is
-    # what resolves it here -- so this floor is also what stops a release
-    # going out against a bindings that cannot serve it
+    # root. The same version for `keys.pubkey_sum`, `xonly.pubkey_verify`
+    # and `xonly.to_pubkey` (btclib-secp256k1#171), which `curves.curve`
+    # calls -- one sum instead of a combine per term, and the two
+    # questions about an x asked as x-only questions. The version is not
+    # on PyPI yet -- `[tool.uv.sources]` below is what resolves it here --
+    # so this floor is also what stops a release going out against a
+    # bindings that cannot serve it
     "btclib_secp256k1>=0.8.0.3",
     "bitcoin-core-rpc>=2026.8.13",
 ]

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -976,8 +976,8 @@ def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
 
     `_libsecp256k1_available` is what `_libsecp256k1_serves` reads on
     every call, so clearing it is the whole package's dispatch and not
-    this module's copy of a predicate. Replacing the four bindings
-    functions besides is what proves they were not asked anyway: a
+    this module's copy of a predicate. Replacing every bindings function
+    the module imports is what proves they were not asked anyway: a
     dispatch this does not cover raises here instead of quietly measuring
     the bindings against themselves.
     """
@@ -994,8 +994,9 @@ def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(curve, "libsecp256k1_mult", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_tweak_add", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_tweak_mul", refuse)
-    monkeypatch.setattr(curve, "libsecp256k1_pubkey_combine", refuse)
-    monkeypatch.setattr(curve, "libsecp256k1_reserialize", refuse)
+    monkeypatch.setattr(curve, "libsecp256k1_pubkey_sum", refuse)
+    monkeypatch.setattr(curve, "libsecp256k1_xonly_pubkey_verify", refuse)
+    monkeypatch.setattr(curve, "libsecp256k1_xonly_to_pubkey", refuse)
 
 
 @pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -12,7 +12,7 @@ from typing import Any
 import pytest
 from btclib_secp256k1 import ssa as libsecp256k1_ssa
 
-from btclib.alias import INF, Point, String
+from btclib.alias import INF, Octets, Point, String
 from btclib.bip32 import BIP32KeyData
 from btclib.curves import (
     PreparedPoint,
@@ -643,6 +643,43 @@ def test_batch_validation_on_the_python_path(monkeypatch: pytest.MonkeyPatch) ->
     sigs[-1] = sigs[0]
     with pytest.raises(BTClibRuntimeError, match="signature verification failed"):
         ssa.assert_batch_as_valid(msgs, Qs, sigs)
+
+
+@pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
+def test_a_batch_refuses_a_bad_key_in_the_lift_s_words(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A batch refuses a key that is no x-coordinate as `ec.y_var` does.
+
+    The twin of the single-signature test above, for the equation: the
+    delegated arm does not lift a key either -- the multiplication's own
+    parse is that square root -- so which term the bindings could not
+    read is found on the refusing path alone, and the message has to come
+    out the same as the arm that lifts. The same four x, for both
+    messages in both renderings.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    ec = secp256k1
+    msgs: list[Octets] = []
+    Qs: list[int] = []
+    sigs: list[ssa.Sig] = []
+    for i in range(1, 3):
+        msg = reduce_to_hlen(bytes(i) * 16)
+        msgs.append(msg)
+        q, Q = ssa.gen_keys(i)
+        Qs.append(Q)
+        sigs.append(ssa.sign_(msg, q))
+
+    ssa.assert_batch_as_valid_(msgs, Qs, sigs)
+
+    for x in (ec.p, ec.p + 1, 0xDEADBEEF00000000, 7):
+        with pytest.raises(BTClibValueError) as batched:
+            ssa.assert_batch_as_valid_(msgs, [Qs[0], x], sigs)
+        with pytest.raises(BTClibValueError) as lifted:
+            ec.y_var(x)
+        assert str(batched.value) == str(lifted.value)
 
 
 def test_musig() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ test = [
 [[package]]
 name = "btclib-secp256k1"
 version = "0.8.0.3"
-source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#8d6f248ec44635dde1514f897f035e9f95aefbdd" }
+source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#8ee6b2cf9b96f65ae88db2f4833f207a0e79c517" }
 dependencies = [
     { name = "cffi" },
 ]


### PR DESCRIPTION
Two issues about `ssa.assert_batch_as_valid_`, and #919 said to read them
as a pair: whether the batch is worth having at all, and — taking it as
given — that its terms are built wrong. Measuring the first is what says
whether the second is worth doing, so they land together.

> **Stacked on https://github.com/btclib-org/btclib/pull/931**, whose
> `_libsecp256k1_multi_mult_` is what the new terms are handed to. Every
> number below was measured on that tree.

## What the batch costs (issue #913)

The docstring said the equation was "cheaper than one verification per
signature". On secp256k1 with sha256 that is false, and it had never
been measured. Against n delegated `ssa.verify_` calls:

| n | batch | n × `verify_` | per sig, batch | per sig, one by one |
| --- | --- | --- | --- | --- |
| 2 | 78.1 µs | 36.6 µs | 39.03 | 18.28 |
| 4 | 152.3 µs | 73.0 µs | 38.07 | 18.25 |
| 8 | 299.5 µs | 146.1 µs | 37.44 | 18.26 |
| 16 | 592.6 µs | 291.9 µs | 37.04 | 18.25 |
| 64 | 2353.2 µs | 1176.1 µs | 36.77 | 18.38 |
| 256 | 9389.9 µs | 4807.3 µs | 36.68 | 18.78 |

Flat in n on both sides, so there is no crossover to find — the batch is
2× slower at every size, before this PR's own change and after it. That
matches what the issue expected, and what it asked to confirm upstream:
there is nothing to delegate the equation to, at `687155df` for
secp256k1 and at the tip of secp256k1-zkp, whose `schnorrsig_halfagg` is
a different construction.

**But the batch does win where it was written to.** With the bindings
switched off — every other curve, every other hash function — the
equation is one multi-scalar multiplication where n verifications are n
double multiplications, and it overtakes them between four signatures
and eight:

| n | batch (Python) | n × `verify_` (Python) |
| --- | --- | --- |
| 2 | 1585.5 µs | 1297.9 µs |
| 4 | 2716.1 µs | 2627.9 µs |
| 8 | 4916.4 µs | 5235.3 µs |
| 16 | 9250.0 µs | 10493.9 µs |

So it stays — that is the issue's option 2, and this is the reason
behind it — with the numbers in the docstring so the next reader does
not re-derive them. What the docstring no longer claims is the thing
that was not true.

## How the terms are built (issue #919)

Each term was a `Point`: `_y_even_var` of `r`, and the lift inside
`point_from_bip340pub_key`. The multiplication then wrote those
coordinates straight back out as 65 octets and parsed them again. Both
terms are the even-y point an x names, which is `0x02 || x` — octets
libsecp256k1 lifts itself, inside the multiplication that wants the
point anyway.

`_batch_sum` is the two arms: octets where the bindings answer, points
where the Python arithmetic does, that being what its terms have to be.

| n | two lifts | compressed octets |
| --- | --- | --- |
| 2 | 89.3 µs | 78.1 µs |
| 16 | 681.3 µs | 592.6 µs |
| 64 | 2700.3 µs | 2353.2 µs |

About two thirds of that is `r` alone, whose lift bought least of all:
`sig.assert_valid` proves it an x-coordinate above the loop, so the y it
found was read for nothing.

**Neither lift was validating anything the multiplication does not.**
`r` is proved above; a key is proved by the parse, which is that same
square root — issue #887, and `assert_as_valid_` has taken exactly this
shape since. What the accepting path no longer pays, the refusing path
does: which term the bindings could not read is found by asking, and the
message stays `ec.y_var`'s, the one the lift raised.
`test_a_batch_refuses_a_bad_key_in_the_lift_s_words` pins the two
spellings together over the same four x its single-signature twin uses,
on both arithmetics.

`multi_mult_var`'s docstring is corrected with it: ssa's batch is still
the caller that hands the bindings many scalars at once, but it is now
the *Python* arm of that sum which arrives there.

Local gates: `pre-commit run --all-files` green, `pytest` green (27844
passed, coverage 100%), `sphinx-build -W` green.

Closes https://github.com/btclib-org/btclib/issues/913
Closes https://github.com/btclib-org/btclib/issues/919

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refine BIP340 batch verification and libsecp256k1 integration, using x-only bindings and a single multi-scalar sum to improve performance, clarify behaviour, and document the true cost of batch verification.

Enhancements:
- Introduce a dedicated `_batch_sum` helper that constructs BIP340 batch equation terms from x-coordinates, delegating to libsecp256k1 with octets when available and to Python point arithmetic otherwise.
- Switch curve utilities from compressed pubkey APIs to x-only `pubkey_verify`/`to_pubkey`, and refactor `_libsecp256k1_multi_mult_` to sum tweaked terms via `pubkey_sum` in one call instead of combining partial totals.
- Clarify `multi_mult_var` and `assert_batch_as_valid_` docstrings to describe how batch verification is wired to libsecp256k1 and how the delegated and Python paths differ.
- Update the minimum `btclib_secp256k1` version to require new x-only and `pubkey_sum` APIs used by the curve and batch helpers.

Build:
- Adjust project dependencies in `pyproject.toml` to depend on `btclib_secp256k1>=0.8.0.3`, aligning with new libsecp256k1 features required by the refactored curve and batch code.

Documentation:
- Expand the CHANGELOG with measured performance characteristics of BIP340 batch verification, the multi-mult refactor, and x-only key handling, including when batch verification is slower than per-signature checks on secp256k1.

Tests:
- Add a parametrized test ensuring batch verification refuses keys that are not x-coordinates with the same error wording as `ec.y_var`, on both bindings and pure Python paths.
- Extend the `no_bindings` helper in curve tests to stub all newly imported libsecp256k1 functions, verifying no unintended dependency on the bindings.

Closes https://github.com/btclib-org/btclib/issues/938
