### PR TITLE
Make the bindings an extra, and a group so the repository keeps them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -408,7 +408,11 @@ jobs:
       - name: Smoke-test the wheel, with its dependencies from PyPI
         run: |
           cd "$RUNNER_TEMP"
-          uv run --isolated --no-project --with "$GITHUB_WORKSPACE"/dist/*.whl \
+          # `set --` for the reason dist-py's copy of this states: the
+          # positional parameters are sh, bash and zsh alike, where a
+          # named array is 0-indexed in one and 1-indexed in another
+          set -- "$GITHUB_WORKSPACE"/dist/*.whl
+          uv run --isolated --no-project --with "$1[secp256k1]" \
             python -c "import btclib; \
               from btclib.ecc import dsa; \
               from btclib.to_pub_key import pub_keyinfo_from_prv_key; \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -281,6 +281,12 @@ jobs:
       # `Requires-Dist` the wheel itself carries, resolved from the index
       # -- which is the question, metadata being what the three checks
       # above only read.
+      # The extra is named on both sides for that reason: the bindings
+      # are `Requires-Dist ... ; extra == "secp256k1"` now, so a wheel
+      # installed without it declares nothing to resolve and the question
+      # goes unasked. `--extra secp256k1` on the export is what puts the
+      # bindings in the constraints, the direct reference below being
+      # where their version comes from
       # The lock arrives as constraints and not as requirements: a
       # requirements file installs the bindings whether or not the wheel
       # asks for them, so a wheel declaring nothing would pass. A
@@ -308,12 +314,19 @@ jobs:
       # an incompatible API imports fine and answers wrongly
       - name: Smoke-test the wheel, with its dependencies from PyPI
         run: |
-          uv export --locked --no-dev --no-emit-project --no-hashes \
-            -o "$RUNNER_TEMP"/constraints.txt
+          uv export --locked --no-dev --extra secp256k1 \
+            --no-emit-project --no-hashes -o "$RUNNER_TEMP"/constraints.txt
           cd "$RUNNER_TEMP"
           uv venv
-          uv pip install --constraints constraints.txt \
-            "$GITHUB_WORKSPACE"/dist/*.whl
+          # `set --` and not `echo`, which would collapse a second wheel
+          # into one space-separated word and fail about a path with a
+          # space in it rather than about there being two; and not a
+          # named array either, whose first element is `[0]` in bash and
+          # `[1]` in zsh, where CONTRIBUTING.md's copy of this command is
+          # pasted. The positional parameters are sh, bash and zsh alike,
+          # so the two stay one string, and a second wheel is `$2`
+          set -- "$GITHUB_WORKSPACE"/dist/*.whl
+          uv pip install --constraints constraints.txt "$1[secp256k1]"
           .venv/bin/python -c "import btclib; \
             from btclib.ecc import dsa; \
             from btclib.to_pub_key import pub_keyinfo_from_prv_key; \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1507,6 +1507,46 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **`btclib_secp256k1` is the `secp256k1` extra, not a dependency**
+  (issue #990, step 4 of issue #966). What a consumer installs is
+  `btclib[secp256k1]`, which is what README.md, the guide and
+  CONTRIBUTING.md now tell a reader to run; a plain `pip install btclib`
+  needs no C toolchain and no wheel of the bindings, and answers on the
+  Python arithmetic. HISTORY.md carries what that costs, an upgrade that
+  forgets the extra being a quiet change of implementation rather than an
+  error.
+
+  uv has no default extra — `[tool.uv]` takes `default-groups` and
+  nothing that would make an extra one — so the same requirement is also
+  a `bindings` dependency group, included by `test`, `lint` and `docs`.
+  That is what keeps `uv sync` and every `--group` command of
+  CONTRIBUTING.md resolving the delegated configuration, with no
+  documented command growing an `--extra`; and it is what makes the job
+  of issue #991 those same commands with one group left out. The
+  requirement is therefore written twice, and
+  `tests/build_system_test.py` fails the day the two stop agreeing.
+
+  `SECURITY.md` says which install gets which arithmetic, which is where
+  this stops being a packaging change: after it, `pip install btclib` —
+  the spelling in every tutorial and every requirements.txt — is a btclib
+  whose signing, verification, BIP32 derivation and key agreement all run
+  the Python arithmetic, and nothing raises to say so. That file is what
+  README.md, HISTORY.md, the guide and the `pyproject.toml` comment all
+  cite for "tens of times slower and not constant-time".
+
+  The wheel is named through the positional parameters — `set -- …/*.whl`
+  and `"$1[secp256k1]"` — rather than through `echo`, which would
+  collapse a second wheel into one space-separated word, or through a
+  named array, whose first element is `[0]` in bash and `[1]` in zsh:
+  CONTRIBUTING.md carries each job's command verbatim and is pasted into
+  whatever shell the reader has, so the two have to be one string.
+
+  The `dist` job names the extra on both sides. The bindings are
+  `Requires-Dist … ; extra == "secp256k1"` now, so a wheel installed
+  without it declares nothing to resolve and the question that job exists
+  to ask — does the published metadata pull the bindings in — would go
+  unasked.
+
 - **The switch that turns the bindings off is public** (issue #992, step
   6 of issue #966). `curve._libsecp256k1_available` is private, and its
   only documented consumer was btclib's own suite; issue #198 puts a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,9 @@ tools, including those needed to build the documentation, is then created with:
 uv sync
 ```
 
-**The declared dependencies are `btclib_secp256k1>=0.8.0.3` and
-`bitcoin-core-rpc>=2026.8.13`, with no upper bound**, and the absence of a
+**The declared dependencies are `bitcoin-core-rpc>=2026.8.13` and, as
+the `secp256k1` extra, `btclib_secp256k1>=0.8.0.3`, with no upper
+bound**, and the absence of a
 ceiling is a decision. Both are btclib-org projects developed by the same
 people, and the bindings' whole purpose is to be the bindings this library
 calls, so a breaking change there is coordinated with the release here —
@@ -359,8 +360,10 @@ allowlist is stated in prose in
 which the suite compares against the script's own constants, so changing
 a rule means changing both. The last
 commands ask for the wheel and nothing else, so
-what pulls btclib_secp256k1 in is the `Requires-Dist` the wheel
-carries; the lock arrives as constraints, which bind a version without
+what pulls btclib_secp256k1 in is the `Requires-Dist` the wheel carries
+for the `secp256k1` extra — which those commands name on both sides, a
+wheel installed without it declaring nothing to resolve. The lock
+arrives as constraints, which bind a version without
 requesting a package, so a release of the bindings cannot turn a required
 check red while the wheel's own metadata still does the work. They run
 from an empty directory, or the import finds the source tree instead of
@@ -376,10 +379,11 @@ uv run --locked --only-group build twine check --strict dist/*
 uv run --locked --only-group build check-wheel-contents dist/*.whl
 uv run --locked --only-group build pyroma --min 10 dist/*.tar.gz
 tmp=$(mktemp -d)
-uv export --locked --no-dev --no-emit-project --no-hashes \
-    -o "$tmp"/constraints.txt
+uv export --locked --no-dev --extra secp256k1 --no-emit-project \
+    --no-hashes -o "$tmp"/constraints.txt
 cd "$tmp" && uv venv &&
-    uv pip install --constraints constraints.txt "$OLDPWD"/dist/*.whl &&
+    set -- "$OLDPWD"/dist/*.whl &&
+    uv pip install --constraints constraints.txt "$1[secp256k1]" &&
     .venv/bin/python -c "import btclib; \
       from btclib.ecc import dsa; \
       from btclib.to_pub_key import pub_keyinfo_from_prv_key; \

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,17 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **`pip install btclib` no longer installs `btclib_secp256k1`.** The
+  bindings are the `secp256k1` extra now — `pip install
+  "btclib[secp256k1]"` — and an install that does not ask for them gets a
+  btclib that answers on its own Python arithmetic: tens of times slower,
+  and not constant-time, both of which `SECURITY.md` publishes. Nothing
+  raises and no import fails, so an upgrade that forgets the extra is a
+  quiet change of implementation rather than an error; ask
+  `btclib.curves.is_libsecp256k1_serving()` if the answer matters.
+  Environments that resolve from a lock file are unaffected until the
+  lock is regenerated.
+
 - **`dsa.recover_pub_key_` reports a key_id outside 0..3 as a
   `BTClibValueError`.** It raised `BTClibRuntimeError` — "signature
   verification failed" — for a key_id whose `x_K = r + j*n` is no field

--- a/README.md
+++ b/README.md
@@ -44,12 +44,14 @@ The library is not limited to secp256k1, and for that curve it always
 calls
 [btclib_secp256k1](https://github.com/btclib-org/btclib-secp256k1),
 FFI bindings to Bitcoin Core's optimized C library
-[libsecp256k1](https://github.com/bitcoin-core/secp256k1). They are a
-required dependency and not an optional accelerator, so installing btclib
-needs one of their wheels or a C toolchain. The Python arithmetic serves
-every other curve, and the suite validates it against the bindings:
-libsecp256k1 says what the right answer is, being what bitcoin consensus
-relies on.
+[libsecp256k1](https://github.com/bitcoin-core/secp256k1). They are the
+recommended install and what `pip install "btclib[secp256k1]"` asks for,
+needing one of their wheels or a C toolchain; without them btclib still
+answers, on the Python arithmetic, tens of times more slowly and not in
+constant time — `SECURITY.md` publishes both. That Python arithmetic
+serves every other curve anyway, and the suite validates it against the
+bindings: libsecp256k1 says what the right answer is, being what bitcoin
+consensus relies on.
 
 Included features are:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -106,18 +106,23 @@ used to teach and to prototype as much as to build:
     or xpub string handed to `derive` or `derive_from_account`: the
     decoded key stays reachable from that cache, bounded by its
     `maxsize`, past whatever reference the caller itself still holds
-- the boundary is not always there. Everything the next bullet says
-    describes an installation whose dispatch is on, which is the default
-    and what the README's install gives you.
+- the boundary is not always there, and an install decides whether it
+    is. `pip install "btclib[secp256k1]"` -- the spelling README.md and
+    the guide give -- installs the bindings, and everything the next
+    bullet says describes that installation. `pip install btclib`
+    installs no C at all: signing, verification, BIP32 derivation and key
+    agreement all run the Python arithmetic the last bullet describes,
+    which is tens of times slower and not constant-time. Nothing raises
+    to say so, and `curves.is_libsecp256k1_serving()` is how a caller
+    asks which of the two it has.
+    The dispatch is a runtime switch besides:
     `curves.set_libsecp256k1_serving(serving=False)` turns it off for the
     whole process, and `BTCLIB_NO_LIBSECP256K1` set in the environment
     makes that the state from the first call — a test framework built on
     btclib wants exactly that, having to check libsecp256k1 with
     something other than libsecp256k1. With the dispatch off, every
-    operation named below is the Python arithmetic the last bullet
-    describes: tens of times slower, and not constant-time.
-    `curves.is_libsecp256k1_serving()` answers which of the two the next
-    call will take
+    operation named below is the Python arithmetic, whichever way the
+    library was installed
 - not every operation crosses that boundary. `mult`, `double_mult_var` and
     `multi_mult_var` reach the bindings for secp256k1 and any point of it, a
     zero scalar and the point at infinity excepted — libsecp256k1 has no

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -59,12 +59,14 @@ Installing
 
 .. code-block:: shell
 
-   python -m pip install --upgrade btclib
+   python -m pip install --upgrade "btclib[secp256k1]"
 
-btclib requires python 3.10 or later and pulls in
-``btclib_secp256k1``, which is a required dependency and not an
-optional accelerator: installing needs one of its wheels or a C
-toolchain to build it.
+btclib requires python 3.10 or later. The ``secp256k1`` extra pulls in
+``btclib_secp256k1``, and it is the recommended install: it needs one of
+that package's wheels or a C toolchain to build it. Plain ``pip install
+btclib`` works and installs no C at all — btclib then answers on its own
+Python arithmetic, tens of times more slowly and not in constant time,
+which ``SECURITY.md`` publishes.
 
 secp256k1 arithmetic is delegated to those bindings, and the delegation
 can be turned off. Setting ``BTCLIB_NO_LIBSECP256K1`` to a non-empty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,22 +25,6 @@ license-files = ["LICENSE", "COPYRIGHT", "AUTHORS.md"]
 authors = [{ name = "The btclib developers", email = "devs@btclib.org" }]
 requires-python = ">=3.10"
 dependencies = [
-    # 0.8.0.3 for `xonly.tweak_add_` (btclib-secp256k1#158), which
-    # `script.taproot` calls: it tweaks the parsed internal key, where
-    # `xonly.tweak_add` parses the x again and that parse is a field square
-    # root. The same version for `keys.pubkey_sum`, `xonly.pubkey_verify`
-    # and `xonly.to_pubkey` (btclib-secp256k1#171), which `curves.curve`
-    # calls -- one sum instead of a combine per term, and the two
-    # questions about an x asked as x-only questions. The same version
-    # again for `keys.pubkey_tweak_mul_sum` (btclib-secp256k1#182), which
-    # is that sum with its terms as well, so that no product of a
-    # multi-scalar multiplication crosses the boundary; and for
-    # `ssa.Signer` (btclib-secp256k1#154), which `ecc.ssa.Signer` holds so
-    # that a keypair is built once per key rather than once per signature.
-    # The version is not on PyPI yet -- `[tool.uv.sources]` below is what
-    # resolves it here -- so this floor is also what stops a release going
-    # out against a bindings that cannot serve it
-    "btclib_secp256k1>=0.8.0.3",
     "bitcoin-core-rpc>=2026.8.13",
 ]
 keywords = [
@@ -99,6 +83,39 @@ classifiers = [
     "Typing :: Typed",
 ]
 
+[project.optional-dependencies]
+# The bindings are the default and the recommended install -- `pip
+# install "btclib[secp256k1]"`, quoted because zsh is macOS's login
+# shell and answers `no matches found` to the bare form, and it is
+# what README.md and the guide tell a reader to run -- and an extra
+# rather than a dependency because
+# btclib answers without them: every delegation asks a dispatch that
+# declines where they are absent, and `btclib._libsecp256k1` is the one
+# import that decides it. What that buys is a btclib a distribution can
+# package with no C toolchain in reach, and a caller that must not check
+# libsecp256k1 with libsecp256k1 (issue #198). What it costs is in
+# HISTORY.md, because an upgrade that stops installing them is an
+# upgrade onto the Python arithmetic, which is tens of times slower and
+# is not constant-time -- SECURITY.md publishes both
+secp256k1 = [
+    # 0.8.0.3 for `xonly.tweak_add_` (btclib-secp256k1#158), which
+    # `script.taproot` calls: it tweaks the parsed internal key, where
+    # `xonly.tweak_add` parses the x again and that parse is a field square
+    # root. The same version for `keys.pubkey_sum`, `xonly.pubkey_verify`
+    # and `xonly.to_pubkey` (btclib-secp256k1#171), which `curves.curve`
+    # calls -- one sum instead of a combine per term, and the two
+    # questions about an x asked as x-only questions. The same version
+    # again for `keys.pubkey_tweak_mul_sum` (btclib-secp256k1#182), which
+    # is that sum with its terms as well, so that no product of a
+    # multi-scalar multiplication crosses the boundary; and for
+    # `ssa.Signer` (btclib-secp256k1#154), which `ecc.ssa.Signer` holds so
+    # that a keypair is built once per key rather than once per signature.
+    # The version is not on PyPI yet -- `[tool.uv.sources]` below is what
+    # resolves it here -- so this floor is also what stops a release going
+    # out against a bindings that cannot serve it
+    "btclib_secp256k1>=0.8.0.3",
+]
+
 [project.urls]
 homepage = "https://btclib.org"
 documentation = "https://btclib.readthedocs.io/"
@@ -109,7 +126,20 @@ issues = "https://github.com/btclib-org/btclib/issues"
 pull_requests = "https://github.com/btclib-org/btclib/pulls"
 
 [dependency-groups]
+# The extra of `project.optional-dependencies` again, as a group. uv has
+# no default extra -- `[tool.uv]` takes `default-groups` and nothing that
+# would make an extra one -- so an extra alone would leave `uv sync` and
+# every `--group` command of CONTRIBUTING.md resolving a btclib without
+# the bindings, which is half a suite: the tests that matter most here
+# compare the two implementations against each other.
+#
+# So the specifier is written twice, and `tests/build_system_test.py`
+# refuses the day the two stop agreeing. What the group buys is that no
+# documented command had to grow an `--extra`, and that the job of issue
+# #991 is those same commands with this group left out
+bindings = ["btclib_secp256k1>=0.8.0.3"]
 test = [
+    { include-group = "bindings" },
     "coverage",
     "hypothesis",
     "pytest",
@@ -117,12 +147,17 @@ test = [
     "pytest-randomly",
     "pytest-xdist",
 ]
-lint = ["mypy", "pre-commit", "ruff"]
+lint = [{ include-group = "bindings" }, "mypy", "pre-commit", "ruff"]
 # the distribution files are built and published by uv itself: what this
 # group holds is what inspects them, before an upload consumes the version
 build = ["check-manifest", "check-wheel-contents", "pyroma", "twine"]
 mutation = ["cosmic-ray"]
-docs = ["myst-parser", "sphinx", "sphinx_rtd_theme"]
+docs = [
+    { include-group = "bindings" },
+    "myst-parser",
+    "sphinx",
+    "sphinx_rtd_theme",
+]
 dev = [
     { include-group = "test" },
     { include-group = "lint" },

--- a/tests/build_system_test.py
+++ b/tests/build_system_test.py
@@ -88,3 +88,43 @@ def test_the_backend_is_the_declarative_one() -> None:
     assert match, "[build-system] declares no build-backend"
 
     assert match.group(1) == "setuptools.build_meta"
+
+
+# the same requirement declared twice on purpose, and the two spellings:
+# `[project.optional-dependencies]` is what a consumer of the wheel asks
+# for, `[dependency-groups]` what this repository resolves for itself.
+# uv has no default extra, so a group is what keeps `uv sync` and every
+# `--group` command of CONTRIBUTING.md on the delegated configuration
+_EXTRA = re.compile(r"^secp256k1 = \[(.*?)^\]", re.MULTILINE | re.DOTALL)
+_GROUP = re.compile(r"^bindings = \[(.*?)\]", re.MULTILINE | re.DOTALL)
+
+
+def _bindings_requirements() -> tuple[list[str], list[str]]:
+    """Return the bindings requirement, as the extra and as the group."""
+    text = _PYPROJECT.read_text(encoding="utf-8")
+    extra = _EXTRA.search(text)
+    group = _GROUP.search(text)
+    assert extra is not None, "no secp256k1 extra in pyproject.toml"
+    assert group is not None, "no bindings dependency group in pyproject.toml"
+    return _QUOTED.findall(extra.group(1)), _QUOTED.findall(group.group(1))
+
+
+def test_the_bindings_extra_and_group_ask_for_the_same_thing() -> None:
+    """One floor, written twice, and this is what keeps them equal.
+
+    The extra is the published fact -- `pip install btclib[secp256k1]` --
+    and the group is how this repository puts the bindings in its own
+    environment, uv having no way to make an extra the default. Two
+    declarations of one requirement drift, and the direction that drifts
+    silently is the dangerous one: a group left behind resolves the suite
+    against a bindings older than the extra promises, so every comparison
+    the suite makes is made against the wrong authority.
+
+    The requirement itself is not spelled here, for the reason the build
+    system above is not: the floor moves with the features btclib calls,
+    and its reason is written beside it in pyproject.toml.
+    """
+    extra, group = _bindings_requirements()
+    assert extra == group, f"the extra asks {extra}, the group asks {group}"
+    assert len(extra) == 1, f"the extra names more than the bindings: {extra}"
+    assert extra[0].startswith("btclib_secp256k1"), extra[0]

--- a/uv.lock
+++ b/uv.lock
@@ -314,10 +314,17 @@ version = "2026.9"
 source = { editable = "." }
 dependencies = [
     { name = "bitcoin-core-rpc" },
+]
+
+[package.optional-dependencies]
+secp256k1 = [
     { name = "btclib-secp256k1" },
 ]
 
 [package.dev-dependencies]
+bindings = [
+    { name = "btclib-secp256k1" },
+]
 build = [
     { name = "check-manifest" },
     { name = "check-wheel-contents" },
@@ -325,6 +332,7 @@ build = [
     { name = "twine" },
 ]
 dev = [
+    { name = "btclib-secp256k1" },
     { name = "check-manifest" },
     { name = "check-wheel-contents" },
     { name = "cosmic-ray" },
@@ -347,6 +355,7 @@ dev = [
     { name = "twine" },
 ]
 docs = [
+    { name = "btclib-secp256k1" },
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "myst-parser", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -355,6 +364,7 @@ docs = [
     { name = "sphinx-rtd-theme" },
 ]
 lint = [
+    { name = "btclib-secp256k1" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "ruff" },
@@ -363,6 +373,7 @@ mutation = [
     { name = "cosmic-ray" },
 ]
 test = [
+    { name = "btclib-secp256k1" },
     { name = "coverage" },
     { name = "hypothesis" },
     { name = "pytest" },
@@ -374,10 +385,12 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "bitcoin-core-rpc", specifier = ">=2026.8.13" },
-    { name = "btclib-secp256k1", git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main" },
+    { name = "btclib-secp256k1", marker = "extra == 'secp256k1'", git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main" },
 ]
+provides-extras = ["secp256k1"]
 
 [package.metadata.requires-dev]
+bindings = [{ name = "btclib-secp256k1", git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main" }]
 build = [
     { name = "check-manifest" },
     { name = "check-wheel-contents" },
@@ -385,6 +398,7 @@ build = [
     { name = "twine" },
 ]
 dev = [
+    { name = "btclib-secp256k1", git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main" },
     { name = "check-manifest" },
     { name = "check-wheel-contents" },
     { name = "cosmic-ray" },
@@ -404,17 +418,20 @@ dev = [
     { name = "twine" },
 ]
 docs = [
+    { name = "btclib-secp256k1", git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main" },
     { name = "myst-parser" },
     { name = "sphinx" },
     { name = "sphinx-rtd-theme" },
 ]
 lint = [
+    { name = "btclib-secp256k1", git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "ruff" },
 ]
 mutation = [{ name = "cosmic-ray" }]
 test = [
+    { name = "btclib-secp256k1", git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main" },
     { name = "coverage" },
     { name = "hypothesis" },
     { name = "pytest" },


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/990 — step 4 of
https://github.com/btclib-org/btclib/issues/966.

**Stacked on https://github.com/btclib-org/btclib/pull/996** (base
`public-switch`), itself on 995 and 994. Retargets as they land.

## What changes for a consumer

`pip install btclib` no longer installs `btclib_secp256k1`.
`pip install "btclib[secp256k1]"` does, and that is what README.md, the
guide and CONTRIBUTING.md now tell a reader to run.

**This is the part worth your judgement.** Nothing raises without the
extra — btclib answers on the Python arithmetic — so an existing user who
upgrades and forgets it gets a silent change of implementation: tens of
times slower and not constant-time, both already published in
`SECURITY.md`. HISTORY.md carries it as a breaking change and names
`is_libsecp256k1_serving()` as the way to ask. If you would rather keep
the bindings in `dependencies` and reach the goal of
https://github.com/btclib-org/btclib/issues/966 through the guarded
import alone (already landed in
https://github.com/btclib-org/btclib/pull/995), say so — that is a
one-line revert of the pyproject move, and the rest of this PR stands.

## uv has no default extra

`[tool.uv]` takes `default-groups` and nothing that would make an extra
one; `default-extras` is not a key it knows (checked against uv 0.12.4,
which lists its valid keys when it refuses). An extra alone would
therefore leave `uv sync` and every `--group` command of CONTRIBUTING.md
resolving a btclib *without* the bindings — half a suite, since the tests
that matter most here compare the two implementations against each other.

So the same requirement is also a `bindings` dependency group, included
by `test`, `lint` and `docs`. No documented command grew an `--extra`,
and the job of https://github.com/btclib-org/btclib/issues/991 becomes
those same commands with one group left out. The requirement is written
twice for that, and `tests/build_system_test.py` fails the day the two
stop agreeing.

## The `dist` job had to name the extra on both sides

Otherwise it stops asking its own question. The bindings are
`Requires-Dist … ; extra == "secp256k1"` now, so a wheel installed
without the extra declares nothing to resolve; and `uv export` without
`--extra secp256k1` leaves the direct reference out of the constraints —
**0.8.0.3 is not on PyPI** (latest published is 0.8.0.2), so that
reference is where the version comes from, not the index.

Verified by hand, not by reasoning: built the wheel, installed
`wheel[secp256k1]` with and without the exported constraints, and read
`Provides-Extra`/`Requires-Dist` out of the built METADATA.

## Gates

- `uv run pytest` — 27914 passed, 6 skipped, coverage 100.00%, exit 0
- `uv run pre-commit run --all-files` — exit 0 (actionlint and zizmor
  included, both workflows touched)
- `sphinx-build -W --keep-going` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make libsecp256k1 bindings an install-time extra and matching dependency group while keeping tests and release checks aligned with that configuration.

New Features:
- Introduce a `secp256k1` optional dependency extra that pulls in `btclib_secp256k1` for consumers who request it.

Enhancements:
- Add a `bindings` dependency group mirroring the `secp256k1` extra and include it in `test`, `lint`, and `docs` groups so local and CI environments use the bindings by default.
- Update build-system tests to assert the bindings extra and dependency group stay in sync and continue to point at the same bindings requirement.
- Clarify documentation and changelog to describe the new extra-based installation model and its performance and security implications.

CI:
- Adjust release and test workflows to install the wheel with the `secp256k1` extra and to export constraints including that extra so metadata-driven checks still validate the bindings resolution.

Tests:
- Extend build system tests to verify that the bindings requirement is identically specified in both the optional dependencies and the dependency groups.