### PR TITLE
Sign the release tag RELEASING.md's tagging step creates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,26 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **`RELEASING.md`'s tagging step signs the tag it creates** (issue
+  #1022). `git tag -a` is annotated and unsigned; `git tag -s` is the
+  same object with a signature on it, and nothing else about the
+  procedure or about `version-check` changes. Every commit reaching
+  `main` already carries a verified signature, `main-integrity`
+  requiring it with no bypass actor, but the tag that turns one of
+  those commits into a PyPI release — `release.yml` triggers on `push:
+  tags: ["v*"]`, and the `pypi` environment is restricted to that
+  pattern — carried none: `v2026.8.7` and `v2026.8.9` are both
+  annotated tag objects with no `BEGIN PGP SIGNATURE` in them. The
+  `pypi` environment's required review from `fametrano` before the
+  publish job runs was already a real compensating control, which is
+  why this went through a filed issue rather than an urgent fix. A tag
+  cannot be signed retroactively without moving it, and moving a
+  released tag is worse than leaving it unsigned, so existing tags stay
+  as they are — this applies from the next release onward. A `tag`
+  ruleset requiring signatures on `v*`, enforcing the same thing at the
+  repository-settings level rather than documenting it, is the issue's
+  other option and is left for a separate, maintainer-authorized change.
+
 - **`claude-review.yml` reads a pull request against `REVIEWING.md`.**
   Two jobs: one on every non-draft pull request, whose prompt names that
   file rather than restating it, so the standard moves without the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -319,7 +319,7 @@ word, and step 1 asks it of both.
    the tag back before pushing it:
 
    ```shell
-   git tag -a v2026.8.4 -m "release v2026.8.4" <sha of the release commit>
+   git tag -s v2026.8.4 -m "release v2026.8.4" <sha of the release commit>
    git show v2026.8.4:pyproject.toml | grep '^version'
    git push origin v2026.8.4
    ```
@@ -519,7 +519,7 @@ above needs no `uv sync` to produce the published bytes.
 
   Both lines, and the local one is the half that is easy to skip: a tag
   is per-repository where a branch is per-worktree, so deleting it in one
-  worktree leaves it in every other, and the `git tag -a` that follows
+  worktree leaves it in every other, and the `git tag -s` that follows
   answers `fatal: tag 'v2026.8.4' already exists` — from a checkout that
   looks uninvolved. Delete locally wherever it is, then re-create.
 


### PR DESCRIPTION
Addresses #1022.

Every commit reaching `main` already carries a verified signature —
`main-integrity` requires it with no bypass actor, for anyone. The tag
that turns a released commit into a PyPI publish trigger carried none:
`release.yml` runs `on: push: tags: ["v*"]`, and the `pypi` environment
is restricted to that pattern, so the tag is the one unattested link in
an otherwise fully-attested chain (signed commits, pinned workflow,
Trusted Publishing with no long-lived token). `v2026.8.7` and
`v2026.8.9` are both annotated tag objects with no
`BEGIN PGP SIGNATURE` in them, which is what `RELEASING.md`'s tagging
step asks for: `git tag -a` is annotated and unsigned.

## What this changes

`RELEASING.md`'s tagging step uses `git tag -s` instead of `git tag
-a`, in both places the command appears (the tagging step itself, and
the "if something goes wrong" retagging paragraph). Same object shape,
nothing else about the procedure or about `version-check` changes. A
CHANGELOG.md entry records it under "Repository", noting that existing
tags are not retroactively signed — moving a released tag is worse
than leaving it unsigned — so this applies from the next release
onward only.

## Scope: this is option (a) only

The issue lays out three options:

> Either `-s` in RELEASING.md's tagging step, which costs one
> character and makes the release's authorizing artifact attested like
> everything around it; or a `tag` ruleset requiring signatures on
> `v*`, which enforces it rather than documenting it; or both.

This PR implements only the first: the one-line `-s` fix in
`RELEASING.md`. It deliberately does not create, modify, or propose a
`tag`-target ruleset — that is a live repository-infrastructure change
with real consequences (misconfigured, it could block a release), and
it needs the maintainer's own explicit, direct authorization outside a
pull-request review cycle. `REPOSITORY.md`'s "Two rulesets beside the
classic rule" section describes how `main-integrity` and
`main-self-merge` are managed today (via `gh api
repos/.../rulesets`, read back and verified, never assumed); a `tag`
ruleset for option (b) would follow that same pattern, but as its own,
separately authorized change.

The issue notes a real compensating control already exists — the
`pypi` environment requires a review from `fametrano` before the
publish job runs — which is why this was filed as a decision to make
rather than treated as urgent.

## Verification

```
$ uv run pre-commit run --all-files   # exit 0
$ uv run pytest tests/release_notes_test.py   # 3 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Require release tags created by the documented procedure to be signed without changing the release workflow or repository rulesets.

Enhancements:
- Update the release procedure to create signed release tags, preserving the attestation chain for PyPI-triggering releases.

Documentation:
- Document that existing unsigned release tags remain unchanged and that signing applies to future releases.