### PR TITLE
Write down what says the Python arm is right, other than the bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1507,6 +1507,32 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **The Python arm's inventory of authorities that are not the bindings**
+  (issue #993). The suite validates the Python arithmetic *against*
+  libsecp256k1, which is right for btclib and is exactly the circle a
+  test framework built on btclib cannot stand in (issue #198). So
+  `tests/python_arm_authority_test.py` records, per arm, which vectors of
+  somebody else's making reach it — a BIP's, Bitcoin Core's, Project
+  Wycheproof's, an RFC's — and fails when an arm is added without an
+  entry, the arms being counted from the source rather than listed.
+
+  The entries were measured and not reasoned: each candidate module run
+  on its own, with no bindings installed, reading back which lines of
+  each arm ran. Thirty-three of the thirty-five arms are reached that
+  way. The two that are not are named, with what would close them:
+  `ecc.commit_nonce.commit_nonce_`, whose sign-to-contract tweak has no
+  published vector set to vendor, and `ecc.dsa.recover_pub_keys_`, the
+  plural spelling, which nothing third-party asks for — a message
+  signature names its own key_id.
+
+  The attribution is per module and the file says so: a module built on
+  third-party vectors may hold tests btclib wrote as well, and
+  sharpening the claim means selecting the vector-driven tests inside a
+  module, which no marker in the tree expresses today. It says the other
+  limit too — nothing re-runs the measurement, so the table's *shape* is
+  gated and its *content* is not, and a module that stops reaching an arm
+  leaves the entry standing.
+
 - **CI runs the suite with no bindings installed** (issue #991, step 5 of
   issue #966, and the step the other four were only claims without). A
   `no-bindings` job installs the `harness` dependency group — the suite's

--- a/tests/python_arm_authority_test.py
+++ b/tests/python_arm_authority_test.py
@@ -1,0 +1,274 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""What says the Python arm is right, other than the bindings.
+
+The suite validates btclib's Python arithmetic *against* libsecp256k1,
+and `tests/bip32/bip32_test.py` says so in as many words: "The bindings
+are the authority on the answer here as everywhere else the library keeps
+a Python path". For btclib that is the property worth checking -- the
+bindings are the reference implementation, and agreeing with them is what
+a second implementation owes.
+
+Issue #198 needs the other property. A test framework built on btclib
+runs the Python arm precisely so that Bitcoin Core's use of libsecp256k1
+is not checked with libsecp256k1; if the only thing that ever says the
+Python arm is right is a comparison with libsecp256k1, the circle is
+closed one level up rather than broken. So this file is the inventory
+issue #993 asks for: per arm, which vectors of somebody else's making
+reach it.
+
+Two things make the inventory possible to keep true rather than to
+believe. The arms are counted from the source -- a function containing a
+call to `_libsecp256k1_serves` is an arm, which is the same definition
+issue #968 made by hand -- so one added without an entry here fails.
+And the entries were measured, not reasoned:
+
+    uv sync --no-default-groups --group harness
+    pytest <one module> --cov=btclib --cov-report=json --cov-fail-under=0
+
+in an environment with no bindings installed, reading back which lines of
+each arm ran. A module is named here when its run reached the arm's body,
+the `def` line excluded -- that line runs at import and would report
+every arm of every imported module as reached.
+
+**Nothing here re-runs the measurement.** Three of the four tests below
+check the table's shape -- its keys against the parser, its empty entries
+against the named set, its cited modules against the vector table -- and
+none checks its content. If `ecc/wycheproof_test.py` stops reaching
+`ecc.dsa.assert_as_valid_`, the arm keeps its entry, the entry keeps its
+module, the module keeps naming its vectors, and the claim quietly
+becomes false. That is the one thing in this file that can rot without a
+red suite, and it is the file's whole content; a job that re-derives the
+table is what would close it.
+
+**The attribution is per module, and a module may also hold tests btclib
+wrote.** `tests/curves/curve_test.py` is the clearest case: it reads
+Core's `pubkey.json` and carries a great deal else. So an entry says "a
+module built on third-party vectors reaches this arm", which is weaker
+than "this vector reaches this arm" and is what the measurement supports.
+Sharpening it means selecting the vector-driven tests within a module,
+which no marker in the tree expresses today.
+
+Two arms are reached by no such module at all, and they are the answer to
+the second half of issue #993 -- where nothing says it, what would:
+
+- `ecc.commit_nonce.commit_nonce_`, the sign-to-contract nonce tweak.
+  There is no published vector set to vendor: the primitive is
+  libsecp256k1-zkp's `s2c` module, whose vectors are C, and no BIP states
+  it. Closing this means either vendoring what that module tests itself
+  against, or a comparison against a second Python implementation.
+- `ecc.dsa.recover_pub_keys_`, the plural spelling. `signmessage.json`
+  reaches the singular `recover_pub_key_` through `ecc.bms`, and nothing
+  third-party asks for every key_id of one signature at once -- a message
+  signature names its own. Vectors would have to be built rather than
+  vendored, which is a decision about whether the plural spelling wants
+  an authority of its own or is the singular one enumerated.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_LIBRARY = Path(__file__).parents[1] / "btclib"
+_TESTS = Path(__file__).parent
+
+# the vendored vectors each module below is built on, by the name they
+# carry in `tests/_data` or a `_data` beside the module. What makes a
+# source third-party is who wrote it: a BIP, Bitcoin Core, Project
+# Wycheproof, an RFC -- and not btclib, which is why `vectors.json` and
+# `btclib_test_vectors.json` appear nowhere here
+_THIRD_PARTY_VECTORS: dict[str, tuple[str, ...]] = {
+    "bip322_test.py": ("basic-test-vectors.json", "generated-test-vectors.json"),
+    "bip32/bip32_test.py": ("bip32_test_vectors.json", "bip32_invalid_keys.json"),
+    "curves/curve_test.py": ("pubkey.json",),
+    "curves/sec_point_test.py": ("script_tests.json",),
+    "ecc/bms_test.py": ("signmessage.json",),
+    "ecc/dleq_test.py": (
+        "test_vectors_generate_proof.csv",
+        "test_vectors_verify_proof.csv",
+    ),
+    "ecc/ellswift_test.py": (
+        "ellswift_decode_test_vectors.csv",
+        "xswiftec_inv_test_vectors.csv",
+    ),
+    "ecc/musig2_test.py": (
+        "key_agg_vectors.json",
+        "nonce_gen_vectors.json",
+        "sig_agg_vectors.json",
+        "sign_verify_vectors.json",
+    ),
+    "ecc/rfc6979_test.py": ("rfc6979.json",),
+    "ecc/ssa_test.py": ("bip340_test_vectors.csv",),
+    "ecc/wycheproof_test.py": (
+        "ecdh_secp256k1_test.json",
+        "ecdsa_secp256k1_sha256_bitcoin_test.json",
+        "ecdsa_secp256k1_sha256_test.json",
+    ),
+    "key_io_test.py": ("key_io_valid.json", "key_io_invalid.json"),
+    "script/sig_hash_legacy_test.py": ("sig_hash_legacy_test_vectors.json",),
+    "script/sig_hash_taproot_test.py": ("taproot_test_vector.json",),
+    "script/taproot_test.py": ("script_assets_test.json",),
+    "script_engine/script_test.py": ("script_tests.json",),
+    "script_engine/transactions_test.py": ("tx_valid.json", "tx_invalid.json"),
+    "silent_payments_test.py": ("send_and_receive_test_vectors.json",),
+}
+
+# arm -> the modules of `_THIRD_PARTY_VECTORS` whose run reaches it. An
+# empty tuple is an arm no third-party vector reaches, and the module
+# docstring says what would
+_AUTHORITY: dict[str, tuple[str, ...]] = {
+    "bip32.bip32.__prv_key_derivation": ("ecc/bms_test.py", "bip32/bip32_test.py"),
+    "bip32.bip32._pub_key_tweak_chain": ("bip32/bip32_test.py",),
+    "curves.curve.__init__": ("silent_payments_test.py", "curves/curve_test.py"),
+    "curves.curve._jac_double_mult": ("ecc/wycheproof_test.py", "ecc/ssa_test.py"),
+    "curves.curve._mult_checked": ("ecc/wycheproof_test.py", "ecc/ssa_test.py"),
+    "curves.curve._multi_mult_x_only_var": ("ecc/ssa_test.py",),
+    "curves.curve._sum_var": ("ecc/musig2_test.py", "silent_payments_test.py"),
+    "curves.curve._tweak_add_var": ("ecc/musig2_test.py", "silent_payments_test.py"),
+    "curves.curve._x_octets": ("ecc/wycheproof_test.py", "ecc/ssa_test.py"),
+    "curves.curve.double_mult_var": ("ecc/ssa_test.py", "ecc/dleq_test.py"),
+    "curves.curve.multi_mult_var": ("ecc/ssa_test.py", "ecc/musig2_test.py"),
+    "curves.sec_point._mult_sec_var": ("silent_payments_test.py",),
+    "curves.sec_point._sec_from_octets": (
+        "ecc/bms_test.py",
+        "script_engine/script_test.py",
+    ),
+    "curves.sec_point.bytes_from_prv_key_int": (
+        "bip32/bip32_test.py",
+        "ecc/musig2_test.py",
+    ),
+    "ecc.bms.assert_as_valid": ("ecc/bms_test.py", "bip322_test.py"),
+    "ecc.commit_nonce.commit_nonce_": (),
+    "ecc.dh.diffie_hellman": ("ecc/wycheproof_test.py",),
+    "ecc.dsa.assert_as_valid_": (
+        "ecc/wycheproof_test.py",
+        "script_engine/transactions_test.py",
+    ),
+    "ecc.dsa.recover_pub_key_": ("ecc/bms_test.py", "bip322_test.py"),
+    "ecc.dsa.recover_pub_keys_": (),
+    "ecc.dsa.sign_": ("ecc/rfc6979_test.py", "script_engine/script_test.py"),
+    "ecc.dsa.sign_recoverable_": ("ecc/bms_test.py", "bip322_test.py"),
+    "ecc.ellswift.create_var": ("ecc/ellswift_test.py",),
+    "ecc.ellswift.decode_var": ("ecc/ellswift_test.py",),
+    "ecc.ellswift.encode_var": ("ecc/ellswift_test.py",),
+    "ecc.ellswift.xdh": ("ecc/ellswift_test.py",),
+    "ecc.ssa.__init__": ("ecc/ssa_test.py",),
+    "ecc.ssa.assert_as_valid_": ("ecc/ssa_test.py", "script/sig_hash_taproot_test.py"),
+    "ecc.ssa.sign_": ("ecc/ssa_test.py", "script/sig_hash_taproot_test.py"),
+    "script.engine.script.dsa_verify": (
+        "script_engine/script_test.py",
+        "script_engine/transactions_test.py",
+    ),
+    "script.engine.tapscript.ssa_verify": (
+        "script/sig_hash_taproot_test.py",
+        "script_engine/transactions_test.py",
+    ),
+    "script.taproot._output_pubkey_and_internal_key": ("script/taproot_test.py",),
+    "script.taproot._tweaked_prvkey": ("script/taproot_test.py",),
+    "script.taproot._tweaked_pubkey": ("script/taproot_test.py",),
+    "script.taproot.check_output_pubkey": (
+        "script/taproot_test.py",
+        "script_engine/transactions_test.py",
+    ),
+}
+
+# the two the measurement found nothing for, named so that closing one is
+# a line deleted here rather than a number nobody re-derives
+_WITHOUT_AN_AUTHORITY = frozenset(
+    {"ecc.commit_nonce.commit_nonce_", "ecc.dsa.recover_pub_keys_"}
+)
+
+
+def _python_arms() -> set[str]:
+    """Return every function of btclib that holds a dispatch to the bindings.
+
+    The definition issue #968 used, applied by the parser rather than by
+    hand: a function whose source calls `_libsecp256k1_serves` has two
+    arms, and the one this file is about is the arm that call declines.
+    `_libsecp256k1_serves` itself is the predicate and not an arm.
+
+    Three things about how it counts, each of which errs loudly rather
+    than quietly, which is the direction this file needs:
+
+    - the match is textual, over the function's own source. A comment or
+      a docstring writing the call spelling invents an arm, and a nested
+      function is attributed to its enclosing function as well as to
+      itself. Neither can hide a real arm. `curve.py` names
+      `_libsecp256k1_serves` in three comments today and none of them has
+      a parenthesis after it, which is what keeps this quiet.
+    - `AsyncFunctionDef` is walked as well as `FunctionDef`. The tree has
+      no async in it; one holding a dispatch would otherwise be invisible
+      rather than reported, and invisible is the direction that costs.
+    - the key is `module.funcname`, so two same-named methods of two
+      classes in one module would collide into one entry and leave one
+      arm unexamined. `curves.curve.__init__` and `ecc.ssa.__init__` are
+      already that shape, in two modules; a third in either would be the
+      case to watch.
+    """
+    found: set[str] = set()
+    for path in sorted(_LIBRARY.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        module = ".".join(path.relative_to(_LIBRARY).with_suffix("").parts)
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if node.name == "_libsecp256k1_serves":
+                continue
+            segment = ast.get_source_segment(source, node) or ""
+            if "_libsecp256k1_serves(" in segment:
+                found.add(f"{module}.{node.name}")
+    return found
+
+
+def test_every_python_arm_is_in_the_inventory() -> None:
+    """An arm added without an entry fails here, which is the point.
+
+    The inventory is worth nothing if it can go quietly out of date: a
+    dispatch added tomorrow would have an unexamined Python arm, and the
+    claim this file makes -- that every arm has an authority other than
+    the bindings, or is one of the two that do not -- would be about the
+    tree of the day it was written.
+    """
+    listed = set(_AUTHORITY)
+    found = _python_arms()
+    assert listed == found, (
+        f"not in the inventory: {sorted(found - listed)};"
+        f" gone from the library: {sorted(listed - found)}"
+    )
+
+
+def test_the_arms_without_an_authority_are_the_two_that_are_known() -> None:
+    """Empty entries and the named set are one fact, stated twice."""
+    empty = {arm for arm, sources in _AUTHORITY.items() if not sources}
+    assert empty == _WITHOUT_AN_AUTHORITY, (
+        f"newly without an authority: {sorted(empty - _WITHOUT_AN_AUTHORITY)};"
+        f" no longer without one: {sorted(_WITHOUT_AN_AUTHORITY - empty)}"
+    )
+
+
+def test_every_named_module_is_in_the_tree_and_reads_its_vectors() -> None:
+    """A module named here exists, and the vectors it is named for do too.
+
+    Both halves, because either one going stale makes the inventory a
+    claim about files rather than about tests: a module renamed leaves an
+    entry pointing at nothing, and a vector file dropped leaves a module
+    named as third-party that no longer is.
+    """
+    for module, vectors in _THIRD_PARTY_VECTORS.items():
+        path = _TESTS / module
+        assert path.is_file(), f"{module} is named in the inventory and is not here"
+        source = path.read_text(encoding="utf-8")
+        for vector in vectors:
+            assert vector in source, f"{module} no longer names {vector}"
+
+
+def test_every_authority_names_a_module_of_the_table() -> None:
+    """No entry may cite a module whose vectors are not written down."""
+    for arm, sources in _AUTHORITY.items():
+        for module in sources:
+            assert module in _THIRD_PARTY_VECTORS, (
+                f"{arm} cites {module}, which no line of _THIRD_PARTY_VECTORS covers"
+            )


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/993.

**Stacked on https://github.com/btclib-org/btclib/pull/999** (base
`ci-no-bindings`). It is the last of the six, and the only one whose
content is independent of the chain — it sits on the tip because the
census it makes has to describe the tree it lands in, and
https://github.com/btclib-org/btclib/pull/994 adds two arms.

## What it is

`tests/python_arm_authority_test.py`: per Python arm, the modules built
on **somebody else's** vectors — a BIP's, Bitcoin Core's, Project
Wycheproof's, an RFC's — that reach it.

The arms are counted from the source (a function calling
`_libsecp256k1_serves` is one — the definition
https://github.com/btclib-org/btclib/issues/968 applied by hand), so an
arm added without an entry **fails** rather than passing unexamined.

## Measured, not reasoned

Each candidate module run on its own, in an environment with no bindings
installed, reading back which lines of each arm ran:

```shell
uv sync --no-default-groups --group harness
pytest <one module> --cov=btclib --cov-report=json --cov-fail-under=0
```

The `def` line is excluded: it runs at import, and the first version of
the measurement reported **every** arm of every imported module as
reached because of it. That mistake is worth naming — it is the shape
where a measurement looks like a strong result and is an artefact.

**33 of the 35 arms are reached.**

## The two that are not

Named in the file, with what would close them:

- `ecc.commit_nonce.commit_nonce_` — the sign-to-contract nonce tweak.
  No published vector set to vendor: the primitive is libsecp256k1-zkp's
  `s2c` module, whose vectors are C, and no BIP states it.
- `ecc.dsa.recover_pub_keys_` — the plural spelling. `signmessage.json`
  reaches the singular `recover_pub_key_` through `ecc.bms`; nothing
  third-party asks for every key_id of one signature at once, a message
  signature naming its own. Vectors would have to be built rather than
  vendored — which is really a question about whether the plural
  spelling wants an authority of its own.

## What the file does not claim

The attribution is **per module**, and a module built on third-party
vectors may hold tests btclib wrote as well —
`tests/curves/curve_test.py` most of all. The docstring says so.
Sharpening it to "this vector reaches this arm" means selecting the
vector-driven tests inside a module, which no marker in the tree
expresses today. If you want that, it is a marker and a second pass, not
a change to this table.

## Gates

- `uv run pytest` — 27918 passed, 6 skipped, coverage 100.00%, exit 0
- the same suite with no bindings installed — 27329 passed, 595 skipped
- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Record which external test vectors independently exercise each Python implementation arm and guard the inventory against structural drift.

New Features:
- Add an inventory of external vector authorities covering the Python implementation’s binding-dispatch arms.
- Identify the two Python arms that currently lack coverage from third-party vectors and document how they could be addressed.

Enhancements:
- Automatically derive the set of Python arms from source and validate that the inventory remains structurally aligned with the codebase.
- Document the inventory’s measurement scope and limitations, including its per-module attribution and lack of runtime remeasurement.

Documentation:
- Document the external authority census and its 33-of-35 arm coverage in the changelog.

Tests:
- Add consistency checks for Python arm enumeration, uncovered-arm tracking, referenced test modules, and third-party vector metadata.