### PR TITLE
Walk a scan's k as a chain of tweaks, the spend key crossing once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4905,6 +4905,82 @@ documented at release-notes length in the first place, and are still in
   is the platform's overcommit policy. Under the address-space ceiling a
   mutation session now runs with, both shapes raise `MemoryError`, and
   that ceiling is what covers the class.
+- **A silent-payment scan hands the spend key over once, not once per k**
+  (issue #916). `scan_outputs` walks k upward from one spend key, and
+  `_tweak_add_var` at each k serialized that same point, had
+  libsecp256k1 parse it, tweak it and serialize the answer back. Only
+  the tweak differs between two k, and consecutive tweaks differ by
+  their difference:
+
+  ```text
+  P_k     = B + t_k*G
+  P_(k+1) = P_k + (t_(k+1) - t_k)*G
+  ```
+
+  so the fan-out of one base over many tweaks is a chain of steps read
+  the other way round, and a chain is what `keys.PubkeyTweakChain`
+  holds a parsed point across. The issue asked for a fan-out object with
+  a non-mutating `tweak_add`, and none is needed: nothing changes in the
+  bindings for this. `curves.curve._TweakChain` is the wrapper — the
+  tweaks it takes are absolute, each measured from the base, so the
+  caller keeps writing what it means and the differences are what cross.
+  Sixteen tweaks of one point 112.7 µs against 133.8, the difference
+  being the fifteen parses that do not happen.
+
+  | outputs found | per-k tweak | chain |
+  | --- | --- | --- |
+  | 1 | 49.29 µs | 47.63 µs |
+  | 2 | 65.74 µs | 61.88 µs |
+  | 4 | 97.48 µs | 91.92 µs |
+  | 8 | 161.48 µs | 149.60 µs |
+  | 16 | 288.73 µs | 264.05 µs |
+
+  Those are whole scans of a transaction whose outputs are all one
+  recipient's, **with no labels**, which is the configuration every
+  figure above was measured in and is not the one BIP352 prescribes:
+  the change label m = 0 is asked of every wallet. What that map costs
+  is the entry below, and it decides what share of a scan this is:
+
+  | scan, with the m = 0 map | per-k tweak | chain |
+  | --- | --- | --- |
+  | 1 output, the recipient's | 50.4 µs | 48.7 µs |
+  | 16 outputs, all the recipient's | 294.5 µs | 270.8 µs |
+  | 10 of a hundred | 2179.2 µs | 2159.4 µs |
+  | 0 of a hundred | 2240.0 µs | 2231.1 µs |
+
+  A transaction whose outputs are all one recipient's pays nothing for
+  the labels — a direct match never reaches `_labelled` — so those two
+  rows are the two above them, at the same 3.4% and 8%. The mixed case
+  is where the label search dominates: ten among a hundred is 190.7 µs
+  against 206.2 with no labels and 2159.4 against 2179.2 with the map,
+  about 20 µs saved with the map and 15 without, out of eleven times the
+  scan, which is 0.9% rather than 7.5%. A scan that matches nothing is
+  47.8 µs against 47.6 with no labels and 2231.1 against 2240.0 with the
+  map, the first tweak paying a parse whichever function makes it.
+
+  Measured against `9890e504` on an Apple M5, macOS 26.6, arm64, CPython
+  3.14.6, best of seven alternating rounds (five for the labelled
+  table), with the scan's own ECDH as the noise detector — 16.4 µs
+  throughout.
+
+  What libsecp256k1 refuses is a step onto infinity, which has no public
+  key — and the refusal clears the point the chain was holding, so the
+  chain is dropped there rather than resumed, that tweak and every later
+  one going to `_tweak_add_var` one call each. A zero step it does not
+  refuse: two equal consecutive tweaks are added like any other tweak,
+  and the point it already holds is the answer.
+
+- **A zero tweak stops taking the Python arm, where the comment sending
+  it there was wrong** (issue #916). `_tweak_add_var`'s docstring listed
+  a zero tweak among what "the bindings decline", and the `if t and ...`
+  guard existed for that belief. libsecp256k1's own header declares the
+  opposite of `secp256k1_ec_pubkey_tweak_add` — the tweak must be "valid
+  according to secp256k1_ec_seckey_verify **or 32 zero bytes**" — and
+  what the guard bought was the slow answer to the easiest question:
+  131.40 µs against 5.01, `mult` having the one scalar libsecp256k1
+  *does* decline and taking the fixed-base ladder to reach the point
+  already in hand. The guard on an infinite P stays, that one being
+  true.
 
 - **A silent-payment scan stops looking for labels a wallet has none of**
   (issue #916). `scan_outputs` called `_labelled` for every output that

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -36,6 +36,9 @@ from pathlib import Path
 from typing import Any
 
 from btclib_secp256k1.keys import (
+    PubkeyTweakChain as Libsecp256k1PubkeyTweakChain,
+)
+from btclib_secp256k1.keys import (
     pubkey_from_prvkey as libsecp256k1_pubkey_from_prvkey,
 )
 from btclib_secp256k1.keys import pubkey_sum as libsecp256k1_pubkey_sum
@@ -1060,20 +1063,115 @@ def _tweak_add_var(P: Point, t: int, ec: Curve) -> Point:
     across a whole path, and `xonly.tweak_add`, which carries the parity
     BIP341 commits to.
 
-    The Python arm is the pair above, and answers everything the bindings
-    decline: a zero tweak, an infinite P, a curve that is not secp256k1,
-    and the sum at infinity -- which libsecp256k1 has no public key for
-    and `add_var` returns.
+    The Python arm is the pair above, and answers what the bindings
+    decline: an infinite P, a curve that is not secp256k1, and the sum at
+    infinity -- which libsecp256k1 has no public key for and `add_var`
+    returns.
+
+    A zero tweak is not in that list and was: libsecp256k1 takes a tweak
+    "valid according to secp256k1_ec_seckey_verify *or 32 zero bytes*",
+    which its own header says of `secp256k1_ec_pubkey_tweak_add`, and
+    answers P. Sending it to the Python pair instead is what the
+    condition on `t` used to do, and it cost 131.40 us against 5.01: the
+    tweak is zero, so `mult` has the scalar libsecp256k1 declines and
+    takes the fixed-base ladder for an answer that is the point already
+    in hand.
     """
     ec.require_on_curve(P)
     t %= ec.n
 
-    if t and P[1] and _libsecp256k1_serves(ec, None):
+    if P[1] and _libsecp256k1_serves(ec, None):
         with contextlib.suppress(ValueError):
             sec = libsecp256k1_pubkey_tweak_add(_sec_from_point(P), t, False)
             return _point_from_sec(sec)
 
     return ec.add_var(P, mult(t, ec.G, ec))
+
+
+class _TweakChain:
+    """One point, many tweaks of it, and one parse on the far side.
+
+    `_tweak_add_var` above crosses the boundary once per tweak: the point
+    is serialized here, libsecp256k1 parses it, tweaks it and serializes
+    the answer, and this side reads that back. A caller tweaking *one*
+    point over and over pays the parse at every tweak, for a point that
+    has not changed since the last one -- BIP352's `scan_outputs` is the
+    caller, walking k upward from one spend key.
+
+    The tweaks asked of this are absolute, each measured from the point
+    the chain was built on, because that is what the caller means by
+    t_k. What crosses is their differences:
+
+        P_k     = B + t_k*G
+        P_(k+1) = P_k + (t_(k+1) - t_k)*G
+
+    which makes many tweaks of one point a chain of steps, each step's
+    output the next one's input, and `keys.PubkeyTweakChain` is the
+    object that holds the parsed point across such a chain. So this
+    needs no fan-out entry point of its own, and the bindings have none:
+    the fan-out is a chain read the other way round. Sixteen tweaks of
+    one point 112.7 us against 133.8, the difference being the fifteen
+    parses that do not happen; what that is worth at the one caller, per
+    number of outputs found, is in the CHANGELOG entry that took it.
+
+    Nothing is required of the order the tweaks arrive in. The
+    difference is taken modulo n, so the same tweak may be asked for
+    twice -- a zero step, which libsecp256k1 adds like any other and
+    answers with the point it already holds, its header saying so of
+    every tweak it takes -- and a later tweak may be smaller than an
+    earlier one. An instance is reusable for that reason: the base never
+    moves, and what is held beside it is only the tweak the next
+    difference is measured from.
+
+    Args:
+        base: the point every tweak is added to.
+        ec: the curve it belongs to.
+
+    Raises:
+        BTClibTypeError: if the curve is not a Curve.
+        BTClibValueError: if the point is not on the curve.
+    """
+
+    def __init__(self, base: Point, ec: Curve = secp256k1) -> None:
+        # both, and in this order, as `PreparedPoint` above has them: the
+        # point is on a curve, so a curve that is not one is what has to
+        # be refused first
+        _assert_valid_ec(ec)
+        ec.require_on_curve(base)
+        self.base = base
+        self.ec = ec
+        # the tweak the chain's point currently stands at, from which the
+        # next step is measured; zero is the base itself
+        self._tweak = 0
+        # infinity has no public key on the other side, and a curve that
+        # is not secp256k1 has no bindings at all: either way there is
+        # nothing to hold across the calls, and `point` below answers
+        # each of them on its own
+        self._chain = (
+            Libsecp256k1PubkeyTweakChain(_sec_from_point(base))
+            if base[1] and _libsecp256k1_serves(ec, None)
+            else None
+        )
+
+    def point(self, t: int) -> Point:
+        """Return base + t*G, taking the step from the last tweak asked for."""
+        t %= self.ec.n
+        if self._chain is not None:
+            try:
+                sec = self._chain.tweak_add((t - self._tweak) % self.ec.n, False)
+            except ValueError:
+                # the step landed on infinity, which libsecp256k1 has no
+                # public key for. The failure clears the point the chain
+                # was holding, so there is nothing left to continue from
+                # and it is dropped rather than resumed -- this tweak and
+                # every later one go to the one-shot pair above, whose
+                # Python arm is what has an infinity to answer with
+                self._chain = None
+            else:
+                self._tweak = t
+                return _point_from_sec(sec)
+
+        return _tweak_add_var(self.base, t, self.ec)
 
 
 def _jac_double_mult(

--- a/btclib/silent_payments.py
+++ b/btclib/silent_payments.py
@@ -68,7 +68,7 @@ from btclib.alias import NetworkType, Octets, Point, String
 from btclib.b32 import power_of_2_base_conversion
 from btclib.bech32 import _BECH32_M_CONST, decode, encode
 from btclib.curves import bytes_from_point, mult, point_from_octets, secp256k1
-from btclib.curves.curve import _sum_var, _tweak_add_var
+from btclib.curves.curve import _sum_var, _tweak_add_var, _TweakChain
 from btclib.curves.sec_point import _mult_sec_var
 from btclib.ecc.ssa import point_from_bip340pub_key
 from btclib.exceptions import BTClibTypeError, BTClibValueError
@@ -695,8 +695,10 @@ def scan_outputs(
     sender is missed.
     """
     secret = shared_secret(b_scan, tweak)
-    B = point_from_pub_key(B_spend)
+    # every k tweaks the one spend key, and `_tweak_add_var` would cross
+    # the boundary with it at each of them: the chain crosses with it once
     label_map = {} if labels is None else labels
+    chain = _TweakChain(point_from_pub_key(B_spend), secp256k1)
     remaining = [
         bytes_from_octets(output, secp256k1.p_size) for output in outputs_to_check
     ]
@@ -704,7 +706,7 @@ def scan_outputs(
     found = []
     for k in range(K_MAX):
         t_k = _output_tweak(secret, k)
-        P_k = _tweak_add_var(B, t_k, secp256k1)
+        P_k = chain.point(t_k)
         x_only_P_k = _x_only(P_k)
         match = None
         for output in remaining:

--- a/tests/curve_parameter_test.py
+++ b/tests/curve_parameter_test.py
@@ -77,6 +77,7 @@ from btclib.curves import CurveGroup, secp256k1
 from btclib.curves.curve import (
     Curve,
     PreparedPoint,
+    _TweakChain,
     double_mult_var,
     mult,
     multi_mult_var,
@@ -166,6 +167,14 @@ _CASES = (
         "btclib.curves.curve.PreparedPoint.__init__",
         PreparedPoint,
         {"point": _PUB_KEY},
+    ),
+    # the other constructor holding a point across calls, private and
+    # driven here all the same: the walk finds it, its `__init__` being a
+    # dunder, and a function the walk finds is one this table drives
+    _Case(
+        "btclib.curves.curve._TweakChain.__init__",
+        _TweakChain,
+        {"base": _PUB_KEY},
     ),
     _Case(
         "btclib.curves.curve.double_mult_var",

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -47,6 +47,7 @@ from btclib.curves.curve import (
     _sec_from_point,
     _sum_var,
     _tweak_add_var,
+    _TweakChain,
     _y_even_var,
 )
 
@@ -999,6 +1000,9 @@ def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_sum", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_xonly_pubkey_verify", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_xonly_to_pubkey", refuse)
+    # a class rather than a function, which is the one dispatch that
+    # builds an object instead of calling through
+    monkeypatch.setattr(curve, "Libsecp256k1PubkeyTweakChain", refuse)
 
 
 @pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
@@ -1037,6 +1041,64 @@ def test_tweak_add_var(bindings: bool, monkeypatch: pytest.MonkeyPatch) -> None:
             assert _tweak_add_var(P, t, other) == other.add_var(
                 P, mult(t, other.G, other)
             )
+
+
+@pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
+def test_tweak_chain(bindings: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A chain of steps answers what a tweak of the base answers.
+
+    `_TweakChain` walks from each tweak to the next by their difference,
+    where `_tweak_add_var` adds every tweak to the base itself, so the
+    two have to agree at every step -- over tweaks that climb, that fall
+    back, that repeat (a zero step), and that are the base's own
+    neighbourhood: 0, 1 and n-1.
+
+    The values libsecp256k1 has none of are what the chain answers for
+    beyond that: a base at infinity, which is no public key and leaves
+    nothing to hold; and a step landing on infinity, which clears the
+    point the chain was holding and so has to be the end of the chain
+    rather than a step in it -- the tweaks after it are still answered,
+    one call each.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    ec = secp256k1
+    tweaks = (0, 1, 7, 3, 3, ec.n // 2, 2, ec.n - 1, 0)
+    for k in (1, 2, 7, ec.n - 1):
+        base = mult(k)
+        chain = _TweakChain(base, ec)
+        for t in tweaks:
+            assert chain.point(t) == _tweak_add_var(base, t, ec)
+
+    # a base at infinity: every tweak is the tweak's own multiple, and
+    # the chain never holds a point
+    chain = _TweakChain(INF, ec)
+    for t in tweaks:
+        assert chain.point(t) == mult(t)
+
+    # a step onto infinity, which is the whole group order away from the
+    # base, and the two tweaks around it -- the one before is the last
+    # the chain itself answers, the one after is answered without it
+    base = mult(7)
+    chain = _TweakChain(base, ec)
+    assert chain.point(5) == _tweak_add_var(base, 5, ec)
+    assert chain.point(ec.n - 7) == INF
+    assert chain.point(5) == _tweak_add_var(base, 5, ec)
+
+    # a point that is not on the curve is refused where it is handed
+    # over, rather than at the first tweak of it
+    with pytest.raises(BTClibValueError, match="point not on curve"):
+        _TweakChain((ec.G[0], ec.G[1] + 1), ec)
+
+    # and a curve the bindings do not serve is the same answer again,
+    # every step of it on the Python arithmetic
+    for other in low_card_curves.values():
+        for k in range(1, 4):
+            base = mult(k, other.G, other)
+            chain = _TweakChain(base, other)
+            for t in range(other.n):
+                assert chain.point(t) == _tweak_add_var(base, t, other)
 
 
 @pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/916, the third of the
three things that issue named -- the other two landed in
https://github.com/btclib-org/btclib/pull/937.

`scan_outputs` walks k upward from one spend key, and `_tweak_add_var`
at each k serialized that same point, had libsecp256k1 parse it, tweak
it and serialize the answer back. Only the tweak differs between two k,
and consecutive tweaks differ by their difference:

```text
P_k     = B + t_k*G
P_(k+1) = P_k + (t_(k+1) - t_k)*G
```

so the fan-out of one base over many tweaks is a chain of steps read the
other way round, and a chain is what `keys.PubkeyTweakChain` holds a
parsed point across. **The issue asked for a fan-out object with a
non-mutating `tweak_add`, and nothing is needed on the other side.**

`curves.curve._TweakChain` is the wrapper the layering wants -- the
scan imports no bindings, `_tweak_add_var` being `curves.curve`'s. Its
tweaks are absolute, each measured from the base, so the caller keeps
writing what it means and the differences are what cross.

| outputs found | per-k tweak | chain |
| --- | --- | --- |
| 1 | 49.29 µs | 47.63 µs |
| 2 | 65.74 µs | 61.88 µs |
| 4 | 97.48 µs | 91.92 µs |
| 8 | 161.48 µs | 149.60 µs |
| 16 | 288.73 µs | 264.05 µs |

Whole scans of a transaction whose outputs are all one recipient's. Ten
outputs among a hundred are 190.7 µs against 206.2, and a scan that
matches nothing measures the same either way -- 47.8 µs against 47.6
over a hundred outputs, the first tweak paying a parse whichever
function makes it. Sixteen tweaks of the point alone 112.7 µs against 133.8,
which is the fifteen parses that do not happen. Measured against
`9890e504` on an Apple M5, macOS 26.6, arm64, CPython 3.14.6, best of
seven alternating rounds, with the scan's own ECDH as the noise detector
(16.4 µs throughout).

**The other premise the issue carried is wrong too, and measured:** a
zero step is not refused. Two equal consecutive tweaks are a hash
collision that cannot happen, and libsecp256k1 adds a zero tweak like
any other anyway, answering with the point it already holds. What it
does refuse is a step onto infinity -- and the refusal clears the point
the chain was holding, so the chain is dropped there rather than
resumed, that tweak and every later one going to `_tweak_add_var` one
call each. Both paths are driven in `test_tweak_chain`.

`curve_parameter_test`'s walk skips a private class the way it already
skips a private function: `_TweakChain.__init__` is a dunder whose class
no caller outside the package can name, so what validates for it is the
public function that builds it.

Gates: `uv run pytest` green at 100%, `uv run pre-commit run --all-files`
green, sphinx `-W` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize silent payment output scanning by reusing a single parsed spend key across multiple tweaks via a tweak chain, improving performance without changing external behavior.

New Features:
- Introduce an internal tweak chain helper that caches a parsed public key and derives multiple tweaked points from it using absolute tweaks.

Enhancements:
- Update silent payment scanning to use the tweak chain instead of per-tweak libsecp256k1 calls, reducing repeated parsing and handling infinity edge cases consistently.
- Extend curve parameter walking tests and new unit tests to validate tweak chain behavior with and without bindings, including infinity and unsupported-curve scenarios.

Documentation:
- Document the silent payment scan performance improvement and libsecp256k1 tweak edge-case behavior in the changelog.

Tests:
- Add tests covering the tweak chain’s equivalence to direct tweaking, its handling of zero steps, infinity, invalid points, and curves not backed by bindings, and adjust curve parameter walk tests to skip private classes.
