### PR TITLE
Print the host's memory while the mutants run, and cut script sooner

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -201,12 +201,22 @@ jobs:
           # mutants, 187 filtered, and 406 judged in 35 minutes. Not folded
           # into the consensus job, which spends 180 of its 200 minutes
           # already, and not into the psbt one, which would then need 90
-          # minutes of its own
+          # minutes of its own.
+          # 20 minutes and not the 45 the sample above was measured with,
+          # which buys less of the scope on purpose: this profile has twice
+          # taken its host down mid-session rather than finishing (issue
+          # #948), at 22.6 minutes on the attempt that got furthest, and a
+          # session `timeout` cuts short is a partial answer where a dead
+          # runner is none at all -- it takes the reports and the artifact
+          # with it. A cut lands ahead of the kill only while the kill is
+          # where it was measured, so this is a floor under the loss and not
+          # a fix; the memory the step below prints is what says where the
+          # fix belongs
           - profile: the script encodings
             slug: script
-            ceiling: 60
+            ceiling: 35
             sessions: |
-              script.toml 45m
+              script.toml 20m
           # the four small scopes, which is what makes them one job: signer
           # finished its 302 filtered mutants in 9 minutes and wallet its
           # 293 in 15, musig2 spends most of a session on the two `%`
@@ -282,6 +292,37 @@ jobs:
         env:
           SESSIONS: ${{ matrix.sessions }}
         run: |
+          # what the host's memory is doing while the mutants run, and the
+          # question is issue #948's: two profiles die here with the job's
+          # own remaining steps reported `skipped` rather than failed, which
+          # is a host that went away rather than a command that exited.
+          # A mutant that widens a size bound allocates towards it --
+          # `ansi_x9_63_kdf` builds a list of digests and `numeric.toml`
+          # puts the weakened bound at gigabytes of keying data, which is
+          # 10^8 objects -- so memory is the reading that tells that apart
+          # from a runner GitHub happened to reclaim.
+          #
+          # To stdout, and this is the whole point of it rather than a
+          # detail: the reports and the artifact are exactly what a dead
+          # host does not leave behind, and a log line already streamed is
+          # what it cannot take back. Every 15 s, because the allocation
+          # that matters develops over tens of seconds and a minute of
+          # spacing would sample either side of it
+          report_memory() {
+            while true; do
+              free -m | awk '/^Mem:/ {
+                print "memory: " $3 " MiB used, " $7 " MiB available"
+              }'
+              sleep 15
+            done
+          }
+          report_memory &
+          memory_reporter=$!
+          # the sessions are what this step waits for, so the sampler has to
+          # be reaped whichever way they end -- including the `return` below
+          # on an unsound status, which leaves the step without running
+          # anything after the loop
+          trap 'kill "$memory_reporter" 2> /dev/null || true' EXIT
           run_session() {
             local config=".github/mutation/$1" session="${1%.toml}.sqlite"
             local budget="$2" status=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,26 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **The weekly mutation run prints the host's memory, and the script
+  profile is cut sooner** (issue #948). Two of the eleven profiles die
+  mid-session with the job's own later steps reported `skipped` rather
+  than failed, which is a host that went away and not a command that
+  exited: the reports and the artifact go with it, so those two produce
+  nothing at all. A mutant that widens a size bound allocates towards it —
+  `ansi_x9_63_kdf` accumulates a list of digests, and `numeric.toml` puts
+  the weakened bound at gigabytes of keying data — which is the reading
+  that tells memory exhaustion from a runner GitHub happened to reclaim.
+
+  The sessions step now prints used and available memory every 15 seconds.
+  To stdout rather than to the artifact, that being exactly what a dead
+  host does not leave behind, and at 15 seconds because the allocation
+  develops over tens of them. `script.toml`'s session budget drops from 45
+  minutes to 20, under the 22.6 the furthest attempt reached, so a
+  `timeout` cut — a partial answer the workflow already handles — lands
+  ahead of the kill while the kill is where it was measured. Neither is
+  the fix: bounding the allocation is, and what to bound it to is what
+  these two measure
+
 - **The editor spell-checks a file outside the workspace folder with this
   repository's configuration too.** `typos` runs in the editor as a language
   server, and it looks for `[tool.typos]` from the workspace folder rather


### PR DESCRIPTION
Two of the eleven mutation profiles die mid-session, and the reading that
says what killed them is not in the logs: the step prints nothing, which
`cosmic-ray exec` does everywhere, and the steps after it are reported
`skipped` rather than failed although both carry `if: always()`. A step
that merely exited non-zero would have let them run, so what happened is
a host that went away.

A mutant that widens a size bound allocates towards it. `numeric.toml`
already names the shape as the reason its per-mutant timeout is wide --
`ansi_x9_63_kdf`'s guard mutated away goes on hashing towards the size it
was asked for, and the weakened bound puts that at gigabytes of keying
data -- and `dh.py` accumulates it as a list of digests before joining,
so gigabytes is on the order of 10^8 objects, each with its own header.
Memory is therefore what tells that apart from a runner GitHub happened
to reclaim, and neither profile's own reports survive to say so.

The sampler goes to stdout, which is the whole of the design rather than
a detail: the artifact is exactly what a dead host does not leave behind,
and a log line already streamed is what it cannot take back. Every 15 s,
the allocation developing over tens of them.

`script.toml` drops from 45 minutes to 20, under the 22.6 of the attempt
that got furthest, so `timeout` cuts it -- exit 124, a partial answer this
workflow already handles -- ahead of the kill. That holds only while the
kill is where it was measured, and the shared profile is left alone
because no budget worth measuring with lands ahead of both of its
attempts: four minutes into a session in one and eleven in the other.
Bounding the allocation is the fix; what to bound it to is what these
two measure.

Closes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add host memory sampling to the weekly mutation workflow and reduce the script profile's time budget so mutation runs fail earlier with observable resource usage instead of losing all results when the runner dies.

New Features:
- Add periodic host memory reporting during mutation sessions to distinguish memory exhaustion from reclaimed runners.

Enhancements:
- Shorten the script mutation profile session budget and ceiling to cut runs earlier and avoid host kills while preserving partial results.

CI:
- Update the weekly mutation workflow to run a background memory sampler during sessions and to adjust time budgets for the script profile.

Documentation:
- Document the new memory reporting behaviour and reduced script profile budget for the weekly mutation run in the changelog.