### PR TITLE
Delegate output_keys to silentpayments.create_outputs (issue #910)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3912,6 +3912,40 @@ documented at release-notes length in the first place, and are still in
   octets every signature has read from, on the delegated arm exactly as
   it already did on the Python one. The bindings pin moves to pick up
   btclib-secp256k1#253.
+- **`silent_payments.output_keys` reaches
+  `btclib_secp256k1.silentpayments.create_outputs` where the bindings
+  serve secp256k1** (issue #910), the sender's half of BIP352 joining
+  `dsa.sign` and `ssa.sign` on the delegated path. Addresses are grouped
+  by scan key and flattened group by group, each group's members kept in
+  the order `output_keys`'s own Python loop would assign k in, which is
+  the same order `secp256k1_silentpayments_sender_create_outputs` assigns
+  k by; the taproot split is `prv_key_sum`'s own -- `is_p2tr` of the
+  script a key spends -- except the even-y negation is not repeated by
+  hand, `secp256k1_keypair_create` doing that internally the same way
+  `ssa.Signer` never negates a key itself either.
+
+  `scan_outputs`, the recipient's half, is not delegated here. It takes
+  `tweak: PubKey` -- the already-reduced `input_hash * A_sum` a light
+  client gets from a server per BIP352's Appendix A, with no outpoints or
+  input public keys in sight -- while
+  `btclib_secp256k1.silentpayments.scan_outputs` wants a `prevouts_summary`
+  built from exactly those, and derives the shared secret from the scan
+  key itself rather than accepting one already reduced. The two have no
+  common precondition without widening `scan_outputs`'s own signature to
+  always demand data a light client never has, which is left for a
+  separate issue rather than folded into this one silently.
+
+  The bindings' own `create_outputs` docstring is explicit that
+  addresses, output types and transaction parsing are not its concern --
+  `pub_key_from_input`'s script and witness reading, `NUMS_H`, `K_MAX`
+  and every eligibility rule stay exactly where they were, in Python, on
+  both arms; `psbt.silent_payments`'s BIP375 path, which reaches
+  `output_key` from an ECDH share a psbt carries rather than from a
+  private key, has no entry point in the bindings to reach either and
+  stays Python-only regardless. `shared_secret`, `input_hash`,
+  `tweak_data`, `pub_key_sum` and `prv_key_sum` are unchanged: libsecp256k1
+  composes those steps and exposes none of them separately, so there is
+  nothing here for them to delegate to.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -208,14 +208,18 @@ may have copied it meanwhile. The constant-time properties are
 libsecp256k1's, and they hold on the C side of the call — not before it,
 and not after.
 
-Not every operation crosses that call. `dsa.sign` and `ssa.sign` reach the
-bindings for secp256k1 with sha256 and no nonce of the caller's; another
-curve, another hash function, or a nonce you supply runs the Python
-arithmetic instead, which the suite validates against the bindings but
-which is not constant-time. So a caller whose threat model includes timing
-should stay on the delegated paths, or keep the key out of the process
-altogether: `btclib.hwi` drives a hardware wallet through HWI, behind the
-same `PsbtSigner` contract a software signer answers.
+Not every operation crosses that call. `dsa.sign`, `ssa.sign` and
+`silent_payments.output_keys` reach the bindings for secp256k1 with sha256
+and no nonce of the caller's; another curve, another hash function, or a
+nonce you supply runs the Python arithmetic instead, which the suite
+validates against the bindings but which is not constant-time. So a caller
+whose threat model includes timing should stay on the delegated paths, or
+keep the key out of the process altogether: `btclib.hwi` drives a hardware
+wallet through HWI, behind the same `PsbtSigner` contract a software
+signer answers. `silent_payments.scan_outputs`, the recipient's half of
+BIP352, is Python-only regardless: it accepts the shared secret already
+reduced, the shape a light client has and the bindings have no entry
+point for.
 
 What that path does about it is in the names, and it is worth knowing
 before calling one. **A function whose duration follows the value it is

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -202,6 +202,16 @@ used to teach and to prototype as much as to build:
     `keys.prvkey_tweak_add` privately and `keys.PubkeyTweakChain`
     publicly, and the Python arm behind them — BIP32's two sums, on
     integers and on a point — is one no argument selects either.
+    `silent_payments.output_keys` is the sender's half of BIP352, which
+    is the same case a third time: it reaches
+    `silentpayments.create_outputs` for every private key an eligible
+    input carries, a keypair built and wiped per taproot input and a
+    scalar buffer per other one, exactly as `dsa.sign` and `ssa.sign`
+    build and wipe theirs. `scan_outputs`, the recipient's half, is not
+    delegated — it takes the shared secret already reduced, which is the
+    shape a BIP352 light client has and the bindings' own `scan_outputs`
+    does not accept, wanting the raw inputs to derive it from instead —
+    so every secret that function meets is still Python's alone.
     Anything else — another
     curve, another hash function, a nonce of your own — runs the Python
     implementation, whose scalar multiplication is

--- a/btclib/_libsecp256k1.py
+++ b/btclib/_libsecp256k1.py
@@ -4,7 +4,7 @@
 
 """Everything btclib asks of libsecp256k1, imported in one place.
 
-Eleven modules delegate to the bindings and none of them imports them:
+The modules that delegate to the bindings import none of them directly:
 they import from here, so the question "are the bindings installed" is
 asked once, at one import, and answered by `AVAILABLE` rather than by
 eleven `try` blocks that could drift apart. `curves.curve` reads that
@@ -60,6 +60,7 @@ __all__ = [
     "pubkey_tweak_mul_sum",
     "pubkey_verify",
     "recovery",
+    "silentpayments",
     "ssa",
     "ssa_verify",
     "xonly",
@@ -75,7 +76,16 @@ try:
     # keypair `ssa` itself builds. Nothing else here needs it, `dsa.sign`
     # and every other wrapped call taking that buffer as the `prvkey` a
     # caller may already hold (btclib-secp256k1#253)
-    from btclib_secp256k1 import dsa, ellswift, ffi, keys, recovery, ssa, xonly
+    from btclib_secp256k1 import (
+        dsa,
+        ellswift,
+        ffi,
+        keys,
+        recovery,
+        silentpayments,
+        ssa,
+        xonly,
+    )
     from btclib_secp256k1.dsa import verify as dsa_verify
     from btclib_secp256k1.keys import (
         PubkeyTweakChain,
@@ -110,6 +120,7 @@ except ImportError:  # pragma: no cover
     # ignore is on the assignment and not on the module: every other
     # name here keeps the type the try branch gave it
     dsa = ellswift = ffi = keys = recovery = ssa = xonly = None  # type: ignore[assignment]
+    silentpayments = None  # type: ignore[assignment]
     # a class rather than a function, so mypy calls it an assignment to
     # a type and wants the second code as well
     PubkeyTweakChain = None  # type: ignore[misc, assignment]

--- a/btclib/silent_payments.py
+++ b/btclib/silent_payments.py
@@ -64,11 +64,17 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 
+from btclib._libsecp256k1 import silentpayments as libsecp256k1_silentpayments
 from btclib.alias import NetworkType, Octets, Point, String
 from btclib.b32 import power_of_2_base_conversion
 from btclib.bech32 import _BECH32_M_CONST, decode, encode
 from btclib.curves import bytes_from_point, mult, point_from_octets, secp256k1
-from btclib.curves.curve import _sum_var, _tweak_add_var, _TweakChain
+from btclib.curves.curve import (
+    _libsecp256k1_serves,
+    _sum_var,
+    _tweak_add_var,
+    _TweakChain,
+)
 from btclib.curves.sec_point import _mult_sec_var
 from btclib.ecc.ssa import point_from_bip340pub_key
 from btclib.exceptions import BTClibTypeError, BTClibValueError
@@ -566,6 +572,60 @@ def output_key(secret: PubKey, B_m: PubKey, k: int) -> bytes:
     return _x_only(_tweak_add_var(point_from_pub_key(B_m), t_k, secp256k1))
 
 
+def _delegated_output_keys(
+    prv_keys: Sequence[tuple[PrvKey, Octets]],
+    outpoints: Sequence[OutPoint],
+    groups: Mapping[Point, list[Point]],
+) -> list[bytes]:
+    """`output_keys` over `silentpayments.create_outputs`, secp256k1 only.
+
+    `groups` is already validated -- `output_keys` built it and checked
+    every K_MAX bound before calling this. Recipients are flattened group
+    by group, each group's addresses kept in the order they were appended,
+    which is the order `output_keys`'s own Python loop would assign k in:
+    `secp256k1_silentpayments_sender_create_outputs` assigns k by a scan
+    key's position of first appearance and increments it per repeat, the
+    same rule BIP352's reference algorithm groups by, so handing it the
+    recipients in that order derives the identical k for every one of
+    them. The list it returns is not re-sorted into address order --
+    `test_sending_vectors` already compares the *set* `output_keys`
+    answers, output order never having been part of the contract.
+
+    The taproot split is `prv_key_sum`'s own -- `is_p2tr` of the script a
+    private key spends -- except the negation for an odd-y point is not
+    redone here: `keypair` on the bindings' side is a
+    `secp256k1_keypair_create` per taproot input, which is BIP340's own
+    even-y normalization and does that negation internally, the same way
+    `ssa.Signer` never negates a key by hand either.
+    """
+    outpoint_smallest36 = min(outpoint.serialize() for outpoint in outpoints)
+    recipients_bytes = [
+        (bytes_from_point(B_scan, secp256k1), bytes_from_point(B_m, secp256k1))
+        for B_scan, B_m_values in groups.items()
+        for B_m in B_m_values
+    ]
+    taproot_prvkeys: list[int] = []
+    prvkeys: list[int] = []
+    for prv_key, script_pub_key in prv_keys:
+        bucket = (
+            taproot_prvkeys if is_p2tr(bytes_from_octets(script_pub_key)) else prvkeys
+        )
+        bucket.append(int_from_prv_key(prv_key))
+    try:
+        return libsecp256k1_silentpayments.create_outputs(
+            recipients_bytes, outpoint_smallest36, taproot_prvkeys, prvkeys
+        )
+    except ValueError as e:
+        # `prv_key_sum` and `input_hash` already ran, above, and are what
+        # give a caller the specific "sum to zero" or "no outpoint"
+        # wording for the two common refusals -- what reaches here is
+        # libsecp256k1's own, coarser message for whatever else its own
+        # validation catches, kept a BTClibValueError rather than left a
+        # bare one so a caller catching this library's exceptions still
+        # does
+        raise BTClibValueError(str(e)) from e
+
+
 def output_keys(
     prv_keys: Sequence[tuple[PrvKey, Octets]],
     outpoints: Sequence[OutPoint],
@@ -596,6 +656,15 @@ def output_keys(
     t_k for both would make the difference of the two output keys equal
     the difference of the two published addresses, which is the recipient
     named in public.
+
+    Where the bindings serve secp256k1 -- BIP352 has no other curve to
+    ask them for -- this is `silentpayments.create_outputs`'s own
+    derivation rather than the Python arithmetic below: one keypair build
+    per taproot input and one shared-secret multiplication per recipient
+    group inside libsecp256k1, in place of `mult` and `_mult_sec_var`
+    here. `a` and `h` are computed either way, for the refusal a zero
+    private-key sum or an empty outpoint sequence already has a specific
+    message for -- see `_delegated_output_keys`.
     """
     a = prv_key_sum(prv_keys)
     h = input_hash(outpoints, mult(a))
@@ -612,6 +681,12 @@ def output_keys(
             err_msg = f"too many recipients sharing one scan key: {len(B_m_values)}"
             err_msg += f" > K_MAX ({K_MAX})"
             raise BTClibValueError(err_msg)
+
+    if not groups:
+        return []
+
+    if _libsecp256k1_serves(secp256k1, None):
+        return _delegated_output_keys(prv_keys, outpoints, groups)
 
     keys: list[bytes] = []
     for B_scan, B_m_values in groups.items():

--- a/tests/python_arm_authority_test.py
+++ b/tests/python_arm_authority_test.py
@@ -331,6 +331,7 @@ _AUTHORITY: dict[str, tuple[str, ...]] = {
         "script_engine/script_test.py",
         "script_engine/transactions_test.py",
     ),
+    "silent_payments.output_keys": ("silent_payments_test.py",),
 }
 
 # the ones the measurement found nothing for, named so that closing one

--- a/tests/silent_payments_test.py
+++ b/tests/silent_payments_test.py
@@ -29,6 +29,7 @@ from typing import Any
 import pytest
 
 from btclib import silent_payments
+from btclib._libsecp256k1 import silentpayments as libsecp256k1_silentpayments
 from btclib.b32 import power_of_2_base_conversion
 from btclib.bech32 import _BECH32_M_CONST, encode
 from btclib.curves import bytes_from_point, mult, secp256k1
@@ -37,7 +38,7 @@ from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
 from btclib.script.witness import Witness
 from btclib.tx.out_point import OutPoint
-from tests import load, vector_id
+from tests import load, needs_bindings, vector_id
 
 _VECTORS = load("_data", "send_and_receive_test_vectors.json", encoding="utf-8")
 
@@ -484,6 +485,130 @@ def test_a_spending_key_of_zero_is_refused() -> None:
     tweak = secp256k1.n - _B_SPEND_PRV
     with pytest.raises(BTClibValueError, match="sum to zero"):
         silent_payments.prv_key_from_tweak(_B_SPEND_PRV, tweak)
+
+
+@needs_bindings
+@pytest.mark.parametrize("index,test", _SENDING, ids=_SENDING_IDS)
+def test_output_keys_matches_across_arms(
+    index: int, test: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The delegated and the Python arm answer the same set of outputs.
+
+    `output_keys`'s own dispatch is `_libsecp256k1_serves(secp256k1,
+    None)`, imported into this module's own namespace the way `dsa` and
+    `ssa` import theirs, so a vector is run twice with the predicate
+    patched between the two -- the same shape `dsa_test.py`'s own
+    cross-arm tests use. `test_sending_vectors` already carries every
+    other assertion this file makes about a vector, including the two
+    refusals (a zero private-key sum, more than K_MAX recipients sharing
+    a scan key), which is why this asks only whether the two arms refuse
+    together or agree on the answer.
+    """
+    given, expected = test["given"], test["expected"]
+    prv_keys = [
+        (v["private_key"], v["prevout"]["scriptPubKey"]["hex"])
+        for v in given["vin"]
+        if _pub_key_of(v) is not None
+    ]
+    if not prv_keys:
+        pytest.skip("nothing eligible to derive a secret from")
+    addresses = [recipient["address"] for recipient in _recipients(given)]
+    outpoints = _outpoints(given["vin"])
+
+    def _keys(*, delegated: bool) -> list[bytes] | None:
+        with monkeypatch.context() as arm:
+            if not delegated:
+                arm.setattr(silent_payments, "_libsecp256k1_serves", lambda *_a: False)
+            try:
+                return silent_payments.output_keys(prv_keys, outpoints, addresses)
+            except BTClibValueError:
+                return None
+
+    delegated_keys = _keys(delegated=True)
+    python_keys = _keys(delegated=False)
+    assert (delegated_keys is None) == (python_keys is None)
+    if delegated_keys is not None:
+        assert python_keys is not None
+        assert set(delegated_keys) == set(python_keys)
+        assert expected["outputs"] and any(
+            {key.hex() for key in delegated_keys} == set(valid)
+            for valid in expected["outputs"]
+        )
+
+
+@needs_bindings
+def test_output_keys_interleaved_groups_match_across_arms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two scan keys interleaved, one of them labelled, taproot and not.
+
+    The vector file has no case mixing a taproot and a non-taproot input
+    while addressing two recipients out of order -- X, Y, X's second
+    label -- so this is the case built by hand: it is the one shape where
+    a grouping mismatch between the two arms would show up as a wrong
+    *set*, not merely a wrong order, because `keys_from_address(X)`'s
+    second address shares X's group and gets the next k after X's first.
+    """
+    a_taproot = 0xEADC78165FF1F8EA94AD7CFDC54990738A4C53F6E0507B42154201B8E5DFF3B1
+    a_legacy = 0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCD
+    taproot_script = "5120" + bytes_from_point(mult(a_taproot))[1:].hex()
+    legacy_script = "0014" + hash160(bytes_from_point(mult(a_legacy))).hex()
+    prv_keys = [(a_taproot, taproot_script), (a_legacy, legacy_script)]
+    outpoints = [OutPoint("00" * 31 + "01", 0), OutPoint("00" * 31 + "02", 1)]
+
+    x_scan, x_spend = 0x11, 0x22
+    y_scan, y_spend = 0x33, 0x44
+    x_address = silent_payments.address_from_keys(mult(x_scan), mult(x_spend))
+    y_address = silent_payments.address_from_keys(mult(y_scan), mult(y_spend))
+    x_labelled = silent_payments.labeled_address_from_keys(x_scan, mult(x_spend), 1)
+    addresses = [x_address, y_address, x_labelled]
+
+    delegated = silent_payments.output_keys(prv_keys, outpoints, addresses)
+    with monkeypatch.context() as no_bindings:
+        no_bindings.setattr(silent_payments, "_libsecp256k1_serves", lambda *_a: False)
+        python = silent_payments.output_keys(prv_keys, outpoints, addresses)
+    assert len(delegated) == len(addresses)
+    assert set(delegated) == set(python)
+
+
+def test_output_keys_pays_nothing_for_no_addresses() -> None:
+    """No recipient is nothing to derive, on either arm.
+
+    `create_outputs` itself refuses an empty recipient list -- "at least
+    one recipient is required" -- so `output_keys` answers before
+    reaching it, the same `[]` the Python loop below would have built
+    from an empty `groups`.
+    """
+    script_pub_key = "0014" + hash160(bytes_from_point(mult(_B_SCAN_PRV))).hex()
+    outpoints = [OutPoint("00" * 31 + "01", 0)]
+    assert (
+        silent_payments.output_keys([(_B_SCAN_PRV, script_pub_key)], outpoints, [])
+        == []
+    )
+
+
+@needs_bindings
+def test_output_keys_wraps_a_delegated_refusal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`create_outputs`'s own ValueError still comes back a BTClibValueError.
+
+    `prv_key_sum` and `input_hash` already cover the two refusals a real
+    transaction can trigger -- a zero private-key sum, no outpoint -- so
+    this is not a case the vector file has: the bindings' own message for
+    whatever else `secp256k1_silentpayments_sender_create_outputs` itself
+    refuses (an output landing on the point at infinity, say) is
+    substituted for rather than reproduced.
+    """
+
+    def _refuse(*_args: object, **_kwargs: object) -> list[bytes]:
+        raise ValueError("silent payment output creation failed")
+
+    monkeypatch.setattr(libsecp256k1_silentpayments, "create_outputs", _refuse)
+    script_pub_key = "0014" + hash160(bytes_from_point(mult(_B_SCAN_PRV))).hex()
+    outpoints = [OutPoint("00" * 31 + "01", 0)]
+    with pytest.raises(BTClibValueError, match="silent payment output creation failed"):
+        silent_payments.output_keys(
+            [(_B_SCAN_PRV, script_pub_key)], outpoints, [_address()]
+        )
 
 
 def test_the_whole_round_trip_without_a_vector() -> None:


### PR DESCRIPTION
Addresses #910. Does not close it: the issue asks for both halves of
BIP352 to reach the bindings' `silentpayments` module, and this lands
the sender's half only -- `scan_outputs` is deliberately left Python,
for a reason found while implementing rather than assumed going in.
See "Scope" below.

## The four decisions the issue asks for

**1. Which functions delegate.** `output_keys` (the sender's whole
operation) to `create_outputs`, gated by
`_libsecp256k1_serves(secp256k1, None)` -- BIP352 has no other curve
to ask the bindings for. `shared_secret`, `input_hash`, `tweak_data`,
`pub_key_sum` and `prv_key_sum` stay exactly as they are: libsecp256k1
composes those steps and exposes none of them separately, so there is
nothing for them to delegate to. `scan_outputs` is not delegated --
see Scope.

**2. `SilentPaymentOutput` from what the bindings return.** Moot for
this PR: `create_outputs` already returns `list[bytes]` of 32-byte
x-only keys in the order its recipients were given, which is exactly
`output_keys`'s own return type, so there is no dataclass to build
here. The question still applies to `scan_outputs`'s
`(output_xonly, tweak, label | None)` triples, and is inherited by
whatever follow-up takes that on.

**3. `label_lookup`'s map against the bindings' `Mapping[bytes,
BytesLike]`.** Also moot here for the same reason -- `output_keys`
never touches labels or the label map at all, that being
`scan_outputs`'s business. Worth recording for the follow-up: the
bindings' own docstring is explicit that a mapping's keys have to stay
`bytes` and only `bytes`, unlike every other argument, `bytearray`
and `memoryview` being unhashable; `label_lookup` already returns
`dict[bytes, int]` with `bytes` keys, so only the tweak values would
need `.to_bytes(32, "big")` on the way in.

**4. The Python arm tested against the bindings.** Yes --
`test_output_keys_matches_across_arms` runs every one of BIP352's own
sending vectors twice, once delegated and once with
`_libsecp256k1_serves` patched false, and asserts the two arms either
refuse together or agree on the exact set of outputs, the same shape
`dsa_test.py`'s own cross-arm tests use.
`tests/python_arm_authority_test.py`'s sentinel (issue #1003) now
carries `silent_payments.output_keys` too, measured against a fresh
no-bindings coverage run rather than asserted:

```
$ UV_PROJECT_ENVIRONMENT=.venv-no-bindings uv sync --locked --no-default-groups --group harness
$ UV_PROJECT_ENVIRONMENT=.venv-no-bindings uv run --locked --no-default-groups --group harness \
    python .github/scripts/check_python_arm_authority.py
Every _AUTHORITY entry matches a fresh no-bindings measurement.
```

## What "found while implementing" narrowed

Grouping. `output_keys` groups addresses by scan key so a group's k is
consecutive (BIP352's own rule -- reusing one t_k for two labelled
addresses of one recipient would leak the recipient). `create_outputs`
assigns k the identical way, by a scan key's position of first
appearance among the recipients it is handed, so `_delegated_output_keys`
flattens the already-built `groups` dict group by group rather than
handing it the addresses in raw input order, which is what makes the
two arms derive the same k for every recipient without needing to
trust that libsecp256k1's own internal grouping matches
`output_keys`'s. This is exercised directly:
`test_output_keys_interleaved_groups_match_across_arms` hand-builds
two scan keys addressed out of order (X, Y, X's second label), mixing
a taproot and a non-taproot input, which the vector file has no case
of.

Even-y negation. `prv_key_sum` negates a taproot input's private key
by hand when its own point has odd y, because BIP340 x-only keys
always mean the even one. `create_outputs` needs no such thing done to
it: `taproot_prvkeys` go through `secp256k1_keypair_create`
internally, which is BIP340's own even-y normalization, the same way
`ssa.Signer` never negates a key by hand either. Handing it a raw,
un-negated key is correct, and re-deriving the negation before
delegating would just be doing the bindings' own job twice.

Validation order. `a = prv_key_sum(prv_keys)` and
`h = input_hash(outpoints, mult(a))` still run unconditionally before
the dispatch, on both arms, even though the delegated arm does not
need either value: it is what keeps every existing refusal message
identical between the two arms -- "input private keys sum to zero",
"no outpoint to derive the input hash from" -- rather than falling
back to `create_outputs`'s own coarser wording for cases this library
already had a specific answer for. What `create_outputs` still refuses
on its own (an output landing on the point at infinity, say, which no
vector in the file triggers) comes back wrapped in `BTClibValueError`
rather than a bare `ValueError`, `test_output_keys_wraps_a_delegated_refusal`
holding that with the call monkeypatched to raise.

## Scope: `scan_outputs` is not here

`scan_outputs(b_scan, B_spend, tweak, outputs_to_check, labels)` takes
`tweak: PubKey` -- the already-reduced `input_hash * A_sum` a light
client gets from a server per BIP352's Appendix A, with no outpoints
or input public keys in sight. `silentpayments.scan_outputs` in the
bindings wants a `prevouts_summary` built from exactly those, and
derives the shared secret from the scan private key itself rather
than accepting one already reduced -- which is precisely the shape
the issue's own "What is bought" section praises, "computed once per
transaction and handed to `scan_outputs` for every scan key," but it
is a *different* precondition from what this tree's `scan_outputs`
promises its caller today.

The two do not compose without either recomputing the summary from
scratch on every scan (defeating the delegation's own point) or
widening `scan_outputs`'s public signature to always demand data a
light client never has, which would break every caller relying on
Appendix A today. That is a real design question and not a small one,
so it is left for a separate, focused issue rather than folded into
this one silently -- `SECURITY.md` and `README.md` both say plainly
that `scan_outputs` stays Python-only for now, so nobody has to read
this PR body to find out.

`pub_key_from_input`'s script and witness reading, `NUMS_H`, `K_MAX`
and every input-eligibility rule stay exactly where they are, on both
arms: the bindings' own `silentpayments` docstring is explicit that
addresses, output types and transaction parsing are not its concern.
`psbt.silent_payments`'s BIP375 path, which reaches `output_key` from
an ECDH share a psbt carries rather than from a private key, has no
entry point in the bindings to reach either way and stays Python-only
regardless of anything decided here.

## Verification

```
$ uv run pre-commit run --all-files   # exit 0, every hook
$ uv run pytest                       # exit 0, 28264 passed, 100% coverage
$ uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html   # exit 0
$ UV_PROJECT_ENVIRONMENT=.venv-no-bindings uv run --locked --no-default-groups \
    --group harness pytest tests/silent_payments_test.py tests/psbt/silent_payments_test.py
131 passed, 29 skipped   # genuinely bindings-free venv, not a re-sync of one that had them
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Delegate silent-payment output-key generation to libsecp256k1 while retaining Python validation, recipient scanning, and unsupported operation paths.

New Features:
- Delegate BIP352 sender output-key derivation to libsecp256k1 when compatible bindings are available.

Bug Fixes:
- Preserve consistent output derivation and error behavior between delegated and Python implementations, including grouped recipients and mixed input types.

Enhancements:
- Keep address parsing, input eligibility checks, and recipient-side scanning in Python while documenting the delegated-operation boundary and security implications.

Documentation:
- Document delegated silent-payment sender operations and clarify that recipient scanning remains Python-only.

Tests:
- Add cross-arm tests covering sending vectors, interleaved recipient groups, empty recipient lists, and delegated refusal handling.
- Extend Python-arm authority coverage to silent-payment output-key derivation.

Chores:
- Expose the silent-payments bindings module through the centralized libsecp256k1 wrapper.