### PR TITLE
Keep strict DER here, and make libsecp256k1 the oracle over it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4600,6 +4600,78 @@ documented at release-notes length in the first place, and are still in
 
 ### Performance
 
+- **BIP340 batch verification stops lifting two points a signature**
+  (issue #919). `assert_batch_as_valid_` built each term as a `Point` —
+  `_y_even_var` of `r`, and the lift inside
+  `point_from_bip340pub_key` — whose coordinates the multiplication then
+  wrote straight back out as 65 octets and parsed again. Neither lift is
+  needed for the arithmetic: both terms are the even-y point an x names,
+  which is `0x02 || x`, octets libsecp256k1 lifts itself inside the
+  multiplication that wants the point anyway.
+  `curves.curve._multi_mult_x_only_var` is the two arms — octets where
+  the bindings answer, points where the Python arithmetic does, which is
+  what its terms have to be. It sits beside `_sum_var` and
+  `_libsecp256k1_multi_mult_` rather than in `ecc.ssa`, the
+  concatenation being an x-only rule like the ones `_x_octets` serves:
+  the difference is the door, `pubkey_tweak_mul` reading a public key
+  and libsecp256k1 having no x-only multiplication to hand a bare x to.
+
+  | signatures | two lifts | compressed octets |
+  | --- | --- | --- |
+  | 2 | 89.3 µs | 78.1 µs |
+  | 16 | 681.3 µs | 592.6 µs |
+  | 64 | 2700.3 µs | 2353.2 µs |
+
+ About two thirds of that is `r` alone, whose
+  lift bought least of all: `sig.assert_valid` proves it an x-coordinate
+  above the loop, so the y it found was read for nothing.
+
+  Neither lift was validating anything the multiplication does not.
+  `r` is proved above; a key is proved by the parse, which is that same
+  square root (issue #887, and `assert_as_valid_` has taken this shape
+  since). What the accepting path no longer pays, the refusing path
+  does: which term the bindings could not read is found by asking, and
+  the message is `ec.y_var`'s, the same one the lift raised — a new test
+  pins the two spellings together over the same four x the
+  single-signature twin uses.
+
+- **`ssa.assert_batch_as_valid_` says what it costs, and it is not what
+  the name suggests** (issue #913). It was documented as "cheaper than
+  one verification per signature", which is false on secp256k1 with
+  sha256 and was never measured. Against n delegated `verify_` calls:
+
+  | n | batch | n × `verify_` | per sig, batch | per sig, one by one |
+  | --- | --- | --- | --- | --- |
+  | 2 | 78.1 µs | 36.6 µs | 39.03 | 18.28 |
+  | 4 | 152.3 µs | 73.0 µs | 38.07 | 18.25 |
+  | 8 | 299.5 µs | 146.1 µs | 37.44 | 18.26 |
+  | 16 | 592.6 µs | 291.9 µs | 37.04 | 18.25 |
+  | 64 | 2353.2 µs | 1176.1 µs | 36.77 | 18.38 |
+  | 256 | 9389.9 µs | 4807.3 µs | 36.68 | 18.78 |
+
+  Flat in n on both sides, so there is no crossover to find.
+  libsecp256k1 has no batch verification to delegate to, checked at
+  `687155df` upstream and at the tip of
+  secp256k1-zkp, whose half-aggregation is a different construction, so
+  what the batch saves in multiplications it spends on a Python term per
+  signature against a whole verification that is one C call.
+
+  It stays, and now says why. On the arithmetic it was written for —
+  every other curve, every other hash function, the bindings switched
+  off — the equation is one multi-scalar multiplication where n
+  verifications are n double multiplications, and it overtakes them
+  between four signatures and eight:
+
+  | n | batch (Python) | n × `verify_` (Python) |
+  | --- | --- | --- |
+  | 2 | 1585.5 µs | 1297.9 µs |
+  | 4 | 2716.1 µs | 2627.9 µs |
+  | 8 | 4916.4 µs | 5235.3 µs |
+  | 16 | 9250.0 µs | 10493.9 µs |
+
+  That, and its being BIP340's own algorithm and the reference the
+  delegated path is read against.
+
 - **A multi-scalar multiplication sums its terms once, not once per
   term** (issue #917). `_libsecp256k1_multi_mult_` multiplied a term,
   combined it into a running total, and did that again for the next one,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1351,6 +1351,75 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **`ecc.ssa.Signer` signs several messages under one key, building the
+  keypair once** (issue #924). `sign_` builds a `secp256k1_keypair` and
+  wipes it in a `finally` before returning, so a second signature under
+  the same key builds it again — and that keypair is a multiplication of
+  the generator, about half of what a BIP340 signature costs. A `Signer`
+  holds one across calls. Octets come back rather than a `Sig`, that
+  being what its callers want — a psbt writes a signature into a field,
+  and building a `Sig` to serialize it again is the round trip this saves
+  beside the keypair.
+
+  | signatures under one key | `sign_` per call | one held `Signer` |
+  | --- | --- | --- |
+  | 1 | 22.28 µs | 15.69 µs |
+  | 2 | 44.85 µs | 23.83 µs |
+  | 5 | 112.41 µs | 48.40 µs |
+  | 10 | 225.22 µs | 88.79 µs |
+
+  so 14 µs a signature, of a signature that is 22.
+
+  It signs BIP340's message of **any size**, as `sign_` does: the
+  bindings' `sign_custom` and not their `sign`, which is the 32-byte
+  entry point and is what issue #169 took out of the dispatch. Signing
+  through that one would have put the gate back in one arm only, the
+  Python arm signing what the delegated arm refused.
+
+  **What it hands the caller is the lifetime of a secret**, and that is
+  the trade it makes deliberately. `sign_` owns a keypair for the length
+  of a call; a signer holds one until told to let go. `wipe` is that
+  instruction and the class is a context manager, so `with
+  ssa.Signer(prv_key) as signer:` wipes on the way out whether the block
+  ended in a signature or in an exception. What `wipe` releases is the
+  keypair, which is libsecp256k1's own memory and is overwritten, and the
+  scalar the signer was built from, which is a python int and can only be
+  dropped — SECURITY.md's limitations section is where that distinction
+  is stated for the library at large. A wiped signer refuses to sign
+  rather than signing with the zeros, and cannot be revived. On a curve
+  or a hash function the bindings decline there is no keypair to hold:
+  every signature is `sign_`'s there, and the `with` still reads the
+  same.
+
+  `SoftwareSigner.sign_schnorr_script_path` is the one caller, and it
+  owns its signer for the length of a call — built, used, wiped on the
+  way out. **Holding one across calls was measured and is not done**,
+  which is the part worth recording: those leaves are the only place this
+  library signs BIP340 more than once under one key, so they are where a
+  kept keypair would pay, and the measurement says it pays from the
+  *second* leaf of a key onward while a key in a single leaf is the
+  ordinary shape.
+
+  | leaves under one key | `ssa.sign_` | `Signer` per call | `Signer` kept |
+  | --- | --- | --- | --- |
+  | 1 | 97.3 µs | 90.5 µs | 90.9 µs |
+  | 2 | 194.8 µs | 181.6 µs | 173.4 µs |
+  | 4 | 389.2 µs | 363.9 µs | 337.7 µs |
+  | 16 | 1558.1 µs | 1451.5 µs | 1322.1 µs |
+  | *marginal, per leaf* | 97.4 µs | 90.7 µs | 82.1 µs |
+
+  At one leaf the last two columns are the same number: all of the gain
+  in the ordinary case is the `Sig` round trip, none of it the kept
+  keypair. So the 6.7 µs a leaf that costs nothing is taken, and the 8.6
+  that would make a secret outlive the call that needed it is not — and
+  `close()` goes on having nothing to release, which is what keeps the
+  contract's promise reachable by a caller who never calls it.
+
+  The rest of a leaf is the BIP32 derivation `_prv_key` makes per call,
+  which is issue #918's subject and not this one's. The other two signing
+  methods keep `sign_`, a lone signature that drops the key afterwards
+  being exactly what it already is.
+
 - **An ECDSA signature crosses the boundary as the two scalars it is**
   (issue #922). It crossed as DER at both ends: `assert_as_valid_` wrote
   the ASN.1 structure for a call whose first act is `parse_der`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4600,6 +4600,66 @@ documented at release-notes length in the first place, and are still in
 
 ### Performance
 
+- **A multi-scalar multiplication sums its terms once, not once per
+  term** (issue #917). `_libsecp256k1_multi_mult_` multiplied a term,
+  combined it into a running total, and did that again for the next one,
+  so a sum of n points crossed the boundary with n-1 combines and n-1
+  serializations of a partial total nothing outside the loop wanted. The
+  running total was there for one reason: an intermediate sum at infinity
+  has no serialization, libsecp256k1 answering 0 both for a point it
+  could not read and for a total at infinity, and comparing the
+  coordinates of a total this side held was the only way of telling the
+  two apart. `keys.pubkey_sum` (btclib-secp256k1#171) tells them apart on
+  the other side — the unreadable key raises through the illegal
+  callback, so a `None` back is the infinity and nothing else — and the
+  loop becomes the terms and one sum.
+
+  Measured on this tree, alternating rounds with the terms alone as the
+  control — which is the noise detector, being what neither shape
+  changes:
+
+  | terms | combine per term | one `pubkey_sum` | control (terms only) |
+  | --- | --- | --- | --- |
+  | 2 | 14.57 µs | 14.51 µs | 10.42 µs |
+  | 3 | 24.16 µs | 20.37 µs | 15.77 µs |
+  | 8 | 71.08 µs | 48.72 µs | 42.28 µs |
+  | 20 | 186.86 µs | 118.68 µs | 107.50 µs |
+  | 64 | 612.94 µs | 376.80 µs | 348.46 µs |
+
+  Two terms — `double_mult_var`, and the shape most callers have — are
+  unchanged: one combine either way, and now no comparison. End to end at
+  the caller the issue names, `musig2.key_agg`: five keys 94.05 µs
+  against 105.70, twenty 388.92 against 456.74, sixty-four 1247.33
+  against 1481.49.
+
+  What this does not do is keep the terms beyond the boundary as well,
+  which is the remaining third and needs a multi-multiplication entry
+  point in the bindings rather than a composition here; the issue stays
+  open on that half.
+
+- **Two questions about an x coordinate are asked as x-only questions**
+  (issue #927). `curves.curve._compressed_sec` wrote `0x02 || x` so that
+  `_is_x_coordinate_var` and `_y_even_var` could reach libsecp256k1
+  through the public-key API, there being no x-only call to reach it
+  through: the caller held an x, and what crossed was a compressed public
+  key built to be discarded, carrying a parity nobody chose.
+  `xonly.pubkey_verify` and `xonly.to_pubkey` (btclib-secp256k1#171) are
+  those calls, and the concatenation is theirs now — libsecp256k1
+  converts a point to an x-only key and has nothing the other way, so the
+  lift is a rule and belongs where the other x-only rules are.
+  `_compressed_sec` becomes `_x_octets`, which is the guard and the
+  encoding without the key around them.
+
+  No answer changes: the same x is refused by all three spellings, which
+  `curves` already asserts, and `to_pubkey` raises for an x that is no
+  x-coordinate, which is the one thing `_y_even_var` was already falling
+  through on. Nor is it a speed change, and it was measured before being
+  taken: 2.44 µs against 2.37 for the verdict and 3.61 against 3.44 for
+  the lift, the same C work through a different door. `_y_even_var`'s
+  recorded figures are corrected to what reproduces while there — 3.6 µs
+  against `ec.y_even_var`'s 73, and 1.2 more than the verdict rather than
+  the 0.3 that was written, a gap the old spelling measures the same.
+
 - **A point plus a multiple of the generator is one call to the bindings,
   wherever it is written.** BIP32's public derivation, BIP341's output
   key, the outputs and labels of BIP352 and the point a sign-to-contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4600,6 +4600,54 @@ documented at release-notes length in the first place, and are still in
 
 ### Performance
 
+- **A sum of points is one call to the bindings** (issue #912). The
+  issue expected this to be a loss and asked for the measurement rather
+  than the assumption, and the measurement went the other way:
+
+  | points | `ec.add_var` chain | one `pubkey_sum` |
+  | --- | --- | --- |
+  | 2 (one addition) | 11.03 µs | 4.41 µs |
+  | 3 | 23.14 µs | 4.94 µs |
+  | 8 | 79.26 µs | 7.25 µs |
+  | 20 | 215.21 µs | 13.01 µs |
+  | 64 | 714.37 µs | 33.75 µs |
+
+  What the estimate had wrong
+  is which side is expensive — the Python arm's `mod_inv_var` is an
+  extended Euclid, and the crossing is the *uncompressed* serialization
+  `_sec_from_point` writes, which `ec_pubkey_parse` reads without lifting
+  an x. A compressed one would have been a field square root a term, and
+  the estimate's 33-byte assumption is where its six crossings came from.
+
+  `curves.curve._sum_var` is the dispatch, a sequence rather than a pair
+  because the callers are sums: BIP352's `pub_key_sum` over the eligible
+  inputs and MuSig2's `nonce_agg` over the signers, both of which added
+  one term at a time into a running total that crossed at every step.
+
+  | caller | running total | `_sum_var` |
+  | --- | --- | --- |
+  | `pub_key_sum`, 1 input | 7.02 µs | 6.47 µs |
+  | … 2 inputs | 24.40 µs | 16.79 µs |
+  | … 5 inputs | 76.46 µs | 36.19 µs |
+  | … 20 inputs | 335.39 µs | 133.07 µs |
+  | `nonce_agg`, 2 signers | 47.85 µs | 33.31 µs |
+  | … 5 signers | 148.07 µs | 68.47 µs |
+  | … 20 signers | 653.16 µs | 241.81 µs |
+
+  A run with
+  no addition left in it does not cross at all — one term is that term,
+  none is infinity — which is what keeps BIP352's one-input sum at 6.47
+  µs rather than the 10.31 a crossing would make of it.
+
+  What kept both callers on the Python arithmetic is stated in
+  `pub_key_sum`'s own docstring and stopped being true: an intermediate
+  sum at infinity is a BIP352 vector, and infinity is what libsecp256k1
+  has no public key for. `keys.pubkey_sum` (btclib-secp256k1#171)
+  answers it as a value, so the sum at infinity comes back and
+  `pub_key_sum` still refuses it, where MuSig2 still writes BIP327's
+  33-zero-byte placeholder for it. A term at infinity is the identity and
+  is dropped rather than handed over.
+
 - **BIP340 batch verification stops lifting two points a signature**
   (issue #919). `assert_batch_as_valid_` built each term as a `Point` —
   `_y_even_var` of `r`, and the lift inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1351,6 +1351,37 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **Strict DER stays written here, and libsecp256k1 is the oracle over
+  it** (issue #911). The bindings have the same encoding as C —
+  `dsa.to_der`, `to_compact`, `normalize` and `is_low_s` — and whether
+  `Sig.serialize`/`Sig.parse` should delegate to them was open. They do
+  not, and `Sig`'s docstring now carries the four reasons rather than
+  leaving them to be re-derived: a `Sig` carries an `ec` and writes its
+  DER for `ec.n_size`, where the bindings answer for secp256k1 alone;
+  there is nothing to win (serializing 0.697 µs here against `to_der`'s
+  1.057, parsing 1.253 against `to_compact`'s 0.971 — and `to_compact`
+  answers `r || s`, which this side would still have to split; `lower_s`
+  0.037 against `is_low_s`'s 0.840); and the per-rule exception messages
+  are a public contract where libsecp256k1 returns a single 0.
+
+  **The fourth reason was found by asking.** `secp256k1_der_parse_integer`
+  treats an integer whose high bit is set as an *overflow* rather than as
+  a malformed encoding: it zeroes the scalar and reports success, so a
+  DER whose `r` is unpadded and negative parses to `r = 0` instead of
+  being refused. BIP66 refuses it and so does btclib. The two agree on
+  every other rule in the corpus — each scalar rule on `r` and again on
+  `s`, the two being one code path reached in one order — which
+  `der_test` now asserts by putting the whole of it to
+  `dsa.signature_verify`, with that one difference pinned on both scalars
+  rather than left for a caller who used `to_compact` as a validator to
+  find — the failure mode of issues #680 and #667, in the
+  other direction.
+
+  The low-s verdict and the normalization are held to their C twins the
+  same way, which is where the bindings *are* worth having here: they are
+  the two predicates btclib computes in python and had no external
+  authority on.
+
 - **`ecc.ssa.Signer` signs several messages under one key, building the
   keypair once** (issue #924). `sign_` builds a `secp256k1_keypair` and
   wipes it in a `finally` before returning, so a second signature under

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -972,6 +972,65 @@ def double_mult_var(
     return ec.aff_from_jac_var(R)
 
 
+def _sum_var(points: Sequence[Point], ec: Curve) -> Point:
+    """Return the sum of points, no scalar in it.
+
+    `ec.add_var` is one modular inversion and a few products, and the
+    reason to hand it over was not obvious: a delegated addition is two
+    serializations and a parse around one C addition, where the Python is
+    an extended Euclid. Measured, the Euclid is what dominates: one
+    addition 4.41 us delegated against 11.03, and the gap widens with
+    every term -- an addition of the Python chain costs 11 us where a
+    term added to a delegated sum costs 0.46. The crossing is cheap
+    because it is the uncompressed serialization `_sec_from_point`
+    writes, which ec_pubkey_parse reads without lifting an x; a
+    compressed one would be a field square root a term.
+
+    A sequence and not a pair, because the callers are sums: BIP352's
+    `pub_key_sum` over the eligible inputs and MuSig2's `nonce_agg` over
+    the signers, where one `keys.pubkey_sum` of all the terms replaces a
+    running total that crossed the boundary at every step, and is worth
+    better than half of both. The measurement per term count, and at
+    those two callers, is in the CHANGELOG entry that took it, an entry
+    being read as the history of a release where this is read as a
+    statement about the code as it stands.
+
+    Infinity is the identity and libsecp256k1 has no public key for it,
+    so a term at infinity is dropped rather than handed over, and a sum
+    at infinity comes back as the None `pubkey_sum` answers with -- which
+    is the whole of what used to keep these callers on the Python
+    arithmetic, an intermediate sum at infinity being a BIP352 vector.
+    """
+    for Q in points:
+        ec.require_on_curve(Q)
+
+    if _libsecp256k1_serves(ec, None):
+        # infinity is the identity and libsecp256k1 has no public key for
+        # it, so a term at infinity is dropped rather than handed over.
+        # y == 0 is infinity and nothing else *here*: the one real point
+        # with a zero y is the two-torsion one, and a group of prime
+        # order has none -- which this arm is, secp256k1 being what
+        # `_libsecp256k1_serves` above has just agreed to. The Python arm
+        # below cannot make that assumption and does not: `add_aff_var`
+        # tests the same y and says why in its own comment
+        secs = [_sec_from_point(Q) for Q in points if Q[1]]
+        # and a run with no addition left in it is answered without
+        # crossing: one term is that term, and none is infinity. 7.11 us
+        # against 10.31 for BIP352's one-input sum, which is a crossing
+        # to be told what was handed over
+        if len(secs) < 2:
+            return _point_from_sec(secs[0]) if secs else INF
+        total = libsecp256k1_pubkey_sum(secs, False)
+        return INF if total is None else _point_from_sec(total)
+
+    # already on the curve, so add_aff_var rather than add_var, which
+    # would ask it again of every partial sum as well
+    total_point: Point = INF
+    for Q in points:
+        total_point = ec.add_aff_var(total_point, Q)
+    return total_point
+
+
 def _tweak_add_var(P: Point, t: int, ec: Curve) -> Point:
     """Return P + t*G, a point plus a multiple of the generator.
 

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -607,6 +607,59 @@ def _libsecp256k1_multi_mult_(
     return libsecp256k1_pubkey_sum(terms, False)
 
 
+def _multi_mult_x_only_var(
+    scalars: Sequence[int], x_coords: Sequence[int], ec: Curve
+) -> Point:
+    """Return sum(scalars[i]*P_i), each P_i the even-y point of an x.
+
+    The terms of BIP340's batch verification, which is the one caller and
+    the one place in btclib that hands the bindings many scalars at once,
+    libsecp256k1 exposing no batch verification of its own.
+
+    The two arms differ in what they need of a term. `0x02 || x` is the
+    even-y point an x-only key names, and the bindings lift it inside the
+    multiplication that wants the point anyway; the Python arithmetic
+    takes a `Point`, so there the lift is the work and is paid here. That
+    is why this takes x-coordinates rather than points, and why the
+    concatenation is written here rather than left to `xonly.to_pubkey`:
+    what the octets are on their way to is `pubkey_tweak_mul`, which
+    reads a public key, and libsecp256k1 has no x-only multiplication to
+    hand them to instead. It is the same rule `_x_octets` above serves,
+    reached through the one door that exists for it.
+
+    `_libsecp256k1_multi_mult_` and not the public `multi_mult_var`, that
+    one taking points -- which is the form the lift would have to build
+    and the multiplication would then write straight back out. Sixteen
+    signatures end to end, i.e. the thirty-two terms: 592.6 us against
+    681.3 with both terms lifted by the caller.
+
+    Every scalar is required to be in 1..n-1 and every x to be an
+    x-coordinate. The caller is what holds to that -- ssa's rand is drawn
+    in that range, its challenge is refused at zero, n is prime -- so
+    what is left for the bindings to refuse is a term they cannot read,
+    and finding which is the lift the accepting path does not pay. Issue
+    622 made that trade the other way round in `Sig.assert_valid`, and it
+    is the same one: the refusing path can afford a square root. The
+    message is `ec.y_var`'s, from the lift itself rather than restated.
+    """
+    if _libsecp256k1_serves(ec, None):
+        secs = [b"\x02" + x.to_bytes(ec.p_size, "big") for x in x_coords]
+        try:
+            total = _libsecp256k1_multi_mult_(scalars, secs)
+        except ValueError:
+            for x in x_coords:
+                _y_even_var(x, ec)
+            # the loop above raises, every ValueError from the bindings
+            # here being a term they could not read: the pragma is the
+            # one borromean and bms carry, for a line the arithmetic
+            # rules out
+            raise  # pragma: no cover
+        return INF if total is None else _point_from_sec(total)
+
+    points = [(x, _y_even_var(x, ec)) for x in x_coords]
+    return multi_mult_var(scalars, points, ec)
+
+
 def _point_from_sec(sec: bytes) -> Point:
     """Return the point of an uncompressed 0x04 || x || y serialization.
 
@@ -1003,9 +1056,15 @@ def multi_mult_var(
 
     Interleaved wNAF on few scalars, Bos-Coster on many: curve_group's
     _multi_mult_var dispatches on the count, at the size the two measure the
-    same. On secp256k1 the bindings serve the whole sum instead, and this
-    is the one caller that hands them many scalars at once -- libsecp256k1
-    exposing no batch verification, ssa's is built on this.
+    same. On secp256k1 the bindings serve the whole sum instead.
+
+    ssa's batch verification is what hands many scalars over at once,
+    libsecp256k1 exposing no batch verification of its own, and it is the
+    Python arm of that sum which arrives here: the delegated arm reaches
+    `_libsecp256k1_multi_mult_` below with its terms as octets, this
+    signature taking points and a point being what its terms would have
+    to be lifted into for the multiplication to write them straight back
+    out.
     """
     _assert_valid_ec(ec)
     if len(scalars) != len(points):

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -35,12 +35,12 @@ from math import isqrt
 from pathlib import Path
 from typing import Any
 
-from btclib_secp256k1.keys import pubkey_combine as libsecp256k1_pubkey_combine
+from btclib_secp256k1.keys import pubkey_sum as libsecp256k1_pubkey_sum
 from btclib_secp256k1.keys import pubkey_tweak_add as libsecp256k1_pubkey_tweak_add
 from btclib_secp256k1.keys import pubkey_tweak_mul as libsecp256k1_pubkey_tweak_mul
-from btclib_secp256k1.keys import pubkey_verify as libsecp256k1_pubkey_verify
-from btclib_secp256k1.keys import reserialize as libsecp256k1_reserialize
 from btclib_secp256k1.mult import mult as libsecp256k1_mult
+from btclib_secp256k1.xonly import pubkey_verify as libsecp256k1_xonly_pubkey_verify
+from btclib_secp256k1.xonly import to_pubkey as libsecp256k1_xonly_to_pubkey
 
 from btclib.alias import INF, HashF, Integer, JacPoint, Point
 from btclib.curves.curve_group import (
@@ -458,19 +458,27 @@ def _libsecp256k1_serves(ec: Curve, hf: HashF | None) -> bool:
     return hf is None or hf is sha256
 
 
-def _compressed_sec(x: int, ec: Curve) -> bytes | None:
-    """Return 0x02 || x for the bindings to parse, None if they cannot.
+def _x_octets(x: int, ec: Curve) -> bytes | None:
+    """Return x as the octets the bindings read, None if they cannot.
 
-    The two functions below ask libsecp256k1 the one question a compressed
-    public key is -- "this x, and the y that goes with it" -- and this is
-    the argument they ask it with, plus the conditions under which there
-    is one: the curve has to be secp256k1, and x has to be a field
-    element, ec_pubkey_parse taking no x-coordinate at or above ec.p and
+    The two functions below ask libsecp256k1 about an x coordinate, and
+    this is the argument they ask with, plus the conditions under which
+    there is one: the curve has to be secp256k1, and x has to be a field
+    element, `xonly` taking no x-coordinate at or above ec.p and
     x.to_bytes raising OverflowError rather than answering for one.
+
+    An x-only key and nothing built around it. What crosses used to be
+    0x02 || x, a compressed public key assembled here so that the
+    question could be put through the public-key API, there being no
+    x-only call to put it through; `xonly.pubkey_verify` and
+    `xonly.to_pubkey` are those calls, and the concatenation is theirs
+    now -- libsecp256k1 converting a point to an x-only key and offering
+    nothing the other way, so the lift is a rule and belongs where the
+    other x-only rules are.
     """
     if not _libsecp256k1_serves(ec, None) or not 0 <= x < ec.p:
         return None
-    return b"\x02" + x.to_bytes(ec.p_size, "big")
+    return x.to_bytes(ec.p_size, "big")
 
 
 def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
@@ -479,11 +487,12 @@ def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
     Existence and nothing else, which is what a caller with no use for
     the y has to ask, and it is a question the Legendre symbol answers
     without ever forming a root: 14 us on secp256k1 against the 75 of
-    ec.y, and `keys.pubkey_verify` answers the same of the compressed key
-    0x02 || x in 2.4, being ec_pubkey_parse and a verdict -- the same
+    ec.y, and `xonly.pubkey_verify` answers the same of the x alone in
+    2.4, being secp256k1_xonly_pubkey_parse and a verdict -- the same
     answer three ways, all three refusing the same x. It is
-    libsecp256k1's own shape, `secp256k1_ge_x_on_curve_var` being
-    `secp256k1_fe_is_square_var` of x^3 + ax + b and nothing else.
+    libsecp256k1's own shape,
+    `secp256k1_ge_x_on_curve_var` being `secp256k1_fe_is_square_var` of
+    x^3 + ax + b and nothing else.
 
     A bool rather than an exception, because the value that names itself
     in an error message is the caller's and not this x: dsa.Sig's
@@ -492,9 +501,9 @@ def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
     of the field elements are not x-coordinates, and the symbol costs the
     same for those as for the others.
     """
-    sec = _compressed_sec(x, ec)
-    if sec is not None:
-        return libsecp256k1_pubkey_verify(sec)
+    octets = _x_octets(x, ec)
+    if octets is not None:
+        return libsecp256k1_xonly_pubkey_verify(octets)
 
     if not 0 <= x < ec.p:
         return False
@@ -507,11 +516,11 @@ def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
 def _y_even_var(x: int, ec: Curve) -> int:
     """Return the even y-coordinate associated to x.
 
-    ec.y_even_var, delegated for secp256k1: the parity a compressed public
-    key carries in its prefix is the same tiebreaker, so 0x02 || x names
-    the even-y point and `keys.reserialize` asked for the uncompressed
-    form hands back the y that was lifted -- 2.7 us against 75. That is
-    0.3 more than _is_x_coordinate_var above, which is why both exist.
+    ec.y_even_var, delegated for secp256k1: the even y is the one an
+    x-only key names, so `xonly.to_pubkey` asked for the uncompressed
+    form hands back the y that was lifted -- 3.6 us against 73. That is
+    1.2 more than _is_x_coordinate_var above, which is why both exist:
+    finding the root is what the verdict does not do.
 
     An x the bindings refuse falls through to ec.y_even_var instead of
     raising here, so that the message stays in the one place that has the
@@ -519,12 +528,13 @@ def _y_even_var(x: int, ec: Curve) -> int:
     the callers of this function wrap that message rather than restating
     it. The fallthrough pays the Python square root on a path whose
     answer is an exception, which is the trade _is_x_coordinate_var exists
-    not to make.
+    not to make. `to_pubkey` raises for one thing only -- an x that is no
+    x-coordinate -- which is the one thing this falls through on.
     """
-    sec = _compressed_sec(x, ec)
-    if sec is not None:
+    octets = _x_octets(x, ec)
+    if octets is not None:
         with contextlib.suppress(ValueError):
-            uncompressed = libsecp256k1_reserialize(sec, compressed=False)
+            uncompressed = libsecp256k1_xonly_to_pubkey(octets, compressed=False)
             return int.from_bytes(uncompressed[ec.p_size + 1 :], "big")
 
     return ec.y_even_var(x)
@@ -570,29 +580,31 @@ def _libsecp256k1_multi_mult_(
     answer for: u*H + v*Q with v*Q == -u*H, and v = n - u with Q == H is
     the one-line case of it.
 
-    That sum is recognized from the coordinates, same x and different y,
-    rather than caught from the combine that fails on it, so that a
-    ValueError raised in here still means what it says instead of
-    doubling as a value. Its price is one combine per term rather than
-    one for all of them, a running total being what has an x to compare:
-    measured on eight terms 112 us against 97, and on sixty-four 925
-    against 774, where the Python arithmetic below takes 2.4 ms and 15 ms.
-    Two terms, which is double_mult_var and the shape most callers have, pay
-    nothing at all: one combine either way.
+    `keys.pubkey_sum` is what answers it, being `pubkey_combine` with that
+    one sum answered rather than refused: libsecp256k1 reports 0 both for
+    a key it could not read and for a total at infinity, and the first
+    raises through the illegal callback, so a None back from here is the
+    infinity and nothing else. What that replaces is a combine per term
+    with a running total this side compared coordinates on, the only way
+    of telling the two zeros apart while the sum was assembled here.
+    Terms first, then one sum, which is worth about a third of the call
+    from eight terms up. Two terms -- double_mult_var, and the shape most
+    callers have -- pay nothing either way: one combine, and now no
+    comparison. The measurement per term count is in the CHANGELOG entry
+    that made the change, which is where a figure belongs: an entry is
+    read as the history of a release and this is read as a statement
+    about the code as it stands.
+
+    At least one term, `pubkey_sum` refusing an empty sequence as
+    `pubkey_combine` does. That is no narrowing of what the callers below
+    reach: fewer than two terms is not a multi_mult_var, and the two other
+    entry points hand over one and two.
     """
-    x_slice = slice(1, secp256k1.p_size + 1)
-    total: bytes | None = None
-    for m, sec in zip(scalars, secs, strict=True):
-        term = libsecp256k1_pubkey_tweak_mul(sec, m, False)
-        if total is None:  # nothing yet, or infinity, and INF + P is P
-            total = term
-        elif total != term and total[x_slice] == term[x_slice]:
-            # same x, different y, i.e. P + (-P): infinity. Equal octets
-            # instead are P + P, which combine doubles like any other sum
-            total = None
-        else:
-            total = libsecp256k1_pubkey_combine([total, term], False)
-    return total
+    terms = [
+        libsecp256k1_pubkey_tweak_mul(sec, m, False)
+        for m, sec in zip(scalars, secs, strict=True)
+    ]
+    return libsecp256k1_pubkey_sum(terms, False)
 
 
 def _point_from_sec(sec: bytes) -> Point:

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -197,6 +197,35 @@ class Sig:
     Bitcoin has a "low s" rule for the s value to be below ec.n,
     but it is only a standardness rule miners are allowed to ignore.
     Moreover, no such rule exists for r.
+
+    **The encoding is not delegated, and it is the one thing about a
+    signature that is not** (issue 911). The bindings have the same
+    encoding as C -- `dsa.to_der`, `to_compact`, `normalize` and
+    `is_low_s` -- and four things say no:
+
+    - a `Sig` carries an `ec` and writes its DER for `ec.n_size`, where
+      the bindings answer for secp256k1 alone. A delegation is a second
+      path gated like the others, for a computation with no arithmetic
+      in it;
+    - there is nothing to win. Serializing is 0.697 us here against
+      `to_der`'s 1.057; parsing is 1.253 against `to_compact`'s 0.971,
+      and what `to_compact` answers is r || s, which this side would
+      still have to split and build a `Sig` from. `lower_s` is one
+      comparison against n // 2, 0.037 us against `is_low_s`'s 0.840;
+    - the exception messages are a public contract. `Sig.parse` names
+      which rule the encoding broke, one message each; libsecp256k1
+      returns a single 0, and the bindings' `parse_der` says "invalid
+      DER signature" for all of them;
+    - and the two do not answer the same question.
+      `secp256k1_der_parse_integer` treats an integer whose high bit is
+      set as an *overflow* rather than as a malformed encoding: it zeroes
+      the scalar and reports success, so a negative r parses to r = 0
+      instead of being refused. BIP66 refuses it, and so does the parser
+      above. `tests/ecc/der_test.py` puts the whole malformed corpus to
+      `dsa.signature_verify` and pins that one difference, the rest
+      agreeing rule for rule -- which is the pairing that bites others,
+      issues 680 and 667 being two libraries that got it wrong in the
+      other direction.
     """
 
     # 32 bytes scalar, 0 < r < ec.n (ec.n is the curve order)

--- a/btclib/ecc/musig2.py
+++ b/btclib/ecc/musig2.py
@@ -75,7 +75,7 @@ from hashlib import sha256
 
 from btclib.alias import INF, Octets, Point
 from btclib.curves import mult, multi_mult_var, secp256k1
-from btclib.curves.curve import _tweak_add_var
+from btclib.curves.curve import _sum_var, _tweak_add_var
 from btclib.curves.sec_point import (
     bytes_from_point,
     bytes_from_prv_key_int,
@@ -493,14 +493,16 @@ def nonce_agg(pub_nonces: Sequence[Octets]) -> bytes:
     nonces = [bytes_from_octets(nonce, _NONCE_SIZE) for nonce in pub_nonces]
     agg_nonce = b""
     for j in (0, 1):
-        R_j = INF
+        R_j: list[Point] = []
         for i, pub_nonce in enumerate(nonces):
             try:
-                R_ij = _cpoint(pub_nonce[j * _PK_SIZE : (j + 1) * _PK_SIZE])
+                R_j.append(_cpoint(pub_nonce[j * _PK_SIZE : (j + 1) * _PK_SIZE]))
             except BTClibValueError as e:
                 raise InvalidContributionError(i, "pubnonce") from e
-            R_j = secp256k1.add_var(R_j, R_ij)
-        agg_nonce += _cbytes_ext(R_j)
+        # the terms handed over at once rather than added into a running
+        # total that crossed the boundary at every signer: the sum at
+        # infinity above is a value now, which is what the placeholder is
+        agg_nonce += _cbytes_ext(_sum_var(R_j, secp256k1))
     return agg_nonce
 
 

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -69,9 +69,9 @@ from btclib.curves.curve import (
     _is_x_coordinate_var,
     _jac_double_mult,
     _libsecp256k1_serves,
+    _multi_mult_x_only_var,
     _y_even_var,
     mult,
-    multi_mult_var,
 )
 from btclib.curves.curve_group import HEX_THRESHOLD
 from btclib.ecc.bip340_nonce import bip340_nonce_
@@ -831,10 +831,43 @@ def assert_batch_as_valid_(
     """Refuse an invalid signature in a batch of prepared messages.
 
     BIP340's batch verification: one multi-scalar equation over
-    random coefficients, cheaper than one verification per signature
-    -- and which signature failed is not in the answer, only that one
-    did. Messages enter as they are; every signature must share one
-    curve.
+    random coefficients -- and which signature failed is not in the
+    answer, only that one did. Messages enter as they are; every
+    signature must share one curve.
+
+    **It is not the fast way to verify n signatures of secp256k1.**
+    Measured against n delegated `verify_` calls, the batch is about 37 us
+    a signature and a `verify_` about 18, both flat in n, so there is no
+    crossover at any batch size. libsecp256k1 has no batch verification to
+    delegate to, checked at 687155df upstream and at the tip of
+    secp256k1-zkp, whose half-aggregation is a different construction; so
+    what the batch saves in multiplications it spends on a Python term per
+    signature, against a whole verification that is one C call.
+
+    Where it does win is the arithmetic it was written for. With the
+    bindings switched off -- every other curve, and every other hash
+    function -- the equation is one multi-scalar multiplication where n
+    verifications are n double multiplications, and it overtakes them
+    between four signatures and eight. That is the reason it stays, beside
+    its being BIP340's own algorithm and the reference the delegated path
+    is read against. Both measurements per batch size are in the CHANGELOG
+    entry that took them, an entry being read as the history of a release
+    where this is read as a statement about the code as it stands.
+
+    **Which leaves the question of why secp256k1 runs the equation at
+    all, rather than a loop of `verify_`.** That loop would be twice as
+    fast and would say *which* signature failed, where this says only
+    that one did, so it is not obviously the wrong answer -- and it is
+    not taken. What a caller asks of this function is BIP340 batch
+    verification: one equation over random coefficients, the construction
+    with the security argument the BIP makes, and the thing an
+    implementation is compared against. A dispatch that answered it with
+    n independent verifications would answer the same *verdict* by a
+    different computation, and would leave nothing running the equation
+    on the curve where the equation is checkable against libsecp256k1 --
+    which is what `test_batch_validation_on_the_python_path` uses it for.
+    A caller who wants n verifications has `verify_` and a loop, and the
+    figures above are here so that the choice is an informed one.
 
     Every signature is asked whether it is one, this being a public
     function handed objects somebody else built: the equation below is
@@ -881,14 +914,21 @@ def assert_batch_as_valid_(
         sig.assert_valid()
     t = 0
     scalars: list[int] = []
-    points: list[Point] = []
+    x_coords: list[int] = []
     for i, (msg, Q, sig) in enumerate(zip(msgs, Qs, sigs, strict=True)):
         # any size, as in sign_ and assert_as_valid_
         msg = bytes_from_octets(msg)  # noqa: PLW2901
 
-        K = sig.r, _y_even_var(sig.r, ec)
-
-        x_Q, y_Q = point_from_bip340pub_key(Q, ec)
+        # the x of each term and no lift, both terms being the even-y
+        # point an x names: r has been proved an x-coordinate by
+        # `sig.assert_valid` above, and x_Q is proved by the
+        # multiplication these terms are on their way to, whose parse is
+        # that same lift -- `assert_as_valid_` takes the shape for the
+        # same reason (issue 887). The range is still this side's to
+        # refuse, `challenge_` writing x_Q into its preimage and
+        # answering an OverflowError for what is no field element
+        x_Q = _x_from_bip340pub_key(Q, ec)
+        _x_only_bytes(x_Q, ec)
 
         c = challenge_(msg, x_Q, sig.r, ec, hf)
 
@@ -899,24 +939,12 @@ def assert_batch_as_valid_(
         # run of the batch verification algorithm
         rand = 1 if i == 0 else 1 + secrets.randbelow(ec.n - 1)
         scalars.append(rand)
-        points.append(K)
+        x_coords.append(sig.r)
         scalars.append(rand * c % ec.n)
-        points.append((x_Q, y_Q))
+        x_coords.append(x_Q)
         t += rand * sig.s
 
-    # the public mult and multi_mult_var, in affine coordinates, rather than
-    # the Jacobian functions of curve_group underneath them and an
-    # equality of projective coordinates: those two are where the
-    # libsecp256k1 dispatch lives, and this sum is the one place in btclib
-    # that hands the bindings many scalars at once, libsecp256k1 exposing
-    # no batch verification of its own. Four signatures, i.e. the eight
-    # terms above: 2.4 ms of Python arithmetic against 122 us, and
-    # assert_batch_as_valid_ as a whole 3.4 ms against 158 us -- what is
-    # left being two lifts and a challenge per signature, some 9 us of
-    # which the lifts are libsecp256k1's. The two affine
-    # conversions the equality costs on every other curve are one modular
-    # inversion each, next to a multi_mult_var of all the terms
-    if mult(t, ec=ec) != multi_mult_var(scalars, points, ec):
+    if mult(t, ec=ec) != _multi_mult_x_only_var(scalars, x_coords, ec):
         raise BTClibRuntimeError("signature verification failed")
     return
 

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -57,6 +57,7 @@ import secrets
 from collections.abc import Sequence
 from dataclasses import dataclass
 from hashlib import sha256
+from types import TracebackType
 from typing import overload
 
 from btclib_secp256k1 import ssa as libsecp256k1_ssa
@@ -93,6 +94,7 @@ from btclib.utils import (
 __all__ = [
     "BIP340PubKey",
     "Sig",
+    "Signer",
     "assert_as_valid",
     "assert_as_valid_",
     "assert_batch_as_valid",
@@ -529,6 +531,145 @@ def sign(
     if commit is None:
         return sign_(msg_hash, prv_key, aux, ec, hf)
     return sign_(msg_hash, prv_key, aux, ec, hf, commit_hash=reduce_to_hlen(commit, hf))
+
+
+class Signer:
+    """Sign several messages under one key, building the keypair once.
+
+    `sign_` builds a `secp256k1_keypair` and wipes it before returning,
+    so a second signature under the same key builds it again -- and that
+    keypair is a multiplication of the generator, about half of what a
+    BIP340 signature costs. This holds one across calls instead, which is
+    worth some 14 us a signature of a signature that is 22. The
+    measurement per batch size is in the CHANGELOG entry that introduced
+    this class, an entry being read as the history of a release where
+    this is read as a statement about the code as it stands.
+
+    The same signatures come out, `sign` here being `sign_` over the
+    keypair the signer holds, with the same default aux -- 32 octets
+    drawn afresh per signature where the caller names none. The octets
+    are what comes back rather than a `Sig`, that being what the callers
+    of this want: a psbt writes a signature into a field, and building a
+    `Sig` to serialize it again is the round trip this saves beside the
+    keypair.
+
+    **What this hands the caller is the lifetime of a secret.**
+    `sign_` owns a keypair for the length of a call and wipes it in a
+    `finally`; a signer holds one until told to let go. `wipe` is that
+    instruction and the `with` statement is how to give it without
+    having to remember::
+
+        with ssa.Signer(prv_key) as signer:
+            ...
+
+    which wipes on the way out whether the block ended in a signature or
+    in an exception. A wiped signer refuses to sign rather than signing
+    with the zeros, and cannot be revived. So this is for a caller that
+    already holds the secret for several signatures -- `SoftwareSigner`
+    signing every leaf a psbt names one key in -- and a lone signature
+    that drops the key afterwards is what `sign_` already is.
+
+    A curve or a hash function the bindings do not serve has no keypair
+    to hold: there every signature is `sign_`'s, so `wipe` has no
+    keypair to overwrite and the `with` still reads the same -- what it
+    does on that arm is drop the scalar and stop the signing, which is
+    all it can. And the scalar is held on that arm alone: where a keypair
+    exists it holds the same secret in memory that can be overwritten, so
+    a second copy as a python int would be kept for nothing. What is not
+    solved either way is the object the private key arrived in, nor that
+    scalar where the Python arm needs it -- an int cannot be overwritten,
+    only dropped, and SECURITY.md's limitations section is where that is
+    stated for the library at large.
+    """
+
+    def __init__(
+        self, prv_key: PrvKey, ec: Curve = secp256k1, hf: HashF = sha256
+    ) -> None:
+        _assert_valid_hf(hf)
+        # the scalar, whatever spelling the key arrived in, and the
+        # validation with it -- this is a public constructor and the
+        # refusal belongs at it rather than at the first signature
+        self._q = int_from_prv_key(prv_key, ec)
+        self._ec = ec
+        self._hf = hf
+        self._hf_len = hf().digest_size
+        self._signer = (
+            libsecp256k1_ssa.Signer(self._q) if _libsecp256k1_serves(ec, hf) else None
+        )
+        # the scalar is what the Python arm signs with, and nothing else
+        # reads it: where a keypair was built it holds the same secret in
+        # memory the bindings can overwrite, so keeping the int beside it
+        # would be a second copy held for nothing -- and the copy that
+        # cannot be erased, at that
+        if self._signer is not None:
+            self._q = 0
+        self._wiped = False
+
+    def __enter__(self) -> Signer:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.wipe()
+
+    def wipe(self) -> None:
+        """Let go of the key, and refuse to sign afterwards.
+
+        The keypair is overwritten where there is one, which is the half
+        of this that really erases: it is libsecp256k1's own memory and
+        the bindings write zeros over it. The scalar this was built from
+        is a python int and is dropped rather than erased -- rebinding
+        the attribute is the whole of what a caller can do about an
+        immutable object, and SECURITY.md's limitations section is where
+        that is stated for the library at large. So a wiped signer is one
+        that cannot sign and holds no keypair, not one that has scrubbed
+        every copy of the secret from the process.
+
+        Idempotent, so that a caller may wipe a signer it is not sure
+        about; the `with` statement is the customary way to run one.
+        """
+        if self._signer is not None:
+            self._signer.wipe()
+            self._signer = None
+        self._q = 0
+        self._wiped = True
+
+    def sign_(self, msg: Octets, aux: Octets | None = None) -> bytes:
+        """Return the signature of a prepared message, as its octets.
+
+        The message is signed as it is, of any size, which is what the
+        trailing underscore says throughout this module.
+        """
+        if self._wiped:
+            raise BTClibValueError("the signer is wiped")
+
+        if self._signer is None:
+            return sign_(msg, self._q, aux, self._ec, self._hf).serialize()
+
+        # the aux `sign_` would have drawn, drawn here for the same
+        # reason: BIP340's auxiliary randomness is per signature, and a
+        # signer reusing one would derive one nonce for two messages
+        msg = bytes_from_octets(msg)
+        aux = (
+            secrets.token_bytes(self._hf_len)
+            if aux is None
+            else bytes_from_octets(aux, self._hf_len)
+        )
+        # `sign_custom` and not `sign`, for the reason `sign_` above
+        # gives at its own dispatch: `sign` is the 32-byte entry point,
+        # and BIP340 puts no size on its message. Signing through it
+        # would put back the gate issue 169 removed -- and would put it
+        # back in only one of this class's two arms, the python one
+        # signing what the delegated one refused
+        return self._signer.sign_custom(msg, aux)
+
+    def sign(self, msg: Octets, aux: Octets | None = None) -> bytes:
+        """Return the signature of a message, reducing it with hf first."""
+        return self.sign_(reduce_to_hlen(msg, self._hf), aux)
 
 
 def _assert_as_valid_(

--- a/btclib/psbt_signer.py
+++ b/btclib/psbt_signer.py
@@ -708,6 +708,11 @@ class SoftwareSigner:
         caller that works with a device too. Asking a closed signer
         anything raises, which is what makes the difference visible in a
         test rather than only against hardware.
+
+        Nothing survives a signature here, which is what keeps that true:
+        `sign_schnorr_script_path` below owns its `ssa.Signer` for the
+        length of a call and wipes it on the way out, so there is no
+        keypair whose release rests on a caller remembering this method.
         """
         self._closed = True
 
@@ -814,8 +819,27 @@ class SoftwareSigner:
         would find it by; a signer holding keys at known paths and
         answering in one call has no user to ask, so what it answers for
         is decided by the same three conditions as the other two methods.
+
+        `ssa.Signer` and not `ssa.sign_`, for one leaf as for many: what
+        it saves is the `Sig` that `sign_` builds and `serialize` takes
+        apart again, 90.5 us a leaf against 97.3, and a psbt wants the
+        octets. The keypair it holds is built and wiped inside the call.
+
+        Holding one *across* calls was measured and is not done. Those
+        leaves are the one place this library signs BIP340 more than once
+        under one key, and a keypair kept between them is 82.1 us a leaf
+        against 90.5 -- but only from the second leaf of a key onward,
+        and a key in a single leaf is the ordinary shape. The saving is
+        the smaller half of what `Signer` buys and the only half that
+        makes a secret outlive the call that needed it, which is not a
+        trade to make for a case that may not arise.
         """
         prv_key = self._prv_key(pub_key, origin)
         if prv_key is None:
             return None
-        return ssa.sign_(msg_hash, prv_key).serialize()
+        # owned for the length of this call and wiped on the way out:
+        # what `Signer` saves here is the `Sig` that `sign_` would build
+        # for `serialize` to take apart again, and holding one across
+        # calls would buy nothing where a key appears in a single leaf
+        with ssa.Signer(prv_key) as signer:
+            return signer.sign_(msg_hash)

--- a/btclib/silent_payments.py
+++ b/btclib/silent_payments.py
@@ -64,11 +64,11 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 
-from btclib.alias import INF, NetworkType, Octets, Point, String
+from btclib.alias import NetworkType, Octets, Point, String
 from btclib.b32 import power_of_2_base_conversion
 from btclib.bech32 import _BECH32_M_CONST, decode, encode
 from btclib.curves import bytes_from_point, mult, point_from_octets, secp256k1
-from btclib.curves.curve import _tweak_add_var
+from btclib.curves.curve import _sum_var, _tweak_add_var
 from btclib.curves.sec_point import _mult_sec_var
 from btclib.ecc.ssa import point_from_bip340pub_key
 from btclib.exceptions import BTClibTypeError, BTClibValueError
@@ -465,13 +465,14 @@ def pub_key_sum(pub_keys: Sequence[PubKey]) -> Point:
     sequence is the same answer, and is what a transaction of nothing but
     skipped inputs sums to.
 
-    Added one at a time rather than through `multi_mult_var`: an intermediate
-    sum at infinity is a BIP352 vector, and infinity is exactly what
-    libsecp256k1 has no public key for.
+    One `keys.pubkey_sum` of all the terms rather than a running total
+    added one at a time: what kept it here was that an intermediate sum
+    at infinity is a BIP352 vector and infinity is what libsecp256k1 has
+    no public key for, and `_sum_var` is where that stopped being a
+    reason -- a sum at infinity comes back as a value now, and this
+    function still refuses it.
     """
-    total: Point = INF
-    for pub_key in pub_keys:
-        total = secp256k1.add_var(total, point_from_pub_key(pub_key))
+    total = _sum_var([point_from_pub_key(pub_key) for pub_key in pub_keys], secp256k1)
     if total[1] == 0:
         raise BTClibValueError("input public keys sum to infinity")
     return total

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,13 @@ dependencies = [
     # 0.8.0.3 for `xonly.tweak_add_` (btclib-secp256k1#158), which
     # `script.taproot` calls: it tweaks the parsed internal key, where
     # `xonly.tweak_add` parses the x again and that parse is a field square
-    # root. The version is not on PyPI yet -- `[tool.uv.sources]` below is
-    # what resolves it here -- so this floor is also what stops a release
-    # going out against a bindings that cannot serve it
+    # root. The same version for `keys.pubkey_sum`, `xonly.pubkey_verify`
+    # and `xonly.to_pubkey` (btclib-secp256k1#171), which `curves.curve`
+    # calls -- one sum instead of a combine per term, and the two
+    # questions about an x asked as x-only questions. The version is not
+    # on PyPI yet -- `[tool.uv.sources]` below is what resolves it here --
+    # so this floor is also what stops a release going out against a
+    # bindings that cannot serve it
     "btclib_secp256k1>=0.8.0.3",
     "bitcoin-core-rpc>=2026.8.13",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,12 @@ dependencies = [
     # root. The same version for `keys.pubkey_sum`, `xonly.pubkey_verify`
     # and `xonly.to_pubkey` (btclib-secp256k1#171), which `curves.curve`
     # calls -- one sum instead of a combine per term, and the two
-    # questions about an x asked as x-only questions. The version is not
-    # on PyPI yet -- `[tool.uv.sources]` below is what resolves it here --
-    # so this floor is also what stops a release going out against a
-    # bindings that cannot serve it
+    # questions about an x asked as x-only questions -- and for
+    # `ssa.Signer` (btclib-secp256k1#154), which `ecc.ssa.Signer` holds so
+    # that a keypair is built once per key rather than once per signature.
+    # The version is not on PyPI yet -- `[tool.uv.sources]` below is what
+    # resolves it here -- so this floor is also what stops a release going
+    # out against a bindings that cannot serve it
     "btclib_secp256k1>=0.8.0.3",
     "bitcoin-core-rpc>=2026.8.13",
 ]

--- a/tests/curve_parameter_test.py
+++ b/tests/curve_parameter_test.py
@@ -310,6 +310,11 @@ _CASES = (
         {"r": _SSA_SIG.r, "s": _SSA_SIG.s},
     ),
     _Case(
+        "btclib.ecc.ssa.Signer.__init__",
+        ssa.Signer,
+        {"prv_key": _PRV_KEY},
+    ),
+    _Case(
         "btclib.ecc.ssa.point_from_bip340pub_key",
         ssa.point_from_bip340pub_key,
         {"x_Q": _PUB_KEY[0]},

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -976,8 +976,8 @@ def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
 
     `_libsecp256k1_available` is what `_libsecp256k1_serves` reads on
     every call, so clearing it is the whole package's dispatch and not
-    this module's copy of a predicate. Replacing the four bindings
-    functions besides is what proves they were not asked anyway: a
+    this module's copy of a predicate. Replacing every bindings function
+    the module imports is what proves they were not asked anyway: a
     dispatch this does not cover raises here instead of quietly measuring
     the bindings against themselves.
     """
@@ -994,8 +994,9 @@ def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(curve, "libsecp256k1_mult", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_tweak_add", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_tweak_mul", refuse)
-    monkeypatch.setattr(curve, "libsecp256k1_pubkey_combine", refuse)
-    monkeypatch.setattr(curve, "libsecp256k1_reserialize", refuse)
+    monkeypatch.setattr(curve, "libsecp256k1_pubkey_sum", refuse)
+    monkeypatch.setattr(curve, "libsecp256k1_xonly_pubkey_verify", refuse)
+    monkeypatch.setattr(curve, "libsecp256k1_xonly_to_pubkey", refuse)
 
 
 @pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -5,6 +5,7 @@
 """Tests for the `btclib.curve` module."""
 
 import copy
+import functools
 import itertools
 from functools import partial
 from hashlib import sha256, sha512
@@ -44,6 +45,7 @@ from btclib.curves.curve import (
     _libsecp256k1_multi_mult_,
     _libsecp256k1_serves,
     _sec_from_point,
+    _sum_var,
     _tweak_add_var,
     _y_even_var,
 )
@@ -1035,6 +1037,46 @@ def test_tweak_add_var(bindings: bool, monkeypatch: pytest.MonkeyPatch) -> None:
             assert _tweak_add_var(P, t, other) == other.add_var(
                 P, mult(t, other.G, other)
             )
+
+
+@pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
+def test_sum_var(bindings: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sum of points is the additions it stands for, however it is made.
+
+    `_sum_var` is one secp256k1_ec_pubkey_combine where the curve allows
+    it and a chain of `add_var` everywhere else, so the two have to be
+    one answer: asserted over runs of every length the callers reach, and
+    over each of the values libsecp256k1 has no public key for -- a term
+    at infinity, which is the identity and is dropped, the empty sum,
+    which is infinity, and the sum at infinity, which comes back as a
+    value now rather than a refusal.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    ec = secp256k1
+    points = [mult(k) for k in (1, 2, 3, 7, 11, ec.n - 1)]
+    for n in range(len(points) + 1):
+        run = points[:n]
+        expected = functools.reduce(ec.add_var, run, INF)
+        assert _sum_var(run, ec) == expected
+
+    # infinity is the identity, wherever in the run it falls
+    assert _sum_var([INF], ec) == INF
+    assert _sum_var([INF, mult(7), INF], ec) == mult(7)
+
+    # and the sum at infinity, which is no public key on either side
+    assert _sum_var([mult(7), ec.negate(mult(7))], ec) == INF
+    assert _sum_var([mult(3), mult(7), ec.negate(mult(10))], ec) == INF
+
+    # a point that is not on the curve is refused rather than summed
+    with pytest.raises(BTClibValueError, match="point not on curve"):
+        _sum_var([ec.G, (ec.G[0], ec.G[1] + 1)], ec)
+
+    # and a curve the bindings do not serve takes the same lines
+    for other in low_card_curves.values():
+        run = [mult(k, other.G, other) for k in range(1, min(5, other.n))]
+        assert _sum_var(run, other) == functools.reduce(other.add_var, run, INF)
 
 
 def test_libsecp256k1_arbitrary_point() -> None:

--- a/tests/ecc/der_test.py
+++ b/tests/ecc/der_test.py
@@ -5,6 +5,7 @@
 """Tests for the `btclib.der` module."""
 
 import pytest
+from btclib_secp256k1 import dsa as libsecp256k1_dsa
 
 from btclib.curves import secp256k1
 from btclib.ecc.dsa import Sig
@@ -150,3 +151,122 @@ def test_der_serialize() -> None:
     err_msg = r"r is not \(congruent to\) a valid x-coordinate: "
     with pytest.raises(BTClibValueError, match=err_msg):
         Sig(5, s)
+
+
+def _element(value: bytes) -> bytes:
+    """Return the [0x02][size][value] element DER writes a scalar as."""
+    return b"\x02" + len(value).to_bytes(1, "big") + value
+
+
+def _sequence(*elements: bytes) -> bytes:
+    """Return the [0x30][size] sequence of already-encoded elements."""
+    body = b"".join(elements)
+    return b"\x30" + len(body).to_bytes(1, "big") + body
+
+
+def _malformed(good: bytes) -> list[tuple[str, bytes]]:
+    """One malformed DER per rule the strict parser above enforces.
+
+    Every scalar rule twice, on r and on s. The two are one code path --
+    `_deserialize_scalar` is called for each -- so what the second half
+    of each pair guards is the order of those two calls rather than the
+    rule itself: an s reached through an r that had to parse first.
+
+    Assembled from the elements rather than by patching `good` in place,
+    so that a case fires the rule it is named for: an s whose size byte
+    is edited where it lies leaves the sequence length disagreeing, and
+    what refuses it is that disagreement and not the scalar rule.
+    """
+    r_value = good[4 : 4 + good[3]]
+    s_value = good[4 + good[3] + 2 :]
+    r, s = _element(r_value), _element(s_value)
+    data_size = good[1]
+    return [
+        ("compound header", b"\x31" + good[1:]),
+        ("sequence length overruns", good[:1] + b"\x41" + good[2:]),
+        (
+            "sequence length short",
+            good[:1] + (data_size + 1).to_bytes(1, "big") + good[2:] + b"\x01",
+        ),
+        ("r is no integer element", _sequence(b"\x03" + r[1:], s)),
+        ("r of zero size", _sequence(b"\x02\x00", s)),
+        ("r padded twice", _sequence(_element(b"\x00\x00" + r_value[1:]), s)),
+        ("s is no integer element", _sequence(r, b"\x03" + s[1:])),
+        ("s of zero size", _sequence(r, b"\x02\x00")),
+        ("s padded twice", _sequence(r, _element(b"\x00\x00" + s_value[1:]))),
+        ("empty", b""),
+        ("truncated", good[:-1]),
+        ("trailing octet", good + b"\x00"),
+    ]
+
+
+def test_der_agrees_with_libsecp256k1_except_where_it_is_stricter() -> None:
+    """libsecp256k1 as the oracle on a DER encoding, and where it is not one.
+
+    Nothing here asks the bindings whether an encoding is well formed,
+    the strict DER of BIP66 being written in python and validated against
+    the BIP's own rules alone -- which is the pairing that bites others:
+    https://github.com/btclib-org/btclib/issues/680 is embit parsing
+    high-s DER differently per backend, and
+    https://github.com/btclib-org/btclib/issues/667 is electrum-ecc
+    normalizing s inside a documented pure conversion. So the corpus
+    above is put to `dsa.signature_verify` as well, which is
+    secp256k1_ecdsa_signature_parse_der and a verdict.
+
+    The two agree on every rule but one, and the exception is not a
+    disagreement about DER: `secp256k1_der_parse_integer` treats an
+    integer whose high bit is set as an *overflow* rather than as a
+    malformed encoding, zeroes the scalar and reports success, so the
+    signature it hands back is r = 0 -- which no verification accepts.
+    btclib refuses the encoding instead, in BIP66's words, and this is
+    what says so out loud rather than leaving the difference to be found
+    by a caller who used `to_compact` as a validator.
+    """
+    sig = Sig(2**255 - 4, 2**247 - 1)
+    good = sig.serialize()
+    compact = sig.r.to_bytes(32, "big") + sig.s.to_bytes(32, "big")
+
+    # the well-formed encoding first, both ways round
+    assert libsecp256k1_dsa.signature_verify(good)
+    assert libsecp256k1_dsa.to_der(compact) == good
+    assert libsecp256k1_dsa.to_compact(good) == compact
+
+    for name, bad in _malformed(good):
+        with pytest.raises(BTClibValueError):
+            Sig.parse(bad, check_validity=False)
+        assert not libsecp256k1_dsa.signature_verify(bad), name
+
+    # and the one rule libsecp256k1 answers otherwise, on each scalar:
+    # a high bit set with no 0x00 in front of it is a negative integer,
+    # which BIP66 refuses and `secp256k1_der_parse_integer` reports as an
+    # overflow -- zeroing the scalar and answering success
+    r_value = good[4 : 4 + good[3]]
+    s_value = good[4 + good[3] + 2 :]
+    r, s = _element(r_value), _element(s_value)
+    for name, bad, zeroed in (
+        ("r", _sequence(_element(b"\x80" + r_value[1:]), s), slice(0, 32)),
+        ("s", _sequence(r, _element(b"\x80" + s_value[1:])), slice(32, 64)),
+    ):
+        with pytest.raises(BTClibValueError, match="invalid negative scalar"):
+            Sig.parse(bad, check_validity=False)
+        assert libsecp256k1_dsa.signature_verify(bad), name
+        # what it read is the zero scalar, not the value those octets spell
+        assert libsecp256k1_dsa.to_compact(bad)[zeroed] == bytes(32), name
+
+
+def test_der_low_s_agrees_with_libsecp256k1() -> None:
+    """The low-s verdict and the normalization, against their C twins.
+
+    `lower_s` is one comparison against n // 2 here, and libsecp256k1 has
+    the same two answers as `is_low_s` and `normalize`. Nothing delegates
+    to them -- 0.037 us against 0.840, a comparison against a parse and a
+    call -- so this is where the two are held together instead.
+    """
+    for s in (1, ec.n // 2, ec.n // 2 + 1, ec.n - 1):
+        sig = Sig(2**255 - 4, s)
+        der = sig.serialize()
+        assert libsecp256k1_dsa.is_low_s(der) == (s <= ec.n // 2)
+
+        normalized = Sig.parse(libsecp256k1_dsa.normalize(der))
+        assert normalized.r == sig.r
+        assert normalized.s == min(s, ec.n - s)

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -12,7 +12,7 @@ from typing import Any
 import pytest
 from btclib_secp256k1 import ssa as libsecp256k1_ssa
 
-from btclib.alias import INF, Point, String
+from btclib.alias import INF, Octets, Point, String
 from btclib.bip32 import BIP32KeyData
 from btclib.curves import (
     PreparedPoint,
@@ -643,6 +643,43 @@ def test_batch_validation_on_the_python_path(monkeypatch: pytest.MonkeyPatch) ->
     sigs[-1] = sigs[0]
     with pytest.raises(BTClibRuntimeError, match="signature verification failed"):
         ssa.assert_batch_as_valid(msgs, Qs, sigs)
+
+
+@pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
+def test_a_batch_refuses_a_bad_key_in_the_lift_s_words(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A batch refuses a key that is no x-coordinate as `ec.y_var` does.
+
+    The twin of the single-signature test above, for the equation: the
+    delegated arm does not lift a key either -- the multiplication's own
+    parse is that square root -- so which term the bindings could not
+    read is found on the refusing path alone, and the message has to come
+    out the same as the arm that lifts. The same four x, for both
+    messages in both renderings.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    ec = secp256k1
+    msgs: list[Octets] = []
+    Qs: list[int] = []
+    sigs: list[ssa.Sig] = []
+    for i in range(1, 3):
+        msg = reduce_to_hlen(bytes(i) * 16)
+        msgs.append(msg)
+        q, Q = ssa.gen_keys(i)
+        Qs.append(Q)
+        sigs.append(ssa.sign_(msg, q))
+
+    ssa.assert_batch_as_valid_(msgs, Qs, sigs)
+
+    for x in (ec.p, ec.p + 1, 0xDEADBEEF00000000, 7):
+        with pytest.raises(BTClibValueError) as batched:
+            ssa.assert_batch_as_valid_(msgs, [Qs[0], x], sigs)
+        with pytest.raises(BTClibValueError) as lifted:
+            ec.y_var(x)
+        assert str(batched.value) == str(lifted.value)
 
 
 def test_musig() -> None:

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -1208,3 +1208,105 @@ def test_a_key_that_is_no_x_coordinate_is_refused_in_the_lift_s_words(
         with pytest.raises(BTClibValueError) as lifted:
             ec.y_var(x)
         assert str(verified.value) == str(lifted.value)
+
+
+@pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
+def test_signer_signs_what_sign_signs(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A held keypair changes what a signature costs and not what it is.
+
+    `Signer.sign_` is `sign_` over a keypair built once, so the two have
+    to answer the same octets: asserted over a spread of messages, with
+    the aux named so that the comparison is of the derivation and not of
+    two draws. And over the arm that holds no keypair at all -- a curve
+    or a hash function the bindings decline -- where `sign_` is the whole
+    of the implementation.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    prv_key, x_Q = ssa.gen_keys(0x1234567890ABCDEF)
+    aux = bytes(32)
+
+    # where a keypair was built it holds the secret in memory that can be
+    # overwritten, so the scalar is not kept beside it; where there is no
+    # keypair the scalar is the whole of what signs, and is
+    held = ssa.Signer(prv_key)
+    assert bool(held._q) is not bindings
+    held.wipe()
+
+    with ssa.Signer(prv_key) as signer:
+        for msg in (b"", b"a message", bytes(32), bytes(1000)):
+            msg_hash = reduce_to_hlen(msg)
+            assert (
+                signer.sign_(msg_hash, aux)
+                == ssa.sign_(msg_hash, prv_key, aux).serialize()
+            )
+            # and the unprepared spelling reduces with hf, as `sign` does
+            assert signer.sign(msg, aux) == ssa.sign(msg, prv_key, aux).serialize()
+            assert ssa.verify_(msg_hash, x_Q, signer.sign_(msg_hash))
+
+        # a *prepared* message of any size, which is the whole of what
+        # the trailing underscore promises and what the bindings' 32-byte
+        # entry point would take away again (issue 169): signing through
+        # that one would leave the two arms of this class disagreeing,
+        # the python one signing what the delegated one refused
+        for size in (0, 1, 31, 33, 64, 1000):
+            of_that_size = bytes(size)
+            assert (
+                signer.sign_(of_that_size, aux)
+                == ssa.sign_(of_that_size, prv_key, aux).serialize()
+            )
+            assert ssa.verify_(of_that_size, x_Q, signer.sign_(of_that_size, aux))
+
+
+def test_a_wiped_signer_refuses_rather_than_signing_with_the_zeros() -> None:
+    """The lifetime a signer hands its caller, and how it is given back.
+
+    `wipe` is the instruction and the `with` block is how to give it
+    without having to remember; both leave a signer that refuses, and
+    neither can be undone -- what the signer held it no longer holds.
+    """
+    prv_key, _ = ssa.gen_keys(0x1234567890ABCDEF)
+    msg_hash = reduce_to_hlen(b"a message")
+
+    signer = ssa.Signer(prv_key)
+    assert signer.sign_(msg_hash)
+    signer.wipe()
+    with pytest.raises(BTClibValueError, match="the signer is wiped"):
+        signer.sign_(msg_hash)
+    # idempotent, as `close` is on the signer contract
+    signer.wipe()
+    # the scalar is let go of and not only the keypair: an int cannot be
+    # overwritten, so dropping the reference is the whole of what `wipe`
+    # can do about it -- but leaving it bound would make "cannot be
+    # revived" false, this being where the key is held on both arms
+    assert not signer._q
+
+    with ssa.Signer(prv_key) as block_signer:
+        assert block_signer.sign_(msg_hash)
+    with pytest.raises(BTClibValueError, match="the signer is wiped"):
+        block_signer.sign_(msg_hash)
+
+    # and the block wipes on the way out of an exception too
+    raising = ssa.Signer(prv_key)
+    with pytest.raises(ZeroDivisionError), raising:
+        _ = 1 / 0
+    with pytest.raises(BTClibValueError, match="the signer is wiped"):
+        raising.sign_(msg_hash)
+
+
+def test_a_signer_refuses_what_sign_refuses() -> None:
+    """The key and the hash function are read at the constructor.
+
+    A public constructor, so the refusal belongs at it rather than at the
+    first signature -- which is the only place a caller could hear it,
+    the keypair being built here.
+    """
+    with pytest.raises(BTClibValueError, match="private key not in 1..n-1"):
+        ssa.Signer(0)
+    with pytest.raises(BTClibValueError, match="private key not in 1..n-1"):
+        ssa.Signer(secp256k1.n)
+    with pytest.raises(BTClibTypeError):
+        ssa.Signer(0x1234567890ABCDEF, secp256k1, "not a hash function")  # type: ignore[arg-type]

--- a/tests/name_contract_test.py
+++ b/tests/name_contract_test.py
@@ -188,7 +188,7 @@ def _argument_less_bools() -> dict[str, bool]:
 #   this one
 # - `close` is an action with a side effect
 _NOT_A_READ = ("assert_", "get_", "to_")
-_AN_ACTION = frozenset({"close"})
+_AN_ACTION = frozenset({"close", "wipe"})
 
 # hashlib's own API, mirrored in a Protocol, and hashlib draws the line
 # itself: `digest()`, `hexdigest()` and `copy()` are calls where

--- a/tests/software_signer_test.py
+++ b/tests/software_signer_test.py
@@ -232,6 +232,23 @@ def test_the_signer_answers_for_its_own_keys_only() -> None:
     assert signer.sign_schnorr_script_path(x_only, None, msg_hash, leaf) is None
     assert signer.sign_schnorr_script_path(x_only, elsewhere, msg_hash, leaf) is None
 
+    # and a second key signs under itself: `Signer` is built per call
+    # from the key `_prv_key` answered, so a run of leaves under one key
+    # and a run under another cannot be confused for each other
+    second_x_only = taproot.key_expressions[0].sec(1)[1:]
+    second_origin = BIP32KeyOrigin(signer.master_fingerprint, "m/86h/0h/0h/0/1")
+    for _ in range(2):
+        second = signer.sign_schnorr_script_path(
+            second_x_only, second_origin, msg_hash, leaf
+        )
+        assert second is not None
+        assert ssa.verify_(msg_hash, second_x_only, second)
+        assert not ssa.verify_(msg_hash, x_only, second)
+
+    # idempotent, as the contract says
+    signer.close()
+    signer.close()
+
 
 def test_a_watch_only_signer_shows_and_derives_but_does_not_sign() -> None:
     """Watching is most of what a signer does, and it is not a broken state.

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ test = [
 [[package]]
 name = "btclib-secp256k1"
 version = "0.8.0.3"
-source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#8d6f248ec44635dde1514f897f035e9f95aefbdd" }
+source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#8ee6b2cf9b96f65ae88db2f4833f207a0e79c517" }
 dependencies = [
     { name = "cffi" },
 ]


### PR DESCRIPTION
> **Stacked on https://github.com/btclib-org/btclib/pull/934**, and
> through it on #933, #932 and #931.

Both halves of the issue: the decision, written into the module, and the
tests that were missing.

## 1. `Sig.serialize`/`Sig.parse` do not delegate

Three reasons the issue foresaw, and one it did not.

- **A `Sig` is generic over the curve.** It carries an `ec` and writes
  its DER for `ec.n_size`; the bindings answer for secp256k1 alone, so a
  delegation is a second gated path for a computation with no arithmetic
  in it.
- **There is nothing to win**, measured:

  | | btclib | bindings |
  | --- | --- | --- |
  | serialize | 0.697 µs | `to_der` 1.057 µs |
  | parse | 1.253 µs | `to_compact` 0.971 µs |
  | low-s verdict | 0.037 µs | `is_low_s` 0.840 µs |

  and `to_compact` answers `r || s`, which this side would still have to
  split into two ints and build a `Sig` from — so the parse row is not
  even the comparison it looks like.
- **The exception messages are a public contract.** `Sig.parse` names
  which rule the encoding broke, one message each; the bindings'
  `parse_der` says `invalid DER signature` for all of them, libsecp256k1
  returning a single 0. (Issue point 3 is moot either way: `parse_der` is
  public now.)

**The fourth reason came out of writing the tests.**
`secp256k1_der_parse_integer` treats an integer whose high bit is set as
an **overflow** rather than as a malformed encoding — it zeroes the
scalar and reports success. So a DER whose `r` is unpadded and negative
parses to `r = 0` rather than being refused:

```
>>> libsecp256k1_dsa.signature_verify(negative_r)
True
>>> libsecp256k1_dsa.to_compact(negative_r)[:32].hex()
'0000000000000000000000000000000000000000000000000000000000000000'
```

BIP66 refuses that encoding, and so does the parser here. Verified
against [`ecdsa_impl.h`](https://github.com/bitcoin-core/secp256k1/blob/master/src/ecdsa_impl.h)
rather than inferred from the behaviour: the `/* Negative. */` branch
sets `overflow = 1`, and the overflow path zeroes the scalar.

It is not a libsecp256k1 bug — `r = 0` fails verification anyway — but it
is exactly the shape that bites a caller who uses `to_compact` as a
validator, which is what issues #680 and #667 are, in the other
direction.

## 2. The tests gain the oracle

`der_test` now puts the whole malformed corpus — one case per rule the
strict parser enforces — to `dsa.signature_verify`, asserting the two
refuse the same encodings, with the one divergence above pinned
explicitly rather than left to be discovered. The round trip through
`to_der`/`to_compact` is asserted on the well-formed side.

And `is_low_s`/`normalize` are held to their python twins over `s = 1`,
`n//2`, `n//2 + 1` and `n-1`. That is where the bindings *are* worth
having here, and the issue says why: they are the two predicates btclib
computes in python and had no external authority on, in a library where
libsecp256k1 is the authority on everything else about a signature.

Local gates: `pre-commit run --all-files` green, `pytest` green (27856
passed, coverage 100%), `sphinx-build -W` green.

Closes https://github.com/btclib-org/btclib/issues/911

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify DER signature handling and batch verification behavior while adding a reusable Schnorr signer and improving libsecp256k1-backed point operations.

New Features:
- Introduce ecc.ssa.Signer for efficient, reusable BIP340 Schnorr signing under a single key, with explicit keypair lifetime management and context-manager support.

Bug Fixes:
- Align strict DER parsing and low-s handling with libsecp256k1, explicitly documenting and testing the one deliberate divergence for negative, unpadded r encodings.

Enhancements:
- Use libsecp256k1 multi-scalar multiplication and point-sum primitives more efficiently, avoiding repeated lifts and combines and delegating sums of points via pubkey_sum where available.
- Refine BIP340 batch verification to operate on x-only inputs and document its true performance characteristics on secp256k1 versus pure-Python verification.
- Delegate x-coordinate checks and even-y lifting to libsecp256k1 x-only APIs, keeping Python fallbacks and error messages aligned.
- Extend SoftwareSigner to reuse a held BIP340 keypair across taproot script-path leaves and ensure proper wiping on close.

Build:
- Bump btclib_secp256k1 minimum version to 0.8.0.3 to rely on new pubkey_sum and x-only APIs used by curve and silent-payments code.

Documentation:
- Expand Sig documentation and changelog entries to describe strict DER policy, libsecp256k1’s role as an oracle, the new Schnorr Signer, and performance notes for batch verification and point summation.

Tests:
- Add targeted tests for DER parsing and low-s normalization against libsecp256k1, for Signer behavior and wiping semantics, for batch verification error messaging, and for point-sum behavior on bindings and non-bindings paths, including infinity edge cases.
- Update name and parameter-contract tests to cover the new Signer class and wipe action semantics.