### PR TITLE
Follow the bindings to their tip again

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ test = [
 [[package]]
 name = "btclib-secp256k1"
 version = "0.8.0.3"
-source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#f124095298cce125972a78042c484b12dbc96b81" }
+source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#9ee70e3bfd87a8a0058aea38e02306ca4f795141" }
 dependencies = [
     { name = "cffi" },
 ]


### PR DESCRIPTION
`[tool.uv.sources]` names the branch, not a revision, so the reference is
already moving; `uv.lock` is where a commit is written down, and it is
written down again here: btclib_secp256k1 f1240952 -> 9ee70e3b.

That one commit moves the bindings' own workflow and hook pins and
touches nothing the package installs, so the version is still 0.8.0.3 and
the floor in `dependencies` stays as it is. The rest of the lock does not
move: `--upgrade-package` re-resolves the one name.

The suite, every hook and sphinx -W pass against the result.

## Summary by Sourcery

Enhancements:
- Refresh uv.lock for btclib_secp256k1 to point at the new workflow-only commit without altering installed artifacts or versioning.