### PR TITLE
Refuse a signet challenge for a testnet, and test that it is refused

### DIFF
--- a/tests/fetch/bitcoin_core_test.py
+++ b/tests/fetch/bitcoin_core_test.py
@@ -313,6 +313,21 @@ def test_a_challenge_is_refused_where_it_would_check_nothing() -> None:
         fetcher(network="signet", signet_challenge=CUSTOM_CHALLENGE)
 
 
+@pytest.mark.parametrize("network", ["testnet", "testnet4"])
+def test_a_challenge_is_refused_for_a_testnet_too(network: str) -> None:
+    """The refusal is inequality with signet, not an ordering against it.
+
+    The chain names are compared as strings, and `main` and `regtest` both
+    sort before `signet` where an ordering and an inequality agree. The
+    testnets sort after it, so they are the two networks a comparison
+    would accept a challenge for -- one that could never be checked,
+    because there is no signet challenge in a testnet's genesis to hold it
+    to.
+    """
+    with pytest.raises(BTClibValueError, match=f"challenge for {network}"):
+        fetcher(network=network, verify_network=True, signet_challenge=CUSTOM_CHALLENGE)
+
+
 def test_a_challenge_that_is_no_script_is_refused_at_construction() -> None:
     """Derived once here, so that the failure is at the line that wrote it.
 


### PR DESCRIPTION
`BitcoinCoreFetcher` refuses a `signet_challenge` where it could never be
checked, and the refusal compares chain names as strings. That makes an
ordering and an inequality agree on exactly the networks the tests use:
`main` and `regtest` both sort before `signet`, and `signet` is itself. The
testnets sort after it, so `<` in place of `!=` accepts a challenge for
`testnet` and `testnet4` -- a challenge with no genesis challenge to hold
it to, on the one path whose purpose is refusing a check the caller
expects and would not get.

`ReplaceComparisonOperator_NotEq_Lt` survives the complete fetch session
for that reason, `test_a_challenge_is_refused_where_it_would_check_nothing`
using mainnet. The case beside it is parametrized over both testnets, and
the mutant dies on both: applied, the two parameters fail and the file's
other 41 tests pass, which is what says the mutant was invisible rather
than unreached.

The rest of that profile's 35.59% is one module's annotations. Of its 63
survivors, 55 are three `X | None` lines mutated eleven and twenty-two
ways -- the PEP 649 class fetch.toml documents -- four in `fetcher.py` are
equivalent by inspection, and three are the keyword-only `*` marker turned
`/`, which no test in the library would catch anywhere: there are 88 such
markers and nothing asserts a keyword-only parameter is one. That is a
question rather than a test, and is not this commit's.

No CHANGELOG entry: nothing in `btclib/` changes, and the behaviour tested
is the behaviour shipped.

Closes #978

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tests:
- Add a parametrized test verifying signet challenges are refused on testnet and testnet4 networks.