### PR TITLE
Read a pull request against REVIEWING.md, from CI

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,162 @@
+---
+name: claude-review
+
+# Claude reading a pull request against REVIEWING.md, which is the standard
+# a review here is written against and the whole of what this workflow has
+# to say: the prompt below names that file rather than restating it, so a
+# change to the standard reaches this workflow without editing it.
+#
+# Not a required check, and it must not become one. What it produces is a
+# comment, which is an opinion for the author to weigh -- REPOSITORY.md's
+# rule is that `main`'s required contexts are named outside the repository,
+# and a review that gates a merge would make a model's judgement a branch
+# rule. The four required checks stay what they are.
+#
+# It is one more job on every pull request, which is not free: GitHub Free
+# gives this organization twenty concurrent jobs and REPOSITORY.md measures
+# what a commit at that ceiling costs in wall clock. It earns the slot by
+# being short -- it reads a diff, it does not build a matrix -- and by
+# skipping a draft, which is the condition test.yml and lint.yml already
+# carry.
+
+on:
+  pull_request:
+    # ready_for_review so a pull request marked ready gets the review the
+    # draft condition below withheld while it was a draft: the default
+    # types do not include it, and without it a readied pull request would
+    # wait for its next push to be reviewed at all. The same reasoning
+    # links.yml carries for the same type
+    types: [opened, synchronize, ready_for_review]
+  # the on-demand half: somebody writes @claude in a comment on a pull
+  # request, or on a line of its diff, and asks for something the automatic
+  # pass did not answer
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+# least privilege for the GITHUB_TOKEN, elevated per job below and nowhere
+# else
+permissions:
+  contents: read
+
+jobs:
+  review:
+    name: Claude review
+    # a draft is work its author is not asking anyone to read yet, and a
+    # comment event is the other job's.
+    #
+    # The fork condition is not a policy but a fact about secrets: "with
+    # the exception of GITHUB_TOKEN, secrets are not passed to the runner
+    # when a workflow is triggered from a forked repository", so on a
+    # contributor's pull request this job would start, find
+    # CLAUDE_CODE_OAUTH_TOKEN empty and fail -- a red job on the pull
+    # requests of exactly the people least able to tell it apart from
+    # their own mistake. Skipped, it reports nothing at all, and the
+    # mention job below is the path that still works there: issue_comment
+    # is a base-repository event, so it is handed the secret.
+    #
+    # Compared by full_name rather than by `.fork`, which asks whether the
+    # head repository is a fork of anything and is true of a branch of
+    # btclib-org/bbt, itself a fork
+    if: >-
+      ${{ github.event_name == 'pull_request'
+          && !github.event.pull_request.draft
+          && github.event.pull_request.head.repo.full_name
+             == github.repository }}
+    runs-on: ubuntu-latest
+    # a diff read and a comment posted; a job past this is hung on the API
+    timeout-minutes: 15
+    # per job rather than per workflow, so that a push cancelling a
+    # superseded review does not also cancel somebody's @claude question
+    # running beside it. Named literally rather than through
+    # github.workflow, as everywhere else here
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      # what posting the review takes, and the only elevation here
+      pull-requests: write
+    steps:
+      # every action pinned to a commit SHA with the tag in the comment: a
+      # tag, let alone a branch, is a name its owner can move
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # see the checkout of the suite job in test.yml
+          persist-credentials: false
+          # depth 1 is enough because the diff comes from `gh pr diff`,
+          # which is the base...head three-dot diff REVIEWING.md asks for,
+          # computed by the forge rather than from local history
+          fetch-depth: 1
+      - name: Review against REVIEWING.md
+        uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Read REVIEWING.md in the repository root and review this pull
+            request against it. That file is the standard: what is under
+            review, what to look for and in what order, what a finding
+            must contain and how it labels its severity, what becomes of
+            everything you notice that the diff is not about, and the two
+            forms the verdict takes. Follow it rather than the review
+            habits you would otherwise bring. CLAUDE.md has the facts
+            about this tree a review has to know, and CONTRIBUTING.md the
+            rules a finding cites.
+
+            One deviation from REVIEWING.md, because this is CI and not a
+            session: do not run the gates. They are running beside you on
+            this same sha, in test.yml, lint.yml and docs.yml, and a
+            second run of them here would buy nothing and cost a slot.
+            Review everything else the standard asks for, and say in the
+            summary that the gates were left to those workflows.
+
+            Do not file issues from here: a collateral finding goes in the
+            summary comment, under a line saying it is not a finding
+            against this pull request, and a person decides whether it
+            becomes one.
+
+            Post GitHub comments only, never review text as a message.
+            `gh pr comment` for the summary,
+            `mcp__github_inline_comment__create_inline_comment` (with
+            `confirmed: true`) for a finding a line is the subject of.
+          # folded rather than literal, and `gh pr` rather than the three
+          # subcommands spelled out: the flag has to reach the CLI as one
+          # line, and the line that spells out comment, diff and view is
+          # past the 100 columns yamllint holds this file to
+          claude_args: >-
+            --allowedTools
+            "mcp__github_inline_comment__create_inline_comment,Bash(gh pr:*),Read,Grep,Glob"
+
+  mention:
+    name: Claude answers a mention
+    # no prompt on this one, deliberately: the action reads the comment
+    # that triggered it and answers what was actually asked, where a
+    # prompt of ours would answer something else. `github.event.issue.pull
+    # _request` is what tells a comment on a pull request from a comment
+    # on an issue, the issue_comment event carrying both
+    if: >-
+      ${{ (github.event_name == 'issue_comment'
+           && github.event.issue.pull_request
+           && contains(github.event.comment.body, '@claude'))
+          || (github.event_name == 'pull_request_review_comment'
+              && contains(github.event.comment.body, '@claude')) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Answer the mention
+        uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -76,8 +76,15 @@ jobs:
       cancel-in-progress: true
     permissions:
       contents: read
-      # what posting the review takes, and the only elevation here
+      # what posting the review takes
       pull-requests: write
+      # not for workload identity federation, which this does not use: the
+      # action mints a GitHub OIDC token during its own startup whatever
+      # the Anthropic credential is. Measured by leaving it out -- the run
+      # died before reaching authentication at all, with "Could not fetch
+      # an OIDC token. Did you remember to add `id-token: write` to
+      # your workflow permissions?"
+      id-token: write
     steps:
       # every action pinned to a commit SHA with the tag in the comment: a
       # tag, let alone a branch, is a name its owner can move
@@ -150,6 +157,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      # the same startup OIDC token the review job above needs
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,25 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **`claude-review.yml` reads a pull request against `REVIEWING.md`.**
+  Two jobs: one on every non-draft pull request, whose prompt names that
+  file rather than restating it, so the standard moves without the
+  workflow being edited; one answering `@claude` in a comment, which
+  carries no prompt of ours on purpose — the action reads the comment
+  that triggered it, where a prompt would answer something else. It
+  gates nothing and must not: `main`'s required contexts are named
+  outside the repository, and a review that held a merge would make a
+  model's judgement a branch rule. The one deviation from `REVIEWING.md`
+  is written into the prompt: the gates are not re-run, `test.yml`,
+  `lint.yml` and `docs.yml` running them beside it on the same sha.
+  Concurrency is per job rather than per workflow, so a push cancelling
+  a superseded review leaves an `@claude` question running. The automatic
+  job skips a pull request from a fork, which is not a policy but what
+  secrets do: none but `GITHUB_TOKEN` reaches a runner a fork triggered,
+  so the job would start, find the token empty and fail on the pull
+  requests of the people least able to read that failure. `@claude`
+  still answers there, `issue_comment` being a base-repository event.
+
 - **The review standard is written down, in `REVIEWING.md`.** What a review
   establishes before it gives an ack — the diff leaves the tree better
   than it found it, which is not the diff the reviewer would have

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ documented at release-notes length in the first place, and are still in
   so the job would start, find the token empty and fail on the pull
   requests of the people least able to read that failure. `@claude`
   still answers there, `issue_comment` being a base-repository event.
+  Both jobs carry `id-token: write`, which is not about workload
+  identity federation: the action mints a GitHub OIDC token during
+  its own startup whatever the Anthropic credential is, and without
+  it the run dies before reaching authentication at all.
 
 - **The review standard is written down, in `REVIEWING.md`.** What a review
   establishes before it gives an ack — the diff leaves the tree better

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,6 +256,7 @@ read by every checkout of this repository.
 | `lint`, `docs` | pull request, push | — |
 | `integration` | pull request, push | a node, two device emulators |
 | `website` | pull request, push, on website files | — |
+| `claude-review` | pull request, and `@claude` in a comment | — |
 | `codeql` | push to main, Tuesday | 2 languages |
 | `windows` | Saturday, a release | 2 Windows images × 7 interpreters |
 | `macos` | Wednesday, a release | 2 macOS images × 7 interpreters |


### PR DESCRIPTION
## What this changes

`claude-review.yml`: Claude reading a pull request against
`REVIEWING.md`. Two jobs.

- **`review`**, on every non-draft pull request. Its prompt names
  `REVIEWING.md` rather than restating it, so the standard moves without
  this workflow being edited.
- **`mention`**, on `@claude` in a comment. It carries no prompt of ours
  on purpose: the action reads the comment that triggered it and answers
  what was asked, where a prompt of ours would answer something else.

**It gates nothing, and must not.** `main`'s required contexts are named
outside the repository, and a review that held a merge would make a
model's judgement a branch rule. The four required checks stay what they
are.

One deviation from `REVIEWING.md` is written into the prompt: **the
gates are not re-run.** `test.yml`, `lint.yml` and `docs.yml` are
running them beside it on the same sha, and a second run would buy
nothing and cost a slot.

The automatic job **skips a pull request from a fork.** That is not a
policy but what secrets do — "with the exception of `GITHUB_TOKEN`,
secrets are not passed to the runner when a workflow is triggered from a
forked repository" — so the job would start, find
`CLAUDE_CODE_OAUTH_TOKEN` empty and fail on the pull requests of the
people least able to tell that apart from their own mistake. `@claude`
still answers there, `issue_comment` being a base-repository event. The
fork test compares `head.repo.full_name` against `github.repository`
rather than reading `.fork`, which asks whether the head repository is a
fork of anything and is true of a branch of `btclib-org/bbt`.

## How it was verified

```shell
uv run pre-commit run --all-files          # clean: actionlint and zizmor included
uv run pytest                              # 27952 passed, coverage 100.00%
```

Both actions are pinned to a commit SHA with the tag in the trailing
comment; `checkout` passes `persist-credentials: false`; the job carries
`timeout-minutes` and a literal concurrency group. Concurrency is **per
job** rather than per workflow, so a push cancelling a superseded review
does not also cancel an `@claude` question running beside it.

This pull request is its own test: the `pull_request` trigger runs the
workflow from the branch, so the review job should appear on it.

## Checks

- [x] `uv run pre-commit run --all-files` is clean
- [x] `uv run pytest` passes
- [x] `CHANGELOG.md` has an entry

## Anything the reviewer should know

**Stacked on #1012**, whose `REVIEWING.md` the prompt names; the base of
this pull request is `claude/reviewing-standard`, so its diff is the
workflow alone. Retarget to `main` once that lands.

`CLAUDE_CODE_OAUTH_TOKEN` is an organization secret with `visibility=all`
— the first secret this organization has ever held. Its *value* is not
verifiable by anyone: the API returns name, visibility and timestamps
and never the content. The first run of this workflow is therefore the
only test of it, and an empty or wrong token fails visibly at the
action's authentication step and only there.

## Summary by Sourcery

Add advisory Claude pull request reviews and on-demand mention responses driven by the repository review standard.

New Features:
- Add a Claude review workflow that automatically reviews non-draft same-repository pull requests against REVIEWING.md.
- Add an on-demand Claude workflow that answers @claude mentions on pull request comments and review comments, including on forked pull requests.

Enhancements:
- Keep automated reviews advisory by excluding them from required checks and avoid rerunning repository gates already handled by existing workflows.
- Limit review execution to pull requests with available secrets while retaining mention support for fork-originated pull requests.
- Apply job-level timeouts, concurrency, least-privilege permissions, and pinned action revisions to the Claude workflow.

CI:
- Document the new claude-review workflow in the repository's CI checks table.

Chores:
- Record the Claude review workflow and its behavior in the changelog.