### PR TITLE
Document the tag-integrity ruleset that closes issue #1022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ documented at release-notes length in the first place, and are still in
   repository-settings level rather than documenting it, is the issue's
   other option and is left for a separate, maintainer-authorized change.
 
+- **A `tag-integrity` ruleset now enforces the other half of issue
+  #1022**, requiring `required_signatures` on `refs/tags/v*`, with no
+  bypass actor. `RELEASING.md`'s tagging step already produces a signed
+  tag by default, so nothing about the release procedure changes; what
+  the ruleset adds is that an unsigned `v*` tag is now refused outright
+  rather than merely undocumented. It carries no `deletion` or
+  `non_fast_forward` rule on purpose: RELEASING.md's own recovery path
+  deletes and re-tags a release that failed before `publish-pypi`, and
+  either rule would block that. Existing tags are unaffected — the
+  ruleset applies to pushes going forward, not retroactively — closing
+  the issue now that both options it named are done.
+
 - **`claude-review.yml` reads a pull request against `REVIEWING.md`.**
   Two jobs: one on every non-draft pull request, whose prompt names that
   file rather than restating it, so the standard moves without the

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -282,7 +282,7 @@ branch, and it is the only branch there is. Issue #158 was the other
 arrangement — two bots pushing through an integration branch that carried
 no protection at all — and one branch is what closed it.
 
-### Two rulesets beside the classic rule
+### Three rulesets beside the classic rule
 
 `enforce_admins` off is one switch that exempts an administrator from
 every rule above at once — there is no way, inside the classic rule
@@ -290,7 +290,10 @@ alone, to relax the review requirement for a solo merge while keeping
 signatures and linear history unconditional. Two rulesets carry that
 split, additive to the classic rule rather than replacing it: rules
 aggregate across rulesets and classic protection, taking the most
-restrictive combination wherever they overlap.
+restrictive combination wherever they overlap. A third targets tags
+rather than `main`, for an unrelated reason: `release.yml` publishes to
+PyPI on `push: tags: ["v*"]`, and that tag was the one unattested link
+in an otherwise fully-signed chain (issue #1022).
 
 - `main-integrity`: required signatures, required linear history, no
   force pushes, no deletions. No bypass actor, for anyone, ever.
@@ -298,6 +301,13 @@ restrictive combination wherever they overlap.
   dismiss stale reviews, conversation resolution — and `squash` as the
   only merge method it will accept. Bypass: the maintainer, in
   **`pull_request` mode**.
+- `tag-integrity`, `target: tag`, `refs/tags/v*`: required signatures,
+  and nothing else. No `deletion` or `non_fast_forward` rule, on
+  purpose — RELEASING.md's own recovery path deletes and re-tags a
+  release that failed before `publish-pypi`, and either rule would
+  block exactly that. No bypass actor, for anyone, ever: RELEASING.md's
+  tagging step already produces a signed tag by default, so there is no
+  case that needs one.
 
 **The bypass mode is the whole of the design.** `pull_request` excuses
 its holder from the rule *while merging a pull request* and at no other
@@ -317,7 +327,7 @@ second half is not hypothetical: a `git merge` run in the wrong working
 tree is enough to advance `main` locally, and under `always` the push
 that follows would be accepted.
 
-Read the two back rather than trusting either:
+Read the three back rather than trusting any one:
 
 ```shell
 gh api repos/btclib-org/btclib/rulesets --jq '.[].id' \
@@ -326,8 +336,9 @@ gh api repos/btclib-org/btclib/rulesets --jq '.[].id' \
            bypass: [.bypass_actors[] | .bypass_mode]}'
 ```
 
-`main-integrity` answers with an empty bypass list, and it is what makes
-an unsigned commit or a rewritten history unlandable by anyone, admin or
+`main-integrity` and `tag-integrity` both answer with an empty bypass
+list, and it is what makes an unsigned commit or a rewritten history
+unlandable, and an unsigned `v*` tag unpushable, by anyone, admin or
 not, through a pull request or otherwise.
 
 **Two settings hold the door, not one.** The classic protection still


### PR DESCRIPTION
Closes #1022.

RELEASING.md already signs the tag it creates (`git tag -s`, PR #1028
— issue #1022's option (a)). This lands option (b): a `tag-integrity`
ruleset, `target: tag`, `refs/tags/v*`, `required_signatures`, no
bypass actor — created directly by the maintainer, outside PR-review
scope, per #1028's own note that a live repository-infrastructure
change needs their explicit authorization rather than a pull request.

Verified after creation:

```
$ gh api repos/btclib-org/btclib/rulesets/21087862 \
    --jq '{name, target, conditions, rules:[.rules[].type], bypass: .bypass_actors}'
{"bypass":[],"conditions":{"ref_name":{"exclude":[],"include":["refs/tags/v*"]}},"name":"tag-integrity","rules":["required_signatures"],"target":"tag"}
```

## What this PR adds

Documentation only — the ruleset itself already exists in the
repository settings.

- `REPOSITORY.md`'s "Two rulesets beside the classic rule" section
  becomes "Three", with `tag-integrity` described alongside
  `main-integrity` and `main-self-merge`, and the verification command
  block's prose updated from "the two" to "the three" (the command
  itself already loops over every ruleset id, so it needed no change).
- `CHANGELOG.md` records the ruleset under "Repository", beside the
  existing entry for PR #1028's `-s` fix.

Deliberately no `deletion` or `non_fast_forward` rule on the ruleset:
RELEASING.md's own recovery path (`git tag -d` + push the deletion,
then re-tag) deletes and re-creates a tag when a release fails before
`publish-pypi`, and either rule would block exactly that.

## Verification

```
$ uv run pre-commit run --all-files   # all hooks passed
$ uv run pytest                       # 28264 passed, 100.00% coverage
$ uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
# build succeeded
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document enforcement of signed version tags to complete the repository’s tag-integrity safeguards.

Enhancements:
- Document the repository’s tag-integrity ruleset, which requires signed version tags without bypass actors while preserving release-tag recovery operations.

Documentation:
- Update repository documentation to describe the third ruleset and its verification alongside the existing branch-integrity rulesets.
- Record the tag-integrity ruleset and its release-policy rationale in the changelog.