### PR TITLE
Let the caller decline the check, and hand it the key it already has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1724,18 +1724,65 @@ documented at release-notes length in the first place, and are still in
   The attempts do not need checking: a faulted one that is discarded cost
   an attempt. The one the loop settles on does, and Core's `CKey::Sign`,
   the bindings' own `dsa._sign_` and issue #982 all describe the same order
-  — grind first, check the survivor. So the attempts pass `verify=False`
-  and the signature that comes back is verified once, with
-  `libsecp256k1_dsa.verify` under the key derived from `q`. That costs
-  20.25 microseconds against the 19.56 the bindings' own default costs per
-  call; the 0.7 between them is the serialization and the parse a caller of
-  the public halves pays and their private ones do not. The *uncompressed*
-  sec is passed for the same kind of reason: parsing `02 || x` is a field
-  square root, and the compressed one would cost 22.20. Alternated in one
-  process, 15 rounds of 3000 calls, minimum kept, noise 0.05 — an Apple M5,
-  macOS 26.6, arm64, CPython 3.14.6. The raise carries `# pragma: no cover`
-  and `dleq.sign`'s reasoning: no input reaches it, and what it reports is
-  the computation having gone wrong.
+  — grind first, check the survivor. The arrangement that answered this
+  first, and shipped in no release, was a loop of `verify=False` attempts
+  with one `libsecp256k1_dsa.verify` after it under a key derived here;
+  the bullet below replaces it, the whole of it now being one call. The
+  raise carries `# pragma: no cover` and `dleq.sign`'s reasoning: no input
+  reaches it, and what it reports is the computation having gone wrong.
+- **The caller can decline the check, and hand it the key it already
+  has** (issue #982). `dsa.sign` and `dsa.sign_` take a keyword-only
+  `verify`, defaulting to True because `CKey::Sign` offers no way out and
+  what the check catches is a computation that went wrong — and a
+  keyword-only `pub_key`, the key it verifies under, so that a caller
+  already holding it does not pay for deriving one per signature. That
+  derivation is most of what ECDSA's check costs over BIP340's, and it is
+  why `ssa`'s own `sign_` has no such argument: there the keypair holds
+  the point already, so the argument would buy nothing and sell one thing,
+  a second reason a check can fail.
+
+  The key is taken on trust and never checked against the private key,
+  because checking it would cost the multiplication it exists to avoid.
+  So a failed check now says which of two things failed:
+  `BTClibValueError` where the signature verifies under the private key's
+  own public key and not under the one given, `BTClibRuntimeError` where
+  it verifies under neither, which is the fault this check has always
+  been for. The failing branch pays the derivation the common one saved.
+  A key beside `verify=False` is refused rather than ignored, and a key
+  that is no point is refused before anything is signed, both arms saying
+  `not a public key`.
+
+  What the trust cannot do is let a bad signature through: the keys a
+  signature verifies under are a property of that signature, which
+  `recover_pub_keys_` walks, so a key fixed before the signature exists
+  is not one of them. The trust can cost a wrong diagnosis, never a wrong
+  success, and that is a test over keys rather than a paragraph.
+- **The delegated arm grinds where it signs**, so Core's low-R counter
+  stops being written twice on the one path that has a library
+  implementing it. `grind` crosses with `verify` and `pub_key`, and
+  libsecp256k1 grinds, keeps the low-r survivor and checks that one
+  inside a single call — `_grind_low_r` is no longer reached there, and
+  neither is a verification of btclib's own. `_grind_low_r` stays the
+  implementation everywhere the delegated arm cannot be taken: a caller's
+  nonce, a commitment, another curve, or no bindings at all.
+  `test_the_delegated_grind_is_the_sequence_the_python_arm_walks` is what
+  lets the sequence live in two places, holding the two to the same
+  signature — not merely to the low-r property, two different low-r
+  signatures of one message being the bug it is for.
+- **What that costs, measured.** The check is 19.54 microseconds with the
+  key derived, 15.99 with a compressed key handed in and 13.75 with an
+  uncompressed one, against a signature of 13.52 — the longer encoding
+  being the cheaper argument because parsing `02 || x` is a field square
+  root. Alternated in one process, 9 rounds of 3000 calls, minimum kept,
+  the unchecked row run again at the end for a noise of 0.04 — an Apple
+  M5, macOS 26.6, arm64, CPython 3.14.6.
+
+  Delegating the grind is worth under a microsecond at the draw counts a
+  signature takes: 0.46 at one draw and 1.61 at five, which is the figure
+  and not the argument. A run of its own, since it has to hold the draw
+  count fixed to say anything — a loop of crossings with a check after it
+  against one call that does both, 9 rounds of 500 calls, minimum kept,
+  noise 0.04, the same machine.
 - **`recovery.sign` is passed `verify=True` rather than left to the
   default.** Its check is not a verification — the bindings recover the key
   and refuse one that is not the signer's, which reads the recovery id, and

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -395,6 +395,36 @@ full year, short month, short day (YYYY-M-D)
   where it read `non-minimal encoding of zero`, the general check now
   answering for it too.
 
+### Worth knowing, though nothing raises
+
+- **Signing on the Python arm now checks the signature before answering
+  with it**, where it did not check at all. Bitcoin Core's `CKey::Sign`
+  does the same and the delegated arm always did, so this is the fallback
+  ceasing to answer differently from the arm it stands in for — a
+  signature that does not verify is a computation that went wrong, and
+  the protection is not publishing one.
+
+  Nothing raises that did not raise before and no signature changes: the
+  same key and message give the same octets. What moves is the time, and
+  it moves a long way. On an installation without the bindings a call
+  that took 165.09 microseconds takes 907.87 — five and a half times what
+  it was — the check adding 742.78, which is about four and a half
+  signatures. One session, 5 rounds of 300 calls, minimum kept, noise
+  0.24, an Apple M5, macOS 26.6, arm64, CPython 3.14.6.
+
+  What to act on, and only if that shows: `dsa.sign(..., verify=False)`
+  declines the check and gives the old time back, and
+  `dsa.sign(..., pub_key=...)` hands in the key the check would otherwise
+  derive, which brings the call to 754.17 — the check down to 589.08.
+
+  Neither is needed on an installation with the bindings, where the call
+  is 33.06 against 13.52 unchecked: the check adds 19.54 there, and
+  handing the key in takes that to 13.75. Same process as the figures
+  above and not the same run — a signature there being a twelfth of one
+  here, those rows are 9 rounds of 3000 calls, noise 0.04.
+  `btclib.curves.is_libsecp256k1_serving()` is what says which arm is
+  answering.
+
 ### The bindings are now `btclib_secp256k1`
 
 - **The secp256k1 bindings were renamed, and btclib requires the new

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -38,11 +38,10 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from hashlib import sha256
 from io import BytesIO
-from typing import overload
+from typing import TypeVar, overload
 
 from btclib import var_bytes
 from btclib._libsecp256k1 import dsa as libsecp256k1_dsa
-from btclib._libsecp256k1 import keys as libsecp256k1_keys
 from btclib._libsecp256k1 import recovery as libsecp256k1_recovery
 from btclib.alias import BinaryData, HashF, JacPoint, Octets, Point
 from btclib.curves import Curve, PreparedPoint, mult, secp256k1
@@ -548,6 +547,15 @@ def _grind_low_r(attempt: Callable[[int], Sig], grind: bool, ec: Curve) -> Sig:
     `extra_entropy[32]` for every counter it reaches, electrum-ecc's
     `counter.to_bytes(32, "little")` and embit's the same.
 
+    The implementation that matters to this file, though, is
+    libsecp256k1's own `grind`: `sign_`'s delegated arm asks for it and
+    the signature it answers with *is* its output, so this loop is what
+    btclib walks where that arm cannot be taken -- a nonce of the
+    caller's, a commitment, a curve of its own, or no bindings at all.
+    The two are held to the same signature by
+    `test_the_delegated_grind_is_the_sequence_the_python_arm_walks`, and
+    that test is why the sequence may be written twice at all.
+
     No attempt cap. Core has none, and one would answer an event of
     probability 2**-k with an error a caller can do nothing about; embit
     breaks its loop at 200, which is a 2**-200 signature that is not low-R
@@ -564,6 +572,200 @@ def _grind_low_r(attempt: Callable[[int], Sig], grind: bool, ec: Curve) -> Sig:
     return sig
 
 
+def _python_key(key: PubKey, ec: Curve) -> tuple[Point, frozenset[JacPoint]]:
+    # the parse the check needs, and the one that refuses a key that is
+    # no point. Its own function because *when* it runs is the point of
+    # it: called before anything is signed, a mistyped argument is a
+    # mistyped argument, where called inside the check it would arrive as
+    # a failed verification of a signature the caller is now holding --
+    # and with grinding, after the whole loop has run. It costs nothing
+    # to hoist, the check paying this parse either way
+    Q = point_from_pub_key(key, ec)
+    # the key's own memoized tables where the caller prepared the point,
+    # which is the shape a signer checking under a key it already holds
+    # is in -- see curves.PreparedPoint
+    fixed = key.fixed if isinstance(key, PreparedPoint) else ec._fixed_points
+    return Q, fixed
+
+
+def _python_verified(
+    c: int, sig: Sig, ec: Curve, key: tuple[Point, frozenset[JacPoint]]
+) -> bool:
+    # the boolean `_abort_unless_checked` asks for, on the arm where the
+    # verification is this package's own arithmetic. lower_s=False for
+    # `assert_as_valid_`'s reason: which of the two s values a signature
+    # carries was settled by whoever signed it, and here that was the
+    # call above -- asking again would be this function refusing what
+    # `lower_s=False` was explicitly allowed to produce
+    Q, fixed = key
+    try:
+        _assert_as_valid_(c, (Q[0], Q[1], 1), sig.r, sig.s, ec, fixed, lower_s=False)
+    except (ValueError, BTClibRuntimeError):
+        return False
+    return True
+
+
+# what a public key is here differs by arm -- SEC octets where the
+# bindings verify, the point and its tables where the Python arithmetic
+# does -- and `_abort_unless_checked` never looks inside one: it hands
+# whatever it is to `verified`. The variable says that, where `PubKey`
+# would have claimed the two arms agree on a representation they do not
+_Key = TypeVar("_Key")
+
+
+def _abort_unless_checked(
+    verified: Callable[[_Key], bool],
+    derive: Callable[[], _Key],
+    given: _Key | None,
+) -> None:
+    """Refuse a signature that does not verify, and say which way it failed.
+
+    The rule, not the only place it is obeyed. The delegated arm never
+    reaches this function -- libsecp256k1 grinds, checks and
+    discriminates inside one call, `dsa._checked` there being this rule
+    written in the package that holds the parsed objects. What is shared
+    is therefore the contract and not the code: a bare verification under
+    the signer's own public key, a supplied key taken on trust, and the
+    two causes of a failure told apart rather than guessed at. This is
+    the Python arm's copy of it, and
+    `test_the_two_arms_answer_the_same_refusals` is what holds the two to
+    the same exception and the same words.
+
+    A key the caller supplied is taken on trust and never checked against
+    the private key on the way in, because checking it would cost the
+    very multiplication supplying it exists to avoid. What that leaves is
+    an ambiguity, since a key that is not this private key's fails
+    verification exactly as a faulted computation does -- so the failing
+    branch, and only the failing branch, derives the key and asks again.
+    It is the rare one by construction, so the derivation costs nothing
+    in practice, and telling a caller their hardware is wrong because
+    they mistyped an argument is worse than the microseconds are worth.
+
+    What the trust cannot do is let a bad signature through. The keys a
+    signature verifies under are a property of that signature --
+    ``recover_pub_keys_`` walks them -- so a key fixed before the
+    signature exists is not one of them, and the trust can cost a wrong
+    diagnosis but never a wrong success.
+
+    Args:
+        verified: whether the signature verifies under a public key.
+        derive: the signer's own public key, computed only where it is
+            needed, which is where nothing was supplied or a supplied
+            key failed.
+        given: the public key the caller supplied, or None.
+
+    Raises:
+        BTClibValueError: if the signature verifies under the private
+            key's own public key and not under the one given.
+        BTClibRuntimeError: if it verifies under neither, which is the
+            fault this check has always been for.
+    """
+    if given is not None:
+        if verified(given):
+            return
+        # the two reasons a supplied key can fail are told apart here
+        # rather than guessed at. This branch also sees what the derived
+        # one cannot: a private key corrupted before it was signed with
+        # agrees with a public key derived from the same corrupt octets,
+        # and disagrees with one that came from anywhere else
+        if verified(derive()):
+            raise BTClibValueError("the public key given is not this private key's")
+        raise BTClibRuntimeError("signing produced a signature that does not verify")
+
+    if not verified(derive()):
+        raise BTClibRuntimeError("signing produced a signature that does not verify")
+
+
+def _libsecp256k1_sign_(
+    msg_hash: bytes,
+    q: int,
+    grind: bool,
+    ec: Curve,
+    *,
+    verify: bool,
+    pub_key: PubKey | None,
+) -> Sig:
+    # Private function: the caller has asked `_libsecp256k1_serves` and
+    # settled the four things this arm cannot answer -- no nonce of its
+    # own, no commitment, and lower_s.
+    #
+    # One call, and that is the whole point of it. Grinding is Core's
+    # `CKey::Sign` counter and libsecp256k1's own `grind` walks the same
+    # sequence, so a loop here would be btclib re-deriving what the
+    # bindings already do -- and would pay a crossing per attempt. What
+    # that is worth is under a microsecond at the draw counts a signature
+    # actually takes, which is small and is the figure rather than the
+    # argument: the argument is that Core's counter stopped being written
+    # twice on the one arm that has a library implementing it.
+    # The two are held to the same signature by
+    # `test_the_delegated_grind_is_the_sequence_the_python_arm_walks`,
+    # which is the defence this delegation rests on: identical on 500 of
+    # 500 keys and messages -- 998 draws taken and 14 in the worst case,
+    # reported in btclib-org/btclib#1005 where that run is -- so a change
+    # of sequence on either side is a red suite and not a signature
+    # nobody can reproduce.
+    #
+    # `verify` and `pub_key` go with it, so the check is the bindings'
+    # too and happens once, on the signature the grind kept rather than
+    # on the attempts it discarded -- `dsa._checked` there being the same
+    # discrimination rule `_abort_unless_checked` is here. That leaves
+    # this arm with no verification of its own to write, which is what
+    # btclib-org/btclib#982 asked for: one crossing, and the rule in one
+    # place.
+    #
+    # check_validity=False, and here the provenance is the argument
+    # (issue 888): what `Sig.parse` would validate is r in 1..n-1, s in
+    # 1..n-1 and r congruent to a valid x-coordinate, of the very values
+    # secp256k1_ecdsa_sign has just computed -- r is the x of the nonce
+    # point reduced mod n and s is a scalar beside it, so neither can be
+    # out of range and an r it produced cannot fail a congruence it was
+    # built from.
+    #
+    # The compact form, r || s, and not the DER `sign` answers by
+    # default: a signature is two scalars, and the DER would be written
+    # by libsecp256k1 and taken apart again here -- 1.25 us to read
+    # against the 0.32 of `_sig_from_compact` (issue 922).
+    #
+    # A key the caller supplied crosses as they hold it, compressed or
+    # not, rather than being brought to the cheaper encoding first: what
+    # makes 02||x dear to parse is the field square root that recovers y,
+    # and that is the same square root re-encoding it would have to do
+    # above the `try`, which holds the foreign call and nothing else: a
+    # `BTClibValueError` this conversion raises -- a tuple that is not on
+    # the curve, an xpub with the wrong prefix -- would otherwise be
+    # caught as a ValueError and re-raised as a new one, btclib
+    # translating its own exception into itself and blaming the library
+    # for it in the `__cause__` chain
+    sec = None if pub_key is None else _sec_from_pub_key(pub_key)
+    try:
+        compact = libsecp256k1_dsa.sign(
+            msg_hash, q, None, compact=True, grind=grind, verify=verify, pubkey=sec
+        )
+    except ValueError as e:
+        # the discrimination is theirs, but the hierarchy has to be
+        # btclib's: a caller catching BTClibValueError should not have to
+        # know which arm answered. Their two ValueErrors are told apart
+        # by asking this package's own question rather than by reading
+        # their wording -- octets that are no point are octets
+        # `point_from_pub_key` cannot parse either, and a key that parses
+        # was simply not this private key's. That is the field square
+        # root declined above, paid only on a branch that has already
+        # failed and is about to raise, which is `_abort_unless_checked`'s
+        # rule one level up. Both arms then say `not a public key`, and
+        # `test_the_two_arms_answer_the_same_refusals` holds them to it
+        if pub_key is not None:
+            try:
+                point_from_pub_key(pub_key, ec)
+            except BTClibValueError:
+                raise BTClibValueError("not a public key") from e
+        raise BTClibValueError(str(e)) from e
+    except RuntimeError as e:  # pragma: no cover
+        # unreachable from an argument, as the Python arm's own is: what
+        # it reports is the computation having gone wrong
+        raise BTClibRuntimeError(str(e)) from e
+    return _sig_from_compact(compact, ec)
+
+
 @overload
 def sign_(
     msg_hash: Octets,
@@ -574,6 +776,8 @@ def sign_(
     hf: HashF = ...,
     *,
     grind: bool = ...,
+    verify: bool = ...,
+    pub_key: PubKey | None = ...,
     commit_hash: None = None,
 ) -> Sig: ...
 
@@ -588,6 +792,8 @@ def sign_(
     hf: HashF = ...,
     *,
     grind: bool = ...,
+    verify: bool = ...,
+    pub_key: PubKey | None = ...,
     commit_hash: Octets,
 ) -> tuple[Sig, Point]: ...
 
@@ -601,6 +807,8 @@ def sign_(
     hf: HashF = sha256,
     *,
     grind: bool = True,
+    verify: bool = True,
+    pub_key: PubKey | None = None,
     commit_hash: Octets | None = None,
 ) -> Sig | tuple[Sig, Point]:
     """Sign a hf_len bytes message according to ECDSA signature algorithm.
@@ -625,6 +833,27 @@ def sign_(
     ec and hf are positional here and a flag inserted before them would
     renumber both.
 
+    verify asks for the signature to be checked before it is answered
+    with, and defaults to True on both implementations: Bitcoin Core's
+    `CKey::Sign` does it without offering a way out, and what it catches
+    is not a bad argument -- those have all raised by then -- but a
+    computation that went wrong, whose cost is a published signature that
+    is invalid and may say something about the key. It is a whole
+    verification, so the flag exists for the caller who has measured that
+    against their own threat model rather than for the one who has not.
+
+    pub_key is the key the check verifies under, for a caller who already
+    holds it: without it the check derives one per signature and throws
+    it away, and that generator multiplication is most of what ECDSA's
+    check costs over BIP340's -- which is why `ssa`'s own `sign_` has no
+    such argument and its absence there is a decision. It is taken on
+    trust and never checked against the private key,
+    `_abort_unless_checked` being where that trust is described and paid
+    for, and it is parsed before anything is signed so that a mistyped
+    argument is not reported as a check on a signature the caller is now
+    holding. Refused beside verify=False, which declines the check it is
+    for.
+
     commit_hash is a value to commit to inside the nonce, sign-to-contract
     style: the signature is an ordinary one, and the receipt returned
     beside it is what opens the commitment (see
@@ -639,6 +868,19 @@ def sign_(
     # both are kinds and neither is read for its truth
     assert_type(lower_s, bool, "lower_s")
     assert_type(grind, bool, "grind")
+    # and not `verify`, which is the line those two are on the other side
+    # of: it turns a check on and changes no answer, so it is read for
+    # whether it is true as `bip39.seed_from_mnemonic`'s verify_checksum
+    # is -- tests/bool_parameter_test.py is where that division is kept
+
+    # the contradiction before anything is signed, and before the key is
+    # parsed: a caller who declined the check and supplied a key to check
+    # with should hear about the two arguments rather than about the
+    # octets of one of them. The bindings refuse the same pair
+    # (btclib-secp256k1#245), and this raises it on both arms so that a
+    # dispatch nobody asked for is not what decides
+    if pub_key is not None and not verify:
+        raise BTClibValueError("pub_key is for the check that verify=False declines")
 
     hf_len = hf().digest_size
     msg_hash = bytes_from_octets(msg_hash, hf_len)
@@ -687,98 +929,54 @@ def sign_(
         and lower_s
         and commit_hash is None
     ):
-        # check_validity=False, and here the provenance is the argument
-        # (issue 888): what `Sig.parse` would validate is r in 1..n-1, s in
-        # 1..n-1 and r congruent to a valid x-coordinate, of the very values
-        # secp256k1_ecdsa_sign has just computed -- r is the x of the nonce
-        # point reduced mod n and s is a scalar beside it, so neither can be
-        # out of range and an r it produced cannot fail a congruence it was
-        # built from. The congruence is another ec_pubkey_parse, of
-        # 0x02 || r, and grinding pays the whole check once per attempt:
-        # 4.05 us against 1.25 for the parse alone, so 2.8 us an attempt.
-        # Per attempt and not per signature, because how many attempts
-        # there are is a property of the key and the message rather than of
-        # the machine -- `_grind_low_r` walks Core's sequence until r is low
-        # -- and a grinding figure without its attempt count says nothing:
-        # one attempt is 16.99 us against 14.22, eight are 132.76 against
-        # 110.53.
-        #
-        # The compact form, r || s, and not the DER `sign` answers by
-        # default: a signature is two scalars, and the DER would be
-        # written by libsecp256k1 and taken apart again here -- 1.25 us to
-        # read against the 0.32 of `_sig_from_compact` (issue 922), once
-        # per attempt. What that also settles is the question the previous
-        # paragraph left open: reading r alone and building one Sig after
-        # the loop is now worth 0.32 us an attempt rather than 0.7, and it
-        # would still cost a second reader beside this one
-        #
-        # verify=False on the attempts, and one check on the one the loop
-        # keeps: Core's order in `CKey::Sign` and the bindings' own inside
-        # `dsa._sign_`, which grinds and then checks once. The bindings
-        # verify by default (btclib-secp256k1#224), and a loop calling
-        # them once per attempt pays a point multiplication and a
-        # verification for signatures it is about to throw away -- 19.5 us
-        # an attempt, seven times the congruence declined two paragraphs
-        # up, and on an eight-attempt grind more than the grind. A
-        # discarded attempt that was faulted costs an attempt; only what
-        # is returned needs checking (issue #982)
-        signature = _grind_low_r(
-            lambda counter: _sig_from_compact(
-                libsecp256k1_dsa.sign(
-                    msg_hash, q, _grind_entropy(counter), compact=True, verify=False
-                ),
-                ec,
-            ),
-            grind,
-            ec,
+        return _libsecp256k1_sign_(
+            msg_hash, q, grind, ec, verify=verify, pub_key=pub_key
         )
-        # the check itself, and it is not the congruence declined above:
-        # that one would ask the library to prove r is an x-coordinate of
-        # a point the library multiplied, where this asks whether the
-        # arithmetic ran correctly at all -- a fault in memory or induced,
-        # whose cost is a published signature that is invalid and may say
-        # something about the key. 20.25 us the way it is written here,
-        # against 19.56 for the bindings' own per-call default: the 0.7 is
-        # the serialization and parse a caller of the public halves pays
-        # and their private ones do not. The *uncompressed* key for the
-        # same reason it is not `q`'s compressed sec: parsing 02||x is a
-        # field square root, and passing it costs 22.20 instead. Measured
-        # alternated in one process, 15 rounds of 3000 calls, minimum
-        # kept, noise 0.05 -- an Apple M5, macOS 26.6, arm64, CPython
-        # 3.14.6
-        verified = libsecp256k1_dsa.verify(
-            msg_hash,
-            libsecp256k1_keys.pubkey_from_prvkey(q, compressed=False),
-            _compact(signature),
-            compact=True,
-        )
-        if not verified:  # pragma: no cover
-            # unreachable from an input, as dleq.sign's own last step is:
-            # what it reports is the computation having gone wrong, which
-            # is what a BTClibRuntimeError means here
-            raise BTClibRuntimeError(
-                "signing produced a signature that does not verify"
-            )
-        return signature
 
     # the challenge
     c = challenge_(msg_hash, ec, hf)  # 4, 5
+
+    # the key parsed before the signing rather than inside the check,
+    # which is where the moment matters: see `_python_key`
+    parsed = None if pub_key is None else _python_key(pub_key, ec)
+
+    def _checked(signature: Sig) -> Sig:
+        # the same contract as the single call into the bindings above --
+        # sign, one check, the key on trust, discriminate on failure --
+        # and the same default, because a fallback answering differently
+        # from the arm it stands in for is two libraries wearing one name.
+        # What it costs here is not what it costs there: a verification is
+        # about five signatures on this arm, where the bindings' check is
+        # rather less than one, and that is an argument for the keyword
+        # existing rather than for a second default
+        if verify:
+            _abort_unless_checked(
+                lambda key: _python_verified(c, signature, ec, key),
+                lambda: (mult(q, ec.G, ec), ec._fixed_points),
+                parsed,
+            )
+        return signature
 
     if commit_hash is None:
         # nonce: an integer in the range 1..n-1.
         if nonce is not None:
             # second part delegated to helper function
-            return _sign_(c, q, int_from_prv_key(nonce, ec), lower_s, ec)
-        return _grind_low_r(
-            lambda counter: _sign_(
-                c,
-                q,
-                _rfc6979_nonce_(c, q, ec, hf, _grind_entropy(counter)),  # 1
-                lower_s,
+            return _checked(_sign_(c, q, int_from_prv_key(nonce, ec), lower_s, ec))
+        # the check is of the signature the loop keeps and not of every
+        # attempt, which is Core's order in `CKey::Sign` and the bindings'
+        # own: a discarded attempt that was faulted costs an attempt
+        return _checked(
+            _grind_low_r(
+                lambda counter: _sign_(
+                    c,
+                    q,
+                    _rfc6979_nonce_(c, q, ec, hf, _grind_entropy(counter)),  # 1
+                    lower_s,
+                    ec,
+                ),
+                grind,
                 ec,
-            ),
-            grind,
-            ec,
+            )
         )
 
     # the commitment enters twice: once as RFC6979 additional data, so
@@ -788,7 +986,11 @@ def sign_(
     entropy = commit_entropy_(commit_hash, _S2C_DATA_TAG, hf)
     nonce = _rfc6979_nonce_(c, q, ec, hf, entropy)
     nonce, receipt = commit_nonce_(commit_hash, nonce, _S2C_POINT_TAG, ec, hf)
-    return _sign_(c, q, nonce, lower_s, ec), receipt
+    # the signature is checked and the receipt is not: what opens the
+    # commitment is `commit_point_` under the same r, which the caller
+    # verifies with commit_hash and receipt in hand. A check here would
+    # be `_assert_commitment_`'s, on this call's own output
+    return _checked(_sign_(c, q, nonce, lower_s, ec)), receipt
 
 
 @overload
@@ -801,6 +1003,8 @@ def sign(
     hf: HashF = ...,
     *,
     grind: bool = ...,
+    verify: bool = ...,
+    pub_key: PubKey | None = ...,
     commit: None = None,
 ) -> Sig: ...
 
@@ -815,6 +1019,8 @@ def sign(
     hf: HashF = ...,
     *,
     grind: bool = ...,
+    verify: bool = ...,
+    pub_key: PubKey | None = ...,
     commit: Octets,
 ) -> tuple[Sig, Point]: ...
 
@@ -828,6 +1034,8 @@ def sign(
     hf: HashF = sha256,
     *,
     grind: bool = True,
+    verify: bool = True,
+    pub_key: PubKey | None = None,
     commit: Octets | None = None,
 ) -> Sig | tuple[Sig, Point]:
     """ECDSA signature with canonical low-s preference.
@@ -850,6 +1058,10 @@ def sign(
     grind asks for a low-R signature, as in `sign_`, which is where the
     loop and the default are explained.
 
+    verify asks for the signature to be checked before it is answered
+    with and pub_key is the key it is checked under, both as in `sign_`,
+    which is where the rule and the reason for the default are written.
+
     commit is a value to commit to inside the nonce, and is reduced by hf
     as msg is: `sign_` is the spelling that takes the two hashes.
 
@@ -858,10 +1070,29 @@ def sign(
     """
     msg_hash = reduce_to_hlen(msg, hf)
     if commit is None:
-        return sign_(msg_hash, prv_key, nonce, lower_s, ec, hf, grind=grind)
+        return sign_(
+            msg_hash,
+            prv_key,
+            nonce,
+            lower_s,
+            ec,
+            hf,
+            grind=grind,
+            verify=verify,
+            pub_key=pub_key,
+        )
     commit_hash = reduce_to_hlen(commit, hf)
     return sign_(
-        msg_hash, prv_key, nonce, lower_s, ec, hf, grind=grind, commit_hash=commit_hash
+        msg_hash,
+        prv_key,
+        nonce,
+        lower_s,
+        ec,
+        hf,
+        grind=grind,
+        verify=verify,
+        pub_key=pub_key,
+        commit_hash=commit_hash,
     )
 
 

--- a/tests/bool_parameter_test.py
+++ b/tests/bool_parameter_test.py
@@ -747,6 +747,22 @@ _TRUTHS = (
         " parsed out of what both readings accept is one signature",
     ),
     _Case(
+        "btclib.ecc.dsa.sign_",
+        "verify",
+        dsa.sign_,
+        {"msg_hash": _MSG_HASH, "prv_key": _PRV_KEY},
+        reason="whether the signature is checked before it is answered with;"
+        " the signature is the same either way, the check being a"
+        " verification of what has already been computed",
+    ),
+    _Case(
+        "btclib.ecc.dsa.sign",
+        "verify",
+        dsa.sign,
+        {"msg": _MSG, "prv_key": _PRV_KEY},
+        reason="whether the signature is checked before it is answered with",
+    ),
+    _Case(
         "btclib.psbt.psbt.assert_signed",
         "allow_partial",
         assert_signed,

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -1719,3 +1719,316 @@ def test_a_key_that_is_no_point_is_refused_by_the_verification_itself(
     for no_point in (b"\x02" + bytes(32), b"\x03" + b"\xff" * 32):
         with pytest.raises(BTClibValueError, match="not a public key"):
             dsa.assert_as_valid(msg, no_point, sig)
+
+
+_ARMS = [
+    pytest.param(True, marks=needs_bindings, id="bindings"),
+    pytest.param(False, id="python"),
+]
+
+
+@pytest.mark.parametrize("bindings", _ARMS)
+def test_the_check_changes_no_signature(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`verify` is a truth: what it turns on reads, and writes nothing.
+
+    The three spellings answer the same octets, which is what puts the
+    flag in `_TRUTHS` rather than beside `lower_s` and `grind` in
+    `_KINDS`, and what makes declining the check a decision about time
+    and not about which signature a key and a message make.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    q, Q = dsa.gen_keys(0x1234567890ABCDEF)
+    msg = b"a message signed three ways"
+    sec = bytes_from_point(Q)
+
+    checked = dsa.sign(msg, q)
+    assert checked == dsa.sign(msg, q, verify=False)
+    assert checked == dsa.sign(msg, q, pub_key=sec)
+    # and grinding is still Core's sequence, the check being of the
+    # signature the loop kept rather than of the ones it discarded
+    assert checked == dsa.sign(msg, q, grind=True, pub_key=Q)
+
+
+@pytest.mark.parametrize("bindings", _ARMS)
+def test_a_key_handed_in_is_the_key_that_would_have_been_derived(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every spelling of the signer's own key is accepted, and is the same key.
+
+    Compressed and uncompressed differ only in what the check pays to
+    parse -- the field square root that recovers y -- and a `Point` or a
+    `PreparedPoint` is what a caller of the Python arithmetic holds. All
+    four are the key the check would have derived, so all four verify.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    q, Q = dsa.gen_keys(0x1234567890ABCDEF)
+    msg = b"a message signed under a key already held"
+    expected = dsa.sign(msg, q, verify=False)
+
+    for key in (
+        bytes_from_point(Q),
+        bytes_from_point(Q, compressed=False),
+        Q,
+        PreparedPoint(Q),
+    ):
+        assert dsa.sign(msg, q, pub_key=key) == expected
+
+
+@pytest.mark.parametrize("bindings", _ARMS)
+def test_the_wrong_key_is_told_apart_from_a_wrong_computation(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A key that is not this private key's is a ValueError, not a fault.
+
+    The whole reason the failing branch derives: a wrong argument and a
+    faulted computation fail the same verification, and reporting one as
+    the other tells a caller their hardware is broken because they
+    mistyped. `BTClibRuntimeError` stays what it has always meant here.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    q, _ = dsa.gen_keys(0x1234567890ABCDEF)
+    _, other = dsa.gen_keys(0xFEDCBA0987654321)
+    msg = b"a message signed under someone else's key"
+
+    with pytest.raises(BTClibValueError, match="not this private key's"):
+        dsa.sign(msg, q, pub_key=bytes_from_point(other))
+
+
+@pytest.mark.parametrize("bindings", _ARMS)
+def test_a_key_is_refused_beside_the_flag_that_declines_the_check(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A caller contradicting themselves is answered, not resolved.
+
+    Raised before anything is signed and before the key is parsed, so
+    what a caller hears is about the two arguments rather than about the
+    octets of one of them -- and raised on both arms, so that a dispatch
+    nobody asked for is not what decides which error arrives.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    q, Q = dsa.gen_keys(0x1234567890ABCDEF)
+    with pytest.raises(BTClibValueError, match="verify=False declines"):
+        dsa.sign(b"a message", q, verify=False, pub_key=bytes_from_point(Q))
+    with pytest.raises(BTClibValueError, match="verify=False declines"):
+        dsa.sign_(sha256(b"a message").digest(), q, verify=False, pub_key=Q)
+
+
+@pytest.mark.parametrize("bindings", _ARMS)
+def test_a_key_fixed_in_advance_cannot_pass_a_signature_of_another_key(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """What makes taking the key on trust safe, stated as a property.
+
+    The keys a signature verifies under are a property of that signature
+    -- `recover_pub_keys_` walks them -- so a key chosen before the
+    signature exists is not one of them. That is why the trust can cost a
+    wrong diagnosis and never a wrong success, and it is checked here
+    over keys and messages rather than argued in a docstring.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    _, wrong = dsa.gen_keys(0x1234567890ABCDEF)
+    for i in range(1, 21):
+        q, _ = dsa.gen_keys(0xFEDCBA0987654321 + i)
+        with pytest.raises(BTClibValueError, match="not this private key's"):
+            dsa.sign(i.to_bytes(32, "big"), q, pub_key=wrong)
+
+
+def test_the_two_arms_answer_the_same_refusals(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One contract, two implementations, and the same words for a failure.
+
+    A fallback that answered differently from the arm it stands in for
+    would be two libraries wearing one name: the signature, the exception
+    type and the message are all held equal here, which is the thing no
+    per-arm test can say.
+    """
+    q, _ = dsa.gen_keys(0x1234567890ABCDEF)
+    _, other = dsa.gen_keys(0xFEDCBA0987654321)
+    msg = b"a message both arms sign"
+
+    def answers() -> tuple[Any, ...]:
+        signature = dsa.sign(msg, q, pub_key=None)
+        with pytest.raises(BTClibValueError) as wrong_key:
+            dsa.sign(msg, q, pub_key=bytes_from_point(other))
+        with pytest.raises(BTClibValueError) as contradiction:
+            dsa.sign(msg, q, verify=False, pub_key=bytes_from_point(other))
+        # the third failure a supplied key can have, and the one this
+        # test's name promised without holding: octets that are no point
+        with pytest.raises(BTClibValueError) as no_point:
+            dsa.sign(msg, q, pub_key=b"\x02" + bytes(32))
+        return (
+            signature,
+            str(wrong_key.value),
+            str(contradiction.value),
+            str(no_point.value),
+        )
+
+    delegated = answers()
+    with monkeypatch.context() as python:
+        python.setattr(dsa, "_libsecp256k1_serves", lambda *_: False)
+        assert answers() == delegated
+
+
+@pytest.mark.parametrize("bindings", _ARMS)
+def test_a_key_that_is_no_point_is_refused_before_anything_is_signed(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Refused by both arms, and on the Python one before it has signed.
+
+    A caller who mistyped an argument should not be told about it by a
+    check on a signature they are now holding -- which with grinding
+    would be after the whole loop. Both arms refuse before signing: the
+    delegated one because the bindings parse `pubkey` on the way in, the
+    Python one because `_python_key` is hoisted above the signing, where
+    the check would have paid the same parse anyway.
+
+    Only the second half is asserted here, and the asymmetry is the
+    point rather than an omission. On the delegated arm the call that
+    parses and the call that signs are one crossing, so nothing this
+    side of it can watch the order; that property is
+    `test_octets_that_are_not_a_key_are_refused_before_anything_is_signed`
+    in btclib-secp256k1, which is where it can be seen. What is held on
+    both arms here is that the refusal arrives and is btclib's own
+    exception.
+
+    The words are held equal too, and that is the cheap half: the
+    delegated arm translates the bindings' `invalid public key` into
+    this package's own `not a public key`, which is what
+    `assert_as_valid_` and `point_from_pub_key` say. Unifying it by
+    proving the key here instead would be a field square root the
+    bindings then repeat, some 2.2 of the 5.8 microseconds handing a key
+    in saves. Pinning the message is what makes the translation safe: a
+    wording that moves upstream fails here rather than quietly ceasing
+    to match.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    q, _ = dsa.gen_keys(0x1234567890ABCDEF)
+    no_point = b"\x02" + bytes(32)
+
+    with pytest.raises(BTClibValueError, match="^not a public key$"):
+        dsa.sign(b"a message", q, pub_key=no_point)
+
+    if bindings:
+        return
+
+    real = dsa._sign_
+    signed = []
+
+    def counting(*args: Any, **kwargs: Any) -> Any:
+        signed.append(1)
+        return real(*args, **kwargs)
+
+    with monkeypatch.context() as counted:
+        counted.setattr(dsa, "_sign_", counting)
+        # the counter is wired to the call that signs, and this says so:
+        # without it the assertion below would pass on a patch of the
+        # wrong function. grind=False so that "exactly one" is a property
+        # of the code rather than of this key and message drawing a low r
+        # on the first attempt -- true here, and a puzzling failure for
+        # whoever changes the message
+        dsa.sign(b"a message", q, verify=False, grind=False)
+        assert signed == [1]
+
+        signed.clear()
+        with pytest.raises(BTClibValueError, match="^not a public key$"):
+            dsa.sign(b"a message", q, pub_key=no_point)
+    assert not signed, "the key was refused after something was signed"
+
+
+def test_a_fault_is_not_reported_as_a_wrong_key() -> None:
+    """The other half of the discrimination, and the one no input reaches.
+
+    A fresh signature verifies under the key that made it, so neither
+    `BTClibRuntimeError` is reachable from an argument -- what they
+    report is memory that flipped or a fault induced on purpose.
+    `_abort_unless_checked` takes the verification as a callable exactly
+    so that this can be said without patching the arithmetic: all four
+    of its branches are entered here, and an inversion of the two causes
+    fails the test rather than passing quietly.
+    """
+    signer = b"\x02" + bytes(31) + b"\x01"
+    other = b"\x02" + bytes(31) + b"\x02"
+    derivations = 0
+
+    def derive() -> bytes:
+        nonlocal derivations
+        derivations += 1
+        return signer
+
+    # nothing supplied, and the signature verifies: the common path,
+    # which pays the derivation because it has no other key to ask about
+    dsa._abort_unless_checked(lambda _: True, derive, None)
+    assert derivations == 1
+
+    # nothing supplied, and it does not: the fault this check is for
+    with pytest.raises(BTClibRuntimeError, match="does not verify"):
+        dsa._abort_unless_checked(lambda _: False, derive, None)
+    assert derivations == 2
+
+    # supplied and verifying: the derivation is not reached at all, which
+    # is the whole of what supplying the key buys
+    dsa._abort_unless_checked(lambda _: True, derive, other)
+    assert derivations == 2
+
+    # supplied, failing, and the signer's own key fails too: a fault
+    # under a handed-in key, which must not be reported as a wrong key
+    with pytest.raises(BTClibRuntimeError, match="does not verify"):
+        dsa._abort_unless_checked(lambda _: False, derive, other)
+    assert derivations == 3
+
+    # supplied, failing, and the signer's own key verifies: a wrong key
+    with pytest.raises(BTClibValueError, match="not this private key's"):
+        dsa._abort_unless_checked(lambda key: key == signer, derive, other)
+    assert derivations == 4
+
+
+@needs_bindings
+def test_the_delegated_grind_is_the_sequence_the_python_arm_walks() -> None:
+    """The defence the delegation rests on, and the reason it is here.
+
+    `sign_` no longer grinds on the delegated arm: libsecp256k1's own
+    `grind` walks Core's `CKey::Sign` counter and so does
+    `_grind_low_r`, so looping here would re-derive what the bindings
+    already do and pay a crossing per attempt -- two on average.
+
+    What that costs is Core's sequence living in two places, and it is
+    only affordable while the two agree. They are held equal here over
+    keys and messages rather than at the one input a smoke test would
+    use, so a change of sequence on either side is a red suite instead
+    of a signature nobody else can reproduce. The signatures are
+    compared, not merely the low-r property: two different low-r
+    signatures of one message would pass that and be the bug this is
+    for.
+    """
+    for i in range(1, 61):
+        q, _ = dsa.gen_keys(0xFEDCBA0987654321 + i * 7919)
+        msg_hash = sha256(i.to_bytes(8, "big")).digest()
+
+        delegated = dsa.sign_(msg_hash, q, grind=True, verify=False)
+        compact = libsecp256k1_dsa.sign(
+            msg_hash, q, compact=True, grind=True, verify=False
+        )
+        assert delegated.r == int.from_bytes(compact[:32], "big")
+        assert delegated.s == int.from_bytes(compact[32:], "big")
+
+        # and it is the signature btclib's own loop reaches, which is the
+        # half that says the delegation changed no answer
+        with pytest.MonkeyPatch.context() as python:
+            python.setattr(dsa, "_libsecp256k1_serves", lambda *_: False)
+            assert dsa.sign_(msg_hash, q, grind=True, verify=False) == delegated
+
+        # the point of grinding at all, and cheap to say here
+        assert dsa._is_low_r(delegated.r, secp256k1)

--- a/uv.lock
+++ b/uv.lock
@@ -459,7 +459,7 @@ test = [
 [[package]]
 name = "btclib-secp256k1"
 version = "0.8.0.3"
-source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#71fbd0ac6b95a928a17bc46c0750c8b2e1d5ffcc" }
+source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#52f913e706f822bd447732a99d8728a86c22e516" }
 dependencies = [
     { name = "cffi" },
 ]


### PR DESCRIPTION
`dsa.sign_` checks every signature it makes and offers no way out, and
it derives a public key per signature to do it. Bitcoin Core's
`CKey::Sign` is where the check comes from and the default stays True
-- what it catches is a computation that went wrong, whose cost is a
published signature that is invalid and may say something about the
key -- but a caller who has measured that against their own threat
model had no keyword to turn, and a caller already holding the public
key paid for a generator multiplication anyway.

`verify` and `pub_key` are those two, keyword-only on `sign_` and
`sign`. Measured on an Apple M5, macOS 26.6, arm64, CPython 3.14.6,
the shapes alternated in one process, 9 rounds of 3 000 calls with the
minimum of each kept, and the unchecked row run again at the end so
the noise has a figure of its own -- microseconds, the check being the
column that matters:

| `dsa.sign_`, grinding | per call | the check |
| --- | --- | --- |
| `verify=False` | 13.52 | |
| the key derived, as before | 33.06 | 19.54 |
| a compressed key handed in | 29.51 | 15.99 |
| an uncompressed key handed in | 27.27 | 13.75 |
| `verify=False` again (the noise) | 13.56 | ±0.04 |

The 5.79 between the second row and the fourth is the derivation, and
2.24 of it is the field square root that recovers y -- which is why
the longer encoding is the cheaper argument here. Under all of it is a
bare verification, which is what BIP340's check has always been.

## Taken on trust, and the failing branch pays for it

Checking the key against the private key on the way in would cost the
multiplication the argument exists to avoid, so it is not checked --
and that changes what a failed check means, a key that is not this
private key's failing verification exactly as a faulted computation
does. `_abort_unless_checked` resolves that and is the whole of the
new logic: where a supplied key fails, and only there, it derives and
asks again. `BTClibRuntimeError` if the signature does not verify
under the key the private key actually has, which is the fault this
check has always been for; `BTClibValueError` if it does and the
supplied one is simply not it.

What the trust cannot do is let a bad signature through: the keys a
signature verifies under are a property of that signature --
`recover_pub_keys_` walks them -- so a key fixed before the signature
exists is not one of them, and the trust can cost a wrong diagnosis
but never a wrong success.

## The Python arm now checks at all, and by the same rule

It did not before, so on that arm this adds a check rather than
letting one be declined. A fallback answering differently from the arm
it stands in for is two libraries wearing one name, and the same
argument settles the default. What it costs there is not what it costs
here -- 742.78 derived and 589.08 with the point handed in, against a
signature of 165.09, 5 rounds of 300 and a noise of 0.24 -- and that
is an argument for the keyword existing, not for a second default.

`_abort_unless_checked` takes the verification as a callable, so the
rule is written once and each arm supplies its own arithmetic. On the
Python arm a `PreparedPoint` handed in is used with its own memoized
tables, which is the shape a signer checking under a key it already
holds is in.

## The delegated arm grinds where it signs

Core's low-R counter had two implementations on this path: btclib's
`_grind_low_r` looping and libsecp256k1's own `grind` unused. So the
loop is gone from the delegated arm and `grind` crosses with the rest --
one call that grinds, keeps the low-r survivor and checks that one,
which is Core's order in `CKey::Sign` and leaves this arm with no
verification of its own to write.

What that is worth is small and is reported rather than implied. A run
of its own, because it has to hold the draw count fixed to say anything:
at the bindings, a loop of crossings with a check after it against one
call that does both, by how many draws the input needs -- 9 rounds of
500 calls, minimum kept, noise 0.04:

| draws | the loop | delegated | saved |
| --- | --- | --- | --- |
| 1 | 31.72 | 31.26 | 0.46 |
| 2 | 43.45 | 42.83 | 0.62 |
| 3 | 56.22 | 55.27 | 0.95 |
| 5 | 80.46 | 78.86 | 1.61 |

Through `sign_` itself it shows as grinding no longer costing more than
not grinding on a message that needs one draw: 19.54 against 19.47,
inside a noise of 0.19, where before this change the same two rows were
22.73 and 19.81 in one session.

So the argument is not the microseconds. It is that Core's sequence
stopped being written twice on the path that had a library implementing
it, and that the check now happens where the signing does.

`test_the_delegated_grind_is_the_sequence_the_python_arm_walks` is what
the delegation rests on, and it is why the sequence may live in two
places at all: over sixty keys and messages the delegated signature is
the bindings' own and is also the one `_grind_low_r` reaches, compared
as signatures rather than as the low-r property -- two different low-r
signatures of one message would pass that and be the bug this is for.
The Python arm keeps its loop, having nothing to delegate to.

## A key that is no point is refused before anything is signed

Both arms, and the same words. On the Python arm the parse is hoisted
above the signing, where the check would have paid it anyway, so a
mistyped argument is a mistyped argument rather than a check on a
signature the caller is holding -- and with grinding, rather than one
after the whole loop. On the delegated arm the bindings parse `pubkey`
on the way in and already refuse there.

Refusing before signing is also the cheaper of the two orders: on the
error path no signature is computed and thrown away, and on every other
path the parse costs the same wherever it runs.

The words are unified rather than declared, and for free: the delegated
arm translates the bindings' `invalid public key` into this package's
own `not a public key`, which is what `assert_as_valid_` and
`point_from_pub_key` say. Proving the key here instead would be a field
square root the bindings then repeat, some 2.2 of the 5.8 microseconds
handing a key in saves. Both messages are pinned by tests across both
arms, so a wording that moves upstream fails the suite rather than
quietly ceasing to match.

## Refused rather than resolved

A key given beside `verify=False` raises, on both arms and before
anything is signed: the check it is for is the one that flag declines,
and a caller contradicting themselves is answered rather than picked
for. `verify` itself is not type-checked, which is the line `lower_s`
and `grind` are on the other side of -- it turns a check on and changes
no answer, so it is read for whether it is true, as
`bip39.seed_from_mnemonic`'s `verify_checksum` is. `tests/bool_parameter_test.py`
is where that division is kept, and it now carries both entries.

## The record, and the two bullets it contradicts

`v2026.9` is open and already carried the arrangement this replaces,
from #983 and the urgent half of #982: a loop of `verify=False` attempts
with one `libsecp256k1_dsa.verify` after it, under a key derived here,
and the 20.25 and 22.20 that measured it. None of that describes the
code any more, and it shipped in no release -- so the bullet is amended
to say what it was and to hand over to the new one rather than left
describing a shape that was removed before the release went out. A
release whose record holds two incompatible arrangements as if both
shipped is the thing to avoid.

The new entries go under "Curves, signatures and keys": the two
keywords and the failure they add, the delegated grind with the test
that defends it, and the figures in a bullet of their own.

HISTORY.md carries the one a user may have to act on -- the Python arm
checking at all. Nothing raises and no signature changes, so it is a
note rather than a breaking change, and it says what to do if the time
shows: `verify=False`, or `pub_key` to bring the check from 742.78 to
589.08. Every figure in that note separates the two things "the check"
can mean -- what the call costs, 907.87 against 165.09 and so five and a
half times what it was, and what the check adds, 742.78, which is about
four and a half signatures -- and each run in it names its own shape,
the bindings rows being the same process but 9 rounds of 3000 where the
Python ones are 5 of 300.

## Verification

`uv run pytest` -- 27 937 passed, coverage 100. `uv run pre-commit run
--all-files` clean, every hook. `sphinx-build -W --keep-going` succeeds.

`tests/ecc/dsa_test.py` gains nine cases, seven of them run on both arms:
the check changing no signature, every spelling of the signer's own key
accepted, the wrong key told apart from a wrong computation, a key
refused beside `verify=False`, the property above over twenty keys, and
the two arms held to the same signature and the same words for a
failure. The seventh drives `_abort_unless_checked` with its
verification substituted -- neither `BTClibRuntimeError` is reachable
from an argument -- and counts the derivations, so that "the failing
branch alone pays it" is checked rather than asserted. The last is the
grinding agreement above.

The docs build is part of the gate here and was run as CI runs it --
`sphinx-build -W --keep-going` succeeds, a trailing underscore outside
backticks in a docstring being a reST target reference and therefore a
failed build.

The bindings' own `ValueError` is translated on the way out rather than
left to leak: `BTClibValueError` is `(BTClibException, ValueError)`, so
a plain one is not caught by `except BTClibValueError` and the delegated
arm would answer a different class for the same failure. The
discrimination and the wording stay theirs, because the rule is.

`uv.lock` moves the bindings to `52f913e`, which is
btclib-org/btclib-secp256k1#245 and is on their `main`: it landed as a
fast-forward, so the sha is in that history and this pin resolves.

Implements the btclib half of btclib-org/btclib#982. The `dsa.Signer`
that issue also asks for is not here: it needs the bindings to accept a
private key in memory they own, which is
btclib-org/btclib-secp256k1#247. `ssa` keeps its hard-coded `verify=True`
for now -- exposing the keyword there is the same change without the
`pub_key` half, its check costing the same whether the key is held or
not.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make ECDSA signing verification configurable and allow callers to reuse an existing public key while keeping both signing implementations consistent.

New Features:
- Add keyword-only controls to ECDSA signing for disabling post-signature verification or supplying an existing public key for that check.

Bug Fixes:
- Align Python and delegated signing behavior by verifying signatures consistently and distinguishing invalid supplied keys from signing computation failures.
- Reject invalid public keys before signing and provide consistent btclib errors across signing implementations.

Enhancements:
- Delegate low-R grinding and final verification to libsecp256k1 on the delegated path while preserving matching signature behavior in the Python implementation.
- Avoid redundant public-key derivation and verification work when callers provide a key or decline verification.

Documentation:
- Document the new signing options, fallback verification behavior, error cases, and associated performance considerations in the changelog and history.

Tests:
- Add coverage for verification controls, supplied-key handling, failure classification, invalid-key rejection, cross-implementation consistency, and delegated grinding equivalence.

Chores:
- Update the libsecp256k1 dependency pin.