### PR TITLE
Skip test.yml's aggregate on a superseded run, fail its step unconditionally

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -437,12 +437,17 @@ jobs:
     # not for a dependency's own result -- unlike failure(), which walks
     # needs -- so this condition goes false, and the job skips instead
     # of failing, only when the run as a whole was superseded. A skipped
-    # job satisfies a required check the way integration.yml's
-    # `paths`-filtered runs already do (REPOSITORY.md); a run that was
-    # not cancelled still reaches the step below even when a dependency
-    # failed, or was individually cancelled (a matrix cell hitting its
-    # own timeout-minutes, say), because cancelled() does not go true
-    # for that.
+    # job satisfies a required check -- this job's own draft/closed
+    # condition below already relies on exactly that, and has since
+    # before this change; integration.yml, by contrast, deliberately
+    # carries no `paths` filter, for the same reason stated in
+    # REPOSITORY.md and in that workflow's own comment: a required check
+    # that never runs blocks a merge, where a skipped one satisfies it,
+    # and a filter would make it never run rather than skip. A run that
+    # was not cancelled still reaches the step below even when a
+    # dependency failed, or was individually cancelled (a matrix cell
+    # hitting its own timeout-minutes, say), because cancelled() does not
+    # go true for that.
     # and the draft condition every job above carries, so a draft
     # skips uniformly rather than tripping the check below -- the
     # closed one for the same reason, added at the trigger above

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -429,26 +429,47 @@ jobs:
     # are what that costs
     name: "test: every job passed"
     needs: [suite, coverage, no-bindings, dist]
-    # not success(): a job whose dependencies failed is skipped, and a
-    # skipped check reports "skipped", which branch protection counts as
-    # satisfied. The gate has to run to be able to fail
+    # !cancelled(), not always(): a run superseded by the concurrency
+    # group above -- the next push landing on this ref, or a re-run
+    # cancelled from the UI -- cancels every job still in flight, and
+    # that means "a newer run is authoritative", not "this tree is
+    # unproven" (issue #1025). cancelled() answers for the run itself,
+    # not for a dependency's own result -- unlike failure(), which walks
+    # needs -- so this condition goes false, and the job skips instead
+    # of failing, only when the run as a whole was superseded. A skipped
+    # job satisfies a required check the way integration.yml's
+    # `paths`-filtered runs already do (REPOSITORY.md); a run that was
+    # not cancelled still reaches the step below even when a dependency
+    # failed, or was individually cancelled (a matrix cell hitting its
+    # own timeout-minutes, say), because cancelled() does not go true
+    # for that.
     # and the draft condition every job above carries, so a draft
-    # skips uniformly rather than tripping the skip check below -- the
+    # skips uniformly rather than tripping the check below -- the
     # closed one for the same reason, added at the trigger above
-    if: ${{ always() && !github.event.pull_request.draft && github.event.action != 'closed' }}
+    if: ${{ !cancelled() && !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      # the condition reads the whole needs context rather than testing
-      # each job by name, so a job added to needs above is covered
-      # without touching this. "skipped" is a failure here too: nothing
-      # in this workflow is conditional, so a skip means something
-      # upstream did not run
+      # unconditional -- no `if:` of its own -- and deciding in the
+      # shell rather than in a boolean `contains(needs.*.result, ...)`
+      # expression: issue #1001 saw four `suite` cells die in "Set up
+      # job" on an action download's HTTP 429, the run's own conclusion
+      # was `failure`, and yet `needs.suite.result` was not `'failure'`
+      # when the old expression checked it -- so that `if:`-gated step
+      # was skipped, and a skipped step leaves the job green by
+      # construction, the same shape the job-level condition used to
+      # have. Looping over every result here instead means the step
+      # always runs and the log always carries what `needs` actually
+      # held, whether or not that matches a run's own conclusion; and it
+      # is what makes a job added to `needs` above covered without
+      # touching this loop, the same as the expression it replaces
       - name: Fail unless every job above succeeded
-        if: >-
-          contains(needs.*.result, 'failure') ||
-          contains(needs.*.result, 'cancelled') ||
-          contains(needs.*.result, 'skipped')
         run: |
-          echo "::error::a job this gate depends on did not succeed"
-          exit 1
+          results='${{ join(needs.*.result, ' ') }}'
+          echo "results: $results"
+          for result in $results; do
+            [ "$result" = success ] || {
+              echo "::error::a job this gate depends on reported $result"
+              exit 1
+            }
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -629,6 +629,30 @@ documented at release-notes length in the first place, and are still in
   nine more places. Nothing fails on either: `actionlint` reads the YAML
   and not the comments, and the `needs:` graph uses the real ids, which
   is how it survived (issue #1004).
+- **`test.yml`'s aggregate no longer turns a superseded run into a failed
+  required check, and no longer goes green while a step of its own was
+  silently skipped.** Two separate defects, both in `test-passed`.
+  Issue #1025: the job carried `if: always()`, and its one step failed
+  on `contains(needs.*.result, 'cancelled')` -- so a run the concurrency
+  group cancelled in favour of a newer push reported a **failure** that
+  described no defect, sometimes leaving a red and a green check of the
+  same name on the same head sha. The job condition is now
+  `!cancelled()`, which answers for the run itself rather than walking
+  `needs` the way `failure()` does, so the job skips -- and a skipped
+  job satisfies a required check -- only when the run as a whole was
+  superseded; a dependency that failed, or was individually cancelled
+  while the run was not, still reaches the step below. Issue #1001: that
+  step was gated by a boolean `contains(needs.*.result, ...)` expression,
+  and on a run where four `suite` cells died in "Set up job" on an
+  action download's HTTP 429, `needs.suite.result` was not `'failure'`
+  by that expression's reckoning, so the step was skipped and the job
+  reported **success** with the run's own conclusion `failure`. The step
+  is now unconditional and loops over `needs.*.result` in the shell,
+  echoing what it saw before failing on anything but `success` -- so it
+  cannot itself be skipped out from under the job, and the log carries
+  the evidence the next time a run's conclusion and this check disagree.
+  `REPOSITORY.md` records the aggregate's resulting semantics and the
+  command to read a run's own job list when the two disagree.
 
 - **`MANIFEST.in` prunes a nested `.mypy_cache`, `.pytest_cache`,
   `.ruff_cache` or `__pycache__`, at whatever depth a tool left one.**

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -19,6 +19,16 @@ aggregate job at the end of `test.yml` that `needs` the matrix; a new job in
 carries the workflow because a context is keyed by name alone: two
 workflows with a job named the same thing produce one ambiguous check.
 
+That aggregate skips, rather than fails, when the run itself was
+cancelled by the concurrency group superseding it -- a skip satisfies a
+required check, the same as a `paths`-filtered run below -- and fails
+hard on anything else a dependency reports that is not success, checked
+by name in a shell loop that always runs rather than a boolean
+expression a skipped step could leave unevaluated. (Issue #1025 and
+issue #1001.) Read the cells, not the aggregate, when a run's own
+conclusion and this check disagree:
+`gh api repos/{owner}/{repo}/actions/runs/<id>/jobs`.
+
 `main` requires four checks, and only four:
 
 | Check | Produced by |

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -21,8 +21,9 @@ workflows with a job named the same thing produce one ambiguous check.
 
 That aggregate skips, rather than fails, when the run itself was
 cancelled by the concurrency group superseding it -- a skip satisfies a
-required check, the same as a `paths`-filtered run below -- and fails
-hard on anything else a dependency reports that is not success, checked
+required check, the same as this very job's own draft/closed condition
+already relies on -- and fails hard on anything else a dependency
+reports that is not success, checked
 by name in a shell loop that always runs rather than a boolean
 expression a skipped step could leave unevaluated. (Issue #1025 and
 issue #1001.) Read the cells, not the aggregate, when a run's own

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -28,7 +28,7 @@ by name in a shell loop that always runs rather than a boolean
 expression a skipped step could leave unevaluated. (Issue #1025 and
 issue #1001.) Read the cells, not the aggregate, when a run's own
 conclusion and this check disagree:
-`gh api repos/{owner}/{repo}/actions/runs/<id>/jobs`.
+`gh api repos/btclib-org/btclib/actions/runs/<id>/jobs`.
 
 `main` requires four checks, and only four:
 


### PR DESCRIPTION
Closes #1025 and closes #1001. Both are about `test-passed`
(`test: every job passed`) in `test.yml`, and the two fixes had to move
together: fixing one while ignoring the other would put the job back
into the failure mode the other issue exists for.

## #1025 -- a cancelled run reported a failed required check

The job carried `if: always()`, and its one step failed whenever
`needs.*.result` contained `'cancelled'`. `test.yml`'s concurrency
group cancels every job still in flight when a newer push (or a
re-run) supersedes the run, and that cancellation is not a defect in
the tree -- it means a newer run is authoritative. With `always()`,
the aggregate still ran, saw `cancelled` among its dependencies, and
failed, sometimes leaving a red and a green check of the same name on
the same head sha.

Fix: `always()` becomes `!cancelled()`. `cancelled()` answers for the
run itself, not for a dependency's own result (unlike `failure()`,
which walks `needs`), so the job now skips -- which satisfies a
required check, the same way `integration.yml`'s `paths`-filtered runs
already do -- only when the run as a whole was superseded. A
dependency that plainly failed, or was individually cancelled (its own
`timeout-minutes`, say) while the run itself was not cancelled, still
reaches the step below, because `cancelled()` does not go true for
that case.

## #1001 -- the aggregate went green with four failed matrix cells

The step's own condition was a boolean
`contains(needs.*.result, ...)` expression. On the run the issue
records, four `suite` cells died in "Set up job" on an action
download's HTTP 429; the run's own conclusion was `failure`, and yet
`needs.suite.result` was not `'failure'` by that expression's
reckoning -- so the step was `skipped`, and a skipped step leaves the
job green by construction, independently of whatever condition gates
the job itself.

Fix (issue's step 1 only): the step is now unconditional and loops
over `needs.*.result` in the shell, echoing what it saw before failing
on anything but `success`. It can no longer be skipped out from under
the job, and the log now carries the evidence for next time a run's
own conclusion and this check disagree.

Issue's step 2 -- reading a run's own job conclusions through the
Actions API if `needs` really can under-report a failure -- is
deliberately left out. It needs a live reproduction to confirm the
premise (that `needs.suite.result` genuinely does not reflect a
cell dying in "Set up job"), which cannot be done from a branch; worth
a follow-up if #1001's mechanism turns out to require it.

## Also

`REPOSITORY.md`'s "Required checks on main" section now states the
aggregate's resulting semantics next to the table it already carries:
skips on supersession, fails hard on any other non-success dependency
result, and points at reading a run's own job list
(`gh api .../actions/runs/<id>/jobs`) when the two disagree -- the
sentence #1025 asked for. `CHANGELOG.md` gets one entry for both
fixes, since they are one change to one job.

`codeql.yml` carries the same `contains(needs.*.result, 'cancelled')`
shape in its own (non-required) aggregate; left unchanged, since it is
not required and the task scope was `test.yml`'s aggregate only.

## Test plan

- `uv run pre-commit run --all-files` -- exit 0, every hook `Passed`
  (`actionlint` needed a fix: GitHub Actions expressions only accept
  single-quoted string literals, so `join(needs.*.result, " ")` in the
  issue's own snippet became `join(needs.*.result, ' ')` here).
- `uv run pytest tests/release_notes_test.py` -- `3 passed`, the
  CHANGELOG.md/HISTORY.md format gate.
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` -- `build
  succeeded`.
- No Python file changed (workflow + two docs files only), so the full
  `uv run pytest` suite was not run; nothing in this diff touches code
  it would cover.
- Not run: the workflow itself, since neither GitHub Actions'
  `cancelled()` semantics nor a superseded/cancelled run can be
  exercised locally. Confirmed the semantics against GitHub's own
  status-check-function documentation and community reports instead:
  `cancelled()` reflects the run's own cancellation, while `failure()`
  is what walks `needs` -- which is the distinction the two fixes'
  interaction depends on.

## Judgment call for the reviewer

The job-level condition trigger is `!cancelled()`, applied to the whole
`test-passed` job (not a per-step `if:`), while the "Fail unless every
job above succeeded" step itself carries no `if:` at all and always
decides in the shell. This is the shape the task asked me to verify
against real GitHub Actions semantics rather than assume; I fetched
GitHub's docs and cross-checked with third-party writeups because the
official docs page alone doesn't spell out `cancelled()` vs `needs`
precisely enough to be sure by inspection. If a reviewer wants to be
extra careful, testing this on a disposable branch before merging (as
issue #1025 itself suggests) is the strongest available check, since
nothing here can be proven from a local run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make the test workflow aggregate skip superseded runs while enforcing and reporting the status of every dependency in all other runs.

Bug Fixes:
- Prevent superseded test workflow runs from reporting a failed required check.
- Ensure the test aggregate fails when any dependency reports a non-success result instead of becoming green after its validation step is skipped.

Enhancements:
- Make the test aggregate always evaluate and log dependency results for clearer diagnosis of discrepancies between aggregate checks and run conclusions.

Documentation:
- Document the test aggregate's cancellation and failure semantics, including how to inspect individual workflow jobs when conclusions disagree.