### PR TITLE
Ask ansi_x9_63_kdf's buffer for once, not a digest at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4877,6 +4877,35 @@ documented at release-notes length in the first place, and are still in
 
 ### Performance
 
+- **`ansi_x9_63_kdf` asks for its buffer once, rather than joining a list
+  of digests** (issue #952). The list, the join's copy and the final
+  slice held the keying data three times over, and reached that total a
+  digest at a time. One `bytearray` of whole blocks, written through a
+  `memoryview` and cut to size on the way out, holds it twice: deriving
+  64 MiB peaks at 128.0 MiB above baseline against 370.3. The keying data
+  is unchanged at every size — the blocks depend on the counter alone, so
+  a size says where the sequence stops and nothing else, which is what
+  the new test holds by deriving every size up to three blocks and
+  comparing each with the longest cut to its length.
+
+  The cost is the derivation itself, a quarter to a half of it: 0.63 µs
+  against 0.41 for 32 octets, 0.90 against 0.69 for 64, 9.16 against 7.81
+  for 1024 — medians of seven alternating rounds of two thousand calls,
+  so a fixed fifth of a microsecond rather than a proportion.
+  `diffie_hellman` reaches the KDF after a scalar multiplication of 15.2
+  µs, which is what a caller actually asked for and what that fifth is
+  around one percent of.
+
+  Why a trade in that direction: issue #948. A mutant that widens the
+  size bound has the loop asked for gigabytes of keying data, and
+  creeping towards them exhausts the host before any one allocation
+  fails — the runner goes away, and the session's verdict with it. A
+  single request that large is one question to the allocator instead,
+  and a refusal is what the existing test turns into a kill. The
+  address-space ceiling of the mutation session covers the class, this
+  being one function of however many allocate without end; what the
+  measurements above decide is this one.
+
 - **A silent-payment scan stops looking for labels a wallet has none of**
   (issue #916). `scan_outputs` called `_labelled` for every output that
   did not match directly, and `_labelled` is a lift of the output key and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4882,29 +4882,29 @@ documented at release-notes length in the first place, and are still in
   slice held the keying data three times over, and reached that total a
   digest at a time. One `bytearray` of whole blocks, written through a
   `memoryview` and cut to size on the way out, holds it twice: deriving
-  64 MiB peaks at 128.0 MiB above baseline against 370.3. The keying data
-  is unchanged at every size — the blocks depend on the counter alone, so
-  a size says where the sequence stops and nothing else, which is what
-  the new test holds by deriving every size up to three blocks and
-  comparing each with the longest cut to its length.
+  64 MiB peaks at 128.0 MiB above baseline against 370.3, which is 2.00x
+  the output against 5.79x. The keying data is unchanged at every size —
+  the blocks depend on the counter alone, so a size says where the
+  sequence stops and nothing else, which is what the new test holds by
+  deriving every size up to three blocks and comparing each with the
+  longest cut to its length.
 
-  The cost is the derivation itself, a quarter to a half of it: 0.63 µs
-  against 0.41 for 32 octets, 0.90 against 0.69 for 64, 9.16 against 7.81
-  for 1024 — medians of seven alternating rounds of two thousand calls,
-  so a fixed fifth of a microsecond rather than a proportion.
-  `diffie_hellman` reaches the KDF after a scalar multiplication of 15.2
-  µs, which is what a caller actually asked for and what that fifth is
-  around one percent of.
+  It costs about 0.03 µs a block, so a proportion and not a constant:
+  1.46x at 32 octets, 1.35x at 64, 1.18x at 1024, 1.11x at 16384, medians
+  of seven alternating rounds. What is fixed is the fifth of a
+  microsecond the one and two blocks cost, and those are the sizes that
+  decide it: `diffie_hellman` reaches the KDF after a scalar
+  multiplication of 15.2 µs, so the overhead where a caller meets it is
+  around one percent of the operation asked for.
 
-  Why a trade in that direction: issue #948. A mutant that widens the
-  size bound has the loop asked for gigabytes of keying data, and
-  creeping towards them exhausts the host before any one allocation
-  fails — the runner goes away, and the session's verdict with it. A
-  single request that large is one question to the allocator instead,
-  and a refusal is what the existing test turns into a kill. The
-  address-space ceiling of the mutation session covers the class, this
-  being one function of however many allocate without end; what the
-  measurements above decide is this one.
+  The peak is the whole of the case, and one thing this does not buy is a
+  refusal in place of an exhaustion. `bytearray(n)` zero-fills — 2^30
+  octets is 0.17 s and 794 MiB of resident memory — so a size no
+  allocator can serve is reached in one statement rather than a loop,
+  which is faster and not different in kind; whether it is refused at all
+  is the platform's overcommit policy. Under the address-space ceiling a
+  mutation session now runs with, both shapes raise `MemoryError`, and
+  that ceiling is what covers the class.
 
 - **A silent-payment scan stops looking for labels a wallet has none of**
   (issue #916). `scan_outputs` called `_labelled` for every output that

--- a/btclib/ecc/dh.py
+++ b/btclib/ecc/dh.py
@@ -88,8 +88,18 @@ def ansi_x9_63_kdf(z: bytes, size: int, hf: HashF, shared_info: bytes | None) ->
     max_size = hf_size * (2**32 - 1)
     if size > max_size:
         raise BTClibValueError(f"cannot derive a key larger than {max_size} bytes")
-    K_temp = []
-    for counter in range(1, ceil(size / hf_size) + 1):
+    # the whole buffer is asked for once, and the blocks are written into
+    # it. A list of digests joined and then sliced holds the keying data
+    # three times over -- the digests, the join's copy, the slice's --
+    # and reaches that total a digest at a time, so a size no allocator
+    # can serve exhausts the host rather than being refused (issue 948).
+    # The peak falls by a factor of three for a fifth of a microsecond,
+    # which is a quarter to a half of the derivation and around one
+    # percent of the scalar multiplication a caller reaches it through
+    n_blocks = ceil(size / hf_size)
+    keying_data = bytearray(n_blocks * hf_size)
+    view = memoryview(keying_data)
+    for counter in range(1, n_blocks + 1):
         h = hf()
         hash_input = (
             z
@@ -97,8 +107,9 @@ def ansi_x9_63_kdf(z: bytes, size: int, hf: HashF, shared_info: bytes | None) ->
             + (b"" if shared_info is None else shared_info)
         )
         h.update(hash_input)
-        K_temp.append(h.digest())
-    return b"".join(K_temp)[:size]
+        start = (counter - 1) * hf_size
+        view[start : start + hf_size] = h.digest()
+    return bytes(view[:size])
 
 
 def diffie_hellman(

--- a/btclib/ecc/dh.py
+++ b/btclib/ecc/dh.py
@@ -91,11 +91,17 @@ def ansi_x9_63_kdf(z: bytes, size: int, hf: HashF, shared_info: bytes | None) ->
     # the whole buffer is asked for once, and the blocks are written into
     # it. A list of digests joined and then sliced holds the keying data
     # three times over -- the digests, the join's copy, the slice's --
-    # and reaches that total a digest at a time, so a size no allocator
-    # can serve exhausts the host rather than being refused (issue 948).
-    # The peak falls by a factor of three for a fifth of a microsecond,
-    # which is a quarter to a half of the derivation and around one
-    # percent of the scalar multiplication a caller reaches it through
+    # where this holds it twice: deriving 64 MiB peaks at 2.00x the
+    # output against 5.79x. It costs about 0.03 us a block, so a fifth of
+    # a microsecond at the one or two blocks `diffie_hellman` asks for,
+    # which is around one percent of the 15.2 us multiplication it
+    # arrives through -- and a tenth of the derivation at sizes far
+    # beyond that
+    #
+    # the `memoryview` is what makes each write exact: a bytearray slice
+    # assignment of the wrong length resizes the buffer and shifts every
+    # block after it, where this raises. At the end `bytes(view[:size])`
+    # copies once, where `bytes(keying_data[:size])` would copy twice
     n_blocks = ceil(size / hf_size)
     keying_data = bytearray(n_blocks * hf_size)
     view = memoryview(keying_data)

--- a/tests/ecc/dh_test.py
+++ b/tests/ecc/dh_test.py
@@ -8,6 +8,7 @@ from hashlib import sha1, sha224, sha256, sha384, sha512
 
 import pytest
 
+from btclib.alias import HashF
 from btclib.curves import bytes_from_point, mult
 from btclib.curves.curve import CURVES
 from btclib.ecc import ansi_x9_63_kdf, dh, diffie_hellman, dsa
@@ -97,6 +98,24 @@ def test_the_smallest_key_a_size_can_ask_for() -> None:
     """
     assert len(ansi_x9_63_kdf(b"z", 1, sha256, None)) == 1
     assert len(ansi_x9_63_kdf(b"z", 32, sha256, None)) == 32
+
+
+@pytest.mark.parametrize("hf", [sha1, sha256, sha512])
+def test_a_shorter_key_is_the_longer_one_cut(hf: HashF) -> None:
+    """Each size answers the block sequence cut at that octet.
+
+    The blocks depend on the counter alone, so what a size changes is
+    where the answer stops. The keying data is written into one buffer of
+    whole blocks and the last of them is the one the size cuts: a buffer
+    handed back whole, or a block written at the wrong offset, breaks
+    this while every size still has the length it asked for.
+    """
+    hf_size = hf().digest_size
+    longest = ansi_x9_63_kdf(b"z", 3 * hf_size, hf, b"deadbeef")
+    for size in range(1, 3 * hf_size + 1):
+        keying_data = ansi_x9_63_kdf(b"z", size, hf, b"deadbeef")
+        assert len(keying_data) == size
+        assert keying_data == longest[:size]
 
 
 def test_gec_2() -> None:

--- a/tests/ecc/dh_test.py
+++ b/tests/ecc/dh_test.py
@@ -107,8 +107,9 @@ def test_a_shorter_key_is_the_longer_one_cut(hf: HashF) -> None:
     The blocks depend on the counter alone, so what a size changes is
     where the answer stops. The keying data is written into one buffer of
     whole blocks and the last of them is the one the size cuts: a buffer
-    handed back whole, or a block written at the wrong offset, breaks
-    this while every size still has the length it asked for.
+    handed back whole is caught by the length, and a block written at the
+    wrong offset is not -- it is the comparison that catches that one,
+    every size still having exactly the length it asked for.
     """
     hf_size = hf().digest_size
     longest = ansi_x9_63_kdf(b"z", 3 * hf_size, hf, b"deadbeef")


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/952.

`ansi_x9_63_kdf` built its answer as a list of digests, joined it and
sliced the join, so it held the keying data three times over. It now asks
for one `bytearray` of whole blocks, writes each block into it through a
`memoryview`, and cuts it to size on the way out — the keying data held
twice.

## Same answer

The two shapes agree byte for byte over 201 sizes from 1 to 65537, under
sha1, sha256 and sha512, with no `shared_info`, an empty one and an
eight-octet one. The blocks depend on the counter alone, so a size says
where the sequence stops and nothing else:
`test_a_shorter_key_is_the_longer_one_cut` derives every size up to three
blocks and compares each with the longest cut to its length, which is
what catches a block written at the wrong offset — a buffer handed back
whole fails the length assertion first.

## The case: the peak

Deriving 64 MiB of keying data, by `tracemalloc`:

| | peak above baseline | of the output |
| --- | ---: | ---: |
| list and join | 370.3 MiB | 5.79x |
| preallocated buffer | 128.0 MiB | 2.00x |

## The cost: a proportion, small where callers meet it

sha256, medians of seven alternating rounds:

| size | blocks | list and join | preallocated | delta | ratio |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 32 | 1 | 0.42 µs | 0.62 µs | +0.20 | 1.46x |
| 64 | 2 | 0.68 µs | 0.91 µs | +0.23 | 1.35x |
| 256 | 8 | 2.19 µs | 2.54 µs | +0.35 | 1.16x |
| 1024 | 32 | 7.86 µs | 9.24 µs | +1.39 | 1.18x |
| 4096 | 128 | 30.43 µs | 34.25 µs | +3.82 | 1.13x |
| 16384 | 512 | 127.44 µs | 142.06 µs | +14.62 | 1.11x |

About 0.03 µs a block once the fixed part is amortized. What is fixed is
the fifth of a microsecond at one and two blocks, and that is what
`diffie_hellman` asks for: it reaches the KDF after a scalar
multiplication of 15.2 µs, so the overhead where a caller meets it is
around one percent of the operation asked for.

## What this does not buy

A refusal in place of an exhaustion. `bytearray(n)` zero-fills —
`bytearray(2**30)` is 0.169 s and +794 MiB of RSS, 6.4 GB/s — so a size
no allocator can serve is reached in one statement rather than a loop,
which is faster and not different in kind; whether it is refused at all
is the platform's overcommit policy. In a mutation session it is the
address-space ceiling of
https://github.com/btclib-org/btclib/pull/951 that makes the refusal
certain, and it makes it certain for the list and join too. The earlier
revision of this branch claimed otherwise in three places; the review on
it measured that, and `31724170` corrects all three.

## Gates

`uv run pytest` (green, coverage at 100.00%), `uv run pre-commit run
--all-files`, and the sphinx `-W` build all pass.

Two commits, so this one lands squashed rather than fast-forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)