### PR TITLE
Rename test-py and dist-py in workflow comments to suite and dist

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the test-py job in test.yml
+          # see the checkout of the suite job in test.yml
           persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/hwi-integration.yml
+++ b/.github/workflows/hwi-integration.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the test-py job in test.yml
+          # see the checkout of the suite job in test.yml
           persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the test-py job in test.yml
+          # see the checkout of the suite job in test.yml
           persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the test-py job in test.yml
+          # see the checkout of the suite job in test.yml
           persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the test-py job in test.yml
+          # see the checkout of the suite job in test.yml
           persist-credentials: false
       - name: Check the links
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the test-py job in test.yml
+          # see the checkout of the suite job in test.yml
           persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -307,7 +307,7 @@ jobs:
         if: env.SELECTED == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the test-py job in test.yml
+          # see the checkout of the suite job in test.yml
           persist-credentials: false
       - name: Setup uv
         if: env.SELECTED == 'true'

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -12,7 +12,7 @@ name: published
 # btclib/*/_data/ -- the twelve BIP39 wordlists among them -- are opened
 # by path at the first call that needs one, not imported, so a wheel
 # missing one of them installs cleanly, imports cleanly, and only fails
-# there. dist-py's smoke test and release.yml's share that blind spot;
+# there. dist's smoke test and release.yml's share that blind spot;
 # this workflow's second check is the one that does not have it.
 #
 # Version-independent on purpose, checking a BIP39 vector and a BIP340
@@ -159,7 +159,7 @@ jobs:
         run: |
           uv venv --python ${{ matrix.python }}
           uv pip install --verbose btclib
-      # BIP340 vector 0 for the ecc surface, exactly what dist-py and
+      # BIP340 vector 0 for the ecc surface, exactly what dist and
       # release.yml already assert; a signature round trip is the one
       # thing an import cannot get wrong by itself, and a bindings release
       # that installs and answers incorrectly is what this catches

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the test-py job in test.yml
+          # see the checkout of the suite job in test.yml
           persist-credentials: false
           # the whole history, where every other checkout in these
           # workflows takes the default single commit: the ancestry check
@@ -307,14 +307,14 @@ jobs:
           # uv.lock, which otherwise declared the unsuffixed version inside
           # a distribution named for the suffixed one
           uv lock
-      # one thing the rehearsal does not cover, deliberately: dist-py, in
+      # one thing the rehearsal does not cover, deliberately: dist, in
       # the workflow this one calls, validates the tree as committed, while
       # this job ships the suffixed version, so twine and pyroma never see
       # the metadata that reaches TestPyPI. What they judge is metadata
       # syntax, README rendering and metadata quality, and a .dev<N> suffix
       # is valid PEP 440 that changes none of them. The smoke test below is
       # the exception, and the reason it is below rather than left to
-      # dist-py: it installs the suffixed wheel itself. Should a packaging
+      # dist: it installs the suffixed wheel itself. Should a packaging
       # check ever become version-sensitive, the suffix has to be plumbed
       # into test.yml as a workflow_call input instead
       # uv build builds the sdist first and then the wheel from it, not
@@ -322,7 +322,7 @@ jobs:
       # from source takes is therefore the one that produced the wheel,
       # which is why no separate "install from the sdist" job is needed.
       # What this job does not do is inspect what it builds: twine,
-      # check-wheel-contents and pyroma run in the dist-py job of the
+      # check-wheel-contents and pyroma run in the dist job of the
       # test workflow, which this workflow calls, so they gate every
       # pull request as well as this one tag. check-manifest is a
       # pre-commit hook, gated by the lint workflow, which this one calls
@@ -389,26 +389,26 @@ jobs:
         with:
           name: sbom
           path: sbom/
-      # dist-py installs a wheel too, but not this one: it builds its own
+      # dist installs a wheel too, but not this one: it builds its own
       # copy, on another runner and -- in a rehearsal -- from another
       # version, the step above having patched pyproject.toml and
       # re-locked. What reaches an index is this artifact, so this one is
       # imported, from an empty directory so the import resolves to the
       # wheel and not to the btclib/ source tree.
-      # Unconstrained, where dist-py pins the runtime dependencies to
+      # Unconstrained, where dist pins the runtime dependencies to
       # uv.lock: no pull request waits on this job, so it can afford the
       # question a required check cannot -- whether the newest published
       # btclib_secp256k1 satisfies the wheel about to be published,
       # which is what a user installing it resolves. A release stopping
       # on that answer is the outcome wanted.
-      # The three assertions are dist-py's, and there for the same
+      # The three assertions are dist's, and there for the same
       # reasons: metadata can be missing (issue #150), `import btclib`
       # runs only __init__.py and touches no binding, and a bindings
       # release can install and still answer wrongly
       - name: Smoke-test the wheel, with its dependencies from PyPI
         run: |
           cd "$RUNNER_TEMP"
-          # `set --` for the reason dist-py's copy of this states: the
+          # `set --` for the reason dist's copy of this states: the
           # positional parameters are sh, bash and zsh alike, where a
           # named array is 0-indexed in one and 1-indexed in another
           set -- "$GITHUB_WORKSPACE"/dist/*.whl

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the test-py job in test.yml
+          # see the checkout of the suite job in test.yml
           persist-credentials: false
       # 3.3.4 is what Pages runs, from the same versions.json the Gemfile
       # names: a build that passes here on a ruby Pages does not have says

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -596,6 +596,19 @@ documented at release-notes length in the first place, and are still in
   `github.head_ref`, set only for `pull_request` events and always the
   pull request's own branch regardless of how it closed, so the closed
   event lands in its own group and the push run is never contended.
+- **The workflow comments still named `test-py` and `dist-py`, the jobs
+  renamed `suite` and `dist`.** CHANGELOG.md, CONTRIBUTING.md and
+  RELEASING.md were corrected at the rename; the workflow files' own
+  comments were not, and they are where a reader following a
+  cross-reference ends up. Nine workflows' checkout step read `see the
+  checkout of the test-py job in test.yml` -- a job `test.yml` no longer
+  has -- in `docs.yml`, `hwi-integration.yml`, `integration.yml`,
+  `latest.yml`, `links.yml`, `lint.yml`, `mutation.yml`, `release.yml`
+  and `website.yml`; `release.yml`'s prose about what `dist` builds and
+  checks, and `published.yml`'s about its blind spot, said `dist-py` in
+  nine more places. Nothing fails on either: `actionlint` reads the YAML
+  and not the comments, and the `needs:` graph uses the real ids, which
+  is how it survived (issue #1004).
 
 - **`MANIFEST.in` prunes a nested `.mypy_cache`, `.pytest_cache`,
   `.ruff_cache` or `__pycache__`, at whatever depth a tool left one.**


### PR DESCRIPTION
Closes #1004

`test-py`, `coverage-py` and `dist-py` were renamed `suite`, `coverage`
and `dist`. CHANGELOG.md, CONTRIBUTING.md and RELEASING.md were
corrected at the time, but the workflow files' own comments were not,
which is where a reader following a cross-reference actually ends up.

Two shapes, both pure prose/comment drift with no behavior change:

- A navigation instruction to a job that no longer exists, on the
  checkout step of nine workflows: `docs.yml`, `hwi-integration.yml`,
  `integration.yml`, `latest.yml`, `links.yml`, `lint.yml`,
  `mutation.yml`, `release.yml`, `website.yml`. `# see the checkout of
  the test-py job in test.yml` now reads `suite`.
- Prose naming the job directly: `release.yml` in seven places,
  `published.yml` in two, all said `dist-py` for what is now `dist`.
  A few needed a small grammatical touch beyond the bare token swap
  (e.g. "dist-py's copy of this" -> "dist's copy of this").

Nothing fails on any of this: `actionlint` reads the YAML and not the
comments, and the `needs:` graph uses the real job ids — which is
exactly why it survived the rename and needed a human/agent pass
rather than a lint rule.

CHANGELOG.md gets an entry under "Packaging, linting and CI" following
the precedent for a comments-only fix.

Files touched:
- `.github/workflows/docs.yml`
- `.github/workflows/hwi-integration.yml`
- `.github/workflows/integration.yml`
- `.github/workflows/latest.yml`
- `.github/workflows/links.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/mutation.yml`
- `.github/workflows/published.yml`
- `.github/workflows/release.yml`
- `.github/workflows/website.yml`
- `CHANGELOG.md`

## Test plan

- [x] `uv run pre-commit run --all-files` exits 0
- [x] `uv run pytest tests/release_notes_test.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align workflow comments and changelog references with the renamed `suite` and `dist` jobs.

Enhancements:
- Update GitHub Actions workflow comments to reference the current `suite` and `dist` job names.

Documentation:
- Document the workflow comment corrections in the changelog.