### PR TITLE
Import the bindings in one place, and let the import answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1507,6 +1507,34 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **`import btclib` no longer needs the bindings installed** (issue #989,
+  step 3 of issue #966). Eleven modules imported `btclib_secp256k1` at
+  module level, so the seam meant to switch the dispatch off could not be
+  reached in the one configuration it exists for: the import failed
+  first. `btclib/_libsecp256k1.py` is now the single place the bindings
+  are imported — one `try`, one `AVAILABLE`, and the whole of the surface
+  btclib asks of them in one list — and `curve._libsecp256k1_available`
+  is what that import answered rather than a constant `True`. The eleven
+  modules import their names from there under the spellings they used, so
+  no call site changed and no call pays an attribute lookup it did not
+  pay before.
+
+  One module-level use of the bindings was not an import:
+  `bip32._PubKeyTweakChain`, a union built eagerly out of the bindings'
+  `PubkeyTweakChain`. It is under `TYPE_CHECKING` now — it annotates two
+  signatures and nothing else, and `from __future__ import annotations`
+  leaves an annotation a string.
+
+  `tests/no_bindings_test.py` is what checks it, and it has to be a child
+  interpreter: by the time a test runs, btclib is imported and its answer
+  is bound. A meta path finder refuses `btclib_secp256k1` in the child,
+  btclib is imported after it, and the arithmetic, both signature
+  schemes, both BIP32 derivations and the script engine's adapter are
+  compared with what this process computes with the bindings serving.
+  That is not the CI job issue #991 asks for and does not replace it —
+  the wheel is still installed — but it makes the configuration
+  answerable on every platform the matrix runs.
+
 - **The script engine's two signature verifications ask the dispatch every
   other delegation in the library asks** (issue #988, step 2 of issue
   #966). `engine.script.dsa_verify` and `engine.tapscript.ssa_verify`

--- a/btclib/_libsecp256k1.py
+++ b/btclib/_libsecp256k1.py
@@ -1,0 +1,88 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Everything btclib asks of libsecp256k1, imported in one place.
+
+Eleven modules delegate to the bindings and none of them imports them:
+they import from here, so the question "are the bindings installed" is
+asked once, at one import, and answered by `AVAILABLE` rather than by
+eleven `try` blocks that could drift apart. `curves.curve` reads that
+answer into `_libsecp256k1_available`, which is the seam every dispatch
+in the package consults, so an absent binding is a dispatch that declines
+rather than an `ImportError` raised before any dispatch is reached.
+
+A module that imports nothing of btclib, and is therefore below every
+package that reads it -- the placement `consensus.py` has and for its
+reason. What it does import is the whole of the surface btclib uses, so
+this file is also the answer to "what does btclib need these bindings
+for", which was previously spread over the eleven import blocks.
+
+The names are re-exported under the bindings' own spelling and the caller
+aliases them as it always did: a caller holding `keys` and reaching
+through it, and a caller naming `pubkey_sum` directly, both keep the call
+they had. Neither shape costs an attribute lookup it did not cost before,
+which matters where `curves.curve` counts tenths of a microsecond.
+
+With the bindings absent every name here is None. Nothing may call one:
+`_libsecp256k1_serves` is False in that configuration, and it is the
+predicate in front of every delegation -- which is a rule about the
+package rather than about this file, and is what `tests/no_bindings_test.py`
+checks by importing btclib with the bindings out of reach.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "AVAILABLE",
+    "PubkeyTweakChain",
+    "dsa",
+    "dsa_verify",
+    "ellswift",
+    "keys",
+    "pubkey_from_prvkey",
+    "pubkey_sum",
+    "pubkey_tweak_add",
+    "pubkey_tweak_mul",
+    "pubkey_tweak_mul_sum",
+    "pubkey_verify",
+    "recovery",
+    "ssa",
+    "ssa_verify",
+    "xonly",
+    "xonly_pubkey_verify",
+    "xonly_to_pubkey",
+]
+
+try:
+    from btclib_secp256k1 import dsa, ellswift, keys, recovery, ssa, xonly
+    from btclib_secp256k1.dsa import verify as dsa_verify
+    from btclib_secp256k1.keys import (
+        PubkeyTweakChain,
+        pubkey_from_prvkey,
+        pubkey_sum,
+        pubkey_tweak_add,
+        pubkey_tweak_mul,
+        pubkey_tweak_mul_sum,
+        pubkey_verify,
+    )
+    from btclib_secp256k1.ssa import verify as ssa_verify
+    from btclib_secp256k1.xonly import pubkey_verify as xonly_pubkey_verify
+    from btclib_secp256k1.xonly import to_pubkey as xonly_to_pubkey
+
+    AVAILABLE = True
+except ImportError:  # pragma: no cover
+    # None and not a callable that raises: what would raise is never
+    # called, so the object would be a second thing to keep true. The
+    # ignore is on the assignment and not on the module: every other
+    # name here keeps the type the try branch gave it
+    dsa = ellswift = keys = recovery = ssa = xonly = None  # type: ignore[assignment]
+    # a class rather than a function, so mypy calls it an assignment to
+    # a type and wants the second code as well
+    PubkeyTweakChain = None  # type: ignore[misc, assignment]
+    dsa_verify = pubkey_from_prvkey = None  # type: ignore[assignment]
+    pubkey_sum = pubkey_tweak_add = pubkey_tweak_mul = None  # type: ignore[assignment]
+    pubkey_tweak_mul_sum = pubkey_verify = ssa_verify = None  # type: ignore[assignment]
+    xonly_pubkey_verify = xonly_to_pubkey = None  # type: ignore[assignment]
+
+    AVAILABLE = False

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -27,10 +27,10 @@ import functools
 import hmac
 from collections.abc import Sequence
 from dataclasses import dataclass
-
-from btclib_secp256k1 import keys as libsecp256k1_keys
+from typing import TYPE_CHECKING
 
 from btclib import base58
+from btclib._libsecp256k1 import keys as libsecp256k1_keys
 from btclib.alias import BinaryData, Octets, String
 from btclib.bip32.der_path import (
     _HARDENED_OFFSET,
@@ -754,8 +754,16 @@ class _PythonPubKeyTweakChain:
 
 
 # the two implementations of one chain: what a caller of the function
-# below holds, and neither of them a state the other has to allow for
-_PubKeyTweakChain = libsecp256k1_keys.PubkeyTweakChain | _PythonPubKeyTweakChain
+# below holds, and neither of them a state the other has to allow for.
+#
+# Under TYPE_CHECKING, because the union is the annotation of two
+# signatures and of nothing else: `from __future__ import annotations`
+# leaves an annotation a string, while a union built at module level is
+# an object, and building this one would ask the bindings for a class
+# where they may not be installed. Nothing calls `get_type_hints` on
+# either signature, which is what would want the name back at runtime
+if TYPE_CHECKING:
+    _PubKeyTweakChain = libsecp256k1_keys.PubkeyTweakChain | _PythonPubKeyTweakChain
 
 
 def _pub_key_tweak_chain(key: bytes) -> _PubKeyTweakChain:

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -35,20 +35,22 @@ from math import isqrt
 from pathlib import Path
 from typing import Any
 
-from btclib_secp256k1.keys import (
+from btclib._libsecp256k1 import AVAILABLE as _bindings_available
+from btclib._libsecp256k1 import (
     PubkeyTweakChain as Libsecp256k1PubkeyTweakChain,
 )
-from btclib_secp256k1.keys import (
+from btclib._libsecp256k1 import (
     pubkey_from_prvkey as libsecp256k1_pubkey_from_prvkey,
 )
-from btclib_secp256k1.keys import pubkey_sum as libsecp256k1_pubkey_sum
-from btclib_secp256k1.keys import pubkey_tweak_add as libsecp256k1_pubkey_tweak_add
-from btclib_secp256k1.keys import (
+from btclib._libsecp256k1 import pubkey_sum as libsecp256k1_pubkey_sum
+from btclib._libsecp256k1 import pubkey_tweak_add as libsecp256k1_pubkey_tweak_add
+from btclib._libsecp256k1 import (
     pubkey_tweak_mul_sum as libsecp256k1_pubkey_tweak_mul_sum,
 )
-from btclib_secp256k1.xonly import pubkey_verify as libsecp256k1_xonly_pubkey_verify
-from btclib_secp256k1.xonly import to_pubkey as libsecp256k1_xonly_to_pubkey
-
+from btclib._libsecp256k1 import (
+    xonly_pubkey_verify as libsecp256k1_xonly_pubkey_verify,
+)
+from btclib._libsecp256k1 import xonly_to_pubkey as libsecp256k1_xonly_to_pubkey
 from btclib.alias import INF, HashF, Integer, JacPoint, Point
 from btclib.curves.curve_group import (
     HEX_THRESHOLD,
@@ -439,10 +441,13 @@ secp256k1 = CURVES["secp256k1"]
 # that import it by name, so a caller that names them delegates in
 # silence wherever it forgets one, and times C while calling it Python.
 #
-# btclib_secp256k1 is a required dependency, so this is never False
-# because the bindings are missing: it is the seam whatever wants the
-# Python arithmetic closes to reach it, the test suite included
-_libsecp256k1_available = True
+# What the import answered, and not a constant: `btclib._libsecp256k1` is
+# the one place the bindings are imported, so an installation without
+# them starts here at False and every dispatch in the package declines.
+# It is also the seam whatever wants the Python arithmetic closes to
+# reach it -- the test suite included, which assigns False to it where
+# the bindings are installed and serving
+_libsecp256k1_available = _bindings_available
 
 
 def _libsecp256k1_serves(ec: Curve, hf: HashF | None) -> bool:

--- a/btclib/curves/sec_point.py
+++ b/btclib/curves/sec_point.py
@@ -6,12 +6,11 @@
 
 import contextlib
 
-from btclib_secp256k1.keys import (
+from btclib._libsecp256k1 import (
     pubkey_from_prvkey as libsecp256k1_pubkey_from_prvkey,
 )
-from btclib_secp256k1.keys import pubkey_tweak_mul as libsecp256k1_pubkey_tweak_mul
-from btclib_secp256k1.keys import pubkey_verify as libsecp256k1_pubkey_verify
-
+from btclib._libsecp256k1 import pubkey_tweak_mul as libsecp256k1_pubkey_tweak_mul
+from btclib._libsecp256k1 import pubkey_verify as libsecp256k1_pubkey_verify
 from btclib.alias import Integer, Octets, Point
 from btclib.curves.curve import (
     Curve,

--- a/btclib/ecc/commit_nonce.py
+++ b/btclib/ecc/commit_nonce.py
@@ -62,8 +62,7 @@ from __future__ import annotations
 
 from hashlib import sha256
 
-from btclib_secp256k1 import keys as libsecp256k1_keys
-
+from btclib._libsecp256k1 import keys as libsecp256k1_keys
 from btclib.alias import HashF, Octets, Point
 from btclib.curves import Curve, bytes_from_point, mult, secp256k1
 from btclib.curves.curve import _libsecp256k1_serves, _tweak_add_var

--- a/btclib/ecc/dh.py
+++ b/btclib/ecc/dh.py
@@ -42,8 +42,7 @@ from __future__ import annotations
 from hashlib import sha256
 from math import ceil
 
-from btclib_secp256k1 import keys as libsecp256k1_keys
-
+from btclib._libsecp256k1 import keys as libsecp256k1_keys
 from btclib.alias import HashF, Point
 from btclib.curves import Curve, bytes_from_point, mult, secp256k1
 from btclib.curves.curve import _assert_valid_ec, _libsecp256k1_serves

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -40,11 +40,10 @@ from hashlib import sha256
 from io import BytesIO
 from typing import overload
 
-from btclib_secp256k1 import dsa as libsecp256k1_dsa
-from btclib_secp256k1 import keys as libsecp256k1_keys
-from btclib_secp256k1 import recovery as libsecp256k1_recovery
-
 from btclib import var_bytes
+from btclib._libsecp256k1 import dsa as libsecp256k1_dsa
+from btclib._libsecp256k1 import keys as libsecp256k1_keys
+from btclib._libsecp256k1 import recovery as libsecp256k1_recovery
 from btclib.alias import BinaryData, HashF, JacPoint, Octets, Point
 from btclib.curves import Curve, PreparedPoint, mult, secp256k1
 from btclib.curves.curve import (

--- a/btclib/ecc/ellswift.py
+++ b/btclib/ecc/ellswift.py
@@ -43,8 +43,7 @@ from __future__ import annotations
 
 import secrets
 
-from btclib_secp256k1 import ellswift as libsecp256k1_ellswift
-
+from btclib._libsecp256k1 import ellswift as libsecp256k1_ellswift
 from btclib.alias import Octets, Point
 from btclib.curves import Curve, bytes_from_point, mult, secp256k1
 from btclib.curves.curve import (

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -60,8 +60,7 @@ from hashlib import sha256
 from types import TracebackType
 from typing import overload
 
-from btclib_secp256k1 import ssa as libsecp256k1_ssa
-
+from btclib._libsecp256k1 import ssa as libsecp256k1_ssa
 from btclib.alias import BinaryData, HashF, Integer, JacPoint, Octets, Point
 from btclib.bip32 import BIP32Key
 from btclib.curves import Curve, PreparedPoint, secp256k1

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from btclib_secp256k1.dsa import verify as _libsecp256k1_dsa_verify
-
+from btclib._libsecp256k1 import dsa_verify as _libsecp256k1_dsa_verify
 from btclib.alias import ScriptList
 from btclib.curves import point_from_octets, secp256k1
 from btclib.curves.curve import _libsecp256k1_serves

--- a/btclib/script/engine/tapscript.py
+++ b/btclib/script/engine/tapscript.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from btclib_secp256k1.ssa import verify as _libsecp256k1_ssa_verify
-
 from btclib import var_bytes
+from btclib._libsecp256k1 import ssa_verify as _libsecp256k1_ssa_verify
 from btclib.alias import ScriptList
 from btclib.curves import secp256k1
 from btclib.curves.curve import _libsecp256k1_serves

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -16,9 +16,8 @@ from __future__ import annotations
 from io import BytesIO
 from typing import cast
 
-from btclib_secp256k1 import xonly as libsecp256k1_xonly
-
 from btclib import var_bytes
+from btclib._libsecp256k1 import xonly as libsecp256k1_xonly
 from btclib.alias import (
     BinaryData,
     Octets,

--- a/tests/no_bindings_test.py
+++ b/tests/no_bindings_test.py
@@ -1,0 +1,160 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""btclib with btclib_secp256k1 not installed, which is a subprocess.
+
+`btclib._libsecp256k1` asks for the bindings once, at import, and
+`curves.curve._libsecp256k1_available` is that answer; so the question
+this file asks -- does the library import and answer without them -- can
+only be asked of an interpreter that has not imported btclib yet. A
+monkeypatch cannot: by the time a test runs, the import has happened and
+its answer is bound.
+
+Uninstalling them is not an option either, the suite being one
+environment. So the bindings are put out of reach by a meta path finder
+that refuses the name, in a child interpreter, and btclib is imported
+after that -- which is what `import btclib` does on a machine that never
+had them.
+
+This is not the CI job of issue #991 and does not replace it: a finder
+that refuses one name leaves the wheel installed and the environment
+resolved, where the job installs neither. What it does is make the
+absent-bindings configuration answerable in the ordinary suite, on every
+platform the matrix runs, rather than only where a second install exists.
+
+What the child returns is compared with what this process computes with
+the bindings in reach: agreement between the two implementations is the
+property, and a child that merely fails to crash proves nothing about it.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import Any
+
+from btclib._libsecp256k1 import AVAILABLE
+from btclib.bip32.bip32 import derive, rootxprv_from_seed, xpub_from_xprv
+from btclib.curves import bytes_from_point, curve, mult
+from btclib.ecc import dsa, ssa
+
+# the seed, key and message the child works from: constants, because the
+# two processes have to be asked the same question
+_SEED = "0f" * 32
+_PRV_KEY = 0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF
+_MSG_HASH = bytes(range(32))
+_DERIVATION = "m/44h/0h/0h/0/7"
+# BIP340 signing is randomized where the caller names no aux -- `sign_`
+# draws `secrets.token_bytes` for it, which is BIP340's own *Default
+# Signing* -- so the two processes are given the same aux and compared
+# octet for octet. ECDSA needs no such argument, RFC6979 making the
+# nonce a function of the message and the key
+_AUX = bytes(32)
+
+# what the child runs: the finder first, btclib after it, and the answers
+# as json on stdout. `-c` and not a file, so that nothing has to be
+# written to disk and cleaned up
+_CHILD = """
+import json, sys
+
+
+class RefuseTheBindings:
+    def find_spec(self, name, path=None, target=None):
+        if name == "btclib_secp256k1" or name.startswith("btclib_secp256k1."):
+            raise ImportError("btclib_secp256k1 is out of reach")
+        return None
+
+
+sys.meta_path.insert(0, RefuseTheBindings())
+
+import btclib
+from btclib._libsecp256k1 import AVAILABLE
+from btclib.bip32.bip32 import derive, rootxprv_from_seed, xpub_from_xprv
+from btclib.curves import curve, mult
+from btclib.ecc import dh, dsa, ellswift, ssa
+from btclib.script.engine import script as engine_script
+from btclib.script.engine import tapscript as engine_tapscript
+
+assert "btclib_secp256k1" not in sys.modules, "the finder let the bindings in"
+
+rootxprv = rootxprv_from_seed({seed!r})
+print(json.dumps({{
+    "available": AVAILABLE,
+    "dispatch": curve._libsecp256k1_available,
+    "point": mult({prv_key}),
+    "dsa": dsa.sign_({msg_hash!r}, {prv_key}).serialize().hex(),
+    "ssa": ssa.sign_({msg_hash!r}, {prv_key}, {aux!r}).serialize().hex(),
+    "xprv": derive(rootxprv, {derivation!r}),
+    "xpub": derive(xpub_from_xprv(rootxprv), "m/0/7"),
+    "engine": engine_script.dsa_verify(
+        {msg_hash!r},
+        bytes.fromhex({sec!r}),
+        bytes.fromhex({sig!r}),
+    ),
+}}))
+"""
+
+
+def _child_answers(sec: str, sig: str) -> dict[str, Any]:
+    """Run the child and return what it printed, failing on its stderr."""
+    source = _CHILD.format(
+        seed=_SEED,
+        prv_key=_PRV_KEY,
+        msg_hash=_MSG_HASH,
+        derivation=_DERIVATION,
+        aux=_AUX,
+        sec=sec,
+        sig=sig,
+    )
+    completed = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", source],
+        capture_output=True,
+        encoding="utf-8",
+        check=False,
+        # large enough to be uninteresting, and there so that a child
+        # that hangs fails as this test rather than as a slow suite: it
+        # would otherwise hold an xdist worker until the job's own
+        # timeout-minutes, and the report would name neither
+        timeout=120,
+    )
+    assert completed.returncode == 0, completed.stderr
+    answers: dict[str, Any] = json.loads(completed.stdout)
+    return answers
+
+
+def test_btclib_answers_with_the_bindings_out_of_reach() -> None:
+    """Import and answer, and answer what the bindings answer.
+
+    Every layer at once, deliberately: the arithmetic (`mult`), the two
+    signature schemes, both BIP32 derivations, and the script engine's
+    adapter -- which is the whole of what issue #966 lists as reaching
+    the bindings. One child process for them, a python interpreter
+    costing more to start than any of them costs to run.
+
+    The child imports all eleven guarded modules and not only the ones it
+    then calls: `btclib/__init__.py` imports nothing eagerly, so `import
+    btclib` is the metadata lookup and no module at all, and a guard
+    nothing imports is a guard nothing checks. `ecc.dh`, `ecc.ellswift`
+    and `script.engine.tapscript` are the three the calls below would not
+    reach on their own.
+    """
+    # the same question this process answers with the bindings serving
+    assert AVAILABLE
+    assert curve._libsecp256k1_available
+
+    sec = bytes_from_point(mult(_PRV_KEY)).hex()
+    sig = dsa.sign_(_MSG_HASH, _PRV_KEY).serialize().hex()
+    rootxprv = rootxprv_from_seed(_SEED)
+
+    answers = _child_answers(sec, sig)
+
+    assert answers["available"] is False
+    assert answers["dispatch"] is False
+    assert tuple(answers["point"]) == mult(_PRV_KEY)
+    assert answers["dsa"] == sig
+    assert answers["ssa"] == ssa.sign_(_MSG_HASH, _PRV_KEY, _AUX).serialize().hex()
+    assert answers["xprv"] == derive(rootxprv, _DERIVATION)
+    assert answers["xpub"] == derive(xpub_from_xprv(rootxprv), "m/0/7")
+    assert answers["engine"] is True


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/989 — step 3 of
https://github.com/btclib-org/btclib/issues/966.

**Stacked on https://github.com/btclib-org/btclib/pull/994** (base
`engine-dispatch`): guarding the engine's import while its call site is
still unconditional would move the failure from import time to call time,
which is worse. Retargets to `main` once 994 lands.

## What it does

Eleven modules imported `btclib_secp256k1` at module level, so `import
btclib` raised `ImportError` without them and the seam could not be
reached in the one configuration it exists for.

`btclib/_libsecp256k1.py` is now that import, once: one `try`, one
`AVAILABLE`, and the whole of the surface btclib asks of the bindings in
one list — which is also the answer to *what btclib needs them for*, a
question that used to be spread over eleven import blocks. The eleven
import their names from there under the spellings they already used, so
**no call site changed** and none pays an attribute lookup it did not pay
before, which matters where `curves/curve.py` counts tenths of a
microsecond.

`curve._libsecp256k1_available` is what that import answered rather than
a constant `True`.

## The one thing that was not an import

`bip32._PubKeyTweakChain` — a union built eagerly out of the bindings'
`PubkeyTweakChain`, at module level. With the bindings absent it is
`None | _PythonPubKeyTweakChain` and the import dies there. It annotates
two signatures and nothing else, and `from __future__ import annotations`
leaves an annotation a string, so it moves under `TYPE_CHECKING`; nothing
in the tree calls `get_type_hints` on either signature (checked:
`get_type_hints` appears only in `tests/alias_test.py`, on `HashObject`).

## How it is checked

`tests/no_bindings_test.py`, and it has to be a child interpreter: by the
time a test runs, btclib is imported and its answer is bound. A meta path
finder refuses `btclib_secp256k1`, btclib is imported after it, and
`mult`, ECDSA, BIP340, both BIP32 derivations and the script engine's
adapter are compared with what the parent computes with the bindings
serving.

Two details worth naming:

- BIP340 signing is randomized where the caller names no `aux` — `sign_`
  draws `secrets.token_bytes`, which is BIP340's own *Default Signing* —
  so the two processes are given the same aux and compared octet for
  octet. ECDSA needs none, RFC6979 making the nonce a function of the
  message and the key.
- this is **not** the CI job of
  https://github.com/btclib-org/btclib/issues/991 and does not replace
  it: the wheel is still installed and the environment still resolved.
  What it buys is the configuration answerable on every platform the
  matrix runs.

The `except ImportError` branch of `_libsecp256k1.py` carries `# pragma:
no cover` — the child that executes it is a subprocess, so no coverage
run reaches it. That is what
https://github.com/btclib-org/btclib/issues/991 will close.

## Gates

- `uv run pytest` — 27906 passed, 6 skipped, coverage 100.00%, exit 0
- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Centralize libsecp256k1 bindings import into a single module so btclib can run without the bindings installed and verify that configuration with a dedicated test.

New Features:
- Add a central btclib._libsecp256k1 module that exposes all libsecp256k1 bindings and an AVAILABLE flag for dispatch decisions.
- Introduce a subprocess-based test that exercises btclib with btclib_secp256k1 made unreachable and compares results against the bindings-backed implementation.

Enhancements:
- Update existing ECC, curve, BIP32, and script engine modules to import libsecp256k1 functionality exclusively via btclib._libsecp256k1 and wire curve dispatch to its availability flag.
- Move the BIP32 _PubKeyTweakChain union type behind TYPE_CHECKING to avoid eagerly requiring bindings at import time.
- Document the new centralized import behavior and absent-bindings configuration in the changelog.

Tests:
- Add tests/no_bindings_test.py to validate that btclib imports and produces consistent results when libsecp256k1 bindings are unavailable.