### PR TITLE
Ask the dispatch before verifying, and run the vectors with it off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1507,6 +1507,35 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **The script engine's two signature verifications ask the dispatch every
+  other delegation in the library asks** (issue #988, step 2 of issue
+  #966). `engine.script.dsa_verify` and `engine.tapscript.ssa_verify`
+  called libsecp256k1 with no predicate in front of them, so
+  `curve._libsecp256k1_available` — the seam meant to switch the whole
+  package's dispatch at once — switched everything except the two
+  verdicts consensus turns on. Both now ask `_libsecp256k1_serves` and
+  answer through `ecc.dsa` and `ecc.ssa` when it declines: the Python arm
+  is code the library runs, not a substitution a test injects.
+
+  `hybrid=True` is what that arm needs and the bindings do not:
+  `ec_pubkey_parse` takes the 0x06/0x07 prefixes always, while
+  `point_from_octets` takes them only when asked, and CHECKSIG must
+  succeed for a hybrid key wherever STRICTENC is off. One `try` covers
+  both arms, because the contract is one — a key or a signature that
+  cannot be parsed is a failed verification and not an exception the
+  interpreter loop sees — and the two arms refuse in two ways: the
+  bindings raise ValueError, `point_from_octets` raises BTClibValueError,
+  `verify_` answers False.
+
+  `tests/script_engine/python_path_test.py` reruns Core's script and
+  transaction vectors with the seam cleared, and clearing it is now the
+  whole fixture: one assignment where there were four monkeypatches, two
+  of them substituting functions the engine no longer needs. The
+  arithmetic goes down the Python arm with the verdict, which is the only
+  configuration an installation without the bindings can be in — 2.95 s
+  against 17.21 s for those vectors, one process, and the suite runs
+  distributed.
+
 - **The grinding loop stops paying for a check once per attempt, and pays
   it once for the signature it keeps** (issue #983, and the urgent half of
   issue #982). `dsa.sign`, `ssa.sign_custom` and `recovery.sign` in

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -11,6 +11,9 @@ from collections.abc import Mapping
 from btclib_secp256k1.dsa import verify as _libsecp256k1_dsa_verify
 
 from btclib.alias import ScriptList
+from btclib.curves import point_from_octets, secp256k1
+from btclib.curves.curve import _libsecp256k1_serves
+from btclib.ecc import dsa
 from btclib.ecc.dsa import Sig
 from btclib.exceptions import (
     BTClibRuntimeError,
@@ -77,10 +80,32 @@ def _assert_bytes_arguments(**arguments: object) -> None:
 def dsa_verify(msg_hash: bytes, pub_key: bytes, sig: bytes) -> bool:
     """Verify an ECDSA signature, returning False if it is malformed.
 
-    The bindings raise a ValueError on a signature or public key that
-    libsecp256k1 refuses to parse, while the engine treats it as a failed
-    verification: DER strictness is enforced upstream, by fix_signature,
-    under the STRICT_DER_FLAGS below.
+    The dispatch every delegation in this library makes, and this one has
+    a second implementation to reach when it declines: `ecc.dsa` answers
+    the same question in Python, so libsecp256k1 out of reach leaves an
+    arm to take rather than an ImportError to raise.
+
+    `hybrid=True` is what the Python arm needs and the bindings do not:
+    `ec_pubkey_parse` takes the 0x06/0x07 prefixes always (eckey_impl.h)
+    while `point_from_octets` takes them only when asked, and consensus
+    wants CHECKSIG to succeed for a hybrid key wherever STRICTENC is off.
+    Both defects of issue #129 were in that arm and neither was a lax
+    function -- one was `Sig.parse` dropping a byte, the other this very
+    prefix -- so what the arm has to agree with the bindings about is the
+    verdict on a whole transaction.
+
+    One try around both arms, because the contract is one: a signature or
+    a public key that cannot be parsed is a failed verification, not an
+    exception the interpreter loop sees. The bindings raise ValueError
+    for it, `point_from_octets` raises BTClibValueError, which is one,
+    and `dsa.verify_` catches its own. DER strictness is enforced
+    upstream either way, by fix_signature under the STRICT_DER_FLAGS
+    below -- and so is the lower-s form, which is what keeps the two arms
+    from disagreeing about a high s: the bindings' `dsa.verify` refuses
+    one where `_assert_as_valid_(..., lower_s=False)` accepts it, and by
+    the time either is asked fix_signature has already negated a high s
+    wherever no flag refuses the signature outright, which is Core's own
+    behaviour.
 
     `bytes` and nothing wider, which is what the three declare: the
     bindings would answer a float with "the message hash must be bytes",
@@ -91,7 +116,9 @@ def dsa_verify(msg_hash: bytes, pub_key: bytes, sig: bytes) -> bool:
     _assert_bytes_arguments(msg_hash=msg_hash, pub_key=pub_key, sig=sig)
 
     try:
-        return bool(_libsecp256k1_dsa_verify(msg_hash, pub_key, sig))
+        if _libsecp256k1_serves(secp256k1, None):
+            return bool(_libsecp256k1_dsa_verify(msg_hash, pub_key, sig))
+        return dsa.verify_(msg_hash, point_from_octets(pub_key, hybrid=True), sig)
     except ValueError:
         return False
 

--- a/btclib/script/engine/tapscript.py
+++ b/btclib/script/engine/tapscript.py
@@ -12,6 +12,9 @@ from btclib_secp256k1.ssa import verify as _libsecp256k1_ssa_verify
 
 from btclib import var_bytes
 from btclib.alias import ScriptList
+from btclib.curves import secp256k1
+from btclib.curves.curve import _libsecp256k1_serves
+from btclib.ecc import ssa
 from btclib.exceptions import BTClibValueError, ScriptError
 from btclib.hashes import tagged_hash
 from btclib.script import sig_hash
@@ -46,9 +49,16 @@ __all__ = [
 def ssa_verify(msg_hash: bytes, pub_key: bytes, sig: bytes) -> bool:
     """Verify a BIP340 signature, returning False if it is malformed.
 
+    The dispatch `engine.script.dsa_verify` makes and for its reason:
+    `ecc.ssa` answers the same question in Python, and the arm is what
+    there is to reach with libsecp256k1 out of reach. No hybrid prefix to
+    ask for here -- an x-only key is 32 bytes and BIP340 says which of
+    the two points it is -- so the arm is the prepared spelling alone.
+
     The bindings raise a ValueError on a signature or x-only public key
-    that libsecp256k1 refuses to parse, while the caller treats it as a
-    failed verification and raises BTClibValueError itself.
+    that libsecp256k1 refuses to parse, and `ssa.verify_` answers False
+    for the same; the caller treats either as a failed verification and
+    raises BTClibValueError itself.
 
     `bytes` and nothing wider, as in `engine.script.dsa_verify` and for
     its reason.
@@ -56,7 +66,9 @@ def ssa_verify(msg_hash: bytes, pub_key: bytes, sig: bytes) -> bool:
     _assert_bytes_arguments(msg_hash=msg_hash, pub_key=pub_key, sig=sig)
 
     try:
-        return bool(_libsecp256k1_ssa_verify(msg_hash, pub_key, sig))
+        if _libsecp256k1_serves(secp256k1, None):
+            return bool(_libsecp256k1_ssa_verify(msg_hash, pub_key, sig))
+        return ssa.verify_(msg_hash, pub_key, sig)
     except ValueError:
         return False
 

--- a/tests/script_engine/python_path_test.py
+++ b/tests/script_engine/python_path_test.py
@@ -4,42 +4,37 @@
 
 """The vendored consensus vectors, judged by the Python implementation.
 
-The engine imports its signature verification from the bindings, which
-are a required dependency, so the Python implementations never face
-these vectors otherwise: a defect in them is unreachable rather than
-absent. Issue #129 found two hiding exactly there, each accepting a
-transaction the data calls invalid.
+btclib keeps two implementations of a signature verification, and an
+installation that has the bindings runs one of them: the vectors below
+reach the Python one only where something asks for it, so a defect there
+is unreachable rather than absent. Issue #129 found two hiding exactly
+there, each accepting a transaction the data calls invalid.
 
-This module is the bindings-less verification, without the packaging:
-the two symbols the engine imports from the bindings are replaced by the
-Python implementations and the same vector sets run again through them,
-so a disagreement between the two implementations about the *verdict*
-on a transaction is caught. Unit tests cannot do that job: neither #129
-defect was "this function is lax" -- one was `Sig.parse` dropping a
-byte, the other `point_from_octets` refusing a hybrid key -- and both
-only became visible as a whole engine accepting a whole transaction it
-must refuse.
+This module is what asks. The dispatch is switched off and the same
+vector sets run again, so a disagreement between the two implementations
+about the *verdict* on a transaction is caught. Unit tests cannot do that
+job: neither #129 defect was "this function is lax" -- one was
+`Sig.parse` dropping a byte, the other `point_from_octets` refusing a
+hybrid key -- and both only became visible as a whole engine accepting a
+whole transaction it must refuse.
 
-The alternative, a CI job installing without the bindings, is not a job
-but a partial revert as the tree stands: every bindings import is a plain
-import, so `import btclib` fails without them and there is nothing for
-such a job to run until the optional-bindings install comes back. Issue
-#966 is that work, and guarding those imports is the step it waits on;
-this module is what holds the vectors meanwhile, at no packaging change
-and no fallback code in the engine.
-
-The substitution is the one already used for ripemd160 in
-tests/hashes_test.py: a module-level name, swapped, to reach the second
-implementation of a primitive that has two.
+It is not the same thing as a CI job installing without the bindings, and
+does not replace one: every bindings import is a plain import, so `import
+btclib` fails without them and there is nothing for such a job to run
+until the optional-bindings install arrives. Issue #966 is that work,
+issue #989 the step it waits on, and issue #991 the job. What this module
+does that no job will is run the two implementations over the same
+vectors in the same session, which is what makes a disagreement visible
+as a disagreement rather than as two red suites nobody compares.
 """
 
 from typing import Any
 
 import pytest
 
-from btclib.curves import point_from_octets
-from btclib.ecc import dsa, ssa
-from btclib.exceptions import BTClibValueError
+# the module, not the name in it: `_libsecp256k1_available` is an
+# attribute of `curve`, and every dispatch in the package reads it there
+from btclib.curves import curve
 from btclib.script.engine import script as engine_script
 from btclib.script.engine import tapscript as engine_tapscript
 
@@ -51,58 +46,34 @@ from tests.script_engine import script_test as script_vector_module
 from tests.script_engine import transactions_test as tx_vector_module
 
 
-def python_dsa_verify(msg_hash: bytes, pub_key: bytes, sig: bytes) -> bool:
-    """Verify an ECDSA signature through the Python implementation.
-
-    `hybrid=True` is the second half of issue #129: `point_from_octets`
-    takes the hybrid 0x06/0x07 prefixes only when asked,
-    `ec_pubkey_parse` takes them always (eckey_impl.h), and
-    consensus wants CHECKSIG to succeed for a hybrid key whenever
-    STRICTENC is off. Raising rather than returning False is deliberate
-    and is what the bindings do: `dsa_verify` catches ValueError, and
-    BTClibValueError is one.
-    """
-    Q = point_from_octets(pub_key, hybrid=True)
-    return dsa.verify_(msg_hash, Q, sig)
-
-
-def python_ssa_verify(msg_hash: bytes, pub_key: bytes, sig: bytes) -> bool:
-    """Verify a BIP340 signature through the Python implementation."""
-    return ssa.verify_(msg_hash, pub_key, sig)
-
-
 @pytest.fixture
 def python_verification(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Route the engine's signature verification through Python.
+    """Run the whole engine, and everything under it, in Python.
 
-    Two patches per algorithm, and both are needed: the engine holds its
-    own reference to the bindings' verify, and `btclib.ecc` would hand
-    secp256k1 with sha256 straight back to them -- the very dispatch that
-    makes the Python path unreachable in the first place.
+    One assignment, and it has to be the global rather than a predicate
+    per module: `_libsecp256k1_serves` reads
+    `curve._libsecp256k1_available`, so clearing it is the package's
+    dispatch switched off at once -- the engine's two verifications,
+    `ecc.dsa` and `ecc.ssa` beneath them, and the field and group
+    arithmetic beneath those. Patching the predicate where a module
+    imported it would reach that module alone and leave the arm mixed:
+    Python down to the verdict and C under it, which is a configuration
+    nothing ships and issue #968 says an arm chosen by availability may
+    never be in.
 
-    The arithmetic under the verdict stays delegated: no third patch on
-    `curves.curve`, whose dispatch is what `dsa._assert_as_valid_` and
-    `ssa._assert_as_valid_` reach for a `double_mult_var` and for the two
-    square roots that lift a key and answer for an r. Patching it off
-    would send those down the Python path on every vector below, at the
-    ratios `curves/curve.py` states beside each of them, and would buy a
-    comparison `tests/curves/curve_test.py` already makes against the
-    bindings -- `test_libsecp256k1_arbitrary_point` for the
-    multiplications, `test_x_coordinate_lift` for the roots -- on a
-    chosen spread of inputs rather than on whatever these vectors happen
-    to carry.
+    It is also the only configuration these vectors can be run in that
+    exists: with the bindings absent nothing is left to delegate to, so
+    a run that keeps the multiplications in C is measuring something no
+    installation will do.
 
-    So the line is drawn where the second implementation is otherwise
-    unreached: `Sig.parse`, the hybrid prefix `point_from_octets` takes
-    only when asked, and the parity and the x comparison
-    `_assert_as_valid_` makes -- which is where both #129 defects were.
-    The field and group arithmetic under all of that is the bindings',
-    as it is everywhere else.
+    The price is real and was measured rather than assumed: the vectors
+    of this module take 2.95 s with the arithmetic delegated and 17.21 s
+    without, one process, `-p no:randomly`, one machine. The suite runs
+    distributed, so what a contributor waits is the slowest worker and
+    not this; and the alternative buys back fourteen seconds by testing a
+    configuration nobody installs.
     """
-    monkeypatch.setattr(dsa, "_libsecp256k1_serves", lambda *_: False)
-    monkeypatch.setattr(ssa, "_libsecp256k1_serves", lambda *_: False)
-    monkeypatch.setattr(engine_script, "_libsecp256k1_dsa_verify", python_dsa_verify)
-    monkeypatch.setattr(engine_tapscript, "_libsecp256k1_ssa_verify", python_ssa_verify)
+    monkeypatch.setattr(curve, "_libsecp256k1_available", False)
 
 
 # the sibling test functions are called rather than reimplemented: two
@@ -143,20 +114,36 @@ def test_invalid_taproot_vectors(vector: dict[str, Any]) -> None:
     tx_vector_module.test_invalid_taproot(vector)
 
 
-def test_dsa_verify_answers_false_for_what_the_bindings_refuse() -> None:
+@pytest.mark.parametrize("delegated", [True, False], ids=["bindings", "python"])
+def test_verify_answers_false_for_what_cannot_be_parsed(
+    monkeypatch: pytest.MonkeyPatch, *, delegated: bool
+) -> None:
     """A malformed signature is a failed CHECKSIG, not an exception.
 
-    `engine_script.dsa_verify` wraps the bindings' verify in a
-    `try/except ValueError` for this, and the vectors never reach it: DER
-    strictness is enforced earlier, by `fix_signature` under any of
-    DERSIG, LOW_S and STRICTENC, so by the time the engine verifies, the
-    encoding has already been ruled on. What is left is the contract
-    itself, which the
-    Python substitute above is written to honour -- it raises where the
-    bindings raise -- and which the bindings do raise: measured, a
-    ValueError of "invalid DER signature" and one of "invalid public
-    key".
+    The contract of both adapters, and it is one contract for two arms
+    that refuse in two different ways: the bindings raise a ValueError of
+    "invalid DER signature" or "invalid public key", `point_from_octets`
+    raises BTClibValueError, and `ecc.dsa.verify_` and `ecc.ssa.verify_`
+    answer False for what they decline. Whichever it is, the interpreter
+    loop must see False.
+
+    The vectors above never reach this: DER strictness is enforced
+    earlier, by `fix_signature` under any of DERSIG, LOW_S and STRICTENC,
+    so by the time the engine verifies, the encoding has been ruled on.
+    So the contract is asserted here, and against both arms rather than
+    the one this installation happens to have.
     """
+    if delegated and not curve._libsecp256k1_available:  # pragma: no cover
+        # the id would say `bindings` and the run would be the Python arm:
+        # both answer False here, so nothing would go red and half the
+        # parametrization would check the same thing twice. Skipped rather
+        # than asserted, this file having to pass wherever it is run --
+        # and unreachable while the bindings are a required dependency,
+        # which is what the pragma is for and what issue #990 changes
+        pytest.skip("the bindings are not serving in this configuration")
+    if not delegated:
+        monkeypatch.setattr(curve, "_libsecp256k1_available", False)
+
     msg_hash = b"\x11" * 32
     # a signature that is not DER at all
     assert not engine_script.dsa_verify(msg_hash, b"\x02" + b"\x33" * 32, b"garbage")
@@ -164,7 +151,7 @@ def test_dsa_verify_answers_false_for_what_the_bindings_refuse() -> None:
     minimal_der = bytes.fromhex("3006020101020101")
     assert not engine_script.dsa_verify(msg_hash, b"\x02" + b"\x00" * 32, minimal_der)
 
-    # the same input through the Python substitute raises instead, which
-    # is the asymmetry the wrapper exists to absorb
-    with pytest.raises(BTClibValueError):
-        python_dsa_verify(msg_hash, b"\x02" + b"\x00" * 32, minimal_der)
+    # the same two refusals of the tapscript adapter: an x that is no
+    # x-coordinate, and a signature of the wrong length
+    assert not engine_tapscript.ssa_verify(msg_hash, b"\x00" * 32, b"\x00" * 64)
+    assert not engine_tapscript.ssa_verify(msg_hash, b"\x33" * 32, b"garbage")


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/988 — step 2 of
https://github.com/btclib-org/btclib/issues/966.

## What was wrong

`curve._libsecp256k1_available` is meant to switch the whole package's
dispatch at once: every delegation asks `_libsecp256k1_serves`, and that
predicate reads the global. The script engine did not ask.
`engine.script.dsa_verify` and `engine.tapscript.ssa_verify` each held a
name bound from `btclib_secp256k1` and called it unconditionally, so the
seam switched everything except the two verdicts consensus turns on.

## What this does

Both adapters ask `_libsecp256k1_serves(secp256k1, None)` and answer
through `ecc.dsa` / `ecc.ssa` when it declines.

- `hybrid=True` is what the Python arm needs and the bindings do not:
  `ec_pubkey_parse` takes the 0x06/0x07 prefixes always,
  `point_from_octets` only when asked, and CHECKSIG must succeed for a
  hybrid key wherever STRICTENC is off. Checked directly: a 65-byte
  hybrid key verifies on both arms.
- One `try` covers both arms, because the contract is one — what cannot
  be parsed is a failed verification, not an exception the interpreter
  loop sees — and the two arms refuse in two different ways: the bindings
  raise `ValueError`, `point_from_octets` raises `BTClibValueError`,
  `verify_` answers `False`.

`tests/script_engine/python_path_test.py` no longer substitutes two
functions into the engine: it clears the seam. One assignment where there
were four monkeypatches, and the two that injected `python_dsa_verify` /
`python_ssa_verify` are gone with the functions.

The arithmetic goes down the Python arm together with the verdict. That
is deliberate and is the point: with the bindings absent there is nothing
left to delegate to, so a run that keeps the multiplications in C
measures a configuration nobody installs — and a predicate patched per
module would leave the arm mixed, which is what
https://github.com/btclib-org/btclib/issues/968 forbids for an arm chosen
by availability alone.

`test_verify_answers_false_for_what_cannot_be_parsed` is parametrized
over both arms and covers the tapscript adapter too, which had no direct
test.

## The price, measured

The vectors of that module: **2.95 s** with the arithmetic delegated,
**17.21 s** without — one process, `-p no:randomly`, one machine. The
suite runs distributed, and the whole of it is 22.8 s here either way.

## Gates

- `uv run pytest` — 27904 passed, 6 skipped, coverage 100.00%, exit 0
- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0

## Not in this PR

The imports are still plain imports, so `import btclib` still fails
without the bindings: that is
https://github.com/btclib-org/btclib/issues/989, and the job that would
build the configuration is
https://github.com/btclib-org/btclib/issues/991. This step stands on its
own — it closes the gap between what the seam claims to switch and what
it switches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route script engine signature verification through the shared dispatch so it can fall back to the Python implementation when libsecp256k1 is unavailable, and update tests and docs to exercise and describe this behavior.

Bug Fixes:
- Ensure script and tapscript signature verification treat malformed keys and signatures as failed checks rather than surfacing backend parsing exceptions across both libsecp256k1 and Python implementations.

Enhancements:
- Make script and tapscript signature verification consult the global libsecp256k1 dispatch predicate and delegate to the Python ecc.dsa/ecc.ssa implementations when the C backend is disabled, including support for hybrid public keys in the Python ECDSA path.
- Add a parametrized test to assert consistent false-return behavior for unparseable signatures and public keys across both delegated and pure-Python verification paths.
- Simplify the Python-path script engine test fixture to flip the global dispatch flag instead of monkeypatching per-module verification functions, so the entire engine stack runs on Python when requested.

Documentation:
- Document in the changelog that script engine signature verification now participates in the global libsecp256k1 dispatch and that the Python verification path is exercised via tests rather than test-only substitutions.