### PR TITLE
ecc.dsa.Signer: derive/parse the public key once; wipe() refuses on the delegated arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1742,6 +1742,53 @@ documented at release-notes length in the first place, and are still in
   second verification pass on a path a caller catching
   `BTClibRuntimeError` may hit often. A comment at each raise records the
   decision, `dsa` and `ssa` read the same way as the issue asked.
+- **`ecc.dsa.Signer` signs several messages under one key, deriving and
+  parsing the public key once** (issue #1009, the fourth item of #982's
+  design, split out because the other three -- `verify` on `dsa.sign_`
+  and `dsa.sign`, the same keyword on both of `ssa`'s spellings and
+  `ssa.Signer`, and the grinding loop checking once rather than per
+  attempt -- had landed and this one had not). `sign_` derives the
+  public key whenever `verify` asks for a check, and on the delegated
+  arm parses it again where a compressed key costs a field square root;
+  a `Signer` holds both instead, one `mult` at construction -- the same
+  multiplication `gen_keys` makes -- and, where the bindings serve
+  `ec` and `hf`, one `_sec_from_pub_key` beside it.
+
+  | ECDSA signature, checked | `sign_` per call | one held `Signer` |
+  | --- | --- | --- |
+  | delegated arm | 31.4 µs | 24.5 µs |
+  | Python arm | 783.9 µs | 657.7 µs |
+
+  **What this does not hand the caller, unlike `ssa.Signer`, is the
+  lifetime of a secret, and that is a limit rather than an omission.**
+  BIP340 signing through the bindings takes a `secp256k1_keypair` --
+  memory this package owns and can overwrite, built once and reused for
+  every signature the object makes. ECDSA has no such object in
+  libsecp256k1: `secp256k1_ecdsa_sign` reads the key from a bare pointer
+  on every call, and the bindings' own wrapper builds that pointer by
+  coercing whatever was passed into a fresh immutable `bytes` object
+  first, on every call, whatever form the key arrived in --
+  `_scalar.scalar()` (btclib-secp256k1#247). So a `Signer` backed by the
+  delegated arm -- secp256k1 with sha256, the default -- hands the
+  bindings a new, unreachable copy of the key on every signature it
+  makes, and `wipe` would be promising an erasure the object structurally
+  cannot do. It raises `NotImplementedError` naming that issue instead of
+  dropping a reference and calling the drop a wipe, which is the shape
+  the class's own docstring argues is worse than not offering `wipe` at
+  all. On any other curve or hash function -- where every signature is
+  the Python arithmetic of `_sign_`, which never crosses into the
+  bindings -- `wipe` genuinely lets go of the scalar, an `int`'s own
+  limit aside: it cannot be overwritten, only dropped, which SECURITY.md
+  already states for the library at large. Which arm a given instance
+  uses is fixed at construction from `ec` and `hf` alone: `sign_` and
+  `sign` take no nonce, no lower-s override and no commitment, unlike the
+  free functions, so nothing a caller passes afterwards can move an
+  instance from one arm to the other -- `wipe`'s promise would otherwise
+  depend on a later call rather than on the object itself.
+
+  No `pub_key` argument either, matching `ssa.Signer`: every signature
+  checks under the key this object already holds, so there is nothing for
+  a caller to supply that is not already parsed.
 
 - **The Python arm's inventory of authorities that are not the bindings**
   (issue #993). The suite validates the Python arithmetic *against*

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -38,6 +38,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from hashlib import sha256
 from io import BytesIO
+from types import TracebackType
 from typing import TypeVar, overload
 
 from btclib import var_bytes
@@ -72,6 +73,7 @@ from btclib.utils import (
 
 __all__ = [
     "Sig",
+    "Signer",
     "anti_exfil_host_commit",
     "anti_exfil_host_verify",
     "anti_exfil_sign",
@@ -1189,6 +1191,256 @@ def sign_recoverable(
     """
     msg_hash = reduce_to_hlen(msg, hf)
     return sign_recoverable_(msg_hash, prv_key, nonce, lower_s, ec, hf)
+
+
+def _delegated_sign_(
+    msg_hash: bytes,
+    q: int,
+    grind: bool,
+    ec: Curve,
+    *,
+    verify: bool,
+    pubkey_sec: bytes,
+) -> Sig:
+    """`_libsecp256k1_sign_` over a public key already in SEC octets.
+
+    `Signer.sign_` calls this rather than `_libsecp256k1_sign_`: that one
+    takes `pub_key` however a caller spelled it and derives its SEC
+    encoding, `_sec_from_pub_key(pub_key)`, on every signature it checks.
+    A `Signer` derives its own public key once, at construction, so
+    handing it in already encoded is the second half of the floor it
+    exists for -- the parse `_libsecp256k1_sign_`'s own comment prices at
+    a field square root for a compressed key, and this call never pays
+    even the cheaper uncompressed one twice.
+
+    `pubkey_sec` is held back where `verify` declines the check it is
+    for -- the bindings refuse the pair, `pubkey is for the check that
+    verify=False declines`, the same contradiction `sign_` itself raises
+    on before anything is signed for a caller-supplied key. A `Signer`
+    cannot raise it the same way: the key is always its own and always
+    in hand, so passing it through unconditionally would turn a caller's
+    `verify=False` into that refusal on every call instead of the
+    cheaper signature it asked for.
+    """
+    try:
+        compact = libsecp256k1_dsa.sign(
+            msg_hash,
+            q,
+            None,
+            compact=True,
+            grind=grind,
+            verify=verify,
+            pubkey=pubkey_sec if verify else None,
+        )
+    except RuntimeError as e:  # pragma: no cover
+        # unreachable from an argument, as `_libsecp256k1_sign_`'s own is:
+        # what it reports is the computation having gone wrong
+        raise BTClibRuntimeError(str(e)) from e
+    return _sig_from_compact(compact, ec)
+
+
+class Signer:
+    """Sign several messages under one key, building the public key once.
+
+    `sign_` derives the public key, when `verify` asks for the check --
+    or the bindings do, on their own arm -- and parses it again where the
+    check is a compressed key's, throwing both away once the call
+    returns. This holds one across calls instead: `mult` once at
+    construction, the generator multiplication `gen_keys` pays, and on
+    the delegated arm the SEC encoding of it besides, so that
+    `_delegated_sign_` hands the bindings octets rather than a point to
+    re-derive. Both are read and never recomputed, which is the floor
+    issue #982 measured and this class is built to reach: a signature is
+    the arithmetic of `_sign_` or one call into the bindings either way,
+    and the check is what a held key removes from it.
+
+    **What this does not hand the caller is the lifetime of a secret,
+    and that is a limit rather than an omission.** `ssa.Signer` can,
+    because BIP340 signing through the bindings takes a
+    `secp256k1_keypair` -- a pointer into memory this package owns and
+    can overwrite, built once and reused for every signature the object
+    makes. ECDSA has no such object in libsecp256k1: `secp256k1_ecdsa_sign`
+    reads the private key from a bare pointer on every call, and the
+    bindings' own wrapper builds that pointer by coercing whatever was
+    passed -- an `int`, `bytes`, a `bytearray` -- into a fresh immutable
+    `bytes` object first, `_scalar.scalar()`, every time
+    (btclib-secp256k1#247). So a `Signer` backed by that arm does not
+    hold one copy of the secret it could later overwrite: it hands the
+    bindings a new, unreachable one on every signature it makes, for as
+    long as it is asked to sign, and `wipe` arriving afterwards would
+    have nothing of that trail left to reach. Promising erasure there
+    would be worse than not offering it, so `wipe` refuses outright
+    rather than pretending a dropped reference undoes what already
+    happened -- see its own docstring.
+
+    That is the delegated arm, secp256k1 with sha256 by default and
+    therefore the common case. On any other curve or hash function --
+    the bindings declining, or `curves.set_libsecp256k1_serving(False)`
+    turning them off for the whole process -- every signature is the
+    Python arithmetic of `_sign_`, which never crosses into the bindings
+    at all: the secret this object holds is a plain integer the whole of
+    its life, and `wipe` genuinely lets go of it, an `int`'s own limit
+    aside -- it cannot be overwritten, only dropped, which SECURITY.md's
+    limitations section states for the library at large. Which arm a
+    given instance uses is decided once, at construction, from `ec` and
+    `hf` alone: `sign_` and `sign` take no nonce, no lower-s override and
+    no commitment, unlike the free functions, precisely so that nothing
+    a caller passes afterwards could move an instance from one arm to
+    the other -- `wipe`'s promise would otherwise depend on an argument
+    to a later call rather than on the object itself.
+
+    No `pub_key` argument either, matching `ssa.Signer`: the point of
+    holding one is that every signature checks under it, so there is
+    nothing for a caller to supply that this object does not already
+    have parsed.
+    """
+
+    def __init__(
+        self, prv_key: PrvKey, ec: Curve = secp256k1, hf: HashF = sha256
+    ) -> None:
+        _assert_valid_hf(hf)
+        # the scalar, whatever spelling the key arrived in, and the
+        # validation with it -- this is a public constructor and the
+        # refusal belongs at it rather than at the first signature
+        self._q = int_from_prv_key(prv_key, ec)
+        self._ec = ec
+        self._hf = hf
+        self._hf_len = hf().digest_size
+
+        # derived once: the same multiplication `gen_keys` makes, paid
+        # here instead of on every signature that checks
+        Q = mult(self._q, ec=ec)
+        self._python_key: tuple[Point, frozenset[JacPoint]] = (Q, ec._fixed_points)
+
+        # parsed once too, and only where the delegated arm would
+        # otherwise re-derive it per call: `None` doubles as "this
+        # instance signs on the Python arm", the same role `ssa.Signer`
+        # gives `self._signer`, and is what `wipe` and `sign_` both read
+        # rather than asking `_libsecp256k1_serves` again -- the
+        # dispatch is decided once, at construction, and not
+        # reconsidered against a switch that may have moved since
+        self._pub_key_sec: bytes | None = (
+            _sec_from_pub_key(Q) if _libsecp256k1_serves(ec, hf) else None
+        )
+        self._wiped = False
+
+    def __enter__(self) -> Signer:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.wipe()
+
+    def wipe(self) -> None:
+        """Let go of the key, where letting go means something.
+
+        On the Python arm -- `self._pub_key_sec is None` -- the scalar
+        this object signs with is the whole of what it holds, and
+        dropping the reference is genuinely the end of its lifetime
+        here: nothing else in this package still has it, and a wiped
+        signer refuses to sign rather than signing with the zeros.
+        Idempotent, so that a caller may wipe a signer it is not sure
+        about; the `with` statement is the customary way to run one.
+
+        On the delegated arm this raises instead of doing that, and the
+        class docstring is where the reason is written in full: every
+        signature already made left an unreachable copy of the key in
+        the bindings' own memory, one that dropping `self._q` does
+        nothing about, so there is no operation left here whose name
+        could honestly be `wipe`. `NotImplementedError` and not
+        `BTClibValueError` or a silent no-op -- `sign_`'s "the signer is
+        wiped" is a caller who asked to keep using a signer that has
+        already let go, which is not this: this is a caller asking for
+        an erasure that btclib-secp256k1#247 makes unavailable, so the
+        signer itself is not marked wiped and goes on signing exactly as
+        before, waiting for that issue to close.
+        """
+        if self._pub_key_sec is not None:
+            raise NotImplementedError(
+                "the bindings coerce a private key into a fresh immutable "
+                "bytes object on every ECDSA signature, and libsecp256k1 "
+                "holds no persistent keypair for ECDSA the way it does for "
+                "BIP340 -- so this signer keeps no secret that wiping "
+                "could reach, and every signature already made left one "
+                "nothing here can overwrite (btclib-secp256k1#247)"
+            )
+        self._q = 0
+        self._wiped = True
+
+    def sign_(
+        self, msg_hash: Octets, *, grind: bool = True, verify: bool = True
+    ) -> bytes:
+        """Return the signature of a hf_len bytes message, as DER octets.
+
+        grind and verify are `sign_`'s own, over the key and public key
+        this signer already holds: grinding is Core's low-R search and
+        the default pairs with it, `verify` is the post-sign check BIP66
+        does not ask for and Bitcoin Core's `CKey::Sign` always makes,
+        and declining it is the caller's to do, exactly as the free
+        function documents. No `nonce`, `lower_s` override or
+        `commit_hash` -- see the class docstring for why the arm this
+        instance uses has to stay the one decided at construction.
+        """
+        if self._wiped:
+            raise BTClibValueError("the signer is wiped")
+
+        # a kind, as `sign_`'s own is and for the same reason: it decides
+        # which signature comes back, so it is not read for its truth
+        assert_type(grind, bool, "grind")
+
+        msg_hash = bytes_from_octets(msg_hash, self._hf_len)
+
+        if self._pub_key_sec is not None:
+            sig = _delegated_sign_(
+                msg_hash,
+                self._q,
+                grind,
+                self._ec,
+                verify=verify,
+                pubkey_sec=self._pub_key_sec,
+            )
+            # check_validity=False, as `_libsecp256k1_sign_`'s own answer
+            # is: these are the bindings' own computed scalars
+            return sig.serialize(check_validity=False)
+
+        # the challenge
+        c = challenge_(msg_hash, self._ec, self._hf)
+
+        def _checked(signature: Sig) -> Sig:
+            # `given=None` always: this object checks under its own key
+            # and takes no other, so there is nothing to trust and
+            # nothing to discriminate against -- `_abort_unless_checked`
+            # still carries the rule for the one key there is
+            if verify:
+                _abort_unless_checked(
+                    lambda key: _python_verified(c, signature, self._ec, key),
+                    lambda: self._python_key,
+                    None,
+                )
+            return signature
+
+        sig = _grind_low_r(
+            lambda counter: _sign_(
+                c,
+                self._q,
+                _rfc6979_nonce_(
+                    c, self._q, self._ec, self._hf, _grind_entropy(counter)
+                ),
+                True,
+                self._ec,
+            ),
+            grind,
+            self._ec,
+        )
+        return _checked(sig).serialize()
+
+    def sign(self, msg: Octets, *, grind: bool = True, verify: bool = True) -> bytes:
+        """Return the signature of a message, reducing it with hf first."""
+        return self.sign_(reduce_to_hlen(msg, self._hf), grind=grind, verify=verify)
 
 
 def _assert_as_valid_(

--- a/tests/bool_parameter_test.py
+++ b/tests/bool_parameter_test.py
@@ -376,6 +376,15 @@ _KINDS = (
         {"msg_hash": _MSG_HASH, "prv_key": _PRV_KEY},
     ),
     _Case("btclib.ecc.dsa.sign", "grind", dsa.sign, {"msg": _MSG, "prv_key": _PRV_KEY}),
+    _Case(
+        "btclib.ecc.dsa.Signer.sign_",
+        "grind",
+        dsa.Signer(_PRV_KEY).sign_,
+        {"msg_hash": _MSG_HASH},
+    ),
+    _Case(
+        "btclib.ecc.dsa.Signer.sign", "grind", dsa.Signer(_PRV_KEY).sign, {"msg": _MSG}
+    ),
     # the script engine: `segwit` says which digest a signature commits
     # to and which script code it is checked against, so it is a
     # consensus answer and not a check
@@ -760,6 +769,20 @@ _TRUTHS = (
         "verify",
         dsa.sign,
         {"msg": _MSG, "prv_key": _PRV_KEY},
+        reason="whether the signature is checked before it is answered with",
+    ),
+    _Case(
+        "btclib.ecc.dsa.Signer.sign_",
+        "verify",
+        dsa.Signer(_PRV_KEY).sign_,
+        {"msg_hash": _MSG_HASH},
+        reason="whether the signature is checked before it is answered with",
+    ),
+    _Case(
+        "btclib.ecc.dsa.Signer.sign",
+        "verify",
+        dsa.Signer(_PRV_KEY).sign,
+        {"msg": _MSG},
         reason="whether the signature is checked before it is answered with",
     ),
     _Case(

--- a/tests/curve_parameter_test.py
+++ b/tests/curve_parameter_test.py
@@ -254,6 +254,11 @@ _CASES = (
         dsa.Sig,
         {"r": _DSA_SIG.r, "s": _DSA_SIG.s},
     ),
+    _Case(
+        "btclib.ecc.dsa.Signer.__init__",
+        dsa.Signer,
+        {"prv_key": _PRV_KEY},
+    ),
     _Case("btclib.ecc.dsa.gen_keys", dsa.gen_keys, {"prv_key": _PRV_KEY}),
     # the same function with the key it draws itself, which is the branch
     # that reads n off the curve rather than reaching int_from_prv_key

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -2136,3 +2136,228 @@ def test_sign_recoverable_asks_the_bindings_to_verify(
         dsa.sign_recoverable_(msg_hash, q)
 
     assert calls == [True]
+
+
+@pytest.mark.parametrize("bindings", _ARMS)
+def test_a_signer_answers_what_sign_answers(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A held key changes what a signature costs and not what it is.
+
+    `Signer.sign_` is `sign_` over a key derived once, so the two answer
+    the same DER octets -- asserted with `verify` both ways and over
+    both `sign_` and `sign`, which reduces with hf first as the free
+    spelling does. And over the arm that holds no bindings key at all --
+    a curve or a hash function the bindings decline -- where `sign_` is
+    the whole of the implementation.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    q, Q = dsa.gen_keys(prv_key_int)
+
+    # not a `with` block: on the delegated arm `wipe` -- which `__exit__`
+    # calls -- refuses rather than running, and this signer is used for
+    # nothing but comparing signatures
+    signer = dsa.Signer(prv_key_int)
+    for msg in (b"", b"a message", bytes(32), bytes(1000)):
+        msg_hash = reduce_to_hlen(msg)
+        for verify in (True, False):
+            expected = dsa.sign_(msg_hash, q, verify=verify).serialize()
+            assert signer.sign_(msg_hash, verify=verify) == expected
+            assert (
+                signer.sign(msg, verify=verify)
+                == dsa.sign(msg, q, verify=verify).serialize()
+            )
+        assert dsa.verify_(msg_hash, Q, signer.sign_(msg_hash))
+
+    # grind reaches the same loop `sign_` walks on both arms
+    for grind in (True, False):
+        expected = dsa.sign(b"grind", q, grind=grind).serialize()
+        assert signer.sign(b"grind", grind=grind) == expected
+
+
+def test_a_signer_derives_and_parses_the_public_key_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The floor this class is for: held once, and never recomputed.
+
+    `Signer.__init__` derives the public key with one `mult` -- the same
+    multiplication `gen_keys` makes -- and on the delegated arm parses it
+    into SEC octets once with `_sec_from_pub_key`, `_delegated_sign_`'s
+    own docstring pricing that parse. What a later `sign_` call reads is
+    the object `__init__` built, asserted here by its identity rather
+    than by a call count: `mult` is not this class's alone, the Python
+    arm's own nonce point costing one per signature, so counting every
+    call would conflate the two. `_sec_from_pub_key` has no such second
+    caller on this path, so it is counted as well, for the one call the
+    constructor is asked to make and `_delegated_sign_` never repeats.
+    """
+    # `getattr`, not `dsa._sec_from_pub_key`: the name is imported into
+    # `dsa` rather than defined there, so mypy's `--no-implicit-reexport`
+    # refuses the plain attribute read even though `setattr` below patches
+    # the same name -- and has to, `Signer.__init__` reading the copy
+    # `from ... import` bound in `dsa`'s own namespace and not a fresh
+    # lookup in `to_pub_key`
+    real_sec = getattr(dsa, "_sec_from_pub_key")  # noqa: B009
+    sec_calls: list[object] = []
+
+    def counting_sec(*args: Any, **kwargs: Any) -> Any:
+        sec_calls.append(1)
+        return real_sec(*args, **kwargs)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(dsa, "_sec_from_pub_key", counting_sec)
+        signer = dsa.Signer(prv_key_int)
+        assert sec_calls == [1]
+        python_key = signer._python_key
+        pub_key_sec = signer._pub_key_sec
+        assert pub_key_sec is not None
+
+        for msg in (b"a", b"b", b"c"):
+            signer.sign(msg)
+        assert sec_calls == [1]
+        assert signer._python_key is python_key
+        assert signer._pub_key_sec is pub_key_sec
+
+    with monkeypatch.context() as patch:
+        no_bindings(patch)
+        python_signer = dsa.Signer(prv_key_int)
+        assert python_signer._pub_key_sec is None
+        held = python_signer._python_key
+
+        for msg in (b"a", b"b", b"c"):
+            python_signer.sign(msg)
+        assert python_signer._python_key is held
+
+
+def test_a_signer_refuses_what_the_constructor_refuses() -> None:
+    """The key and the hash function are read at the constructor.
+
+    A public constructor, so the refusal belongs at it rather than at
+    the first signature -- which is the only place a caller could hear
+    it, the public key being derived here.
+    """
+    with pytest.raises(BTClibValueError, match="private key not in 1..n-1"):
+        dsa.Signer(0)
+    with pytest.raises(BTClibValueError, match="private key not in 1..n-1"):
+        dsa.Signer(secp256k1.n)
+    with pytest.raises(BTClibTypeError):
+        dsa.Signer(prv_key_int, secp256k1, "not a hash function")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bindings", _ARMS)
+def test_the_arms_refuse_a_signature_that_does_not_verify(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The check is wired to the raise, not merely written near it.
+
+    No input reaches it -- a fresh signature verifies under the key that
+    made it -- so what says the branch is live is a substituted
+    verification: the bindings' own `_verify_` for the delegated arm,
+    `_python_verified` for the Python one, each where its own check
+    lives. Nothing about either refusal is fabricated, so the sentence
+    is the one the real implementation raises.
+    """
+    msg = b"a message whose check is made to fail"
+
+    if bindings:
+        signer = dsa.Signer(prv_key_int)
+        with monkeypatch.context() as patch:
+            patch.setattr(libsecp256k1_dsa, "_verify_", lambda *_, **__: False)
+            with pytest.raises(BTClibRuntimeError, match="does not verify"):
+                signer.sign(msg)
+            # verify=False never reaches the substituted check
+            signer.sign(msg, verify=False)
+        return
+
+    no_bindings(monkeypatch)
+    signer = dsa.Signer(prv_key_int)
+    with monkeypatch.context() as patch:
+        patch.setattr(dsa, "_python_verified", lambda *_, **__: False)
+        with pytest.raises(BTClibRuntimeError, match="does not verify"):
+            signer.sign(msg)
+        signer.sign(msg, verify=False)
+
+
+def test_a_wiped_python_signer_refuses_rather_than_signing_with_the_zeros(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The lifetime a signer hands its caller, on the arm that can give it.
+
+    `wipe` is the instruction and the `with` block is how to give it
+    without having to remember; both leave a signer that refuses, and
+    neither can be undone -- what the signer held it no longer holds. On
+    this arm the scalar is the whole of what signing needs, so dropping
+    it is genuinely the end of this signer's lifetime, an `int`'s own
+    limit aside.
+    """
+    no_bindings(monkeypatch)
+
+    signer = dsa.Signer(prv_key_int)
+    assert signer.sign_(sha256(b"a message").digest())
+    assert signer._q
+    signer.wipe()
+    assert not signer._q
+    with pytest.raises(BTClibValueError, match="the signer is wiped"):
+        signer.sign_(sha256(b"a message").digest())
+    # idempotent, as `close` is on the signer contract
+    signer.wipe()
+    assert not signer._q
+
+    with dsa.Signer(prv_key_int) as block_signer:
+        assert block_signer.sign(b"a message")
+    with pytest.raises(BTClibValueError, match="the signer is wiped"):
+        block_signer.sign(b"a message")
+
+    # and the block wipes on the way out of an exception too
+    raising = dsa.Signer(prv_key_int)
+    with pytest.raises(ZeroDivisionError), raising:
+        _ = 1 / 0
+    with pytest.raises(BTClibValueError, match="the signer is wiped"):
+        raising.sign(b"a message")
+
+
+@needs_bindings
+def test_a_delegated_signer_s_wipe_refuses_rather_than_pretending() -> None:
+    """`wipe` here would be a promise this arm cannot keep, so it refuses.
+
+    ECDSA has no libsecp256k1 keypair the way BIP340 does: every
+    signature this arm makes hands the bindings a fresh, unreachable copy
+    of the key (btclib-secp256k1#247), so there is no persistent secret a
+    later `wipe` could still reach -- unlike the Python arm, dropping
+    `self._q` here would not undo anything already done. `NotImplementedError`
+    says so rather than a silent no-op that would let a caller believe
+    the key is gone, and the signer is left exactly as usable as before,
+    the refusal not being recorded as a wipe.
+    """
+    signer = dsa.Signer(prv_key_int)
+    assert signer.sign(b"a message")
+
+    with pytest.raises(NotImplementedError, match="btclib-secp256k1#247"):
+        signer.wipe()
+    # refused, not silently accepted: the signer still holds its key and
+    # still signs, which is what "not marked wiped" means in practice
+    assert signer.sign(b"a message")
+    with pytest.raises(NotImplementedError, match="btclib-secp256k1#247"):
+        signer.wipe()
+
+    # the `with` statement wipes on the way out, so it raises too -- even
+    # where the block signed nothing and ended cleanly
+    with (
+        pytest.raises(NotImplementedError, match="btclib-secp256k1#247"),
+        dsa.Signer(prv_key_int) as block_signer,
+    ):
+        assert block_signer.sign(b"a message")
+
+    # and where the block itself raised, python's own `with` semantics
+    # are what decide the outcome and not this class's: `__exit__`
+    # raising a new exception replaces the one the block was propagating,
+    # chaining it on as `__context__` rather than losing it -- a caller
+    # who wants to know the block itself failed reads that attribute
+    with (
+        pytest.raises(NotImplementedError, match="btclib-secp256k1#247") as raised,
+        dsa.Signer(prv_key_int),
+    ):
+        _ = 1 / 0
+    assert isinstance(raised.value.__context__, ZeroDivisionError)

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -2177,6 +2177,7 @@ def test_a_signer_answers_what_sign_answers(
         assert signer.sign(b"grind", grind=grind) == expected
 
 
+@needs_bindings
 def test_a_signer_derives_and_parses_the_public_key_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -128,6 +128,8 @@ KEYWORD_ONLY: dict[str, list[str]] = {
     "btclib.ecc.dsa:Sig.__init__": ["check_validity"],
     "btclib.ecc.dsa:Sig.parse": ["check_validity", "strict"],
     "btclib.ecc.dsa:Sig.serialize": ["check_validity"],
+    "btclib.ecc.dsa:Signer.sign": ["grind", "verify"],
+    "btclib.ecc.dsa:Signer.sign_": ["grind", "verify"],
     "btclib.ecc.dsa:assert_as_valid": ["commit", "receipt"],
     "btclib.ecc.dsa:assert_as_valid_": ["commit_hash", "receipt"],
     "btclib.ecc.dsa:sign": ["grind", "verify", "pub_key", "commit"],

--- a/tests/python_arm_authority_test.py
+++ b/tests/python_arm_authority_test.py
@@ -51,9 +51,9 @@ than "this vector reaches this arm" and is what the measurement supports.
 Sharpening it means selecting the vector-driven tests within a module,
 which no marker in the tree expresses today.
 
-Three arms are reached by no such module at all, and two of them are the
-answer to the second half of issue #993 -- where nothing says it, what
-would:
+Some arms are reached by no such module at all, and some of those are
+the answer to the second half of issue #993 -- where nothing says it,
+what would:
 
 - `ecc.commit_nonce.commit_nonce_`, the sign-to-contract nonce tweak.
   There is no published vector set to vendor: the primitive is

--- a/tests/python_arm_authority_test.py
+++ b/tests/python_arm_authority_test.py
@@ -51,14 +51,21 @@ than "this vector reaches this arm" and is what the measurement supports.
 Sharpening it means selecting the vector-driven tests within a module,
 which no marker in the tree expresses today.
 
-Two arms are reached by no such module at all, and they are the answer to
-the second half of issue #993 -- where nothing says it, what would:
+Three arms are reached by no such module at all, and two of them are the
+answer to the second half of issue #993 -- where nothing says it, what
+would:
 
 - `ecc.commit_nonce.commit_nonce_`, the sign-to-contract nonce tweak.
   There is no published vector set to vendor: the primitive is
   libsecp256k1-zkp's `s2c` module, whose vectors are C, and no BIP states
   it. Closing this means either vendoring what that module tests itself
   against, or a comparison against a second Python implementation.
+- `ecc.dsa.__init__`, `Signer`'s constructor (issue #1009). Every
+  existing third-party vector reaches `dsa.sign_` or
+  `dsa.assert_as_valid_` directly, through the free functions, and
+  nothing yet builds a `Signer` over one. Closing this means pointing
+  one of those same modules at the class instead, which is a test to
+  write rather than a vector to find.
 - `ecc.dsa.recover_pub_keys_`, the plural spelling. `signmessage.json`
   reaches the singular `recover_pub_key_` through `ecc.bms`, and nothing
   third-party asks for every key_id of one signature at once -- a message
@@ -143,6 +150,7 @@ _AUTHORITY: dict[str, tuple[str, ...]] = {
     "ecc.bms.assert_as_valid": ("ecc/bms_test.py", "bip322_test.py"),
     "ecc.commit_nonce.commit_nonce_": (),
     "ecc.dh.diffie_hellman": ("ecc/wycheproof_test.py",),
+    "ecc.dsa.__init__": (),
     "ecc.dsa.assert_as_valid_": (
         "ecc/wycheproof_test.py",
         "script_engine/transactions_test.py",
@@ -178,7 +186,11 @@ _AUTHORITY: dict[str, tuple[str, ...]] = {
 # the two the measurement found nothing for, named so that closing one is
 # a line deleted here rather than a number nobody re-derives
 _WITHOUT_AN_AUTHORITY = frozenset(
-    {"ecc.commit_nonce.commit_nonce_", "ecc.dsa.recover_pub_keys_"}
+    {
+        "ecc.commit_nonce.commit_nonce_",
+        "ecc.dsa.__init__",
+        "ecc.dsa.recover_pub_keys_",
+    }
 )
 
 

--- a/tests/python_arm_authority_test.py
+++ b/tests/python_arm_authority_test.py
@@ -183,8 +183,8 @@ _AUTHORITY: dict[str, tuple[str, ...]] = {
     ),
 }
 
-# the two the measurement found nothing for, named so that closing one is
-# a line deleted here rather than a number nobody re-derives
+# the ones the measurement found nothing for, named so that closing one
+# is a line deleted here rather than a number nobody re-derives
 _WITHOUT_AN_AUTHORITY = frozenset(
     {
         "ecc.commit_nonce.commit_nonce_",
@@ -252,7 +252,7 @@ def test_every_python_arm_is_in_the_inventory() -> None:
     )
 
 
-def test_the_arms_without_an_authority_are_the_two_that_are_known() -> None:
+def test_the_arms_without_an_authority_are_the_ones_that_are_known() -> None:
     """Empty entries and the named set are one fact, stated twice."""
     empty = {arm for arm, sources in _AUTHORITY.items() if not sources}
     assert empty == _WITHOUT_AN_AUTHORITY, (


### PR DESCRIPTION
Addresses #1009. Does not close it: the issue is explicit that a
`dsa.Signer` genuinely wipeable on the delegated arm waits on
btclib-secp256k1#247, upstream and unresolved, so this lands only the
part the issue says is not blocked and leaves the issue open for the
rest.

## Investigation (issue's parts (a) and (b))

**(a) — can the pure-Python signing arithmetic run end-to-end without
ever routing the key through the bindings' `bytes` coercion?**

Yes, unconditionally. `dsa._sign_`/`_sign_recoverable_`
(`btclib/ecc/dsa.py:507-512`, `432-504`) are plain modular arithmetic
over `q` as a Python `int` — no bindings call anywhere in the signing
computation itself, on any curve or hash function the bindings decline.
This holds regardless of which arm handles the *rest* of a `Signer`'s
work.

The qualifier: the post-sign check is not free of the same problem.
`dsa._abort_unless_checked`'s `derive` callback
(`btclib/ecc/dsa.py:616-676`, called from `sign_`'s own `_checked` at
`953-957`) computes `mult(q, ec.G, ec)` — the public key — and on
secp256k1, `curves.curve._mult_checked`
(`btclib/curves/curve.py:803-811`) dispatches a nonzero-scalar
generator multiplication to `libsecp256k1_pubkey_from_prvkey(m, ...)`,
which itself calls `_scalar.scalar()`
(`btclib_secp256k1/_secret.py:229` via `keys.py`), coercing the raw
private key to an immutable `bytes` object — the very defect #1009
describes, just reached through key *derivation* rather than through
`dsa.sign`. So "Python arm, genuinely wipeable, ordinary secp256k1
ECDSA" is not one free combination: it needs the check declined
(`verify=False`) or a correct `pub_key` supplied so `derive()` is never
reached — a narrower claim than "the Python arm is always safe", but a
real and reachable one.

**(b) — is the arm decided once, at construction, or dynamically
per-call?**

`dsa.sign_`'s own dispatch condition is
`_libsecp256k1_serves(ec, hf) and nonce is None and lower_s and
commit_hash is None` (`btclib/ecc/dsa.py:926-934`) — four conditions,
three of them per-call arguments. A `Signer` exposing `nonce`,
`commit_hash` or a `lower_s` override could not pin its arm at
construction. `ssa.Signer` already avoids this by not exposing a nonce
or a commitment on its signing methods, so its dispatch reduces to
`_libsecp256k1_serves(ec, hf)` alone, evaluated once
(`btclib/ecc/ssa.py:700-702`) and never revisited. `dsa.Signer` copies
that narrowing: `sign_`/`sign` take no `nonce`, no `lower_s` override
and no `commit_hash`, so the arm is `_libsecp256k1_serves(ec, hf)`,
fixed at `__init__` and read from a cached attribute
(`self._pub_key_sec is not None`) thereafter, exactly as `ssa.Signer`
already does with `self._signer`.

**A structural asymmetry (a) and (b) alone don't cover, found while
implementing**: `btclib_secp256k1`'s ECDSA wrapper
(`btclib_secp256k1/dsa.py`) has no keypair-like persistent object at
all — `secp256k1_ecdsa_sign` takes a raw seckey pointer, so `dsa.sign()`
calls `scalar(prvkey, ...)` fresh on *every* call
(`btclib_secp256k1/dsa.py:382`). `ssa`'s bindings build a
`secp256k1_keypair` once (`btclib_secp256k1/_secret.py:229`, called
from `ssa.Signer.__init__`) and reuse it — one `bytes` coercion at
construction, then a real, wipeable C buffer for every signature after.
ECDSA has no such buffer to hold or wipe: a `Signer` on the delegated
arm would manufacture a fresh, unreachable `bytes` copy on *every*
signature for its whole life, and there is nothing `wipe()` could ever
reach — not "weaker than `ssa.Signer`", but a different, structurally
worse situation that a `wipe()` mirroring `ssa.Signer`'s shape would
misrepresent.

## Decision

Implemented, with `wipe()`/`__exit__` scoped so they never overclaim:

- **Python arm** (any curve/hash function the bindings decline, or
  `set_libsecp256k1_serving(False)`): `wipe()` genuinely drops the
  scalar and refuses further signing — the same partial promise
  `ssa.Signer` already makes on its own weaker arm, and no worse.
- **Delegated arm** (secp256k1 + sha256, the default): `wipe()` raises
  `NotImplementedError` naming btclib-secp256k1#247, rather than
  silently no-op-ing or dropping a reference and calling it a wipe.
  `__exit__` calls `wipe()`, so `with dsa.Signer(key) as s: ...` raises
  on exit on this arm too — deliberately, not a bug: Python's own
  `with` semantics replace whatever the block was propagating and chain
  it as `__context__`, tested explicitly.

What's landed either way, independent of `wipe()`: the public key
derived once at construction (`mult`, the same multiplication
`gen_keys` makes) and, on the delegated arm, parsed once into SEC
octets — removing the per-call derivation `dsa.sign_`'s own check pays.
Measured on this branch (not copied from the issue, which measured the
check alone rather than a full signature):

| ECDSA signature, checked | `sign_` per call | one held `Signer` |
| --- | --- | --- |
| delegated arm | 31.4 µs | 24.5 µs |
| Python arm | 783.9 µs | 657.7 µs |

## What's in this PR

- `btclib/ecc/dsa.py`: `Signer` class and a private `_delegated_sign_`
  helper (signs over an already-SEC-encoded public key, so the
  delegated arm never re-derives it per call — `_libsecp256k1_sign_`
  would, since it takes `pub_key` however a caller spelled it).
- Tests: round trip against the free functions on both arms
  (`no_bindings` for the Python one), `verify=True/False`, `grind`,
  constructor refusals, the `_abort_unless_checked`-style refusal path
  on both arms (bindings' own `_verify_` faulted for the delegated arm,
  `dsa._python_verified` for the Python one), `wipe()`/context-manager
  behavior explicitly checked on both arms (Python arm: `_q` actually
  zeroed, idempotent, refuses after; delegated arm: raises, object
  stays usable, exception chaining verified) — no test merely asserts
  `wipe()` "doesn't crash".
- Four meta/inventory registries updated for the new surface:
  `tests/keyword_only_test.py`, `tests/curve_parameter_test.py`,
  `tests/python_arm_authority_test.py` (`ecc.dsa.__init__` added
  without a third-party-vector authority, alongside the two existing
  entries), `tests/bool_parameter_test.py` (`grind` classified as a
  kind, `verify` as a truth, matching the free functions).
- CHANGELOG.md entry under "Curves, signatures and keys", stating what
  landed, what's still blocked and why, linking
  btclib-secp256k1#247 by number.

## Gates

`uv run pytest` (100% coverage), `uv run pre-commit run --all-files`
(mypy strict included), and the sphinx `-W --keep-going` docs build all
pass locally.

**Flagging for careful review**: this is private-key-handling code, and
the central claim — that `wipe()` must refuse rather than approximate
on the delegated arm — is a judgment call I'd like checked rather than
taken on faith.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a reusable ECDSA signer that caches public-key data and makes key wiping behavior explicit for each signing backend.

New Features:
- Add `ecc.dsa.Signer` for signing multiple messages with a key whose public key is derived once and reused across signatures.

Bug Fixes:
- Prevent delegated ECDSA signing from repeatedly deriving and parsing the public key for each checked signature.

Enhancements:
- Fix signer dispatch at construction time based on curve and hash function, keeping the signing arm stable across calls.
- Provide arm-specific key lifecycle behavior: Python-arm signers can be wiped and reject further signing, while delegated-arm wiping explicitly refuses because the underlying bindings cannot safely erase per-call key copies.
- Support context-manager cleanup through `__enter__` and `__exit__`, including explicit failure behavior when delegated-arm wiping is unavailable.

Documentation:
- Document the new signer API, its performance characteristics, and the delegated-arm wiping limitation in the changelog.

Tests:
- Add coverage for signer parity with the existing signing functions, key derivation and parsing reuse, constructor validation, verification failures, wiping, and context-manager behavior across both signing arms.
- Register the new signer API in keyword-only, curve-parameter, boolean-parameter, and Python-arm authority test inventories.