### PR TITLE
Put the fraction's boundary where this table puts it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5002,12 +5002,12 @@ documented at release-notes length in the first place, and are still in
   | 20 | 163.93 µs | 140.49 µs |
   | 64 | 522.73 µs | 449.20 µs |
 
-  About a seventh of the call from three terms up and a little less at
-  two — 12.9% there against 14.1 to 14.3 above it — which is where it
-  differs from the sum it follows: that one was worth a third at eight
-  terms and nothing at two, and this is one serialization and one parse
-  a term whatever the count. End to end at the callers, and
-  `double_mult_var` is the two-term shape most of them have:
+  About a seventh of the call, climbing from 12.9% at two terms to 14.3
+  by twenty — which is where it differs from the sum it follows: that
+  one was worth a third at eight terms and nothing at two, and this is
+  one serialization and one parse a term whatever the count. End to end
+  at the callers, and `double_mult_var` is the two-term shape most of
+  them have:
 
   | caller | term at a time | one call |
   | --- | --- | --- |

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -599,8 +599,8 @@ def _libsecp256k1_multi_mult_(
     The terms stopped crossing after it, which is the other half and the
     smaller one: a `pubkey_tweak_mul` per term serialized its product for
     a `pubkey_sum` that parsed it straight back, a seventh of what the
-    call cost with them, from three terms up and a little less at two --
-    which is `double_mult_var`'s count and the one most callers have.
+    call cost with them from eight terms up, a little less below it --
+    including `double_mult_var`'s two, the count most callers have.
     Handing over the whole equation is what stops it, and that is the one
     composition the bindings hold rather than this side
     (btclib-secp256k1#182): a term of a multi-scalar multiplication is a


### PR DESCRIPTION
Follows https://github.com/btclib-org/btclib/pull/955, which landed with
a fraction whose boundary its own table does not have. Review:
https://github.com/btclib-org/btclib/pull/955#pullrequestreview-4946155051.

`abe4c1ae` says *from three terms up and a little less at two — 12.9%
there against 14.1 to 14.3 above it*. Its table:

| terms | saving | of the old call |
| ---: | ---: | ---: |
| 2 | 2.46 µs | 12.89% |
| 3 | 3.53 µs | **13.13%** |
| 5 | 5.94 µs | **13.88%** |
| 8 | 9.45 µs | 14.20% |
| 20 | 23.44 µs | 14.30% |
| 64 | 73.53 µs | 14.07% |

Three terms and five are outside the stated interval, and two is not the
one row below it: the fraction climbs across every row from 2 to 20 and
settles at eight, not at three.

The phrase is btclib-secp256k1#182's, where it is true of *that* table —
two terms 13.5%, three to sixty-four 14.0 to 15.4, so the step is at
three there. It did not survive the move to these numbers, and the
percentages added beside it in the same pass are what made the mismatch
checkable.

## What this says instead

- **CHANGELOG**: *About a seventh of the call, climbing from 12.9% at two
  terms to 14.3 by twenty* — true of every row, and the comparison
  against the sum is untouched, "whatever the count" staying where it
  belongs: one serialization and one parse a term is what does not vary.
- **`_libsecp256k1_multi_mult_`**: the same without figures, *from eight
  terms up, a little less below it — including `double_mult_var`'s two,
  the count most callers have*. The per-term-count measurement stays in
  the entry, which that docstring already says is where it belongs.

*About a seventh* is right at every count either way: 1/7.8 at two up to
1/7.0 at eight.

## What cannot be corrected

`abe4c1ae`'s own commit message carries both the claim and the interval,
and its abbreviated table drops the three-term row while keeping the
five, so `42.78 → 36.84` — 13.9% — sits directly under them. That is
history; the tree is what this fixes.

## Gates

`uv run pytest` green (27870 passed, coverage ratchet at 100%), `uv run
pre-commit run --all-files` green, and `sphinx-build -W --keep-going`
green with the `href="#./` grep finding nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify and correct descriptive text about multi-multiplication performance proportions to match the actual benchmark data.

Enhancements:
- Adjust the _libsecp256k1_multi_mult_ docstring to describe performance behavior in a way that matches the current measurements and term-count behavior.

Documentation:
- Update CHANGELOG wording to accurately describe the percentage of call time saved across term counts in the benchmark table.