### PR TITLE
Key each pull_request-triggered concurrency group on head_ref

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,11 +21,17 @@ on:
     # draft condition below withheld while it was a draft.
     # closed too, though the job below declines the real work on it: a
     # merge or a close is neither a push nor a synchronize, so a run this
-    # ref's concurrency group is still holding survives either unless the
-    # closed event lands in that same group -- which this type is what
-    # makes it do, cancel-in-progress above turning the landing into the
-    # cancellation. A closed pull request has nothing left to ask this
-    # workflow, the merge commit being main's own push trigger's question
+    # PR's own concurrency group is still holding survives either unless
+    # the closed event lands in that same group -- which this type is
+    # what makes it do, cancel-in-progress above turning the landing
+    # into the cancellation. A closed pull request has nothing left to
+    # ask this workflow, the merge commit being main's own push
+    # trigger's question. The group below keys on github.head_ref rather
+    # than plain github.ref for exactly this event: a merged pull
+    # request's closed event sets github.ref to the base branch, not the
+    # merge ref, which used to land it in main's own push group and race
+    # the merge commit's run for cancellation (PR 1023's bug) instead of
+    # the PR's own group as intended
     types: [opened, reopened, synchronize, ready_for_review, closed]
   # lets the release workflow gate publication on this check too
   workflow_call:
@@ -43,9 +49,14 @@ permissions:
 # The group is named literally rather than with github.workflow, which in a
 # called workflow is the caller's name: the release workflow calls this one
 # alongside test.yml and lint.yml, and with that expression they would share
-# a group and cancel each other
+# a group and cancel each other.
+# head_ref falls back to ref rather than being used bare: it is set only
+# for pull_request events, to the PR's head branch, so a push run (ref
+# refs/heads/main) still gets its own group -- and a pull_request event
+# always groups by the PR's branch, closed and merged ones included, so
+# it never collides with a push's group the way bare ref did
 concurrency:
-  group: docs-${{ github.ref }}
+  group: docs-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -72,11 +72,17 @@ on:
     # would wait for its next push to be checked at all.
     # closed too, though the job below declines the real work on it: a
     # merge or a close is neither a push nor a synchronize, so a run this
-    # ref's concurrency group is still holding survives either unless the
-    # closed event lands in that same group -- which this type is what
-    # makes it do, cancel-in-progress above turning the landing into the
-    # cancellation. A closed pull request has nothing left to ask this
-    # workflow, the merge commit being main's own push trigger's question
+    # PR's own concurrency group is still holding survives either unless
+    # the closed event lands in that same group -- which this type is
+    # what makes it do, cancel-in-progress above turning the landing
+    # into the cancellation. A closed pull request has nothing left to
+    # ask this workflow, the merge commit being main's own push
+    # trigger's question. The group below keys on github.head_ref rather
+    # than plain github.ref for exactly this event: a merged pull
+    # request's closed event sets github.ref to the base branch, not the
+    # merge ref, which used to land it in main's own push group and race
+    # the merge commit's run for cancellation (PR 1023's bug) instead of
+    # the PR's own group as intended
     types: [opened, reopened, synchronize, ready_for_review, closed]
     # no `paths` filter any more: the regtest job below is a required
     # check on main, and a required check that never runs blocks a merge
@@ -103,9 +109,14 @@ env:
 
 # cancel superseded runs. Named literally rather than through
 # github.workflow, as everywhere else here: in a called workflow that
-# expression is the caller's name
+# expression is the caller's name.
+# head_ref falls back to ref rather than being used bare: it is set only
+# for pull_request events, to the PR's head branch, so a push run (ref
+# refs/heads/main) still gets its own group -- and a pull_request event
+# always groups by the PR's branch, closed and merged ones included, so
+# it never collides with a push's group the way bare ref did
 concurrency:
-  group: integration-${{ github.ref }}
+  group: integration-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -47,10 +47,15 @@ on:
     # would wait for its next push to be checked at all.
     # closed too, though the job below declines the real work on it: a
     # merge or a close is neither a push nor a synchronize, so a run this
-    # ref's concurrency group is still holding survives either unless the
-    # closed event lands in that same group -- which this type is what
-    # makes it do, cancel-in-progress above turning the landing into the
-    # cancellation
+    # PR's own concurrency group is still holding survives either unless
+    # the closed event lands in that same group -- which this type is
+    # what makes it do, cancel-in-progress above turning the landing
+    # into the cancellation. The group below keys on github.head_ref
+    # rather than plain github.ref for exactly this event: a merged pull
+    # request's closed event sets github.ref to the base branch, not the
+    # merge ref, which used to land it in main's own group -- racing the
+    # weekly schedule run for cancellation (PR 1023's bug) instead of
+    # the PR's own group as intended
     types: [opened, reopened, synchronize, ready_for_review, closed]
     paths:
       - .github/workflows/links.yml
@@ -68,9 +73,15 @@ permissions:
 
 # cancel superseded runs. Named literally rather than through
 # github.workflow, as everywhere else here: in a called workflow that
-# expression is the caller's name
+# expression is the caller's name.
+# head_ref falls back to ref rather than being used bare: it is set only
+# for pull_request events, to the PR's head branch, so a scheduled or
+# dispatched run (ref refs/heads/main) still gets its own group -- and a
+# pull_request event always groups by the PR's branch, closed and
+# merged ones included, so it never collides with that group the way
+# bare ref did
 concurrency:
-  group: links-${{ github.ref }}
+  group: links-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,11 +29,17 @@ on:
     # would wait for its next push to be checked at all.
     # closed too, though the job below declines the real work on it: a
     # merge or a close is neither a push nor a synchronize, so a run this
-    # ref's concurrency group is still holding survives either unless the
-    # closed event lands in that same group -- which this type is what
-    # makes it do, cancel-in-progress above turning the landing into the
-    # cancellation. A closed pull request has nothing left to ask this
-    # workflow, the merge commit being main's own push trigger's question
+    # PR's own concurrency group is still holding survives either unless
+    # the closed event lands in that same group -- which this type is
+    # what makes it do, cancel-in-progress above turning the landing
+    # into the cancellation. A closed pull request has nothing left to
+    # ask this workflow, the merge commit being main's own push
+    # trigger's question. The group below keys on github.head_ref rather
+    # than plain github.ref for exactly this event: a merged pull
+    # request's closed event sets github.ref to the base branch, not the
+    # merge ref, which used to land it in main's own push group and race
+    # the merge commit's run for cancellation (PR 1023's bug) instead of
+    # the PR's own group as intended
     types: [opened, reopened, synchronize, ready_for_review, closed]
   # lets the release workflow gate publication on these same checks
   workflow_call:
@@ -51,9 +57,14 @@ permissions:
 # The group is named literally rather than with github.workflow, which in
 # a called workflow is the caller's name: the release workflow calls both
 # this and test.yml, and with that expression the two would share a group
-# and cancel each other
+# and cancel each other.
+# head_ref falls back to ref rather than being used bare: it is set only
+# for pull_request events, to the PR's head branch, so a push run (ref
+# refs/heads/main) still gets its own group -- and a pull_request event
+# always groups by the PR's branch, closed and merged ones included, so
+# it never collides with a push's group the way bare ref did
 concurrency:
-  group: lint-${{ github.ref }}
+  group: lint-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,11 +39,17 @@ on:
     # would wait for its next push to be checked at all.
     # closed too, though every job below declines the real work on it: a
     # merge or a close is neither a push nor a synchronize, so a run this
-    # ref's concurrency group is still holding survives either unless the
-    # closed event lands in that same group -- which this type is what
-    # makes it do, cancel-in-progress above turning the landing into the
-    # cancellation. A closed pull request has nothing left to ask this
-    # workflow, the merge commit being main's own push trigger's question
+    # PR's own concurrency group is still holding survives either unless
+    # the closed event lands in that same group -- which this type is
+    # what makes it do, cancel-in-progress above turning the landing
+    # into the cancellation. A closed pull request has nothing left to
+    # ask this workflow, the merge commit being main's own push
+    # trigger's question. The group below keys on github.head_ref rather
+    # than plain github.ref for exactly this event: a merged pull
+    # request's closed event sets github.ref to the base branch, not the
+    # merge ref, which used to land it in main's own push group and race
+    # the merge commit's run for cancellation (PR 1023's bug) instead of
+    # the PR's own group as intended
     types: [opened, reopened, synchronize, ready_for_review, closed]
   # allows the release workflow to reuse the whole build/test pipeline
   workflow_call:
@@ -61,9 +67,14 @@ permissions:
 # The group is named literally rather than with github.workflow, which in
 # a called workflow is the caller's name: the release workflow calls both
 # this and lint.yml, and with that expression the two would share a group
-# and cancel each other
+# and cancel each other.
+# head_ref falls back to ref rather than being used bare: it is set only
+# for pull_request events, to the PR's head branch, so a push run (ref
+# refs/heads/main) still gets its own group -- and a pull_request event
+# always groups by the PR's branch, closed and merged ones included, so
+# it never collides with a push's group the way bare ref did
 concurrency:
-  group: test-${{ github.ref }}
+  group: test-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -33,10 +33,15 @@ on:
     # would wait for its next push to be checked at all.
     # closed too, though the job below declines the real work on it: a
     # merge or a close is neither a push nor a synchronize, so a run this
-    # ref's concurrency group is still holding survives either unless the
-    # closed event lands in that same group -- which this type is what
-    # makes it do, cancel-in-progress above turning the landing into the
-    # cancellation
+    # PR's own concurrency group is still holding survives either unless
+    # the closed event lands in that same group -- which this type is
+    # what makes it do, cancel-in-progress above turning the landing
+    # into the cancellation. The group below keys on github.head_ref
+    # rather than plain github.ref for exactly this event: a merged pull
+    # request's closed event sets github.ref to the base branch, not the
+    # merge ref, which used to land it in main's own group -- racing the
+    # monthly schedule run for cancellation (PR 1023's bug) instead of
+    # the PR's own group as intended
     types: [opened, reopened, synchronize, ready_for_review, closed]
     paths:
       - .github/workflows/vendored-vectors.yml
@@ -47,8 +52,14 @@ permissions:
   contents: read
   issues: write
 
+# head_ref falls back to ref rather than being used bare: it is set only
+# for pull_request events, to the PR's head branch, so a scheduled or
+# dispatched run (ref refs/heads/main) still gets its own group -- and a
+# pull_request event always groups by the PR's branch, closed and
+# merged ones included, so it never collides with that group the way
+# bare ref did
 concurrency:
-  group: vendored-vectors-${{ github.ref }}
+  group: vendored-vectors-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -51,11 +51,17 @@ on:
     # draft condition below withheld while it was a draft.
     # closed too, though the job below declines the real work on it: a
     # merge or a close is neither a push nor a synchronize, so a run this
-    # ref's concurrency group is still holding survives either unless the
-    # closed event lands in that same group -- which this type is what
-    # makes it do, cancel-in-progress above turning the landing into the
-    # cancellation. A closed pull request has nothing left to ask this
-    # workflow, the merge commit being main's own push trigger's question
+    # PR's own concurrency group is still holding survives either unless
+    # the closed event lands in that same group -- which this type is
+    # what makes it do, cancel-in-progress above turning the landing
+    # into the cancellation. A closed pull request has nothing left to
+    # ask this workflow, the merge commit being main's own push
+    # trigger's question. The group below keys on github.head_ref rather
+    # than plain github.ref for exactly this event: a merged pull
+    # request's closed event sets github.ref to the base branch, not the
+    # merge ref, which used to land it in main's own push group and race
+    # the merge commit's run for cancellation (PR 1023's bug) instead of
+    # the PR's own group as intended
     types: [opened, reopened, synchronize, ready_for_review, closed]
     paths:
       - README.md
@@ -78,9 +84,14 @@ permissions:
 
 # cancel superseded runs on the same branch/PR. The group is named
 # literally rather than with github.workflow, which in a called workflow
-# is the caller's name
+# is the caller's name.
+# head_ref falls back to ref rather than being used bare: it is set only
+# for pull_request events, to the PR's head branch, so a push run (ref
+# refs/heads/main) still gets its own group -- and a pull_request event
+# always groups by the PR's branch, closed and merged ones included, so
+# it never collides with a push's group the way bare ref did
 concurrency:
-  group: website-${{ github.ref }}
+  group: website-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -581,6 +581,22 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **Merging a pull request no longer has a chance of cancelling its own
+  merge commit's checks.** `closed`, added to `lint.yml`, `docs.yml`,
+  `integration.yml`, `test.yml`, `links.yml`, `vendored-vectors.yml` and
+  `website.yml`'s `pull_request` types by PR 1023 so the event could
+  land in a stale run's concurrency group and cancel it, keyed that
+  group on plain `github.ref` — which for a *merged* pull request's
+  `closed` event is the base branch, not the merge ref the same event
+  carries while the pull request is open. That put every merge's closed
+  event in the same group as the merge commit's own `push` run, and
+  `cancel-in-progress` cancelled whichever of the two GitHub queued
+  second — the push run about half the time, showing a cancelled `X` on
+  a required check instead of a result. The group now keys on
+  `github.head_ref`, set only for `pull_request` events and always the
+  pull request's own branch regardless of how it closed, so the closed
+  event lands in its own group and the push run is never contended.
+
 - **`MANIFEST.in` prunes a nested `.mypy_cache`, `.pytest_cache`,
   `.ruff_cache` or `__pycache__`, at whatever depth a tool left one.**
   `.gitignore` covers these, but the sdist's file list comes from


### PR DESCRIPTION
## Summary

`main`'s checks have been showing a cancelled `X` on roughly half of
every merge since PR 1023 — this is that regression, root-caused and
fixed.

PR 1023 added `closed` to `lint.yml`, `docs.yml`, `integration.yml`,
`test.yml`, `links.yml`, `vendored-vectors.yml` and `website.yml`'s
`pull_request` types, so that event could land in a stale run's
concurrency group and let `cancel-in-progress` supersede it — the
point being to stop a run finishing on a branch nobody will look at
again once its pull request closes.

The group was keyed on plain `github.ref`. For an *open* pull request
that's the merge ref (`refs/pull/N/merge`), which is what makes the
mechanism work for an abandoned branch. But for a *merged* pull
request's `closed` event, GitHub sets `github.ref` to the **base
branch** instead — confirmed directly from GitHub's own cancellation
annotation on a real run:

```
Canceling since a higher priority waiting request for lint-refs/heads/main exists
```

So every merge to `main` fires both a `push` event and a `pull_request`
`closed` event that land in the *same* concurrency group as the merge
commit's own `push` run, and `cancel-in-progress` cancels whichever of
the two GitHub happens to queue second — the real run about half the
time, since the closed event's own job always declines the real work
either way.

## Fix

`github.head_ref` is set only for `pull_request` events, and is always
the pull request's own head branch regardless of how it closed (opened,
synchronize, or closed via merge or abandonment). Keying every group on
`head_ref || ref` keeps a push run in its own `refs/heads/main`-based
group and always puts a pull_request-triggered run — closed ones
included — in the PR's own branch-based group instead, so the two can
never collide again.

## Test plan

- [x] `uv run pre-commit run --all-files` exits 0, `actionlint` and
      `zizmor` included
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html` succeeds
- [x] `uv run pytest tests/release_notes_test.py` passes (CHANGELOG.md
      format)
- [ ] Watch the next merge to `main` land with green (not cancelled)
      `lint`, `docs`, `integration` and `test` checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent merged pull request events from colliding with push checks by separating their concurrency groups.

Bug Fixes:
- Prevent pull request closure events from cancelling the merge commit's own checks by isolating them from push-triggered workflow runs.

Enhancements:
- Key concurrency groups for pull request events by the pull request head branch while preserving ref-based grouping for other events across the affected workflows.

Documentation:
- Document the concurrency cancellation fix in the changelog.