### PR TITLE
Check taproot's and bms's Python arms reach no bindings too

### DIFF
--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -7,9 +7,6 @@
 import hmac
 import itertools
 import re
-import sys
-import types
-from collections.abc import Callable
 from dataclasses import FrozenInstanceError, fields, replace
 from typing import Any
 
@@ -48,9 +45,9 @@ from btclib.bip32.der_path import _indexes_from_der_path_str
 from btclib.curves import (
     bytes_from_point,
     bytes_from_prv_key_int,
-    # the module: `_libsecp256k1_available` is an attribute of it, and
-    # clearing it is how the two tests below reach the Python arm
-    curve,
+    # the module: `mod_sqrt_var` is a function on it, and patching it to
+    # raise is how the test below pins that validating an xpub takes no
+    # modular square root
     curve_group,
     mult,
     point_from_octets,
@@ -62,7 +59,7 @@ from btclib.hashes import hash160
 from btclib.network import NETWORKS
 from btclib.to_pub_key import pub_keyinfo_from_key
 from tests import load, needs_bindings, replace_unchecked, vector_id
-from tests.curves.curve_test import no_bindings
+from tests.curves.curve_test import no_bindings, no_bindings_anywhere
 
 
 def test_exceptions() -> None:
@@ -815,11 +812,13 @@ def test_the_python_arm_reaches_no_bindings(monkeypatch: pytest.MonkeyPatch) -> 
     arm. Construction is a thing to check rather than to trust, and a
     per-operation dispatch would end it without touching this file.
 
-    Checked by putting the whole of btclib_secp256k1 out of reach, which
-    takes both halves: the package's own callables, for a caller holding
-    the module and reaching through it as bip32 does, and every name
-    btclib has already bound from it, `from ... import x as y` having
-    copied the object rather than looked it up again.
+    `no_bindings_anywhere` is the check, generic to any arm of this shape:
+    it puts the whole of btclib_secp256k1 out of reach, which takes both
+    halves -- the package's own callables, for a caller holding the module
+    and reaching through it as bip32 does, and every name btclib has
+    already bound from it, `from ... import x as y` having copied the
+    object rather than looked it up again -- and switches the dispatch
+    off.
 
     Not the same thing as `no_bindings_bip32` below, which switches the
     dispatch off and refuses bip32's own module: this refuses what every
@@ -835,33 +834,14 @@ def test_the_python_arm_reaches_no_bindings(monkeypatch: pytest.MonkeyPatch) -> 
         pub_key_derivation_tweaks(xpub.key, xpub.chain_code, "m/1/2"),
     )
 
-    def refuse(what: str) -> Callable[..., Any]:
-        def asked(*_args: object, **_kwargs: object) -> Any:
-            # a green suite is one where this never runs
-            raise AssertionError(  # pragma: no cover
-                f"the Python arm reached libsecp256k1: {what}"
-            )
+    no_bindings_anywhere(monkeypatch)
 
-        return asked
-
-    for mod_name, mod in list(sys.modules.items()):
-        if mod_name.split(".")[0] not in {"btclib", "btclib_secp256k1"}:
-            continue
-        for attr, value in list(vars(mod).items()):
-            if isinstance(value, types.ModuleType) or not callable(value):
-                continue
-            origin = getattr(value, "__module__", None) or ""
-            if origin.split(".")[0] == "btclib_secp256k1":
-                monkeypatch.setattr(mod, attr, refuse(f"{mod_name}.{attr}"))
-
-    # the two bip32 itself would have called, so that a loop reaching
+    # the two bip32 itself would have called, so that a walk reaching
     # nothing would fail here rather than pass by touching nothing
     with pytest.raises(AssertionError, match="reached libsecp256k1"):
         libsecp256k1_keys.prvkey_tweak_add(b"\x01" * 32, b"\x02" * 32)
     with pytest.raises(AssertionError, match="reached libsecp256k1"):
         libsecp256k1_keys.PubkeyTweakChain(b"\x02" + b"\x01" * 32)
-
-    monkeypatch.setattr(curve, "_libsecp256k1_available", False)
 
     assert (
         derive(rootxprv, "m/0h/1/2h"),

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -7,9 +7,13 @@
 import copy
 import functools
 import itertools
+import sys
+import types
+from collections.abc import Callable
 from functools import partial
 from hashlib import sha256, sha512
 from math import ceil, isqrt, sqrt
+from typing import Any
 
 import pytest
 
@@ -1005,6 +1009,52 @@ def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
     # a class rather than a function, which is the one dispatch that
     # builds an object instead of calling through
     monkeypatch.setattr(curve, "Libsecp256k1PubkeyTweakChain", refuse)
+
+
+def no_bindings_anywhere(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Put every already-bound btclib_secp256k1 callable out of reach.
+
+    `no_bindings` above answers for `curve.py`'s own six names and the one
+    class beside them, which is what every arm gated on the curve and the
+    hash function alone reaches through. An arm gated on availability
+    alone can hold a binding of its own a module further out --
+    `bip32.bip32` imports `keys`, `script.taproot` imports `xonly`,
+    `ecc.bms` imports `dsa`, whose own `_libsecp256k1_recover_sec_` binds
+    `recovery` -- and `from ... import x as y` copies the object rather
+    than looking it up again, so a patch on the module the bindings live
+    in does not reach a name already copied out of it.
+
+    So this walks every module already loaded under `btclib` or
+    `btclib_secp256k1` and replaces every callable there whose
+    `__module__` traces back to the bindings with one that raises,
+    whichever module holds the name; `_libsecp256k1_available` is cleared
+    alongside it, since a caller with the flag still on and every name
+    unreachable is not the configuration a missing install produces. An
+    arm this does not cover fails by calling through instead of passing
+    by measuring the bindings against themselves.
+    """
+
+    def refuse(what: str) -> Callable[..., Any]:
+        def asked(*_args: object, **_kwargs: object) -> Any:
+            # a green suite is one where this never runs, the same pragma
+            # no_bindings above carries for a call the dispatch rules out
+            raise AssertionError(  # pragma: no cover
+                f"the Python arm reached libsecp256k1: {what}"
+            )
+
+        return asked
+
+    for mod_name, mod in list(sys.modules.items()):
+        if mod_name.split(".")[0] not in {"btclib", "btclib_secp256k1"}:
+            continue
+        for attr, value in list(vars(mod).items()):
+            if isinstance(value, types.ModuleType) or not callable(value):
+                continue
+            origin = getattr(value, "__module__", None) or ""
+            if origin.split(".")[0] == "btclib_secp256k1":
+                monkeypatch.setattr(mod, attr, refuse(f"{mod_name}.{attr}"))
+
+    monkeypatch.setattr(curve, "_libsecp256k1_available", False)
 
 
 @pytest.mark.parametrize(

--- a/tests/ecc/bms_test.py
+++ b/tests/ecc/bms_test.py
@@ -24,6 +24,7 @@ from typing import Any
 import pytest
 
 from btclib import b32, b58
+from btclib._libsecp256k1 import recovery as libsecp256k1_recovery
 from btclib.alias import Point
 from btclib.b58 import h160_from_address
 from btclib.bip32 import bip32
@@ -34,7 +35,8 @@ from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.hashes import magic_message
 from btclib.mnemonic import bip39
 from btclib.to_prv_key import prv_keyinfo_from_prv_key
-from tests import load, vector_id
+from tests import load, needs_bindings, vector_id
+from tests.curves.curve_test import no_bindings_anywhere
 
 ec = secp256k1
 
@@ -1032,6 +1034,41 @@ def test_the_python_path_answers_the_same(
     with monkeypatch.context() as no_bindings:
         no_bindings.setattr(curve, "_libsecp256k1_available", False)
         vector_test()
+
+
+@needs_bindings
+def test_the_python_arm_reaches_no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The recovery gated on availability alone must be Python throughout.
+
+    A mixed arm is the one shape that is never right: with libsecp256k1 in
+    reach `_libsecp256k1_recover_sec_` is the better call, and out of
+    reach there is nothing to mix. `assert_as_valid`'s guard picks between
+    that and `dsa.recover_pub_key(..., sha256)` for its Python arm, itself
+    a dispatch on the same predicate rather than a call that could
+    delegate on its own.
+
+    `no_bindings_anywhere` is the check `tests.bip32.bip32_test` and
+    `tests.script.taproot_test` use for the same shape: it puts the whole
+    of btclib_secp256k1 out of reach, module and already-bound name alike,
+    and switches the dispatch off -- which `dsa.recover_pub_key`'s own
+    guard then reads the same way `assert_as_valid`'s does, so the walk
+    covering `_libsecp256k1_recover_sec_` covers this arm's delegate too.
+    """
+    wif, addr = bms.gen_keys()
+    msg = b"a message signed once and recovered from twice"
+    sig = bms.sign(msg, wif)
+    # what the bindings answer, taken while they are still in reach
+    delegated = bms.verify(msg, addr, sig)
+    assert delegated
+
+    no_bindings_anywhere(monkeypatch)
+
+    # what bms itself would have called, so that a walk reaching nothing
+    # would fail here rather than pass by touching nothing
+    with pytest.raises(AssertionError, match="reached libsecp256k1"):
+        libsecp256k1_recovery.recover(bytes(32), bytes(64), 0, True)
+
+    assert bms.verify(msg, addr, sig) == delegated
 
 
 def test_parse_length_is_not_a_validity_opinion() -> None:

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -17,6 +17,7 @@ from typing import Any
 import pytest
 
 from btclib import b32
+from btclib._libsecp256k1 import xonly as libsecp256k1_xonly
 from btclib.alias import ScriptList
 from btclib.curves import bytes_from_point, curve_group, mult
 from btclib.exceptions import BTClibTypeError, BTClibValueError
@@ -41,8 +42,8 @@ from btclib.script.taproot import (
     tree_helper,
 )
 from btclib.tx import TxOut
-from tests import load, vector_id
-from tests.curves.curve_test import low_card_curves
+from tests import load, needs_bindings, vector_id
+from tests.curves.curve_test import low_card_curves, no_bindings_anywhere
 from tests.script import serialize_non_canonical
 
 
@@ -219,6 +220,56 @@ def test_the_python_prvkey_tweak_lifts_nothing(
         no_bindings.setattr(curve_group, "mod_sqrt_var", refuse)
         for tree, expected in zip(SCRIPT_TREES, delegated, strict=True):
             assert output_prvkey(prv_key, tree) == expected
+
+
+@needs_bindings
+def test_the_python_arm_reaches_no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Three of the four guards this module keeps must be Python throughout.
+
+    A mixed arm is the one shape that is never right: with libsecp256k1 in
+    reach `libsecp256k1_xonly.tweak_add` and `.prvkey_tweak_add` are the
+    better calls, and out of reach there is nothing to mix.
+    `_output_pubkey_and_internal_key`'s choice of which form of the
+    internal key to build, `_tweaked_pubkey`'s tweak and
+    `_tweaked_prvkey`'s are that shape, gated on `secp256k1` and nothing
+    else, and `output_pubkey` together with `output_prvkey` reach all
+    three between them.
+
+    `check_output_pubkey`'s guard is not: it adds `len(q) == 32` to the
+    same predicate, so with the bindings in reach and a q of another
+    length its Python arm still runs, and that arm calls `mult`, which
+    delegates on its own -- the mixed arm SECURITY.md documents for dsa
+    and ssa, real there for the same reason it is real here. That guard
+    is left out of this test on purpose; the fallthrough it takes with
+    the bindings installed is what
+    `test_check_output_pubkey_of_a_key_that_is_not_32_bytes` exercises.
+
+    `no_bindings_anywhere` is the check `tests.bip32.bip32_test` uses for
+    the same shape: it puts the whole of btclib_secp256k1 out of reach,
+    module and already-bound name alike, and switches the dispatch off.
+    """
+    prv_key = 0xC0FFEE
+    pub_key = mult(prv_key)
+    script_tree: TaprootScriptTree = [[(0xC0, ["OP_2"])], [(0xC0, ["OP_3"])]]
+    # what the bindings answer, taken while they are still in reach
+    delegated = (
+        output_pubkey(pub_key, script_tree),
+        output_prvkey(prv_key, script_tree),
+    )
+
+    no_bindings_anywhere(monkeypatch)
+
+    # the two taproot itself would have called, so that a walk reaching
+    # nothing would fail here rather than pass by touching nothing
+    with pytest.raises(AssertionError, match="reached libsecp256k1"):
+        libsecp256k1_xonly.tweak_add(bytes(32), bytes(32))
+    with pytest.raises(AssertionError, match="reached libsecp256k1"):
+        libsecp256k1_xonly.prvkey_tweak_add(bytes(32), bytes(32))
+
+    assert (
+        output_pubkey(pub_key, script_tree),
+        output_prvkey(prv_key, script_tree),
+    ) == delegated
 
 
 def test_the_python_commitment_check_is_the_bindings_one(


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/968

## What it does

#967 added `test_the_python_arm_reaches_no_bindings` for bip32's two
arms gated on availability alone. #968 asked for the same check on the
other four the issue's census named, and left two things open: where
the walk that check needs lives, and whether one test per module reads
better than one per arm. This resolves both and adds the tests.

**Where the walk lives.** It moves to `tests/curves/curve_test.py` as
`no_bindings_anywhere`, beside the existing `no_bindings` -- the home
the issue itself proposed, and the file `ssa_test.py` and others
already import from for the same kind of shared fixture. It does not
replace `no_bindings`: that one answers for `curve.py`'s own six bound
names and the class beside them, for an arm gated on the curve and the
hash function; `no_bindings_anywhere` walks every module already
loaded under `btclib` or `btclib_secp256k1` and refuses every callable
whose `__module__` traces back to the bindings, for an arm that holds
a binding of its own a module further out -- `bip32.bip32` imports
`keys`, `script.taproot` imports `xonly`, `ecc.dsa` (bms's own
delegate) imports `recovery`. `bip32_test.py`'s own test is refactored
onto the shared helper; its assertions and monkeypatches are
unchanged, only their order shifts slightly (the sanity check that the
walk reached something now runs after the dispatch is switched off
instead of before, which the sanity check itself does not depend on,
since it calls the patched bindings function directly rather than
through the dispatch).

**One test per module.** `taproot_test.py` and `bms_test.py` each get
one `test_the_python_arm_reaches_no_bindings`, following the issue's
own proposed shape.

**The census, verified against the tree rather than trusted to the
issue** (which was filed before `taproot.py`'s last edit): four
`_libsecp256k1_serves(secp256k1, None)` guards exist in `taproot.py`
today --

- `btclib/script/taproot.py:279`, in
  `_output_pubkey_and_internal_key` (which of the two internal-key
  forms to build)
- `btclib/script/taproot.py:364`, in `_tweaked_pubkey`
- `btclib/script/taproot.py:426`, in `_tweaked_prvkey`
- `btclib/script/taproot.py:529`, in `check_output_pubkey`

The first three are gated on availability alone and are what the new
`taproot_test.py` test covers, through `output_pubkey` and
`output_prvkey` between them. The fourth is not: it adds `len(q) ==
32` to the same predicate, so with the bindings in reach and a `q` of
another length its Python arm still runs -- and that arm's `mult(t)`
delegates on its own, the mixed arm `SECURITY.md` documents for `dsa`
and `ssa`, not the shape this issue is about. The comment above
`_tweaked_pubkey` (`taproot.py:356`) groups all four as "the four
guards in this module", but that is about where the predicate is
computed once rather than about which of them may mix; left untested
here on purpose, and already exercised with the bindings installed by
`test_check_output_pubkey_of_a_key_that_is_not_32_bytes`.

`btclib/ecc/bms.py:400`, in `assert_as_valid`, is the fifth and last:
gated on availability alone, its Python arm being
`dsa.recover_pub_key(..., sha256)`, itself a dispatch on the same
predicate rather than a call that could delegate on its own -- so the
walk covering `dsa`'s own bound `recovery` module covers this arm's
delegate too.

**CHANGELOG.md**: no entry. Nothing here changes what btclib does,
only what the suite checks of an invariant that already held; #967's
own entry is about the functional Python arm it restored, not about
this shape of test. Two recent single-commit, test-only PRs
(`88a81b74`, `56e7f811`) landed the same way, unlogged.

## Evidence

- Mutation-checked by hand: forcing `_tweaked_prvkey`'s Python arm to
  call `libsecp256k1_xonly.prvkey_tweak_add` unconditionally, and
  `assert_as_valid`'s to call `_libsecp256k1_recover_sec_`
  unconditionally, each failed its new test by name
  (`the Python arm reached libsecp256k1: ...`) rather than passing
  silently; reverted before committing.
- `uv run pytest`: green, coverage 100.00%.
- `uv run pre-commit run --all-files`: green.
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html`: green, and the
  `href="#./"` grep the docs job runs after it finds nothing.

## Summary by Sourcery

Verify that taproot and BMS Python execution paths avoid libsecp256k1 bindings by sharing a comprehensive test fixture across affected modules.

Enhancements:
- Centralize the shared no-bindings test fixture so it detects bound libsecp256k1 callables throughout loaded btclib modules.
- Add coverage ensuring taproot and BMS Python execution paths do not reach libsecp256k1 bindings, and reuse the shared check for bip32.

Tests:
- Extend tests to verify taproot and BMS Python arms remain binding-free when the optimized library is unavailable.