### PR TITLE
Assert the chain contract no derivation here reaches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1515,6 +1515,19 @@ documented at release-notes length in the first place, and are still in
   the sum at infinity — which is one of the three children BIP32 declares
   invalid, and reaches the caller as `_invalid_child` words it.
 
+  For every argument a caller here passes, that is, and `compressed` is
+  the one where the two would part: `bytes_from_point` refuses a value
+  that is not a bool, and the bindings' serialization takes it for the
+  flag it is truthy as. `_PythonPubKeyTweakChain` is the stricter, which
+  is the side to be on, and its ordering follows from that — the
+  serialization happens before the step, so a call that raised leaves the
+  point where the last call that answered left it. Neither that ordering
+  nor the flag's answer had a caller to reach them, both derivations
+  passing the literal `True`, so both are now asserted rather than
+  described: swapping the two lines, or ignoring the flag, each fails a
+  test of its own. Not asserted of the bindings, whose behaviour here is
+  a dependency's and would make this suite red for growing a check.
+
   What the Python arm costs, µs, median of four alternating rounds, best
   of five × 200 calls:
 

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -695,6 +695,16 @@ class _PythonPubKeyTweakChain:
     refuses too, `_invalid_child` being what the callers turn it into --
     and the constructor raises it for octets that are no point.
 
+    Theirs for every argument a caller here passes, and `compressed` is
+    where the two would part if one did not: `bytes_from_point` refuses a
+    value that is not a bool and their serialization takes it for the
+    flag it is truthy as. This one is the stricter, and stricter is the
+    side to be on -- but it is what makes the order below matter, so it
+    is written here rather than left to be rediscovered from a raise the
+    other implementation does not make. Both callers pass the literal,
+    `compressed` is typed `bool`, and the union alias is what has mypy
+    hold them to it.
+
     A refused step ends the chain, which is that contract too: "pubkey
     will be set to an invalid value if this function returns 0" is what
     libsecp256k1 says of `secp256k1_ec_pubkey_tweak_add`, and that pubkey

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -38,7 +38,12 @@ from btclib.bip32 import (
     xpub_from_xprv,
     xpub_from_xprv_,
 )
-from btclib.bip32.bip32 import _BIP32KeyData, _derive, _pub_key_tweak_chain
+from btclib.bip32.bip32 import (
+    _BIP32KeyData,
+    _derive,
+    _pub_key_tweak_chain,
+    _PythonPubKeyTweakChain,
+)
 from btclib.bip32.der_path import _indexes_from_der_path_str
 from btclib.curves import (
     bytes_from_point,
@@ -938,6 +943,50 @@ def test_the_python_arm_answers_what_the_primitive_answers(
         else:
             with pytest.raises(ValueError):
                 libsecp256k1_keys.prvkey_tweak_add(key, offset)
+
+
+def test_the_chain_contract_no_derivation_here_asks_for() -> None:
+    """`compressed`, and what a call that raised leaves the chain holding.
+
+    Two halves of `tweak_add` that neither derivation reaches: both pass
+    `compressed=True` as a literal, and the only refusal a path can
+    provoke is the sum at infinity above. The union alias makes them a
+    contract even so, mypy checking one call against both
+    implementations, and a contract with no caller is a comment unless
+    something asserts it.
+
+    The flag by its answer and not by its type. `bytes_from_point`
+    refuses a `compressed` that is not a bool, which is the check
+    `bool_parameter_test` reaches, and a body that ignored the flag
+    altogether would pass that one unchanged.
+
+    The refusal by what the chain holds afterwards.
+    `_PythonPubKeyTweakChain` serializes before it steps, so a call that
+    raises leaves the point where the last call that answered left it --
+    which is what the comment there says and what nothing said back. The
+    two implementations part here and this one is the stricter: the
+    bindings step first and serialize after, and do not refuse a non-bool
+    at all, their serialization taking whatever it is truthy as. Not
+    asserted of them, a dependency that grew the check being a change
+    this suite should not go red for; asserted of the one whose ordering
+    is a decision this file made.
+    """
+    key = bytes_from_prv_key_int(7)
+    tweak = (3).to_bytes(32, byteorder="big", signed=False)
+
+    compressed = _PythonPubKeyTweakChain(key).tweak_add(tweak)
+    uncompressed = _PythonPubKeyTweakChain(key).tweak_add(tweak, compressed=False)
+    assert uncompressed[0] == 0x04
+    assert bytes_from_point(point_from_octets(uncompressed)) == compressed
+    assert (
+        libsecp256k1_keys.PubkeyTweakChain(key).tweak_add(tweak, compressed=False)
+        == uncompressed
+    )
+
+    chain = _PythonPubKeyTweakChain(key)
+    with pytest.raises(BTClibTypeError, match="invalid compressed type"):
+        chain.tweak_add(tweak, compressed="yes")  # type: ignore[arg-type]
+    assert chain.tweak_add(tweak) == compressed
 
 
 @pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])


### PR DESCRIPTION
Follow-up to #967, from the post-merge review on it
([comment](https://github.com/btclib-org/btclib/pull/967#issuecomment-5309440110)).
`17af5e89` landed a `_PythonPubKeyTweakChain` that states two things about
itself which nothing held.

**It serializes before it steps.** The comment says why — *a chain left
stepped by a call that raised would answer the next tweak from a point its
caller never received* — and the new `_Case` in `bool_parameter_test`
repeats it. Swapping the two lines left the suite at **27895 passed**.

**It answers `compressed`.** Replacing the parameter in the body with a
hardcoded `True` was killed only by `test_a_kind_refuses_a_non_bool`, which
is the *kind* of the argument and not the answer it asks for.

Neither has a caller to reach it: both derivations pass the literal `True`,
and the only refusal a path can provoke is the sum at infinity. That is what
makes them a contract rather than a behaviour — the union alias has mypy
check one call against both implementations — and a contract with no caller
is a comment unless something asserts it. Both are asserted here, and each
fails its own line of `test_the_chain_contract_no_derivation_here_asks_for`.

### And one thing the class docstring did not say

The two implementations *do* part on `compressed`, while the docstring says
the contract is the bindings':

```
python    tweak_add(t, compressed="yes")  ->  BTClibTypeError: invalid compressed type: str
bindings  tweak_add(t, compressed="yes")  ->  03...   (no raise; the chain has stepped)
```

`bytes_from_point` refuses a value that is not a bool; libsecp256k1's
serialization takes it for the flag it is truthy as. This one is the
stricter, which is the side to be on — and it is what makes the ordering
matter at all, the other implementation never raising there. Unreachable
from here, `compressed` being typed `bool` and passed as one, so it is
written down rather than left to be rediscovered.

Not asserted of the bindings: their behaviour there is a dependency's, and a
suite that pinned it would go red for a check they grew.

### Verified

- gate: `uvx pre-commit run --all-files`, every hook Passed
- suite and ratchet: `27896 passed, 6 skipped`, coverage 100.00%
- both mutations, under `PYTHONDONTWRITEBYTECODE=1` with a passing baseline
  before and a passing control after: the swapped order and the ignored flag
  each now fail, by name

Refs #966 — the script engine's two verifications and the eleven unguarded
imports are what is still between here and an installed btclib that answers
without the bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Assert the behaviour contract of the Python BIP32 pubkey tweak chain around the compressed flag and serialization order, and document the stricter semantics versus the bindings implementation.

Documentation:
- Clarify in the changelog and _PythonPubKeyTweakChain docstring how compressed is handled, the stricter validation of non-bool values, and why serialization precedes the tweak step.

Tests:
- Add a dedicated BIP32 test verifying that _PythonPubKeyTweakChain enforces bool-only compressed, serializes before stepping, and remains consistent with the bindings chain where their behaviour is relied upon.