### PR TITLE
ecc.dsa.Signer.wipe() reaches the delegated arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3897,6 +3897,22 @@ documented at release-notes length in the first place, and are still in
   and `BOS_COSTER_THRESHOLD` sends the call to Bos-Coster, which builds no
   table at all.
 
+- **`ecc.dsa.Signer.wipe()` reaches the delegated arm now** (issue
+  #1009). It used to raise `NotImplementedError` there: ECDSA has no
+  persistent keypair in libsecp256k1 the way BIP340 does, and the
+  bindings coerced whatever private key was passed into a fresh
+  immutable `bytes` object on every signature regardless
+  (btclib-secp256k1#247), so a `Signer` holding one copy of the key had
+  nothing left to overwrite by the time `wipe` was called.
+  btclib-secp256k1#253 removed that coercion for this case: `dsa.sign`'s
+  `prvkey` argument now accepts a caller-owned 32-octet cffi array and
+  passes it through unconverted rather than copying it. `Signer` now
+  builds one such buffer at construction and hands the bindings that
+  same pointer on every signature it makes, so `wipe` overwrites the 32
+  octets every signature has read from, on the delegated arm exactly as
+  it already did on the Python one. The bindings pin moves to pick up
+  btclib-secp256k1#253.
+
 ### Security
 
 - **`SECURITY.md` says the bindings offer a buffer for a secret, and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -131,7 +131,16 @@ used to teach and to prototype as much as to build:
     it — a buffer too short, a buffer that is not writable, what the
     function then returns. btclib declines that too, for the reason
     the bullet above already gives: no Python object holding a secret
-    is zeroized, on either path, and this one is no exception to it
+    is zeroized, on either path, and this one is no exception to it.
+    `dsa.Signer.__init__` (`btclib/ecc/dsa.py:1346`) crosses the same
+    boundary the other way, once, at construction: the plain `int`
+    `int_from_prv_key` already produced becomes a transient `bytes` via
+    `self._q.to_bytes(32, "big")` on the way into the owned buffer
+    `wipe` overwrites afterwards. That `bytes` is dropped rather than
+    erased, same as the `int` it replaces — one call rather than the
+    buffer's whole lifetime, which is the trade this class exists to
+    make, and stated here for the same reason the other three call
+    sites are
 - the boundary is not always there, and an install decides whether it
     is. `pip install "btclib[secp256k1]"` -- the spelling README.md and
     the guide give -- installs the bindings, and everything the next

--- a/btclib/_libsecp256k1.py
+++ b/btclib/_libsecp256k1.py
@@ -51,6 +51,7 @@ __all__ = [
     "dsa",
     "dsa_verify",
     "ellswift",
+    "ffi",
     "keys",
     "pubkey_from_prvkey",
     "pubkey_sum",
@@ -67,7 +68,14 @@ __all__ = [
 ]
 
 try:
-    from btclib_secp256k1 import dsa, ellswift, keys, recovery, ssa, xonly
+    # `ffi` is the one object here that is not a wrapped call: issue #1009
+    # is why it is needed at all -- `ecc.dsa.Signer` builds its own
+    # `unsigned char[32]` with it, to hold a private key in memory this
+    # package can overwrite, the way `ssa.Signer` already can through the
+    # keypair `ssa` itself builds. Nothing else here needs it, `dsa.sign`
+    # and every other wrapped call taking that buffer as the `prvkey` a
+    # caller may already hold (btclib-secp256k1#253)
+    from btclib_secp256k1 import dsa, ellswift, ffi, keys, recovery, ssa, xonly
     from btclib_secp256k1.dsa import verify as dsa_verify
     from btclib_secp256k1.keys import (
         PubkeyTweakChain,
@@ -101,7 +109,7 @@ except ImportError:  # pragma: no cover
     # called, so the object would be a second thing to keep true. The
     # ignore is on the assignment and not on the module: every other
     # name here keeps the type the try branch gave it
-    dsa = ellswift = keys = recovery = ssa = xonly = None  # type: ignore[assignment]
+    dsa = ellswift = ffi = keys = recovery = ssa = xonly = None  # type: ignore[assignment]
     # a class rather than a function, so mypy calls it an assignment to
     # a type and wants the second code as well
     PubkeyTweakChain = None  # type: ignore[misc, assignment]

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -39,10 +39,11 @@ from dataclasses import dataclass
 from hashlib import sha256
 from io import BytesIO
 from types import TracebackType
-from typing import TypeVar, overload
+from typing import Any, TypeVar, overload
 
 from btclib import var_bytes
 from btclib._libsecp256k1 import dsa as libsecp256k1_dsa
+from btclib._libsecp256k1 import ffi as libsecp256k1_ffi
 from btclib._libsecp256k1 import recovery as libsecp256k1_recovery
 from btclib.alias import BinaryData, HashF, JacPoint, Octets, Point
 from btclib.curves import Curve, PreparedPoint, mult, secp256k1
@@ -1195,7 +1196,7 @@ def sign_recoverable(
 
 def _delegated_sign_(
     msg_hash: bytes,
-    q: int,
+    prvkey_buffer: Any,
     grind: bool,
     ec: Curve,
     *,
@@ -1213,6 +1214,14 @@ def _delegated_sign_(
     a field square root for a compressed key, and this call never pays
     even the cheaper uncompressed one twice.
 
+    `prvkey_buffer` is the `unsigned char[32]` the `Signer` built and
+    holds, not an `int`: `dsa.sign`'s `prvkey` argument passes a cffi
+    array of exactly that length straight through to libsecp256k1
+    unconverted rather than coercing it to a fresh `bytes`
+    (btclib-secp256k1#253), which is what lets the class docstring's
+    `wipe` reach every signature this makes and not only the reference
+    this object drops.
+
     `pubkey_sec` is held back where `verify` declines the check it is
     for -- the bindings refuse the pair, `pubkey is for the check that
     verify=False declines`, the same contradiction `sign_` itself raises
@@ -1225,7 +1234,7 @@ def _delegated_sign_(
     try:
         compact = libsecp256k1_dsa.sign(
             msg_hash,
-            q,
+            prvkey_buffer,
             None,
             compact=True,
             grind=grind,
@@ -1254,40 +1263,44 @@ class Signer:
     the arithmetic of `_sign_` or one call into the bindings either way,
     and the check is what a held key removes from it.
 
-    **What this does not hand the caller is the lifetime of a secret,
-    and that is a limit rather than an omission.** `ssa.Signer` can,
-    because BIP340 signing through the bindings takes a
-    `secp256k1_keypair` -- a pointer into memory this package owns and
-    can overwrite, built once and reused for every signature the object
-    makes. ECDSA has no such object in libsecp256k1: `secp256k1_ecdsa_sign`
-    reads the private key from a bare pointer on every call, and the
-    bindings' own wrapper builds that pointer by coercing whatever was
-    passed -- an `int`, `bytes`, a `bytearray` -- into a fresh immutable
-    `bytes` object first, `_scalar.scalar()`, every time
-    (btclib-secp256k1#247). So a `Signer` backed by that arm does not
-    hold one copy of the secret it could later overwrite: it hands the
-    bindings a new, unreachable one on every signature it makes, for as
-    long as it is asked to sign, and `wipe` arriving afterwards would
-    have nothing of that trail left to reach. Promising erasure there
-    would be worse than not offering it, so `wipe` refuses outright
-    rather than pretending a dropped reference undoes what already
-    happened -- see its own docstring.
+    **This hands the caller the lifetime of a secret on both arms, which
+    issue #1009 first found a real limit on the delegated one.** ECDSA
+    has no persistent object in libsecp256k1 the way BIP340 does --
+    `secp256k1_ecdsa_sign` reads the private key from a bare pointer on
+    every call rather than from a `secp256k1_keypair` built once -- and
+    at the time that finding stood, the bindings' own wrapper coerced
+    whatever was passed into a fresh immutable `bytes` object on every
+    call regardless, `_scalar.scalar()`, so a `Signer` holding one copy
+    of the key had nothing to overwrite: every signature left an
+    unreachable one of its own in the bindings' memory
+    (btclib-secp256k1#247). That coercion is what btclib-secp256k1#253
+    removed for exactly this case: `dsa.sign`'s `prvkey` argument now
+    takes a cffi array of exactly 32 octets and passes it through
+    unconverted, so a caller who owns the buffer keeps owning it. This
+    class builds one such buffer at construction --
+    `ffi.new("unsigned char[32]", ...)` -- and hands the bindings that
+    same pointer on every signature it makes rather than the plain `int`
+    the class held before, so there is now one copy of the secret this
+    holds throughout its life, on both arms, and `wipe` overwrites it on
+    both: the buffer's own 32 octets here, `secp256k1_keypair`'s there.
 
-    That is the delegated arm, secp256k1 with sha256 by default and
-    therefore the common case. On any other curve or hash function --
-    the bindings declining, or `curves.set_libsecp256k1_serving(False)`
-    turning them off for the whole process -- every signature is the
-    Python arithmetic of `_sign_`, which never crosses into the bindings
-    at all: the secret this object holds is a plain integer the whole of
-    its life, and `wipe` genuinely lets go of it, an `int`'s own limit
-    aside -- it cannot be overwritten, only dropped, which SECURITY.md's
-    limitations section states for the library at large. Which arm a
-    given instance uses is decided once, at construction, from `ec` and
-    `hf` alone: `sign_` and `sign` take no nonce, no lower-s override and
-    no commitment, unlike the free functions, precisely so that nothing
-    a caller passes afterwards could move an instance from one arm to
-    the other -- `wipe`'s promise would otherwise depend on an argument
-    to a later call rather than on the object itself.
+    On the delegated arm, secp256k1 with sha256 by default and therefore
+    the common case, `wipe` zeroes that buffer. On any other curve or
+    hash function -- the bindings declining, or
+    `curves.set_libsecp256k1_serving(False)` turning them off for the
+    whole process -- every signature is the Python arithmetic of
+    `_sign_`, which never crosses into the bindings at all: the secret
+    this object holds there is a plain integer the whole of its life,
+    and `wipe` lets go of it -- an `int`'s own limit rather than this
+    class's, since it cannot be overwritten, only dropped, which
+    SECURITY.md's limitations section states for the library at large.
+    Which arm a given instance uses is decided once, at construction,
+    from `ec` and `hf` alone: `sign_` and `sign` take no nonce, no
+    lower-s override and no commitment, unlike the free functions,
+    precisely so that nothing a caller passes afterwards could move an
+    instance from one arm to the other -- `wipe`'s promise would
+    otherwise depend on an argument to a later call rather than on the
+    object itself.
 
     No `pub_key` argument either, matching `ssa.Signer`: the point of
     holding one is that every signature checks under it, so there is
@@ -1322,6 +1335,26 @@ class Signer:
         self._pub_key_sec: bytes | None = (
             _sec_from_pub_key(Q) if _libsecp256k1_serves(ec, hf) else None
         )
+
+        # the buffer `_delegated_sign_` hands the bindings on every
+        # signature and `wipe` overwrites on the way out, built here
+        # rather than left as the `int` above: `dsa.sign`'s `prvkey`
+        # passes a 32-octet cffi array through unconverted
+        # (btclib-secp256k1#253), so this is the one copy of the secret
+        # this arm holds for the whole of the instance's life
+        self._prvkey_buffer: Any | None = (
+            libsecp256k1_ffi.new("unsigned char[32]", self._q.to_bytes(32, "big"))
+            if self._pub_key_sec is not None
+            else None
+        )
+        if self._prvkey_buffer is not None:
+            # the same reasoning `ssa.Signer` already gives for its own
+            # `self._q = 0` beside a keypair: the buffer above holds the
+            # same secret in memory this object can overwrite, so
+            # keeping the int beside it would be a second copy held for
+            # nothing -- and the one copy of the two that cannot be
+            # erased, at that
+            self._q = 0
         self._wiped = False
 
     def __enter__(self) -> Signer:
@@ -1341,33 +1374,25 @@ class Signer:
         On the Python arm -- `self._pub_key_sec is None` -- the scalar
         this object signs with is the whole of what it holds, and
         dropping the reference is genuinely the end of its lifetime
-        here: nothing else in this package still has it, and a wiped
-        signer refuses to sign rather than signing with the zeros.
-        Idempotent, so that a caller may wipe a signer it is not sure
-        about; the `with` statement is the customary way to run one.
+        here: nothing else in this package still has it.
 
-        On the delegated arm this raises instead of doing that, and the
-        class docstring is where the reason is written in full: every
-        signature already made left an unreachable copy of the key in
-        the bindings' own memory, one that dropping `self._q` does
-        nothing about, so there is no operation left here whose name
-        could honestly be `wipe`. `NotImplementedError` and not
-        `BTClibValueError` or a silent no-op -- `sign_`'s "the signer is
-        wiped" is a caller who asked to keep using a signer that has
-        already let go, which is not this: this is a caller asking for
-        an erasure that btclib-secp256k1#247 makes unavailable, so the
-        signer itself is not marked wiped and goes on signing exactly as
-        before, waiting for that issue to close.
+        On the delegated arm the buffer built at construction is what is
+        overwritten, `ffi.buffer(self._prvkey_buffer)[:] = bytes(32)`
+        (btclib-secp256k1#253 is what makes it the same memory every
+        signature reads, rather than a copy the bindings threw away):
+        this arm's every signature has read the same 32 octets this
+        instance holds, so wiping them reaches every one of them at
+        once, unlike the free `sign` this class replaces, which never
+        held a buffer to wipe in the first place.
+
+        Either way a wiped signer refuses to sign rather than signing
+        with the zeros. Idempotent, so that a caller may wipe a signer
+        it is not sure about; the `with` statement is the customary way
+        to run one.
         """
-        if self._pub_key_sec is not None:
-            raise NotImplementedError(
-                "the bindings coerce a private key into a fresh immutable "
-                "bytes object on every ECDSA signature, and libsecp256k1 "
-                "holds no persistent keypair for ECDSA the way it does for "
-                "BIP340 -- so this signer keeps no secret that wiping "
-                "could reach, and every signature already made left one "
-                "nothing here can overwrite (btclib-secp256k1#247)"
-            )
+        if self._prvkey_buffer is not None:
+            libsecp256k1_ffi.buffer(self._prvkey_buffer)[:] = bytes(32)
+            self._prvkey_buffer = None
         self._q = 0
         self._wiped = True
 
@@ -1397,7 +1422,7 @@ class Signer:
         if self._pub_key_sec is not None:
             sig = _delegated_sign_(
                 msg_hash,
-                self._q,
+                self._prvkey_buffer,
                 grind,
                 self._ec,
                 verify=verify,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,11 @@ secp256k1 = [
     # is that sum with its terms as well, so that no product of a
     # multi-scalar multiplication crosses the boundary; and for
     # `ssa.Signer` (btclib-secp256k1#154), which `ecc.ssa.Signer` holds so
-    # that a keypair is built once per key rather than once per signature.
+    # that a keypair is built once per key rather than once per signature;
+    # and for `dsa.sign` accepting a caller-owned 32-octet cffi array as
+    # `prvkey` and passing it through unconverted (btclib-secp256k1#253),
+    # which `ecc.dsa.Signer` now holds so that `wipe` reaches the
+    # delegated arm too (issue #1009).
     # The version is not on PyPI yet -- `[tool.uv.sources]` below is what
     # resolves it here -- so this floor is also what stops a release going
     # out against a bindings that cannot serve it

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -11,6 +11,7 @@ from typing import Any
 import pytest
 
 from btclib._libsecp256k1 import dsa as libsecp256k1_dsa
+from btclib._libsecp256k1 import ffi as libsecp256k1_ffi
 from btclib._libsecp256k1 import recovery as libsecp256k1_recovery
 from btclib.alias import INF, JacPoint, Point
 from btclib.curves import (
@@ -2320,45 +2321,42 @@ def test_a_wiped_python_signer_refuses_rather_than_signing_with_the_zeros(
 
 
 @needs_bindings
-def test_a_delegated_signer_s_wipe_refuses_rather_than_pretending() -> None:
-    """`wipe` here would be a promise this arm cannot keep, so it refuses.
+def test_a_delegated_signer_s_wipe_zeroes_the_buffer_it_signs_from() -> None:
+    """`wipe` reaches this arm's key now, not only the reference to it.
 
-    ECDSA has no libsecp256k1 keypair the way BIP340 does: every
-    signature this arm makes hands the bindings a fresh, unreachable copy
-    of the key (btclib-secp256k1#247), so there is no persistent secret a
-    later `wipe` could still reach -- unlike the Python arm, dropping
-    `self._q` here would not undo anything already done. `NotImplementedError`
-    says so rather than a silent no-op that would let a caller believe
-    the key is gone, and the signer is left exactly as usable as before,
-    the refusal not being recorded as a wipe.
+    btclib-secp256k1#253 is what makes this true: `dsa.sign`'s `prvkey`
+    argument passes a 32-octet cffi array through unconverted rather
+    than coercing it to a fresh, unreachable `bytes` on every call
+    (btclib-secp256k1#247, closed by that change), so the buffer this
+    signer built at construction is the same 32 octets every signature
+    it has made was read from, and overwriting it now reaches every one
+    of them at once -- not only the copy this object happens to be
+    holding when `wipe` is called.
     """
     signer = dsa.Signer(prv_key_int)
     assert signer.sign(b"a message")
 
-    with pytest.raises(NotImplementedError, match="btclib-secp256k1#247"):
-        signer.wipe()
-    # refused, not silently accepted: the signer still holds its key and
-    # still signs, which is what "not marked wiped" means in practice
-    assert signer.sign(b"a message")
-    with pytest.raises(NotImplementedError, match="btclib-secp256k1#247"):
-        signer.wipe()
+    buffer = signer._prvkey_buffer
+    assert bytes(libsecp256k1_ffi.buffer(buffer)) != bytes(32)
+    signer.wipe()
+    assert bytes(libsecp256k1_ffi.buffer(buffer)) == bytes(32)
+    assert signer._prvkey_buffer is None
 
-    # the `with` statement wipes on the way out, so it raises too -- even
-    # where the block signed nothing and ended cleanly
-    with (
-        pytest.raises(NotImplementedError, match="btclib-secp256k1#247"),
-        dsa.Signer(prv_key_int) as block_signer,
-    ):
+    with pytest.raises(BTClibValueError, match="the signer is wiped"):
+        signer.sign(b"a message")
+    # idempotent, as `close` is on the signer contract
+    signer.wipe()
+    with pytest.raises(BTClibValueError, match="the signer is wiped"):
+        signer.sign(b"a message")
+
+    with dsa.Signer(prv_key_int) as block_signer:
         assert block_signer.sign(b"a message")
+    with pytest.raises(BTClibValueError, match="the signer is wiped"):
+        block_signer.sign(b"a message")
 
-    # and where the block itself raised, python's own `with` semantics
-    # are what decide the outcome and not this class's: `__exit__`
-    # raising a new exception replaces the one the block was propagating,
-    # chaining it on as `__context__` rather than losing it -- a caller
-    # who wants to know the block itself failed reads that attribute
-    with (
-        pytest.raises(NotImplementedError, match="btclib-secp256k1#247") as raised,
-        dsa.Signer(prv_key_int),
-    ):
+    # and the block wipes on the way out of an exception too
+    raising = dsa.Signer(prv_key_int)
+    with pytest.raises(ZeroDivisionError), raising:
         _ = 1 / 0
-    assert isinstance(raised.value.__context__, ZeroDivisionError)
+    with pytest.raises(BTClibValueError, match="the signer is wiped"):
+        raising.sign(b"a message")

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -2157,9 +2157,6 @@ def test_a_signer_answers_what_sign_answers(
 
     q, Q = dsa.gen_keys(prv_key_int)
 
-    # not a `with` block: on the delegated arm `wipe` -- which `__exit__`
-    # calls -- refuses rather than running, and this signer is used for
-    # nothing but comparing signatures
     signer = dsa.Signer(prv_key_int)
     for msg in (b"", b"a message", bytes(32), bytes(1000)):
         msg_hash = reduce_to_hlen(msg)

--- a/uv.lock
+++ b/uv.lock
@@ -459,7 +459,7 @@ test = [
 [[package]]
 name = "btclib-secp256k1"
 version = "0.8.0.3"
-source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#52f913e706f822bd447732a99d8728a86c22e516" }
+source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#bc36867fa1dc4901b5ccd6cf2b2d0240d6a07984" }
 dependencies = [
     { name = "cffi" },
 ]


### PR DESCRIPTION
Closes #1009.

`Signer.wipe()` used to raise `NotImplementedError` on the delegated
arm, citing btclib-secp256k1#247: ECDSA has no persistent keypair in
libsecp256k1 the way BIP340 does, and the bindings coerced whatever
private key was passed into a fresh immutable `bytes` object on every
signature regardless of what a `Signer` held, so there was no copy of
the secret left for `wipe` to reach.

That premise is stale. btclib-secp256k1#247 closed on 2026-08-18, via
btclib-secp256k1 PR #253: `dsa.sign`'s `prvkey` argument now accepts a
caller-owned cffi array of exactly 32 octets and passes it through
unconverted — a caller who owns the buffer keeps owning it, and
libsecp256k1 reads the same pointer on every call rather than a fresh
copy of it. The pin was 16 commits behind btclib-secp256k1's main, so
this also carries `uv lock --upgrade-package btclib-secp256k1` forward
to pick it up.

## What this changes

`Signer.__init__` builds one `ffi.new("unsigned char[32]", ...)` at
construction, on the delegated arm, instead of keeping the plain `int`
it held before. `_delegated_sign_` hands the bindings that same buffer
on every signature — confirmed byte-identical to signing from the
equivalent `bytes` before making this change. `wipe()` overwrites those
32 octets (`ffi.buffer(...)[:] = bytes(32)`) instead of raising, which
reaches every signature this instance has made, not only the reference
it is currently holding: the whole point of #1009 was a `Signer` that
does not leave a trail of unreachable copies behind it, and now it
does not.

`ffi` is the one new name crossing `btclib/_libsecp256k1.py`'s
chokepoint — it is a public export of `btclib_secp256k1` (not a
private/underscore module), used the same way the class already uses
`libsecp256k1_dsa`.

## Scope

I looked at three ways to close the gap and want to be explicit that
this is the middle one:

- reaching into `btclib_secp256k1._secret` (`scalar_buffer`/`wipe`),
  which is what `ssa.py`, `xonly.py` and `silentpayments.py` use
  *inside* that package — rejected, since it is underscore-private and
  can change with no notice, even across a patch release, and nothing
  in btclib touches bindings internals like that anywhere else;
- building the buffer directly with the public `ffi` export, zeroing
  it with plain cffi — what this PR does, at the cost of a few lines
  `_secret.wipe`/`_secret.scalar_buffer` would have saved, but with no
  dependency on anything not part of the bindings' public surface;
- asking upstream for a public `dsa`-side facility mirroring `ssa`'s
  own `Signer` class — not needed: the public `ffi` export plus PR
  #253's change to `dsa.sign` itself is already a complete, stable
  surface for this.

## Verification

```
$ uv run pytest                               # 28234 passed, 6 skipped, 100% coverage
$ uv run pre-commit run --all-files           # every hook, exit 0
$ uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
                                               # build succeeded
$ UV_PROJECT_ENVIRONMENT=.venv-nobindings \
    uv sync --locked --no-default-groups --group harness
$ UV_PROJECT_ENVIRONMENT=.venv-nobindings uv run --locked \
    --no-default-groups --group harness pytest --cov
                                               # 22405 passed, 5835 skipped
                                               # (this arm alone is not
                                               # the 100% gate; coverage-union
                                               # combines it with the main run)
```

By hand: a `Signer` built from a buffer and one built from the
equivalent `bytes` sign identically; after `wipe()`, the buffer this
test kept a reference to reads all zero and a further `sign()` raises
`the signer is wiped` — mirrored on `tests/ecc/dsa_test.py`'s new
`test_a_delegated_signer_s_wipe_zeroes_the_buffer_it_signs_from`,
alongside the existing Python-arm wipe test, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make delegated ECDSA signers retain their private key in a wipeable buffer so `Signer.wipe()` clears the key and disables subsequent signing.

New Features:
- Enable `ecc.dsa.Signer.wipe()` to securely zero the delegated arm’s persistent signing key buffer and prevent further signing.

Bug Fixes:
- Ensure delegated ECDSA signers no longer retain inaccessible per-signature secret copies, allowing wipe to reach the key material used by all signatures.

Enhancements:
- Expose the secp256k1 bindings’ public `ffi` handle for constructing and clearing the signer-owned key buffer.

Build:
- Upgrade the pinned `btclib-secp256k1` dependency to support caller-owned private-key buffers.

Documentation:
- Document the delegated signer’s key-buffer lifetime and the remaining limitations around transient secret representations.

Tests:
- Update delegated signer coverage to verify buffer zeroization, idempotent wiping, and rejection of signing after wipe.