### PR TITLE
Record the decision on ssa/dsa assert_as_valid_'s message mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1696,6 +1696,20 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **`dsa.assert_as_valid_` and `ssa.assert_as_valid_` keep disagreeing on
+  the message, on purpose** (issue #998). Both raise
+  `BTClibRuntimeError` on either arm for an invalid signature, which is
+  the contract; the delegated arm always says "signature verification
+  failed", the one sentence a libsecp256k1 bool leaves room for, while
+  the Python arm names which check failed -- "y_K is odd", "invalid
+  (INF) key" -- because it has the arithmetic to say so. Left as is
+  rather than squared either way: silencing the Python arm's diagnosis
+  for a cosmetic match costs real information, and having the delegated
+  arm re-run the failing verification in Python to recover it costs a
+  second verification pass on a path a caller catching
+  `BTClibRuntimeError` may hit often. A comment at each raise records the
+  decision, `dsa` and `ssa` read the same way as the issue asked.
+
 - **The Python arm's inventory of authorities that are not the bindings**
   (issue #993). The suite validates the Python arithmetic *against*
   libsecp256k1, which is right for btclib and is exactly the circle a

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -1224,6 +1224,13 @@ def _assert_as_valid_(
 
     # Fail if infinite(K).
     # K = w*(c + r*q)*G is INF whenever c == -r*q (mod n)
+    #
+    # This arm names which check failed, "invalid (INF) key" here and
+    # "signature verification failed" below, where the delegated arm at
+    # assert_as_valid_'s libsecp256k1_dsa.verify call always says the
+    # latter -- it has a bool to work with and this function has the
+    # arithmetic. Left unequal on purpose (issue 998, ssa.py's own
+    # `_assert_as_valid_` reading the same for the reason stated there)
     if KJ[2] == 0:  # 5
         err_msg = "invalid (INF) key"
         raise BTClibRuntimeError(err_msg)
@@ -1360,6 +1367,12 @@ def assert_as_valid_(
             # as `to_pub_key` does not echo them either
             raise BTClibValueError("not a public key") from e
         if not verified:
+            # one fixed sentence, as ssa.assert_as_valid_'s own delegated
+            # arm raises: libsecp256k1 answers a bool and this is btclib's
+            # wording for it, where the Python arm below can name which
+            # check failed. Diagnostic, not API -- issue 998 reads dsa and
+            # ssa as the same question and answers both by leaving the
+            # arms' messages unequal rather than paying for a match
             raise BTClibRuntimeError("signature verification failed")
         return
 

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -826,6 +826,15 @@ def _assert_as_valid_(
     # if moved after 'Fail if x_K ≠ r' it would never be executed
     # Fail if infinite(KJ).
     # Fail if y_K is odd.
+    #
+    # This arm names which BIP340 check failed, where the delegated one
+    # at assert_as_valid_'s libsecp256k1_ssa.verify call can only say
+    # "signature verification failed" -- it has a bool to work with and
+    # this function has the arithmetic. Kept deliberately unequal rather
+    # than squared either way: silencing the diagnosis here for a
+    # cosmetic match, or re-deriving it on the delegated arm by re-running
+    # the failing verification in Python, are the other two options
+    # issue 998 weighs and declines
     if ec.y_aff_from_jac_var(KJ) % 2:
         raise BTClibRuntimeError("y_K is odd")
 
@@ -945,6 +954,15 @@ def assert_as_valid_(
         except ValueError as e:
             raise BTClibValueError(_invalid_x(x_Q)) from e
         if not verified:
+            # one fixed sentence, because libsecp256k1 answers a bool and
+            # this is btclib's own wording for it, not a report of which
+            # BIP340 check failed -- the Python arm below says that
+            # instead. Both raise BTClibRuntimeError, which is the
+            # contract; the message is diagnostic, not API, and a caller
+            # is not meant to branch on it (issue 998, deciding to leave
+            # the two arms disagreeing on wording rather than making them
+            # agree at the cost of the diagnosis or of a second
+            # verification pass on this path)
             raise BTClibRuntimeError("signature verification failed")
         return
 

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -827,14 +827,12 @@ def _assert_as_valid_(
     # Fail if infinite(KJ).
     # Fail if y_K is odd.
     #
-    # This arm names which BIP340 check failed, where the delegated one
-    # at assert_as_valid_'s libsecp256k1_ssa.verify call can only say
-    # "signature verification failed" -- it has a bool to work with and
-    # this function has the arithmetic. Kept deliberately unequal rather
-    # than squared either way: silencing the diagnosis here for a
-    # cosmetic match, or re-deriving it on the delegated arm by re-running
-    # the failing verification in Python, are the other two options
-    # issue 998 weighs and declines
+    # This arm names which check failed, "y_K is odd" here and
+    # "signature verification failed" below, where the delegated one at
+    # assert_as_valid_'s libsecp256k1_ssa.verify call always says the
+    # latter -- it has a bool to work with and this function has the
+    # arithmetic. Left unequal on purpose (issue 998, dsa.py's own
+    # `_assert_as_valid_` reading the same for the reason stated there)
     if ec.y_aff_from_jac_var(KJ) % 2:
         raise BTClibRuntimeError("y_K is odd")
 


### PR DESCRIPTION
Closes #998

Decision: leave the two arms of `assert_as_valid_` disagreeing on the
message, and write the decision down at the point each arm raises,
rather than leaving it recoverable only from the issue.

`ecc.ssa.assert_as_valid_` and `ecc.dsa.assert_as_valid_` both raise
`BTClibRuntimeError` on either arm for an invalid signature — that is
the contract, and it already held. The delegated arm can only ever
say "signature verification failed" (libsecp256k1 answers a bool, and
btclib supplies the one fixed sentence); the Python arm names which
BIP340/ECDSA check actually failed ("y_K is odd", "invalid (INF)
key"), because it does the arithmetic itself.

Of the issue's three options I picked "leave it": the message is
diagnostic, not API surface, and a caller branching on message text is
already doing something wrong. The other two were rejected for a
reason worth stating rather than assuming obvious:

- making the Python arm answer the generic sentence throws away real
  information (which check failed) for a cosmetic match between arms;
- making the delegated arm re-run the failing verification in Python
  to recover that diagnosis buys it at the cost of a second, full
  Python verification pass — on a path a caller catching
  `BTClibRuntimeError` may hit often, e.g. validating untrusted
  signatures in a loop.

`dsa.assert_as_valid_` already has the identical shape (fixed message
delegated, per-check message on the Python arm), so it needed the same
documenting comment and no behaviour change — confirming the answer is
the same for both schemes, as the issue asked.

Comments added, at each raise site:

- `ssa.py`, delegated arm (`assert_as_valid_`):
  > one fixed sentence, because libsecp256k1 answers a bool and this
  > is btclib's own wording for it, not a report of which BIP340 check
  > failed -- the Python arm below says that instead. Both raise
  > BTClibRuntimeError, which is the contract; the message is
  > diagnostic, not API, and a caller is not meant to branch on it
  > (issue 998, deciding to leave the two arms disagreeing on wording
  > rather than making them agree at the cost of the diagnosis or of a
  > second verification pass on this path)
- `ssa.py`, Python arm (`_assert_as_valid_`), and the mirrored pair in
  `dsa.py` at its own delegated and Python raise sites, phrased for
  each file's own call names.

No test changes: `tests/script/sig_hash_taproot_test.py` already
carries the alternation `_REFUSED = "signature verification
failed|y_K is odd"` with a comment citing issue #998 (from the #991
PR), and no other test asserts message text on the dispatching
`assert_as_valid_`/`_` — the remaining `match="y_K is odd"` and
`match=r"invalid \(INF\) key"` hits are on the private, Python-only
`_assert_as_valid_` helpers, called directly and not through the
arm-dispatching public function, so they are deterministic regardless
of whether the bindings are installed.

CHANGELOG.md: added one entry under "Curves, signatures and keys" for
v2026.9, at the top of the section, recording the decision (this repo
logs decision-only changes when they're worth the record, per the
"Packaging, linting and CI" precedent; no HISTORY.md entry since
nothing here is user-actionable).

Gates run, from this worktree:

- `uv run pre-commit run --all-files` — exit 0, every hook Passed
  (mypy strict included), both before and after the rebase onto
  `origin/main`.
- `uv run pytest` (bare invocation, the coverage gate too) —
  28207 passed, 6 skipped (integration tests requiring env vars/
  hardware), 100.00% coverage.
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` — build succeeded,
  no warnings.
- `git log -1 --format='%G? %GS'` after the rebase — `G`, signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the decision to retain distinct diagnostic messages for Python and delegated DSA/SSA signature validation failures.

Enhancements:
- Document the intentional difference between delegated and Python signature-validation error messages in the DSA and SSA assertion paths while preserving diagnostic detail and avoiding an extra verification pass.

Chores:
- Record the issue #998 decision in the changelog.