### PR TITLE
Put the ceiling entry back together, the union driver having split it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
-- **A mutation session runs under an 8 GiB ceiling, so a mutant that
 - **The squash is made here rather than pressed, so every landing is the
   fast-forward** (issue #958). #944 wrote the rule as two: a branch of
   several commits merged with the button, a branch of one
@@ -62,7 +61,8 @@ documented at release-notes length in the first place, and are still in
   close between the merge and the tag is a surprise worth not having.
   The twin, landed first, is
   [btclib-secp256k1's `7944dce`](https://github.com/btclib-org/btclib-secp256k1/commit/7944dce)
-- **A mutation session runs under a 2 GiB ceiling, so a mutant that
+
+- **A mutation session runs under an 8 GiB ceiling, so a mutant that
   allocates without end is recorded rather than fatal** (issue #948). The
   mutant in question is already killed by a test that exists:
   `tests/ecc/dh_test.py` asks `ansi_x9_63_kdf` for one octet past the


### PR DESCRIPTION
`main` carries one entry twice and neither copy whole: a headline saying
2 GiB above a body arguing 8, and the 8 GiB headline stranded thirty
lines above it with no body under it at all. The separating blank line
went with them, so the entry before it runs straight into the next
bullet.

Nothing deleted it. `.gitattributes` gives CHANGELOG.md `merge=union`,
which keeps the added lines of both sides rather than stopping at a
conflict, and #956 had *edited* an existing entry -- the number in its
headline and the paragraph under it -- while #958's branch carried that
same entry unedited from its own base. Union had two versions of one
line and kept both, which is the price the driver is chosen for and the
one case it cannot get right: it is meant for two branches appending
bullets, and neither side conflicts when they rewrite the same one.

The entry is the one #956 landed, byte for byte apart from the headline
the merge left stale -- checked against `a61f6651` rather than rewritten
from memory.

Nothing here changes what the release notes say happened, only what they
manage to say.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Correct the mutation session ceiling note in CHANGELOG to consistently describe the 8 GiB limit and repair the broken bullet formatting.