### PR TITLE
Cancel a run still going when its pull request closes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,8 +18,15 @@ on:
     branches: [main]
   pull_request:
     # ready_for_review, so a pull request marked ready gets the run the
-    # draft condition below withheld while it was a draft
-    types: [opened, reopened, synchronize, ready_for_review]
+    # draft condition below withheld while it was a draft.
+    # closed too, though the job below declines the real work on it: a
+    # merge or a close is neither a push nor a synchronize, so a run this
+    # ref's concurrency group is still holding survives either unless the
+    # closed event lands in that same group -- which this type is what
+    # makes it do, cancel-in-progress above turning the landing into the
+    # cancellation. A closed pull request has nothing left to ask this
+    # workflow, the merge commit being main's own push trigger's question
+    types: [opened, reopened, synchronize, ready_for_review, closed]
   # lets the release workflow gate publication on this check too
   workflow_call:
   # the escape hatch: a run on demand for a branch whose pull request is
@@ -59,7 +66,12 @@ jobs:
     # name and not by the workflow that reported it, which is what let the
     # move happen without touching the rule
     name: Build the documentation
-    if: ${{ !github.event.pull_request.draft }}
+    # a draft pull request is work in progress and spends no runner here
+    # either: a draft is work its author is not asking anyone to read
+    # yet. A closed pull request spends none either -- the trigger above
+    # takes the closed event only to supersede a run this ref's group is
+    # still holding
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     # about ten seconds of sphinx; a job that takes minutes is hung
     timeout-minutes: 20

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -69,8 +69,15 @@ on:
     # ready_for_review, so a pull request marked ready gets the run the
     # draft condition below withheld while it was a draft: the default
     # types do not include it, and without it a readied pull request
-    # would wait for its next push to be checked at all
-    types: [opened, reopened, synchronize, ready_for_review]
+    # would wait for its next push to be checked at all.
+    # closed too, though the job below declines the real work on it: a
+    # merge or a close is neither a push nor a synchronize, so a run this
+    # ref's concurrency group is still holding survives either unless the
+    # closed event lands in that same group -- which this type is what
+    # makes it do, cancel-in-progress above turning the landing into the
+    # cancellation. A closed pull request has nothing left to ask this
+    # workflow, the merge commit being main's own push trigger's question
+    types: [opened, reopened, synchronize, ready_for_review, closed]
     # no `paths` filter any more: the regtest job below is a required
     # check on main, and a required check that never runs blocks a merge
     # where a skipped one satisfies it -- a filter and a required check
@@ -107,8 +114,11 @@ jobs:
     # a draft pull request is work in progress and spends no runner
     # here either: a draft is work its author is not asking anyone to
     # read yet. The same condition lint.yml and test.yml carry, and
-    # ready_for_review is a trigger type above for the same reason
-    if: ${{ !github.event.pull_request.draft }}
+    # ready_for_review is a trigger type above for the same reason.
+    # A closed pull request spends none either -- the trigger above takes
+    # the closed event only to supersede a run this ref's group is still
+    # holding
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     # the whole flow is seconds -- two tests, a node that answers its
     # first rpc call in well under a second, and a chain of a few blocks

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -44,8 +44,14 @@ on:
     # ready_for_review, so a pull request marked ready gets the run the
     # draft condition below withheld while it was a draft: the default
     # types do not include it, and without it a readied pull request
-    # would wait for its next push to be checked at all
-    types: [opened, reopened, synchronize, ready_for_review]
+    # would wait for its next push to be checked at all.
+    # closed too, though the job below declines the real work on it: a
+    # merge or a close is neither a push nor a synchronize, so a run this
+    # ref's concurrency group is still holding survives either unless the
+    # closed event lands in that same group -- which this type is what
+    # makes it do, cancel-in-progress above turning the landing into the
+    # cancellation
+    types: [opened, reopened, synchronize, ready_for_review, closed]
     paths:
       - .github/workflows/links.yml
       - .lycheeignore
@@ -75,8 +81,11 @@ jobs:
     # a draft from one release to the next, and its runs are what
     # read yet. The same condition lint.yml and
     # test.yml carry, and ready_for_review is a trigger type above for
-    # the same reason
-    if: ${{ !github.event.pull_request.draft }}
+    # the same reason.
+    # A closed pull request spends none either -- the trigger above takes
+    # the closed event only to supersede a run this ref's group is still
+    # holding
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     # a few hundred requests with retries; a job past this is hung on one
     timeout-minutes: 15

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,8 +26,15 @@ on:
     # ready_for_review, so a pull request marked ready gets the run the
     # draft condition below withheld while it was a draft: the default
     # types do not include it, and without it a readied pull request
-    # would wait for its next push to be checked at all
-    types: [opened, reopened, synchronize, ready_for_review]
+    # would wait for its next push to be checked at all.
+    # closed too, though the job below declines the real work on it: a
+    # merge or a close is neither a push nor a synchronize, so a run this
+    # ref's concurrency group is still holding survives either unless the
+    # closed event lands in that same group -- which this type is what
+    # makes it do, cancel-in-progress above turning the landing into the
+    # cancellation. A closed pull request has nothing left to ask this
+    # workflow, the merge commit being main's own push trigger's question
+    types: [opened, reopened, synchronize, ready_for_review, closed]
   # lets the release workflow gate publication on these same checks
   workflow_call:
   # the escape hatch: a run on demand for a branch whose pull request is
@@ -58,7 +65,10 @@ jobs:
     # request is marked ready, which is why ready_for_review is a
     # trigger type above.
     # The exception is by base branch, and it is the release pull
-    if: ${{ !github.event.pull_request.draft }}
+    # A closed pull request spends no runner either, for the reason the
+    # trigger above gives: closed is taken only to supersede a run this
+    # ref's group is still holding
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     # nothing here takes minutes; a job that does is hung
     timeout-minutes: 20

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,15 @@ on:
     # ready_for_review, so a pull request marked ready gets the run the
     # draft condition below withheld while it was a draft: the default
     # types do not include it, and without it a readied pull request
-    # would wait for its next push to be checked at all
-    types: [opened, reopened, synchronize, ready_for_review]
+    # would wait for its next push to be checked at all.
+    # closed too, though every job below declines the real work on it: a
+    # merge or a close is neither a push nor a synchronize, so a run this
+    # ref's concurrency group is still holding survives either unless the
+    # closed event lands in that same group -- which this type is what
+    # makes it do, cancel-in-progress above turning the landing into the
+    # cancellation. A closed pull request has nothing left to ask this
+    # workflow, the merge commit being main's own push trigger's question
+    types: [opened, reopened, synchronize, ready_for_review, closed]
   # allows the release workflow to reuse the whole build/test pipeline
   workflow_call:
   # the escape hatch: the matrix on demand for a branch whose pull
@@ -70,8 +77,12 @@ jobs:
     # the whole matrix on a tree its author is not asking anyone to
     # review yet. The gate below carries the same condition, so a draft
     # skips uniformly and the gate does not read that skip as a job that
-    # should have run
-    if: ${{ !github.event.pull_request.draft }}
+    # should have run.
+    # A closed pull request spends none either: the trigger above takes
+    # the closed event only to supersede a run this ref's group is still
+    # holding, and every job here carries the same skip for the reason
+    # the draft one already does
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -176,7 +187,7 @@ jobs:
   # reports before it reads a number, so the pair needs no job of its own
   coverage:
     name: Measure coverage, gated at 100%
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -228,7 +239,7 @@ jobs:
   # makes this a suite and not a smoke test
   no-bindings:
     name: Run the suite with no bindings installed
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -269,7 +280,7 @@ jobs:
   # could only be red, for a reason nobody could fix from a branch
   dist:
     name: Build the distribution and install it
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -411,8 +422,9 @@ jobs:
     # skipped check reports "skipped", which branch protection counts as
     # satisfied. The gate has to run to be able to fail
     # and the draft condition every job above carries, so a draft
-    # skips uniformly rather than tripping the skip check below
-    if: ${{ always() && !github.event.pull_request.draft }}
+    # skips uniformly rather than tripping the skip check below -- the
+    # closed one for the same reason, added at the trigger above
+    if: ${{ always() && !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -30,8 +30,14 @@ on:
     # ready_for_review, so a pull request marked ready gets the run the
     # draft condition below withheld while it was a draft: the default
     # types do not include it, and without it a readied pull request
-    # would wait for its next push to be checked at all
-    types: [opened, reopened, synchronize, ready_for_review]
+    # would wait for its next push to be checked at all.
+    # closed too, though the job below declines the real work on it: a
+    # merge or a close is neither a push nor a synchronize, so a run this
+    # ref's concurrency group is still holding survives either unless the
+    # closed event lands in that same group -- which this type is what
+    # makes it do, cancel-in-progress above turning the landing into the
+    # cancellation
+    types: [opened, reopened, synchronize, ready_for_review, closed]
     paths:
       - .github/workflows/vendored-vectors.yml
       - .github/scripts/check_vendored_vectors.py
@@ -53,8 +59,11 @@ jobs:
     # a draft from one release to the next, and its runs are what
     # read yet. The same condition lint.yml and
     # test.yml carry, and ready_for_review is a trigger type above for
-    # the same reason
-    if: ${{ !github.event.pull_request.draft }}
+    # the same reason.
+    # A closed pull request spends none either -- the trigger above takes
+    # the closed event only to supersede a run this ref's group is still
+    # holding
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -48,8 +48,15 @@ on:
       - .github/workflows/website.yml
   pull_request:
     # ready_for_review, so a pull request marked ready gets the run the
-    # draft condition below withheld while it was a draft
-    types: [opened, reopened, synchronize, ready_for_review]
+    # draft condition below withheld while it was a draft.
+    # closed too, though the job below declines the real work on it: a
+    # merge or a close is neither a push nor a synchronize, so a run this
+    # ref's concurrency group is still holding survives either unless the
+    # closed event lands in that same group -- which this type is what
+    # makes it do, cancel-in-progress above turning the landing into the
+    # cancellation. A closed pull request has nothing left to ask this
+    # workflow, the merge commit being main's own push trigger's question
+    types: [opened, reopened, synchronize, ready_for_review, closed]
     paths:
       - README.md
       - _config.yml
@@ -79,7 +86,11 @@ concurrency:
 jobs:
   website:
     name: Build the website
-    if: ${{ !github.event.pull_request.draft }}
+    # a draft pull request is work in progress and spends no runner here
+    # either. A closed one spends none either -- the trigger above takes
+    # the closed event only to supersede a run this ref's group is still
+    # holding
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     # a minute of bundler and seconds of jekyll; a job that takes ten is
     # hung rather than slow


### PR DESCRIPTION
## What it does

Merging or closing a pull request is neither a push nor a synchronize,
so a run `test.yml`, `lint.yml`, `docs.yml`, `links.yml`,
`vendored-vectors.yml`, `website.yml` or `integration.yml` is still
holding in that ref's concurrency group survives it —
`cancel-in-progress` only fires when a new run lands in the same
group, and nothing did. The run then finishes on a branch nobody is
going to look at again, for however long the rest of its matrix
takes.

`closed` joins each workflow's `pull_request` types, landing an event
in that same group so `cancel-in-progress` supersedes the stale run
the moment the pull request closes. Every job carries the same skip
the draft condition already does (`3b66dde3`, `ec95a1e3`), so the
closed run itself declines the real work rather than running the
whole thing a second time for nothing: a closed pull request has
nothing left to ask any of these.

`codeql.yml`, `hwi-integration.yml`, `latest.yml`, `macos.yml`,
`mutation.yml` and `windows.yml` carry no `pull_request` trigger and
are untouched; `published.yml` and `release.yml` carry `pull_request`
but `cancel-in-progress: false` on purpose, a release never being
cancelled, so `closed` would only queue behind a run already there
rather than replace it, and gets no `closed` type either.

## Evidence

`27954 tests pass, coverage 100.00%`, `uv run pre-commit run --all-files`
exits 0 including `actionlint` and `zizmor`, and the sphinx `-W` docs
build succeeds. Every edited file re-parses as valid YAML.

## Local gates, on the rebased tip

- `uv run pytest`: 27954 passed, 6 skipped, coverage 100.00%
- `uv run pre-commit run --all-files`: every hook passes
- `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html`: build succeeded

## Summary by Sourcery

Cancel obsolete validation runs when their pull requests close while avoiding redundant work for the closing event.

Bug Fixes:
- Cancel in-progress pull request workflow runs when the pull request is merged or closed.

Enhancements:
- Extend pull request triggers and job conditions across the affected validation workflows so closed events supersede stale runs without executing unnecessary jobs.