### PR TITLE
Set Sonnet as the default Claude Code model

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+    "model": "sonnet"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,17 @@ Your own branch is what you push, and the pull request is what moves
 `main`: CONTRIBUTING.md's "Pull Request" section has how a branch under
 review is corrected and how it is merged.
 
+## Model
+
+The default model for this repository is Sonnet. Switch to Opus only
+for architectural decisions with conflicting constraints -- design
+choices with non-obvious trade-offs, refactors that cross the layer
+boundaries above with unclear dependencies, diagnosis where the
+symptom does not point to the cause. Use `/model opus` for the
+session, then switch back to Sonnet.
+
+Do not use Fable unless explicitly instructed.
+
 ## Non-obvious facts that will otherwise waste a session
 
 - **`main` is the only branch**, and nothing is pushed to it directly:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,8 @@ ignore = [
     # gate enforces, and no more part of a distribution than the website
     # below is
     ".vscode/*",
+    # Claude Code's own workspace config, same argument as .vscode/* above
+    ".claude/*",
     "CNAME",
     "Gemfile",
     "_config.yml",


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` pinning `"model": "sonnet"` as this repository's default Claude Code model.
- Add a `## Model` section to CLAUDE.md, placed right after "The primary checkout is the maintainer's": switch to Opus only for architectural decisions with conflicting constraints (design choices with non-obvious trade-offs, refactors crossing the layer boundaries in "Architecture" with unclear dependencies, diagnosis where the symptom doesn't point to the cause), via `/model opus` for the session; do not use Fable unless explicitly instructed.
- Add `.claude/*` to `[tool.check-manifest]`'s `ignore` list in pyproject.toml, alongside `.vscode/*`: the new settings file is workspace config, not sdist content, and the gate otherwise fails on any new file under `.claude/`.

Equivalent to [checksig#660](https://github.com/checksig-custody/checksig/pull/660), opened for every repository in this organization.

## Test plan
- [x] `uv run pre-commit run --files CLAUDE.md pyproject.toml .claude/settings.json` — all hooks pass, including check-manifest and Pyroma
- [x] `git log -1 --format='%G? %GS'` — `G Ferdinando M. Ametrano`

## Summary by Sourcery

Configure Sonnet as the default Claude Code model and align repository guidance and packaging checks with the new workspace configuration.

Enhancements:
- Set Sonnet as the repository's default Claude Code model and document when to switch to Opus for complex architectural decisions.

Build:
- Exclude Claude Code workspace configuration from manifest checks so it is not treated as source distribution content.

Documentation:
- Document the repository's Claude Code model-selection policy, including the prohibition on Fable unless explicitly requested.