### PR TITLE
Let the mutation button ask for one profile

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -39,6 +39,36 @@ on:
   # the escape hatch, and the way to spend a whole afternoon on the engine
   # session that the weekly budget only samples
   workflow_dispatch:
+    inputs:
+      profile:
+        # one scope's numbers are what a question about that scope needs,
+        # and without this the only way to ask is the whole matrix: eleven
+        # runners and, at the consensus job's ceiling, most of an
+        # afternoon. Re-measuring one configuration -- a budget changed, a
+        # timeout argued about, a survivor that moved -- is worth minutes
+        # rather than that, and a question nobody can afford to ask twice
+        # gets answered once and quoted for months.
+        # `all` is the default and is what the schedule does, the
+        # button having had no other behaviour before this input
+        # existed. Spelled rather than left empty: a blank entry in a
+        # dropdown reads as a mistake
+        description: one profile's slug, or all of them
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - consensus
+          - parsers
+          - keys
+          - signing
+          - block
+          - shared
+          - signatures
+          - descriptors
+          - psbt
+          - script
+          - boundaries
   # No pull_request trigger, unlike links.yml, which does run itself when
   # its own configuration changes. The difference is the clock: a link
   # sweep is a couple of hundred requests, a mutation session is hours, so
@@ -75,6 +105,21 @@ jobs:
     # job would have to come out of its 180 minutes or push it past the
     # ceiling
     timeout-minutes: ${{ matrix.ceiling }}
+    # whether this profile is one the run was asked for. It is an `env` and
+    # not the job's `if`, which cannot see `matrix` -- the context is
+    # offered to `timeout-minutes` above and to `env` here, and withheld
+    # from `if`, so a job cannot decline itself on what the matrix gave it.
+    # The steps below decline instead: an unasked-for profile still takes a
+    # runner and gives it back in seconds, which is the price of keeping
+    # the matrix a literal list with its reasoning beside each entry rather
+    # than json a setup job prints.
+    # `!inputs.profile` is the schedule's case, which has no `inputs` at
+    # all: the negation reads that absence as every profile, where a
+    # comparison would be against null
+    env:
+      SELECTED: >-
+        ${{ !inputs.profile || inputs.profile == 'all'
+            || inputs.profile == matrix.slug }}
     strategy:
       # one profile's runner dying is not a reason to take the other's
       # numbers with it
@@ -235,11 +280,13 @@ jobs:
       # every action is pinned to a commit SHA, the tag in the comment: a
       # tag, let alone a branch, is a name its owner can move
       - name: Checkout code
+        if: env.SELECTED == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # see the checkout of the test-py job in test.yml
           persist-credentials: false
       - name: Setup uv
+        if: env.SELECTED == 'true'
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # the wheels uv.lock pins do not change between runs, so the
@@ -262,6 +309,7 @@ jobs:
       # rather than reporting every mutant killed -- the failure mode the
       # paragraph above is already about
       - name: Check the baselines
+        if: env.SELECTED == 'true'
         env:
           SESSIONS: ${{ matrix.sessions }}
         run: |
@@ -296,6 +344,7 @@ jobs:
       # turn -- SIGTERM leaves the marker at its mutated value, SIGINT at
       # its restored one, timeout still exiting 124 either way
       - name: Run the mutation sessions
+        if: env.SELECTED == 'true'
         env:
           SESSIONS: ${{ matrix.sessions }}
         run: |
@@ -400,7 +449,7 @@ jobs:
       # short, or one whose exec died, still holds every verdict reached
       # before that, and those are what somebody reads on Monday
       - name: Write the reports
-        if: always()
+        if: always() && env.SELECTED == 'true'
         env:
           SESSIONS: ${{ matrix.sessions }}
         run: |
@@ -457,7 +506,7 @@ jobs:
       # uploads under one name is an error, and the slug is what tells the
       # consensus sessions from the parser ones in the Actions tab
       - name: Upload the sessions and the reports
-        if: always()
+        if: always() && env.SELECTED == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mutation-${{ matrix.slug }}-sessions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **The mutation button asks for one profile, where it used to cost the
+  whole matrix.** `workflow_dispatch` takes a `profile` input naming a
+  slug, `all` being the default and what the schedule does. A question
+  about one scope — a budget changed, a survivor that moved, a timeout
+  argued about — was answered by eleven runners and, at the consensus
+  job's ceiling, most of an afternoon, which is a question nobody asks
+  twice: it gets answered once and quoted for months instead. The matrix
+  stays a literal list with its reasoning beside each entry rather than
+  json a setup job prints, so an unasked-for profile still takes a runner
+  and gives it back in seconds; the selection is an `env` the steps read,
+  the job's own `if` being the one place `matrix` is withheld
+
 - **The squash is made here rather than pressed, so every landing is the
   fast-forward** (issue #958). #944 wrote the rule as two: a branch of
   several commits merged with the button, a branch of one


### PR DESCRIPTION
A question about one scope costs the whole matrix: eleven runners and, at
the consensus job's ceiling, most of an afternoon. That is a question
nobody asks twice, so a budget changed, a survivor that moved or a
timeout argued about gets answered once and quoted for months instead of
re-measured. `workflow_dispatch` takes a `profile` input naming a slug,
`all` the default and what the schedule already does.

The matrix stays a literal list with its reasoning beside each entry.
Filtering it would mean a setup job printing json, and the comments that
say why the consensus job holds 200 minutes and the parser one 45 are
worth more than the runners an unasked-for profile starts and gives back
in seconds.

The selection is an `env` rather than the job's `if`, which is the one
job-level key `matrix` is withheld from -- `timeout-minutes` above it
takes the same context -- so a job cannot decline itself on what the
matrix gave it and the steps decline instead. `always()` stays first on
the two that carry it: a condition that dropped it would skip the reports
of a session that failed, which are the whole product.

`!inputs.profile` covers the schedule, which has no `inputs` at all,
where a comparison would be against null. `all` is spelled rather than
left empty because a blank entry in a dropdown reads as a mistake.

Stacked on #964: both touch the head of the CHANGELOG's Repository group, and two independent branches there would recreate the union split #964 repairs. Retarget to `main` once #964 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow the mutation workflow dispatch button to run either a single selected profile or the full matrix, and document this behavior in the changelog.

New Features:
- Add a workflow_dispatch input to the mutation CI workflow to select a specific mutation profile or run all profiles.

Enhancements:
- Gate mutation workflow steps on an environment-based selection flag so unrequested profiles exit quickly while preserving the explicit matrix definition.

Documentation:
- Document the new profile-selectable mutation button behavior in the Repository section of the changelog.