### PR TITLE
Kill the two numeric survivors that are tests and not equivalences

### DIFF
--- a/tests/amount_test.py
+++ b/tests/amount_test.py
@@ -215,6 +215,23 @@ def test_a_satoshi_amount_that_int_refuses_is_refused_in_kind() -> None:
             valid_sats_amount(other)
 
 
+@pytest.mark.parametrize("amount", [1.5, -1.5, Decimal("2.5"), Decimal("-2.5")])
+def test_a_fraction_of_a_satoshi_is_refused_at_either_sign(amount: object) -> None:
+    """A negative fraction is refused as a non-integer, not as a range.
+
+    `int()` truncates towards zero, so the truncation is *below* a
+    positive amount and *above* a negative one. A check that the
+    truncation changed the value therefore has to be an inequality and
+    not a comparison: at -1.5 the truncation is -1, which is greater, and
+    an ordering test lets it through to the range check below -- where it
+    is still refused, but as an invalid amount rather than as a
+    non-integer one. Which exception a caller catches is the distinction
+    this function's own comment is about.
+    """
+    with pytest.raises(BTClibTypeError, match="non-integer satoshi amount"):
+        valid_sats_amount(amount)
+
+
 @pytest.mark.parametrize(
     "amount",
     [float("inf"), float("-inf"), Decimal("Infinity"), Decimal("-Infinity")],

--- a/tests/fee_test.py
+++ b/tests/fee_test.py
@@ -342,6 +342,21 @@ def test_the_package_is_rounded_once_and_not_twice() -> None:
     assert package_fee(400, rate, ancestor_vsize=400) == 1
 
 
+def test_ancestors_that_paid_nothing_are_what_the_default_says() -> None:
+    """`ancestor_fee` defaults to nothing already paid.
+
+    The case above leaves the default in place too, and cannot see it: the
+    800 vB package owes 0.8 there, the ceiling makes it 1, and the child's
+    own fee is 1, so the larger of the two is 1 whether nothing or one
+    satoshi is subtracted. At 1200 vB the package owes 2 and the child
+    still owes 1, which is where a default of one satoshi would read 1
+    instead.
+    """
+    rate = FeeRate(sats_per_kvbyte=1)
+    assert package_fee(400, rate, ancestor_vsize=800) == 2
+    assert package_fee(400, rate, ancestor_vsize=800, ancestor_fee=1) == 1
+
+
 def test_a_zero_rate_owes_zero_however_much_was_paid() -> None:
     """No discount goes the other way either: a fee is never negative."""
     rate = FeeRate(sats_per_kvbyte=0)


### PR DESCRIPTION
The complete session leaves 49 mutants alive and 47 of them are
equivalent -- annotations PEP 649 cannot tell apart, a bound lowered past
anything a test reaches, a block count the return truncates, arithmetic
identities, CPython's one-byte `bytes` cache. Two are not, and each is
one case in a file that already holds its neighbours.

`valid_sats_amount`'s `sats != amount` survives as `sats < amount`
because `int()` truncates towards zero: below a positive amount, above a
negative one. The tests pass positives only, so the ordering agrees with
the inequality on every one of them. At -1.5 it does not -- the
truncation is -1, which is greater -- and the mutant falls through to the
range check, refusing the amount as invalid rather than as non-integer.
Both refuse it, so nothing wrong is accepted; what changes is the
exception, and which builtin each of this function's answers stands for
is what its own comment is about. The parametrization carries both signs
and both types, which is what makes the asymmetry the point rather than
the value.

`package_fee`'s `ancestor_fee: int = 0` survives as `1`, and not because
no test leaves the default: `test_the_package_is_rounded_once_and_not_twice`
does, at the one size where a satoshi cannot be seen. Its 800 vB package
owes 0.8 at that rate, the ceiling makes it 1, and the child owes 1
itself, so the larger of the two is 1 whether nothing or one satoshi is
subtracted. At 1200 vB the package owes 2 against the child's 1, and the
default is visible. The explicit `ancestor_fee=1` beside it is what says
the two differ there rather than leaving the reader to work it out.

Both verified by applying the mutation and watching the new test fail:
the first fails on -1.5 and Decimal("-2.5") and passes on the positives,
which is the asymmetry itself; the second fails outright. No CHANGELOG
entry, nothing in `btclib/` changing and no behaviour with it -- these
pin what the library already does.

Closes #976

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add tests to pin existing behaviour for satoshi amount validation and package fee default handling.

Tests:
- Add parametrized tests ensuring fractional satoshi amounts are rejected consistently for both positive and negative values and numeric types.
- Add tests verifying package fee calculations when ancestors have paid no fee, confirming the default ancestor_fee represents zero payment.