### PR TITLE
Say that a pull request lands two ways, one of them a fast-forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,29 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **Three files said squash was how a pull request lands; one of the two
+  ways is a fast-forward** (issue #941). `REPOSITORY.md` has documented
+  the `main-self-merge` bypass and its fast-forward sequence since the day
+  the rulesets went up, and its own *Merge methods* section two headings
+  below said "squash is the only method enabled" — true of the button and
+  read as true of the landing. `CONTRIBUTING.md` said "a pull request is
+  merged with Squash and merge" without qualification, and `RELEASING.md`
+  said "the way every pull request here is merged".
+
+  The two are decided by the branch rather than by taste: a contributor's
+  pull request usually carries several commits and is squashed, the
+  maintainer's usually carries one and is fast-forwarded. What the
+  fast-forward buys is what a squash cannot — the sha does not change, so
+  `main` receives the exact commit CI tested, signed by the maintainer
+  rather than by GitHub's web-flow key, and a branch stacked on it keeps
+  applying instead of needing a rebase and a fresh matrix run per level.
+
+  `RELEASING.md` gains the case where it matters most: a release branch of
+  one commit wants the fast-forward and not merely tolerates it, the tag
+  otherwise going over a commit the maintainer did not sign.
+  `CONTRIBUTING.md` says the fast-forward needs a bypass no contributor
+  has, which is why it is described there rather than instructed.
+
 - **The HWI emulator jobs no longer appear on a pull request's checks.**
   `HWI against a Trezor emulator` and `HWI against a Ledger emulator`
   ran as jobs of `integration.yml`, guarded by `if:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1284,11 +1284,24 @@ check starts again from a commit nobody has seen. Add the fix on top, with
 a message saying what it fixes, and reply to the comment with the sha.
 
 Nothing is lost in `main`'s history by doing so, because **a pull request
-is merged with "Squash and merge"**: the branch becomes one commit, so
-the review's commits are the record of the review and `main` keeps one
-commit per landed change. A merge commit would put the branch's steps
-into `main` and a rebase merge would replay them one by one — `main` is
-linear by branch rule, and one change is one commit there.
+of several commits is merged with "Squash and merge"**: the branch
+becomes one commit, so the review's commits are the record of the review
+and `main` keeps one commit per landed change. A merge commit would put
+the branch's steps into `main` and a rebase merge would replay them one
+by one — `main` is linear by branch rule, and one change is one commit
+there.
+
+**A pull request that is already one commit may instead land as a
+fast-forward**, which is the maintainer's own path and needs a ruleset
+bypass no contributor has: REPOSITORY.md describes it. It is worth
+knowing about from here for two reasons. The sha does not change, so the
+commit `main` receives is the exact commit CI tested and the signature on
+it is the author's rather than GitHub's web-flow key — and a branch
+stacked on that one keeps applying, where a squash would have rewritten
+its base. Which is why a correction added on top of a reviewed branch is
+still the right shape: whether the branch is squashed or fast-forwarded
+is decided when it lands, and by then the review has its record either
+way.
 
 What that commit says is the repository's to answer, not this file's:
 
@@ -1304,9 +1317,9 @@ is the branch's commit messages either way — never the pull request's
 body, which stays on the pull request.
 
 **It is a setting and not a choice made once per pull request.** Squash is
-the only method the repository enables, so there is no other button to
-read; REPOSITORY.md has that setting and what the other two would have
-cost.
+the only *button* the repository enables, so there is no other to read;
+REPOSITORY.md has that setting, what the other two would have cost, and
+the fast-forward that is not a button at all.
 
 The one force-push that stays right is the one that carries no new work: a
 `git rebase origin/main` on a branch whose base has moved, which is how a

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -288,13 +288,19 @@ word, and step 1 asks it of both.
    enforces, and a pull request that never mentions them reads exactly
    like one that skipped them.
 
-   And merge it the way every pull request here is merged, with **"Squash
-   and merge"**: this branch carries a version bump and two retitles, not
-   a cycle of work, and CONTRIBUTING.md gives the rest of the reason. It
-   is the only method the repository enables, so the button offers no
-   other — a merge commit was refused by `main`'s required linear history
-   anyway, and a rebase merge would have replayed the branch's steps into
-   a history whose rule is one commit per landed change.
+   And merge it with **"Squash and merge"** where it carries more than
+   one commit, which it usually does: a version bump and two retitles,
+   not a cycle of work, and CONTRIBUTING.md gives the rest of the
+   reason. Squash is the only *button* the repository enables — a merge
+   commit was refused by `main`'s required linear history anyway, and a
+   rebase merge would have replayed the branch's steps into a history
+   whose rule is one commit per landed change.
+
+   Where the release branch is a single commit, the fast-forward of
+   REPOSITORY.md is the better landing and not merely an allowed one: it
+   is the release commit that gets tagged, and a squash would replace it
+   with one signed by GitHub's web-flow key, leaving the tag over a
+   commit the maintainer did not sign.
 
    Then read `lint` and `test` on the commit `main` ends up at before
    tagging, rather than trust the pull request's own green run:

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -320,8 +320,8 @@ git push origin <branch>:main
 
 ## Merge methods
 
-**Squash is the only method enabled**, so it is a setting and not only the
-convention CONTRIBUTING.md states:
+**Squash is the only *button* enabled**, so it is a setting and not only
+the convention CONTRIBUTING.md states:
 
 ```shell
 gh api repos/btclib-org/btclib \
@@ -329,6 +329,18 @@ gh api repos/btclib-org/btclib \
 ```
 
 answers `true` for the first and `false` for the other two.
+
+It is not the only way a pull request lands, and this section named it as
+if it were while the section above it documented the other: **a branch of
+a single commit is fast-forwarded** through the `main-self-merge` bypass,
+which is the sequence written there. What that buys is what a squash
+cannot: the sha does not change, so `main` receives the exact commit CI
+tested, signed by the maintainer rather than by GitHub's web-flow key,
+and a branch stacked on it keeps applying instead of needing a rebase and
+a fresh run of the matrix per level. Which of the two applies is decided
+by the branch and not by taste — a contributor's pull request usually
+carries several commits and is squashed; the maintainer's usually carries
+one.
 
 The merge commit was refused by the required linear history above already,
 so turning it off takes away a button that could not have worked. The


### PR DESCRIPTION
> Independent of https://github.com/btclib-org/btclib/pull/943; both sit
> on `main`.

## One correction to the issue first

It says *"the merge method changed on 16 August 2026"*. It did not.
`git log -S` puts both halves on the **same day**, 12 August:

```
c0d1a3b8 2026-08-12  Document main-integrity and main-self-merge, the maintainer's second path
f712e6c9 2026-08-12  Make squash the only merge method, and say so where it is decided
```

So the two paths have coexisted since the rulesets went up, and one file
has contradicted itself for four days: `REPOSITORY.md` documents the
fast-forward sequence, and its own *Merge methods* section two headings
below says "squash is the only method enabled". What changed on the 16th
is that the fast-forward was *exercised*, nine times in a row, which is
what made the omission visible. That matters for the fix — this is
correcting a description, not recording a new policy.

## What was untrue, and what it says now

- **`REPOSITORY.md`** — "the only method enabled" is true of the *button*
  and was read as true of the landing. The section now says so and names
  the other path, pointing at the bypass two headings above.
- **`CONTRIBUTING.md`** — "a pull request is merged with 'Squash and
  merge'", unqualified. Now: a pull request *of several commits* is; one
  that is already a single commit may land as a fast-forward, which needs
  a bypass no contributor has. It is described rather than instructed,
  for that reason, and it is worth a contributor knowing because it is
  visible in `main` afterwards.
- **`RELEASING.md`** — "the way every pull request here is merged". Now
  keyed to the branch, and it gains the case where the difference is not
  cosmetic: **a release branch of one commit wants the fast-forward**, the
  tag otherwise going over a commit signed by GitHub's web-flow key
  rather than by the maintainer.

## The two choices I made, both cheap to overturn

The issue lists three things to decide.

1. **Which is the default.** Neither: the *branch* decides — several
   commits are squashed, one commit is fast-forwarded. That reads better
   than a default with an exception because it is what actually happens,
   and a contributor and the maintainer land on opposite sides of it
   without either being irregular.
2. **Whether `CONTRIBUTING.md` mentions the fast-forward at all**, given
   that no contributor can perform one. Yes, briefly. A contributor whose
   branch is told "it will be squashed" and then sees it land unsquashed
   has been told something false; and the paragraph it sits in is the one
   arguing that a correction goes on top of a reviewed branch, which is
   the shape the fast-forward makes *more* valuable, not less.
3. **The twin change in `btclib-org/btclib-secp256k1`.** Not here — a
   different repository, and the same three sentences want the same
   reading of its own settings rather than a copy of this one.

Local gates: `pre-commit run --all-files` green, `pytest` green,
`sphinx-build -W` green.

Closes https://github.com/btclib-org/btclib/issues/941

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify repository documentation around how pull requests land, distinguishing squash merges from maintainer fast-forward merges based on branch shape.

Bug Fixes:
- Correct misleading statements in CONTRIBUTING, RELEASING, and REPOSITORY docs that implied all pull requests are squashed when a fast-forward path also exists.

Enhancements:
- Document that branches with multiple commits are squashed while single-commit branches may be fast-forwarded, and explain the implications for signatures, CI-tested shas, and stacked branches.
- Update RELEASING instructions to prefer fast-forward for single-commit release branches so tags reference the maintainer-signed release commit.

Documentation:
- Align CONTRIBUTING, RELEASING, REPOSITORY, and CHANGELOG documentation with current merge policies, including explicit mention of the maintainer-only fast-forward path and its effects on history and signatures.