### PR TITLE
Prune nested caches from the sdist, whatever their depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -454,6 +454,20 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **`MANIFEST.in` prunes a nested `.mypy_cache`, `.pytest_cache`,
+  `.ruff_cache` or `__pycache__`, at whatever depth a tool left one.**
+  `.gitignore` covers these, but the sdist's file list comes from
+  `MANIFEST.in`'s own include rules walking the tree, not from
+  `.gitignore`, so a cache the VS Code mypy extension writes beside the
+  file it just checked was shipped whole: its `.json` files matched
+  `recursive-include btclib *.json` the same way a vendored vector does
+  (issue #985). `global-exclude` cannot take it back out — it drops a
+  member whose own name matches the pattern, not what a matched
+  directory contains — so the fix is `recursive-exclude`, wildcarded to
+  reach the cache under any top-level directory the same way
+  `recursive-include` reaches a vendored vector, with one line per depth
+  for the cache's own nesting, which a wildcard segment does not cross.
+
 - **The bindings floor is `btclib_secp256k1>=0.8.0.3`, and
   `[tool.uv.sources]` points at their `main` until PyPI serves it.**
   That version carries `xonly.tweak_add_` (btclib-secp256k1#158), which

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -88,14 +88,25 @@ recursive-include docs Makefile
 # directory the cache sits under -- but that reach is spent on getting
 # to the cache directory, and does not carry through to what is inside
 # it: a wildcard segment matches one path component, not several, so
-# the cache's own depth needs one line per level, deep enough for a
-# cache mirroring the tree it was told to check:
-#   find btclib tests -type d | awk -F/ '{print NF}' | sort -un
+# the cache's own depth needs one line per level.
+#
+# mypy names a cache entry after the checked module's fully qualified
+# name, one directory per dotted component, under a python-version
+# directory of its own -- btclib.script.engine.flags caches to
+# .mypy_cache/<pyver>/btclib/script/engine/flags.data.json regardless
+# of where .mypy_cache itself sits -- so the level a mypy cache needs is
+# the tree's own deepest *package*, plus one for <pyver> and one for the
+# file itself:
+#   find btclib tests -type d | grep -v /__pycache__ \
+#       | awk -F/ '{print NF}' | sort -un
+# tops out at 3, btclib/script/engine/ being the one package this deep,
+# so 3 + 2 = 5 levels inside .mypy_cache/ cover it
 recursive-exclude * .mypy_cache
 recursive-exclude * .mypy_cache/*
 recursive-exclude * .mypy_cache/*/*
 recursive-exclude * .mypy_cache/*/*/*
 recursive-exclude * .mypy_cache/*/*/*/*
+recursive-exclude * .mypy_cache/*/*/*/*/*
 recursive-exclude * .pytest_cache
 recursive-exclude * .pytest_cache/*
 recursive-exclude * .pytest_cache/*/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -66,3 +66,43 @@ recursive-include docs *.md
 recursive-include docs *.rst
 recursive-include docs *.txt
 recursive-include docs Makefile
+
+# a cache a linter or type checker writes beside the file it just
+# checked -- .mypy_cache, .pytest_cache, .ruff_cache, __pycache__ -- and
+# not something anyone puts there on purpose: the VS Code mypy
+# extension writes one per directory it type-checks, so it can appear
+# under btclib/ecc/ and tests/ecc/ alike. .gitignore's rule for it does
+# not reach here: the sdist's file list comes from the include rules
+# above walking the tree, which does not read .gitignore, so a nested
+# cache was shipped whole -- its .json files matched
+# "recursive-include btclib *.json" and its .md files matched
+# "recursive-include tests *.md" (issue #985).
+#
+# global-exclude cannot take it back out: it drops a member whose own
+# name matches the pattern, not the members a matched directory
+# contains, so "global-exclude .mypy_cache" removes the directory entry
+# and ships its files regardless. recursive-exclude does reach them --
+# its dir argument reaches an arbitrary depth exactly the way
+# "recursive-include btclib *.json" reaches a vendored vector nested
+# under btclib/, wildcarded to "*" here for whichever top-level
+# directory the cache sits under -- but that reach is spent on getting
+# to the cache directory, and does not carry through to what is inside
+# it: a wildcard segment matches one path component, not several, so
+# the cache's own depth needs one line per level, deep enough for a
+# cache mirroring the tree it was told to check:
+#   find btclib tests -type d | awk -F/ '{print NF}' | sort -un
+recursive-exclude * .mypy_cache
+recursive-exclude * .mypy_cache/*
+recursive-exclude * .mypy_cache/*/*
+recursive-exclude * .mypy_cache/*/*/*
+recursive-exclude * .mypy_cache/*/*/*/*
+recursive-exclude * .pytest_cache
+recursive-exclude * .pytest_cache/*
+recursive-exclude * .pytest_cache/*/*
+recursive-exclude * .pytest_cache/*/*/*
+recursive-exclude * .ruff_cache
+recursive-exclude * .ruff_cache/*
+recursive-exclude * .ruff_cache/*/*
+recursive-exclude * .ruff_cache/*/*/*
+recursive-exclude * __pycache__
+recursive-exclude * __pycache__/*


### PR DESCRIPTION
## Summary

- `MANIFEST.in` prunes `.mypy_cache`, `.pytest_cache`, `.ruff_cache` and
  `__pycache__` from the sdist, at whatever depth a tool left one, instead of
  shipping a nested cache's contents whole.
- `global-exclude` cannot do this — it only drops a member whose own name
  matches the pattern, not what a matched directory contains — so the fix
  uses `recursive-exclude`, wildcarded to reach the cache under any
  top-level directory, with one line per depth level for the cache's own
  nesting.

Fixes #985.

## Test plan

- [x] Reproduced the issue exactly as filed (`btclib/ecc/.mypy_cache/...`),
  confirmed the built sdist shipped it before the fix.
- [x] Planted nested caches for all four tools (including a deeper,
  package-mirroring `.mypy_cache` layout) and confirmed `uv build --sdist`
  ships none of them after the fix.
- [x] `uv run pre-commit run --all-files` — all hooks pass, including
  `check-manifest` with the planted caches present.
- [x] `uv run pytest` — 100% coverage maintained (MANIFEST.in is not
  Python, no new lines to cover).
- [x] `sphinx-build -W --keep-going` — docs gate green.

## Summary by Sourcery

Bug Fixes:
- Prevent nested `.mypy_cache`, `.pytest_cache`, `.ruff_cache`, and `__pycache__` contents from being included in source distributions at any depth.