### PR TITLE
Stop paying for a proof of what the bindings just computed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1507,6 +1507,73 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **The grinding loop stops paying for a check once per attempt, and pays
+  it once for the signature it keeps** (issue #983, and the urgent half of
+  issue #982). `dsa.sign`, `ssa.sign_custom` and `recovery.sign` in
+  btclib-secp256k1 grew a keyword-only `verify` defaulting to True — the
+  library verifies what it has just computed before answering with it,
+  which is `CKey::Sign`'s policy — and `[tool.uv.sources]` pins the
+  bindings to their branch, so this repository started paying for it
+  without a line changing. `_grind_low_r` calls into them once per attempt,
+  so the bill was 19.5 microseconds *an attempt*: seven times the
+  `check_validity` congruence the comment right above declines, and on an
+  eight-attempt grind more than the grind.
+- **What the attempts pay and what the survivor pays are different
+  questions**, which is why this is not `verify=False` and nothing else.
+  The attempts do not need checking: a faulted one that is discarded cost
+  an attempt. The one the loop settles on does, and Core's `CKey::Sign`,
+  the bindings' own `dsa._sign_` and issue #982 all describe the same order
+  — grind first, check the survivor. So the attempts pass `verify=False`
+  and the signature that comes back is verified once, with
+  `libsecp256k1_dsa.verify` under the key derived from `q`. That costs
+  20.25 microseconds against the 19.56 the bindings' own default costs per
+  call; the 0.7 between them is the serialization and the parse a caller of
+  the public halves pays and their private ones do not. The *uncompressed*
+  sec is passed for the same kind of reason: parsing `02 || x` is a field
+  square root, and the compressed one would cost 22.20. Alternated in one
+  process, 15 rounds of 3000 calls, minimum kept, noise 0.05 — an Apple M5,
+  macOS 26.6, arm64, CPython 3.14.6. The raise carries `# pragma: no cover`
+  and `dleq.sign`'s reasoning: no input reaches it, and what it reports is
+  the computation having gone wrong.
+- **`recovery.sign` is passed `verify=True` rather than left to the
+  default.** Its check is not a verification — the bindings recover the key
+  and refuse one that is not the signer's, which reads the recovery id, and
+  the id is a value this call is made for that nothing downstream
+  re-derives. A faulted `r` or `s` fails the first verification anybody
+  makes; a wrong id does not. 22.4 microseconds, once per signature, this
+  path not grinding. Written out because the policy belongs at the call
+  site, which is the same argument that writes `False` in the loop above,
+  and because it survives the day btclib-secp256k1#224 asks again whether
+  that default should be per scheme.
+- **BIP340 keeps its check, and now says so where the calls are.** An
+  earlier revision of this change passed `verify=False` to
+  `ssa.sign_custom` too, for one policy across the call sites. With the
+  ECDSA path checking its survivor, one policy means the opposite: a check
+  per signature, which is exactly what BIP340's single call already pays.
+  Declining it there would have left the scheme whose *Default Signing*
+  ends in a verification as the only one btclib does not check — and the
+  remedy offered to a caller who wanted it back, verifying the answer,
+  costs more than the step declined: `ssa.verify` is 14.275 microseconds
+  against 12.7 for the inline check, which has the point in hand where a
+  caller's has to parse a serialized x-only key. So the keyword is written
+  out as `verify=True`, as `sign_recoverable_` writes its own and `sign_`
+  writes its `False`: **all four** of btclib's calls into the bindings'
+  signers state their policy, and the one a specification asks for is not
+  the one left to a default. The fourth is `ssa.Signer.sign_`'s delegated
+  arm, where the check is the largest share of what it is added to — the
+  keypair built when the signer was takes the signature down to 8.18
+  microseconds against a fresh one's 15.87, so the same check is 61% of the
+  call against 44% there, and it is the call a caller would most plausibly
+  want to decline. The recorder in `tests/ecc/ssa_test.py` takes the
+  keyword and forwards it, a stub that swallowed it recording a call the
+  package does not make; nothing records the `Signer` path, which is issue
+  #986.
+- **What stays open is the rest of issue #982**, and it is the larger part:
+  a `verify` keyword of btclib's own on `dsa.sign_`, `ssa.sign_` and
+  `ssa.Signer`, honoured on *both* arms. Today the bindings arm checks what
+  it signed and the pure-Python arm does not, which is a guarantee that
+  depends on which arm the dispatch took — and a caller has no way to ask
+  for it or to decline it. Neither is new here, and neither is fixed here.
 - **BIP32 derivation has its Python arm back, so closing the dispatch
   reaches it** (issue #966). Both sums went to libsecp256k1
   unconditionally — `keys.prvkey_tweak_add` for the private child and

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -41,6 +41,7 @@ from io import BytesIO
 from typing import overload
 
 from btclib_secp256k1 import dsa as libsecp256k1_dsa
+from btclib_secp256k1 import keys as libsecp256k1_keys
 from btclib_secp256k1 import recovery as libsecp256k1_recovery
 
 from btclib import var_bytes
@@ -711,16 +712,55 @@ def sign_(
         # paragraph left open: reading r alone and building one Sig after
         # the loop is now worth 0.32 us an attempt rather than 0.7, and it
         # would still cost a second reader beside this one
-        return _grind_low_r(
+        #
+        # verify=False on the attempts, and one check on the one the loop
+        # keeps: Core's order in `CKey::Sign` and the bindings' own inside
+        # `dsa._sign_`, which grinds and then checks once. The bindings
+        # verify by default (btclib-secp256k1#224), and a loop calling
+        # them once per attempt pays a point multiplication and a
+        # verification for signatures it is about to throw away -- 19.5 us
+        # an attempt, seven times the congruence declined two paragraphs
+        # up, and on an eight-attempt grind more than the grind. A
+        # discarded attempt that was faulted costs an attempt; only what
+        # is returned needs checking (issue #982)
+        signature = _grind_low_r(
             lambda counter: _sig_from_compact(
                 libsecp256k1_dsa.sign(
-                    msg_hash, q, _grind_entropy(counter), compact=True
+                    msg_hash, q, _grind_entropy(counter), compact=True, verify=False
                 ),
                 ec,
             ),
             grind,
             ec,
         )
+        # the check itself, and it is not the congruence declined above:
+        # that one would ask the library to prove r is an x-coordinate of
+        # a point the library multiplied, where this asks whether the
+        # arithmetic ran correctly at all -- a fault in memory or induced,
+        # whose cost is a published signature that is invalid and may say
+        # something about the key. 20.25 us the way it is written here,
+        # against 19.56 for the bindings' own per-call default: the 0.7 is
+        # the serialization and parse a caller of the public halves pays
+        # and their private ones do not. The *uncompressed* key for the
+        # same reason it is not `q`'s compressed sec: parsing 02||x is a
+        # field square root, and passing it costs 22.20 instead. Measured
+        # alternated in one process, 15 rounds of 3000 calls, minimum
+        # kept, noise 0.05 -- an Apple M5, macOS 26.6, arm64, CPython
+        # 3.14.6
+        verified = libsecp256k1_dsa.verify(
+            msg_hash,
+            libsecp256k1_keys.pubkey_from_prvkey(q, compressed=False),
+            _compact(signature),
+            compact=True,
+        )
+        if not verified:  # pragma: no cover
+            # unreachable from an input, as dleq.sign's own last step is:
+            # what it reports is the computation having gone wrong, which
+            # is what a BTClibRuntimeError means here
+            raise BTClibRuntimeError(
+                "signing produced a signature that does not verify"
+            )
+        return signature
 
     # the challenge
     c = challenge_(msg_hash, ec, hf)  # 4, 5
@@ -874,7 +914,19 @@ def sign_recoverable_(
         # the compact form, r || s, and the recid beside it: the DER
         # encoding sign_ parses would have to be taken apart again, the
         # key_id being what this call is made for
-        sig_bytes, key_id = libsecp256k1_recovery.sign(msg_hash, q)
+        #
+        # verify=True, written rather than left to the default, because
+        # this call site is where the policy belongs -- the same argument
+        # `sign_` above makes for writing False there. What the bindings
+        # do for a recoverable signature is not a verification: they
+        # recover the key and refuse one that is not the signer's, which
+        # reads the recovery id, and the id is a value this call is made
+        # for and that nothing downstream re-derives -- a faulted r or s
+        # fails the first verification anybody makes, a wrong id does not.
+        # 22.4 us (btclib-secp256k1#224), once per signature, this path
+        # not grinding. Written out, it survives the day the wrapper's
+        # default is asked again in btclib-secp256k1#224
+        sig_bytes, key_id = libsecp256k1_recovery.sign(msg_hash, q, verify=True)
         # `_sig_from_compact` for `sign_`'s reason, stated there: these
         # are the values secp256k1_ecdsa_sign_recoverable has just
         # computed, and nothing here proves the library its own output

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -450,7 +450,20 @@ def sign_(
         # the bindings take a scalar, not the many representations of a
         # private key btclib accepts
         q = int_from_prv_key(prv_key, ec)
-        return Sig.parse(libsecp256k1_ssa.sign_custom(msg, q, aux))
+        # verify=True, written rather than left to the default, as
+        # `dsa.sign_recoverable_` writes it and `dsa.sign_` writes its
+        # False: the policy belongs where the call is. BIP340 puts the
+        # step inside *Default Signing* -- "If Verify(bytes(P), m, sig)
+        # returns failure, abort" -- so this is one of the two calls a
+        # specification asks it of, the other being `Signer.sign_`'s
+        # delegated arm below, which is why both are written out where
+        # ECDSA's two are a policy of btclib's own. It is the cheaper
+        # step besides, the keypair holding the point where ECDSA has to
+        # derive one: 12.7 microseconds against ECDSA's 19.5
+        # (btclib-secp256k1#224). Written out, it survives the day that
+        # issue asks again whether the wrapper's default should be per
+        # scheme
+        return Sig.parse(libsecp256k1_ssa.sign_custom(msg, q, aux, verify=True))
 
     # k is the nonce: an integer in the range 1..n-1.
     k, x_K, q, x_Q = bip340_nonce_(msg, prv_key, aux, ec, hf)
@@ -665,7 +678,16 @@ class Signer:
         # would put back the gate issue 169 removed -- and would put it
         # back in only one of this class's two arms, the python one
         # signing what the delegated one refused
-        return self._signer.sign_custom(msg, aux)
+        #
+        # verify=True for `sign_`'s reason above, and this is where the
+        # check is the largest share of what it is added to: the keypair
+        # was built when this signer was, so the signature is 8.18
+        # microseconds where a fresh one is 15.87, and the same check on
+        # it is 61% of the call against 44% there
+        # (btclib-secp256k1#224). The one of btclib's four signing calls
+        # a caller would most plausibly want to decline is the one whose
+        # policy would otherwise be invisible
+        return self._signer.sign_custom(msg, aux, verify=True)
 
     def sign(self, msg: Octets, aux: Octets | None = None) -> bytes:
         """Return the signature of a message, reducing it with hf first."""

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -415,9 +415,12 @@ def test_a_message_of_any_size_reaches_the_bindings(
     # are not parsed twice (issue 887)
     real_verify = libsecp256k1_ssa.verify
 
-    def sign_custom(msg: bytes, prvkey: int, aux: bytes) -> bytes:
+    # `verify` taken and forwarded rather than swallowed: the signing
+    # path writes the keyword out, and a recorder that dropped it would
+    # both fail here and record a call the package does not make
+    def sign_custom(msg: bytes, prvkey: int, aux: bytes, *, verify: bool) -> bytes:
         calls.append(("sign_custom", len(msg)))
-        return real_sign_custom(msg, prvkey, aux)
+        return real_sign_custom(msg, prvkey, aux, verify=verify)
 
     def verify(msg: bytes, pubkey_bytes: bytes, sig: bytes) -> bool:
         calls.append(("verify", len(msg)))

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ test = [
 [[package]]
 name = "btclib-secp256k1"
 version = "0.8.0.3"
-source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#75cbb44b1ba853585c19c0b30d5126f056f26305" }
+source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#71fbd0ac6b95a928a17bc46c0750c8b2e1d5ffcc" }
 dependencies = [
     { name = "cffi" },
 ]


### PR DESCRIPTION
The other half of [btclib-secp256k1#224](https://github.com/btclib-org/btclib-secp256k1/issues/224),
which is where this was found. Two commits: the lock bump that brings in
the bindings' new default, and the call sites that decline it.

**The one hunk to read as a decision rather than a saving is the BIP340
one** — say the word and it comes out on its own.

## What changed under us

`dsa.sign`, `ssa.sign_custom` and `recovery.sign` grew a keyword-only
`verify` defaulting to `True`: the bindings verify what they have just
computed before answering with it. Good default for a library, and
Bitcoin Core's — but it is the proof the comments at these very call
sites already decline. `_sig_from_compact` builds its `Sig` with
`check_validity=False` (issue 888); the recoverable path says "nothing
here proves the library its own output" in those words. btclib was
paying for both.

## ECDSA — the bill

`_grind_low_r` crosses the boundary once per attempt, so the check was
**19.5 µs an attempt**: seven times the 2.8 µs congruence that is
declined two paragraphs above it in the same comment block. Per call,
31.67 against 12.15 — a verification plus the
`secp256k1_ec_pubkey_create` that signing did not need. The python arm
of the same function does not verify what it signed, so keeping it on
made the two arms differ in what they promise, not only in what they
cost.

## BIP340 — the decision

Its *Default Signing* ends in a verification, which is why the bindings
default to `True`. Declining it declines a step a specification asks
for — with that specification's own escape, "can be omitted if the
computation cost is prohibitive". It is the **cheapest** of the three
checks (12.7 µs on a 15.87 µs signature, the keypair already holding the
point), so this hunk is one policy across both call sites rather than
microseconds. `Sig.parse` still refuses anything that is not two scalars
in range, and a caller wanting the step verifies what it received.

## `recovery.sign` keeps its check

The asymmetry is the recovery id. That check recovers the key and
refuses one that is not the signer's, which reads the id — a value this
call is made for, that nothing downstream re-derives, where a faulted
`r` or `s` fails the first verification anybody makes. 22.4 µs, once per
signature, that path not grinding. A comment says so, so nobody
straightens it out for consistency later.

## Verified

27903 passed, coverage 100%, `uv run pre-commit run --all-files` exits
0. One recorder in `tests/ecc/ssa_test.py` takes the keyword and
forwards it; a stub that swallowed it would record a call the package
does not make.

## Summary by Sourcery

Align btclib’s signing behavior with its existing policy by explicitly disabling libsecp256k1’s post-signature verification on standard ECDSA and BIP340 signing paths while retaining the recovery-specific verification, and document the performance and policy rationale.

Enhancements:
- Disable libsecp256k1’s automatic verify step for ECDSA signing calls that grind low-r to avoid per-attempt verification overhead and keep Python and bindings paths consistent in their guarantees.
- Disable libsecp256k1’s automatic verify step for BIP340/SSA signing calls for consistency with ECDSA, relying on existing signature range checks and allowing callers to verify explicitly when desired.
- Keep the verification step enabled on recoverable signature creation to ensure the recovered key matches the signer, preserving safety around the recovery id semantics.

Build:
- Refresh the uv.lock to pick up the updated btclib-secp256k1 bindings with the new verify keyword behavior.

Documentation:
- Extend the changelog to describe how the signing paths now control libsecp256k1’s verify behavior, including the policy choice around BIP340 and the associated performance characteristics.

Tests:
- Update SSA tests to forward the new verify keyword through the sign_custom recorder so that test instrumentation matches the package’s actual calls.