### PR TITLE
Say three shared facts once, and the landing convention that is in force

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,13 @@ documented at release-notes length in the first place, and are still in
   of the matrix: a button recreates rather than moves, GitHub's
   documentation saying rebase-and-merge "always updates the committer
   information and creates new commit SHAs", so the count of commits was
-  never what decided it.
+  never what decided it. `REPOSITORY.md`'s "maintainer's second path"
+  section goes with it: there is no second path, so what described one —
+  the push sequence, the two cases of whether GitHub reconciles what
+  landed, the deletion left to do by hand — is replaced by the one case
+  that remains. Every landing is a pull request GitHub merges, so the
+  `Closes #N` in the description always fires and the head branch always
+  goes.
 
 - **The review standard is written down, in `REVIEWING.md`.** What a review
   establishes before it gives an ack — the diff leaves the tree better

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **The landing convention says what actually happens: the squash
+  button.** `CONTRIBUTING.md` said "how that commit reaches `main` is a
+  push rather than a button", `RELEASING.md` that the button was the
+  wrong landing for a release, and `REPOSITORY.md` that no button was
+  the landing at all. `main` has been taking squash merges GitHub
+  composes and signs with its web-flow key throughout, which is what the
+  branch rule asks for: a valid signature, not a particular signer. The
+  three files now say that, and reserve the command-line fast-forward
+  for the one case that still wants it — a single-commit pull request
+  that is the base of a stacked one, where a button would orphan the
+  child. A button recreates rather than moves, GitHub's documentation
+  saying rebase-and-merge "always updates the committer information and
+  creates new commit SHAs", so the number of commits is not what decides
+  it.
+
 - **The review standard is written down, in `REVIEWING.md`.** What a review
   establishes before it gives an ack — the diff leaves the tree better
   than it found it, which is not the diff the reviewer would have
@@ -64,8 +79,7 @@ documented at release-notes length in the first place, and are still in
   rows — and REPOSITORY.md keeps the number. Self-approval was stated
   from scratch in `REPOSITORY.md` where `CONTRIBUTING.md` already
   states it, and now points. "Squash is the only button" was in three
-  files; `RELEASING.md` keeps only the reason it is the wrong landing
-  for a release, the tag going over a commit GitHub's key signed.
+  files and is now in `REPOSITORY.md` alone.
 
 - **`REPOSITORY.md`'s "Merge methods" no longer corrects itself in
   place.** It opened by naming the squash button as how a pull request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,26 @@ documented at release-notes length in the first place, and are still in
   own: it says which files to read, `REVIEWING.md` first.
   `check-manifest`'s ignore entry becomes `.claude/**`, `.claude/*` being
   one level and the commands now a directory deeper.
+- **Three facts that were in two files are in one.** The concurrency
+  ceiling and what it measured were stated in full in both
+  `CONTRIBUTING.md` and `REPOSITORY.md`, the first pointing at the
+  second and then repeating it anyway; `CONTRIBUTING.md` keeps the
+  consequence its workflow table is about — which rows a pull request
+  waits for, and the macOS and Windows figures that decided the other
+  rows — and REPOSITORY.md keeps the number. Self-approval was stated
+  from scratch in `REPOSITORY.md` where `CONTRIBUTING.md` already
+  states it, and now points. "Squash is the only button" was in three
+  files; `RELEASING.md` keeps only the reason it is the wrong landing
+  for a release, the tag going over a commit GitHub's key signed.
+
+- **`REPOSITORY.md`'s "Merge methods" no longer corrects itself in
+  place.** It opened by naming the squash button as how a pull request
+  lands, then said in the next paragraph that the section had done so
+  and that the landing is the fast-forward two headings above. Prose
+  that carries the history of its own edit is what
+  `CONTRIBUTING.md`'s "no history" rule is against: the section now
+  states the landing first and the button settings as what bounds a
+  landing nobody drove from a shell.
 
 - **The numeric mutation profile finishes its scope instead of sampling a
   fifth of it.** Its per-mutant `timeout` is 30 seconds rather than 300,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,13 +31,20 @@ documented at release-notes length in the first place, and are still in
   the landing at all. `main` has been taking squash merges GitHub
   composes and signs with its web-flow key throughout, which is what the
   branch rule asks for: a valid signature, not a particular signer. The
-  three files now say that, and reserve the command-line fast-forward
-  for the one case that still wants it — a single-commit pull request
-  that is the base of a stacked one, where a button would orphan the
-  child. A button recreates rather than moves, GitHub's documentation
-  saying rebase-and-merge "always updates the committer information and
-  creates new commit SHAs", so the number of commits is not what decides
-  it.
+  three files now say that, and say that it is the only way in: the
+  `main-self-merge` bypass moves from `always` to `pull_request` mode,
+  so it excuses the approving review a solo repository cannot produce
+  and excuses nothing else — a direct push to `main` is refused for
+  everyone, the holder of the bypass included — and the ruleset names
+  `squash` as the only merge method it accepts, stating the constraint
+  where the rule is rather than only in a repository toggle. The
+  command-line fast-forward that used to be the landing is therefore
+  gone rather than demoted. Its one remaining use, keeping a stacked
+  child's base alive, is paid for instead with a rebase and a fresh run
+  of the matrix: a button recreates rather than moves, GitHub's
+  documentation saying rebase-and-merge "always updates the committer
+  information and creates new commit SHAs", so the count of commits was
+  never what decided it.
 
 - **The review standard is written down, in `REVIEWING.md`.** What a review
   establishes before it gives an ack — the diff leaves the tree better

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1317,10 +1317,9 @@ by branch rule, and one change is one commit there.
 **How that commit reaches `main` is the squash button**, pressed by
 auto-merge once the review and the checks are in. GitHub composes it and
 signs it with its web-flow key, which is a valid signature and therefore
-all the branch rule asks for. REPOSITORY.md has the setting, and the one
-exception: a single-commit pull request that is the base of a stacked
-one is fast-forwarded from the command line instead, so that its sha
-survives and the child is not left needing a rebase.
+all the branch rule asks for. There is no other path: `main` takes a
+pull request and nothing else, a direct push being refused for everyone.
+REPOSITORY.md has the settings that make that true.
 
 Either way the decision belongs to the landing and not to the branch,
 which is why a correction added on top of a reviewed branch is still the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1343,7 +1343,8 @@ only of what a press produces.
 
 **It is a setting and not a choice made once per pull request**, so
 there is no other button to read. REPOSITORY.md has it, what the other
-two would have cost, and the fast-forward exception above.
+two would have cost, and the ruleset that names `squash` as the only
+merge method it accepts.
 
 The one force-push that stays right is the one that carries no new work: a
 `git rebase origin/main` on a branch whose base has moved, which is how a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1314,18 +1314,17 @@ per landed change. A merge commit would put the branch's steps into
 `main` and a rebase merge would replay them one by one — `main` is linear
 by branch rule, and one change is one commit there.
 
-**How that commit reaches `main` is a push rather than a button**, which
-is the maintainer's own path and needs a ruleset bypass no contributor
-has: REPOSITORY.md describes it, squashing the branch locally where it
-carries more than one commit and fast-forwarding the result. It is worth
-knowing about from here for two reasons. The commit that lands is signed
-by the maintainer rather than by GitHub's web-flow key; and where what
-lands is the head CI ran on, its sha does not change, so a branch stacked
-on that one keeps applying where a squash composed at the merge would
-have rewritten its base. Which is why a correction added on top of a
-reviewed branch is still the right shape: whether the branch is squashed
-or fast-forwarded is decided when it lands, and by then the review has
-its record either way.
+**How that commit reaches `main` is the squash button**, pressed by
+auto-merge once the review and the checks are in. GitHub composes it and
+signs it with its web-flow key, which is a valid signature and therefore
+all the branch rule asks for. REPOSITORY.md has the setting, and the one
+exception: a single-commit pull request that is the base of a stacked
+one is fast-forwarded from the command line instead, so that its sha
+survives and the child is not left needing a rebase.
+
+Either way the decision belongs to the landing and not to the branch,
+which is why a correction added on top of a reviewed branch is still the
+right shape: by the time it is squashed the review has its record.
 
 What that commit says is the repository's to answer, not this file's:
 
@@ -1343,10 +1342,9 @@ and a squash made locally follows the same convention by hand, the
 setting being the statement of what the message should say rather than
 only of what a press produces.
 
-**It is a setting and not a choice made once per pull request.** Squash is
-the only *button* the repository enables, so there is no other to read;
-REPOSITORY.md has that setting, what the other two would have cost, and
-the fast-forward that is not a button at all.
+**It is a setting and not a choice made once per pull request**, so
+there is no other button to read. REPOSITORY.md has it, what the other
+two would have cost, and the fast-forward exception above.
 
 The one force-push that stays right is the one that carries no new work: a
 `git rebase origin/main` on a branch whose base has moved, which is how a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,19 +269,18 @@ The first four rows are what a merge waits for, and between them they report
 the four required checks: `lint` and `docs` share a row and report one each.
 
 What the other rows have in common is that a pull request does not wait for
-them, and the reason is one number: GitHub Free gives an organization twenty
-concurrent jobs. A commit used to ask for thirty-nine, and a repository at
-that ceiling spends a pull request's wall clock waiting for a slot rather
-than running the suite — measured over a working afternoon, nineteen or
-twenty jobs were running for 1375 of 2100 seconds. So a platform row earns
-its place before a review only if it is cheap to wait for: macOS queued 29.4
+them, and the reason is one number: the ceiling GitHub Free puts on an
+organization's concurrent jobs. REPOSITORY.md measures it and what it cost,
+and the consequence is this table's: at that ceiling a pull request's wall
+clock is the wait for a slot rather than the suite, so a platform row earns
+its place before a review only if it is cheap to wait for. macOS queued 29.4
 and 23.2 minutes on average against 0.5 to 1.6 elsewhere, and the fourteen
 Windows cells were 2357 of the 3556 seconds of matrix work per commit, the
 slowest rows and the longest queues. Both answer weekly and before a
 release instead, which is a regression sitting on `main` for at most a week
 against every review paying for it. `codeql` is there for the same
 arithmetic, with `zizmor` in `lint` still reading these workflows on every
-pull request; REPOSITORY.md has that trade in full.
+pull request.
 
 `macos` and `latest` share a morning half an hour apart, which is what makes
 the pair readable: red in both is the platform, red in `latest` alone is the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -292,10 +292,8 @@ word, and step 1 asks it of both.
    button, pressed by auto-merge once the review and the checks are in.
    There is no other way in: `main` takes a pull request and nothing
    else. That the commit under the tag carries GitHub's web-flow
-   signature rather than the maintainer's costs nothing — the branch
-   rule asks for a valid signature and not for a particular signer, and
-   the attestation that is the maintainer's own is the tag, which
-   `git tag -s` signs.
+   signature rather than the maintainer's costs nothing: the branch rule
+   asks for a valid signature and not for a particular signer.
 
    This branch carries more than one commit every time, a version bump
    and two retitles never being one, so the commit that lands is one

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -290,13 +290,12 @@ word, and step 1 asks it of both.
 
    And land it the way every other pull request here lands: the squash
    button, pressed by auto-merge once the review and the checks are in.
-   Nothing about a release asks for the fast-forward exception —
-   REPOSITORY.md reserves that for a single-commit pull request that is
-   the base of a stacked one, which a release is not. That the commit
-   under the tag carries GitHub's web-flow signature rather than the
-   maintainer's costs nothing: the branch rule asks for a valid
-   signature and not for a particular signer, and the attestation that
-   is the maintainer's own is the tag, which `git tag -s` signs.
+   There is no other way in: `main` takes a pull request and nothing
+   else. That the commit under the tag carries GitHub's web-flow
+   signature rather than the maintainer's costs nothing — the branch
+   rule asks for a valid signature and not for a particular signer, and
+   the attestation that is the maintainer's own is the tag, which
+   `git tag -s` signs.
 
    This branch is the squashed case every time, a version bump and two
    retitles never being one commit, so push the squash to the branch

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -293,10 +293,10 @@ word, and step 1 asks it of both.
    version bump and two retitles, not a cycle of work, and
    CONTRIBUTING.md gives the rest of the reason — and fast-forwarded onto
    `main`, REPOSITORY.md having the sequence and the bypass it needs.
-   Squash is the only *button* the repository enables, and it is the
-   wrong landing here in particular: it is the release commit that gets
-   tagged, so a squash composed by GitHub would leave the tag over a
-   commit signed by the web-flow key rather than by the maintainer.
+   The squash button REPOSITORY.md leaves enabled is the wrong landing
+   here in particular: it is the release commit that gets tagged, so a
+   squash composed by GitHub would leave the tag over a commit signed by
+   the web-flow key rather than by the maintainer.
 
    This branch is the squashed case every time, a version bump and two
    retitles never being one commit, so push the squash to the branch

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -288,15 +288,15 @@ word, and step 1 asks it of both.
    enforces, and a pull request that never mentions them reads exactly
    like one that skipped them.
 
-   And land it the way every other pull request here lands: squashed
-   locally into one signed commit where it carries more than one — a
-   version bump and two retitles, not a cycle of work, and
-   CONTRIBUTING.md gives the rest of the reason — and fast-forwarded onto
-   `main`, REPOSITORY.md having the sequence and the bypass it needs.
-   The squash button REPOSITORY.md leaves enabled is the wrong landing
-   here in particular: it is the release commit that gets tagged, so a
-   squash composed by GitHub would leave the tag over a commit signed by
-   the web-flow key rather than by the maintainer.
+   And land it the way every other pull request here lands: the squash
+   button, pressed by auto-merge once the review and the checks are in.
+   Nothing about a release asks for the fast-forward exception —
+   REPOSITORY.md reserves that for a single-commit pull request that is
+   the base of a stacked one, which a release is not. That the commit
+   under the tag carries GitHub's web-flow signature rather than the
+   maintainer's costs nothing: the branch rule asks for a valid
+   signature and not for a particular signer, and the attestation that
+   is the maintainer's own is the tag, which `git tag -s` signs.
 
    This branch is the squashed case every time, a version bump and two
    retitles never being one commit, so push the squash to the branch

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -297,13 +297,11 @@ word, and step 1 asks it of both.
    the attestation that is the maintainer's own is the tag, which
    `git tag -s` signs.
 
-   This branch is the squashed case every time, a version bump and two
-   retitles never being one commit, so push the squash to the branch
-   before fast-forwarding it: the checks below then run on the object
-   that lands, and GitHub still marks the pull request Merged. Land the
-   squash straight from a worktree instead and nothing is reconciled —
-   the pull request has to be closed by hand, which is a surprise worth
-   not having between here and the tag.
+   This branch carries more than one commit every time, a version bump
+   and two retitles never being one, so the commit that lands is one
+   GitHub composes at the button and no local object matches it. That
+   is why the checks are read again below, on what `main` ends up at
+   rather than on the branch head they ran against.
 
    Then read `lint` and `test` on the commit `main` ends up at before
    tagging, rather than trust the pull request's own green run:

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -271,96 +271,68 @@ branch, and it is the only branch there is. Issue #158 was the other
 arrangement — two bots pushing through an integration branch that carried
 no protection at all — and one branch is what closed it.
 
-### The maintainer's second path: two rulesets beside the classic rule
+### Two rulesets beside the classic rule
 
 `enforce_admins` off is one switch that exempts an administrator from
 every rule above at once — there is no way, inside the classic rule
 alone, to relax the review requirement for a solo merge while keeping
-signatures and linear history unconditional. Every issue tracking a
-change to the library gets one of two endings: a pull request that
-carries a real review from somebody else, which closes it automatically
-on merge (`Closes #N`); or, when the maintainer is working alone, this
-second path, which closes it by hand, referencing the commit that
-landed.
-
-Two rulesets carry that split, additive to the classic rule rather than
-replacing it — rules aggregate across rulesets and classic protection,
-taking the most restrictive combination wherever they overlap:
+signatures and linear history unconditional. Two rulesets carry that
+split, additive to the classic rule rather than replacing it: rules
+aggregate across rulesets and classic protection, taking the most
+restrictive combination wherever they overlap.
 
 - `main-integrity`: required signatures, required linear history, no
   force pushes, no deletions. No bypass actor, for anyone, ever.
-- `main-self-merge`: require a pull request (one approving review,
-  dismiss stale reviews, conversation resolution). Bypass: the
-  maintainer, "Always" mode.
+- `main-self-merge`: require a pull request — one approving review,
+  dismiss stale reviews, conversation resolution — and `squash` as the
+  only merge method it will accept. Bypass: the maintainer, in
+  **`pull_request` mode**.
 
-"Always" is what permits a direct push rather than only a PR merge
-without review, and it is scoped to `main-self-merge` alone: being
-bypassed there does not exempt from `main-integrity`, which has no
-bypass entry for anyone. Verified on a disposable branch before either
-ruleset touched `main`: a direct push with no bypass was rejected
-("Changes must be made through a pull request"); the same push,
-bypassed, was accepted as a fast-forward with no new commit created
-("Bypassed rule violations"); a force-push under that same bypass was
-still rejected ("Cannot force-push to this branch"), which is the proof
-that the isolation holds rather than an assumption about it.
+**The bypass mode is the whole of the design.** `pull_request` excuses
+its holder from the rule *while merging a pull request* and at no other
+time, so it answers the one thing a solo-maintainer repository cannot
+do — produce an approving review from somebody else — and answers
+nothing further. A direct push to `main` is refused for everyone, the
+holder included: outside a pull request there is no bypass to apply, and
+the rule says changes must come through one.
 
-What the maintainer cannot do, with or without the bypass, is land
-something on `main` that is unsigned or that rewrites history:
-`main-integrity` answers that question the same way for every push,
-admin or not. Exercising the bypass is therefore always the same
-sequence — the fast-forward is what has to hold, not a force push
-standing in for one:
+The other mode, `always`, permits a direct push as well, and it is not
+used here. What it would buy is a landing that keeps the maintainer's
+own signature on the commit; what it costs is a `main` any local mistake
+can reach. The first half is worth nothing once the branch rule is read
+as asking for a valid signature rather than for a particular signer,
+which makes GitHub's web-flow key as good as the maintainer's — and the
+second half is not hypothetical: a `git merge` run in the wrong working
+tree is enough to advance `main` locally, and under `always` the push
+that follows would be accepted.
+
+Read the two back rather than trusting either:
 
 ```shell
-git fetch origin && git rebase origin/main   # must end fast-forwardable
-git log --format='%h %G?' origin/main..      # every commit G, none N
-# local gates: pytest, pre-commit run --all-files, the sphinx -W build
-git push origin <branch>:main
+gh api repos/btclib-org/btclib/rulesets --jq '.[].id' \
+  | xargs -I{} gh api repos/btclib-org/btclib/rulesets/{} \
+    --jq '{name, rules: [.rules[].type],
+           bypass: [.bypass_actors[] | .bypass_mode]}'
 ```
 
-Where the branch carries more than one commit it is squashed into a
-single signed commit first — `git reset --soft origin/main && git
-commit`, with `--author` where the branch is somebody else's, GitHub's
-button being what would otherwise have kept their name on it — and that
-commit is what the push fast-forwards. Squashing here rather than
-pressing the button is the whole of what keeps the signature the
-maintainer's: GitHub composes a squash server-side and signs it with its
-own web-flow key, while a push signs nothing and has nothing to sign, the
-commit arriving with the signature it already carried.
+`main-integrity` answers with an empty bypass list, and it is what makes
+an unsigned commit or a rewritten history unlandable by anyone, admin or
+not, through a pull request or otherwise.
 
-**The bypass is not the whole of the permission.** The classic protection
-still carries `required_pull_request_reviews` and its `strict` required
-checks, and what a push to `main` clears those with is `enforce_admins`
-being `false` and the pusher holding `admin`; the ruleset bypass alone
-would not be enough. So the path depends on two settings, and the fragile
-one is that: turning `enforce_admins` on closes the fast-forward whatever
-the ruleset says.
+**Two settings hold the door, not one.** The classic protection still
+carries `required_pull_request_reviews`, and what clears it for the
+maintainer is `enforce_admins` being `false` together with holding
+`admin` — the ruleset bypass alone would not be enough. Turning
+`enforce_admins` on would therefore deadlock every solo merge, the
+classic review requirement having no bypass list to be named in.
 
-**Whether GitHub reconciles the push depends on one thing: whether what
-lands is the sha the pull request names at that moment**, a pull request
-being marked merged when its head becomes reachable from the base branch.
-
-- **it names what lands** — the branch's own head is fast-forwarded,
-  whether it reached that shape as one commit or as a squash **pushed to
-  the branch first**, and a rebase force-pushed to the branch is this
-  case too. GitHub marks the pull request **Merged** on its own, the
-  `Closes #N` in its description closes the issue, and
-  `delete_branch_on_merge` takes the head branch a second later.
-- **it names something else** — the squash or the rebase was made locally
-  and pushed straight to `main`. What lands is an object no pull request
-  names, so nothing is reconciled and nothing is deleted: close it by
-  hand, and let the issue close from the `Closes #N` in the *commit
-  message*, which is the reason for the keyword to be there and not only
-  in the description.
-
-Which is an argument for pushing the squash to the branch before landing
-it: CI then runs on the very object that will land rather than on a head
-that never will, and the reconciliation does the closing. Both halves
-were measured here — #953 was squashed straight onto `main` and is
-**Closed** with `mergedAt: null`, its issue having closed twenty-two
-seconds earlier from the commit message, and #930 was deleted ahead of
-the reconciliation and came out Closed with its commit on `main` all the
-same.
+**Every landing is now a pull request GitHub merges**, which is what
+retires the question this section used to answer at length: whether the
+object arriving on `main` is the one the pull request names. It always
+is. GitHub marks the pull request **Merged**, the `Closes #N` in its
+description closes the issue, and `delete_branch_on_merge` takes the
+head branch a second later — with nothing left to close by hand, and no
+case where a commit lands that no pull request knows about.
 
 ## Merge methods
 
@@ -436,13 +408,13 @@ head. And a pull request **closed without merging** keeps its head branch:
 GitHub cannot know whether that work was abandoned or is waiting, so those
 are the ones still worth looking at now and then.
 
-A fast-forward is covered where GitHub reconciles it, the setting hanging
-on the merge GitHub records rather than on the one a button performed.
-Measured in btclib-secp256k1, whose configuration is this one: a squash
-pushed to the branch and then fast-forwarded was marked Merged at
-12:39:19 and had `head_ref_deleted` at 12:39:20, with nobody asking. What
-is left there is not to get ahead of it, #930 being what that costs; the
-deletion by hand belongs to the landing GitHub never sees.
+The setting hangs on the merge GitHub records, and every landing here is
+one it records, so nothing is left to delete by hand. Measured in
+btclib-secp256k1, whose configuration is this one: a pull request marked
+Merged at 12:39:19 had `head_ref_deleted` at 12:39:20, with nobody
+asking. The thing not to do is get ahead of it — #930 was deleted before
+the reconciliation and came out Closed rather than Merged, with its
+commit on `main` all the same.
 
 ## Token permissions
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -251,12 +251,12 @@ request: the four checks above with `strict`, one approving review,
 pushes, no deletions, `required_conversation_resolution`, and
 `enforce_admins` *off* — an administrator can bypass all of it.
 
-That last one is what carries the review. A review cannot be satisfied by
-its author, GitHub not allowing self-approval, so on a solo-maintainer
-repository the rule as written stops every pull request the maintainer
-opens, and the bypass is what lets one merge at all. The trade is the
-review's other half: it is there for a contributor's pull request, where
-there *is* somebody else to ask.
+That last one is what carries the review. CONTRIBUTING.md states why a
+review cannot be satisfied by its author; the consequence here is that on
+a solo-maintainer repository the rule as written stops every pull request
+the maintainer opens, and the bypass is what lets one merge at all. The
+trade is the review's other half: it is there for a contributor's pull
+request, where there *is* somebody else to ask.
 
 Required signatures cost the maintainer nothing when a pull request is
 what lands on `main`: the only thing writing to it is a merge GitHub
@@ -364,29 +364,26 @@ same.
 
 ## Merge methods
 
-**Squash is the only *button* enabled**, so it is a setting and not only
-the convention CONTRIBUTING.md states:
+**No button is how a pull request lands here.** Every landing is the
+fast-forward of the sequence above, through the `main-self-merge` bypass,
+with the squash a multi-commit branch needs made locally before it. What
+that buys is what a button cannot: the commit is signed by the maintainer
+rather than by GitHub's web-flow key, and where what lands is the head CI
+ran on, its sha does not change either, so a branch stacked on it keeps
+applying instead of needing a rebase and a fresh run of the matrix per
+level.
+
+What the settings below bound is therefore a landing nobody drove from a
+shell, and **squash is the only *button* enabled**:
 
 ```shell
 gh api repos/btclib-org/btclib \
   --jq '{allow_squash_merge, allow_merge_commit, allow_rebase_merge}'
 ```
 
-answers `true` for the first and `false` for the other two.
-
-It is not how a pull request lands at all, and this section named it as
-if it were while the section above it documented the other: **every
-landing is the fast-forward** of that sequence, through the
-`main-self-merge` bypass, with the squash a multi-commit branch needs
-made locally before it. What that buys is what a button cannot: the
-commit is signed by the maintainer rather than by GitHub's web-flow key,
-and where what lands is the head CI ran on, its sha does not change
-either, so a branch stacked on it keeps applying instead of needing a
-rebase and a fresh run of the matrix per level.
-
-The setting is what bounds a landing nobody drove from a shell: the
-auto-merge dropdown the next paragraph describes is what reaches the
-button, and GitHub's key is what signs whatever it presses.
+answers `true` for the first and `false` for the other two. The
+auto-merge dropdown below is what reaches that button, and GitHub's key
+is what signs whatever it presses.
 
 The merge commit was refused by the required linear history above already,
 so turning it off takes away a button that could not have worked. The

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -364,26 +364,30 @@ same.
 
 ## Merge methods
 
-**No button is how a pull request lands here.** Every landing is the
-fast-forward of the sequence above, through the `main-self-merge` bypass,
-with the squash a multi-commit branch needs made locally before it. What
-that buys is what a button cannot: the commit is signed by the maintainer
-rather than by GitHub's web-flow key, and where what lands is the head CI
-ran on, its sha does not change either, so a branch stacked on it keeps
-applying instead of needing a rebase and a fresh run of the matrix per
-level.
-
-What the settings below bound is therefore a landing nobody drove from a
-shell, and **squash is the only *button* enabled**:
+**Squash is the only *button* enabled, and it is how a pull request
+lands here** — auto-merge presses it once the review and the checks are
+in, so the default landing is one GitHub performs and signs with its
+web-flow key. That signature satisfies `main-integrity` exactly as the
+maintainer's own would: what the rule requires is a valid signature, not
+a particular signer.
 
 ```shell
 gh api repos/btclib-org/btclib \
   --jq '{allow_squash_merge, allow_merge_commit, allow_rebase_merge}'
 ```
 
-answers `true` for the first and `false` for the other two. The
-auto-merge dropdown below is what reaches that button, and GitHub's key
-is what signs whatever it presses.
+answers `true` for the first and `false` for the other two.
+
+**The fast-forward of the sequence above is the exception, not the
+rule**, and it is worth one case: a single-commit pull request that is
+the base of a stacked one. A button recreates rather than moves —
+GitHub's own documentation says rebase-and-merge "always updates the
+committer information and creates new commit SHAs", and a squash mints a
+commit that never existed — so either leaves the child's base orphaned
+and costs it a rebase and a fresh run of the matrix. A fast-forward
+moves a pointer at an object that already exists and is already signed,
+so the sha survives and the child keeps applying. Nothing else is a
+reason to reach for it.
 
 The merge commit was refused by the required linear history above already,
 so turning it off takes away a button that could not have worked. The

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -378,16 +378,24 @@ gh api repos/btclib-org/btclib \
 
 answers `true` for the first and `false` for the other two.
 
-**The fast-forward of the sequence above is the exception, not the
-rule**, and it is worth one case: a single-commit pull request that is
-the base of a stacked one. A button recreates rather than moves —
-GitHub's own documentation says rebase-and-merge "always updates the
-committer information and creates new commit SHAs", and a squash mints a
-commit that never existed — so either leaves the child's base orphaned
-and costs it a rebase and a fresh run of the matrix. A fast-forward
-moves a pointer at an object that already exists and is already signed,
-so the sha survives and the child keeps applying. Nothing else is a
-reason to reach for it.
+**There is no second path: `main` is reachable through a pull request
+and nothing else.** The `main-self-merge` bypass is scoped to
+`pull_request` mode, so it excuses the maintainer from the approving
+review a solo repository cannot produce and excuses nothing else — a
+direct push is refused for everyone, holder of the bypass included. The
+ruleset also names `squash` as the only merge method it will accept, so
+the constraint is stated where the rule is and not only in a repository
+toggle a setting page can flip.
+
+What that costs is a stacked pull request: once the parent lands, the
+child's base is an object no longer on `main` — a button recreates
+rather than moves, GitHub's documentation saying rebase-and-merge
+"always updates the committer information and creates new commit SHAs"
+— so the child is rebased and pays a fresh run of the matrix. That is
+the price of having no way to write to `main` by hand, and it is the
+one worth paying: the afternoon this rule was written, a `git merge` run
+in the wrong working tree advanced `main` locally, and only the absence
+of a push kept it off the remote.
 
 The merge commit was refused by the required linear history above already,
 so turning it off takes away a button that could not have worked. The

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -350,16 +350,12 @@ gh api repos/btclib-org/btclib \
 
 answers `true` for the first and `false` for the other two.
 
-**There is no second path: `main` is reachable through a pull request
-and nothing else.** The `main-self-merge` bypass is scoped to
-`pull_request` mode, so it excuses the maintainer from the approving
-review a solo repository cannot produce and excuses nothing else — a
-direct push is refused for everyone, holder of the bypass included. The
-ruleset also names `squash` as the only merge method it will accept, so
-the constraint is stated where the rule is and not only in a repository
-toggle a setting page can flip.
+**There is no second path**, the section above having the bypass mode
+that closes it and the ruleset entry that names `squash` as the only
+merge method the rule will accept.
 
-What that costs is a stacked pull request: once the parent lands, the
+What a pull request as the only way in costs is a stacked pull
+request: once the parent lands, the
 child's base is an object no longer on `main` — a button recreates
 rather than moves, GitHub's documentation saying rebase-and-merge
 "always updates the committer information and creates new commit SHAs"
@@ -412,9 +408,7 @@ The setting hangs on the merge GitHub records, and every landing here is
 one it records, so nothing is left to delete by hand. Measured in
 btclib-secp256k1, whose configuration is this one: a pull request marked
 Merged at 12:39:19 had `head_ref_deleted` at 12:39:20, with nobody
-asking. The thing not to do is get ahead of it — #930 was deleted before
-the reconciliation and came out Closed rather than Merged, with its
-commit on `main` all the same.
+asking.
 
 ## Token permissions
 


### PR DESCRIPTION
## What this changes

Three facts that were stated in full in two files each are now stated
once, and one section stops correcting itself in prose.

- **The concurrency ceiling.** `CONTRIBUTING.md` and `REPOSITORY.md`
  both carried "twenty concurrent jobs", "thirty-nine" and "1375 of
  2100 seconds" — the first pointing at the second and then repeating
  it anyway. `CONTRIBUTING.md` keeps the consequence its workflow table
  is about, including the macOS and Windows figures that decided the
  other rows, and `REPOSITORY.md` keeps the measurement.
- **Self-approval.** `REPOSITORY.md` restated from scratch what
  `CONTRIBUTING.md` already states, and now points at it, keeping the
  consequence that is its own: why `enforce_admins` off is what carries
  the review on a solo-maintainer repository.
- **"Squash is the only button."** In three files. `RELEASING.md` keeps
  only the reason it is the wrong landing for a *release* — the tag
  would go over a commit GitHub's web-flow key signed.

And **the landing convention now says what is actually in force.**
`REPOSITORY.md`'s "Merge methods" opened by naming the squash button as
how a pull request lands and then spent a paragraph correcting itself;
the first version of this branch replaced that with a confident *"No
button is how a pull request lands here"*, which is wrong — #1012 landed
with `committer=GitHub`, from the button. `CONTRIBUTING.md` said "a push
rather than a button" and `RELEASING.md` that the button was the wrong
landing for a release.

All three now say: **squash + auto-merge is the landing**, GitHub signs
it, and a valid signature is what the rule asks for rather than a
particular signer. The command-line fast-forward is kept for the one
case that earns it — a single-commit pull request that is the base of a
stacked one, where a button would orphan the child, because a button
recreates rather than moves.

## How it was verified

```shell
uv run pre-commit run --all-files          # clean
uv run pytest                              # 27952 passed, coverage 100.00%
```

Prose only: no code changes, and `tests/release_notes_test.py` is the
one that has an opinion about the files touched.

## Checks

- [x] `uv run pre-commit run --all-files` is clean
- [x] `uv run pytest` passes
- [x] `CHANGELOG.md` has an entry

## Anything the reviewer should know

**One of three pull requests**, and the one that is independent of the
other two: it can land in any order relative to them. The union merge on
`CHANGELOG.md` means it will not conflict with either.

What to check, since nothing automates it: that each deduplication left
the *consequence* where it belongs and moved only the shared fact. The
concurrency one is the arguable case — `CONTRIBUTING.md` now names no
number at all there, and whether the sentence still earns its place
without one is a reasonable thing to push back on.

## Summary by Sourcery

Make the repository documentation accurately describe squash auto-merge as the sole landing path and consolidate shared policy facts without duplicating their consequences.

Enhancements:
- Align repository documentation around squash plus auto-merge as the enforced pull request landing convention, with GitHub’s valid web-flow signature satisfying branch protection.
- Remove duplicated explanations of concurrency limits, self-approval, and merge-method policy while preserving each document’s relevant consequences.
- Clarify the ruleset bypass and eliminate obsolete documentation for direct-push landings and manual pull request reconciliation.

Documentation:
- Update contributing, repository, and release documentation to consistently describe the active landing and release-tagging conventions.

Chores:
- Record the documentation policy updates in the changelog.
