### PR TITLE
Follow the bindings to their tip again, the other pins being current

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ test = [
 [[package]]
 name = "btclib-secp256k1"
 version = "0.8.0.3"
-source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#7098ddb42ae51ce8f99ae3edb2731b909b8afc48" }
+source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#75cbb44b1ba853585c19c0b30d5126f056f26305" }
 dependencies = [
     { name = "cffi" },
 ]


### PR DESCRIPTION
`[tool.uv.sources]` names the branch, so the reference already moves and
`uv.lock` is where a commit is written down. It is written down again
here: btclib_secp256k1 7098ddb4 -> 75cbb44b, five of those seven commits
reaching the installed package, and the version is still 0.8.0.3, so the
floor in `dependencies` stays as it is.

One of the five is a change of contract, not only of cost:
`context.guarded` is gone, and eight refusals move from ValueError to
RuntimeError with it. All eight are serializations reading an object the
caller parsed itself, and btclib passes octets everywhere, so none of
them is a call this package makes. What it does hold across calls is
`keys.PubkeyTweakChain`, built from a sec, and its step onto infinity is
still the ValueError `curves.curve.PointChain.point` catches -- the
suite runs that branch, the coverage gate being at 100.00%. The other
four are additive: `dsa.sign(grind=True)`, the `dsa.is_low_r` that goes
with it, a keyword-only `into=` buffer, and prose.

That grinding loop is the one `ecc.dsa._grind_low_r` already runs in
python, and it stays: the bindings measured a caller's own loop over
the public wrappers at 24.7 microseconds against 24.8 for theirs, noise
0.1, so crossing the boundary once per signature instead of once per
attempt is not what the difference would be about.

`uv lock --upgrade` moves nothing else -- every other pin already
resolves to its newest release -- and `pre-commit autoupdate` offers
only the two revs that stay where they are for the reasons written
beside them: typos' moving `v1` tag, and pyroma's 5.1b1 beta. Each
action pinned by SHA is at its latest release tag, checked against the
tag object rather than the comment.

The suite, every hook and sphinx -W pass against the result.

## Summary by Sourcery

Update dependency lockfile to track latest btclib_secp256k1 commit while keeping existing version constraints

Build:
- Refresh uv.lock to point btclib_secp256k1 at a newer upstream commit without changing the declared version floor

Chores:
- Regenerate lockfile to reflect current upstream state after running uv lock --upgrade and dependency checks