### PR TITLE
Assert what verify the bindings signing calls cross with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6252,6 +6252,22 @@ documented at release-notes length in the first place, and are still in
 
 ### Tests
 
+- **A recorder per bindings signing call site asserts what `verify` it
+  crosses with** (issue #986). `dsa.sign_`'s delegated arm, its
+  `sign_recoverable_`, and `ssa.sign_`'s all cross into the bindings with
+  a `verify` keyword, and the keyword changes no output byte -- the
+  bindings' own suite states that as the reason a signature can never
+  tell which value was passed. Nothing else here can either, so each
+  crossing is recorded and the value it received is asserted directly:
+  `test_the_delegated_arm_asks_the_bindings_to_verify` holds `dsa.sign_`
+  to one crossing per call, carrying the caller's own `verify`, whether
+  it grinds or not; `test_sign_recoverable_asks_the_bindings_to_verify`
+  holds the hardcoded `verify=True` `sign_recoverable_` writes there
+  rather than leaving to the bindings' default; and
+  `test_the_delegated_arm_forwards_verify` holds `ssa.sign_`'s to the
+  caller's own value too, beside the existing recorder that already held
+  the keyword itself to being forwarded and not dropped.
+
 - **The input-validation gate's own verdict is exercised** (issue #776).
   `_classify` is the three answers a call can give -- the rule held, a
   native exception got out and here is its class, nothing was raised at

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -2032,3 +2032,73 @@ def test_the_delegated_grind_is_the_sequence_the_python_arm_walks() -> None:
 
         # the point of grinding at all, and cheap to say here
         assert dsa._is_low_r(delegated.r, secp256k1)
+
+
+@needs_bindings
+def test_the_delegated_arm_asks_the_bindings_to_verify(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`verify` reaches `secp256k1_ecdsa_sign` once, as the caller wrote it.
+
+    Nothing before this recorded it: the crossing above shows the two
+    arms agree on the signature `grind=True, verify=False` produces, not
+    that `verify` is the argument deciding whether a check follows it, or
+    that grinding pays for one crossing and not one per attempt (issue
+    986). `_grind_low_r`'s own loop is the Python arm's; the delegated
+    arm's grinding is `secp256k1_ecdsa_sign`'s own, which this call does
+    not see -- what it can see, and what this asserts, is that btclib
+    crosses into it once per `sign_` call, whether that call grinds or
+    not.
+    """
+    real_sign = libsecp256k1_dsa.sign
+    calls: list[bool] = []
+
+    def sign(*args: Any, **kwargs: Any) -> bytes:
+        calls.append(kwargs["verify"])
+        return real_sign(*args, **kwargs)
+
+    q, _ = dsa.gen_keys(prv_key_int)
+    msg_hash = sha256(b"a message").digest()
+
+    with monkeypatch.context() as patch:
+        patch.setattr(libsecp256k1_dsa, "sign", sign)
+        for grind in (True, False):
+            for verify in (True, False):
+                calls.clear()
+                dsa.sign_(msg_hash, q, grind=grind, verify=verify)
+                # one crossing, carrying the caller's own verify -- not
+                # zero, which is #982's bill, and not two, which is the
+                # grinding loop this arm no longer walks
+                assert calls == [verify]
+
+
+@needs_bindings
+def test_sign_recoverable_asks_the_bindings_to_verify(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`verify=True` reaches `secp256k1_ecdsa_sign_recoverable`, written out.
+
+    `sign_recoverable_` takes no `verify` of its own: the comment at its
+    call into the bindings argues why True belongs there rather than at
+    the bindings' default, the recovery id being a value nothing
+    downstream re-derives the way a faulted r or s is caught by the
+    first verification anybody makes of a plain signature. Nothing held
+    that argument to the keyword actually written before this (issue
+    986): a refactor dropping it, or writing False, changes no signature
+    and no recovered key, and would still be caught by nothing.
+    """
+    real_sign = libsecp256k1_recovery.sign
+    calls: list[bool] = []
+
+    def sign(*args: Any, **kwargs: Any) -> tuple[bytes, int]:
+        calls.append(kwargs["verify"])
+        return real_sign(*args, **kwargs)
+
+    q, _ = dsa.gen_keys(prv_key_int)
+    msg_hash = sha256(b"a message").digest()
+
+    with monkeypatch.context() as patch:
+        patch.setattr(libsecp256k1_recovery, "sign", sign)
+        dsa.sign_recoverable_(msg_hash, q)
+
+    assert calls == [True]

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -441,6 +441,37 @@ def test_a_message_of_any_size_reaches_the_bindings(
     ]
 
 
+@needs_bindings
+def test_the_delegated_arm_forwards_verify(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`verify` reaches `secp256k1_schnorrsig_sign_custom`, as `sign_` took it.
+
+    The recorder above holds that `sign_custom` is called and forwards
+    the keyword -- a dropped one raises `TypeError` there, its own local
+    `sign_custom` declaring `verify` with no default -- but every call it
+    makes is at the caller's own default, `verify=True`. Nothing held the
+    *value* that crosses to be the caller's own rather than one written
+    over on the way (issue 986): BIP340 is the one scheme #984 argues
+    must keep the check on, which is exactly what a silent `verify=True`
+    written at this crossing would still pass.
+    """
+    real_sign_custom = libsecp256k1_ssa.sign_custom
+    calls: list[bool] = []
+
+    def sign_custom(*args: Any, **kwargs: Any) -> bytes:
+        calls.append(kwargs["verify"])
+        return real_sign_custom(*args, **kwargs)
+
+    q, _ = ssa.gen_keys(0x1234567890ABCDEF)
+    msg = b"a message"
+
+    with monkeypatch.context() as patch:
+        patch.setattr(libsecp256k1_ssa, "sign_custom", sign_custom)
+        for verify in (True, False):
+            calls.clear()
+            ssa.sign_(msg, q, verify=verify)
+            assert calls == [verify]
+
+
 def test_verify_with_a_message_that_is_not_32_bytes_on_both_arithmetics(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Adds a recorder per bindings signing call site, asserting the actual
  `verify` value each one crosses with, not merely that the keyword is
  forwarded:
  - `test_the_delegated_arm_asks_the_bindings_to_verify` (dsa_test.py) —
    `dsa.sign_`'s delegated arm crosses exactly once per call, carrying
    the caller's own `verify`, whichever way `grind` is set.
  - `test_sign_recoverable_asks_the_bindings_to_verify` (dsa_test.py) —
    `dsa.sign_recoverable_` always crosses with the hardcoded
    `verify=True` its call site writes out.
  - `test_the_delegated_arm_forwards_verify` (ssa_test.py) — `ssa.sign_`'s
    delegated arm crosses with the caller's own `verify`, beside the
    existing recorder that already held the keyword itself (not its
    value) to being forwarded.
- No production code changes: `verify` changes no output byte on any of
  the three arms, which is exactly why none of this was held by an
  ordinary test before.

Fixes #986.

## Test plan

- [x] Each new test's assertion was confirmed to actually catch a
  regression: mutated each of the three call sites in turn (a hardcoded
  `verify=True`/`verify=False` in place of the forwarded keyword),
  confirmed the matching new test fails, then reverted.
- [x] `uv run pytest` — 27955 passed, 100% coverage maintained.
- [x] `uv run pre-commit run --all-files` — all hooks pass, mypy strict
  included.
- [x] `sphinx-build -W --keep-going` — docs gate green.

## Summary by Sourcery

Strengthen signing-boundary tests by asserting the exact `verify` values passed to the native bindings.

Enhancements:
- Add targeted assertions that DSA and SSA signing bindings receive the caller-specified or explicitly required `verify` value at every signing call site.

Tests:
- Add recorder-based tests covering delegated DSA signing, recoverable signing, and delegated SSA signing, including call counts and forwarded `verify` values.