### PR TITLE
Stop counting the bindings imports, and say what the job waits on

### DIFF
--- a/tests/script_engine/python_path_test.py
+++ b/tests/script_engine/python_path_test.py
@@ -21,10 +21,12 @@ only became visible as a whole engine accepting a whole transaction it
 must refuse.
 
 The alternative, a CI job installing without the bindings, is not a job
-but a partial revert: all five bindings imports are plain imports, so
-`import btclib` itself fails without them and the optional-bindings
-install would have to come back in order to be tested.
-This costs no packaging change and no fallback code in the library.
+but a partial revert as the tree stands: every bindings import is a plain
+import, so `import btclib` fails without them and there is nothing for
+such a job to run until the optional-bindings install comes back. Issue
+#966 is that work, and guarding those imports is the step it waits on;
+this module is what holds the vectors meanwhile, at no packaging change
+and no fallback code in the engine.
 
 The substitution is the one already used for ripemd160 in
 tests/hashes_test.py: a module-level name, swapped, to reach the second


### PR DESCRIPTION
python_path_test.py's docstring says "all five bindings imports are plain
imports", of a tree that has eleven modules importing them. The number is
the smaller half of the problem: nothing here should state a count, and
the paragraph reads as a door closed on a CI job installing without the
bindings when what it describes is a dependency -- #966 proposes that job
as its last step, with guarding the imports as the step before.

So the count goes, the argument stays, and the issue is named. The
sentence about what the substitution costs says "no fallback code in the
engine" rather than "in the library": bip32 has an arm of its own since
17af5e89, and the engine's two verifications are what this module still
stands in for, which is #966's second step.

The same words are in CHANGELOG.md's entry for #129 and stay there. That
one records what was true when it was written, which is what a changelog
is for; this one is a claim about the tree as it stands.

Refs #966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Update the python_path_test documentation comment to remove hard-coded import counts and explain what the CI job would wait on in the current tree.