### PR TITLE
Publish the switch, and let the environment set it before the import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1507,6 +1507,36 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **The switch that turns the bindings off is public** (issue #992, step
+  6 of issue #966). `curve._libsecp256k1_available` is private, and its
+  only documented consumer was btclib's own suite; issue #198 puts a
+  consumer outside, since a test framework built on btclib must not check
+  Bitcoin Core's use of libsecp256k1 with libsecp256k1 — the rule Core's
+  own framework already keeps, `test/functional/test_framework` holding
+  no `ctypes` and no `libsecp` anywhere in it.
+
+  Two ways in, because they answer at different times.
+  `BTCLIB_NO_LIBSECP256K1`, set to a non-empty value, is read once at
+  import and makes the initial state False: that is what a test runner
+  wants, settling before the interpreter reaches `import btclib`, where
+  a function call cannot. `curves.set_libsecp256k1_serving(serving=…)`
+  is the same decision from inside a running process, and
+  `curves.is_libsecp256k1_serving()` reads it back.
+
+  One observable state and not two: installed-and-refused answers what
+  absent answers, because the difference is not something a caller can
+  act on. Asking for the bindings where none are installed is refused
+  rather than ignored — a caller that asked for C and was left on Python
+  would be timing Python and calling it C.
+
+  `SECURITY.md` says so too, and had to: its "Limitations, not
+  vulnerabilities" section was written on the premise that the delegation
+  cannot be turned off from outside the test suite, and said as much
+  three times — "which no caller can", "no argument of a caller's selects
+  either", "`dsa.verify` and `ssa.verify` are one libsecp256k1 call
+  each". A caller can now, twice over, and those are the sentences a
+  reader worried about constant-time behaviour reads.
+
 - **`import btclib` no longer needs the bindings installed** (issue #989,
   step 3 of issue #966). Eleven modules imported `btclib_secp256k1` at
   module level, so the seam meant to switch the dispatch off could not be

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -106,6 +106,18 @@ used to teach and to prototype as much as to build:
     or xpub string handed to `derive` or `derive_from_account`: the
     decoded key stays reachable from that cache, bounded by its
     `maxsize`, past whatever reference the caller itself still holds
+- the boundary is not always there. Everything the next bullet says
+    describes an installation whose dispatch is on, which is the default
+    and what the README's install gives you.
+    `curves.set_libsecp256k1_serving(serving=False)` turns it off for the
+    whole process, and `BTCLIB_NO_LIBSECP256K1` set in the environment
+    makes that the state from the first call — a test framework built on
+    btclib wants exactly that, having to check libsecp256k1 with
+    something other than libsecp256k1. With the dispatch off, every
+    operation named below is the Python arithmetic the last bullet
+    describes: tens of times slower, and not constant-time.
+    `curves.is_libsecp256k1_serving()` answers which of the two the next
+    call will take
 - not every operation crosses that boundary. `mult`, `double_mult_var` and
     `multi_mult_var` reach the bindings for secp256k1 and any point of it, a
     zero scalar and the point at infinity excepted — libsecp256k1 has no
@@ -119,7 +131,8 @@ used to teach and to prototype as much as to build:
     nonce and the offsetting of a parent key by the left half of an hmac
     being four other places a secret meets the curve.
     Verification crosses it whole, not only in its multiplication:
-    `dsa.verify` and `ssa.verify` are one libsecp256k1 call each for
+    `dsa.verify` and `ssa.verify` are one libsecp256k1 call each, where
+    the dispatch is on, for
     secp256k1 with sha256, a high-s signature being normalized first
     where the lower-s form is not being enforced. Batch verification is
     the exception, libsecp256k1 having no call for it, so
@@ -143,13 +156,12 @@ used to teach and to prototype as much as to build:
     `bms.sign` is delegated outright, `recovery.sign` signing and naming
     the recovery flag in one call: message signing is defined for
     secp256k1 alone, so there is no argument that sends it down the
-    Python path — which the test suite reaches by switching the dispatch
-    off, and which no caller can. BIP32 derivation is the same case, and
+    Python path — the switch above is what reaches it, and nothing a
+    caller passes does. BIP32 derivation is the same case, and
     for the same reason: `bip32.derive` adds the offset with
     `keys.prvkey_tweak_add` privately and `keys.PubkeyTweakChain`
     publicly, and the Python arm behind them — BIP32's two sums, on
-    integers and on a point — is one no argument of a caller's selects
-    either.
+    integers and on a point — is one no argument selects either.
     Anything else — another
     curve, another hash function, a nonce of your own — runs the Python
     implementation, whose scalar multiplication is

--- a/btclib/_libsecp256k1.py
+++ b/btclib/_libsecp256k1.py
@@ -33,8 +33,20 @@ checks by importing btclib with the bindings out of reach.
 
 from __future__ import annotations
 
+import os
+
+# the environment variable that refuses the bindings without uninstalling
+# them, read once and here: a caller settling it after `import btclib`
+# would be settling it after this module has answered. `BTCLIB_` and "set
+# to ask for it", which is the spelling the suite's own switches use --
+# BTCLIB_INTEGRATION, BTCLIB_HWI_SIGN -- and an empty value is not set,
+# so `BTCLIB_NO_LIBSECP256K1=` leaves them serving
+NO_LIBSECP256K1 = "BTCLIB_NO_LIBSECP256K1"
+
 __all__ = [
-    "AVAILABLE",
+    "ENABLED",
+    "INSTALLED",
+    "NO_LIBSECP256K1",
     "PubkeyTweakChain",
     "dsa",
     "dsa_verify",
@@ -70,7 +82,7 @@ try:
     from btclib_secp256k1.xonly import pubkey_verify as xonly_pubkey_verify
     from btclib_secp256k1.xonly import to_pubkey as xonly_to_pubkey
 
-    AVAILABLE = True
+    INSTALLED = True
 except ImportError:  # pragma: no cover
     # None and not a callable that raises: what would raise is never
     # called, so the object would be a second thing to keep true. The
@@ -85,4 +97,9 @@ except ImportError:  # pragma: no cover
     pubkey_tweak_mul_sum = pubkey_verify = ssa_verify = None  # type: ignore[assignment]
     xonly_pubkey_verify = xonly_to_pubkey = None  # type: ignore[assignment]
 
-    AVAILABLE = False
+    INSTALLED = False
+
+# installed and not refused, which is one state and not two: a caller
+# asking whether the bindings serve has no use for the difference, and
+# `curves.curve` starts its seam from this
+ENABLED = INSTALLED and not os.environ.get(NO_LIBSECP256K1)

--- a/btclib/curves/__init__.py
+++ b/btclib/curves/__init__.py
@@ -91,9 +91,11 @@ from btclib.curves.curve import (
     Curve,
     PreparedPoint,
     double_mult_var,
+    is_libsecp256k1_serving,
     mult,
     multi_mult_var,
     secp256k1,
+    set_libsecp256k1_serving,
 )
 from btclib.curves.curve_group import CurveGroup
 from btclib.curves.curve_group_f import find_all_points, find_subgroup_points
@@ -113,8 +115,10 @@ __all__ = [
     "double_mult_var",
     "find_all_points",
     "find_subgroup_points",
+    "is_libsecp256k1_serving",
     "mult",
     "multi_mult_var",
     "point_from_octets",
     "secp256k1",
+    "set_libsecp256k1_serving",
 ]

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -35,7 +35,8 @@ from math import isqrt
 from pathlib import Path
 from typing import Any
 
-from btclib._libsecp256k1 import AVAILABLE as _bindings_available
+from btclib._libsecp256k1 import ENABLED as _bindings_enabled
+from btclib._libsecp256k1 import INSTALLED as _bindings_installed
 from btclib._libsecp256k1 import (
     PubkeyTweakChain as Libsecp256k1PubkeyTweakChain,
 )
@@ -84,9 +85,11 @@ __all__ = [
     "SEC2v2",
     "SEC2v2_params2",
     "double_mult_var",
+    "is_libsecp256k1_serving",
     "mult",
     "multi_mult_var",
     "secp256k1",
+    "set_libsecp256k1_serving",
 ]
 
 
@@ -447,7 +450,53 @@ secp256k1 = CURVES["secp256k1"]
 # It is also the seam whatever wants the Python arithmetic closes to
 # reach it -- the test suite included, which assigns False to it where
 # the bindings are installed and serving
-_libsecp256k1_available = _bindings_available
+_libsecp256k1_available = _bindings_enabled
+
+
+def is_libsecp256k1_serving() -> bool:
+    """Return True if the bindings are what this process delegates to.
+
+    One question and not two: installed, and not refused. A caller has no
+    use for the difference -- what it can act on is whether the answer it
+    is about to get comes from libsecp256k1 or from the Python
+    arithmetic -- and two observable states where there is one is how a
+    caller comes to handle only the state it happened to meet.
+
+    The public reading of the seam every dispatch consults. It is what a
+    project built on btclib asks when it must not check libsecp256k1 with
+    libsecp256k1: Bitcoin Core's own test framework keeps that rule --
+    `crypto/secp256k1.py` is "designed for ease of understanding, not
+    performance" -- and issue #198 is btclib's side of it.
+    """
+    return _libsecp256k1_available
+
+
+def set_libsecp256k1_serving(*, serving: bool) -> None:
+    """Ask for the bindings, or for the Python arithmetic, from here on.
+
+    Process-wide and immediate: every dispatch in the package asks
+    `_libsecp256k1_serves`, and that predicate reads the global this
+    assigns, so nothing has to be re-imported and no module keeps an
+    answer of its own.
+
+    `serving=True` with the bindings not installed is a request that
+    cannot be served, and is refused rather than silently ignored:
+    a caller that asked for C and got Python would be timing Python and
+    calling it C. `is_libsecp256k1_serving` is how the answer is read back.
+
+    The environment variable is the other way in, and the earlier one:
+    `BTCLIB_NO_LIBSECP256K1` set to a non-empty value makes the initial
+    state False, which is what a test runner wants -- it settles before
+    the first import, where this function cannot.
+    """
+    assert_type(serving, bool, "serving")
+    if serving and not _bindings_installed:
+        raise BTClibValueError(
+            "btclib_secp256k1 is not installed: the bindings cannot serve"
+        )
+
+    global _libsecp256k1_available  # noqa: PLW0603
+    _libsecp256k1_available = serving
 
 
 def _libsecp256k1_serves(ec: Curve, hf: HashF | None) -> bool:

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -66,6 +66,28 @@ btclib requires python 3.10 or later and pulls in
 optional accelerator: installing needs one of its wheels or a C
 toolchain to build it.
 
+secp256k1 arithmetic is delegated to those bindings, and the delegation
+can be turned off. Setting ``BTCLIB_NO_LIBSECP256K1`` to a non-empty
+value in the environment, before btclib is imported, makes *off* the
+state the process starts in:
+
+.. code-block:: shell
+
+   BTCLIB_NO_LIBSECP256K1=1 python your_script.py
+
+:func:`btclib.curves.set_libsecp256k1_serving` changes it from inside a
+running process — including back on, so the variable sets the initial
+state rather than locking one — and
+:func:`btclib.curves.is_libsecp256k1_serving` reads the answer back.
+Both are one state and not two: what they report is whether the next
+call goes to libsecp256k1 or to the Python arithmetic, which is the only
+difference a caller can act on.
+
+The Python arithmetic is a second implementation and not a fallback of
+convenience: it is slower — tens of times, and ``SECURITY.md`` publishes
+that it is not constant-time — and it is what a project must run when it
+has to check libsecp256k1 with something that is not libsecp256k1.
+
 .. doctest is the reason the version is asserted loosely: the value
    moves with every release, and pinning it here would make this page
    fail on the release commit rather than on a real defect

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -347,10 +347,12 @@ def test_ec_exports_the_curve_api_not_the_benchmark() -> None:
         "double_mult_var",
         "find_all_points",
         "find_subgroup_points",
+        "is_libsecp256k1_serving",
         "mult",
         "multi_mult_var",
         "point_from_octets",
         "secp256k1",
+        "set_libsecp256k1_serving",
     ]
 
     # the implementations are still there, in the module that defines them

--- a/tests/bool_parameter_test.py
+++ b/tests/bool_parameter_test.py
@@ -96,7 +96,11 @@ from btclib.bip32.der_path import (
     int_from_index_str,
 )
 from btclib.block.block import Block
-from btclib.curves.curve import Curve, SEC2v1_params2
+from btclib.curves.curve import (
+    Curve,
+    SEC2v1_params2,
+    set_libsecp256k1_serving,
+)
 from btclib.curves.sec_point import (
     bytes_from_point,
     bytes_from_prv_key_int,
@@ -641,6 +645,19 @@ _KINDS = (
         KeyGroup,
         {"threshold": 2, "keys": [_XPUB, _XPUB]},
         valid=False,
+    ),
+    # `serving` chooses which implementation every later call reaches, so
+    # it is as much a kind as `compressed` is: a value read for its truth
+    # would let `serving="no"` ask for C and `serving=0` for Python, and
+    # a caller that asked for one and got the other would be timing the
+    # other and calling it the one. `valid=True` and not False, so that
+    # the call this file makes leaves the state an installation with the
+    # bindings is normally in
+    _Case(
+        "btclib.curves.curve.set_libsecp256k1_serving",
+        "serving",
+        set_libsecp256k1_serving,
+        {},
     ),
 )
 

--- a/tests/name_contract_test.py
+++ b/tests/name_contract_test.py
@@ -154,24 +154,31 @@ def _argument_less_bools() -> dict[str, bool]:
     for path in sorted(_LIBRARY.rglob("*.py")):
         module = ".".join(path.relative_to(_LIBRARY.parent).with_suffix("").parts)
         tree = ast.parse(path.read_text(encoding="utf-8"))
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.FunctionDef) or node.name.startswith("_"):
+        # classes and what is in them, not `ast.walk(tree)`: a property is
+        # a class thing, which is what `_class_members` below says in as
+        # many words, so a module-level function is out of scope however
+        # few arguments it takes and cannot be told to become one
+        for cls in ast.walk(tree):
+            if not isinstance(cls, ast.ClassDef):
                 continue
-            if node.returns is None or ast.unparse(node.returns) != "bool":
-                continue
-            arguments = [
-                a.arg
-                for a in [
-                    *node.args.posonlyargs,
-                    *node.args.args,
-                    *node.args.kwonlyargs,
+            for node in ast.walk(cls):
+                if not isinstance(node, ast.FunctionDef) or node.name.startswith("_"):
+                    continue
+                if node.returns is None or ast.unparse(node.returns) != "bool":
+                    continue
+                arguments = [
+                    a.arg
+                    for a in [
+                        *node.args.posonlyargs,
+                        *node.args.args,
+                        *node.args.kwonlyargs,
+                    ]
+                    if a.arg != "self"
                 ]
-                if a.arg != "self"
-            ]
-            if arguments:
-                continue
-            decorated = {ast.unparse(d) for d in node.decorator_list}
-            found[f"{module}.{node.name}"] = _is_a_read(decorated)
+                if arguments:
+                    continue
+                decorated = {ast.unparse(d) for d in node.decorator_list}
+                found[f"{module}.{node.name}"] = _is_a_read(decorated)
     return found
 
 

--- a/tests/no_bindings_test.py
+++ b/tests/no_bindings_test.py
@@ -31,14 +31,24 @@ property, and a child that merely fails to crash proves nothing about it.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from typing import Any
 
-from btclib._libsecp256k1 import AVAILABLE
+import pytest
+
+from btclib._libsecp256k1 import ENABLED, INSTALLED, NO_LIBSECP256K1
 from btclib.bip32.bip32 import derive, rootxprv_from_seed, xpub_from_xprv
-from btclib.curves import bytes_from_point, curve, mult
+from btclib.curves import (
+    bytes_from_point,
+    curve,
+    is_libsecp256k1_serving,
+    mult,
+    set_libsecp256k1_serving,
+)
 from btclib.ecc import dsa, ssa
+from btclib.exceptions import BTClibValueError
 
 # the seed, key and message the child works from: constants, because the
 # two processes have to be asked the same question
@@ -70,10 +80,11 @@ class RefuseTheBindings:
 sys.meta_path.insert(0, RefuseTheBindings())
 
 import btclib
-from btclib._libsecp256k1 import AVAILABLE
+from btclib._libsecp256k1 import ENABLED, INSTALLED, NO_LIBSECP256K1
 from btclib.bip32.bip32 import derive, rootxprv_from_seed, xpub_from_xprv
 from btclib.curves import curve, mult
 from btclib.ecc import dh, dsa, ellswift, ssa
+from btclib.exceptions import BTClibValueError
 from btclib.script.engine import script as engine_script
 from btclib.script.engine import tapscript as engine_tapscript
 
@@ -81,7 +92,7 @@ assert "btclib_secp256k1" not in sys.modules, "the finder let the bindings in"
 
 rootxprv = rootxprv_from_seed({seed!r})
 print(json.dumps({{
-    "available": AVAILABLE,
+    "installed": INSTALLED,
     "dispatch": curve._libsecp256k1_available,
     "point": mult({prv_key}),
     "dsa": dsa.sign_({msg_hash!r}, {prv_key}).serialize().hex(),
@@ -141,7 +152,8 @@ def test_btclib_answers_with_the_bindings_out_of_reach() -> None:
     reach on their own.
     """
     # the same question this process answers with the bindings serving
-    assert AVAILABLE
+    assert INSTALLED
+    assert ENABLED
     assert curve._libsecp256k1_available
 
     sec = bytes_from_point(mult(_PRV_KEY)).hex()
@@ -150,7 +162,7 @@ def test_btclib_answers_with_the_bindings_out_of_reach() -> None:
 
     answers = _child_answers(sec, sig)
 
-    assert answers["available"] is False
+    assert answers["installed"] is False
     assert answers["dispatch"] is False
     assert tuple(answers["point"]) == mult(_PRV_KEY)
     assert answers["dsa"] == sig
@@ -158,3 +170,86 @@ def test_btclib_answers_with_the_bindings_out_of_reach() -> None:
     assert answers["xprv"] == derive(rootxprv, _DERIVATION)
     assert answers["xpub"] == derive(xpub_from_xprv(rootxprv), "m/0/7")
     assert answers["engine"] is True
+
+
+def test_the_environment_variable_refuses_the_installed_bindings() -> None:
+    """`BTCLIB_NO_LIBSECP256K1` is the way in that settles before import.
+
+    A public function cannot do this job on its own: `btclib.
+    _libsecp256k1` answers at import, so a caller that wants the Python
+    arithmetic from the first call has to say so before the interpreter
+    reaches `import btclib`. A test runner is exactly that caller, which
+    is why the variable exists beside `set_libsecp256k1_serving` rather
+    than instead of it.
+
+    Installed and refused answers what absent answers -- one state, not
+    two -- so the assertion is the same as the child above makes.
+    """
+    probe = (
+        "from btclib._libsecp256k1 import ENABLED, INSTALLED;"
+        "from btclib.curves import is_libsecp256k1_serving;"
+        "print(INSTALLED, ENABLED, is_libsecp256k1_serving())"
+    )
+    answered = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        encoding="utf-8",
+        check=True,
+        env={**os.environ, NO_LIBSECP256K1: "1"},
+    ).stdout.split()
+    assert answered == ["True", "False", "False"]
+
+    # and an empty value is not set: the bindings serve
+    answered = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        encoding="utf-8",
+        check=True,
+        env={**os.environ, NO_LIBSECP256K1: ""},
+    ).stdout.split()
+    assert answered == ["True", "True", "True"]
+
+
+def test_the_switch_refuses_to_promise_bindings_that_are_not_there(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Asking for C where there is none is refused, not ignored.
+
+    A caller that asked for the bindings and was quietly left on the
+    Python arithmetic would be timing Python and calling it C, which is
+    the mistake `curves/curve.py` says the seam exists to make
+    impossible.
+    """
+    monkeypatch.setattr(curve, "_bindings_installed", False)
+    with pytest.raises(BTClibValueError, match="btclib_secp256k1 is not installed"):
+        set_libsecp256k1_serving(serving=True)
+
+    # try/finally and not a monkeypatch for the restore: monkeypatch puts
+    # back the value it found, and it would find the False this test has
+    # just set -- which is a process-wide switch left off for whatever
+    # runs next in this worker
+    try:
+        # switching them off is allowed whatever is installed: it is the
+        # direction that always has an implementation to fall back to
+        set_libsecp256k1_serving(serving=False)
+        assert not is_libsecp256k1_serving()
+    finally:
+        monkeypatch.undo()
+        set_libsecp256k1_serving(serving=ENABLED)
+
+
+def test_the_switch_is_read_back_by_the_reader() -> None:
+    """The pair is one state: what is set is what is read."""
+    assert is_libsecp256k1_serving() is curve._libsecp256k1_available
+    delegated = mult(_PRV_KEY)
+
+    try:
+        set_libsecp256k1_serving(serving=False)
+        assert is_libsecp256k1_serving() is False
+        # every dispatch reads it, which is what makes the pair worth
+        # having: the arithmetic answers the same either way
+        assert mult(_PRV_KEY) == delegated
+        set_libsecp256k1_serving(serving=True)
+        assert is_libsecp256k1_serving() is True
+    finally:
+        set_libsecp256k1_serving(serving=ENABLED)


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/992 — step 6 of
https://github.com/btclib-org/btclib/issues/966, added there for
https://github.com/btclib-org/btclib/issues/198.

**Stacked on https://github.com/btclib-org/btclib/pull/995** (base
`guard-imports`, itself on
https://github.com/btclib-org/btclib/pull/994). Retargets as those land.

## The API

Two ways in, because they answer at different times.

| | when | what it is for |
| --- | --- | --- |
| `BTCLIB_NO_LIBSECP256K1=1` | read once, at import | a test runner: it settles before the interpreter reaches `import btclib`, where a call cannot |
| `curves.set_libsecp256k1_serving(serving=…)` | any time | a running process changing its mind |
| `curves.is_libsecp256k1_serving()` | | reads the answer back |

**One observable state and not two**, which is what the issue asks for:
`_libsecp256k1.ENABLED` is *installed and not refused*, and `INSTALLED`
stays private because the difference is not something a caller can act
on. Asking for the bindings where none are installed is refused rather
than ignored — a caller that asked for C and was left on Python would be
timing Python and calling it C.

## One contract test had to be corrected

`tests/name_contract_test.py::_argument_less_bools` walked **every**
function of a file, so a module-level one is reported as "a bool about
the object … it is a `@property`, not a method" — a shape no module-level
function can have. It walks classes now, which is what `_class_members`
right beside it already states the rule to mean:

> A property is a class thing, so a module-level function is out of scope
> however few arguments it takes — `fetch.fetcher.client_errors` is a
> context manager and could not be one.

The methods the rule is about are reached exactly as before; no entry
left the set except module-level functions, of which the tree had none
until this PR. If you would rather keep the walk as it was and give the
reader an argument instead, say so and I will turn it round.

`serving` is classified in `tests/bool_parameter_test.py` as a **kind**,
not a truth: read for its truth, `serving="no"` would ask for C and
`serving=0` for Python.

## Two things worth knowing for the next PRs

- `tests/bool_parameter_test.py::test_the_call_works` calls
  `set_libsecp256k1_serving(serving=True)`. Under the no-bindings job of
  https://github.com/btclib-org/btclib/issues/991 that call raises by
  design, so that job will have to say something about this case. Noted
  here rather than left to be discovered there.
- a test that flips a process-wide switch cannot restore it with
  `monkeypatch`: monkeypatch puts back the value it *found*, which is the
  one the test had already set. `try/finally` does it; found by two
  bip32 tests going red in a randomized order, not by reasoning.

## Gates

- `uv run pytest` — 27913 passed, 6 skipped, coverage 100.00%, exit 0;
  and three further randomized orders, all green
- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Publish controls for selecting and inspecting libsecp256k1 dispatch while preserving explicit behavior when bindings are unavailable.

New Features:
- Expose public APIs to query and change whether libsecp256k1 serves curve operations at runtime.
- Support the BTCLIB_NO_LIBSECP256K1 environment variable for selecting the initial dispatch mode before import.

Bug Fixes:
- Reject requests to enable libsecp256k1 when its bindings are not installed instead of silently falling back to Python arithmetic.

Enhancements:
- Unify the installed-and-enabled dispatch state behind a single observable serving status.
- Update security guidance to describe the configurable constant-time and performance characteristics of the selected implementation.
- Correct the name contract test to inspect argument-less boolean methods only within classes.

Documentation:
- Document the new libsecp256k1 dispatch controls and their security and performance implications.

Tests:
- Add coverage for environment-based initialization, runtime switching, unavailable bindings, and state restoration.