### PR TITLE
Combine coverage across the delegated and no-bindings runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,6 +229,30 @@ jobs:
         run: >
           uv run --locked --no-default-groups --group test
           pytest --cov
+        env:
+          # not the default `.coverage`: the `coverage-union` job downloads
+          # this artifact beside the `no-bindings` job's, and two files
+          # named alike would overwrite each other on the runner that
+          # combines them. `COVERAGE_FILE` is `--data-file`'s environment
+          # variable, coverage's own, so `pytest --cov` writes here without
+          # a second flag naming what the report step above already reads
+          # from tool.coverage.run
+          COVERAGE_FILE: coverage-data-bindings
+      # issue #1002: this run already fails at 100% on its own, unchanged
+      # above, and this is the second, weaker thing the same data buys --
+      # the union `coverage-union` gates below. Uploaded rather than kept
+      # only as the percentage this job already reported, because a
+      # percentage cannot be combined with another job's and a line
+      # reachable only from the `no-bindings` run is invisible to it
+      - name: Upload coverage data
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-data-bindings
+          path: coverage-data-bindings
+          # a coverage data file with nothing collected would mean this
+          # job did not run pytest at all, which the run above failing
+          # already reports -- the default here would hide that
+          if-no-files-found: error
 
   # the configuration issue #966 exists for, and the one thing that keeps
   # its guard from being a claim nobody checks: btclib installed without
@@ -241,10 +265,18 @@ jobs:
   # and uv's `--no-group` suppresses a group that was selected, not one
   # another group includes. So the split in pyproject.toml is what this
   # job is, and there is no second lock file.
-  # `--no-cov`, because the delegated arms are unreachable here by
-  # construction: a coverage report of this run would fail the 100% gate
-  # for the one reason the run exists to create. The `coverage` job above
-  # is where that number comes from.
+  # `--cov --cov-fail-under=0`, not `--no-cov`, since issue #1002: the
+  # delegated arms are still unreachable here by construction, and a
+  # report of this run *alone* would still fail the 100% gate for the one
+  # reason the run exists to create -- `--cov-fail-under=0` is what keeps
+  # this job from being that report, collecting the data without gating
+  # this run on it. The data goes into `coverage-union` below, which
+  # gates the union of this run and the `coverage` job's at 100% as well,
+  # answering the question this job's own comment used to leave open: a
+  # test marked `needs_bindings` too broadly, or a Python arm no test
+  # here reaches, now shows up as a line neither run covers rather than
+  # as nothing. What it costs is this job's wall clock, now instrumented
+  # like the `coverage` job's rather than the `suite` matrix's
   # The tests that hold both implementations and compare them are marked
   # `bindings` and skip themselves; everything else runs, which is what
   # makes this a suite and not a smoke test
@@ -277,7 +309,87 @@ jobs:
       - name: Run pytest
         run: >
           uv run --locked --no-default-groups --group harness
-          pytest --no-cov
+          pytest --cov --cov-fail-under=0
+        env:
+          # the `coverage` job's comment on its own `COVERAGE_FILE` is why
+          # this is not `.coverage` either: the two artifacts land beside
+          # each other in `coverage-union` below
+          COVERAGE_FILE: coverage-data-no-bindings
+      - name: Upload coverage data
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-data-no-bindings
+          path: coverage-data-no-bindings
+          if-no-files-found: error
+
+  # the union `coverage` and `no-bindings` together answer for, and the
+  # gate is added to what `coverage` already is rather than instead of
+  # it. A line reachable only from this job's run is a line the delegated
+  # configuration -- the one an ordinary `pip install btclib[secp256k1]`
+  # gets -- never executes, and the `coverage` job's own 100% already
+  # says so by going red. Combining the two runs into one report and
+  # gating only that report would let such a line pass in silence, which
+  # is not the question issue #1002 asks: the question is what line no
+  # test anywhere reaches, not which configuration reaches which.
+  # This is why no `# pragma: no cover` in the tree became removable the
+  # day this job was added, despite what #995 and #1002 both hoped:
+  # `btclib/_libsecp256k1.py`'s `except ImportError:` and
+  # `tests/conftest.py`'s `_skip_what_needs_the_bindings` are reached by
+  # this job's own run and would make the union 100% without their
+  # pragma, and are unreachable in the `coverage` job's single run by
+  # construction all the same -- so removing either pragma fails that
+  # job's own gate, which stands exactly as it did before this job
+  # existed. What this job protects instead is every line beside those:
+  # new dead code in either configuration, or a `needs_bindings` marker
+  # drawn wider than it should be, now shows up as a line neither run
+  # covers rather than as nothing.
+  # What it costs: a third job, an artifact round trip in each direction,
+  # and coverage.py's own combine step, which is the same trade the
+  # `coverage` job already made against the `suite` matrix, applied once
+  # more
+  coverage-union:
+    name: Combine coverage from both runs, gated at 100% too
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
+    needs: [coverage, no-bindings]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # the source files coverage.py reports against: a data file alone
+      # names lines by path and number, not by content
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          python-version: "3.14"
+      - name: Download coverage data from the coverage job
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-data-bindings
+      - name: Download coverage data from the no-bindings job
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-data-no-bindings
+      # `--group harness` and not `--group test`: combining and reporting
+      # read coverage.py's own data files and the source tree checked out
+      # above, neither of which needs btclib importable, let alone the
+      # bindings
+      - name: Combine the two runs
+        run: >
+          uv run --locked --no-default-groups --group harness
+          coverage combine coverage-data-bindings coverage-data-no-bindings
+      # `fail_under` in pyproject.toml is what the `coverage` job's report
+      # already reads; asked for explicitly here too, since this report is
+      # of the combined file the block comment above argues for gating
+      # rather than of the one `tool.coverage.run`'s default location
+      # would have produced
+      - name: Report the union, gated at 100%
+        run: >
+          uv run --locked --no-default-groups --group harness
+          coverage report --fail-under=100
 
   # the packaging metadata is checked on every pull request, not only on
   # the tag that ships it: a release is the one place where finding a
@@ -428,7 +540,7 @@ jobs:
     # day either grows a second one, this pattern and a change to the rule
     # are what that costs
     name: "test: every job passed"
-    needs: [suite, coverage, no-bindings, dist]
+    needs: [suite, coverage, no-bindings, coverage-union, dist]
     # !cancelled(), not always(): a run superseded by the concurrency
     # group above -- the next push landing on this ref, or a re-run
     # cancelled from the UI -- cancels every job still in flight, and

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ pip-delete-this-directory.txt
 htmlcov/
 .coverage
 .coverage.*
+coverage-data-bindings
+coverage-data-no-bindings
 .cache
 nosetests.xml
 coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -671,9 +671,11 @@ documented at release-notes length in the first place, and are still in
   `coverage report --fail-under=100` on the result: a line reachable in
   either configuration is a line this library runs, and locally, with
   every no-bindings-only pragma in the tree removed, that combined
-  report reaches exactly 100.00% (41485 statements, 0 missed) —
-  confirming both that the mechanism works and that nothing today is
-  invisible to both runs at once.
+  report reaches exactly 100.00% — confirming both that the mechanism
+  works and that nothing today is invisible to both runs at once. The
+  percentage is what `--fail-under=100` re-checks on every run; the
+  statement count behind it moves with every commit touching `btclib/`
+  or `tests/` and is not repeated here for that reason.
 
   The gate is added beside the `coverage` job's existing 100%, not
   instead of it, deliberately: a line covered only by the no-bindings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -653,6 +653,54 @@ documented at release-notes length in the first place, and are still in
   the evidence the next time a run's conclusion and this check disagree.
   `REPOSITORY.md` records the aggregate's resulting semantics and the
   command to read a run's own job list when the two disagree.
+- **`test.yml` gains a `coverage-union` job, and `# pragma: no cover`
+  markers stay put (issue #1002).** The `no-bindings` job's whole
+  purpose is that the Python arms are reached by absence rather than by
+  a monkeypatch, and nothing checked that they were: it ran with
+  `--no-cov`, which the job's own comment defended on the grounds that
+  the delegated arms are unreachable there by construction — true of
+  those arms, and beside the point for the one line that is not one of
+  them, `btclib/_libsecp256k1.py`'s `except ImportError:`. #995 called
+  its pragma transitional, pending #991; #991 is this very job, and it
+  measured nothing, so the pragma was permanent and dishonest about it.
+
+  `no-bindings` now runs `pytest --cov --cov-fail-under=0`, collecting
+  data without gating this run on it alone, and uploads it as an
+  artifact beside the one the `coverage` job now also uploads.
+  `coverage-union` downloads both, runs `coverage combine`, then
+  `coverage report --fail-under=100` on the result: a line reachable in
+  either configuration is a line this library runs, and locally, with
+  every no-bindings-only pragma in the tree removed, that combined
+  report reaches exactly 100.00% (41485 statements, 0 missed) —
+  confirming both that the mechanism works and that nothing today is
+  invisible to both runs at once.
+
+  The gate is added beside the `coverage` job's existing 100%, not
+  instead of it, deliberately: a line covered only by the no-bindings
+  run is a line the delegated configuration — the one `pip install
+  btclib[secp256k1]` gets — never executes, and only the unchanged
+  `coverage` job says so, by going red. A union gated alone would not;
+  it would let such a line pass in silence, and the two configurations
+  are not equally important. What that decision costs, measured against
+  keeping the `coverage` job's report and its pragmas exactly as they
+  are: `# pragma: no cover` still owed to `_libsecp256k1.py`'s `except
+  ImportError:` and to `tests/conftest.py`'s
+  `_skip_what_needs_the_bindings` and its call, none of them removable
+  after all — the `coverage` job's own single run has the bindings
+  installed by construction, so `INSTALLED` is always True and
+  `except ImportError` only reachable by a subprocess whose coverage
+  that job does not collect (`tests/no_bindings_test.py`), and removing
+  either pragma fails that unchanged gate on its own, regardless of
+  what `coverage-union` reports. The union's standing benefit is
+  therefore not today's pragma count but tomorrow's: new dead code
+  specific to either configuration, or a `needs_bindings` marker drawn
+  too wide, now shows up as a line neither run covers rather than as
+  nothing — which is the second half of what issue #1002 asked for, and
+  what issue #993's inventory can be checked against instead of read by
+  hand. What it costs beyond the design point above: a third job, an
+  artifact round trip in each direction, and the `no-bindings` job's
+  wall clock, now instrumented like the `coverage` job's rather than
+  the `suite` matrix's.
 
 - **`MANIFEST.in` prunes a nested `.mypy_cache`, `.pytest_cache`,
   `.ruff_cache` or `__pycache__`, at whatever depth a tool left one.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -342,7 +342,8 @@ the coverage command rather than this one.
 The `coverage` job, gated by `fail_under` in pyproject.toml:
 
 ```shell
-uv run --locked --no-default-groups --group test pytest --cov
+COVERAGE_FILE=coverage-data-bindings \
+    uv run --locked --no-default-groups --group test pytest --cov
 ```
 
 What `--cov` measures and how it reports are `tool.coverage.run`'s
@@ -350,10 +351,14 @@ What `--cov` measures and how it reports are `tool.coverage.run`'s
 and the bare `uv run pytest` above are the same measurement: the job
 cannot gate on a scope a contributor's run does not have. The flag is
 written out here even though addopts already carries it, this being the
-job's command verbatim. The job then uploads the `.coverage` data file
-this command wrote as an artifact, for the `coverage-union` job below to
-read; that step has no command of its own to reproduce, being a plain
-`actions/upload-artifact`.
+job's command verbatim. `COVERAGE_FILE` is `--data-file`'s environment
+variable, coverage's own, and is the job's real step verbatim too, not a
+local-reproduction addition: the two artifacts this job and `no-bindings`
+below produce would overwrite each other under the default `.coverage`
+name once both land in the `coverage-union` job that reads them. The job
+then uploads the data file this command wrote as an artifact, for
+`coverage-union` to read; that step has no command of its own to
+reproduce, being a plain `actions/upload-artifact`.
 
 The `no-bindings` job, which runs the suite against a btclib that has no
 `btclib_secp256k1` to delegate to:
@@ -364,7 +369,8 @@ uv run --locked --no-default-groups --group harness \
       assert not INSTALLED, 'btclib_secp256k1 is installed'; \
       from btclib.curves import is_libsecp256k1_serving; \
       assert not is_libsecp256k1_serving()"
-uv run --locked --no-default-groups --group harness \
+COVERAGE_FILE=coverage-data-no-bindings \
+    uv run --locked --no-default-groups --group harness \
     pytest --cov --cov-fail-under=0
 ```
 
@@ -377,9 +383,9 @@ report of this run *alone* would still fail the 100% gate for the one
 reason the run exists to create — `--cov-fail-under=0` collects the data
 without gating this run on it. The tests that hold both implementations
 and compare them carry the `bindings` marker and skip themselves;
-everything else runs. This job's `.coverage` data is uploaded as an
-artifact too, under a name of its own so it does not collide with the
-`coverage` job's when both are downloaded into the same job.
+everything else runs. This job's data is uploaded as an artifact too,
+under the name `COVERAGE_FILE` gave it above, so it does not collide
+with the `coverage` job's when both are downloaded into the same job.
 
 The `coverage-union` job, which combines the two data files above and
 gates their union at 100% as well — beside the `coverage` job's own
@@ -394,11 +400,12 @@ uv run --locked --no-default-groups --group harness \
     coverage report --fail-under=100
 ```
 
-Reproducing this one locally needs the two data files the commands
-above produced, renamed to the two names this job downloads them under
-— `COVERAGE_FILE=coverage-data-bindings` and
-`COVERAGE_FILE=coverage-data-no-bindings` on the two commands above, in
-two passes since one `.venv` cannot hold and lack the bindings at once.
+Reproducing this one locally needs the two data files the commands above
+already produced, under the two names they already wrote them with — no
+renaming step, since `COVERAGE_FILE` on each command is what named them
+that way in the first place. The two commands above run in two passes
+either way, one `.venv` not being able to hold and lack the bindings at
+once.
 
 The `dist` job, which inspects what would be published and then
 installs it. The first two commands after the build read the *members* of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -350,7 +350,10 @@ What `--cov` measures and how it reports are `tool.coverage.run`'s
 and the bare `uv run pytest` above are the same measurement: the job
 cannot gate on a scope a contributor's run does not have. The flag is
 written out here even though addopts already carries it, this being the
-job's command verbatim.
+job's command verbatim. The job then uploads the `.coverage` data file
+this command wrote as an artifact, for the `coverage-union` job below to
+read; that step has no command of its own to reproduce, being a plain
+`actions/upload-artifact`.
 
 The `no-bindings` job, which runs the suite against a btclib that has no
 `btclib_secp256k1` to delegate to:
@@ -361,17 +364,41 @@ uv run --locked --no-default-groups --group harness \
       assert not INSTALLED, 'btclib_secp256k1 is installed'; \
       from btclib.curves import is_libsecp256k1_serving; \
       assert not is_libsecp256k1_serving()"
-uv run --locked --no-default-groups --group harness pytest --no-cov
+uv run --locked --no-default-groups --group harness \
+    pytest --cov --cov-fail-under=0
 ```
 
 `harness` and not `test`: `test` is `harness` plus `bindings`, and uv's
 `--no-group` suppresses a group that was selected rather than one another
 group includes, so the split in pyproject.toml is what this job is.
-`--no-cov` because the delegated arms are unreachable in this
-configuration by construction, so a report of this run would fail the
-100% gate for the one reason the run exists to create. The tests that
-hold both implementations and compare them carry the `bindings` marker
-and skip themselves; everything else runs.
+`--cov --cov-fail-under=0`, not `--no-cov` (issue #1002): the delegated
+arms are still unreachable in this configuration by construction, so a
+report of this run *alone* would still fail the 100% gate for the one
+reason the run exists to create — `--cov-fail-under=0` collects the data
+without gating this run on it. The tests that hold both implementations
+and compare them carry the `bindings` marker and skip themselves;
+everything else runs. This job's `.coverage` data is uploaded as an
+artifact too, under a name of its own so it does not collide with the
+`coverage` job's when both are downloaded into the same job.
+
+The `coverage-union` job, which combines the two data files above and
+gates their union at 100% as well — beside the `coverage` job's own
+gate on the delegated run alone, not instead of it, so that a line
+covered only by the no-bindings run cannot pass in silence just because
+the union reached it:
+
+```shell
+uv run --locked --no-default-groups --group harness \
+    coverage combine coverage-data-bindings coverage-data-no-bindings
+uv run --locked --no-default-groups --group harness \
+    coverage report --fail-under=100
+```
+
+Reproducing this one locally needs the two data files the commands
+above produced, renamed to the two names this job downloads them under
+— `COVERAGE_FILE=coverage-data-bindings` and
+`COVERAGE_FILE=coverage-data-no-bindings` on the two commands above, in
+two passes since one `.venv` cannot hold and lack the bindings at once.
 
 The `dist` job, which inspects what would be published and then
 installs it. The first two commands after the build read the *members* of

--- a/btclib/_libsecp256k1.py
+++ b/btclib/_libsecp256k1.py
@@ -83,6 +83,19 @@ try:
     from btclib_secp256k1.xonly import to_pubkey as xonly_to_pubkey
 
     INSTALLED = True
+# issue #1002 measured this branch rather than assuming it stays
+# transitional: `test.yml`'s `no-bindings` job executes it every run, and
+# `coverage-union` combines that run's data with the `coverage` job's.
+# The combined report is 100% with this pragma removed -- so the branch
+# is reached and is not dead code -- and the pragma still belongs here
+# regardless, because `coverage-union` is a second gate beside the
+# `coverage` job's, not instead of it: that job's own report, `pytest
+# --cov` on this configuration alone, has bindings installed by
+# construction, an `ImportError` only reachable by actually removing
+# them, and a subprocess that does (`tests/no_bindings_test.py`) whose
+# coverage that job does not collect. So this branch is a structural
+# miss in that report regardless of the union, and removing the pragma
+# would fail the one gate this issue chose to leave unchanged
 except ImportError:  # pragma: no cover
     # None and not a callable that raises: what would raise is never
     # called, so the object would be a second thing to keep true. The

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,9 +221,17 @@ def check_golden(path: Path, name: str, value: Any, module: str) -> None:
 def _skip_what_needs_the_bindings(items: list[pytest.Item]) -> None:  # pragma: no cover
     """Skip every test marked `bindings`, naming why once.
 
-    Runs only where `btclib_secp256k1` is absent, which no coverage run
-    measures: the job that builds that configuration passes `--no-cov`,
-    the delegated arms being unreachable in it by construction.
+    Runs only where `btclib_secp256k1` is absent, `INSTALLED` being set
+    once at import and not something a test can fake in-process. Issue
+    #1002 asked whether that still leaves this unmeasured, given
+    `test.yml`'s `coverage-union` job: it does not go unmeasured -- the
+    no-bindings job's own `--cov` reaches this function and the combined
+    report is 100% with the pragma removed -- but the pragma stays,
+    because `coverage-union` gates beside the `coverage` job's report and
+    not instead of it, and that job's own single run has the bindings
+    installed, so `INSTALLED` is always True there and this function is
+    never called. Removing the pragma would fail that gate, which this
+    issue chose to leave exactly as it was.
     """
     skip = pytest.mark.skip(reason="btclib_secp256k1 is not installed")
     for item in items:


### PR DESCRIPTION
Closes #1002.

## The mechanism

`test.yml`'s `coverage` job (delegated, bindings installed) now writes
its coverage data to `coverage-data-bindings` (`COVERAGE_FILE`, not the
default `.coverage`) and uploads it as an artifact of the same name. The
`no-bindings` job switches from `pytest --no-cov` to `pytest --cov
--cov-fail-under=0` — collecting data without gating this run on it
alone — and uploads its own `coverage-data-no-bindings`. A new
`coverage-union` job, depending on both, downloads the two artifacts,
runs `coverage combine coverage-data-bindings coverage-data-no-bindings`,
then `coverage report --fail-under=100` on the result. `test-passed`'s
`needs:` list gains the one job id.

The `coverage` job's own gate — `pytest --cov`, `fail_under=100` from
`pyproject.toml`, on the delegated run alone — is untouched. This is the
explicit "gate both" decision the issue asks for, not the union gated
alone: a line covered only by the no-bindings run is a line the
delegated configuration (an ordinary `pip install btclib[secp256k1]`)
never executes, and only the still-standing `coverage` job says so, by
going red. A union gated alone would let such a line pass in silence.

## What I found working through the "real design question"

The issue's own text suggested `# pragma: no cover` in
`btclib/_libsecp256k1.py`'s `except ImportError:` "becomes removable"
once the union exists. I tested that directly rather than assuming it,
and it does not hold under gate-both — which is itself a useful, testable
answer to the question the issue leaves open ("whether that is
acceptable... deserves an answer before the plumbing"):

- With every no-bindings-only pragma removed and both runs executed
  locally (`COVERAGE_FILE=coverage-data-bindings uv run --locked
  --no-default-groups --group test pytest --cov`, then the equivalent
  `--group harness` run with the bindings actually uninstalled via `uv
  sync --exact`), `coverage combine` + `coverage report --fail-under=100`
  on the two data files reaches **exactly 100.00% (41485 statements, 0
  missed)** — so the mechanism is sound and the branch genuinely is
  reached only by the no-bindings run.
- But the `coverage` job's *own* single run has the bindings installed
  by construction, so that branch (and `tests/conftest.py`'s
  `_skip_what_needs_the_bindings`, gated on `INSTALLED` being False) is
  a structural miss in that report regardless of the union —
  `tests/no_bindings_test.py`'s subprocess trick reaches the branch
  within the `coverage` job too, but coverage.py does not collect
  subprocess coverage (`pyproject.toml`'s `[tool.coverage.run]` comment
  already says so, for an unrelated reason). Removing the pragma drops
  the delegated-alone report to 99.97% and fails that job's gate on its
  own, which the issue explicitly asks to leave unchanged.

So I left all three no-bindings-only pragmas in place
(`btclib/_libsecp256k1.py:86`, `tests/conftest.py:221` and `:256`), and
updated their comments to state this — tested, not assumed — reasoning
instead of the now-stale "no coverage run measures this" claim #995
left behind. I did not find any other pragma in the tree that exists
specifically because a line is reachable only in the no-bindings
configuration — the rest (`curves/curve.py`, `borromean.py`,
`dleq.py`, `dsa.py`, `ellswift.py`, `musig2.py`,
`psbt/musig2.py`, and the assertion-only ones under `tests/`) guard
branches arithmetic rules out or that only a delegated-bindings failure
reaches, unrelated to bindings absence.

**What the union does buy**, given none of today's pragmas move: it
answers the issue's second half, the "claim" nothing checked — that the
`no-bindings` job's tests actually *reach* every Python arm they're
meant to exercise. A `needs_bindings` marker drawn too wide, or new dead
code specific to either configuration, now shows up as a line neither
run covers, where before it would go unnoticed. That is real protection
even though it does not shrink today's pragma count.

## Cost

A third job, an artifact round trip in each direction, and the
`no-bindings` job's wall clock, now instrumented like the `coverage`
job's rather than the `suite` matrix's cells. CHANGELOG.md has the full
account.

## Verified locally

- `uv run pytest` — 28207 passed, 6 skipped, 100.00% coverage (the
  unchanged `coverage` job's own measurement, pragmas in place).
- `uv run pre-commit run --all-files` — every hook passes, actionlint
  and zizmor included.
- `uv run pytest tests/release_notes_test.py` — 3 passed (CHANGELOG
  format).
- `sphinx-build -W --keep-going -b html docs/source docs/build/html` —
  build succeeded, no warnings (touched `CONTRIBUTING.md`, which the
  docs pull in).
- The local `coverage combine` + `--fail-under=100` run described above,
  both with pragmas removed (100.00%, confirming reachability) and with
  them restored (also 100.00%, confirming the unchanged `coverage` job
  stays green).

What I could not validate locally: the actual multi-runner artifact
upload/download round trip — `actions/upload-artifact` and
`actions/download-artifact` only exist inside a real Actions run. The
local combine used two data files in one checkout instead of two
runners' artifacts, which exercises the coverage.py mechanics but not
the artifact plumbing itself. Please watch the first CI run on this PR
closely for exactly that reason — a wrong artifact name, a missing
`include-hidden-files`-style quirk (avoided here by naming the data
files without a leading dot), or a checkout path mismatch between jobs
would only show up there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Combine coverage from bindings and no-bindings CI runs while preserving independent coverage enforcement for the delegated configuration.

New Features:
- Add a CI job that combines coverage from the bindings and no-bindings test runs and enforces 100% coverage on the union.

Enhancements:
- Collect and preserve separate coverage data from both test configurations while retaining the existing delegated-run coverage gate.
- Clarify the rationale for retaining no-bindings-only coverage pragmas and document the updated coverage workflow.

CI:
- Extend the test workflow with coverage artifact upload/download, coverage combination, and union gating; include the new job in the aggregate test status.

Documentation:
- Update contributor guidance with commands for producing, combining, and reporting the two coverage datasets.

Chores:
- Record the coverage workflow and pragma decisions in the changelog.