### PR TITLE
Raise the session ceiling past what uv reserves, and stop cutting script

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -202,21 +202,21 @@ jobs:
           # into the consensus job, which spends 180 of its 200 minutes
           # already, and not into the psbt one, which would then need 90
           # minutes of its own.
-          # 20 minutes and not the 45 the sample above was measured with,
-          # which buys less of the scope on purpose: this profile has twice
-          # taken its host down mid-session rather than finishing (issue
-          # #948), at 22.6 minutes on the attempt that got furthest, and a
-          # session `timeout` cuts short is a partial answer where a dead
-          # runner is none at all -- it takes the reports and the artifact
-          # with it. A cut lands ahead of the kill only while the kill is
-          # where it was measured, so this is a floor under the loss and not
-          # a fix; the memory the step below prints is what says where the
-          # fix belongs
+          # 45 again, the 20 it was cut to having bought its answer: this
+          # profile twice took its host down mid-session (issue #948), and a
+          # session cut ahead of the kill was a floor under the loss while
+          # the mechanism was unknown. It is no longer the only thing
+          # holding the profile up -- the ceiling above refuses a runaway
+          # allocation whatever the budget -- and a cut session cannot be
+          # compared with the week before it, which is what this profile is
+          # for. If it dies here again the budget was the only thing holding
+          # it, and that is a mechanism still to find rather than one this
+          # file should hide
           - profile: the script encodings
             slug: script
-            ceiling: 35
+            ceiling: 60
             sessions: |
-              script.toml 20m
+              script.toml 45m
           # the four small scopes, which is what makes them one job: signer
           # finished its 302 filtered mutants in 9 minutes and wallet its
           # 293 in 15, musig2 spends most of a session on the two `%`
@@ -265,7 +265,7 @@ jobs:
         env:
           SESSIONS: ${{ matrix.sessions }}
         run: |
-          ulimit -v 2097152
+          ulimit -v 8388608
           while read -r config _; do
             [ -n "$config" ] || continue
             uv run --locked --no-default-groups --group test --group mutation \
@@ -299,39 +299,47 @@ jobs:
         env:
           SESSIONS: ${{ matrix.sessions }}
         run: |
-          # 2 GiB of address space, inherited by `cosmic-ray exec` and by
-          # every test command under it, which is what turns issue #948's
-          # dead host into a recorded verdict. The mutant is already killed
-          # by a test that exists: `dh_test.py` asks for one octet past the
-          # bound expecting a refusal, and `pytest.raises(BTClibValueError)`
-          # does not catch the MemoryError that arrives instead, so the
-          # command exits non-zero and the mutant is KILLED. What was
-          # missing is a process alive to say so -- unbounded, the loop
-          # grows past the host's own 16 GiB and takes the job's remaining
-          # steps with it.
+          # address space, inherited by `cosmic-ray exec` and by every test
+          # command under it, which is what turns issue #948's dead host
+          # into a recorded verdict. The mutant is already killed by a test
+          # that exists: `dh_test.py` asks for one octet past the bound
+          # expecting a refusal, and `pytest.raises(BTClibValueError)` does
+          # not catch the MemoryError that arrives instead, so the command
+          # exits non-zero and the mutant is KILLED. What was missing is a
+          # process alive to say so.
           #
-          # 2 GiB because it sits between two numbers far apart: these test
-          # commands run in a fraction of it, and the loop wants 358 GiB, so
-          # anything between them works and the low end is what makes a
-          # mutant cheap. Measured at 89.4 bytes an iteration, the ceiling
-          # is 24e6 iterations away -- seconds, against a host that does not
-          # come back. Whether it clears what pytest needs is not asserted
-          # here: the baseline step above runs under the same limit and
-          # fails the run if it does not.
+          # The ceiling is not sensitive, which is why it is set high. The
+          # buffer is asked for in one statement, so any limit below the
+          # 137 GB that request is refuses it at the mmap -- instantly, and
+          # without the zero-fill an unbounded host pays at 6.4 GB/s.
+          # Nothing is bought by lowering it, and 2 GiB was low enough to
+          # fail three profiles' baselines: `uv` is a multithreaded Rust
+          # binary whose thread stacks alone reserve tens of MiB apiece, and
+          # `ulimit -v` counts address space rather than the memory a
+          # process touches. What the number has to do is clear that
+          # reservation and stay under the host's own 16 GiB, so that the
+          # process dies before the runner does.
           #
-          # Not the per-mutant `timeout`, which cannot reach this: 300 s is
-          # a width the slow-but-harmless mutants are measured against, and
-          # memory goes at well under it
-          ulimit -v 2097152
+          # Whether it clears what pytest needs is not asserted here: the
+          # baseline step above runs under the same limit, against the
+          # unmutated tree, and fails the run rather than reporting every
+          # mutant killed.
+          #
+          # Not the per-mutant `timeout`, which cannot reach either shape of
+          # this: 300 s is a width the slow-but-harmless mutants are
+          # measured against, and a refused allocation raises at once
+          ulimit -v 8388608
           # what the host's memory is doing while the mutants run, and the
           # question is issue #948's: two profiles die here with the job's
           # own remaining steps reported `skipped` rather than failed, which
           # is a host that went away rather than a command that exited.
-          # A mutant that widens a size bound allocates towards it --
-          # `ansi_x9_63_kdf` builds a list of digests and `numeric.toml`
-          # puts the weakened bound at gigabytes of keying data, which is
-          # 10^8 objects -- so memory is the reading that tells that apart
-          # from a runner GitHub happened to reclaim.
+          # A mutant that widens a size bound asks for it --
+          # `ansi_x9_63_kdf` sizes one `bytearray` from the block count and
+          # `numeric.toml` puts the weakened bound at gigabytes of keying
+          # data -- and `bytearray` zero-fills, so an unrefused request is
+          # touched rather than merely reserved. Memory is therefore the
+          # reading that tells an exhausted host from a runner GitHub
+          # happened to reclaim.
           #
           # To stdout, and this is the whole point of it rather than a
           # detail: the reports and the artifact are exactly what a dead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,46 +24,43 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
-- **A mutation session runs under a 2 GiB ceiling, so a mutant that
+- **A mutation session runs under an 8 GiB ceiling, so a mutant that
   allocates without end is recorded rather than fatal** (issue #948). The
   mutant in question is already killed by a test that exists:
   `tests/ecc/dh_test.py` asks `ansi_x9_63_kdf` for one octet past the
   bound and expects a refusal, and with the guard mutated away what
   arrives instead is not the `BTClibValueError` the test catches. What was
-  missing is a process alive to report it — the loop appends a digest per
-  iteration towards 358 GiB, so the host's memory went first and the job's
-  later steps died with it, which is why those profiles produced neither
-  report nor artifact.
+  missing is a process alive to report it — unbounded, the host's memory
+  went first and the job's later steps died with it, which is why those
+  profiles produced neither report nor artifact.
 
   `ulimit -v` bounds the address space `cosmic-ray exec` and every test
   command under it inherit, so the failure lands inside pytest as a
-  `MemoryError` and the verdict is KILLED. 2 GiB sits between two numbers
-  far apart — what these commands need against what the loop wants — and
-  the low end is what makes such a mutant cost seconds. The baseline step
-  runs under the same limit, so a ceiling too low for legitimate use fails
-  the run against the unmutated tree instead of reporting every mutant
-  killed. The per-mutant `timeout` cannot do this: memory goes at well
-  under its 300 seconds
+  `MemoryError` and the verdict is KILLED. The number is deliberately high
+  and does not need to be tuned: the buffer is asked for in one statement,
+  so any limit below the 137 GB it asks for refuses it at the mmap, before
+  the zero-fill an unbounded host pays at 6.4 GB/s. What the ceiling has to
+  do is clear what `uv` reserves — a multithreaded Rust binary whose thread
+  stacks alone take tens of MiB apiece, `ulimit -v` counting address space
+  rather than memory touched — and stay under the host's own 16 GiB, so the
+  process dies before the runner. The baseline step runs under the same
+  limit, so a ceiling too low for legitimate use fails the run against the
+  unmutated tree instead of reporting every mutant killed. The per-mutant
+  `timeout` cannot do this: a refused allocation raises at once
 
-- **The weekly mutation run prints the host's memory, and the script
-  profile is cut sooner** (issue #948). Two of the eleven profiles die
-  mid-session with the job's own later steps reported `skipped` rather
-  than failed, which is a host that went away and not a command that
-  exited: the reports and the artifact go with it, so those two produce
-  nothing at all. A mutant that widens a size bound allocates towards it —
-  `ansi_x9_63_kdf` accumulates a list of digests, and `numeric.toml` puts
-  the weakened bound at gigabytes of keying data — which is the reading
-  that tells memory exhaustion from a runner GitHub happened to reclaim.
+- **The weekly mutation run prints the host's memory** (issue #948). Two of
+  the eleven profiles die mid-session with the job's own later steps
+  reported `skipped` rather than failed, which is a host that went away and
+  not a command that exited: the reports and the artifact go with it, so
+  those two produce nothing at all. A mutant that widens a size bound asks
+  for it — `ansi_x9_63_kdf` sizes one buffer from the block count, and
+  `numeric.toml` puts the weakened bound at gigabytes of keying data, which
+  `bytearray` then zero-fills — so memory is the reading that tells an
+  exhausted host from a runner GitHub happened to reclaim.
 
-  The sessions step now prints used and available memory every 15 seconds.
-  To stdout rather than to the artifact, that being exactly what a dead
-  host does not leave behind, and at 15 seconds because the allocation
-  develops over tens of them. `script.toml`'s session budget drops from 45
-  minutes to 20, under the 22.6 the furthest attempt reached, so a
-  `timeout` cut — a partial answer the workflow already handles — lands
-  ahead of the kill while the kill is where it was measured. Neither is
-  the fix: bounding the allocation is, and what to bound it to is what
-  these two measure
+  The sessions step prints used and available memory every 15 seconds, to
+  stdout rather than to the artifact, that being exactly what a dead host
+  does not leave behind
 
 - **The editor spell-checks a file outside the workspace folder with this
   repository's configuration too.** `typos` runs in the editor as a language


### PR DESCRIPTION
A 2 GiB ceiling failed three profiles at `Check the baselines`, against
the unmutated tree: shared helpers, signature signing and extended keys,
the last two green the week before. `ulimit -v` counts address space and
not the memory a process touches, and `uv` is a multithreaded Rust binary
whose thread stacks alone reserve tens of MiB apiece, so the number was
chosen against the wrong quantity.

It did not have to be that low, and now it has to be nothing in
particular. `ansi_x9_63_kdf` asks for its buffer in one statement, so any
limit under the 137 GB that request is refuses it at the mmap -- at once,
and without the zero-fill an unbounded host pays at 6.4 GB/s. Lowering
the ceiling buys nothing once the allocation is a single one; what it has
to do is clear what uv reserves and stay under the host's own 16 GiB, so
the process dies before the runner. 8 GiB does both with room.

The baseline step keeps the same ceiling, and that is what caught this:
it failed in minutes, against code nobody had mutated, rather than
reporting a session of mutants killed by a limit no test could meet --
the one failure mode of a mutation run that looks like good news.

`script.toml` goes back to 45 minutes. The cut to 20 was a floor under
the loss while the mechanism was unknown, and it has bought its answer:
the ceiling now refuses a runaway allocation whatever the budget, and a
session cut short cannot be compared with the week before it, which is
what that profile is for. If it dies again at 45 the budget was the only
thing holding it up, and that is a mechanism to find rather than one this
file should hide.

The two comments here that described the old shape -- a list of digests
accumulated towards 358 GiB -- describe the buffer instead. The premises
in `numeric.toml` are the other half of #954 and wait for the session
that re-measures them: its survivor list and its timeout are verdicts,
and writing them now would be predicting rather than reporting.

Towards #954

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Raise mutation session memory ceiling to avoid conflicts with uv's reserved address space and restore the full script profile budget while keeping mutation runs observable and non-fatal.

Bug Fixes:
- Ensure runaway allocation mutants are recorded as killed without crashing the CI runner by increasing the mutation job memory ceiling.

Enhancements:
- Restore the script profile mutation session to its original 45-minute budget with a higher per-session ceiling for more representative weekly runs.

CI:
- Increase ulimit-based address space ceiling for mutation workflows so baseline and mutation steps run reliably under uv while still failing truly excessive allocations.

Documentation:
- Update changelog and workflow comments to reflect the new 8 GiB mutation ceiling and the restored script profile timing, clarifying how memory limits interact with uv and mutation behavior.