### PR TITLE
Write twenty-one million once, and convert it as this module converts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -990,6 +990,14 @@ documented at release-notes length in the first place, and are still in
 
 ### Transactions, blocks and PSBT
 
+- **Twenty-one million is written once** (issue #962). `_MAX_SATOSHI` and
+  `_MAX_BITCOIN` each spelled the bound out, so nothing held them to each
+  other and the paragraph explaining why it is `MAX_MONEY` rather than the
+  supply the halving schedule issues belonged to both. The satoshi bound
+  is the bitcoin one converted now, through the same expression
+  `sats_from_btc` uses, and both keep their value, their type and their
+  callers
+
 - **A json `null` is not an amount** (issue #875).
   `TxOut.from_dict({"value": null})` built an output of zero satoshi:
   `valid_sats_amount` reads `None` as zero, for the caller it was written

--- a/btclib/amount.py
+++ b/btclib/amount.py
@@ -55,8 +55,12 @@ _BITCOIN_PER_SATOSHI = Decimal("0.00000001")
 # validity rule, an amount above it being unfundable rather than
 # invalid, and bounding by it would make btclib refuse to so much as
 # parse two transactions the network considers valid (issue 167)
-_MAX_SATOSHI = 21_000_000 * _SATOSHI_PER_BITCOIN
+# twenty-one million is written once and converted the way every other
+# amount in this module is, `sats_from_btc` below being that same
+# expression: two spellings of one bound can be edited apart, and the
+# paragraph above belongs to both of them
 _MAX_BITCOIN = Decimal(21_000_000)
+_MAX_SATOSHI = int(_MAX_BITCOIN * _SATOSHI_PER_BITCOIN)
 
 
 def valid_btc_amount(amount: Any, dust: Decimal = Decimal(0)) -> Decimal:


### PR DESCRIPTION
`_MAX_SATOSHI` and `_MAX_BITCOIN` each spelled the bound out. Nothing
held the two to each other, so one could be edited without the other, and
the paragraph above them -- why this is `MAX_MONEY` and not the supply
the halving schedule issues -- belongs to both.

The satoshi bound is the bitcoin bound converted now, through the
expression `sats_from_btc` already is. Same value, same type, same
callers: `tx.py` imports `_MAX_SATOSHI`, and the two validators read one
each.

It also gives the mutation session its budget back, which is a
consequence and not the argument. `ReplaceBinaryOperator_Mul_Pow` turned
the old line into `21_000_000 ** 100_000_000`, an integer of some 7.3e8
digits computed at import until the per-mutant `timeout` cut it: one
mutant, 300 s of numeric.toml's 900. Over `amount.py` and `fee.py` -- 396
mutants, 389 killed and 7 survived -- the session takes 427 s at a 300 s
timeout and 135 s at 10 s, for identical verdicts, and this is the only
mutant of the 396 whose output reads `timeout`. On the shape here the
same mutation is `Decimal(21_000_000) ** 100_000_000`, past the decimal
context's exponent and raising `Overflow` in 2 us -- killed by an
exception at import rather than by the clock.

Closes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Unify the definition of the maximum bitcoin supply by defining it once in bitcoin and deriving the satoshi limit via the module’s standard conversion, and document this change in the changelog.

Enhancements:
- Align `_MAX_SATOSHI` with `_MAX_BITCOIN` by computing the satoshi limit from the single bitcoin-denominated constant using the existing conversion pattern.

Documentation:
- Add changelog entry describing that the maximum bitcoin amount is now written once and converted for the satoshi bound.