### PR TITLE
Say that the buffer the bindings offer for a secret goes untaken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3541,6 +3541,27 @@ documented at release-notes length in the first place, and are still in
   and `BOS_COSTER_THRESHOLD` sends the call to Bos-Coster, which builds no
   table at all.
 
+### Security
+
+- **`SECURITY.md` says the bindings offer a buffer for a secret, and
+  that btclib takes none of them** (issue #973). `btclib_secp256k1`
+  lets a caller own the buffer a secret is written into, a
+  keyword-only `into=` on eight entry points that produce one, and
+  btclib passes none of them at the four call sites of its own that
+  could. At three of the four — `bip32.derive`,
+  `commit_nonce.commit_nonce_` and `taproot._tweaked_prvkey` — the
+  answer becomes a Python `int` one line later regardless, and an
+  `int` is not zeroizable and outlives the call, so the buffer would
+  buy nothing there without a change to how btclib holds a private
+  key. `ellswift.xdh` is the fourth, and the one that returns octets
+  rather than an int, so it is the one site where the buffer could
+  matter on its own terms — and btclib declines it there too, rather
+  than grow a public signature and own the contract that comes with
+  it. No code changed: the limitation `SECURITY.md` already stated
+  covers the consequence, and this entry is what makes not using
+  `into=` a decision on the record rather than something nobody
+  noticed.
+
 ### The public API and the module layout
 
 - **BIP32 derivation has a spelling that does not go through Base58Check**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -106,6 +106,32 @@ used to teach and to prototype as much as to build:
     or xpub string handed to `derive` or `derive_from_account`: the
     decoded key stays reachable from that cache, bounded by its
     `maxsize`, past whatever reference the caller itself still holds
+- the bindings also let a caller own the buffer a secret is written
+    into: a keyword-only `into=`, on every entry point that produces
+    one — `keys.prvkey_negate`, `keys.prvkey_tweak_add`,
+    `keys.prvkey_tweak_mul`, `xonly.prvkey_tweak_add`,
+    `ecdh.shared_secret`, `ellswift.xdh`, `dsa.nonce_rfc6979` and
+    `ssa.nonce_bip340`. btclib passes none of them, and that is a
+    decision, not an oversight. Three call sites read one of those
+    straight into a Python `int`: `bip32.derive`
+    (`btclib/bip32/bip32.py:624`), `commit_nonce.commit_nonce_`
+    (`btclib/ecc/commit_nonce.py:145`) and `taproot._tweaked_prvkey`
+    (`btclib/script/taproot.py:429`). A caller-owned buffer can be
+    wiped once the call that filled it returns; the `int` it is read
+    into cannot be, and outlives the call regardless —
+    `bip32.derive` keeps `prv_key_int` for the life of the key
+    object — so taking the buffer at these three would cost a public
+    signature and buy nothing, short of btclib no longer holding a
+    private key as a Python `int`, which is a change to that
+    representation and not to a call site. `ellswift.xdh`
+    (`btclib/ecc/ellswift.py:346`) is the one of them that returns
+    octets rather than an `int`, so a caller-owned buffer there would
+    hold what it wiped: taking it means growing `xdh`'s public
+    signature with `into=` and owning the contract that comes with
+    it — a buffer too short, a buffer that is not writable, what the
+    function then returns. btclib declines that too, for the reason
+    the bullet above already gives: no Python object holding a secret
+    is zeroized, on either path, and this one is no exception to it
 - the boundary is not always there, and an install decides whether it
     is. `pip install "btclib[secp256k1]"` -- the spelling README.md and
     the guide give -- installs the bindings, and everything the next


### PR DESCRIPTION
## What this changes

Nothing in code. `SECURITY.md`'s "Limitations, not vulnerabilities"
section gets a bullet beside the one it already had on Python objects
not being zeroized, and `CHANGELOG.md` gets a Security entry.

Issue #973: `btclib_secp256k1` lets a caller own the buffer eight of
its entry points write a secret into — a keyword-only `into=` — and
btclib passes none of them, at four call sites of its own that could
(`bip32.derive`, `commit_nonce.commit_nonce_`,
`taproot._tweaked_prvkey`, `ellswift.xdh`). The issue asked which of
the tree's two positions that silence actually is: `SECURITY.md`,
`README.md` and `ecc/__init__.py` already publish non-zeroization as a
limitation, while `ecc.musig2` and `ecc.ssa.Signer` do wipe what they
hold. `into=` was the occasion to say which of the two this is,
explicitly, rather than let it stay implicit.

The maintainer decided: take none of the eight. At the three sites
that hand back a tweaked private key, the buffer would buy nothing as
things stand — the bytes become a Python `int` one line later
regardless, and an `int` cannot be zeroized and outlives the call, so
taking the buffer there would need btclib to stop holding a private
key as an int, which is a change to the representation and not to a
call site. `ellswift.xdh` is the one call that leaves the secret as
octets, so it is the one site a caller-owned buffer could matter on
its own terms, and it is declined too — taking it would grow a public
signature and owe it a contract (a buffer too short, a buffer that is
not writable, what the function returns) that this decision does not
take on.

`README.md` and `ecc/__init__.py` are left alone: both already say "on
either path" without enumerating a mechanism, and this addition is
detail their own prose deliberately stays short of.

## How it was verified

```shell
uv run pytest                              # 27952 passed, coverage 100.00%
uv run pre-commit run --all-files          # clean
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
```

## Checks

- [x] `uv run pre-commit run --all-files` is clean
- [x] `uv run pytest` passes
- [x] `CHANGELOG.md` has an entry

## Anything the reviewer should know

Docs-only: no public API changed, no `into=` added anywhere. The line
numbers cited in `SECURITY.md` (`bip32.py:624`,
`commit_nonce.py:145`, `taproot.py:429`, `ellswift.py:346`) were
re-checked against this tree with `grep -n` rather than copied from
the issue, and three of the four have moved by a line or two since it
was filed.

Closes #973.

## Summary by Sourcery

Clarify that btclib intentionally does not use the bindings' caller-owned secret buffers because its secret-handling limitations remain unchanged.

Enhancements:
- Document the deliberate decision not to use caller-owned secret buffers exposed by the secp256k1 bindings, explaining the zeroization implications and affected call sites.

Documentation:
- Expand the security limitations documentation with the bindings' unused `into=` buffers and their consequences.

Chores:
- Record the security documentation clarification in the changelog.