### PR TITLE
Hand the whole equation over, so that no term crosses the boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4982,6 +4982,55 @@ documented at release-notes length in the first place, and are still in
   already in hand. The guard on an infinite P stays, that one being
   true.
 
+- **No term of a multi-scalar multiplication crosses the boundary any
+  more** (issue #917). The sum stopped crossing per term when
+  `keys.pubkey_sum` arrived; the terms went on doing it, each
+  `pubkey_tweak_mul` serializing its product as 65 octets for the
+  `pubkey_sum` that parsed them straight back.
+  `keys.pubkey_tweak_mul_sum` (btclib-secp256k1#182) takes the whole
+  equation instead — a `secp256k1_ec_pubkey_tweak_mul` per term and one
+  `secp256k1_ec_pubkey_combine` over them, every product staying a
+  `secp256k1_pubkey` — so `curves.curve._libsecp256k1_multi_mult_` is
+  one call.
+
+  | terms | term at a time | one call |
+  | --- | --- | --- |
+  | 2 | 19.09 µs | 16.63 µs |
+  | 3 | 26.88 µs | 23.35 µs |
+  | 5 | 42.78 µs | 36.84 µs |
+  | 8 | 66.56 µs | 57.11 µs |
+  | 20 | 163.93 µs | 140.49 µs |
+  | 64 | 522.73 µs | 449.20 µs |
+
+  About a seventh of the call from three terms up and a little less at
+  two — 12.9% there against 14.1 to 14.3 above it — which is where it
+  differs from the sum it follows: that one was worth a third at eight
+  terms and nothing at two, and this is one serialization and one parse
+  a term whatever the count. End to end at the callers, and
+  `double_mult_var` is the two-term shape most of them have:
+
+  | caller | term at a time | one call |
+  | --- | --- | --- |
+  | `double_mult_var` | 21.77 µs | 19.36 µs |
+  | `multi_mult_var`, 20 terms | 186.38 µs | 162.89 µs |
+  | `multi_mult_var`, 64 terms | 592.49 µs | 518.36 µs |
+  | `musig2.key_agg`, 2 signers | 36.20 µs | 32.99 µs |
+  | … 5 signers | 94.20 µs | 88.58 µs |
+  | … 20 signers | 388.09 µs | 363.54 µs |
+  | `ssa.assert_batch_as_valid_`, 16 signatures | 595.02 µs | 553.70 µs |
+
+  Measured on an Apple M5, macOS 26.6, arm64, CPython 3.14.6, best of
+  seven alternating rounds, with the old spelling patched in as the
+  other arm and `mult` as the noise detector (8.85 µs across every
+  round).
+
+  The composition is the bindings' now and not this side's, which is
+  where issue #917 said it belonged: a term is a `secp256k1_pubkey`
+  nobody outside the sum has a use for, and btclib holds no parsed key
+  by design. It is the second function there that is more than one
+  libsecp256k1 decision, and btclib-secp256k1#182 is where the rule
+  admitting it is written down.
+
 - **A silent-payment scan stops looking for labels a wallet has none of**
   (issue #916). `scan_outputs` called `_labelled` for every output that
   did not match directly, and `_labelled` is a lift of the output key and

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -43,7 +43,9 @@ from btclib_secp256k1.keys import (
 )
 from btclib_secp256k1.keys import pubkey_sum as libsecp256k1_pubkey_sum
 from btclib_secp256k1.keys import pubkey_tweak_add as libsecp256k1_pubkey_tweak_add
-from btclib_secp256k1.keys import pubkey_tweak_mul as libsecp256k1_pubkey_tweak_mul
+from btclib_secp256k1.keys import (
+    pubkey_tweak_mul_sum as libsecp256k1_pubkey_tweak_mul_sum,
+)
 from btclib_secp256k1.xonly import pubkey_verify as libsecp256k1_xonly_pubkey_verify
 from btclib_secp256k1.xonly import to_pubkey as libsecp256k1_xonly_to_pubkey
 
@@ -495,9 +497,8 @@ def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
     ec.y, and `xonly.pubkey_verify` answers the same of the x alone in
     2.4, being secp256k1_xonly_pubkey_parse and a verdict -- the same
     answer three ways, all three refusing the same x. It is
-    libsecp256k1's own shape,
-    `secp256k1_ge_x_on_curve_var` being `secp256k1_fe_is_square_var` of
-    x^3 + ax + b and nothing else.
+    libsecp256k1's own shape, `secp256k1_ge_x_on_curve_var` being
+    `secp256k1_fe_is_square_var` of x^3 + ax + b and nothing else.
 
     A bool rather than an exception, because the value that names itself
     in an error message is the caller's and not this x: dsa.Sig's
@@ -572,10 +573,12 @@ def _libsecp256k1_multi_mult_(
 ) -> bytes | None:
     """Return sum(scalars[i]*points[i]) as octets, None for infinity.
 
-    The bytes-in/bytes-out layer the gain lives on: a term is one
-    ec_pubkey_tweak_mul, the running total one ec_pubkey_combine, and no
-    intermediate becomes a Point -- each of those would pay a parse on
-    the way out and a serialization on the way back in.
+    The bytes-in/bytes-out layer the gain lives on: one
+    `keys.pubkey_tweak_mul_sum`, which is an ec_pubkey_tweak_mul per term
+    and one ec_pubkey_combine over them, and no intermediate crosses the
+    boundary at all -- neither as a Point, which would pay a parse on the
+    way out and a serialization on the way back in, nor as the octets a
+    term written here would be, which is the same pair one layer down.
 
     None rather than octets, because infinity has no serialization: a
     libsecp256k1 pubkey is a point of the curve and never the identity.
@@ -585,31 +588,35 @@ def _libsecp256k1_multi_mult_(
     answer for: u*H + v*Q with v*Q == -u*H, and v = n - u with Q == H is
     the one-line case of it.
 
-    `keys.pubkey_sum` is what answers it, being `pubkey_combine` with that
-    one sum answered rather than refused: libsecp256k1 reports 0 both for
-    a key it could not read and for a total at infinity, and the first
-    raises through the illegal callback, so a None back from here is the
+    The sum inside answers it, being `pubkey_combine` with that one sum
+    answered rather than refused: libsecp256k1 reports 0 both for a key
+    it could not read and for a total at infinity, and the first raises
+    through the illegal callback, so a None back from here is the
     infinity and nothing else. What that replaces is a combine per term
     with a running total this side compared coordinates on, the only way
     of telling the two zeros apart while the sum was assembled here.
-    Terms first, then one sum, which is worth about a third of the call
-    from eight terms up. Two terms -- double_mult_var, and the shape most
-    callers have -- pay nothing either way: one combine, and now no
-    comparison. The measurement per term count is in the CHANGELOG entry
-    that made the change, which is where a figure belongs: an entry is
-    read as the history of a release and this is read as a statement
-    about the code as it stands.
 
-    At least one term, `pubkey_sum` refusing an empty sequence as
-    `pubkey_combine` does. That is no narrowing of what the callers below
-    reach: fewer than two terms is not a multi_mult_var, and the two other
-    entry points hand over one and two.
+    The terms stopped crossing after it, which is the other half and the
+    smaller one: a `pubkey_tweak_mul` per term serialized its product for
+    a `pubkey_sum` that parsed it straight back, a seventh of what the
+    call cost with them, from three terms up and a little less at two --
+    which is `double_mult_var`'s count and the one most callers have.
+    Handing over the whole equation is what stops it, and that is the one
+    composition the bindings hold rather than this side
+    (btclib-secp256k1#182): a term of a multi-scalar multiplication is a
+    `secp256k1_pubkey` nobody outside the sum has a use for, and this
+    library holds no parsed key by design. The measurement per term count
+    is in the CHANGELOG entry that took each half, which is where a
+    figure belongs: an entry is read as the history of a release and this
+    is read as a statement about the code as it stands.
+
+    At least one term, the sum refusing an empty sequence as
+    `pubkey_combine` does, and as many scalars as points, which is what
+    the entry point raises for itself. Neither narrows what the callers
+    below reach: fewer than two terms is not a multi_mult_var, and the two
+    other entry points hand over one and two, each with its scalar.
     """
-    terms = [
-        libsecp256k1_pubkey_tweak_mul(sec, m, False)
-        for m, sec in zip(scalars, secs, strict=True)
-    ]
-    return libsecp256k1_pubkey_sum(terms, False)
+    return libsecp256k1_pubkey_tweak_mul_sum(secs, scalars, False)
 
 
 def _multi_mult_x_only_var(
@@ -627,16 +634,17 @@ def _multi_mult_x_only_var(
     takes a `Point`, so there the lift is the work and is paid here. That
     is why this takes x-coordinates rather than points, and why the
     concatenation is written here rather than left to `xonly.to_pubkey`:
-    what the octets are on their way to is `pubkey_tweak_mul`, which
-    reads a public key, and libsecp256k1 has no x-only multiplication to
-    hand them to instead. It is the same rule `_x_octets` above serves,
+    what the octets are on their way to is `pubkey_tweak_mul_sum`, whose
+    terms are public keys, and libsecp256k1 has no x-only multiplication
+    to hand them to instead. It is the same rule `_x_octets` above serves,
     reached through the one door that exists for it.
 
     `_libsecp256k1_multi_mult_` and not the public `multi_mult_var`, that
     one taking points -- which is the form the lift would have to build
-    and the multiplication would then write straight back out. Sixteen
-    signatures end to end, i.e. the thirty-two terms: 592.6 us against
-    681.3 with both terms lifted by the caller.
+    and the multiplication would then write straight back out. The
+    thirty-two terms of sixteen signatures: 301.9 us against 387.5 with
+    both terms lifted by the caller, of the 553.9 that batch costs end to
+    end.
 
     Every scalar is required to be in 1..n-1 and every x to be an
     x-coordinate. The caller is what holds to that -- ssa's rand is drawn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,10 @@ dependencies = [
     # root. The same version for `keys.pubkey_sum`, `xonly.pubkey_verify`
     # and `xonly.to_pubkey` (btclib-secp256k1#171), which `curves.curve`
     # calls -- one sum instead of a combine per term, and the two
-    # questions about an x asked as x-only questions -- and for
+    # questions about an x asked as x-only questions. The same version
+    # again for `keys.pubkey_tweak_mul_sum` (btclib-secp256k1#182), which
+    # is that sum with its terms as well, so that no product of a
+    # multi-scalar multiplication crosses the boundary; and for
     # `ssa.Signer` (btclib-secp256k1#154), which `ecc.ssa.Signer` holds so
     # that a keypair is built once per key rather than once per signature.
     # The version is not on PyPI yet -- `[tool.uv.sources]` below is what

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -996,7 +996,7 @@ def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(curve, "_libsecp256k1_available", False)
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_from_prvkey", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_tweak_add", refuse)
-    monkeypatch.setattr(curve, "libsecp256k1_pubkey_tweak_mul", refuse)
+    monkeypatch.setattr(curve, "libsecp256k1_pubkey_tweak_mul_sum", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_pubkey_sum", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_xonly_pubkey_verify", refuse)
     monkeypatch.setattr(curve, "libsecp256k1_xonly_to_pubkey", refuse)

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ test = [
 [[package]]
 name = "btclib-secp256k1"
 version = "0.8.0.3"
-source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#9ee70e3bfd87a8a0058aea38e02306ca4f795141" }
+source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#f7d5dc013aafd177b472166cd71a598eef3b3220" }
 dependencies = [
     { name = "cffi" },
 ]


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/917, the half that
was waiting on the bindings —
https://github.com/btclib-org/btclib-secp256k1/pull/182 landed as
`f7d5dc01`, and the lock moves here with it.

The sum of a multi-scalar multiplication stopped crossing per term when
`keys.pubkey_sum` arrived (PR
https://github.com/btclib-org/btclib/pull/931). The terms went on doing
it: a `pubkey_tweak_mul` each, serializing its product as 65 octets for
the `pubkey_sum` that parsed them straight back.
`keys.pubkey_tweak_mul_sum` takes the equation whole, so every product
stays a `secp256k1_pubkey` and `_libsecp256k1_multi_mult_` is one call.

| terms | term at a time | one call |
| --- | --- | --- |
| 2 | 19.09 µs | 16.63 µs |
| 3 | 26.88 µs | 23.35 µs |
| 5 | 42.78 µs | 36.84 µs |
| 8 | 66.56 µs | 57.11 µs |
| 20 | 163.93 µs | 140.49 µs |
| 64 | 522.73 µs | 449.20 µs |

A flat seventh, which is where it differs from the sum it follows: that
one was worth a third at eight terms and nothing at two, and this is one
serialization and one parse a term, the same fraction whatever the
count. End to end at the callers:

| caller | term at a time | one call |
| --- | --- | --- |
| `double_mult_var` | 21.77 µs | 19.36 µs |
| `multi_mult_var`, 20 terms | 186.38 µs | 162.89 µs |
| `multi_mult_var`, 64 terms | 592.49 µs | 518.36 µs |
| `musig2.key_agg`, 2 signers | 36.20 µs | 32.99 µs |
| … 20 signers | 388.09 µs | 363.54 µs |
| `ssa.assert_batch_as_valid_`, 16 signatures | 595.02 µs | 553.70 µs |

Measured on an Apple M5, macOS 26.6, arm64, CPython 3.14.6, best of
seven alternating rounds, with the old spelling patched in as the other
arm and `mult` as the noise detector (8.85 µs across every round).

**Where the composition lives is the decision the issue asked for**, and
it is the bindings': a term is a `secp256k1_pubkey` nothing outside the
sum has a use for, and btclib holds no parsed key by design. It is the
naive form and not a batched algorithm — `secp256k1_ecmult_multi_var` is
declared in libsecp256k1's `src/ecmult.h` and not in its public header —
so what is saved is the crossing, flat in the term count, which is worth
saying where BIP340 batch verification is one of the callers.

`no_bindings` patches the new name instead of the old one, which is what
keeps the Python arm provably unmeasured against itself; nothing else in
the tests changes, the arithmetic being unchanged.

Gates: `uv run pytest` green at 100%, `uv run pre-commit run
--all-files` green, sphinx `-W` green, all against the re-locked
bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch multi-scalar multiplication to use the new libsecp256k1 binding that aggregates all terms in a single call so no intermediate products cross the Python/libsecp boundary.

Enhancements:
- Use btclib_secp256k1.keys.pubkey_tweak_mul_sum in _libsecp256k1_multi_mult_ so multi-scalar multiplication is handled entirely within libsecp256k1 without per-term serialization.
- Document the new multi-scalar multiplication composition and its performance impact in the changelog.
- Clarify dependency comments to note the requirement on the btclib-secp256k1 version that provides pubkey_tweak_mul_sum.

Build:
- Refresh the uv lockfile to align with the re-locked btclib-secp256k1 bindings providing the new API.

Tests:
- Update curve tests that exercise the no-bindings path to patch the new pubkey_tweak_mul_sum symbol instead of the old per-term tweak function.