### PR TITLE
Filter the annotation-only BitOr noise, and run the orphaned curve_group session

### DIFF
--- a/.github/mutation/bip32.toml
+++ b/.github/mutation/bip32.toml
@@ -18,6 +18,24 @@ timeout = 300
 
 excluded-modules = []
 
+# The `BitOr` exclusion wallet.toml explains and parsers.toml argues.
+# Measured rather than assumed, as script.toml's own comment on this
+# exclusion asks:
+#
+#   grep -n ' | ' btclib/bip32/bip32.py btclib/bip32/key_origin.py \
+#       btclib/bip32/der_path.py
+#
+# Every hit is an annotation. Confirmed by running the filter itself
+# rather than by the grep alone: `cosmic-ray init` over this file
+# enumerates 1387 mutants today (more than the 1356 the session below
+# ran against, the file having grown since), and
+# `cosmic_ray.tools.filters.operators_filter` marks 132 of them SKIPPED
+# -- more than the 66 the session below found equivalent by inspection,
+# the same growth -- leaving 1255 for a future session to have an
+# opinion about (issue #987).
+[cosmic-ray.filters.operators-filter]
+exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
+
 # 1356 mutants, complete: 1123 killed, 233 survived. 66 are the deferred-
 # annotation class fetch.toml documents, 19 the keyword-only `*` to `/`
 # marker sig_hash.toml's docstring already names, 6 an `is` CPython's

--- a/.github/mutation/block.toml
+++ b/.github/mutation/block.toml
@@ -20,6 +20,24 @@ timeout = 300
 
 excluded-modules = []
 
+# The `BitOr` exclusion wallet.toml explains and parsers.toml argues.
+# Measured rather than assumed, as script.toml's own comment on this
+# exclusion asks:
+#
+#   grep -n ' | ' btclib/block/block.py btclib/block/block_header.py \
+#       btclib/block/proof_of_work.py
+#
+# Every hit is an annotation. Confirmed by running the filter itself
+# rather than by the grep alone: `cosmic-ray init` over this file
+# enumerates 1587 mutants today (more than the 1481 the session below
+# ran against, the file having grown since), and
+# `cosmic_ray.tools.filters.operators_filter` marks 55 of them SKIPPED
+# -- the same 55 the session below already found equivalent by
+# inspection -- leaving 1532 for a future session to have an opinion
+# about (issue #987).
+[cosmic-ray.filters.operators-filter]
+exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
+
 # 1481 mutants, complete: 1314 killed, 167 survived. 55 are the deferred-
 # annotation class fetch.toml documents, 9 the keyword-only marker, 4 an
 # `is` CPython's small-int cache makes indistinguishable from `==`.

--- a/.github/mutation/bms.toml
+++ b/.github/mutation/bms.toml
@@ -22,18 +22,26 @@ excluded-modules = []
 #   grep -n ' | ' btclib/ecc/bms.py
 #
 # Every hit outside the docstring's own recovery-flag table is an
-# annotation -- none of the arithmetic the sample below found equivalent
-# for `+`/`|`/`^` is a literal `|` in the source, that being a mutation
-# of `+` and not of this operator. Confirmed by running the filter
-# itself: `cosmic-ray init` over this file enumerates 494 mutants today,
-# and `cosmic_ray.tools.filters.operators_filter` marks 66 of them
-# SKIPPED -- the same 66 the session below already found equivalent by
-# inspection -- leaving 428, so a future sample does not spend a draw on
-# them (issue #987).
+# annotation -- none of the arithmetic the session below found
+# equivalent for `+`/`|`/`^` is a literal `|` in the source, that being
+# a mutation of `+` and not of this operator. Confirmed by running the
+# filter itself: `cosmic-ray init` over this file enumerates 494
+# mutants today, close to the 496 the session below completed, and
+# `cosmic_ray.tools.filters.operators_filter` marks 66 of them SKIPPED
+# -- the same 66 that session already found equivalent by inspection --
+# leaving 428, so a future session does not spend a run on them (issue
+# #987).
 [cosmic-ray.filters.operators-filter]
 exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 
-# 496 of the 977 mutants sampled in 1200 s: 360 killed, 136 survived. 66
+# 496 mutants, complete: 360 killed, 136 survived. Its own comment once
+# read "496 of the 977 sampled in 1200 s" -- 977 was never what
+# `cosmic-ray init` enumerates for this file, on any commit or cosmic-ray
+# version checked, and 360 + 136 already equals the 496 above it, which
+# is what a complete session looks like rather than a partial one.
+# `mutation.yml`'s own comment on the job this profile runs in carried
+# the same 977, for bip322.toml too, and is corrected there as well
+# (issue #987, caught incidentally while adding the exclusion above). 66
 # are the deferred-annotation class fetch.toml documents, 5 the keyword-
 # only marker, 2 an `is` CPython's small-int cache makes indistinguishable
 # from `==`.

--- a/.github/mutation/bms.toml
+++ b/.github/mutation/bms.toml
@@ -15,6 +15,24 @@ timeout = 300
 
 excluded-modules = []
 
+# The `BitOr` exclusion wallet.toml explains and parsers.toml argues.
+# Measured rather than assumed, as script.toml's own comment on this
+# exclusion asks:
+#
+#   grep -n ' | ' btclib/ecc/bms.py
+#
+# Every hit outside the docstring's own recovery-flag table is an
+# annotation -- none of the arithmetic the sample below found equivalent
+# for `+`/`|`/`^` is a literal `|` in the source, that being a mutation
+# of `+` and not of this operator. Confirmed by running the filter
+# itself: `cosmic-ray init` over this file enumerates 494 mutants today,
+# and `cosmic_ray.tools.filters.operators_filter` marks 66 of them
+# SKIPPED -- the same 66 the session below already found equivalent by
+# inspection -- leaving 428, so a future sample does not spend a draw on
+# them (issue #987).
+[cosmic-ray.filters.operators-filter]
+exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
+
 # 496 of the 977 mutants sampled in 1200 s: 360 killed, 136 survived. 66
 # are the deferred-annotation class fetch.toml documents, 5 the keyword-
 # only marker, 2 an `is` CPython's small-int cache makes indistinguishable

--- a/.github/mutation/curve_group.toml
+++ b/.github/mutation/curve_group.toml
@@ -34,10 +34,13 @@ timeout = 300
 excluded-modules = []
 
 # no session has run yet. `cosmic-ray init` over this file enumerates
-# 5548 mutants, more than double signatures.toml's dsa.py/ssa.py pair at
-# 2475 -- sampled there rather than finished, and likely sampled here
-# too. The wall clock a sample takes, and what it finds, are issue
-# #822's follow-up rather than a guess written down here in their place
+# 5529 mutants today (5548 when this profile was written, both modules
+# having changed some since -- re-checked for issue #987, which is what
+# wires this profile into a job at last), nearly double
+# signatures.toml's dsa.py/ssa.py pair at 2980 -- sampled there rather
+# than finished, and likely sampled here too. The wall clock a sample
+# takes, and what it finds, are issue #822's follow-up rather than a
+# guess written down here in their place
 
 [cosmic-ray.distributor]
 name = "local"

--- a/.github/mutation/fetch.toml
+++ b/.github/mutation/fetch.toml
@@ -21,6 +21,24 @@ timeout = 300
 
 excluded-modules = []
 
+# The `BitOr` exclusion wallet.toml explains and parsers.toml argues.
+# Measured rather than assumed, as script.toml's own comment on this
+# exclusion asks:
+#
+#   grep -n ' | ' btclib/fetch/transport.py btclib/fetch/esplora.py \
+#       btclib/fetch/bitcoin_core.py btclib/fetch/fetcher.py
+#
+# Every hit is an annotation. Confirmed by running the filter itself
+# rather than by the grep alone: `cosmic-ray init` over this file still
+# enumerates the 177 mutants the session below did, and
+# `cosmic_ray.tools.filters.operators_filter` marks 55 of them SKIPPED
+# -- the same 55 the session below already found equivalent by
+# inspection, and the "class fetch.toml documents" every other
+# profile's own comment points back to -- leaving 122 for a future
+# session to have an opinion about (issue #987).
+[cosmic-ray.filters.operators-filter]
+exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
+
 # 177 mutants, complete: 114 killed, 63 survived. One of the 63 is killed
 # now -- `chain_from_network(self.network) != "signet"` weakened to `<`,
 # which accepted a challenge for the two testnets whose chain names sort

--- a/.github/mutation/mnemonic.toml
+++ b/.github/mutation/mnemonic.toml
@@ -19,6 +19,25 @@ timeout = 300
 
 excluded-modules = []
 
+# The `BitOr` exclusion wallet.toml explains and parsers.toml argues.
+# Measured rather than assumed, as script.toml's own comment on this
+# exclusion asks:
+#
+#   grep -n ' | ' btclib/mnemonic/bip39.py btclib/mnemonic/entropy.py
+#
+# Every hit outside the docstring's own entropy/checksum table is an
+# annotation -- the `|`/`^` the sample below found equivalent to `+` is
+# a mutation of that operator and not a literal `|` in the source.
+# Confirmed by running the filter itself rather than by the grep alone:
+# `cosmic-ray init` over this file enumerates 772 mutants today (more
+# than the 739 the session below sampled from, the file having grown
+# since), and `cosmic_ray.tools.filters.operators_filter` marks 88 of
+# them SKIPPED -- more than the 11 the 150-mutant sample below found,
+# the same growth and a wider slice -- leaving 684, so a future sample
+# does not spend a draw on them (issue #987).
+[cosmic-ray.filters.operators-filter]
+exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
+
 # 150 of the 739 mutants sampled in 600 s: 111 killed, 39 survived. 11 of
 # the 39 are the deferred-annotation class fetch.toml documents, and one
 # is `is` for `==` on two small ints CPython interns.

--- a/.github/mutation/numeric.toml
+++ b/.github/mutation/numeric.toml
@@ -44,6 +44,22 @@ timeout = 30
 
 excluded-modules = []
 
+# The `BitOr` exclusion wallet.toml explains and parsers.toml argues.
+# Measured rather than assumed, as script.toml's own comment on this
+# exclusion asks:
+#
+#   grep -n ' | ' btclib/amount.py btclib/fee.py btclib/ecc/dh.py
+#
+# Every hit is an annotation. Confirmed by running the filter itself
+# rather than by the grep alone: `cosmic-ray init` over this file still
+# enumerates the 602 mutants the session below did, and
+# `cosmic_ray.tools.filters.operators_filter` marks 22 of them SKIPPED
+# -- the same 22 the session below already found equivalent by
+# inspection -- leaving 580 for a future session to have an opinion
+# about (issue #987).
+[cosmic-ray.filters.operators-filter]
+exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
+
 # 602 mutants, all of them: 553 killed, 49 survived, 8.14%. The first
 # session of this profile to finish rather than sample, which is what the
 # budget and the timeout above buy together -- and what lets this state a

--- a/.github/mutation/signatures.toml
+++ b/.github/mutation/signatures.toml
@@ -42,6 +42,26 @@ timeout = 300
 
 excluded-modules = []
 
+# The `BitOr` exclusion wallet.toml explains and parsers.toml argues.
+# Measured rather than assumed, as script.toml's own comment on this
+# exclusion asks:
+#
+#   grep -n ' | ' btclib/ecc/ssa.py btclib/ecc/dsa.py
+#
+# Every hit is an annotation or, at `dsa.py`'s one comment quoting
+# libsecp256k1's own `is_odd(r.y) | (overflow ? 2 : 0)`, not code at
+# all -- the recovery id these two modules actually build reads
+# `2 * (x_K // ec.n) + (K[1] & 1)`, `+` and `&`, and no literal `|`.
+# Confirmed by running the filter itself rather than by the grep alone:
+# `cosmic-ray init` over this file enumerates 2980 mutants today (more
+# than the 2475 the session below sampled from, the two modules having
+# grown since), and `cosmic_ray.tools.filters.operators_filter` marks
+# 880 of them SKIPPED -- more than the 228 the 812-mutant sample below
+# found, the same growth and a wider slice -- leaving 2100, so a future
+# sample does not spend a draw on them (issue #987).
+[cosmic-ray.filters.operators-filter]
+exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
+
 # 812 of the 2475 mutants sampled in 5400 s -- the largest scope in this
 # session and the one furthest from finishing, both modules together
 # being nearly as large as sig_hash.py and engine.toml combined. 507

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -42,7 +42,7 @@ on:
     inputs:
       profile:
         # one scope's numbers are what a question about that scope needs,
-        # and without this the only way to ask is the whole matrix: eleven
+        # and without this the only way to ask is the whole matrix: twelve
         # runners and, at the consensus job's ceiling, most of an
         # afternoon. Re-measuring one configuration -- a budget changed, a
         # timeout argued about, a survivor that moved -- is worth minutes
@@ -65,6 +65,7 @@ on:
           - block
           - shared
           - signatures
+          - curves
           - descriptors
           - psbt
           - script
@@ -225,6 +226,20 @@ jobs:
             ceiling: 100
             sessions: |
               signatures.toml 90m
+          # the pure-Python point arithmetic under the two signing modules
+          # above: 5548 mutants, more than double their pair, and written
+          # for issue #822 -- which this scope answers and signatures.toml's
+          # own header still names as the profile with none of it yet --
+          # but never added to a job of its own, so no session has run it.
+          # 90 minutes, matching signatures.toml's budget for a scope more
+          # than double the size, is a first sample rather than a measured
+          # one; what it finds is #822's follow-up, the same note
+          # curve_group.toml itself makes
+          - profile: the pure-Python curve arithmetic
+            slug: curves
+            ceiling: 100
+            sessions: |
+              curve_group.toml 90m
           # output descriptors and miniscript, and the largest scope in
           # this matrix by a factor of three: 10831 mutants, of which the
           # first session judged 383 in 31 minutes -- 4.9 s each with four

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -179,9 +179,11 @@ jobs:
               bip32.toml 45m
               codecs.toml 30m
           # the message-signing formats: bms.toml and bip322.toml each
-          # finish their own count -- 977 mutants apiece -- in about two
+          # finish their own count -- 496 and 552 mutants -- in about two
           # minutes, small enough that the budget below is headroom rather
-          # than a measurement
+          # than a measurement. Both were "977 apiece" here until
+          # bms.toml's own comment was checked against `cosmic-ray init`
+          # for issue #987 and found not to hold on either file
           - profile: message signing and BIP322
             slug: signing
             ceiling: 35
@@ -227,14 +229,14 @@ jobs:
             sessions: |
               signatures.toml 90m
           # the pure-Python point arithmetic under the two signing modules
-          # above: 5548 mutants, more than double their pair, and written
-          # for issue #822 -- which this scope answers and signatures.toml's
-          # own header still names as the profile with none of it yet --
-          # but never added to a job of its own, so no session has run it.
-          # 90 minutes, matching signatures.toml's budget for a scope more
-          # than double the size, is a first sample rather than a measured
-          # one; what it finds is #822's follow-up, the same note
-          # curve_group.toml itself makes
+          # above: 5529 mutants, nearly double their pair's 2980, and
+          # written for issue #822 -- which this scope answers and
+          # signatures.toml's own header still names as the profile with
+          # none of it yet -- but never added to a job of its own, so no
+          # session has run it. 90 minutes, matching signatures.toml's
+          # budget for a scope nearly double the size, is a first sample
+          # rather than a measured one; what it finds is #822's follow-up,
+          # the same note curve_group.toml itself makes
           - profile: the pure-Python curve arithmetic
             slug: curves
             ceiling: 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,32 @@ documented at release-notes length in the first place, and are still in
   `check-manifest`'s ignore entry becomes `.claude/**`, `.claude/*` being
   one level and the commands now a directory deeper.
 
+- **Seven more mutation profiles filter the deferred-annotation `BitOr`
+  class already named in each one's own report** (issue #987):
+  `bip32.toml`, `block.toml`, `bms.toml`, `fetch.toml`, `mnemonic.toml`,
+  `numeric.toml` and `signatures.toml`. Each was measured rather than
+  assumed, the way `script.toml`'s own comment on the same exclusion
+  argues: `grep -n ' | '` over the scope's modules, confirming every hit
+  is an annotation, and `cosmic_ray.tools.filters.operators_filter` run
+  locally against the configuration, confirming the mutants it marks
+  `SKIPPED` are exactly those the file's own prose already found
+  equivalent by inspection — 22 to 880 of them per profile today, at or
+  above what each session originally reported, the difference where the
+  file has grown since.
+  Left unfiltered, checked the same way and found to carry real `|`
+  arithmetic rather than annotations alone: `bip322.toml` (script-flag
+  combination), `codecs.toml` (`bech32`'s bit-packing), `engine.toml`
+  (the same script-flag combination), `sig_hash.toml`
+  (`ANYONECANPAY | ALL` and its siblings) and `curve_group.toml` (GLV
+  scalar recoding and set union).
+
+  `curve_group.toml` itself was written for issue #822 and never wired
+  into a job — `mutation.yml`'s matrix named twenty of the twenty-one
+  configurations under `.github/mutation/`, and `cosmic-ray init` over
+  this one enumerates 5529 mutants for nothing every week. A twelfth
+  job, `curves`, runs it now, budgeted like `signatures.toml`'s own job
+  for a scope more than double that pair's size.
+
 - **The numeric mutation profile finishes its scope instead of sampling a
   fifth of it.** Its per-mutant `timeout` is 30 seconds rather than 300,
   and its session budget 25 minutes rather than 15. About one mutant in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,12 +75,20 @@ documented at release-notes length in the first place, and are still in
   (`ANYONECANPAY | ALL` and its siblings) and `curve_group.toml` (GLV
   scalar recoding and set union).
 
+  Measuring `bms.toml` this way turned up a second, unrelated error in
+  its own comment: "496 of the 977 mutants sampled" was never what
+  `cosmic-ray init` enumerates for that file, on any commit or
+  cosmic-ray version checked — 496 is complete, and 977 does not belong
+  to it. `mutation.yml`'s job comment carried the same 977 for
+  `bip322.toml` too; both are corrected to their actual counts, 496 and
+  552.
+
   `curve_group.toml` itself was written for issue #822 and never wired
   into a job — `mutation.yml`'s matrix named twenty of the twenty-one
   configurations under `.github/mutation/`, and `cosmic-ray init` over
   this one enumerates 5529 mutants for nothing every week. A twelfth
   job, `curves`, runs it now, budgeted like `signatures.toml`'s own job
-  for a scope more than double that pair's size.
+  for a scope nearly double that pair's size.
 
 - **The numeric mutation profile finishes its scope instead of sampling a
   fifth of it.** Its per-mutant `timeout` is 30 seconds rather than 300,


### PR DESCRIPTION
## Summary

Scoped to issue #987's step 1 and its loose end only, as agreed — step 2
(per-config timeout measurement via paired CI dispatches) and step 3
(the extended engine cycle) are follow-up work, not attempted here.

- **Filters the deferred-annotation `BitOr` class in seven profiles**
  that already name it as noise in their own report but never filtered
  it at the config level: `bip32.toml`, `block.toml`, `bms.toml`,
  `fetch.toml`, `mnemonic.toml`, `numeric.toml`, `signatures.toml`.
  Each addition states the measurement it rests on: `grep -n ' | '`
  over the scope's modules (every hit an annotation), confirmed by
  actually running `cosmic-ray init` + `operators_filter` locally
  against each configuration and checking the mutants marked `SKIPPED`
  are exactly that class.
- **Left five profiles unfiltered on purpose**, having found real
  bitwise `|` arithmetic rather than annotations alone: `bip322.toml`
  (`ScriptFlag` combination), `codecs.toml` (`bech32`'s bit-packing),
  `engine.toml` (the same flag combination), `sig_hash.toml`
  (`ANYONECANPAY | ALL` and its siblings) and `curve_group.toml` (GLV
  scalar recoding, set union).
- **Wires the orphaned `curve_group.toml` into a job.** It was written
  for issue #822, fully documented, and never added to `mutation.yml`'s
  matrix — 20 of the 21 `.github/mutation/*.toml` configs ran, this one
  enumerated 5529 mutants for nothing every week. A twelfth job,
  `curves`, budgeted like `signatures.toml`'s own job, runs it on the
  existing weekly schedule now.

## Test plan

- [x] For every one of the 7 filtered configs: `grep -n ' | '` over its
  module-path files, confirmed by reading each hit that it is a type
  annotation (or, for `signatures.toml`, a comment quoting C code) and
  not real arithmetic.
- [x] For every one of the 7, ran `cosmic-ray init` then
  `cosmic_ray.tools.filters.operators_filter` locally and confirmed the
  `SKIPPED` count matches (or exceeds, where the scope has grown since
  the historical session quoted in-file) the annotation-class count
  already documented in that file's own prose.
- [x] For the 5 left unfiltered, same `grep` check, confirming each has
  at least one real (non-annotation, non-comment) `|` use.
- [x] `curve_group.toml` still initializes cleanly under `cosmic-ray
  init` (5529 mutants today).
- [x] `uv run pre-commit run --all-files` — all hooks pass, including
  `actionlint` and `zizmor` on the workflow change.
- [x] `uv run pytest` — 100% coverage maintained (no Python changed).
- [x] `sphinx-build -W --keep-going` — docs gate green.

## Summary by Sourcery

Reduce mutation-testing noise by excluding annotation-only BitOr mutants and schedule the previously orphaned curve-group profile.

Bug Fixes:
- Correct inaccurate mutation totals for the BMS and BIP322 profiles.

Enhancements:
- Filter annotation-only BitOr mutants from seven mutation profiles while preserving real bitwise operations in the remaining profiles.

CI:
- Add the curve-group mutation profile to the weekly mutation workflow as a dedicated job.

Documentation:
- Document the measured BitOr exclusions and updated mutation counts in the changelog and profile comments.