### PR TITLE
Read a pull request against REVIEWING.md, from CI

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,171 @@
+---
+name: claude-review
+
+# Claude reading a pull request against REVIEWING.md, which is the standard
+# a review here is written against and the whole of what this workflow has
+# to say: the prompt below names that file rather than restating it, so a
+# change to the standard reaches this workflow without editing it.
+#
+# Not a required check, and it must not become one. What it produces is a
+# comment, which is an opinion for the author to weigh -- REPOSITORY.md's
+# rule is that `main`'s required contexts are named outside the repository,
+# and a review that gates a merge would make a model's judgement a branch
+# rule. The four required checks stay what they are.
+#
+# It is one more job on every pull request, which is not free: GitHub Free
+# gives this organization twenty concurrent jobs and REPOSITORY.md measures
+# what a commit at that ceiling costs in wall clock. It earns the slot by
+# being short -- it reads a diff, it does not build a matrix -- and by
+# skipping a draft, which is the condition test.yml and lint.yml already
+# carry.
+
+on:
+  pull_request:
+    # ready_for_review so a pull request marked ready gets the review the
+    # draft condition below withheld while it was a draft: the default
+    # types do not include it, and without it a readied pull request would
+    # wait for its next push to be reviewed at all. The same reasoning
+    # links.yml carries for the same type
+    types: [opened, reopened, synchronize, ready_for_review]
+  # the on-demand half: somebody writes @claude in a comment on a pull
+  # request, or on a line of its diff, and asks for something the automatic
+  # pass did not answer
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+# least privilege for the GITHUB_TOKEN, elevated per job below and nowhere
+# else
+permissions:
+  contents: read
+
+jobs:
+  review:
+    name: Claude review
+    # a draft is work its author is not asking anyone to read yet, and a
+    # comment event is the other job's.
+    #
+    # The fork condition is not a policy but a fact about secrets: "with
+    # the exception of GITHUB_TOKEN, secrets are not passed to the runner
+    # when a workflow is triggered from a forked repository", so on a
+    # contributor's pull request this job would start, find
+    # CLAUDE_CODE_OAUTH_TOKEN empty and fail -- a red job on the pull
+    # requests of exactly the people least able to tell it apart from
+    # their own mistake. Skipped, it reports nothing at all, and the
+    # mention job below is the path that still works there: issue_comment
+    # is a base-repository event, so it is handed the secret.
+    #
+    # Compared by full_name rather than by `.fork`, which asks whether the
+    # head repository is a fork of anything and is true of a branch of
+    # btclib-org/bbt, itself a fork
+    if: >-
+      ${{ github.event_name == 'pull_request'
+          && !github.event.pull_request.draft
+          && github.event.pull_request.head.repo.full_name
+             == github.repository }}
+    runs-on: ubuntu-latest
+    # a diff read and a comment posted; a job past this is hung on the API
+    timeout-minutes: 15
+    # per job rather than per workflow, so that a push cancelling a
+    # superseded review does not also cancel somebody's @claude question
+    # running beside it. Named literally rather than through
+    # github.workflow, as everywhere else here
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      # what posting the review takes
+      pull-requests: write
+      # not for workload identity federation, which this does not use: the
+      # action mints a GitHub OIDC token during its own startup whatever
+      # the Anthropic credential is. Measured by leaving it out -- the run
+      # died before reaching authentication at all, with "Could not fetch
+      # an OIDC token. Did you remember to add `id-token: write` to
+      # your workflow permissions?"
+      id-token: write
+    steps:
+      # every action pinned to a commit SHA with the tag in the comment: a
+      # tag, let alone a branch, is a name its owner can move
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # see the checkout of the suite job in test.yml
+          persist-credentials: false
+          # depth 1 is enough because the diff comes from `gh pr diff`,
+          # which is the base...head three-dot diff REVIEWING.md asks for,
+          # computed by the forge rather than from local history
+          fetch-depth: 1
+      - name: Review against REVIEWING.md
+        uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Read REVIEWING.md in the repository root and review this pull
+            request against it. That file is the standard: what is under
+            review, what to look for and in what order, what a finding
+            must contain and how it labels its severity, what becomes of
+            everything you notice that the diff is not about, and the two
+            forms the verdict takes. Follow it rather than the review
+            habits you would otherwise bring. CLAUDE.md has the facts
+            about this tree a review has to know, and CONTRIBUTING.md the
+            rules a finding cites.
+
+            One deviation from REVIEWING.md, because this is CI and not a
+            session: do not run the gates. They are running beside you on
+            this same sha, in test.yml, lint.yml and docs.yml, and a
+            second run of them here would buy nothing and cost a slot.
+            Review everything else the standard asks for, and say in the
+            summary that the gates were left to those workflows.
+
+            Do not file issues from here: a collateral finding goes in the
+            summary comment, under a line saying it is not a finding
+            against this pull request, and a person decides whether it
+            becomes one.
+
+            Post GitHub comments only, never review text as a message.
+            `gh pr comment` for the summary,
+            `mcp__github_inline_comment__create_inline_comment` (with
+            `confirmed: true`) for a finding a line is the subject of.
+          # folded rather than literal, and `gh pr` rather than the three
+          # subcommands spelled out: the flag has to reach the CLI as one
+          # line, and the line that spells out comment, diff and view is
+          # past the 100 columns yamllint holds this file to
+          claude_args: >-
+            --allowedTools
+            "mcp__github_inline_comment__create_inline_comment,Bash(gh pr:*),Read,Grep,Glob"
+
+  mention:
+    name: Claude answers a mention
+    # no prompt on this one, deliberately: the action reads the comment
+    # that triggered it and answers what was actually asked, where a
+    # prompt of ours would answer something else. `github.event.issue.pull
+    # _request` is what tells a comment on a pull request from a comment
+    # on an issue, the issue_comment event carrying both
+    if: >-
+      ${{ (github.event_name == 'issue_comment'
+           && github.event.issue.pull_request
+           && contains(github.event.comment.body, '@claude'))
+          || (github.event_name == 'pull_request_review_comment'
+              && contains(github.event.comment.body, '@claude')) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      # the same startup OIDC token the review job above needs
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Answer the mention
+        uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -113,6 +113,7 @@ jobs:
             exit 1
           fi
       - name: Review against REVIEWING.md
+        id: review
         uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -153,6 +154,30 @@ jobs:
           claude_args: >-
             --allowedTools
             "mcp__github_inline_comment__create_inline_comment,Bash(gh pr:*),Read,Grep,Glob"
+
+      # the action refuses to run when this file differs from the copy on
+      # the default branch -- a pull request must not be able to edit the
+      # workflow that holds the credential -- and it reports that refusal
+      # by *skipping*, with the job still green. Two runs were read as
+      # proof that this workflow worked before the log said otherwise, so
+      # the skip is made loud here: `execution_file` is empty exactly when
+      # the action did not run.
+      #
+      # The consequence is deliberate: on the pull request that adds or
+      # edits this file, this job is red until the change is on `main`.
+      # It gates nothing, and a red check that says "no review happened"
+      # is the honest shape of that.
+      - name: Refuse to report a review that never ran
+        env:
+          EXECUTION: ${{ steps.review.outputs.execution_file }}
+        run: |
+          if [ -z "$EXECUTION" ]; then
+            echo "::error::the action produced no execution file, so no" \
+                 "review was written. The usual cause is workflow" \
+                 "validation: this file differs from the copy on the" \
+                 "default branch, which the action refuses to run under."
+            exit 1
+          fi
 
   mention:
     name: Claude answers a mention

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -97,6 +97,21 @@ jobs:
           # which is the base...head three-dot diff REVIEWING.md asks for,
           # computed by the forge rather than from local history
           fetch-depth: 1
+      # a missing credential is a silent pass without this, which is the
+      # worst shape a gate can take: measured on the first run after the
+      # organization secret was deleted -- the action found the token
+      # empty, reviewed nothing, and reported success. Fail loudly
+      # instead, and say which secret and where it lives
+      - name: Refuse to review without a credential
+        env:
+          TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::error::CLAUDE_CODE_OAUTH_TOKEN is empty. It is an" \
+                 "organization secret of btclib-org, visible to all" \
+                 "repositories; without it this workflow reviews nothing."
+            exit 1
+          fi
       - name: Review against REVIEWING.md
         uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50 # v1
         with:
@@ -165,6 +180,21 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 1
+      # a missing credential is a silent pass without this, which is the
+      # worst shape a gate can take: measured on the first run after the
+      # organization secret was deleted -- the action found the token
+      # empty, reviewed nothing, and reported success. Fail loudly
+      # instead, and say which secret and where it lives
+      - name: Refuse to review without a credential
+        env:
+          TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::error::CLAUDE_CODE_OAUTH_TOKEN is empty. It is an" \
+                 "organization secret of btclib-org, visible to all" \
+                 "repositories; without it this workflow reviews nothing."
+            exit 1
+          fi
       - name: Answer the mention
         uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50 # v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,35 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **`claude-review.yml` reads a pull request against `REVIEWING.md`.**
+  Two jobs: one on every non-draft pull request, whose prompt names that
+  file rather than restating it, so the standard moves without the
+  workflow being edited; one answering `@claude` in a comment, carrying
+  no prompt of ours on purpose — the action reads the comment that
+  triggered it, where a prompt would answer something else. Both need
+  `id-token: write`, which is not about workload identity federation:
+  the action mints a GitHub OIDC token during its own startup whatever
+  the Anthropic credential is, and without it the run dies before
+  reaching authentication at all.
+
+  It gates nothing and must not: `main`'s required contexts are named
+  outside the repository, and a review that held a merge would make a
+  model's judgement a branch rule. The one deviation from `REVIEWING.md`
+  is written into the prompt — the gates are not re-run, `test.yml`,
+  `lint.yml` and `docs.yml` running them beside it on the same sha.
+  Concurrency is per job rather than per workflow, so a push cancelling
+  a superseded review leaves an `@claude` question running. The
+  automatic job skips a pull request from a fork, which is not a policy
+  but what secrets do: none but `GITHUB_TOKEN` reaches a runner a fork
+  triggered, so the job would start, find the token empty and fail on
+  the pull requests of the people least able to read that failure.
+  `@claude` still answers there, `issue_comment` being a
+  base-repository event.
+
+  It is the one workflow in `CONTRIBUTING.md`'s table that takes no
+  `workflow_dispatch`: both jobs read the pull request or the comment
+  that triggered them, so a manual run would have nothing to read.
+
 - **The landing convention says what actually happens: the squash
   button.** `CONTRIBUTING.md` said "how that commit reaches `main` is a
   push rather than a button", `RELEASING.md` that the button was the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@ documented at release-notes length in the first place, and are still in
   `workflow_dispatch`: both jobs read the pull request or the comment
   that triggered them, so a manual run would have nothing to read.
 
+  Both jobs refuse to start without the credential, which is not
+  belt and braces: measured on the first run after the organization
+  secret was deleted, the action found `CLAUDE_CODE_OAUTH_TOKEN` empty,
+  reviewed nothing and reported **success**. A green check that read no
+  diff is worse than a red one, so the step that would have been silent
+  now names the secret and fails.
+
 - **The landing convention says what actually happens: the squash
   button.** `CONTRIBUTING.md` said "how that commit reaches `main` is a
   push rather than a button", `RELEASING.md` that the button was the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,12 +53,22 @@ documented at release-notes length in the first place, and are still in
   `workflow_dispatch`: both jobs read the pull request or the comment
   that triggered them, so a manual run would have nothing to read.
 
-  Both jobs refuse to start without the credential, which is not
-  belt and braces: measured on the first run after the organization
-  secret was deleted, the action found `CLAUDE_CODE_OAUTH_TOKEN` empty,
-  reviewed nothing and reported **success**. A green check that read no
-  diff is worse than a red one, so the step that would have been silent
-  now names the secret and fails.
+  Two things it refuses to do silently, both of which it did before
+  being asked not to. Without `CLAUDE_CODE_OAUTH_TOKEN` the action
+  reviewed nothing and reported **success**; and the action refuses to
+  run at all when this file differs from the copy on the default branch
+  — a pull request must not be able to edit the workflow holding the
+  credential — reporting that refusal by skipping, green. Two runs were
+  read as evidence that this workflow worked before the log said
+  otherwise. It now fails on an empty secret, and fails when the
+  action's `execution_file` output is empty, which is exactly when no
+  review was written.
+
+  The consequence is deliberate: on a pull request that adds or edits
+  this file the job is red until the change is on `main`, because that
+  is when the action starts running it. It gates nothing, and a red
+  check saying "no review happened" is the honest shape of a review that
+  did not happen.
 
 - **The landing convention says what actually happens: the squash
   button.** `CONTRIBUTING.md` said "how that commit reaches `main` is a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,6 +256,7 @@ read by every checkout of this repository.
 | `lint`, `docs` | pull request, push | — |
 | `integration` | pull request, push | a node, two device emulators |
 | `website` | pull request, push, on website files | — |
+| `claude-review` | pull request, and `@claude` in a comment | — |
 | `codeql` | push to main, Tuesday | 2 languages |
 | `windows` | Saturday, a release | 2 Windows images × 7 interpreters |
 | `macos` | Wednesday, a release | 2 macOS images × 7 interpreters |
@@ -290,6 +291,9 @@ Wednesday the queue this arrangement exists to remove. Every workflow in the
 table also takes `workflow_dispatch`, the gates included: a branch whose
 pull request is not open yet has no other way to ask, and for `codeql` and
 the two platform workflows it is the only way to ask about a branch at all.
+`claude-review` is the exception, and takes none: both its jobs read the
+pull request or the comment that triggered them, so a manual dispatch
+would start a run with nothing to read.
 
 ### Reproducing what CI runs
 


### PR DESCRIPTION
## What this changes

`claude-review.yml`, restored. #1014 added this workflow and was closed
as redundant: the `claude` GitHub App was producing a `Claude Code
Review` check of its own on every pull request, so this would have been
a second review against a credential to pay for.

**That premise is gone.** The App's automatic review is off for this
organization — the three pull requests opened since carry no Claude
check at all — so what this workflow duplicated no longer exists.

It comes back in the shape whose run went **green**, not the shape that
first failed. Both jobs carry `id-token: write`: not for workload
identity federation, which this does not use, but because the action
mints a GitHub OIDC token during its own startup whatever the Anthropic
credential is. Without it the run dies before reaching authentication at
all, with `Could not fetch an OIDC token`.

Two jobs:

- **`review`**, on every non-draft pull request. Its prompt names
  `REVIEWING.md` rather than restating it, so the standard moves without
  this workflow being edited.
- **`mention`**, on `@claude` in a comment, carrying no prompt of ours on
  purpose: the action reads the comment that triggered it and answers
  what was asked.

**It gates nothing, and must not.** `main`'s required contexts are named
outside the repository, and a review that held a merge would make a
model's judgement a branch rule.

## The two findings from #1014, addressed rather than earned again

The review on that pull request left two, and both were right:

- **`reopened` joins the `pull_request` types.** Every sibling workflow
  with this same draft-skip pattern already has it, and a
  closed-then-reopened pull request fires no `synchronize` event — so
  the review would have waited for the next push.
- **The table row would have made the prose below it false.**
  `CONTRIBUTING.md` says every workflow in that table also takes
  `workflow_dispatch`. This one takes none, and adding it would be a
  no-op — both jobs read the pull request or the comment that triggered
  them, so a manual run would have nothing to read. The sentence names
  the exception now. (I checked the claim before qualifying it: all
  fourteen other workflows do declare `workflow_dispatch`.)

## How it was verified

```shell
uv run pre-commit run --all-files          # clean: actionlint and zizmor included
```

**This pull request is not its own test, and cannot be.** The action
refuses to run when the workflow file differs from the copy on the
default branch — a pull request must not be able to edit the workflow
that holds the credential — and it reports that refusal by *skipping*,
leaving the job green.

That is worth stating plainly because I read two runs as evidence that
this workflow worked before reading the log: the one after
`id-token: write` was added, and the first one after the secret was
restored. **Both were skips.** The `id-token` diagnosis was right and
fixed a real error, but `success` never meant a review had been written.

So the `Claude review` job on *this* pull request is **red on purpose**:
`execution_file` is empty exactly when the action did not run, and the
step after it fails on that. It gates nothing. The first real run is the
one on the pull request after this lands.

**It needs `CLAUDE_CODE_OAUTH_TOKEN` as an organization secret.** That
secret existed, was deleted when #1014 was closed, and has to be created
again before this can do anything — a run without it fails at the
action's authentication step. Its *value* is verifiable by nobody: the
API returns name, visibility and timestamps and never the content, so
the first run of this workflow is the only test of it.

## Checks

- [x] `uv run pre-commit run --all-files` is clean
- [x] `CHANGELOG.md` has an entry
- [ ] `uv run pytest` — untouched by this change, and green on `main`

## Anything the reviewer should know

**External contributors get no automatic review**, and that is not a
policy: "with the exception of `GITHUB_TOKEN`, secrets are not passed to
the runner when a workflow is triggered from a forked repository", so
the job would start, find the token empty and fail on the pull requests
of the people least able to tell that apart from their own mistake. It
skips a fork instead. `@claude` still answers there, `issue_comment`
being a base-repository event.

**One more job on every pull request**, against twenty concurrent jobs
shared across the organization. It earns the slot by reading a diff
rather than building a matrix, and by skipping drafts — the condition
`test.yml` and `lint.yml` already carry.

## Summary by Sourcery

Restore CI-driven Claude pull-request reviews while keeping them non-blocking and making failures to perform a review explicit.

New Features:
- Add CI-based Claude review for non-draft pull requests using REVIEWING.md as its review standard.
- Allow contributors to invoke Claude through @claude comments on pull requests and review comments.

Bug Fixes:
- Prevent reviews from silently succeeding when credentials are missing or when the action produces no review.
- Handle reopened pull requests and avoid attempting automatic reviews for fork-originated pull requests without available secrets.

Enhancements:
- Keep Claude reviews informational rather than making them required merge checks.
- Document the new workflow and its manual-dispatch exception in the contributor workflow table.

CI:
- Add the pinned Claude review workflow with separate automatic-review and mention-response jobs, scoped permissions, concurrency control, and execution safeguards.

Documentation:
- Document the claude-review workflow and clarify that it does not support workflow_dispatch.
