### PR TITLE
Bound a mutation session's memory, so a verdict survives the mutant

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -254,11 +254,18 @@ jobs:
       # The matrix value reaches the shell through the environment rather
       # than through a `${{ }}` inside the script, which would be text
       # pasted into it: the value is this file's own, and the habit is what
-      # zizmor's template-injection rule is asking for
+      # zizmor's template-injection rule is asking for.
+      #
+      # Under the same ceiling as the sessions below, and that is what makes
+      # this step the ceiling's own test: a limit too low for what the test
+      # commands legitimately need fails here, against the unmutated tree,
+      # rather than reporting every mutant killed -- the failure mode the
+      # paragraph above is already about
       - name: Check the baselines
         env:
           SESSIONS: ${{ matrix.sessions }}
         run: |
+          ulimit -v 2097152
           while read -r config _; do
             [ -n "$config" ] || continue
             uv run --locked --no-default-groups --group test --group mutation \
@@ -292,6 +299,30 @@ jobs:
         env:
           SESSIONS: ${{ matrix.sessions }}
         run: |
+          # 2 GiB of address space, inherited by `cosmic-ray exec` and by
+          # every test command under it, which is what turns issue #948's
+          # dead host into a recorded verdict. The mutant is already killed
+          # by a test that exists: `dh_test.py` asks for one octet past the
+          # bound expecting a refusal, and `pytest.raises(BTClibValueError)`
+          # does not catch the MemoryError that arrives instead, so the
+          # command exits non-zero and the mutant is KILLED. What was
+          # missing is a process alive to say so -- unbounded, the loop
+          # grows past the host's own 16 GiB and takes the job's remaining
+          # steps with it.
+          #
+          # 2 GiB because it sits between two numbers far apart: these test
+          # commands run in a fraction of it, and the loop wants 358 GiB, so
+          # anything between them works and the low end is what makes a
+          # mutant cheap. Measured at 89.4 bytes an iteration, the ceiling
+          # is 24e6 iterations away -- seconds, against a host that does not
+          # come back. Whether it clears what pytest needs is not asserted
+          # here: the baseline step above runs under the same limit and
+          # fails the run if it does not.
+          #
+          # Not the per-mutant `timeout`, which cannot reach this: 300 s is
+          # a width the slow-but-harmless mutants are measured against, and
+          # memory goes at well under it
+          ulimit -v 2097152
           # what the host's memory is doing while the mutants run, and the
           # question is issue #948's: two profiles die here with the job's
           # own remaining steps reported `skipped` rather than failed, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,27 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **A mutation session runs under a 2 GiB ceiling, so a mutant that
+  allocates without end is recorded rather than fatal** (issue #948). The
+  mutant in question is already killed by a test that exists:
+  `tests/ecc/dh_test.py` asks `ansi_x9_63_kdf` for one octet past the
+  bound and expects a refusal, and with the guard mutated away what
+  arrives instead is not the `BTClibValueError` the test catches. What was
+  missing is a process alive to report it — the loop appends a digest per
+  iteration towards 358 GiB, so the host's memory went first and the job's
+  later steps died with it, which is why those profiles produced neither
+  report nor artifact.
+
+  `ulimit -v` bounds the address space `cosmic-ray exec` and every test
+  command under it inherit, so the failure lands inside pytest as a
+  `MemoryError` and the verdict is KILLED. 2 GiB sits between two numbers
+  far apart — what these commands need against what the loop wants — and
+  the low end is what makes such a mutant cost seconds. The baseline step
+  runs under the same limit, so a ceiling too low for legitimate use fails
+  the run against the unmutated tree instead of reporting every mutant
+  killed. The per-mutant `timeout` cannot do this: memory goes at well
+  under its 300 seconds
+
 - **The weekly mutation run prints the host's memory, and the script
   profile is cut sooner** (issue #948). Two of the eleven profiles die
   mid-session with the job's own later steps reported `skipped` rather


### PR DESCRIPTION
The mutant that takes the host down is already killed by a test that
exists. `dh_test.py` asks `ansi_x9_63_kdf` for one octet past the bound
and expects the refusal; with the guard mutated away what arrives is not
the `BTClibValueError` that `pytest.raises` catches, so the command exits
non-zero and cosmic-ray records KILLED. Nothing is owed a test here.

What is missing is a process alive to say it. Unbounded, the loop appends
a digest an iteration towards 358 GiB, so the host's 16 run out first --
and a host that goes away takes the reports, the artifact and every later
step with it, which is why the profile answers nothing at all rather than
answering wrong. Sixteen of `dh.py`'s 162 mutants reach that loop: two on
the guard and fourteen on the bound above it, two of those an integer of
6.4e9 digits before the loop is even reached.

`ulimit -v` is inherited, so one line covers `cosmic-ray exec` and every
test command under it. 2 GiB because the two numbers it separates are far
apart -- these commands run in a fraction of it, the loop wants 358 GiB --
and the low end is what makes such a mutant cost seconds: at the 89.4
bytes an iteration measured for that loop, the ceiling is 24e6 iterations
away. Not the per-mutant `timeout`, which cannot reach it, 300 s being a
width the slow-but-harmless mutants are measured against while memory
goes at well under it.

The baseline step takes the same ceiling, which is what tests the number:
too low for what the test commands legitimately need and the run fails
there, against the unmutated tree, rather than reporting every mutant
killed -- the one failure mode of a mutation run that looks like good
news, and the reason that step exists.

`script.toml`'s lowered budget stays. Its two deaths are not explained by
this mechanism -- the walk a mutated bound stops advancing feeds a counter
in this profile's scope, not an accumulator -- so the containment holds
until the memory trace says what happens there.

Towards #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bound mutation testing sessions to a 2 GiB virtual-memory limit so runaway mutants are captured as failed tests instead of crashing the host, and documented the new safeguard in the changelog.

CI:
- Add a 2 GiB ulimit to baseline and mutation steps in the GitHub Actions workflow so memory-exhausting mutants produce recorded verdicts rather than aborting the job.

Documentation:
- Document the new 2 GiB memory ceiling for mutation sessions and its impact on reporting runaway mutants in the repository changelog.