### PR TITLE
Make the squash local, so that every landing is the fast-forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,44 @@ documented at release-notes length in the first place, and are still in
 ### Repository
 
 - **A mutation session runs under an 8 GiB ceiling, so a mutant that
+- **The squash is made here rather than pressed, so every landing is the
+  fast-forward** (issue #958). #944 wrote the rule as two: a branch of
+  several commits merged with the button, a branch of one
+  fast-forwarded. The button is what that costs —
+  [`d9ff94e5`](https://github.com/btclib-org/btclib/commit/d9ff94e5)
+  landed through it after #944 with `GitHub <noreply@github.com>` as its
+  committer and the web-flow key's signature on it, and it is 23 of the
+  last 40 commits on `main`. A `git reset --soft origin/main && git
+  commit` before the same push leaves the signature the maintainer's,
+  with `--author` where the branch is somebody else's, which is the one
+  thing the button was doing that the shell has to be told.
+
+  Three things btclib-secp256k1 measured after #944 come with it, that
+  repository's configuration being this one's. Whether GitHub reconciles
+  a push turns on whether what lands is the sha the pull request names at
+  that moment — not on whether a rebase happened, a rebase force-pushed
+  to the branch leaving it naming the new one. So push the squash to the
+  branch before landing it: the squashed branch is then the reconciled
+  case too, CI runs on the object that lands rather than on a head that
+  never will, and `delete_branch_on_merge` fires, measured at one second
+  after the merge. Landed straight from a worktree, nothing is reconciled
+  and nothing is deleted, which is #953 — **Closed** with
+  `mergedAt: null`, its issue closed by the `Closes` in the commit
+  message — and getting ahead of the reconciliation is #930.
+
+  REPOSITORY.md gains that split and the permission the sequence actually
+  rests on: the push clears the classic protection's review and its
+  `strict` checks because `enforce_admins` is `false` and the pusher
+  holds `admin`, the ruleset bypass alone not being enough.
+  CONTRIBUTING.md says the landing is a push rather than a button, and
+  that the squash settings state what the message should say rather than
+  only what a press produces. RELEASING.md gets the case where it always
+  applies: a version bump and two retitles is never one commit, so the
+  release pull request is the squashed case every time, and a manual
+  close between the merge and the tag is a surprise worth not having.
+  The twin, landed first, is
+  [btclib-secp256k1's `7944dce`](https://github.com/btclib-org/btclib-secp256k1/commit/7944dce)
+- **A mutation session runs under a 2 GiB ceiling, so a mutant that
   allocates without end is recorded rather than fatal** (issue #948). The
   mutant in question is already killed by a test that exists:
   `tests/ecc/dh_test.py` asks `ansi_x9_63_kdf` for one octet past the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1284,24 +1284,24 @@ check starts again from a commit nobody has seen. Add the fix on top, with
 a message saying what it fixes, and reply to the comment with the sha.
 
 Nothing is lost in `main`'s history by doing so, because **a pull request
-of several commits is merged with "Squash and merge"**: the branch
-becomes one commit, so the review's commits are the record of the review
-and `main` keeps one commit per landed change. A merge commit would put
-the branch's steps into `main` and a rebase merge would replay them one
-by one — `main` is linear by branch rule, and one change is one commit
-there.
+lands as one commit**: a branch of several is squashed into one, so the
+review's commits are the record of the review and `main` keeps one commit
+per landed change. A merge commit would put the branch's steps into
+`main` and a rebase merge would replay them one by one — `main` is linear
+by branch rule, and one change is one commit there.
 
-**A pull request that is already one commit may instead land as a
-fast-forward**, which is the maintainer's own path and needs a ruleset
-bypass no contributor has: REPOSITORY.md describes it. It is worth
-knowing about from here for two reasons. The sha does not change, so the
-commit `main` receives is the exact commit CI tested and the signature on
-it is the author's rather than GitHub's web-flow key — and a branch
-stacked on that one keeps applying, where a squash would have rewritten
-its base. Which is why a correction added on top of a reviewed branch is
-still the right shape: whether the branch is squashed or fast-forwarded
-is decided when it lands, and by then the review has its record either
-way.
+**How that commit reaches `main` is a push rather than a button**, which
+is the maintainer's own path and needs a ruleset bypass no contributor
+has: REPOSITORY.md describes it, squashing the branch locally where it
+carries more than one commit and fast-forwarding the result. It is worth
+knowing about from here for two reasons. The commit that lands is signed
+by the maintainer rather than by GitHub's web-flow key; and where what
+lands is the head CI ran on, its sha does not change, so a branch stacked
+on that one keeps applying where a squash composed at the merge would
+have rewritten its base. Which is why a correction added on top of a
+reviewed branch is still the right shape: whether the branch is squashed
+or fast-forwarded is decided when it lands, and by then the review has
+its record either way.
 
 What that commit says is the repository's to answer, not this file's:
 
@@ -1314,7 +1314,10 @@ gh api repos/btclib-org/btclib --jq \
 so a branch of one commit lands under that commit's own subject, a branch
 of several under the pull request's title with its number, and the body
 is the branch's commit messages either way — never the pull request's
-body, which stays on the pull request.
+body, which stays on the pull request. That is what the button writes,
+and a squash made locally follows the same convention by hand, the
+setting being the statement of what the message should say rather than
+only of what a press produces.
 
 **It is a setting and not a choice made once per pull request.** Squash is
 the only *button* the repository enables, so there is no other to read;

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -288,19 +288,23 @@ word, and step 1 asks it of both.
    enforces, and a pull request that never mentions them reads exactly
    like one that skipped them.
 
-   And merge it with **"Squash and merge"** where it carries more than
-   one commit, which it usually does: a version bump and two retitles,
-   not a cycle of work, and CONTRIBUTING.md gives the rest of the
-   reason. Squash is the only *button* the repository enables — a merge
-   commit was refused by `main`'s required linear history anyway, and a
-   rebase merge would have replayed the branch's steps into a history
-   whose rule is one commit per landed change.
+   And land it the way every other pull request here lands: squashed
+   locally into one signed commit where it carries more than one — a
+   version bump and two retitles, not a cycle of work, and
+   CONTRIBUTING.md gives the rest of the reason — and fast-forwarded onto
+   `main`, REPOSITORY.md having the sequence and the bypass it needs.
+   Squash is the only *button* the repository enables, and it is the
+   wrong landing here in particular: it is the release commit that gets
+   tagged, so a squash composed by GitHub would leave the tag over a
+   commit signed by the web-flow key rather than by the maintainer.
 
-   Where the release branch is a single commit, the fast-forward of
-   REPOSITORY.md is the better landing and not merely an allowed one: it
-   is the release commit that gets tagged, and a squash would replace it
-   with one signed by GitHub's web-flow key, leaving the tag over a
-   commit the maintainer did not sign.
+   This branch is the squashed case every time, a version bump and two
+   retitles never being one commit, so push the squash to the branch
+   before fast-forwarding it: the checks below then run on the object
+   that lands, and GitHub still marks the pull request Merged. Land the
+   squash straight from a worktree instead and nothing is reconciled —
+   the pull request has to be closed by hand, which is a surprise worth
+   not having between here and the tag.
 
    Then read `lint` and `test` on the commit `main` ends up at before
    tagging, rather than trust the pull request's own green run:

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -318,6 +318,50 @@ git log --format='%h %G?' origin/main..      # every commit G, none N
 git push origin <branch>:main
 ```
 
+Where the branch carries more than one commit it is squashed into a
+single signed commit first — `git reset --soft origin/main && git
+commit`, with `--author` where the branch is somebody else's, GitHub's
+button being what would otherwise have kept their name on it — and that
+commit is what the push fast-forwards. Squashing here rather than
+pressing the button is the whole of what keeps the signature the
+maintainer's: GitHub composes a squash server-side and signs it with its
+own web-flow key, while a push signs nothing and has nothing to sign, the
+commit arriving with the signature it already carried.
+
+**The bypass is not the whole of the permission.** The classic protection
+still carries `required_pull_request_reviews` and its `strict` required
+checks, and what a push to `main` clears those with is `enforce_admins`
+being `false` and the pusher holding `admin`; the ruleset bypass alone
+would not be enough. So the path depends on two settings, and the fragile
+one is that: turning `enforce_admins` on closes the fast-forward whatever
+the ruleset says.
+
+**Whether GitHub reconciles the push depends on one thing: whether what
+lands is the sha the pull request names at that moment**, a pull request
+being marked merged when its head becomes reachable from the base branch.
+
+- **it names what lands** — the branch's own head is fast-forwarded,
+  whether it reached that shape as one commit or as a squash **pushed to
+  the branch first**, and a rebase force-pushed to the branch is this
+  case too. GitHub marks the pull request **Merged** on its own, the
+  `Closes #N` in its description closes the issue, and
+  `delete_branch_on_merge` takes the head branch a second later.
+- **it names something else** — the squash or the rebase was made locally
+  and pushed straight to `main`. What lands is an object no pull request
+  names, so nothing is reconciled and nothing is deleted: close it by
+  hand, and let the issue close from the `Closes #N` in the *commit
+  message*, which is the reason for the keyword to be there and not only
+  in the description.
+
+Which is an argument for pushing the squash to the branch before landing
+it: CI then runs on the very object that will land rather than on a head
+that never will, and the reconciliation does the closing. Both halves
+were measured here — #953 was squashed straight onto `main` and is
+**Closed** with `mergedAt: null`, its issue having closed twenty-two
+seconds earlier from the commit message, and #930 was deleted ahead of
+the reconciliation and came out Closed with its commit on `main` all the
+same.
+
 ## Merge methods
 
 **Squash is the only *button* enabled**, so it is a setting and not only
@@ -330,17 +374,19 @@ gh api repos/btclib-org/btclib \
 
 answers `true` for the first and `false` for the other two.
 
-It is not the only way a pull request lands, and this section named it as
-if it were while the section above it documented the other: **a branch of
-a single commit is fast-forwarded** through the `main-self-merge` bypass,
-which is the sequence written there. What that buys is what a squash
-cannot: the sha does not change, so `main` receives the exact commit CI
-tested, signed by the maintainer rather than by GitHub's web-flow key,
-and a branch stacked on it keeps applying instead of needing a rebase and
-a fresh run of the matrix per level. Which of the two applies is decided
-by the branch and not by taste — a contributor's pull request usually
-carries several commits and is squashed; the maintainer's usually carries
-one.
+It is not how a pull request lands at all, and this section named it as
+if it were while the section above it documented the other: **every
+landing is the fast-forward** of that sequence, through the
+`main-self-merge` bypass, with the squash a multi-commit branch needs
+made locally before it. What that buys is what a button cannot: the
+commit is signed by the maintainer rather than by GitHub's web-flow key,
+and where what lands is the head CI ran on, its sha does not change
+either, so a branch stacked on it keeps applying instead of needing a
+rebase and a fresh run of the matrix per level.
+
+The setting is what bounds a landing nobody drove from a shell: the
+auto-merge dropdown the next paragraph describes is what reaches the
+button, and GitHub's key is what signs whatever it presses.
 
 The merge commit was refused by the required linear history above already,
 so turning it off takes away a button that could not have worked. The
@@ -380,6 +426,14 @@ be removed by anything — including a pull request that somehow had it as a
 head. And a pull request **closed without merging** keeps its head branch:
 GitHub cannot know whether that work was abandoned or is waiting, so those
 are the ones still worth looking at now and then.
+
+A fast-forward is covered where GitHub reconciles it, the setting hanging
+on the merge GitHub records rather than on the one a button performed.
+Measured in btclib-secp256k1, whose configuration is this one: a squash
+pushed to the branch and then fast-forwarded was marked Merged at
+12:39:19 and had `head_ref_deleted` at 12:39:20, with nobody asking. What
+is left there is not to get ahead of it, #930 being what that costs; the
+deletion by hand belongs to the landing GitHub never sees.
 
 ## Token permissions
 


### PR DESCRIPTION
#944 wrote the rule as two landings: a branch of several commits merged
with the button, a branch of one fast-forwarded. This makes it one — the
squash is made **locally** and every landing is the fast-forward, the
button staying enabled and unpressed.

## What the button costs, measured here

[`d9ff94e5`](https://github.com/btclib-org/btclib/commit/d9ff94e5) landed
through it after #944: committer `GitHub <noreply@github.com>`, and the
signature on it is the web-flow key's rather than the maintainer's. It is
23 of the last 40 commits on `main`. The alternative is one command
before the same push:

```shell
git reset --soft origin/main && git commit   # --author, where the branch is somebody else's
```

`--author` is the one thing the button was doing that the shell has to be
told.

## What comes with it, measured in the twin

btclib-secp256k1's configuration is this one's — `main-integrity` with no
bypass actor, `main-self-merge` naming the maintainer, `enforce_admins`
off, squash the only button — so what it learned after #944 applies
verbatim:

- **the criterion is whether what lands is the sha the pull request names
  at that moment**, not whether a rebase happened: a rebase force-pushed
  to the branch leaves it naming the new one, and lands reconciled;
- **so push the squash to the branch before landing it.** The squashed
  branch becomes the reconciled case too, CI runs on the object that
  lands rather than on a head that never will, and
  `delete_branch_on_merge` does the deletion — measured at one second
  after the merge;
- landed straight from a worktree, nothing is reconciled and nothing is
  deleted. Both halves of that are this repository's own: #953 is
  **Closed** with `mergedAt: null`, its issue closed by the `Closes` in
  the commit message, and #930 was deleted ahead of the reconciliation
  and came out Closed with its commit on `main` all the same.

`REPOSITORY.md` also gains the permission the sequence rests on and never
stated: the push clears the classic protection's review and its `strict`
checks because `enforce_admins` is `false` and the pusher holds `admin` —
the ruleset bypass alone would not be enough.

`CONTRIBUTING.md` says the landing is a push rather than a button, and
that the squash-message settings state what the message should say rather
than only what a press produces. `RELEASING.md` gets the case where it
always applies: a version bump and two retitles is never one commit, so
the release pull request is the squashed case every time, and a manual
close between the merge and the tag is a surprise worth not having.

Documentation only. The twin, landed first, is
[btclib-secp256k1@`7944dce`](https://github.com/btclib-org/btclib-secp256k1/commit/7944dce).

Closes #958

## Summary by Sourcery

Document a maintainer workflow where all pull request landings are performed as local squashes followed by fast-forward pushes, preserving maintainer signatures and GitHub reconciliation behavior.

New Features:
- Describe the standardized landing path where all pull requests, including releases, are squashed locally and fast-forwarded onto main instead of using GitHub’s squash button.

Enhancements:
- Clarify repository rules around fast-forward landings, admin-based protection bypass, and how GitHub reconciles and auto-deletes branches when the landed commit matches the pull request head.
- Align CONTRIBUTING, REPOSITORY, and RELEASING documentation to consistently describe push-based landings, the semantics of squash commit messages, and the special handling of release branches.

Documentation:
- Expand REPOSITORY.md with detailed guidance on local squashing, fast-forward pushes, and the interaction with branch protections, rulesets, and GitHub’s merge reconciliation.
- Update CONTRIBUTING.md to explain that landings are performed via pushes, not buttons, and that squash settings define the expected commit message format even for locally created squashes.
- Revise RELEASING.md to describe the release PR as always being squashed locally and fast-forwarded, ensuring the tagged release commit carries the maintainer’s signature.
- Record these workflow changes and their rationale in CHANGELOG.md under the Repository section.