### PR TITLE
Give BIP32 derivation its Python arm back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1489,6 +1489,75 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **BIP32 derivation has its Python arm back, so closing the dispatch
+  reaches it** (issue #966). Both sums went to libsecp256k1
+  unconditionally — `keys.prvkey_tweak_add` for the private child and
+  `keys.PubkeyTweakChain.tweak_add` for the public one — on the argument
+  that BIP32 is defined for secp256k1 alone, so no other curve could ask
+  for a fallback. The curve is not the only question that argument has to
+  answer: `curve._libsecp256k1_available` is the seam every other
+  dispatch in the package reads, and bip32 read nothing, so clearing it
+  left the derivation in C. `derive(xprv, "m/0h/1/2h")` with the seam
+  closed made three `prvkey_tweak_add` calls; the public path, two
+  `PubkeyTweakChain` and four `tweak_add`.
+
+  BIP32's own equations are back where they were — `ki = parse256(IL) +
+  kpar (mod n)` and `Ki = point(parse256(IL)) + Kpar` — behind
+  `_libsecp256k1_serves`, which is what every other dispatch asks.
+  A public path is walked with a chain either way, and
+  `_pub_key_tweak_chain` answers which: `keys.PubkeyTweakChain` where the
+  bindings serve, `_PythonPubKeyTweakChain` where they do not — one class
+  each, chosen once for a path rather than tested at every step of it,
+  and neither carrying a state the other one needs. The second holds an
+  affine point across the levels, so it pays one `point_from_octets` — a
+  modular square root — per path rather than one per level. The contract
+  is the bindings': `ValueError` for octets that are no point, and for
+  the sum at infinity — which is one of the three children BIP32 declares
+  invalid, and reaches the caller as `_invalid_child` words it.
+
+  What the Python arm costs, µs, median of four alternating rounds, best
+  of five × 200 calls:
+
+  | call | bindings | Python |
+  | --- | --- | --- |
+  | `derive(xprv, "m/0")` | 22.8 | 161.0 |
+  | `derive(xprv, "m/0h/1/2h")` | 36.4 | 308.8 |
+  | `derive(xpub, "m/0")` | 32.2 | 276.6 |
+  | `derive(xpub, "m/1/2")` | 44.5 | 437.4 |
+  | `pub_key_derivation_tweaks(…, "m/1/2")` | 27.3 | 393.4 |
+  | `base58.decode(xpub)`, the control | 5.0 | 4.9 |
+
+  The control is there because `BIP32KeyData.b58decode` is not one: it
+  validates the key, `_is_x_coordinate_var` is on the same seam, and it
+  moves from 4.1 µs to 14.6 — part of every derivation in the table, and
+  already Python on that arm before this change.
+
+  Per step, which is what the levels of a path multiply:
+
+  | step | bindings | Python |
+  | --- | --- | --- |
+  | the chain's parse of the parent key | 2.9 | 84.7 |
+  | one `tweak_add` | 11.6 | 175.2 |
+  | the private sum | 0.65 | 0.12 |
+
+  `__pub_key_derivation`'s comment carried a Python step of 33.4 µs from
+  before this change, which was `mult` delegating — with the dispatch off
+  altogether the multiplication is Python too, and the step is the 175.2
+  above. One measurement, one number: the comment now names this one.
+
+  The private sum is the one place the Python arm is *faster*, and it
+  buys what `keys.prvkey_tweak_add` is called for — a sum on a secret
+  that does not branch, and no unzeroized copy of the intermediates.
+
+  No caller reaches the new arm. The bindings are a required dependency,
+  so this is a seam the test suite closes and nothing else can, as with
+  `bms.sign`'s Python path; what changes is that closing it now measures
+  Python. The BIP32 test vectors run on both arms, and so do the two
+  invalid children of each derivation, the tweaks of a public path, and
+  the non-points an empty path still has to refuse. Issue #966 has the
+  rest of what running without the bindings asks for, the unguarded
+  imports first.
+
 - **The generator's multiplication no longer imports a module the
   bindings have removed** (issue #929). `curves.curve` reached
   `btclib_secp256k1.mult.mult` for `m*G`, and that module is gone:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -113,10 +113,11 @@ used to teach and to prototype as much as to build:
     secp256k1 with sha256, the lower-s form, no caller-imposed nonce and
     no commitment; `ssa.sign` for secp256k1 with sha256, a message of
     any size and no commitment; `taproot.output_prvkey`,
-    `dh.diffie_hellman` and `commit_nonce.commit_nonce_` for secp256k1,
-    the tweaking of a key, the shared point of a key agreement and the
-    tweaking of a sign-to-contract nonce being three other places a
-    secret meets the curve.
+    `dh.diffie_hellman`, `commit_nonce.commit_nonce_` and the private
+    half of `bip32.derive` for secp256k1, the tweaking of a key, the
+    shared point of a key agreement, the tweaking of a sign-to-contract
+    nonce and the offsetting of a parent key by the left half of an hmac
+    being four other places a secret meets the curve.
     Verification crosses it whole, not only in its multiplication:
     `dsa.verify` and `ssa.verify` are one libsecp256k1 call each for
     secp256k1 with sha256, a high-s signature being normalized first
@@ -143,7 +144,12 @@ used to teach and to prototype as much as to build:
     the recovery flag in one call: message signing is defined for
     secp256k1 alone, so there is no argument that sends it down the
     Python path — which the test suite reaches by switching the dispatch
-    off, and which no caller can.
+    off, and which no caller can. BIP32 derivation is the same case, and
+    for the same reason: `bip32.derive` adds the offset with
+    `keys.prvkey_tweak_add` privately and `keys.PubkeyTweakChain`
+    publicly, and the Python arm behind them — BIP32's two sums, on
+    integers and on a point — is one no argument of a caller's selects
+    either.
     Anything else — another
     curve, another hash function, a nonce of your own — runs the Python
     implementation, whose scalar multiplication is

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -38,10 +38,13 @@ from btclib.bip32.der_path import (
     indexes_from_der_path,
 )
 from btclib.curves import (
+    bytes_from_point,
     bytes_from_prv_key_int,
+    mult,
+    point_from_octets,
     secp256k1,
 )
-from btclib.curves.curve import _is_x_coordinate_var
+from btclib.curves.curve import _is_x_coordinate_var, _libsecp256k1_serves
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
 from btclib.network import (
@@ -610,20 +613,33 @@ def __prv_key_derivation(xkey: _BIP32KeyData, index: int, pub_key: bytes) -> Non
     # here; it costs 0.55 us against 0.03, on a derivation whose hmac
     # and public key are some 15 us of their own.
     #
-    # BIP32 is defined for secp256k1 and for nothing else, so this is
-    # not gated on the curve as the rest of the library's dispatches
-    # are: there is no other curve for a fallback to serve
-    try:
-        key = libsecp256k1_keys.prvkey_tweak_add(xkey.key[1:], offset)
-    except ValueError as e:
-        # past the range check above, the one sum libsecp256k1 refuses
-        # is the zero BIP32 refuses too
-        raise _invalid_child(index, "the child private key is zero") from e
+    # The dispatch is not on the curve, BIP32 being defined for secp256k1
+    # alone: it is on whether the bindings are there to serve it, which is
+    # the one question `_libsecp256k1_serves` answers that another curve
+    # would not have asked. What the Python arm below is for is a caller
+    # without them, and SECURITY.md says of it what it says of every
+    # Python path: the arithmetic is on integers and is not constant-time
+    if _libsecp256k1_serves(secp256k1, None):
+        try:
+            key = libsecp256k1_keys.prvkey_tweak_add(xkey.key[1:], offset)
+        except ValueError as e:
+            # past the range check above, the one sum libsecp256k1 refuses
+            # is the zero BIP32 refuses too
+            raise _invalid_child(index, "the child private key is zero") from e
+        prv_key_int = int.from_bytes(key, byteorder="big", signed=False)
+    else:
+        # ki = parse256(IL) + kpar (mod n), which is BIP32's own equation
+        prv_key_int = (
+            xkey.prv_key_int + int.from_bytes(offset, byteorder="big", signed=False)
+        ) % secp256k1.n
+        if prv_key_int == 0:
+            raise _invalid_child(index, "the child private key is zero")
+        key = prv_key_int.to_bytes(32, byteorder="big", signed=False)
 
     # xkey is mutated only past the checks, so a rejected index leaves
     # it the key it was rather than half a derivation
     xkey.chain_code = hmac_[32:]
-    xkey.prv_key_int = int.from_bytes(key, byteorder="big", signed=False)
+    xkey.prv_key_int = prv_key_int
     xkey.key = b"\x00" + key
 
 
@@ -647,6 +663,105 @@ def _pub_key_offset(chain_code: bytes, key: bytes, index: int) -> tuple[bytes, b
     if offset >= _N_BYTES:
         raise _invalid_child(index, "the hmac left half is not a valid scalar")
     return offset, hmac_[32:]
+
+
+class _PythonPubKeyTweakChain:
+    """What `keys.PubkeyTweakChain` is, in the arithmetic of this library.
+
+    The other half of `_pub_key_offset` above: that answers the scalar a
+    step adds, this adds it to the point. A path is a chain because each
+    step's child is the next step's parent, so the point is held from one
+    step to the next rather than parsed again out of the octets the step
+    before it has just written -- which is what the bindings' class holds
+    it for, and is worth more here: `point_from_octets` on a compressed
+    key is a modular square root, 84.7 us where their own parse is 2.9,
+    so a path of any length pays one instead of one per level.
+
+    `curves.curve` has the same arithmetic twice over -- `_tweak_add_var`
+    ends in `ec.add_var(P, mult(t, ec.G, ec))`, and `_TweakChain` is a
+    point with many tweaks of it and the bindings' chain where they serve
+    -- and this is not written here for want of noticing. Three things
+    differ, and each is the whole of a step: `_TweakChain`'s tweaks are
+    absolute, measured from the point it was built on, where BIP32's are
+    successive; `_tweak_add_var` pays a `require_on_curve` per step, on a
+    point this one has just computed itself; and a refused tweak drops
+    `_TweakChain` to the one-shot pair and it answers the next one, where
+    BIP32 has to end the path instead.
+
+    The contract is theirs, so that `_pub_key_tweak_chain` below can
+    answer either and its callers need not know which: `tweak_add`
+    answers the serialized child key and raises `ValueError` for the sum
+    at infinity -- which libsecp256k1 has no public key for and BIP32
+    refuses too, `_invalid_child` being what the callers turn it into --
+    and the constructor raises it for octets that are no point.
+
+    A refused step ends the chain, which is that contract too: "pubkey
+    will be set to an invalid value if this function returns 0" is what
+    libsecp256k1 says of `secp256k1_ec_pubkey_tweak_add`, and that pubkey
+    is what their chain holds. So there is nothing to step from
+    afterwards and neither implementation defines what a further step
+    answers; both callers here raise instead of asking again, a refused
+    index ending the whole derivation.
+
+    Python throughout, and it has to be: with libsecp256k1 in reach their
+    class is the better answer, so a chain that mixed the two would be
+    the one shape never worth building. It cannot mix as written --
+    `mult` and the lift inside `point_from_octets` gate on
+    `_libsecp256k1_serves(secp256k1, None)`, which is the call that chose
+    this implementation, and cannot answer it differently -- and
+    `test_the_python_arm_reaches_no_bindings` checks that rather than
+    trusting it, a dispatch made finer-grained one day being what would
+    end it silently.
+    """
+
+    def __init__(self, key: bytes) -> None:
+        self._point = point_from_octets(key, secp256k1)
+
+    def tweak_add(self, tweak: bytes, compressed: bool = True) -> bytes:
+        """Return the key of point + tweak*G, and step the chain to it."""
+        # Ki = point(parse256(IL)) + Kpar, which is BIP32's own equation
+        point = secp256k1.add_var(
+            self._point, mult(int.from_bytes(tweak, byteorder="big", signed=False))
+        )
+        if not point[1]:
+            # y == 0 is how an affine point spells infinity here, its x
+            # being arbitrary -- INF is (5, 0), and `curve_group`'s
+            # add_aff_var says why: the group has one point more than a
+            # pair of field elements can name, so no formula reaches that
+            # spelling and the one real point with y == 0, a two-torsion
+            # point, has no affine form at all. Comparing with INF would
+            # test the arbitrary x as well
+            raise BTClibValueError("the sum is the point at infinity")
+
+        # serialized before the step is taken, as __prv_key_derivation
+        # mutates only past its own checks: `compressed` is read by
+        # bytes_from_point, which refuses a value that is not a bool, and
+        # a chain left stepped by a call that raised would answer the
+        # next tweak from a point its caller never received
+        sec = bytes_from_point(point, secp256k1, compressed)
+        self._point = point
+        return sec
+
+
+# the two implementations of one chain: what a caller of the function
+# below holds, and neither of them a state the other has to allow for
+_PubKeyTweakChain = libsecp256k1_keys.PubkeyTweakChain | _PythonPubKeyTweakChain
+
+
+def _pub_key_tweak_chain(key: bytes) -> _PubKeyTweakChain:
+    """Return the chain a public derivation path is walked with.
+
+    The dispatch, made once for a whole path rather than at every step of
+    it: BIP32 is defined for secp256k1 alone, so what is asked here is
+    not which curve this is but whether the bindings are there to serve
+    it, which is the one question `_libsecp256k1_serves` answers that
+    another curve would not have asked.
+    """
+    return (
+        libsecp256k1_keys.PubkeyTweakChain(key)
+        if _libsecp256k1_serves(secp256k1, None)
+        else _PythonPubKeyTweakChain(key)
+    )
 
 
 # BIP328's chain code, which is the sha256 of "MuSig2MuSig2MuSig2": an
@@ -686,13 +801,13 @@ def pub_key_derivation_tweaks(
     # one parse for the whole path rather than one per index: each step
     # still needs its own serialized key, to hash into the next tweak,
     # but not a fresh parse of the bytes the step before it just
-    # serialized -- PubkeyTweakChain holds the point in between.
+    # serialized -- the chain holds the point in between.
     # Outside the loop and not inside an `if indexes:`, so that a path of
     # no steps is the one spelling of this call that still looks at the
     # key it was handed: [] is the right answer for it, and the right
     # answer for 33 bytes that are not a point is no answer
     try:
-        chain = libsecp256k1_keys.PubkeyTweakChain(key)
+        chain = _pub_key_tweak_chain(key)
     except ValueError as e:
         raise BTClibValueError(f"invalid public key: {key.hex()}") from e
 
@@ -705,28 +820,30 @@ def pub_key_derivation_tweaks(
 
 
 def __pub_key_derivation(
-    xkey: _BIP32KeyData, index: int, chain: libsecp256k1_keys.PubkeyTweakChain
+    xkey: _BIP32KeyData, index: int, chain: _PubKeyTweakChain
 ) -> None:
     offset, chain_code = _pub_key_offset(xkey.chain_code, xkey.key, index)
 
-    # the parent point plus the generator times the offset, which is
-    # what secp256k1_ec_pubkey_tweak_add computes: 12.4 us against the
-    # 33.4 of mult(offset) followed by a Python point addition, and xkey
-    # holds the key serialized throughout -- no point of btclib's own is
-    # ever built, ffi.new's raw C struct staying inside the bindings.
+    # the parent point plus the generator times the offset: one step is
+    # 11.6 us where secp256k1_ec_pubkey_tweak_add computes it and 175.2
+    # where `add_var(P, mult(t))` does, which is what a caller without
+    # the bindings pays here -- the dispatch being off altogether on that
+    # arm, so the multiplication is Python as well. xkey holds the key
+    # serialized throughout on the delegated one: no point of btclib's
+    # own is ever built, ffi.new's raw C struct staying inside the
+    # bindings.
     # Compressed on the way out, which is the spelling an extended key
     # holds: asking for the uncompressed form to read a y out of it costs
     # a second serialize and the parity arithmetic that follows, for a
     # coordinate nothing here goes on to use. `chain` is __pub_key_path_
     # derivation's, held across every index of the path so that only the
-    # first of them pays for parsing xkey.key rather than every one.
-    #
-    # Not gated on the curve, BIP32 being defined for secp256k1 alone
+    # first of them pays for parsing xkey.key rather than every one --
+    # and which of the two it holds is its own business
     try:
         sec = chain.tweak_add(offset, compressed=True)
     except ValueError as e:
-        # past the range check above, the one sum libsecp256k1 refuses
-        # is the point at infinity BIP32 refuses too
+        # past the range check above, the one sum the chain refuses is
+        # the point at infinity BIP32 refuses too
         raise _invalid_child(
             index, "the child public key is the point at infinity"
         ) from e
@@ -760,7 +877,7 @@ def __pub_key_path_derivation(xkey: _BIP32KeyData, indexes: list[int]) -> None:
     """
     if any(index >= _HARDENED_OFFSET for index in indexes):
         raise BTClibValueError("invalid hardened derivation from public key")
-    chain = libsecp256k1_keys.PubkeyTweakChain(xkey.key)
+    chain = _pub_key_tweak_chain(xkey.key)
     for index in indexes[:-1]:
         __pub_key_derivation(xkey, index, chain)
     xkey.parent_fingerprint = hash160(xkey.key)[:4]
@@ -961,7 +1078,7 @@ def derive_from_account_range_(
 
     Which is the larger half of what issue 918 asked about, and not the
     half it named. The parse of the account key is one per *path* and not
-    one per level -- `PubkeyTweakChain` holds the point across the levels
+    one per level -- `_PubKeyTweakChain` holds the point across the levels
     of a walk, so the branch key is never parsed from octets -- so what a
     range saves there is 2.34 us of an address that is 37, six percent
     and not worth an entry point. The level is worth one.

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -5,7 +5,11 @@
 """Tests for the `btclib.bip32` module."""
 
 import hmac
+import itertools
 import re
+import sys
+import types
+from collections.abc import Callable
 from dataclasses import FrozenInstanceError, fields, replace
 from typing import Any
 
@@ -17,6 +21,10 @@ from btclib.b58 import p2pkh
 from btclib.bip32 import (
     BIP328_CHAIN_CODE,
     BIP32KeyData,
+    # the module, not only the names in it: `libsecp256k1_keys` is a
+    # module attribute, and putting it out of reach is how
+    # no_bindings_bip32 below proves the Python arm asked nothing of it
+    bip32,
     crack_prv_key_var,
     derive,
     derive_,
@@ -30,11 +38,14 @@ from btclib.bip32 import (
     xpub_from_xprv,
     xpub_from_xprv_,
 )
-from btclib.bip32.bip32 import _BIP32KeyData, _derive
+from btclib.bip32.bip32 import _BIP32KeyData, _derive, _pub_key_tweak_chain
 from btclib.bip32.der_path import _indexes_from_der_path_str
 from btclib.curves import (
     bytes_from_point,
     bytes_from_prv_key_int,
+    # the module: `_libsecp256k1_available` is an attribute of it, and
+    # clearing it is how the two tests below reach the Python arm
+    curve,
     curve_group,
     mult,
     point_from_octets,
@@ -46,6 +57,7 @@ from btclib.hashes import hash160
 from btclib.network import NETWORKS
 from btclib.to_pub_key import pub_keyinfo_from_key
 from tests import load, replace_unchecked, vector_id
+from tests.curves.curve_test import no_bindings
 
 
 def test_exceptions() -> None:
@@ -223,6 +235,30 @@ def test_serialization() -> None:
     assert xpub == xpub2
 
 
+def no_bindings_bip32(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Switch the dispatch off, and bip32's own bindings out of reach.
+
+    `no_bindings` clears `_libsecp256k1_available`, which is what every
+    `_libsecp256k1_serves` in the package reads, so it is the whole
+    dispatch and not one module's copy of a predicate. What it cannot
+    show is that *this* module asked: bip32 imports `keys` as a module,
+    and a stand-in refusing every name in it is the proof -- a derivation
+    that still reaches libsecp256k1 fails here rather than quietly
+    measuring the bindings against themselves.
+    """
+
+    class Refuse:
+        def __getattr__(self, name: str) -> Any:
+            # a green suite is one where this never runs, which is the
+            # pragma curve_test.no_bindings carries for the same reason
+            raise AssertionError(  # pragma: no cover
+                f"the dispatch is switched off, and bip32 asked for {name}"
+            )
+
+    no_bindings(monkeypatch)
+    monkeypatch.setattr(bip32, "libsecp256k1_keys", Refuse())
+
+
 def bip32_vectors() -> list[Any]:
     """One case per derivation of BIP32 test vectors #1 to #4.
 
@@ -240,12 +276,29 @@ def bip32_vectors() -> list[Any]:
     ]
 
 
+@pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
 @pytest.mark.parametrize("seed, der_path, xpub, xprv", bip32_vectors())
-def test_bip32_vectors(seed: str, der_path: str, xpub: str, xprv: str) -> None:
+def test_bip32_vectors(
+    seed: str,
+    der_path: str,
+    xpub: str,
+    xprv: str,
+    bindings: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """BIP32 test vectors #1, #2, #3, and #4.
 
     https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+
+    Both arms of the derivation, because BIP32 is what each of them
+    answers to: `keys.prvkey_tweak_add` and `keys.PubkeyTweakChain` where
+    the bindings are installed, and the two sums written out in Python
+    where they are not. The vectors are the authority either way, so
+    neither arm is checked against the other's answer here.
     """
+    if not bindings:
+        no_bindings_bip32(monkeypatch)
+
     mxprv = rootxprv_from_seed(seed)
     assert xprv == derive(mxprv, der_path)
     assert xpub == xpub_from_xprv(xprv)
@@ -698,12 +751,15 @@ def test_derivation_is_the_arithmetic_bip32_defines() -> None:
     """Both derivations, against the scalar and point arithmetic in Python.
 
     libsecp256k1 adds the offset to the key, privately and publicly, and
-    BIP32 is defined for secp256k1 alone: there is no other curve for a
-    fallback to serve, so nothing in the library computes either sum the
-    other way any more. What holds the delegation to BIP32's own
-    equations is having them here -- `ki = parse256(IL) + kpar (mod n)`
-    and `Ki = point(parse256(IL)) + Kpar` -- written out over the same
-    hmac the derivation takes, and the shipped vectors for the rest.
+    what holds that delegation to BIP32's own equations is having them
+    here -- `ki = parse256(IL) + kpar (mod n)` and `Ki =
+    point(parse256(IL)) + Kpar` -- written out over the same hmac the
+    derivation takes, and the shipped vectors for the rest.
+
+    Written out here and not read out of the library's own Python arm,
+    which is the same two equations and would be checking a copy against
+    itself. That arm is checked where it has an authority to answer to:
+    `test_bip32_vectors[python]`.
     """
     rootxprv = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
     parent = BIP32KeyData.b58decode(rootxprv)
@@ -733,8 +789,168 @@ def test_derivation_is_the_arithmetic_bip32_defines() -> None:
     assert child_pub.key == bytes_from_prv_key_int(child_prv_key)
 
 
-def test_invalid_child_prv_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Refuse the two invalid private children, on a dictated hmac."""
+def test_the_python_arm_reaches_no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Python arm must be Python throughout, or it has no reason to be.
+
+    A mixed arm is the one shape that is never right: with libsecp256k1
+    in reach `keys.PubkeyTweakChain` and `keys.prvkey_tweak_add` are the
+    better calls, and out of reach there is nothing to mix. So the arm
+    holds no call that could delegate -- which today it does not by
+    construction, `mult` and the lift under `point_from_octets` gating on
+    `_libsecp256k1_serves(secp256k1, None)`, the very call that chose the
+    arm. Construction is a thing to check rather than to trust, and a
+    per-operation dispatch would end it without touching this file.
+
+    Checked by putting the whole of btclib_secp256k1 out of reach, which
+    takes both halves: the package's own callables, for a caller holding
+    the module and reaching through it as bip32 does, and every name
+    btclib has already bound from it, `from ... import x as y` having
+    copied the object rather than looked it up again.
+
+    Not the same thing as `no_bindings_bip32` below, which switches the
+    dispatch off and refuses bip32's own module: this refuses what every
+    layer beneath it would have called too.
+    """
+    rootxprv = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
+    rootxpub = xpub_from_xprv(rootxprv)
+    xpub = BIP32KeyData.b58decode(rootxpub)
+    # what the bindings answer, taken while they are still in reach
+    delegated = (
+        derive(rootxprv, "m/0h/1/2h"),
+        derive(rootxpub, "m/1/2"),
+        pub_key_derivation_tweaks(xpub.key, xpub.chain_code, "m/1/2"),
+    )
+
+    def refuse(what: str) -> Callable[..., Any]:
+        def asked(*_args: object, **_kwargs: object) -> Any:
+            # a green suite is one where this never runs
+            raise AssertionError(  # pragma: no cover
+                f"the Python arm reached libsecp256k1: {what}"
+            )
+
+        return asked
+
+    for mod_name, mod in list(sys.modules.items()):
+        if mod_name.split(".")[0] not in {"btclib", "btclib_secp256k1"}:
+            continue
+        for attr, value in list(vars(mod).items()):
+            if isinstance(value, types.ModuleType) or not callable(value):
+                continue
+            origin = getattr(value, "__module__", None) or ""
+            if origin.split(".")[0] == "btclib_secp256k1":
+                monkeypatch.setattr(mod, attr, refuse(f"{mod_name}.{attr}"))
+
+    # the two bip32 itself would have called, so that a loop reaching
+    # nothing would fail here rather than pass by touching nothing
+    with pytest.raises(AssertionError, match="reached libsecp256k1"):
+        libsecp256k1_keys.prvkey_tweak_add(b"\x01" * 32, b"\x02" * 32)
+    with pytest.raises(AssertionError, match="reached libsecp256k1"):
+        libsecp256k1_keys.PubkeyTweakChain(b"\x02" + b"\x01" * 32)
+
+    monkeypatch.setattr(curve, "_libsecp256k1_available", False)
+
+    assert (
+        derive(rootxprv, "m/0h/1/2h"),
+        derive(rootxpub, "m/1/2"),
+        pub_key_derivation_tweaks(xpub.key, xpub.chain_code, "m/1/2"),
+    ) == delegated
+
+
+def test_the_python_arm_answers_what_the_primitive_answers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each arm of the two sums, against the call the other one makes.
+
+    The bindings are the authority on the answer here as everywhere else
+    the library keeps a Python path. `_pub_key_tweak_chain` answers one
+    secp256k1_ec_pubkey_tweak_add per step where they serve and
+    `add_var(P, mult(t))` where they do not, so the two are asserted step
+    by step over a spread of parent keys and tweaks; the private sum is
+    `keys.prvkey_tweak_add` against `(kpar + IL) % n` over the same
+    spread.
+
+    Successive steps rather than one apiece, the chain's whole point
+    being that a step starts from what the last one answered: an arm that
+    dropped the walk would still pass a one-step comparison.
+
+    The spread holds what a derivation's own tweaks never will, those
+    being hmac output: a zero tweak, which libsecp256k1's header says it
+    answers with the key unchanged; a tweak of n-1; and the two sums it
+    declines, the zero child and the child at infinity.
+    """
+    keys = [bytes_from_prv_key_int(q) for q in (1, 2, 7, ec.n // 2, ec.n - 1)]
+    tweaks = [0, 1, 2, 7, ec.n // 2, ec.n - 1]
+
+    def walk(key: bytes) -> list[bytes | str]:
+        """Step through the tweaks, stopping where the chain refuses."""
+        chain = _pub_key_tweak_chain(key)
+        steps: list[bytes | str] = []
+        for t in tweaks:
+            try:
+                steps.append(
+                    chain.tweak_add(t.to_bytes(32, byteorder="big", signed=False))
+                )
+            except ValueError:
+                # a refused step ends the chain, so what the arms have to
+                # agree on is where it happened and not what comes after:
+                # n-1 tweaked by 1 is the sum at infinity, and this walk
+                # is the one caller that reaches it
+                steps.append("refused")
+                break
+        return steps
+
+    delegated = [walk(key) for key in keys]
+    assert any("refused" in steps for steps in delegated)
+    with monkeypatch.context() as no_c:
+        no_bindings_bip32(no_c)
+        assert [walk(key) for key in keys] == delegated
+
+    # the sum neither implementation has an answer for, and both refuse
+    # by raising what the callers turn into BIP32's invalid children.
+    #
+    # The Python one is matched on its message, which is what makes its
+    # guard load-bearing: `bytes_from_point` refuses infinity too, with a
+    # BTClibValueError of its own, so deleting the guard leaves the type
+    # of the exception and every other assertion in this file untouched
+    # -- and leaves `pub_key_derivation_tweaks`, which does not wrap this
+    # loop, telling its caller about a serialization it never asked for
+    for q in (1, 2, 7):
+        key = bytes_from_prv_key_int(q)
+        offset = (ec.n - q).to_bytes(32, byteorder="big", signed=False)
+        with pytest.raises(ValueError):
+            _pub_key_tweak_chain(key).tweak_add(offset)
+        with monkeypatch.context() as no_c:
+            no_bindings_bip32(no_c)
+            with pytest.raises(
+                BTClibValueError, match="the sum is the point at infinity"
+            ):
+                _pub_key_tweak_chain(key).tweak_add(offset)
+
+    # and the private sum, whose delegated arm is the primitive itself
+    for q, t in itertools.product((1, 2, 7, ec.n // 2, ec.n - 1), tweaks):
+        key = q.to_bytes(32, byteorder="big", signed=False)
+        offset = t.to_bytes(32, byteorder="big", signed=False)
+        child = (q + t) % ec.n
+        if child:
+            assert libsecp256k1_keys.prvkey_tweak_add(key, offset) == child.to_bytes(
+                32, byteorder="big", signed=False
+            )
+        else:
+            with pytest.raises(ValueError):
+                libsecp256k1_keys.prvkey_tweak_add(key, offset)
+
+
+@pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
+def test_invalid_child_prv_key(bindings: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Refuse the two invalid private children, on a dictated hmac.
+
+    On both arms: the zero child is the sum libsecp256k1 refuses and the
+    comparison the Python arm makes, so one refusal has two spellings and
+    they have to raise the same error.
+    """
+    if not bindings:
+        no_bindings_bip32(monkeypatch)
+
     rootxprv = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
     xkey = BIP32KeyData.b58decode(rootxprv)
     prv_key_int = int.from_bytes(xkey.key[1:], byteorder="big", signed=False)
@@ -752,8 +968,17 @@ def test_invalid_child_prv_key(monkeypatch: pytest.MonkeyPatch) -> None:
         derive(rootxprv, "m/0")
 
 
-def test_invalid_child_pub_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Refuse the two invalid public children, on a dictated hmac."""
+@pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
+def test_invalid_child_pub_key(bindings: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Refuse the two invalid public children, on a dictated hmac.
+
+    On both arms, as the private children above: the sum at infinity is
+    the one libsecp256k1 has no public key for, and the one the Python
+    arm recognizes by its zero y.
+    """
+    if not bindings:
+        no_bindings_bip32(monkeypatch)
+
     rootxprv = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
     rootxpub = xpub_from_xprv(rootxprv)
     xkey = BIP32KeyData.b58decode(rootxprv)
@@ -1049,7 +1274,10 @@ def test_pub_key_derivation_tweaks_are_32_bytes_each() -> None:
     assert all(len(tweak) == 32 for tweak in tweaks)
 
 
-def test_a_path_of_no_steps_still_looks_at_the_public_key() -> None:
+@pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
+def test_a_path_of_no_steps_still_looks_at_the_public_key(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """[] is the right answer for an empty path, and not for a non-point.
 
     `if indexes:` around the whole body made the empty path the one
@@ -1057,7 +1285,14 @@ def test_a_path_of_no_steps_still_looks_at_the_public_key() -> None:
     public key -- a prefix of 0x00, an x above p, x = 0 -- all came back
     as `[]`, the answer a caller reads as "derivation succeeded, nothing
     to apply".
+
+    Both arms build the chain, so both are asked: the four keys below are
+    refused by `PubkeyTweakChain`'s parse where the bindings serve, and by
+    `point_from_octets` where they do not.
     """
+    if not bindings:
+        no_bindings_bip32(monkeypatch)
+
     rootxprv = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
     xpub = BIP32KeyData.b58decode(xpub_from_xprv(rootxprv))
 
@@ -1148,7 +1383,10 @@ def test_check_validity_defaults_to_true() -> None:
     assert BIP32KeyData.parse(as_bytes, check_validity=False) == invalid
 
 
-def test_the_tweaks_of_a_public_derivation_are_the_derivation() -> None:
+@pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
+def test_the_tweaks_of_a_public_derivation_are_the_derivation(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The scalars a path adds up to, against the key the path derives.
 
     What they are for is a key that cannot be derived from -- a BIP327
@@ -1156,7 +1394,14 @@ def test_the_tweaks_of_a_public_derivation_are_the_derivation() -> None:
     the signers as tweaks (BIP373, `btclib.psbt.musig2`) -- and what says
     they are right is that applying them by hand lands on the key `derive`
     answers for the same path.
+
+    On both arms, the tweaks being the hmac's left halves and so the same
+    scalars either way: what differs is the chain walking the key from one
+    to the next, which is where the two could part.
     """
+    if not bindings:
+        no_bindings_bip32(monkeypatch)
+
     rootxprv = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
     xpub = BIP32KeyData.b58decode(xpub_from_xprv(rootxprv))
 

--- a/tests/bool_parameter_test.py
+++ b/tests/bool_parameter_test.py
@@ -81,6 +81,7 @@ import pytest
 
 from btclib import b32, b58, bip322, core_import, slip132, var_bytes
 from btclib.bip32.bip32 import (
+    _PythonPubKeyTweakChain,
     derive,
     derive_from_account,
     derive_from_account_,
@@ -297,6 +298,16 @@ _KINDS = (
         optional=True,
     ),
     _Case("btclib.b58.p2pkh", "compressed", b58.p2pkh, {"key": _SEC}, optional=True),
+    # the one that is a bound method: a chain holds the point it steps,
+    # so the instance is built here and `bytes_from_point` above is the
+    # check this one reaches. A refused call must not step it, which is
+    # why the serialization happens before the step rather than after
+    _Case(
+        "btclib.bip32.bip32._PythonPubKeyTweakChain.tweak_add",
+        "compressed",
+        _PythonPubKeyTweakChain(_SEC).tweak_add,
+        {"tweak": _PRV_KEY.to_bytes(32, byteorder="big", signed=False)},
+    ),
     _Case(
         "btclib.ecc.bms.gen_keys",
         "compressed",


### PR DESCRIPTION
Both sums went to libsecp256k1 unconditionally -- keys.prvkey_tweak_add
for the private child, keys.PubkeyTweakChain.tweak_add for the public one
-- on the argument that BIP32 is defined for secp256k1 alone, so no other
curve could ask for a fallback. The curve is not the only question that
argument has to answer: curve._libsecp256k1_available is the seam every
other dispatch in the package reads, and bip32 read nothing, so clearing
it left the derivation in C. Measured: derive(xprv, "m/0h/1/2h") with the
seam closed still made three prvkey_tweak_add calls, and the public path
two PubkeyTweakChain and four tweak_add.

BIP32's own equations are back behind _libsecp256k1_serves, as every
other dispatch is: ki = parse256(IL) + kpar (mod n), and
Ki = point(parse256(IL)) + Kpar. _PubKeyTweakChain is what a path walks
either way -- keys.PubkeyTweakChain where the bindings serve, an affine
point held across the levels where they do not, so that arm pays one
point_from_octets per path rather than one per level, 84.7 us against the
bindings' 2.9 parse. One contract for both arms, and it is the bindings':
ValueError for 33 octets that are no point, and for the sum at infinity,
which is one of the three children BIP32 declares invalid.

A whole derivation costs eight to ten times as much on the Python arm --
36.4 us against 308.8 for m/0h/1/2h, 44.5 against 437.4 for a public
m/1/2 -- and CHANGELOG.md has the table, the control that says the
measurement is one, and the per-step numbers under it.

No caller reaches the new arm: the bindings are a required dependency, so
this is a seam the test suite closes and nothing else can, as with
bms.sign's Python path. What changes is that closing it now measures
Python. The BIP32 test vectors run on both arms, and so do the two
invalid children of each derivation, the tweaks of a public path and the
non-points an empty path has to refuse; no_bindings_bip32 puts the
module's own bindings out of reach besides clearing the dispatch, so an
arm that still asked for them fails rather than measuring them against
themselves.

SECURITY.md names the private derivation beside the other three places a
secret meets the curve, and its Python arm beside bms.sign's.

Refs #966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restore a Python-based BIP32 derivation path alongside the libsecp256k1-backed implementation and wire it into the existing dispatch seam so it is used when the C bindings are unavailable.

New Features:
- Introduce a Python implementation of BIP32 private and public child derivation based on the standard scalar and point equations, used when libsecp256k1 bindings are not serving.

Enhancements:
- Add an internal _PubKeyTweakChain abstraction that unifies public derivation path walking for both the libsecp256k1 and Python implementations while preserving error semantics.
- Document performance characteristics and behavior of the Python BIP32 arm versus the bindings in CHANGELOG.md and clarify its security profile in SECURITY.md.

Tests:
- Extend BIP32 test coverage to run core vector and invalid-child tests against both bindings and Python arms, and add helpers to force operation without libsecp256k1 bindings for measurement.