### PR TITLE
Assert a keyword-only parameter stays keyword-only, library-wide (issue 980)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6334,7 +6334,13 @@ documented at release-notes length in the first place, and are still in
   `(callable, parameter)` pair, so a single mutant fails by name instead
   of by count; and one completeness test that recomputes the walk and
   diffs it against the table, so a keyword-only parameter added to the
-  surface without a line here fails a test rather than running none.
+  surface without a line here fails a test rather than running none. A
+  class is walked once per public method of its own, not only its
+  `__init__`: an alternate constructor -- `Bip21.parse`, a dozen
+  `from_dict`s and `b58decode`s -- carries `check_validity` the same
+  way, and a table stopping at the constructor would leave the walk's
+  own completeness test agreeing with itself while missing every one of
+  them.
 
 - **The input-validation gate's own verdict is exercised** (issue #776).
   `_classify` is the three answers a call can give -- the rule held, a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6322,6 +6322,19 @@ documented at release-notes length in the first place, and are still in
   `test_the_delegated_arm_forwards_verify` holds `ssa.sign_`'s to the
   caller's own value too, beside the existing recorder that already held
   the keyword itself to being forwarded and not dropped.
+- **A keyword-only parameter is asserted to stay keyword-only**
+  (issue #980). `*` in a signature is a calling-convention promise --
+  `check_validity`, `network`, and a dozen other names that recur -- and
+  nothing tested it: a mutant turning `*` to `/` drops the keyword-only
+  rule and adds a positional-only one in its place, and every test still
+  passed, at every public callable that took a keyword-only parameter.
+  `tests/keyword_only_test.py` walks every module's `__all__` once,
+  frozen as `KEYWORD_ONLY`, and asserts two things against the live
+  signature of every recorded site: one parametrized test per
+  `(callable, parameter)` pair, so a single mutant fails by name instead
+  of by count; and one completeness test that recomputes the walk and
+  diffs it against the table, so a keyword-only parameter added to the
+  surface without a line here fails a test rather than running none.
 
 - **The input-validation gate's own verdict is exercised** (issue #776).
   `_classify` is the three answers a call can give -- the rule held, a

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -1,0 +1,275 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests that a keyword-only parameter stays keyword-only.
+
+`*` in a signature is a calling-convention promise -- `check_validity`,
+`network`, a dozen others that recur -- and nothing asserted it: a
+mutant of `*` to `/` drops the keyword-only rule and adds a
+positional-only one in its place, and every test still passed, at every
+public callable that took a keyword-only parameter (issue #980). The
+reason a whole suite could miss it is the same reason a single test can
+catch all of it: the property is mechanical, one
+`inspect.signature(...).parameters[name].kind` per site, so walking
+`__all__` once covers every site a hand-written test would have to
+repeat once per callable.
+
+`KEYWORD_ONLY` is that walk, run once against the current tree and
+frozen here rather than recomputed by the test: recomputing it from the
+same code the test is meant to guard would make the assertion read
+whatever a mutation had just done to it and call that the answer, which
+is the blindness this file exists to remove. What is derived at test
+time is the *live* signature of each recorded site, checked against the
+kind frozen above -- a `*` a mutant turned to `/` is read here as
+`POSITIONAL_ONLY` where the table says `KEYWORD_ONLY`, and the two no
+longer agree.
+
+A class is named by its `__init__`, which is where a keyword-only
+parameter of a dataclass or a plain one lives; a function under a
+package's `__all__` is named directly. Deduplicated by the id of the
+callable object once resolved, so a name re-exported under a second
+`__all__` -- `btclib.fetch.bitcoin_core` aliasing the `bitcoin-core-rpc`
+package, `all_test.py`'s `REEXPORTED` -- is one entry and not two.
+"""
+
+from __future__ import annotations
+
+import inspect
+from importlib import import_module
+from typing import Any
+
+import pytest
+
+from tests.all_test import library_modules
+
+# Walked from `btclib`, on the commit this file is part of: every public
+# callable that takes at least one keyword-only parameter, and the names
+# of those parameters in declaration order. A site dropping out of this
+# table -- a parameter renamed, one no longer keyword-only, a callable
+# removed from `__all__` -- and a site missing from it -- a new
+# keyword-only parameter nothing here has asked about yet -- are both
+# a deliberate edit to make, which is what
+# test_the_recorded_surface_is_the_whole_of_it asks for
+KEYWORD_ONLY: dict[str, list[str]] = {
+    "btclib.bip21:Bip21.__init__": ["check_validity"],
+    "btclib.bip322:assert_as_valid": ["legacy"],
+    "btclib.bip322:to_sign": ["version", "lock_time", "sequence", "extra_inputs"],
+    "btclib.bip322:verify": ["legacy"],
+    "btclib.bip32:BIP32KeyData.__init__": ["check_validity"],
+    "btclib.bip32:BIP32KeyOrigin.__init__": ["check_validity"],
+    "btclib.bip32:decode_from_bip32_derivs": ["check_validity"],
+    "btclib.bip32:hardenings_from_der_path": ["bip380_enforced"],
+    "btclib.bip32:indexes_from_der_path": ["bip380_enforced"],
+    "btclib.bip32:int_from_index_str": ["bip380_enforced"],
+    "btclib.block.mining:candidate_block_header": ["version"],
+    "btclib.block.proof_of_work:next_bits": ["pow_limit_bits"],
+    "btclib.block:Block.__init__": ["check_validity"],
+    "btclib.block:BlockContext.__init__": ["check_validity"],
+    "btclib.block:BlockHeader.__init__": ["check_validity"],
+    "btclib.core_import:account_import_requests": ["active", "key_range"],
+    "btclib.core_import:import_request": [
+        "internal",
+        "active",
+        "key_range",
+        "next_index",
+        "label",
+    ],
+    "btclib.curves:point_from_octets": ["hybrid"],
+    "btclib.curves:set_libsecp256k1_serving": ["serving"],
+    "btclib.descriptors:AddrDescriptor.__init__": ["network"],
+    "btclib.descriptors:ComboDescriptor.__init__": ["network"],
+    "btclib.descriptors:Descriptor.__init__": ["network"],
+    "btclib.descriptors:MiniscriptDescriptor.__init__": ["network"],
+    "btclib.descriptors:MultiDescriptor.__init__": ["network"],
+    "btclib.descriptors:PkDescriptor.__init__": ["network"],
+    "btclib.descriptors:PkhDescriptor.__init__": ["network"],
+    "btclib.descriptors:RawDescriptor.__init__": ["network"],
+    "btclib.descriptors:RawTrDescriptor.__init__": ["network"],
+    "btclib.descriptors:ShDescriptor.__init__": ["network"],
+    "btclib.descriptors:TrDescriptor.__init__": ["network"],
+    "btclib.descriptors:WpkhDescriptor.__init__": ["network"],
+    "btclib.descriptors:WshDescriptor.__init__": ["network"],
+    "btclib.ecc.bms:Sig.__init__": ["check_validity"],
+    "btclib.ecc.dsa:Sig.__init__": ["check_validity"],
+    "btclib.ecc.dsa:assert_as_valid": ["commit", "receipt"],
+    "btclib.ecc.dsa:assert_as_valid_": ["commit_hash", "receipt"],
+    "btclib.ecc.dsa:sign": ["grind", "verify", "pub_key", "commit"],
+    "btclib.ecc.dsa:sign_": ["grind", "verify", "pub_key", "commit_hash"],
+    "btclib.ecc.dsa:verify": ["commit", "receipt"],
+    "btclib.ecc.dsa:verify_": ["commit_hash", "receipt"],
+    "btclib.ecc.ecies:Envelope.__init__": ["check_validity"],
+    "btclib.ecc.ecies:decrypt": ["magic"],
+    "btclib.ecc.ecies:encrypt": ["eph_prv_key", "magic"],
+    "btclib.ecc.ssa:Sig.__init__": ["check_validity"],
+    "btclib.ecc.ssa:assert_as_valid": ["commit", "receipt"],
+    "btclib.ecc.ssa:assert_as_valid_": ["commit_hash", "receipt"],
+    "btclib.ecc.ssa:sign": ["verify", "commit"],
+    "btclib.ecc.ssa:sign_": ["verify", "commit_hash"],
+    "btclib.ecc.ssa:verify": ["commit", "receipt"],
+    "btclib.ecc.ssa:verify_": ["commit_hash", "receipt"],
+    "btclib.fee:FeeRate.__init__": ["sats_per_kvbyte"],
+    "btclib.fee:package_fee": ["ancestor_vsize", "ancestor_fee"],
+    "btclib.fetch.transport:http_request": [
+        "data",
+        "headers",
+        "timeout",
+        "max_body_size",
+        "transport",
+    ],
+    "btclib.fetch:BitcoinCoreFetcher.__init__": [
+        "verify_network",
+        "signet_challenge",
+    ],
+    "btclib.fetch:BitcoinCoreRpcClient.__init__": [
+        "user",
+        "password",
+        "cookie_path",
+        "timeout",
+        "transport",
+    ],
+    "btclib.fetch:EsploraFetcher.__init__": ["network", "timeout", "transport"],
+    "btclib.fetch:urlopen_transport": ["max_body_size"],
+    "btclib.hwi:HwiSigner.__init__": [
+        "executable",
+        "network",
+        "timeout",
+        "max_output",
+        "emulators",
+        "capabilities",
+    ],
+    "btclib.hwi:enumerate_devices": [
+        "executable",
+        "network",
+        "timeout",
+        "max_output",
+        "emulators",
+    ],
+    "btclib.network:Network.__init__": ["check_validity"],
+    "btclib.psbt.musig2:add_participant_pub_keys": ["sort"],
+    "btclib.psbt.musig2:nonce_gen": ["leaf_hash", "extra_in"],
+    "btclib.psbt.musig2:partial_sig_verify": ["leaf_hash"],
+    "btclib.psbt.musig2:partial_sign": ["leaf_hash"],
+    "btclib.psbt.musig2:partial_sigs_agg": ["leaf_hash"],
+    "btclib.psbt.musig2:session_context": ["leaf_hash"],
+    "btclib.psbt.psbt_utils:deserialize_sized_int": ["signed"],
+    "btclib.psbt.psbt_utils:deserialize_tx": ["unsigned_template"],
+    "btclib.psbt.psbt_utils:serialize_sized_int": ["signed"],
+    "btclib.psbt.psbt_utils:taproot_bip32_from_dict": ["check_validity"],
+    "btclib.psbt:Psbt.__init__": ["check_validity"],
+    "btclib.psbt:PsbtIn.__init__": ["check_validity"],
+    "btclib.psbt:PsbtOut.__init__": ["check_validity"],
+    "btclib.psbt:assert_signed": ["allow_partial"],
+    "btclib.psbt:ecdsa_sig_hash": ["hash_type"],
+    "btclib.psbt:estimated_input_sizes": ["sizer"],
+    "btclib.psbt:extract_tx": ["check_validity"],
+    "btclib.psbt:finalize": ["solver"],
+    "btclib.psbt:taproot_sig_hash": ["leaf_hash", "hash_type"],
+    "btclib.psbt_signer:SoftwareSigner.__init__": ["musig2"],
+    "btclib.psbt_signer_contract:assert_psbt_signer": ["der_path", "signable"],
+    "btclib.script.sig_hash:from_tx": ["codesep_index"],
+    "btclib.script:Script.__init__": ["check_validity"],
+    "btclib.script:ScriptPubKey.__init__": ["check_validity"],
+    "btclib.script:Witness.__init__": ["check_validity"],
+    "btclib.tx:OutPoint.__init__": ["check_validity"],
+    "btclib.tx:Tx.__init__": ["check_validity"],
+    "btclib.tx:TxIn.__init__": ["check_validity"],
+    "btclib.tx:TxOut.__init__": ["check_validity"],
+    "btclib.tx_or_psbt:tx_or_psbt_from_any": ["check_validity"],
+}
+
+
+def _resolve(label: str) -> Any:
+    """Import `module:Class.__init__` or `module:function` back to the object.
+
+    The colon is the split point rather than the last dot: a module name
+    is dotted too (`btclib.ecc.dsa`), so the pair is stored apart instead
+    of concatenated and re-split.
+    """
+    module_name, _, attr_path = label.partition(":")
+    obj: Any = import_module(module_name)
+    for part in attr_path.split("."):
+        obj = getattr(obj, part)
+    return obj
+
+
+def _live_keyword_only() -> dict[str, list[str]]:
+    """Recompute `KEYWORD_ONLY` from the tree currently under test.
+
+    The same walk that produced the table above, run again: every
+    module's `__all__`, a class read as its own `__init__` and skipped
+    when it has none of its own, deduplicated by the id of the resolved
+    callable so one object reachable under two names is one entry.
+    """
+    seen_ids: set[int] = set()
+    found: dict[str, list[str]] = {}
+    for module in library_modules():
+        names = getattr(module, "__all__", None)
+        if not names:
+            continue
+        for name in names:
+            obj = getattr(module, name)
+            if inspect.ismodule(obj):
+                continue
+            if inspect.isclass(obj):
+                target = obj.__dict__.get("__init__")
+                if target is None:
+                    continue
+                label = f"{module.__name__}:{name}.__init__"
+            elif inspect.isfunction(obj) or inspect.isbuiltin(obj):
+                target = obj
+                label = f"{module.__name__}:{name}"
+            else:
+                continue
+            if id(target) in seen_ids:
+                continue
+            seen_ids.add(id(target))
+            kwonly = [
+                parameter.name
+                for parameter in inspect.signature(target).parameters.values()
+                if parameter.kind == inspect.Parameter.KEYWORD_ONLY
+            ]
+            if kwonly:
+                found[label] = kwonly
+    return found
+
+
+def test_the_recorded_surface_is_the_whole_of_it() -> None:
+    """Nothing keyword-only is missing from the table, nothing extra is in it.
+
+    The half `test_a_keyword_only_parameter_stays_keyword_only` cannot
+    ask: that test parametrizes over `KEYWORD_ONLY` itself, so a
+    keyword-only parameter added to the public surface without a line
+    here would run no test at all rather than fail one. This recomputes
+    the walk and asks the two agree -- a new site, a removed one, and a
+    renamed parameter all show up as one dictionary differing from
+    another rather than as a `KeyError` or a silent gap.
+    """
+    assert _live_keyword_only() == KEYWORD_ONLY
+
+
+@pytest.mark.parametrize(
+    "label, param_name",
+    [
+        pytest.param(label, param_name, id=f"{label}:{param_name}")
+        for label, params in sorted(KEYWORD_ONLY.items())
+        for param_name in params
+    ],
+)
+def test_a_keyword_only_parameter_stays_keyword_only(
+    label: str, param_name: str
+) -> None:
+    """One assertion per recorded site, so a mutant of one `*` fails by name.
+
+    `ReplaceBinaryOperator_Mul_Div` turns the `*` in front of a
+    keyword-only parameter into `/`, which makes every parameter in
+    front of it positional-only and every one after it -- this one
+    included -- plain `POSITIONAL_OR_KEYWORD` rather than
+    `KEYWORD_ONLY`. Nothing about a call already written with the
+    keyword changes, and nothing about the value returned does either,
+    which is why no other test in the suite notices (issue #980).
+    """
+    kind = inspect.signature(_resolve(label)).parameters[param_name].kind
+    assert kind == inspect.Parameter.KEYWORD_ONLY, (
+        f"{label}'s {param_name} is {kind}, not keyword-only"
+    )

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -25,12 +25,20 @@ kind frozen above -- a `*` a mutant turned to `/` is read here as
 `POSITIONAL_ONLY` where the table says `KEYWORD_ONLY`, and the two no
 longer agree.
 
-A class is named by its `__init__`, which is where a keyword-only
-parameter of a dataclass or a plain one lives; a function under a
-package's `__all__` is named directly. Deduplicated by the id of the
-callable object once resolved, so a name re-exported under a second
-`__all__` -- `btclib.fetch.bitcoin_core` aliasing the `bitcoin-core-rpc`
-package, `all_test.py`'s `REEXPORTED` -- is one entry and not two.
+A function under a package's `__all__` is named directly; a class is
+named once per public method of its own -- `__init__`, and every other
+name in its own `__dict__` that does not start with an underscore, so
+an alternate constructor (`parse`, `b58decode`, `from_dict`) and an
+instance method (`serialize`, `b58encode`) are sites of their own and
+not only `__init__`. `Bip21.parse`'s `check_validity` is exactly the
+shape `Bip21.__init__`'s does not cover: a classmethod the walk would
+have missed had it stopped at the constructor, `*` turned to `/` there
+passing both tests below in an earlier revision of this file. Inherited
+methods are not walked a second time under a subclass that does not
+override them, deduplication being by the id of the underlying function
+once resolved, so a name re-exported under a second `__all__` --
+`btclib.fetch.bitcoin_core` aliasing the `bitcoin-core-rpc` package,
+`all_test.py`'s `REEXPORTED` -- is one entry and not two either.
 """
 
 from __future__ import annotations
@@ -53,11 +61,25 @@ from tests.all_test import library_modules
 # test_the_recorded_surface_is_the_whole_of_it asks for
 KEYWORD_ONLY: dict[str, list[str]] = {
     "btclib.bip21:Bip21.__init__": ["check_validity"],
+    "btclib.bip21:Bip21.parse": ["check_validity"],
+    "btclib.bip21:Bip21.serialize": ["check_validity"],
+    "btclib.bip322:Sig.b64decode": ["check_validity"],
+    "btclib.bip322:Sig.b64encode": ["check_validity"],
+    "btclib.bip322:Sig.serialize": ["check_validity"],
     "btclib.bip322:assert_as_valid": ["legacy"],
     "btclib.bip322:to_sign": ["version", "lock_time", "sequence", "extra_inputs"],
     "btclib.bip322:verify": ["legacy"],
     "btclib.bip32:BIP32KeyData.__init__": ["check_validity"],
+    "btclib.bip32:BIP32KeyData.b58decode": ["check_validity"],
+    "btclib.bip32:BIP32KeyData.b58encode": ["check_validity"],
+    "btclib.bip32:BIP32KeyData.parse": ["check_validity"],
+    "btclib.bip32:BIP32KeyData.serialize": ["check_validity"],
     "btclib.bip32:BIP32KeyOrigin.__init__": ["check_validity"],
+    "btclib.bip32:BIP32KeyOrigin.from_description": ["check_validity"],
+    "btclib.bip32:BIP32KeyOrigin.from_dict": ["check_validity"],
+    "btclib.bip32:BIP32KeyOrigin.parse": ["check_validity"],
+    "btclib.bip32:BIP32KeyOrigin.serialize": ["check_validity"],
+    "btclib.bip32:BIP32KeyOrigin.to_dict": ["check_validity"],
     "btclib.bip32:decode_from_bip32_derivs": ["check_validity"],
     "btclib.bip32:hardenings_from_der_path": ["bip380_enforced"],
     "btclib.bip32:indexes_from_der_path": ["bip380_enforced"],
@@ -65,8 +87,16 @@ KEYWORD_ONLY: dict[str, list[str]] = {
     "btclib.block.mining:candidate_block_header": ["version"],
     "btclib.block.proof_of_work:next_bits": ["pow_limit_bits"],
     "btclib.block:Block.__init__": ["check_validity"],
+    "btclib.block:Block.from_dict": ["check_validity"],
+    "btclib.block:Block.parse": ["check_validity"],
+    "btclib.block:Block.serialize": ["check_validity"],
+    "btclib.block:Block.to_dict": ["check_validity"],
     "btclib.block:BlockContext.__init__": ["check_validity"],
     "btclib.block:BlockHeader.__init__": ["check_validity"],
+    "btclib.block:BlockHeader.from_dict": ["check_validity"],
+    "btclib.block:BlockHeader.parse": ["check_validity"],
+    "btclib.block:BlockHeader.serialize": ["check_validity"],
+    "btclib.block:BlockHeader.to_dict": ["check_validity"],
     "btclib.core_import:account_import_requests": ["active", "key_range"],
     "btclib.core_import:import_request": [
         "internal",
@@ -91,7 +121,13 @@ KEYWORD_ONLY: dict[str, list[str]] = {
     "btclib.descriptors:WpkhDescriptor.__init__": ["network"],
     "btclib.descriptors:WshDescriptor.__init__": ["network"],
     "btclib.ecc.bms:Sig.__init__": ["check_validity"],
+    "btclib.ecc.bms:Sig.b64decode": ["check_validity"],
+    "btclib.ecc.bms:Sig.b64encode": ["check_validity"],
+    "btclib.ecc.bms:Sig.parse": ["check_validity"],
+    "btclib.ecc.bms:Sig.serialize": ["check_validity"],
     "btclib.ecc.dsa:Sig.__init__": ["check_validity"],
+    "btclib.ecc.dsa:Sig.parse": ["check_validity", "strict"],
+    "btclib.ecc.dsa:Sig.serialize": ["check_validity"],
     "btclib.ecc.dsa:assert_as_valid": ["commit", "receipt"],
     "btclib.ecc.dsa:assert_as_valid_": ["commit_hash", "receipt"],
     "btclib.ecc.dsa:sign": ["grind", "verify", "pub_key", "commit"],
@@ -99,9 +135,18 @@ KEYWORD_ONLY: dict[str, list[str]] = {
     "btclib.ecc.dsa:verify": ["commit", "receipt"],
     "btclib.ecc.dsa:verify_": ["commit_hash", "receipt"],
     "btclib.ecc.ecies:Envelope.__init__": ["check_validity"],
+    "btclib.ecc.ecies:Envelope.b64decode": ["magic", "check_validity"],
+    "btclib.ecc.ecies:Envelope.b64encode": ["check_validity"],
+    "btclib.ecc.ecies:Envelope.from_ciphertext": ["magic"],
+    "btclib.ecc.ecies:Envelope.parse": ["magic", "check_validity"],
+    "btclib.ecc.ecies:Envelope.serialize": ["check_validity"],
     "btclib.ecc.ecies:decrypt": ["magic"],
     "btclib.ecc.ecies:encrypt": ["eph_prv_key", "magic"],
     "btclib.ecc.ssa:Sig.__init__": ["check_validity"],
+    "btclib.ecc.ssa:Sig.parse": ["check_validity"],
+    "btclib.ecc.ssa:Sig.serialize": ["check_validity"],
+    "btclib.ecc.ssa:Signer.sign": ["verify"],
+    "btclib.ecc.ssa:Signer.sign_": ["verify"],
     "btclib.ecc.ssa:assert_as_valid": ["commit", "receipt"],
     "btclib.ecc.ssa:assert_as_valid_": ["commit_hash", "receipt"],
     "btclib.ecc.ssa:sign": ["verify", "commit"],
@@ -128,6 +173,17 @@ KEYWORD_ONLY: dict[str, list[str]] = {
         "timeout",
         "transport",
     ],
+    "btclib.fetch:BitcoinCoreRpcClient.assert_chain": ["signet_challenge"],
+    "btclib.fetch:BitcoinCoreRpcClient.call": ["request_timeout", "max_body_size"],
+    "btclib.fetch:BitcoinCoreRpcClient.from_chain": [
+        "user",
+        "password",
+        "cookie_path",
+        "timeout",
+        "transport",
+        "verify_chain",
+        "signet_challenge",
+    ],
     "btclib.fetch:EsploraFetcher.__init__": ["network", "timeout", "transport"],
     "btclib.fetch:urlopen_transport": ["max_body_size"],
     "btclib.hwi:HwiSigner.__init__": [
@@ -146,6 +202,8 @@ KEYWORD_ONLY: dict[str, list[str]] = {
         "emulators",
     ],
     "btclib.network:Network.__init__": ["check_validity"],
+    "btclib.network:Network.from_dict": ["check_validity"],
+    "btclib.network:Network.to_dict": ["check_validity"],
     "btclib.psbt.musig2:add_participant_pub_keys": ["sort"],
     "btclib.psbt.musig2:nonce_gen": ["leaf_hash", "extra_in"],
     "btclib.psbt.musig2:partial_sig_verify": ["leaf_hash"],
@@ -157,8 +215,27 @@ KEYWORD_ONLY: dict[str, list[str]] = {
     "btclib.psbt.psbt_utils:serialize_sized_int": ["signed"],
     "btclib.psbt.psbt_utils:taproot_bip32_from_dict": ["check_validity"],
     "btclib.psbt:Psbt.__init__": ["check_validity"],
+    "btclib.psbt:Psbt.b64decode": ["check_validity"],
+    "btclib.psbt:Psbt.b64encode": ["check_validity"],
+    "btclib.psbt:Psbt.from_dict": ["check_validity"],
+    "btclib.psbt:Psbt.from_tx": ["check_validity"],
+    "btclib.psbt:Psbt.parse": ["check_validity"],
+    "btclib.psbt:Psbt.serialize": ["check_validity"],
+    "btclib.psbt:Psbt.to_dict": ["check_validity"],
     "btclib.psbt:PsbtIn.__init__": ["check_validity"],
+    "btclib.psbt:PsbtIn.from_dict": ["check_validity"],
+    "btclib.psbt:PsbtIn.parse": ["psbt_version", "check_validity"],
+    "btclib.psbt:PsbtIn.serialize": ["psbt_version", "check_validity"],
+    "btclib.psbt:PsbtIn.to_dict": ["check_validity"],
     "btclib.psbt:PsbtOut.__init__": ["check_validity"],
+    "btclib.psbt:PsbtOut.from_dict": ["check_validity"],
+    "btclib.psbt:PsbtOut.parse": ["psbt_version", "check_validity"],
+    "btclib.psbt:PsbtOut.serialize": ["psbt_version", "check_validity"],
+    "btclib.psbt:PsbtOut.to_dict": ["check_validity"],
+    "btclib.psbt:PsbtView.ecdsa_sig_hash": ["hash_type"],
+    "btclib.psbt:PsbtView.input": ["check_validity"],
+    "btclib.psbt:PsbtView.output": ["check_validity"],
+    "btclib.psbt:PsbtView.taproot_sig_hash": ["leaf_hash", "hash_type"],
     "btclib.psbt:assert_signed": ["allow_partial"],
     "btclib.psbt:ecdsa_sig_hash": ["hash_type"],
     "btclib.psbt:estimated_input_sizes": ["sizer"],
@@ -166,21 +243,52 @@ KEYWORD_ONLY: dict[str, list[str]] = {
     "btclib.psbt:finalize": ["solver"],
     "btclib.psbt:taproot_sig_hash": ["leaf_hash", "hash_type"],
     "btclib.psbt_signer:SoftwareSigner.__init__": ["musig2"],
+    "btclib.psbt_signer:SoftwareSigner.from_accounts": ["musig2"],
     "btclib.psbt_signer_contract:assert_psbt_signer": ["der_path", "signable"],
     "btclib.script.sig_hash:from_tx": ["codesep_index"],
     "btclib.script:Script.__init__": ["check_validity"],
     "btclib.script:ScriptPubKey.__init__": ["check_validity"],
+    "btclib.script:ScriptPubKey.from_address": ["check_validity"],
+    "btclib.script:ScriptPubKey.nulldata": ["check_validity"],
+    "btclib.script:ScriptPubKey.p2ms": ["check_validity"],
+    "btclib.script:ScriptPubKey.p2pk": ["check_validity"],
+    "btclib.script:ScriptPubKey.p2pkh": ["check_validity"],
+    "btclib.script:ScriptPubKey.p2sh": ["check_validity"],
+    "btclib.script:ScriptPubKey.p2tr": ["check_validity"],
+    "btclib.script:ScriptPubKey.p2wpkh": ["check_validity"],
+    "btclib.script:ScriptPubKey.p2wsh": ["check_validity"],
     "btclib.script:Witness.__init__": ["check_validity"],
+    "btclib.script:Witness.from_dict": ["check_validity"],
+    "btclib.script:Witness.parse": ["check_validity"],
+    "btclib.script:Witness.serialize": ["check_validity"],
+    "btclib.script:Witness.to_dict": ["check_validity"],
     "btclib.tx:OutPoint.__init__": ["check_validity"],
+    "btclib.tx:OutPoint.from_dict": ["check_validity"],
+    "btclib.tx:OutPoint.parse": ["check_validity"],
+    "btclib.tx:OutPoint.serialize": ["check_validity"],
+    "btclib.tx:OutPoint.to_dict": ["check_validity"],
     "btclib.tx:Tx.__init__": ["check_validity"],
+    "btclib.tx:Tx.assert_valid": ["unsigned_template"],
+    "btclib.tx:Tx.from_dict": ["check_validity"],
+    "btclib.tx:Tx.parse": ["check_validity"],
+    "btclib.tx:Tx.serialize": ["check_validity"],
+    "btclib.tx:Tx.to_dict": ["check_validity"],
     "btclib.tx:TxIn.__init__": ["check_validity"],
+    "btclib.tx:TxIn.from_dict": ["check_validity"],
+    "btclib.tx:TxIn.parse": ["check_validity"],
+    "btclib.tx:TxIn.serialize": ["check_validity"],
+    "btclib.tx:TxIn.to_dict": ["check_validity"],
     "btclib.tx:TxOut.__init__": ["check_validity"],
+    "btclib.tx:TxOut.from_dict": ["check_validity"],
+    "btclib.tx:TxOut.parse": ["check_validity"],
+    "btclib.tx:TxOut.serialize": ["check_validity"],
+    "btclib.tx:TxOut.to_dict": ["check_validity"],
     "btclib.tx_or_psbt:tx_or_psbt_from_any": ["check_validity"],
 }
 
 
 def _resolve(label: str) -> Any:
-    """Import `module:Class.__init__` or `module:function` back to the object.
+    """Import `module:Class.method` or `module:function` back to the object.
 
     The colon is the split point rather than the last dot: a module name
     is dotted too (`btclib.ecc.dsa`), so the pair is stored apart instead
@@ -193,13 +301,54 @@ def _resolve(label: str) -> Any:
     return obj
 
 
+def _kwonly_names(signature: inspect.Signature) -> list[str]:
+    """Return the keyword-only parameter names of one signature, in order."""
+    return [
+        parameter.name
+        for parameter in signature.parameters.values()
+        if parameter.kind == inspect.Parameter.KEYWORD_ONLY
+    ]
+
+
+def _class_sites(
+    module: Any, name: str, cls: type, seen_ids: set[int]
+) -> dict[str, list[str]]:
+    """Every public method of one exported class that is keyword-only somewhere.
+
+    `__init__` plus every name in the class's own `__dict__` that does
+    not start with an underscore, so an alternate constructor (`parse`,
+    `b58decode`, `from_dict`) and an instance method (`serialize`,
+    `b58encode`) are sites of their own rather than invisible because
+    they are not the constructor. A method inherited and not overridden
+    is in a base class's own `__dict__` instead, so it is walked once,
+    there.
+    """
+    found: dict[str, list[str]] = {}
+    attr_names = sorted(
+        attr for attr in vars(cls) if attr == "__init__" or not attr.startswith("_")
+    )
+    for attr_name in attr_names:
+        bound = getattr(cls, attr_name)
+        if not (inspect.isfunction(bound) or inspect.ismethod(bound)):
+            continue  # a property or a plain class attribute
+        target = bound.__func__ if inspect.ismethod(bound) else bound
+        if id(target) in seen_ids:
+            continue
+        seen_ids.add(id(target))
+        kwonly = _kwonly_names(inspect.signature(bound))
+        if kwonly:
+            found[f"{module.__name__}:{name}.{attr_name}"] = kwonly
+    return found
+
+
 def _live_keyword_only() -> dict[str, list[str]]:
     """Recompute `KEYWORD_ONLY` from the tree currently under test.
 
     The same walk that produced the table above, run again: every
-    module's `__all__`, a class read as its own `__init__` and skipped
-    when it has none of its own, deduplicated by the id of the resolved
-    callable so one object reachable under two names is one entry.
+    module's `__all__`, a function named directly and a class expanded
+    by `_class_sites`. Deduplicated by the id of the resolved function --
+    `__func__` for a bound classmethod, the function itself otherwise --
+    so an object reachable under two names is one entry.
     """
     seen_ids: set[int] = set()
     found: dict[str, list[str]] = {}
@@ -209,28 +358,15 @@ def _live_keyword_only() -> dict[str, list[str]]:
             continue
         for name in names:
             obj = getattr(module, name)
-            if inspect.ismodule(obj):
-                continue
             if inspect.isclass(obj):
-                target = obj.__dict__.get("__init__")
-                if target is None:
-                    continue
-                label = f"{module.__name__}:{name}.__init__"
+                found.update(_class_sites(module, name, obj, seen_ids))
             elif inspect.isfunction(obj) or inspect.isbuiltin(obj):
-                target = obj
-                label = f"{module.__name__}:{name}"
-            else:
-                continue
-            if id(target) in seen_ids:
-                continue
-            seen_ids.add(id(target))
-            kwonly = [
-                parameter.name
-                for parameter in inspect.signature(target).parameters.values()
-                if parameter.kind == inspect.Parameter.KEYWORD_ONLY
-            ]
-            if kwonly:
-                found[label] = kwonly
+                if id(obj) in seen_ids:
+                    continue
+                seen_ids.add(id(obj))
+                kwonly = _kwonly_names(inspect.signature(obj))
+                if kwonly:
+                    found[f"{module.__name__}:{name}"] = kwonly
     return found
 
 


### PR DESCRIPTION
## Summary

`*` in a signature is a calling-convention promise — `check_validity`,
`network`, and a dozen other names that recur — and nothing in the
suite tested it: a mutant turning `*` to `/` drops the keyword-only
rule and adds a positional-only one in its place, and every test still
passed, at every public callable that takes a keyword-only parameter.

Chose option 1 from #980: one test parametrized over the public
surface, walking `__all__` and reading `inspect.signature`.

## Changes

`tests/keyword_only_test.py` is new. `KEYWORD_ONLY` is a frozen table
— walked once from the current tree, every public callable (a class
named by its `__init__`) that takes at least one keyword-only
parameter, deduplicated by object identity so a re-export is not
counted twice. Two tests read it:

- `test_a_keyword_only_parameter_stays_keyword_only` — parametrized
  over every `(callable, parameter)` pair in the table; for each, reads
  the callable's *live* signature and asserts the parameter's `kind` is
  still `KEYWORD_ONLY`. A single mutant of one `*` fails by name rather
  than by count.
- `test_the_recorded_surface_is_the_whole_of_it` — recomputes the same
  walk against the current tree and diffs it against the frozen table,
  so a keyword-only parameter added to the public surface without a
  line here fails a test instead of running none.

The table is frozen rather than recomputed at test time on purpose:
recomputing it from the same code the test is meant to guard would read
whatever a mutation had just done and call that the answer.

Closes #980.

## Test plan

- [x] `uv run pytest -q` — 28092 passed, 100% coverage
- [x] Verified the new tests fail against the mutant `#980` names
      (`BitcoinCoreFetcher.__init__`'s `*` turned to `/`), and pass on
      `main`'s code
- [x] `uv run pre-commit run --files tests/keyword_only_test.py
      CHANGELOG.md` — all hooks pass
- [x] `sphinx-build -W --keep-going` — build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Protect the public API’s keyword-only calling conventions with comprehensive signature coverage.

Enhancements:
- Add library-wide tests that verify every recorded public keyword-only parameter retains its keyword-only calling convention.
- Cover public classes and methods, including alternate constructors and re-exported callables, while checking that the recorded surface remains complete.

Tests:
- Add parametrized signature tests for all public keyword-only parameters and a completeness check against the exported API surface.