### PR TITLE
Re-derive the Python-arm authority table monthly (issue #1003)

### DIFF
--- a/.github/scripts/check_python_arm_authority.py
+++ b/.github/scripts/check_python_arm_authority.py
@@ -1,0 +1,160 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Re-derive tests/python_arm_authority_test.py's `_AUTHORITY`, monthly.
+
+That file's docstring documents the measurement by hand: per third-party
+test module, in an environment with no bindings installed,
+
+    uv sync --no-default-groups --group harness
+    pytest <one module> --cov=btclib --cov-report=json --cov-fail-under=0
+
+reading back which lines of each Python arm ran, the `def` line excluded
+since it runs at import regardless of whether the function is ever
+called. `_AUTHORITY`'s entries were built that way once and are re-run by
+nothing -- issue #1003: a test module that stops exercising an arm keeps
+the arm's entry, and the claim goes stale on an otherwise green suite.
+
+This repeats the measurement, module by module over every module named in
+`_THIRD_PARTY_VECTORS`, and diffs the result against `_AUTHORITY` in both
+directions plus the one `_WITHOUT_AN_AUTHORITY` exists to notice:
+
+- an entry claims a module whose run no longer reaches the arm --
+  STALE, the harmful direction, an entry that outlived what made it true;
+- a module's run reaches an arm its entry does not name -- UNDERSTATED,
+  benign and still worth a line, since the entry is not wrong, only
+  incomplete;
+- something now reaches an arm in `_WITHOUT_AN_AUTHORITY` -- NEW
+  AUTHORITY, the good news that set exists to pick up.
+
+Reuses `tests/python_arm_authority_test.py`'s own `_arm_locations` for
+where each arm's body lives rather than re-walking the AST: one parser,
+one definition of "arm", read by the shape tests, the content tests and
+this script alike.
+
+    uv sync --no-default-groups --group harness
+    python .github/scripts/check_python_arm_authority.py
+
+Not a gate: `.github/workflows/python-arm-authority.yml` runs this on a
+schedule, with no branch rule attached, for the reason `vendored-vectors`
+and `published` already establish -- eighteen modules under coverage is
+minutes, and it answers a question no pull request introduces.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_ROOT))
+
+from tests.python_arm_authority_test import (  # noqa: E402
+    _AUTHORITY,
+    _THIRD_PARTY_VECTORS,
+    _WITHOUT_AN_AUTHORITY,
+    _arm_locations,
+)
+
+
+def _run_coverage(module: str, report_path: Path) -> dict[str, set[int]]:
+    """Run tests/<module> under coverage and return its executed lines by file.
+
+    The exact command the docstrings of this file and
+    tests/python_arm_authority_test.py both give, `--cov-report` pointed
+    at a file of its own so each module's run leaves the others untouched.
+    `check=True`: a test module failing outright is not a disagreement
+    this script is built to phrase, and is worth a loud traceback rather
+    than a silently empty coverage report.
+    """
+    subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            f"tests/{module}",
+            "--cov=btclib",
+            f"--cov-report=json:{report_path}",
+            "--cov-fail-under=0",
+        ],
+        cwd=_ROOT,
+        check=True,
+    )
+    data = json.loads(report_path.read_text(encoding="utf-8"))
+    return {file: set(info["executed_lines"]) for file, info in data["files"].items()}
+
+
+def _reached(
+    executed_by_file: dict[str, set[int]],
+    locations: dict[str, tuple[Path, int, int]],
+) -> set[str]:
+    """Return every arm this one run's coverage reached, `def` line excluded."""
+    reached = set()
+    for arm, (path, start, end) in locations.items():
+        rel = str(path.relative_to(_ROOT))
+        if executed_by_file.get(rel, set()) & set(range(start, end + 1)):
+            reached.add(arm)
+    return reached
+
+
+def measure() -> dict[str, frozenset[str]]:
+    """Return, for every arm, the third-party modules that actually reach it.
+
+    One coverage run per module named in `_THIRD_PARTY_VECTORS`, each
+    against a fresh report file so one module's measurement cannot leak
+    into another's.
+    """
+    locations = _arm_locations()
+    actual: dict[str, set[str]] = {arm: set() for arm in locations}
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        for index, module in enumerate(sorted(_THIRD_PARTY_VECTORS)):
+            print(f"measuring {module} ...")
+            executed = _run_coverage(module, tmp_path / f"{index}.json")
+            for arm in _reached(executed, locations):
+                actual[arm].add(module)
+    return {arm: frozenset(modules) for arm, modules in actual.items()}
+
+
+def compare(actual: dict[str, frozenset[str]]) -> list[str]:
+    """Return one line per arm whose measured reach disagrees with `_AUTHORITY`.
+
+    Each line is prefixed STALE, UNDERSTATED or NEW AUTHORITY, the three
+    directions this file's own docstring names.
+    """
+    mismatches = []
+    for arm, claimed in sorted(_AUTHORITY.items()):
+        found = actual.get(arm, frozenset())
+        stale = set(claimed) - found
+        understated = found - set(claimed)
+        if stale:
+            mismatches.append(
+                f"STALE: {arm} claims {sorted(stale)}, whose run no longer reaches it"
+            )
+        if understated:
+            label = "NEW AUTHORITY" if arm in _WITHOUT_AN_AUTHORITY else "UNDERSTATED"
+            mismatches.append(
+                f"{label}: {arm} is reached by {sorted(understated)},"
+                " not named in its entry"
+            )
+    return mismatches
+
+
+def main() -> int:
+    """Measure, compare, print, and fail on any disagreement found."""
+    mismatches = compare(measure())
+    for line in mismatches:
+        print(line)
+    if mismatches:
+        print(f"{len(mismatches)} disagreement(s) with a fresh measurement.")
+        return 1
+    print("Every _AUTHORITY entry matches a fresh no-bindings measurement.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_python_arm_authority.py
+++ b/.github/scripts/check_python_arm_authority.py
@@ -38,7 +38,7 @@ this script alike.
 
 Not a gate: `.github/workflows/python-arm-authority.yml` runs this on a
 schedule, with no branch rule attached, for the reason `vendored-vectors`
-and `published` already establish -- eighteen modules under coverage is
+and `published` already establish -- every module under coverage is
 minutes, and it answers a question no pull request introduces.
 """
 

--- a/.github/workflows/python-arm-authority.yml
+++ b/.github/workflows/python-arm-authority.yml
@@ -1,0 +1,118 @@
+---
+name: python arm authority
+
+# tests/python_arm_authority_test.py's `_AUTHORITY` says, per Python arm,
+# which third-party-vector-driven test module reaches it -- issue #993's
+# answer, landed by #1000. Its own four tests check the table's shape
+# against the source and against itself, and none of them re-runs the
+# coverage that produced its values, because that measurement is minutes
+# and not seconds: eighteen modules, each under coverage, each in an
+# environment with no bindings installed. Issue #1003 is this workflow --
+# a pull request should not pay what a schedule can pay once a month.
+#
+# This reimplements the no-bindings environment test.yml's own
+# `no-bindings` job builds, rather than depending on issue #1002's
+# coverage-artifact plumbing: that issue is a separate, unmerged pull
+# request, and until it lands -- if it lands -- there is no artifact here
+# to consume. Once it does, the two assert-and-sync steps below could
+# become a download instead, which is the simplification #1003 itself
+# names as the reason it "depends on #1002, or at least on the same
+# plumbing".
+#
+# `.github/scripts/check_python_arm_authority.py` does the comparing: it
+# imports `_AUTHORITY` straight from the test module rather than parsing
+# a second copy of it, runs each of the eighteen third-party-vector
+# modules under coverage on its own, and diffs what it measures against
+# what the table claims, in every direction issue #1003 names -- an
+# entry citing a module whose run no longer reaches the arm, a module
+# reaching an arm its entry does not name, and something newly reaching
+# an arm `_WITHOUT_AN_AUTHORITY` says nothing reaches. It exits non-zero
+# on any of the three, which is what makes this job red.
+#
+# No `issues: write`, unlike `vendored-vectors.yml`: that workflow's
+# subject is a vendored file nothing else in this repository ever looks
+# at again, so a failed run's notification is the only signal a drifted
+# pin gets and a persistent issue is what carries it past that one
+# email. `_AUTHORITY` is different -- it is a tracked file a pull request
+# touching `btclib/curves/` or `btclib/ecc/` can and does edit, reviewed
+# the ordinary way, so a red scheduled run and the Actions tab it lands
+# on are enough, the same choice `links.yml` and `published.yml` already
+# make for a comparable reason.
+
+on:
+  schedule:
+    # the 15th of the month, 04:07 UTC. Not the 1st, which
+    # `vendored-vectors` and `published` already share, and not on the
+    # hour: GitHub queues same-minute scheduled workflows across every
+    # repository that asked for it, and a long queue can drop the run
+    # outright. Minute 07 is not shared with any other cron in this
+    # repository (13, 17, 19, 23, 29, 31, 41, 43, 53)
+    - cron: "07 4 15 * *"
+  workflow_dispatch:
+  pull_request:
+    # ready_for_review, so a pull request marked ready gets the run the
+    # draft condition below withheld while it was a draft: the default
+    # types do not include it, and without it a readied pull request
+    # would wait for its next push to be checked at all.
+    # closed too, though the job below declines the real work on it: a
+    # merge or a close is neither a push nor a synchronize, so a run this
+    # ref's concurrency group is still holding survives either unless the
+    # closed event lands in that same group -- which this type is what
+    # makes it do, cancel-in-progress above turning the landing into the
+    # cancellation
+    types: [opened, reopened, synchronize, ready_for_review, closed]
+    paths:
+      - .github/workflows/python-arm-authority.yml
+      - .github/scripts/check_python_arm_authority.py
+      - tests/python_arm_authority_test.py
+
+permissions:
+  contents: read
+
+concurrency:
+  group: python-arm-authority-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  authority:
+    name: Re-derive the Python-arm authority table
+    # a draft pull request is work in progress and spends no runner
+    # here either: a draft is work its author is not asking anyone to
+    # review yet, and its runs are what the required checks already
+    # read. The same condition test.yml's no-bindings job carries, and
+    # ready_for_review is a trigger type above for the same reason.
+    # A closed pull request spends none either -- the trigger above takes
+    # the closed event only to supersede a run this ref's group is still
+    # holding
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          python-version: "3.14"
+
+      # test.yml's own no-bindings job, verbatim: asked before the
+      # measurement and of the interpreter rather than of the resolver,
+      # so a job that silently kept the bindings would report every arm
+      # reached by the bindings-serving path and not the Python one --
+      # exactly the failure this step exists to make impossible
+      - name: Assert the bindings are absent
+        run: >
+          uv run --locked --no-default-groups --group harness
+          python -c "from btclib._libsecp256k1 import INSTALLED;
+          assert not INSTALLED, 'btclib_secp256k1 is installed';
+          from btclib.curves import is_libsecp256k1_serving;
+          assert not is_libsecp256k1_serving()"
+
+      - name: Re-derive the authority table against a fresh measurement
+        run: >
+          uv run --locked --no-default-groups --group harness
+          python .github/scripts/check_python_arm_authority.py

--- a/.github/workflows/python-arm-authority.yml
+++ b/.github/workflows/python-arm-authority.yml
@@ -3,7 +3,7 @@ name: python arm authority
 
 # tests/python_arm_authority_test.py's `_AUTHORITY` says, per Python arm,
 # which third-party-vector-driven test module reaches it -- issue #993's
-# answer, landed by #1000. Its own four tests check the table's shape
+# answer, landed by #1000. Its own tests check the table's shape
 # against the source and against itself, and none of them re-runs the
 # coverage that produced its values, because that measurement is minutes
 # and not seconds: every module `_THIRD_PARTY_VECTORS` names, each under

--- a/.github/workflows/python-arm-authority.yml
+++ b/.github/workflows/python-arm-authority.yml
@@ -6,8 +6,9 @@ name: python arm authority
 # answer, landed by #1000. Its own four tests check the table's shape
 # against the source and against itself, and none of them re-runs the
 # coverage that produced its values, because that measurement is minutes
-# and not seconds: eighteen modules, each under coverage, each in an
-# environment with no bindings installed. Issue #1003 is this workflow --
+# and not seconds: every module `_THIRD_PARTY_VECTORS` names, each under
+# coverage, each in an environment with no bindings installed. Issue
+# #1003 is this workflow --
 # a pull request should not pay what a schedule can pay once a month.
 #
 # This reimplements the no-bindings environment test.yml's own
@@ -21,8 +22,8 @@ name: python arm authority
 #
 # `.github/scripts/check_python_arm_authority.py` does the comparing: it
 # imports `_AUTHORITY` straight from the test module rather than parsing
-# a second copy of it, runs each of the eighteen third-party-vector
-# modules under coverage on its own, and diffs what it measures against
+# a second copy of it, runs each `_THIRD_PARTY_VECTORS` module under
+# coverage on its own, and diffs what it measures against
 # what the table claims, in every direction issue #1003 names -- an
 # entry citing a module whose run no longer reaches the arm, a module
 # reaching an arm its entry does not name, and something newly reaching
@@ -56,10 +57,15 @@ on:
     # would wait for its next push to be checked at all.
     # closed too, though the job below declines the real work on it: a
     # merge or a close is neither a push nor a synchronize, so a run this
-    # ref's concurrency group is still holding survives either unless the
-    # closed event lands in that same group -- which this type is what
-    # makes it do, cancel-in-progress above turning the landing into the
-    # cancellation
+    # PR's own concurrency group is still holding survives either unless
+    # the closed event lands in that same group -- which this type is
+    # what makes it do, cancel-in-progress above turning the landing
+    # into the cancellation. The group below keys on github.head_ref
+    # rather than plain github.ref for exactly this event: a merged pull
+    # request's closed event sets github.ref to the base branch, not the
+    # merge ref, which would land it in the scheduled run's own group
+    # and race it for cancellation (PR 1023's bug, PR 1026's fix) instead
+    # of the PR's own group as intended
     types: [opened, reopened, synchronize, ready_for_review, closed]
     paths:
       - .github/workflows/python-arm-authority.yml
@@ -69,8 +75,14 @@ on:
 permissions:
   contents: read
 
+# head_ref falls back to ref rather than being used bare: it is set only
+# for pull_request events, to the PR's head branch, so a scheduled or
+# dispatched run (ref refs/heads/main) still gets its own group -- and a
+# pull_request event always groups by the PR's branch, closed and
+# merged ones included, so it never collides with that group the way
+# bare ref did
 concurrency:
-  group: python-arm-authority-${{ github.ref }}
+  group: python-arm-authority-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -703,6 +703,35 @@ documented at release-notes length in the first place, and are still in
   artifact round trip in each direction, and the `no-bindings` job's
   wall clock, now instrumented like the `coverage` job's rather than
   the `suite` matrix's.
+- **`python-arm-authority.yml` re-derives `_AUTHORITY` against a fresh
+  measurement, monthly** (issue #1003). Issue #993's inventory —
+  `tests/python_arm_authority_test.py`, landed by #1000 — was checked for
+  shape and never for content: nothing reran the by-hand coverage that
+  produced its values, so a test module that stopped reaching an arm
+  would leave the entry standing on an otherwise green suite.
+  `.github/scripts/check_python_arm_authority.py` reruns it, one
+  third-party-vector module at a time under coverage in a no-bindings
+  environment — the same environment `test.yml`'s `no-bindings` job
+  builds, reimplemented here rather than made to depend on issue #1002's
+  still-unmerged coverage-artifact plumbing — and diffs the result
+  against the table in every direction: an entry claiming a module whose
+  run no longer reaches the arm, a module reaching an arm its entry does
+  not name, and something newly reaching an arm the table says nothing
+  reaches. A sentinel and not a gate, on the 15th at 04:07 UTC —
+  `vendored-vectors` and `published` already share the 1st.
+
+  The re-derivation found the table itself out of date the first time it
+  ran, of the thirty-five entries: twenty understated their arm's
+  reach — mostly the arithmetic `curves/curve.py` and `curves/sec_point.py`
+  hold in common, which nearly every module that signs or verifies
+  anything exercises once the bindings are absent — and
+  `ecc.commit_nonce.commit_nonce_` turned out to have an authority after
+  all, `ecc/ssa_test.py`'s own sign-to-contract test reaching it through
+  `ssa.sign(..., commit=...)` — a test btclib wrote, inside a module built
+  on BIP340 vectors, which is the module-not-vector weakness the file's
+  docstring already names. Both are corrected against the fresh
+  measurement here rather than left for the sentinel's first scheduled
+  run to report on a table this pull request could have landed accurate.
 
 - **`MANIFEST.in` prunes a nested `.mypy_cache`, `.pytest_cache`,
   `.ruff_cache` or `__pycache__`, at whatever depth a tool left one.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -721,17 +721,19 @@ documented at release-notes length in the first place, and are still in
   `vendored-vectors` and `published` already share the 1st.
 
   The re-derivation found the table itself out of date the first time it
-  ran, of the thirty-five entries: twenty understated their arm's
-  reach — mostly the arithmetic `curves/curve.py` and `curves/sec_point.py`
-  hold in common, which nearly every module that signs or verifies
-  anything exercises once the bindings are absent — and
-  `ecc.commit_nonce.commit_nonce_` turned out to have an authority after
-  all, `ecc/ssa_test.py`'s own sign-to-contract test reaching it through
-  `ssa.sign(..., commit=...)` — a test btclib wrote, inside a module built
-  on BIP340 vectors, which is the module-not-vector weakness the file's
-  docstring already names. Both are corrected against the fresh
-  measurement here rather than left for the sentinel's first scheduled
-  run to report on a table this pull request could have landed accurate.
+  ran — most entries understated their arm's reach, mostly the arithmetic
+  `curves/curve.py` and `curves/sec_point.py` hold in common, which
+  nearly every module that signs or verifies anything exercises once the
+  bindings are absent — and `ecc.commit_nonce.commit_nonce_` turned out
+  to have an authority after all, `ecc/ssa_test.py`'s own
+  sign-to-contract test reaching it through `ssa.sign(..., commit=...)`
+  — a test btclib wrote, inside a module built on BIP340 vectors, which
+  is the module-not-vector weakness the file's docstring already names.
+  Both are corrected against the fresh measurement here rather than left
+  for the sentinel's first scheduled run to report on a table this pull
+  request could have landed accurate. `uv sync --no-default-groups
+  --group harness && python .github/scripts/check_python_arm_authority.py`
+  repeats the measurement, whenever the count is wanted.
 
 - **`MANIFEST.in` prunes a nested `.mypy_cache`, `.pytest_cache`,
   `.ruff_cache` or `__pycache__`, at whatever depth a tool left one.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,6 +264,7 @@ read by every checkout of this repository.
 | `links`, `mutation` | weekly | — |
 | `vendored-vectors` | monthly | upstream's vectors |
 | `published` | monthly, a release | what PyPI serves |
+| `python-arm-authority` | monthly | the arm-to-vector-module table |
 | `release` | a tag | calls test, lint, docs, macos, windows, published |
 
 The first four rows are what a merge waits for, and between them they report

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -45,6 +45,7 @@ recursive-include tests *.py
 # website's files, whose absence is check-manifest's configuration and not
 # this file's; [tool.check-manifest] ignore names them too, a tracked
 # file the sdist omits being exactly what that tool reports
+exclude tests/check_python_arm_authority_test.py
 exclude tests/check_vendored_vectors_test.py
 exclude tests/generate_sbom_test.py
 exclude tests/mutation_counts_test.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,6 +241,7 @@ ignore = [
     # .github and therefore not shipped either. The suite an sdist carries
     # has to be runnable from it, and a test whose subject is absent is not
     # a test but a fixture error; MANIFEST.in excludes them and says the same
+    "tests/check_python_arm_authority_test.py",
     "tests/check_vendored_vectors_test.py",
     "tests/generate_sbom_test.py",
     "tests/mutation_counts_test.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -817,6 +817,10 @@ ignore = [
 # job that started an emulator: what it saw and how long it took, or the
 # ::error:: annotation naming what it saw instead
 ".github/scripts/wait_for_hwi_device.py" = ["T201"]
+# and the Python-arm authority re-derivation: which module it is
+# measuring, one line per disagreement found, and the all-clear or count
+# at the end are what a monthly run's log says happened
+".github/scripts/check_python_arm_authority.py" = ["T201"]
 # the D rules are not here: a public test function, fixture or method
 # states what it verifies -- the property, the vector, the failure
 # mode -- under the same docstring gate as the library's public

--- a/tests/check_python_arm_authority_test.py
+++ b/tests/check_python_arm_authority_test.py
@@ -1,0 +1,99 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for `compare()`, the diff logic of the monthly Python-arm sentinel.
+
+`measure()` is what actually runs the suite under coverage, module by
+module -- exactly what this repository collects no coverage from, the
+reason `.github/scripts` sits outside `tool.coverage.run`'s `source` in
+the first place. `compare()` takes none of that: a
+`dict[str, frozenset[str]]` in, the three-way STALE/UNDERSTATED/NEW
+AUTHORITY diff against `_AUTHORITY` and `_WITHOUT_AN_AUTHORITY` out, no
+subprocess or coverage run needed to exercise it. `_AUTHORITY` and
+`_WITHOUT_AN_AUTHORITY` are monkeypatched to small synthetic tables here
+rather than read from `tests/python_arm_authority_test.py`, so a change
+to the real table cannot make this test pass or fail by accident.
+
+Loaded by path, the same reason and the same shape as
+`tests/check_vendored_vectors_test.py`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).parents[1] / ".github" / "scripts" / "check_python_arm_authority.py"
+)
+
+
+@pytest.fixture
+def checker(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Return the script, imported by path, registered before it runs."""
+    spec = importlib.util.spec_from_file_location("check_python_arm_authority", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "check_python_arm_authority", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_compare_finds_nothing_when_every_arm_matches(
+    checker: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A measurement equal to `_AUTHORITY` reports no mismatch at all."""
+    monkeypatch.setattr(checker, "_AUTHORITY", {"an.arm": ("a.json",)})
+    monkeypatch.setattr(checker, "_WITHOUT_AN_AUTHORITY", frozenset())
+
+    assert checker.compare({"an.arm": frozenset({"a.json"})}) == []
+
+
+def test_compare_reports_stale_understated_and_new_authority(
+    checker: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One line per direction `compare()` can report, sorted by arm name."""
+    monkeypatch.setattr(
+        checker,
+        "_AUTHORITY",
+        {
+            "match.arm": ("b.json",),
+            "new.arm": (),
+            "stale.arm": ("a.json",),
+            "understated.arm": ("c.json",),
+        },
+    )
+    monkeypatch.setattr(checker, "_WITHOUT_AN_AUTHORITY", frozenset({"new.arm"}))
+
+    mismatches = checker.compare(
+        {
+            "match.arm": frozenset({"b.json"}),
+            "new.arm": frozenset({"e.json"}),
+            "stale.arm": frozenset(),
+            "understated.arm": frozenset({"c.json", "d.json"}),
+        }
+    )
+
+    assert mismatches == [
+        "NEW AUTHORITY: new.arm is reached by ['e.json'], not named in its entry",
+        "STALE: stale.arm claims ['a.json'], whose run no longer reaches it",
+        "UNDERSTATED: understated.arm is reached by ['d.json'], not named in its entry",
+    ]
+
+
+def test_compare_treats_an_arm_missing_from_the_measurement_as_empty(
+    checker: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An arm `_AUTHORITY` claims, and the measurement never mentions: STALE."""
+    monkeypatch.setattr(checker, "_AUTHORITY", {"an.arm": ("a.json",)})
+    monkeypatch.setattr(checker, "_WITHOUT_AN_AUTHORITY", frozenset())
+
+    assert checker.compare({}) == [
+        "STALE: an.arm claims ['a.json'], whose run no longer reaches it"
+    ]

--- a/tests/python_arm_authority_test.py
+++ b/tests/python_arm_authority_test.py
@@ -33,15 +33,28 @@ each arm ran. A module is named here when its run reached the arm's body,
 the `def` line excluded -- that line runs at import and would report
 every arm of every imported module as reached.
 
-**Nothing here re-runs the measurement.** Three of the four tests below
-check the table's shape -- its keys against the parser, its empty entries
-against the named set, its cited modules against the vector table -- and
-none checks its content. If `ecc/wycheproof_test.py` stops reaching
-`ecc.dsa.assert_as_valid_`, the arm keeps its entry, the entry keeps its
-module, the module keeps naming its vectors, and the claim quietly
-becomes false. That is the one thing in this file that can rot without a
-red suite, and it is the file's whole content; a job that re-derives the
-table is what would close it.
+**Nothing here re-runs the measurement.** The four tests below check the
+table's shape -- its keys against the parser, its empty entries against
+the named set, its cited modules against the vector table, its entries
+against that same table -- and none reruns the coverage that produced
+`_AUTHORITY`'s values, because a pull request is not where that question
+belongs: eighteen modules under coverage, in an environment with no
+bindings, is minutes rather than seconds, and nothing here asks a
+contributor's branch to pay for it.
+
+That re-derivation runs monthly instead, is
+`.github/workflows/python-arm-authority.yml`, calling
+`.github/scripts/check_python_arm_authority.py` -- issue #1003's answer.
+It repeats the measurement above, module by module, and fails loudly on
+any of three disagreements: an entry claims a module that no longer
+reaches the arm (stale, the harmful direction), a module reaches an arm
+its entry does not name (the table understates, still worth knowing), or
+something now reaches an arm in `_WITHOUT_AN_AUTHORITY` (the good news
+this file is written to notice). A sentinel and not a gate: it has no
+branch rule, so between one run and the next -- and on any pull request
+that is not itself about this file, the script or the workflow -- the
+table can go stale exactly as it could before, for up to a month rather
+than forever.
 
 **The attribution is per module, and a module may also hold tests btclib
 wrote.** `tests/curves/curve_test.py` is the clearest case: it reads
@@ -72,6 +85,18 @@ what would:
   signature names its own. Vectors would have to be built rather than
   vendored, which is a decision about whether the plural spelling wants
   an authority of its own or is the singular one enumerated.
+
+`ecc.commit_nonce.commit_nonce_`, the sign-to-contract nonce tweak, was
+the other -- issue #1003's re-derivation found `ecc/ssa_test.py` does
+reach it, through `ssa.sign(..., commit=...)`, a test btclib wrote rather
+than a BIP340 vector. That is the module-not-vector weakness two
+paragraphs up made concrete: the entry now says a module built on
+third-party vectors reaches the arm, which is true and is what the
+measurement supports, and not that a third-party vector exercises the
+sign-to-contract tweak itself -- no BIP states that primitive and no
+vector set for it exists to vendor, libsecp256k1-zkp's `s2c` module being
+C. Sharpening the entry to the vector-driven tests within the module
+would leave this arm without one again.
 """
 
 from __future__ import annotations
@@ -127,75 +152,197 @@ _THIRD_PARTY_VECTORS: dict[str, tuple[str, ...]] = {
 # empty tuple is an arm no third-party vector reaches, and the module
 # docstring says what would
 _AUTHORITY: dict[str, tuple[str, ...]] = {
-    "bip32.bip32.__prv_key_derivation": ("ecc/bms_test.py", "bip32/bip32_test.py"),
+    "bip32.bip32.__prv_key_derivation": ("bip32/bip32_test.py", "ecc/bms_test.py"),
     "bip32.bip32._pub_key_tweak_chain": ("bip32/bip32_test.py",),
-    "curves.curve.__init__": ("silent_payments_test.py", "curves/curve_test.py"),
-    "curves.curve._jac_double_mult": ("ecc/wycheproof_test.py", "ecc/ssa_test.py"),
-    "curves.curve._mult_checked": ("ecc/wycheproof_test.py", "ecc/ssa_test.py"),
+    "curves.curve.__init__": ("curves/curve_test.py", "silent_payments_test.py"),
+    "curves.curve._jac_double_mult": (
+        "bip322_test.py",
+        "ecc/bms_test.py",
+        "ecc/musig2_test.py",
+        "ecc/rfc6979_test.py",
+        "ecc/ssa_test.py",
+        "ecc/wycheproof_test.py",
+        "script/sig_hash_legacy_test.py",
+        "script/sig_hash_taproot_test.py",
+        "script_engine/script_test.py",
+        "script_engine/transactions_test.py",
+        "silent_payments_test.py",
+    ),
+    "curves.curve._mult_checked": (
+        "bip32/bip32_test.py",
+        "bip322_test.py",
+        "curves/curve_test.py",
+        "curves/sec_point_test.py",
+        "ecc/bms_test.py",
+        "ecc/dleq_test.py",
+        "ecc/ellswift_test.py",
+        "ecc/musig2_test.py",
+        "ecc/rfc6979_test.py",
+        "ecc/ssa_test.py",
+        "ecc/wycheproof_test.py",
+        "script/sig_hash_legacy_test.py",
+        "script/sig_hash_taproot_test.py",
+        "script/taproot_test.py",
+        "script_engine/script_test.py",
+        "script_engine/transactions_test.py",
+        "silent_payments_test.py",
+    ),
     "curves.curve._multi_mult_x_only_var": ("ecc/ssa_test.py",),
-    "curves.curve._sum_var": ("ecc/musig2_test.py", "silent_payments_test.py"),
-    "curves.curve._tweak_add_var": ("ecc/musig2_test.py", "silent_payments_test.py"),
-    "curves.curve._x_octets": ("ecc/wycheproof_test.py", "ecc/ssa_test.py"),
-    "curves.curve.double_mult_var": ("ecc/ssa_test.py", "ecc/dleq_test.py"),
-    "curves.curve.multi_mult_var": ("ecc/ssa_test.py", "ecc/musig2_test.py"),
-    "curves.sec_point._mult_sec_var": ("silent_payments_test.py",),
+    "curves.curve._sum_var": (
+        "curves/curve_test.py",
+        "ecc/musig2_test.py",
+        "silent_payments_test.py",
+    ),
+    "curves.curve._tweak_add_var": (
+        "curves/curve_test.py",
+        "ecc/musig2_test.py",
+        "silent_payments_test.py",
+    ),
+    "curves.curve._x_octets": (
+        "bip32/bip32_test.py",
+        "bip322_test.py",
+        "curves/curve_test.py",
+        "curves/sec_point_test.py",
+        "ecc/bms_test.py",
+        "ecc/dleq_test.py",
+        "ecc/ellswift_test.py",
+        "ecc/musig2_test.py",
+        "ecc/rfc6979_test.py",
+        "ecc/ssa_test.py",
+        "ecc/wycheproof_test.py",
+        "script/sig_hash_legacy_test.py",
+        "script/sig_hash_taproot_test.py",
+        "script/taproot_test.py",
+        "script_engine/script_test.py",
+        "script_engine/transactions_test.py",
+        "silent_payments_test.py",
+    ),
+    "curves.curve.double_mult_var": (
+        "curves/curve_test.py",
+        "ecc/dleq_test.py",
+        "ecc/ssa_test.py",
+    ),
+    "curves.curve.multi_mult_var": (
+        "bip32/bip32_test.py",
+        "curves/curve_test.py",
+        "ecc/musig2_test.py",
+        "ecc/ssa_test.py",
+    ),
+    "curves.sec_point._mult_sec_var": (
+        "curves/sec_point_test.py",
+        "silent_payments_test.py",
+    ),
     "curves.sec_point._sec_from_octets": (
+        "bip322_test.py",
+        "curves/sec_point_test.py",
         "ecc/bms_test.py",
         "script_engine/script_test.py",
+        "script_engine/transactions_test.py",
     ),
     "curves.sec_point.bytes_from_prv_key_int": (
         "bip32/bip32_test.py",
+        "bip322_test.py",
+        "curves/curve_test.py",
+        "curves/sec_point_test.py",
+        "ecc/bms_test.py",
         "ecc/musig2_test.py",
+        "script/sig_hash_legacy_test.py",
+        "script/sig_hash_taproot_test.py",
+        "script_engine/script_test.py",
     ),
-    "ecc.bms.assert_as_valid": ("ecc/bms_test.py", "bip322_test.py"),
-    "ecc.commit_nonce.commit_nonce_": (),
+    "ecc.bms.assert_as_valid": ("bip322_test.py", "ecc/bms_test.py"),
+    "ecc.commit_nonce.commit_nonce_": ("ecc/ssa_test.py",),
     "ecc.dh.diffie_hellman": ("ecc/wycheproof_test.py",),
     "ecc.dsa.__init__": (),
     "ecc.dsa.assert_as_valid_": (
+        "bip322_test.py",
+        "ecc/bms_test.py",
+        "ecc/rfc6979_test.py",
         "ecc/wycheproof_test.py",
+        "script/sig_hash_legacy_test.py",
+        "script_engine/script_test.py",
         "script_engine/transactions_test.py",
     ),
-    "ecc.dsa.recover_pub_key_": ("ecc/bms_test.py", "bip322_test.py"),
+    "ecc.dsa.recover_pub_key_": ("bip322_test.py", "ecc/bms_test.py"),
     "ecc.dsa.recover_pub_keys_": (),
-    "ecc.dsa.sign_": ("ecc/rfc6979_test.py", "script_engine/script_test.py"),
-    "ecc.dsa.sign_recoverable_": ("ecc/bms_test.py", "bip322_test.py"),
+    "ecc.dsa.sign_": (
+        "bip322_test.py",
+        "ecc/bms_test.py",
+        "ecc/rfc6979_test.py",
+        "script/sig_hash_legacy_test.py",
+        "script_engine/script_test.py",
+    ),
+    "ecc.dsa.sign_recoverable_": ("bip322_test.py", "ecc/bms_test.py"),
     "ecc.ellswift.create_var": ("ecc/ellswift_test.py",),
     "ecc.ellswift.decode_var": ("ecc/ellswift_test.py",),
     "ecc.ellswift.encode_var": ("ecc/ellswift_test.py",),
     "ecc.ellswift.xdh": ("ecc/ellswift_test.py",),
     "ecc.ssa.__init__": ("ecc/ssa_test.py",),
-    "ecc.ssa.assert_as_valid_": ("ecc/ssa_test.py", "script/sig_hash_taproot_test.py"),
-    "ecc.ssa.sign_": ("ecc/ssa_test.py", "script/sig_hash_taproot_test.py"),
+    "ecc.ssa.assert_as_valid_": (
+        "bip322_test.py",
+        "ecc/musig2_test.py",
+        "ecc/ssa_test.py",
+        "script/sig_hash_taproot_test.py",
+        "script_engine/script_test.py",
+        "script_engine/transactions_test.py",
+        "silent_payments_test.py",
+    ),
+    "ecc.ssa.sign_": (
+        "bip322_test.py",
+        "ecc/ssa_test.py",
+        "script/sig_hash_taproot_test.py",
+        "script_engine/script_test.py",
+        "silent_payments_test.py",
+    ),
     "script.engine.script.dsa_verify": (
+        "bip322_test.py",
+        "script/sig_hash_legacy_test.py",
         "script_engine/script_test.py",
         "script_engine/transactions_test.py",
     ),
     "script.engine.tapscript.ssa_verify": (
+        "bip322_test.py",
         "script/sig_hash_taproot_test.py",
+        "script_engine/script_test.py",
         "script_engine/transactions_test.py",
     ),
-    "script.taproot._output_pubkey_and_internal_key": ("script/taproot_test.py",),
-    "script.taproot._tweaked_prvkey": ("script/taproot_test.py",),
-    "script.taproot._tweaked_pubkey": ("script/taproot_test.py",),
-    "script.taproot.check_output_pubkey": (
+    "script.taproot._output_pubkey_and_internal_key": (
+        "bip322_test.py",
+        "script/sig_hash_taproot_test.py",
         "script/taproot_test.py",
+        "script_engine/script_test.py",
+    ),
+    "script.taproot._tweaked_prvkey": (
+        "bip322_test.py",
+        "script/sig_hash_taproot_test.py",
+        "script/taproot_test.py",
+        "script_engine/script_test.py",
+    ),
+    "script.taproot._tweaked_pubkey": (
+        "bip322_test.py",
+        "script/sig_hash_taproot_test.py",
+        "script/taproot_test.py",
+        "script_engine/script_test.py",
+    ),
+    "script.taproot.check_output_pubkey": (
+        "bip322_test.py",
+        "script/sig_hash_taproot_test.py",
+        "script/taproot_test.py",
+        "script_engine/script_test.py",
         "script_engine/transactions_test.py",
     ),
 }
 
 # the ones the measurement found nothing for, named so that closing one
-# is a line deleted here rather than a number nobody re-derives
-_WITHOUT_AN_AUTHORITY = frozenset(
-    {
-        "ecc.commit_nonce.commit_nonce_",
-        "ecc.dsa.__init__",
-        "ecc.dsa.recover_pub_keys_",
-    }
-)
+# is a line deleted here rather than a number nobody re-derives.
+# `ecc.commit_nonce.commit_nonce_` was among them, until issue #1003's
+# re-derivation found `ecc/ssa_test.py` does reach it -- the module
+# docstring above says through what
+_WITHOUT_AN_AUTHORITY = frozenset({"ecc.dsa.__init__", "ecc.dsa.recover_pub_keys_"})
 
 
-def _python_arms() -> set[str]:
-    """Return every function of btclib that holds a dispatch to the bindings.
+def _arm_locations() -> dict[str, tuple[Path, int, int]]:
+    """Return every Python arm, mapped to where its body runs.
 
     The definition issue #968 used, applied by the parser rather than by
     hand: a function whose source calls `_libsecp256k1_serves` has two
@@ -219,8 +366,16 @@ def _python_arms() -> set[str]:
       arm unexamined. `curves.curve.__init__` and `ecc.ssa.__init__` are
       already that shape, in two modules; a third in either would be the
       case to watch.
+
+    The range is the function's own body -- `node.body[0].lineno` through
+    `node.end_lineno`, the `def` line itself excluded on purpose, since it
+    runs at import regardless of whether the function is ever called and
+    would otherwise report every arm of every imported module as reached.
+    `.github/scripts/check_python_arm_authority.py` is what reads this
+    range against a coverage run's `executed_lines` to re-derive
+    `_AUTHORITY`; `_python_arms()` below reads only the keys.
     """
-    found: set[str] = set()
+    found: dict[str, tuple[Path, int, int]] = {}
     for path in sorted(_LIBRARY.rglob("*.py")):
         source = path.read_text(encoding="utf-8")
         module = ".".join(path.relative_to(_LIBRARY).with_suffix("").parts)
@@ -231,8 +386,22 @@ def _python_arms() -> set[str]:
                 continue
             segment = ast.get_source_segment(source, node) or ""
             if "_libsecp256k1_serves(" in segment:
-                found.add(f"{module}.{node.name}")
+                assert node.end_lineno is not None  # set by ast.parse always
+                found[f"{module}.{node.name}"] = (
+                    path,
+                    node.body[0].lineno,
+                    node.end_lineno,
+                )
     return found
+
+
+def _python_arms() -> set[str]:
+    """Return every function of btclib that holds a dispatch to the bindings.
+
+    The keys of `_arm_locations()`, which is where the counting rule --
+    and the collision it can hit -- is written down.
+    """
+    return set(_arm_locations())
 
 
 def test_every_python_arm_is_in_the_inventory() -> None:
@@ -241,8 +410,8 @@ def test_every_python_arm_is_in_the_inventory() -> None:
     The inventory is worth nothing if it can go quietly out of date: a
     dispatch added tomorrow would have an unexamined Python arm, and the
     claim this file makes -- that every arm has an authority other than
-    the bindings, or is one of the two that do not -- would be about the
-    tree of the day it was written.
+    the bindings, or is the one that does not -- would be about the tree
+    of the day it was written.
     """
     listed = set(_AUTHORITY)
     found = _python_arms()

--- a/tests/python_arm_authority_test.py
+++ b/tests/python_arm_authority_test.py
@@ -33,7 +33,7 @@ each arm ran. A module is named here when its run reached the arm's body,
 the `def` line excluded -- that line runs at import and would report
 every arm of every imported module as reached.
 
-**Nothing here re-runs the measurement.** The four tests below check the
+**Nothing here re-runs the measurement.** The tests below check the
 table's shape -- its keys against the parser, its empty entries against
 the named set, its cited modules against the vector table, its entries
 against that same table -- and none reruns the coverage that produced

--- a/tests/python_arm_authority_test.py
+++ b/tests/python_arm_authority_test.py
@@ -38,9 +38,9 @@ table's shape -- its keys against the parser, its empty entries against
 the named set, its cited modules against the vector table, its entries
 against that same table -- and none reruns the coverage that produced
 `_AUTHORITY`'s values, because a pull request is not where that question
-belongs: eighteen modules under coverage, in an environment with no
-bindings, is minutes rather than seconds, and nothing here asks a
-contributor's branch to pay for it.
+belongs: every module `_THIRD_PARTY_VECTORS` names, under coverage, in
+an environment with no bindings, is minutes rather than seconds, and
+nothing here asks a contributor's branch to pay for it.
 
 That re-derivation runs monthly instead, is
 `.github/workflows/python-arm-authority.yml`, calling

--- a/tests/python_arm_authority_test.py
+++ b/tests/python_arm_authority_test.py
@@ -87,7 +87,7 @@ what would:
   an authority of its own or is the singular one enumerated.
 
 `ecc.commit_nonce.commit_nonce_`, the sign-to-contract nonce tweak, was
-the other -- issue #1003's re-derivation found `ecc/ssa_test.py` does
+among them -- issue #1003's re-derivation found `ecc/ssa_test.py` does
 reach it, through `ssa.sign(..., commit=...)`, a test btclib wrote rather
 than a BIP340 vector. That is the module-not-vector weakness two
 paragraphs up made concrete: the entry now says a module built on


### PR DESCRIPTION
Closes #1003.

## What this adds

`tests/python_arm_authority_test.py`'s `_AUTHORITY` (issue #993, landed
by #1000) maps each Python arm to the third-party-vector test modules
that reach it. Its four existing tests check the table's *shape* --
every key is a real arm the source parses, the "without an authority"
entries are exactly the known ones, every named module exists and reads
its vectors, no entry cites an unlisted module -- and none of them
re-run the by-hand coverage measurement that produced the table's
*content*. A module that stops exercising an arm keeps the entry, and
the claim quietly goes false on an otherwise green suite.

`.github/scripts/check_python_arm_authority.py` re-derives it: for each
of the eighteen modules in `_THIRD_PARTY_VECTORS`, it runs that module
alone under coverage, in an environment with no bindings installed
(`--cov=btclib --cov-report=json --cov-fail-under=0`, exactly the
command the test file's own docstring already gives for the by-hand
measurement), and reads back which arm bodies the run's `executed_lines`
touched -- reusing `_arm_locations` (split out of the existing
`_python_arms` for this, so there is one AST walk and one definition of
"arm" for the shape tests, the content check and this script alike). It
diffs the result against `_AUTHORITY` in the three directions issue
#1003 names:

- **STALE** -- an entry claims a module whose run no longer reaches the
  arm (the harmful direction: the claim outlived what made it true);
- **UNDERSTATED** -- a module's run reaches an arm its entry does not
  name (benign, still worth a line: the entry is incomplete, not wrong);
- **NEW AUTHORITY** -- something now reaches an arm in
  `_WITHOUT_AN_AUTHORITY` (the good news that set exists to pick up).

`.github/workflows/python-arm-authority.yml` runs it monthly, on the
15th at 04:07 UTC -- not the 1st, which `vendored-vectors` and
`published` already share, and not on the hour, for the same
same-minute-queue reason every other cron comment in this repository
gives (`13, 17, 19, 23, 29, 31, 41, 43, 53` were the minutes already
claimed; `07` was not). A sentinel and not a gate: scheduled,
`workflow_dispatch`, a narrow `pull_request` `paths` filter over its own
inputs, and no branch rule. No `issues: write` either, unlike
`vendored-vectors.yml`: that workflow's subject is a vendored file
nothing else ever looks at again, so a persistent issue is what carries
a drift finding past one missed email. `_AUTHORITY` is an ordinarily
reviewed tracked file a pull request touching `btclib/curves/` or
`btclib/ecc/` can and does edit, so a red scheduled run and the Actions
tab it lands on are enough -- the same choice `links.yml` already makes
for a comparable reason.

## Why it rebuilds the environment instead of consuming #1002's artifact

Issue #1003 says it "depends on #1002, or at least on the same
plumbing": the measurement is coverage data from a no-bindings run, and
#1002 proposes producing exactly that as a build artifact. #1002 is a
separate, unmerged pull request someone else is currently writing, so
this does not read or depend on its branch. Instead the workflow
reimplements the no-bindings environment the way `test.yml`'s own
`no-bindings` job already does -- `uv sync --no-default-groups --group
harness`, then the same "assert the bindings are absent" guard -- and
the script drives its own eighteen `pytest --cov` subprocess runs rather
than reading a shared artifact. If #1002 lands, the two "sync and
assert" steps could become a download instead; that is a possible future
simplification, not a prerequisite for this one.

## Running it against the current tree found the table itself stale

The first real run, in a no-bindings environment built the way the
workflow builds it, did **not** come back clean, contrary to the
expectation that a table #1000 had just landed would still be accurate.
Twenty of the thirty-five entries understated their arm's reach --
mostly the arithmetic `curves/curve.py` and `curves/sec_point.py` hold
in common (`_jac_double_mult`, `_mult_checked`, `_x_octets`, and others),
which nearly every module that signs or verifies anything ends up
exercising once the bindings are absent and every dispatch takes the
Python arm. And `ecc.commit_nonce.commit_nonce_`, one of the two
documented as having no authority, turned out to have one:
`ecc/ssa_test.py` reaches it through `ssa.sign(..., commit=...)` -- a
test btclib wrote, inside a module built on BIP340 vectors, which is
exactly the module-not-vector weakness the file's own docstring already
names. Both are corrected in this PR against the fresh measurement,
verified by re-running the script until it reported a clean pass, rather
than left for the sentinel's first scheduled run to report on a table
this PR could land accurate.

Real local output, `uv run --no-project python
.github/scripts/check_python_arm_authority.py` in the rebuilt
no-bindings environment, after the `_AUTHORITY` correction in this PR:

```
measuring bip32/bip32_test.py ...
measuring bip322_test.py ...
measuring curves/curve_test.py ...
measuring curves/sec_point_test.py ...
measuring ecc/bms_test.py ...
measuring ecc/dleq_test.py ...
measuring ecc/ellswift_test.py ...
measuring ecc/musig2_test.py ...
measuring ecc/rfc6979_test.py ...
measuring ecc/ssa_test.py ...
measuring ecc/wycheproof_test.py ...
measuring key_io_test.py ...
measuring script/sig_hash_legacy_test.py ...
measuring script/sig_hash_taproot_test.py ...
measuring script/taproot_test.py ...
measuring script_engine/script_test.py ...
measuring script_engine/transactions_test.py ...
measuring silent_payments_test.py ...
Every _AUTHORITY entry matches a fresh no-bindings measurement.
```

Also run and green locally: `uv run pre-commit run --all-files`
(actionlint and zizmor included), the full `uv run pytest` suite
(28207 passed, 100.00% coverage), and `uv run pytest
tests/release_notes_test.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Keep the Python-arm authority table accurate by refreshing its coverage data and adding a scheduled drift detector.

New Features:
- Add a script that re-measures Python-arm coverage for each third-party vector test module and reports stale, incomplete, or newly authoritative entries.
- Add a monthly GitHub Actions sentinel with manual and targeted pull-request triggers to detect authority-table drift.

Bug Fixes:
- Refresh the Python-arm authority table to match current no-bindings coverage, including recognizing sign-to-contract nonce coverage from SSA tests.

Enhancements:
- Share AST-derived arm locations between the authority shape tests and coverage re-derivation logic.
- Add focused tests for authority comparison and document the scheduled authority check.

CI:
- Run the monthly authority-table verification in a no-bindings environment with explicit binding-absence checks.

Documentation:
- Document the new monthly Python-arm authority verification in the changelog and contributor workflow schedule.

Tests:
- Add unit tests covering matching, stale, understated, and newly authoritative entries.