### PR TITLE
Follow the bindings to their tip again

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ test = [
 [[package]]
 name = "btclib-secp256k1"
 version = "0.8.0.3"
-source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#f7d5dc013aafd177b472166cd71a598eef3b3220" }
+source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#7098ddb42ae51ce8f99ae3edb2731b909b8afc48" }
 dependencies = [
     { name = "cffi" },
 ]


### PR DESCRIPTION
`[tool.uv.sources]` names the branch, not a revision, so the reference is
already moving; `uv.lock` is where a commit is written down, and it is
written down again here: btclib_secp256k1 f7d5dc01 -> 7098ddb4.

Two of those commits reach the installed package, and neither changes
what btclib asks of it: a keyword-only `into=` buffer beside the entry
points that produce a secret, additive and unused here, and the callback
guard said with a class rather than a generator. The rest is the
bindings' own workflows, pins and prose. The version is still 0.8.0.3,
so the floor in `dependencies` stays as it is, and the rest of the lock
does not move: `--upgrade-package` re-resolves the one name.

The suite, every hook and sphinx -W pass against the result.

## Summary by Sourcery

Build:
- Refresh uv.lock to point btclib_secp256k1 at commit 7098ddb4 while keeping the declared package version unchanged.