### PR TITLE
Reach the generator's multiplication where the bindings keep it now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1351,6 +1351,27 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **The generator's multiplication no longer imports a module the
+  bindings have removed** (issue #929). `curves.curve` reached
+  `btclib_secp256k1.mult.mult` for `m*G`, and that module is gone:
+  btclib-secp256k1#174 folded its last function into `keys`, it being
+  `keys.pubkey_from_prvkey(m, compressed=False)` with the flag fixed —
+  and a module that is one call of another is what that repository's own
+  rule refuses. The arm calls `keys.pubkey_from_prvkey` directly and
+  reads the answer with `_point_from_sec`, which is what the *other* arm
+  of the same function already read its own with, so the two ways back
+  to a `Point` become one.
+
+  Nothing was broken when the issue was filed and nothing would have been
+  until the dependency was re-locked — `uv.lock` still pinned a revision
+  that had the module, and any `pyproject.toml` edit would have triggered
+  the re-lock on its own. The lock moves here, so the break is taken
+  rather than left waiting: `8ee6b2cf` → `e7dfc9cb`.
+
+  The generator's multiplication is 8.9 µs end to end, of which 8.5 is
+  the bindings call; what this side now does, the removed function did
+  inside itself.
+
 - **`bip32.derive_from_account_range_` derives many siblings, walking to
   the branch once** (issue #918). A wallet enumerates: a gap-limit scan,
   a ranged descriptor, an account being listed. Asked one address at a

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -35,10 +35,12 @@ from math import isqrt
 from pathlib import Path
 from typing import Any
 
+from btclib_secp256k1.keys import (
+    pubkey_from_prvkey as libsecp256k1_pubkey_from_prvkey,
+)
 from btclib_secp256k1.keys import pubkey_sum as libsecp256k1_pubkey_sum
 from btclib_secp256k1.keys import pubkey_tweak_add as libsecp256k1_pubkey_tweak_add
 from btclib_secp256k1.keys import pubkey_tweak_mul as libsecp256k1_pubkey_tweak_mul
-from btclib_secp256k1.mult import mult as libsecp256k1_mult
 from btclib_secp256k1.xonly import pubkey_verify as libsecp256k1_xonly_pubkey_verify
 from btclib_secp256k1.xonly import to_pubkey as libsecp256k1_xonly_to_pubkey
 
@@ -736,7 +738,13 @@ def _mult_checked(m: int, Q: Point | None, ec: Curve, *, prepared: bool) -> Poin
     if m and _libsecp256k1_serves(ec, None):
         # the generator is ec_pubkey_create, with no point to parse first
         if Q is None or Q == ec.G:
-            return libsecp256k1_mult(m)
+            # uncompressed and read by `_point_from_sec`, which is what
+            # the other arm below reads its own answer with: the two ways
+            # back to a `Point` were one function each until the bindings
+            # folded their `mult` module into `keys`, that module's last
+            # call having been this one with the flag fixed
+            sec = libsecp256k1_pubkey_from_prvkey(m, compressed=False)
+            return _point_from_sec(sec)
         # any other point, infinity excepted: that one is not a pubkey,
         # and m*INF == INF is what the Python path below answers anyway
         if Q[1]:

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -993,7 +993,7 @@ def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
     monkeypatch.setattr(curve, "_libsecp256k1_available", False)
-    monkeypatch.setattr(curve, "libsecp256k1_mult", refuse)
+    monkeypatch.setattr(curve, "libsecp256k1_pubkey_from_prvkey", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_tweak_add", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_tweak_mul", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_sum", refuse)

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ test = [
 [[package]]
 name = "btclib-secp256k1"
 version = "0.8.0.3"
-source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#8ee6b2cf9b96f65ae88db2f4833f207a0e79c517" }
+source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#e7dfc9cb25ac3324d715c9d3ba0f3312b65269ba" }
 dependencies = [
     { name = "cffi" },
 ]


### PR DESCRIPTION
`curves/curve.py` imported `btclib_secp256k1.mult.mult` for `m*G`, and
that module no longer exists:
[btclib-secp256k1#174](https://github.com/btclib-org/btclib-secp256k1/pull/174)
folded its last function into `keys`, it being
`keys.pubkey_from_prvkey(m, compressed=False)` with the flag fixed — and
a module that is one call of another is what that repository's own rule
refuses.

Verified rather than taken from the issue: `btclib_secp256k1/mult.py` is
404 on the bindings' `main`, and with the lock moved the suite fails at
the import —

```
E   ModuleNotFoundError: No module named 'btclib_secp256k1.mult'
```

## The change

```diff
-from btclib_secp256k1.mult import mult as libsecp256k1_mult
+from btclib_secp256k1.keys import (
+    pubkey_from_prvkey as libsecp256k1_pubkey_from_prvkey,
+)
```

and the arm reads its answer the way the arm beside it already did:

```python
sec = libsecp256k1_pubkey_from_prvkey(m, compressed=False)
return _point_from_sec(sec)
```

`_point_from_sec` is what `_libsecp256k1_multi_mult_` reads *its* answer
with, so the two ways back to a `Point` become one rather than each
having its own. `curve_test.no_bindings` patches the new alias, so the
Python arm is still reached on purpose rather than by accident.

Measured here: 8.9 µs end to end for the generator's multiplication, of
which 8.5 is the bindings call. What this side now does is what the
removed function did inside itself.

## Why the lock moves with it

Nothing was broken when the issue was filed and nothing would have been
until the dependency was re-locked — `uv.lock` still pinned `8ee6b2cf`,
which has the module, and `uv sync --locked` kept resolving it. But any
`pyproject.toml` edit triggers a re-lock on its own, so the break was
waiting rather than avoided. It is taken here: `8ee6b2cf` → `e7dfc9cb`,
which also brings btclib-secp256k1#172 and the schnorr nonce entry point
beside it, neither of which this tree calls yet.

Local gates: `pre-commit run --all-files` green, `pytest` green (27862
passed, coverage 100%), `sphinx-build -W` green.

Closes https://github.com/btclib-org/btclib/issues/929

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update secp256k1 generator multiplication to use the current bindings API and keep behavior aligned between bindings and Python paths.

Enhancements:
- Align generator multiplication in `curves.curve` with the bindings’ `keys.pubkey_from_prvkey` entry point, sharing the same SEC-to-Point conversion path as the non-generator branch.

Documentation:
- Document the generator multiplication change, dependency re-lock, and performance characteristics in the changelog under curves/signatures/keys.

Tests:
- Adjust curve tests to monkeypatch the new `libsecp256k1_pubkey_from_prvkey` alias when simulating the no-bindings path.

Chores:
- Re-lock the btclib-secp256k1 dependency to a revision that has removed the `mult` module and folded its functionality into `keys`.