### PR TITLE
Let the caller decline BIP340's check too, and check on both arms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1757,6 +1757,55 @@ documented at release-notes length in the first place, and are still in
   `recover_pub_keys_` walks, so a key fixed before the signature exists
   is not one of them. The trust can cost a wrong diagnosis, never a wrong
   success, and that is a test over keys rather than a paragraph.
+- **`ssa` takes the same `verify`, and its Python arm checks at all**
+  (issue #982). `ssa.sign`, `ssa.sign_` and both spellings of
+  `ssa.Signer` grew the keyword-only flag `dsa` has, defaulting to True —
+  and here the default is the specification's rather than this library's
+  policy, BIP340 putting the step inside *Default Signing*: "If
+  Verify(bytes(P), m, sig) returns failure, abort". The delegated arm
+  passes it across, where it used to write `verify=True` and give a
+  caller nowhere to turn; the Python arm performs the check, where it
+  performed none.
+
+  A `Signer` is the call this was worth exposing for: it holds the
+  keypair, so the signature is the cheap part and the check is not, and
+  it was the one signing call in the library whose policy a caller could
+  neither see nor decline.
+
+  **No `pub_key` beside it, and the absence is the decision.** What such
+  an argument buys in `dsa` is the generator multiplication the check
+  would otherwise do per signature; BIP340 has none to save, the keypair
+  holding the point already, so it would buy nothing and sell one thing
+  — a second reason a check can fail, and the discrimination step that
+  costs. What the check costs on the delegated arm is measured in
+  btclib-secp256k1#224 and cited rather than re-measured here: a figure
+  of theirs kept in this repository is one that ages when they change
+  and says nothing when it does.
+- **A failed check says the same thing whichever arm answered, and says
+  it as one of this package's own exceptions** (issue #1008). Both arms
+  now raise `BTClibRuntimeError("signing produced a signature that does
+  not verify")`, which is `dsa`'s sentence on both of its arms and the
+  bindings' own. The delegated arm used to let their bare `RuntimeError`
+  through, so a caller who wrote the `except BTClibException` this
+  package publishes did not catch the one failure signing has; the
+  Python arm answered `assert_as_valid_`'s words — `y_K is odd`,
+  `signature verification failed` — which are a verifier's and say what
+  the check saw rather than what happened. Those are kept as the cause,
+  so the reason is still in hand, and the two arms are held to one
+  exception type and one message by a test — for both faults the check
+  can refuse: a signature that does not verify, and one whose K lands on
+  the point at infinity, which has no y to answer with and refuses in
+  the other hierarchy.
+- **What the Python arm's check costs, measured**, that arm being
+  btclib's own arithmetic and therefore btclib's to measure. A signature
+  is 305.50 microseconds and the checked call 962.81, so signing there is
+  3.15 times what it was, the check adding 657.31 — about two signatures,
+  where `dsa`'s is about four and a half. BIP340 pays less because the
+  key is in hand: `bip340_nonce_` has already computed the point to
+  answer x_Q, and only the even-y lift is done again. Alternated in one
+  process, 9 rounds of 300 calls, minimum kept, the unchecked row run
+  again at the end for a noise of 3.01 — an Apple M5, macOS 26.6, arm64,
+  CPython 3.14.6.
 - **The delegated arm grinds where it signs**, so Core's low-R counter
   stops being written twice on the one path that has a library
   implementing it. `grind` crosses with `verify` and `pub_key`, and

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -425,6 +425,21 @@ full year, short month, short day (YYYY-M-D)
   `btclib.curves.is_libsecp256k1_serving()` is what says which arm is
   answering.
 
+- **The same is true of BIP340 signing**, and there the check is the
+  specification's own step rather than a policy of this library:
+  `ssa.sign`, `ssa.sign_` and `ssa.Signer` now check before answering,
+  where the Python arm checked not at all. On an installation without the
+  bindings a call that took 305.50 microseconds takes 962.81 — 3.15 times
+  what it was — the check adding 657.31, which is about two signatures.
+  One session, 9 rounds of 300 calls, minimum kept, noise 3.01, the same
+  machine as above.
+
+  `verify=False` declines it, on the free functions and on a `Signer`
+  alike. There is no key to hand in as there is for ECDSA: BIP340 checks
+  under a point the signer already holds, which is why that scheme pays
+  two signatures where ECDSA pays four and a half, and why no `pub_key`
+  argument exists here to bring it down.
+
 ### The bindings are now `btclib_secp256k1`
 
 - **The secp256k1 bindings were renamed, and btclib requires the new

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -370,6 +370,7 @@ def sign_(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
+    verify: bool = ...,
     commit_hash: None = None,
 ) -> Sig: ...
 
@@ -382,6 +383,7 @@ def sign_(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
+    verify: bool = ...,
     commit_hash: Octets,
 ) -> tuple[Sig, Point]: ...
 
@@ -393,6 +395,7 @@ def sign_(
     ec: Curve = secp256k1,
     hf: HashF = sha256,
     *,
+    verify: bool = True,
     commit_hash: Octets | None = None,
 ) -> Sig | tuple[Sig, Point]:
     """Sign a message of any size according to BIP340 signature algorithm.
@@ -405,6 +408,27 @@ def sign_(
 
     If the deterministic nonce is not provided, the BIP340 specification
     (not RFC6979) is used.
+
+    verify asks for the signature to be checked before it is answered
+    with, and defaults to True. Here the default is the specification's
+    and not only this library's policy: BIP340 puts the step inside
+    *Default Signing* -- "If Verify(bytes(P), m, sig) returns failure,
+    abort" -- where ECDSA's comes from Bitcoin Core. The flag exists for
+    the caller who has measured the check against their own threat model,
+    and `dsa.sign_` is where the same keyword is described at length. A
+    check that fails raises BTClibRuntimeError saying that signing
+    produced a signature that does not verify -- the words both arms use
+    and `dsa`'s own -- with what the verification saw kept as the cause.
+
+    No pub_key beside it, and that absence is a decision rather than an
+    omission. What such an argument buys in `dsa` is the generator
+    multiplication the check would otherwise do per signature; here there
+    is none to save, the keypair holding the point already, so the check
+    costs what it costs whether the caller holds the key or not --
+    btclib-secp256k1#224 is where that is measured, and #982 is where the
+    two schemes are put side by side. It would buy nothing and sell one
+    thing: a second reason a check can fail, and with it the
+    discrimination step `dsa._abort_unless_checked` has to pay for.
 
     commit_hash is a value to commit to inside the nonce, sign-to-contract
     style: the signature is an ordinary BIP340 one, and the receipt
@@ -449,28 +473,78 @@ def sign_(
         # the bindings take a scalar, not the many representations of a
         # private key btclib accepts
         q = int_from_prv_key(prv_key, ec)
-        # verify=True, written rather than left to the default, as
-        # `dsa.sign_recoverable_` writes it and `dsa.sign_` writes its
-        # False: the policy belongs where the call is. BIP340 puts the
-        # step inside *Default Signing* -- "If Verify(bytes(P), m, sig)
-        # returns failure, abort" -- so this is one of the two calls a
-        # specification asks it of, the other being `Signer.sign_`'s
-        # delegated arm below, which is why both are written out where
-        # ECDSA's two are a policy of btclib's own. It is the cheaper
-        # step besides, the keypair holding the point where ECDSA has to
-        # derive one: 12.7 microseconds against ECDSA's 19.5
-        # (btclib-secp256k1#224). Written out, it survives the day that
-        # issue asks again whether the wrapper's default should be per
-        # scheme
-        return Sig.parse(libsecp256k1_ssa.sign_custom(msg, q, aux, verify=True))
+        # the caller's `verify`, crossing with the rest: the bindings
+        # perform the check and there is nothing for this arm to add,
+        # BIP340's step being a bare verification under a point the
+        # keypair already holds. What it costs is measured where it is
+        # performed -- 12.7 microseconds against ECDSA's 19.5,
+        # btclib-secp256k1#224 -- and is not re-measured here, a figure
+        # of theirs kept in this file being one that ages when they
+        # change and says nothing when it does
+        try:
+            signature = libsecp256k1_ssa.sign_custom(msg, q, aux, verify=verify)
+        except RuntimeError as e:
+            # the refusal is theirs and the hierarchy has to be btclib's,
+            # which is `dsa`'s rule at its own call into the bindings: a
+            # caller catching BTClibException should not have to know
+            # which arm answered. Their sentence is kept rather than
+            # reworded, `_checked` below raising the same one, so the two
+            # arms refuse in the same words as well as under the same type
+            raise BTClibRuntimeError(str(e)) from e
+        return Sig.parse(signature)
 
     # k is the nonce: an integer in the range 1..n-1.
     k, x_K, q, x_Q = bip340_nonce_(msg, prv_key, aux, ec, hf)
 
+    def _checked(c: int, signature: Sig) -> Sig:
+        # the same contract as the single call into the bindings above,
+        # the same default and the same refusal: a fallback answering
+        # differently from the arm it stands in for is two libraries
+        # wearing one name, and the answer to a check that failed is half
+        # of what it answers. The challenge is passed in because the
+        # commitment path recomputes it after the tweak, and it is the
+        # tweaked one the signature commits to.
+        #
+        # The lift is the one thing this arm pays that the delegated one
+        # does not: `bip340_nonce_` computes Q to answer x_Q and keeps
+        # only the x, so the even-y point has to be recovered here --
+        # `assert_as_valid_` does the same and for the same reason. No
+        # `pub_key` argument would remove it, the caller's key being
+        # x-only in this scheme, which is the second half of why the
+        # docstring declines one
+        if not verify:
+            return signature
+        QJ = x_Q, _y_even_var(x_Q, ec), 1
+        try:
+            _assert_as_valid_(c, QJ, signature.r, signature.s, ec, ec._fixed_points)
+        except (ValueError, BTClibRuntimeError) as e:
+            # its words are a verifier's -- `y_K is odd`, `signature
+            # verification failed`, `INF has no y-coordinate` -- and are
+            # not this caller's: they say what the check saw, where a
+            # signer needs to hear what happened, which is that the
+            # computation went wrong. They cannot be changed either, the
+            # public `assert_as_valid_` sharing them, so the signing
+            # sentence is raised over them and they are kept as the
+            # cause. It is the bindings' own sentence and `dsa`'s on both
+            # of its arms.
+            #
+            # Both hierarchies, which is the pair this file catches at
+            # `verify_` and `verify` and `dsa` catches at the same
+            # helper: a K that lands on infinity has no y to answer with
+            # and is a ValueError, and that is the shape a nonce zeroed
+            # after its point was computed takes -- s = c*q, so
+            # sG - cQ is the point at infinity. `BTClibRuntimeError` by
+            # name and not `RuntimeError`, because a RecursionError is
+            # one and is not an answer about a signature
+            raise BTClibRuntimeError(
+                "signing produced a signature that does not verify"
+            ) from e
+        return signature
+
     if commit_hash is None:
         # the challenge
         c = challenge_(msg, x_Q, x_K, ec, hf)
-        return _sign_(c, q, k, x_K, ec)
+        return _checked(c, _sign_(c, q, k, x_K, ec))
 
     # the tweak moves the nonce's point, and BIP340 signs with the
     # even-y one: k comes back from bip340_nonce_ already normalized,
@@ -484,7 +558,10 @@ def sign_(
 
     c = challenge_(msg, x_Q, x_K, ec, hf)
 
-    return _sign_(c, q, k, x_K, ec), receipt
+    # the signature is checked and the receipt is not: what opens the
+    # commitment is `commit_point_` under the same r, which the caller
+    # verifies with commit_hash and receipt in hand
+    return _checked(c, _sign_(c, q, k, x_K, ec)), receipt
 
 
 @overload
@@ -495,6 +572,7 @@ def sign(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
+    verify: bool = ...,
     commit: None = None,
 ) -> Sig: ...
 
@@ -507,6 +585,7 @@ def sign(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
+    verify: bool = ...,
     commit: Octets,
 ) -> tuple[Sig, Point]: ...
 
@@ -518,6 +597,7 @@ def sign(
     ec: Curve = secp256k1,
     hf: HashF = sha256,
     *,
+    verify: bool = True,
     commit: Octets | None = None,
 ) -> Sig | tuple[Sig, Point]:
     """Sign message according to BIP340 signature algorithm.
@@ -536,13 +616,25 @@ def sign(
 
     The BIP340 deterministic nonce (not RFC6979) is used.
 
+    verify asks for the signature to be checked before it is answered
+    with, as in `sign_`, which is where the default and the absence of a
+    pub_key beside it are explained.
+
     commit is a value to commit to inside the nonce, and is reduced by hf
     as msg is: `sign_` is the spelling that takes the two hashes.
     """
     msg_hash = reduce_to_hlen(msg, hf)
     if commit is None:
-        return sign_(msg_hash, prv_key, aux, ec, hf)
-    return sign_(msg_hash, prv_key, aux, ec, hf, commit_hash=reduce_to_hlen(commit, hf))
+        return sign_(msg_hash, prv_key, aux, ec, hf, verify=verify)
+    return sign_(
+        msg_hash,
+        prv_key,
+        aux,
+        ec,
+        hf,
+        verify=verify,
+        commit_hash=reduce_to_hlen(commit, hf),
+    )
 
 
 class Signer:
@@ -650,17 +742,27 @@ class Signer:
         self._q = 0
         self._wiped = True
 
-    def sign_(self, msg: Octets, aux: Octets | None = None) -> bytes:
+    def sign_(
+        self, msg: Octets, aux: Octets | None = None, *, verify: bool = True
+    ) -> bytes:
         """Return the signature of a prepared message, as its octets.
 
         The message is signed as it is, of any size, which is what the
         trailing underscore says throughout this module.
+
+        verify is the free function's, and this is the call where it is
+        the largest share of what it turns off: the keypair was built
+        when this signer was, so the signature is the cheap part and the
+        check is not. See `sign_` for the default and for why no pub_key
+        joins it.
         """
         if self._wiped:
             raise BTClibValueError("the signer is wiped")
 
         if self._signer is None:
-            return sign_(msg, self._q, aux, self._ec, self._hf).serialize()
+            return sign_(
+                msg, self._q, aux, self._ec, self._hf, verify=verify
+            ).serialize()
 
         # the aux `sign_` would have drawn, drawn here for the same
         # reason: BIP340's auxiliary randomness is per signature, and a
@@ -678,19 +780,27 @@ class Signer:
         # back in only one of this class's two arms, the python one
         # signing what the delegated one refused
         #
-        # verify=True for `sign_`'s reason above, and this is where the
-        # check is the largest share of what it is added to: the keypair
-        # was built when this signer was, so the signature is 8.18
-        # microseconds where a fresh one is 15.87, and the same check on
-        # it is 61% of the call against 44% there
-        # (btclib-secp256k1#224). The one of btclib's four signing calls
-        # a caller would most plausibly want to decline is the one whose
-        # policy would otherwise be invisible
-        return self._signer.sign_custom(msg, aux, verify=True)
+        # the caller's `verify`, and this is where the check is the
+        # largest share of what it is added to: the keypair was built
+        # when this signer was, so the signature is 8.18 microseconds
+        # where a fresh one is 15.87, and the same check on it is 61% of
+        # the call against 44% there (btclib-secp256k1#224). It is the
+        # one of btclib's signing calls a caller would most plausibly
+        # want to decline, which is why the keyword reaching here is the
+        # point of exposing it at all
+        try:
+            return self._signer.sign_custom(msg, aux, verify=verify)
+        except RuntimeError as e:
+            # translated as at `sign_`'s own crossing above, and for the
+            # same reason: this is the second of the two calls that let
+            # the bindings' bare RuntimeError out
+            raise BTClibRuntimeError(str(e)) from e
 
-    def sign(self, msg: Octets, aux: Octets | None = None) -> bytes:
+    def sign(
+        self, msg: Octets, aux: Octets | None = None, *, verify: bool = True
+    ) -> bytes:
         """Return the signature of a message, reducing it with hf first."""
-        return self.sign_(reduce_to_hlen(msg, self._hf), aux)
+        return self.sign_(reduce_to_hlen(msg, self._hf), aux, verify=verify)
 
 
 def _assert_as_valid_(

--- a/tests/bool_parameter_test.py
+++ b/tests/bool_parameter_test.py
@@ -108,7 +108,7 @@ from btclib.curves.sec_point import (
     point_from_octets,
 )
 from btclib.descriptors.descriptors import parse as descriptor_from_string
-from btclib.ecc import bms, dsa, musig2
+from btclib.ecc import bms, dsa, musig2, ssa
 from btclib.exceptions import BTClibTypeError
 from btclib.fetch.bitcoin_core import BitcoinCoreFetcher
 from btclib.hwi import HwiSigner, enumerate_devices
@@ -760,6 +760,36 @@ _TRUTHS = (
         "verify",
         dsa.sign,
         {"msg": _MSG, "prv_key": _PRV_KEY},
+        reason="whether the signature is checked before it is answered with",
+    ),
+    _Case(
+        "btclib.ecc.ssa.sign_",
+        "verify",
+        ssa.sign_,
+        {"msg": _MSG, "prv_key": _PRV_KEY},
+        reason="whether the signature is checked before it is answered with;"
+        " the signature is the same either way, the check being a"
+        " verification of what has already been computed",
+    ),
+    _Case(
+        "btclib.ecc.ssa.sign",
+        "verify",
+        ssa.sign,
+        {"msg": _MSG, "prv_key": _PRV_KEY},
+        reason="whether the signature is checked before it is answered with",
+    ),
+    _Case(
+        "btclib.ecc.ssa.Signer.sign_",
+        "verify",
+        ssa.Signer(_PRV_KEY).sign_,
+        {"msg": _MSG},
+        reason="whether the signature is checked before it is answered with",
+    ),
+    _Case(
+        "btclib.ecc.ssa.Signer.sign",
+        "verify",
+        ssa.Signer(_PRV_KEY).sign,
+        {"msg": _MSG},
         reason="whether the signature is checked before it is answered with",
     ),
     _Case(

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -1335,3 +1335,208 @@ def test_a_signer_refuses_what_sign_refuses() -> None:
         ssa.Signer(secp256k1.n)
     with pytest.raises(BTClibTypeError):
         ssa.Signer(0x1234567890ABCDEF, secp256k1, "not a hash function")  # type: ignore[arg-type]
+
+
+_ARMS = [
+    pytest.param(True, marks=needs_bindings, id="bindings"),
+    pytest.param(False, id="python"),
+]
+
+
+@pytest.mark.parametrize("bindings", _ARMS)
+def test_the_check_changes_no_signature(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`verify` is a truth: what it turns on reads, and writes nothing.
+
+    Every spelling answers the same octets, which is what puts the flag
+    in `_TRUTHS` rather than beside the kinds, and what makes declining
+    the check a decision about time and not about which signature a key
+    and a message make. `aux` is fixed because BIP340 draws it at random
+    otherwise, and two signatures of one message would differ for a
+    reason that has nothing to do with the flag.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    prv_key = 0x1234567890ABCDEF
+    msg = b"a message signed twice"
+    aux = bytes(32)
+
+    checked = ssa.sign(msg, prv_key, aux)
+    assert checked == ssa.sign(msg, prv_key, aux, verify=False)
+    assert checked == ssa.sign_(reduce_to_hlen(msg, hf), prv_key, aux)
+    assert checked == ssa.sign_(reduce_to_hlen(msg, hf), prv_key, aux, verify=False)
+
+    # the commitment path answers the same pair either way, and its check
+    # is of the signature and not of the receipt
+    committed = ssa.sign(msg, prv_key, aux, commit=b"a commitment")
+    assert committed == ssa.sign(
+        msg, prv_key, aux, commit=b"a commitment", verify=False
+    )
+
+
+@pytest.mark.parametrize("bindings", _ARMS)
+def test_a_signer_answers_what_the_free_function_answers(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The flag reaches the call it was exposed for.
+
+    A `Signer` holds the keypair, so the signature is the cheap part and
+    the check is not -- which is why this is the signing call a caller
+    would most plausibly decline. Both of its spellings take the keyword
+    and both answer the free function's signature.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    prv_key = 0x1234567890ABCDEF
+    msg = b"a message signed by a signer"
+    aux = bytes(32)
+    expected = ssa.sign(msg, prv_key, aux).serialize()
+
+    with ssa.Signer(prv_key) as signer:
+        assert signer.sign(msg, aux) == expected
+        assert signer.sign(msg, aux, verify=False) == expected
+        assert signer.sign_(reduce_to_hlen(msg, hf), aux) == expected
+        assert signer.sign_(reduce_to_hlen(msg, hf), aux, verify=False) == expected
+
+
+def test_the_python_arm_refuses_a_signature_that_does_not_verify() -> None:
+    """The check is wired to the raise, not merely written near it.
+
+    No input reaches it -- a fresh signature verifies under the key that
+    made it -- so what says the branch is live is a substituted
+    verification, as `tests/ecc/dsa_test.py` does for the same reason.
+    Read in both directions: with the check refusing everything the
+    signature is not answered with, and with `verify=False` the
+    substitution is never reached at all, which is what says the flag is
+    honoured rather than ignored on a path whose output does not change.
+
+    What comes back is the signing sentence and not the check's own
+    words, which are a verifier's; the check's are kept as the cause, so
+    what the verification saw is still in hand.
+    """
+
+    def refuse(*_: Any, **__: Any) -> None:
+        raise BTClibRuntimeError("signature verification failed")
+
+    prv_key = 0x1234567890ABCDEF
+    msg = b"a message whose check is made to fail"
+    aux = bytes(32)
+
+    with pytest.MonkeyPatch.context() as patched:
+        patched.setattr(ssa, "_libsecp256k1_serves", lambda *_: False)
+        unchecked = ssa.sign(msg, prv_key, aux, verify=False)
+        patched.setattr(ssa, "_assert_as_valid_", refuse)
+        with pytest.raises(BTClibRuntimeError, match="does not verify") as plain:
+            ssa.sign(msg, prv_key, aux)
+        assert str(plain.value.__cause__) == "signature verification failed"
+        with pytest.raises(BTClibRuntimeError, match="does not verify") as committed:
+            ssa.sign(msg, prv_key, aux, commit=b"a commitment")
+        assert str(committed.value.__cause__) == "signature verification failed"
+        # and the flag is read: the same substitution is not reached,
+        # and the signature that comes back is the one the checked call
+        # would have answered had its check not been made to fail
+        assert ssa.sign(msg, prv_key, aux, verify=False) == unchecked
+
+
+@needs_bindings
+def test_the_two_arms_answer_the_same_signature_and_the_same_refusal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One contract, two implementations, checked or not.
+
+    A fallback answering differently from the arm it stands in for would
+    be two libraries wearing one name, and how it refuses is half of
+    what it answers: the signatures, the exception type and the message
+    are all held equal here, as `tests/ecc/dsa_test.py`'s namesake holds
+    them. `verify` adds no failure an argument can reach -- BIP340's
+    check is a bare verification under a point the keypair already
+    holds, so there is no key to hand in and no second reason to fail --
+    so each arm is driven into its real failing branch instead.
+
+    The fault is installed in a different place per arm because that is
+    where each arm's check lives: the bindings' own verification for the
+    delegated one, and for the Python one a signature that is not the
+    one the nonce and the key make, which its own `_assert_as_valid_`
+    then refuses. Nothing about either refusal is fabricated, so the two
+    rows are the words each implementation really says.
+
+    Twice on the Python arm, because its check refuses in two
+    hierarchies: a signature that simply does not verify, and one whose
+    K lands on the point at infinity -- what a nonce zeroed after its
+    point was computed leaves behind -- which has no y to answer with
+    and comes back as a `ValueError`. Both have to arrive as the one
+    sentence, and the second is the one a clause naming only
+    `BTClibRuntimeError` lets through.
+
+    Marked for the bindings because the delegated row is what the Python
+    one is compared against; without them both rows would be the Python
+    arm.
+    """
+    prv_key = 0x1234567890ABCDEF
+    msg = b"a message both arms sign"
+    aux = bytes(32)
+
+    def signatures() -> tuple[Any, ...]:
+        return (
+            ssa.sign(msg, prv_key, aux),
+            ssa.sign(msg, prv_key, aux, verify=False),
+            ssa.sign(msg, prv_key, aux, commit=b"a commitment"),
+        )
+
+    def refusal() -> tuple[Any, ...]:
+        with pytest.raises(BTClibRuntimeError) as refused:
+            ssa.sign(msg, prv_key, aux)
+        return type(refused.value), str(refused.value)
+
+    delegated = signatures()
+    with monkeypatch.context() as faulted:
+        # their `_abort_unless_verified` reads this and raises, so the
+        # words this row contributes are the bindings' own
+        faulted.setattr(libsecp256k1_ssa, "_verify_", lambda *_, **__: False)
+        delegated_refusal = refusal()
+
+    signed = ssa._sign_
+    with monkeypatch.context() as python:
+        python.setattr(ssa, "_libsecp256k1_serves", lambda *_: False)
+        assert signatures() == delegated
+
+        def a_signature_that_cannot_verify(*args: Any) -> ssa.Sig:
+            signature = signed(*args)
+            return ssa.Sig(signature.r, signature.s + 1, signature.ec)
+
+        python.setattr(ssa, "_sign_", a_signature_that_cannot_verify)
+        assert refusal() == delegated_refusal
+
+        def a_signature_whose_point_is_at_infinity(
+            c: int, q: int, k: int, x_K: int, ec: Curve
+        ) -> ssa.Sig:
+            # s = c*q is what a zeroed nonce leaves, and sG - cQ is then
+            # the point at infinity: the same check, refusing in the
+            # other hierarchy
+            return ssa.Sig(x_K, c * q % ec.n, ec)
+
+        python.setattr(ssa, "_sign_", a_signature_whose_point_is_at_infinity)
+        assert refusal() == delegated_refusal
+
+
+@needs_bindings
+def test_a_signer_refuses_under_the_same_sentence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The other crossing into the bindings, translated as the first is.
+
+    `Signer.sign_` calls them rather than going through `sign_`, so the
+    two calls are two chances for a bare RuntimeError to reach a caller
+    who wrote the hierarchy this package publishes. Driven into the
+    bindings' own failing branch the way the test above drives it.
+    """
+    monkeypatch.setattr(libsecp256k1_ssa, "_verify_", lambda *_, **__: False)
+
+    with (
+        ssa.Signer(0x1234567890ABCDEF) as signer,
+        pytest.raises(BTClibRuntimeError, match="does not verify"),
+    ):
+        signer.sign(b"a message whose check is made to fail")


### PR DESCRIPTION
`ssa` wrote `verify=True` at its dispatch and gave a caller nowhere to
turn, while its Python arm checked nothing at all. Both are now the
one contract `dsa` was given: the keyword is exposed, it defaults to
True, and the fallback performs the check rather than answering
differently from the arm it stands in for.

The default is the specification's here and not only this library's
policy. BIP340 puts the step inside *Default Signing* -- "If
Verify(bytes(P), m, sig) returns failure, abort" -- where ECDSA's comes
from Bitcoin Core; what it catches either way is a computation that
went wrong, whose cost is a published signature that is invalid and may
say something about the key.

`ssa.sign`, `ssa.sign_`, `ssa.Signer.sign` and `ssa.Signer.sign_` all
take it. The `Signer` is the call this was worth exposing for, and its
own comment said so before this change did: it holds the keypair, so
the signature is the cheap part and the check is not, and it was the
one signing call in the library whose policy a caller could neither see
nor decline.

## No pub_key, and the absence is the decision

What such an argument buys in `dsa` is the generator multiplication the
check would otherwise do per signature. BIP340 has none to save, the
keypair holding the point already, so it would buy nothing and sell one
thing: a second reason a check can fail, and with it the discrimination
step `dsa._abort_unless_checked` has to pay for.

That the check does not depend on holding the key is measured in
btclib-secp256k1#224, and cited rather than re-measured here. A figure
of theirs kept in this repository is one that ages when they change and
says nothing when it does -- which is also why the delegated arm's cost
is not restated in this entry.

## The Python arm, which is btclib's to measure

A signature is 305.50 microseconds and the checked call 962.81, so
signing there is 3.15 times what it was, the check adding 657.31 --
about two signatures, where `dsa`'s is about four and a half. BIP340
pays less because the key is in hand: `bip340_nonce_` has already
computed the point to answer x_Q, and only the even-y lift is done
again. Alternated in one process, 9 rounds of 300 calls, minimum kept,
the unchecked row run again at the end for a noise of 3.01 -- an Apple
M5, macOS 26.6, arm64, CPython 3.14.6.

The lift is the one thing this arm pays that the delegated one does
not, and no argument would remove it: the caller's key is x-only in
this scheme, so there is nothing to hand in that would not have to be
lifted anyway.

## The refusal, which is half of the contract

The two arms have to answer a failed check the same way, or the contract
claimed above is only about the signature. They did not, at first: the
delegated arm let the bindings' bare `RuntimeError` cross untouched, so a
caller who wrote the `except BTClibException` this package publishes did
not catch the one failure signing has, and the Python arm answered
`_assert_as_valid_`'s words -- `y_K is odd`, `signature verification
failed` -- which are a verifier's and say what the check saw rather than
what happened.

Both now raise `BTClibRuntimeError("signing produced a signature that
does not verify")`: the bindings' own sentence, and what `dsa` says on
both of its arms. `_assert_as_valid_`'s wording could not simply be
changed, the public `assert_as_valid_` sharing it, so the signing
sentence is raised over it and the check's own reason is kept as the
cause. `Signer.sign_` calls the bindings itself rather than through
`sign_`, so it is a second crossing and takes the same translation --
which is what closes ISS 1008, the delegated half of this and older than
the branch.

## Verification

`uv run pytest` -- 27 951 passed, coverage 100. `uv run pre-commit run
--all-files` clean, every hook. `sphinx-build -W --keep-going` -- build
succeeded.

`tests/ecc/ssa_test.py` gains five cases, two of them on both arms: the
check changing no signature in every spelling including the
commitment's, a `Signer` answering the free function's signature with
the flag either way, the raise proven wired by a substituted
verification -- no input reaches it, a fresh signature verifying under
the key that made it -- the two arms held to the same three signatures
*and* to one exception type and one message, and the `Signer`'s own
crossing refusing under that same sentence.

The cross-arm case drives each arm into its real failing branch rather
than into a substituted one: the bindings' `_verify_` made to answer
False, so their `_abort_unless_verified` raises what it raises, and a
signature that is not the one the nonce and the key make, so
`_assert_as_valid_` refuses it for real. Nothing about either refusal is
fabricated, which is what lets the type and the words be compared. It
carries `needs_bindings` for that reason -- the delegated row is what the
Python one is held against.

The substitution is read in both directions, which is the half that
says the flag is honoured rather than ignored: the signature is the
same octets whichever way it goes, so a `verify` nobody reads would
answer exactly what it should.

`tests/bool_parameter_test.py` carries the four new flags as truths.
They turn a check on and change no answer, so they are read for whether
they are true and not type-checked, which is the line `aux` and the
kinds are on the other side of.

Closes #1008.

Completes the decision in btclib-org/btclib#982 that both schemes
expose the keyword. What that issue still asks for and this does not
give is `dsa.Signer`, which needs the bindings to accept a private key
in memory they own -- btclib-org/btclib-secp256k1#247.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Expose optional, specification-defaulted signature verification across SSA signing APIs and unify failure handling between the delegated and pure-Python implementations.

New Features:
- Add a keyword-only `verify` option, defaulting to enabled, to all BIP340 SSA signing APIs, including `Signer` methods.
- Perform signature verification in the pure-Python SSA signing path before returning signatures.

Bug Fixes:
- Make delegated and pure-Python SSA signing paths expose the same verification behavior and consistently translate failed checks into `BTClibRuntimeError` with a common message.
- Ensure commitment-signing and signer-based APIs honor the verification option.

Documentation:
- Document the SSA verification option, its default behavior, and the rationale for not accepting a public-key argument.

Tests:
- Add coverage for verification toggling, identical signatures across both implementations, signer methods, commitment signing, and consistent failure exceptions.
- Extend boolean-parameter tests to cover all new SSA `verify` arguments.

Chores:
- Update changelog and history entries for the SSA verification behavior and performance impact.
