### PR TITLE
A truth's True has to be its conservative value (#884)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4113,10 +4113,16 @@ documented at release-notes length in the first place, and are still in
   written down and read back arrives as whatever it was written as and
   `"false"` is true; a flag that decides only *whether a check runs* is
   read for its truth. Applying it meant the census, and the census is
-  `tests/bool_parameter_test.py`: seventy-eight `bool` parameters besides
-  `check_validity`, fifty-three of them kinds and twenty-five truths, with
-  every one of the seventy-eight in one of the two tables or the run is
-  red.
+  `tests/bool_parameter_test.py`: two tables, every `bool` parameter of the
+  library but `check_validity` in one of them, and a walk that turns the
+  run red on a flag in neither. The split is measured rather than stated,
+  the file having grown since:
+
+  ```shell
+  uv run python -c 'import sys; sys.path.insert(0, ".")
+  from tests.bool_parameter_test import _bool_parameters, _KINDS, _TRUTHS
+  print(len(_bool_parameters()), len(_KINDS), len(_TRUTHS))'
+  ```
 
   What was open were the two the issue names, and thirty-odd more of the
   same shape:
@@ -4151,15 +4157,61 @@ documented at release-notes length in the first place, and are still in
   The truths are the other half of the census and they stay read for their
   truth, each with the reason in the table: `check_validity` (whose own
   file holds it), `check_root_xkey`, `verify_checksum`, `strict`,
-  `bip380_enforced`, `forbid_zero_size`, `allow_partial`, `check_amounts`,
-  `verify_network`, `branches_0_1_only`, `hybrid`, `power_of_two`,
-  `order_check`, `weakness_check`, the four `enforce_same_*`,
-  `unsigned_template` on `Tx.assert_valid`, and the engine's `final` and
-  `verified`. What makes the classification checkable rather than asserted
-  is that a truth is *driven* too: it is called with `"no"`, `0` and `1` on
-  a fixture its `True` accepts, and all three go through. A truth that
-  starts refusing fails that test, and the entry has to move to the kinds
-  rather than the test being edited.
+  `bip380_enforced`, `forbid_zero_size`, `check_amounts`,
+  `verify_network`, `branches_0_1_only`, `power_of_two`, `order_check`,
+  `weakness_check`, the four `enforce_same_*`, `unsigned_template` on
+  `Tx.assert_valid`, and the engine's `final`. What makes the
+  classification checkable rather than asserted is that a truth is
+  *driven* too: it is called with `"no"`, `0` and `1` on a fixture its
+  `True` accepts, and all three go through. A truth that starts refusing
+  fails that test, and the entry has to move to the kinds rather than the
+  test being edited. Three that this bullet filed as truths are kinds now,
+  moved by the polarity rule the bullet below is.
+
+- **A truth's `True` has to be its conservative value, and three whose
+  `True` was the permissive one are kinds now** (issue #884). The issue
+  asked about the script engine's `verified` and `final`, the two truths
+  of the census its author was least sure of, and the answer turned out to
+  be neither "both" nor "the engine": every wrong value is true, so the
+  misreading a non-bool makes is never "the flag was off" — it is always
+  the one the flag's `True` stands for. That, and not the fact that a
+  truth changes no answer, is what has been making the truths safe.
+  `verify_checksum="no"` checks the checksum, `strict="no"` is strict,
+  `forbid_zero_size="no"` forbids: the wrong value falls on the side that
+  refuses more, which is the side that cannot accept what was to be
+  refused.
+
+  So the classifying question is the polarity of the flag's own name, and
+  a flag whose `True` is the permissive value is a kind however little it
+  computes. Three were, each waiving the refusal it was written to make:
+
+  ```text
+  assert_nullfail(flags, verified="no", sigs, op)  -> NULLFAIL never fires
+  assert_signed(psbt, allow_partial="no")          -> an input nobody signed
+  point_from_octets(sec, hybrid="no")              -> 0x06 and 0x07 parsed
+  ```
+
+  `verified` is the one that costs money. It is not a caller's waiver but
+  a fact the engine derived — `op_checksig`'s answer, passed on — and its
+  `True` suppresses NULLFAIL, so a non-bool lets a non-empty signature
+  that failed to verify through a consensus rule, which is btclib calling
+  valid a transaction the network rejects. `allow_partial` stores as
+  complete a psbt still going round a signing session, and `hybrid` parses
+  the very prefixes it is off by default to keep out.
+
+  `verify_script`'s `final` stays a truth, which is the contrast that
+  shows the rule is about direction and not about the engine: it demands
+  the script end on a true stack, so a non-bool there fails a script
+  rather than passing one, and a script that fails is nobody's money. That
+  `segwit` beside it was already a kind is no longer the asymmetry the
+  issue reported — `segwit` picks a digest, `final` tightens an ending,
+  and the two are refused and read by the same rule read twice.
+
+  A caller passing a `bool` is unaffected; `0` and `1` are refused too, as
+  everywhere the kinds are. CONTRIBUTING.md states the rule beside the one
+  it completes, and `tests/bool_parameter_test.py` carries the three under
+  a comment of their own, being kinds by their polarity rather than by any
+  answer they choose.
 
 - **The input contract reaches `ec`, which had no check anywhere** (issue
   #868). The census of parameters behind a default put it fourth by

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -969,6 +969,21 @@ only *whether a check runs* is read for its truth: `check_validity` and
 `slip132`'s `check_root_xkey` either run a check or skip one, and neither
 changes an answer. `tests/check_validity_test.py` owns that convention.
 
+**A truth's `True` has to be its conservative value**, which is the second
+half of the same rule and the one issue #884 asked for. Every wrong value
+is true, so the misreading is never "the flag was off": it is always the
+one the flag's `True` stands for. That is what makes a truth safe —
+`verify_checksum="no"` checks the checksum, `strict="no"` is strict,
+`forbid_zero_size="no"` forbids — and it is a fact about the *name*, not
+about the check. So a flag whose `True` is the permissive value is a kind
+however little it computes, because the misreading waives the very refusal
+it was written to make: `verified` suppressing the script engine's NULLFAIL
+is the sharp one, with `allow_partial` accepting an input nobody signed and
+`hybrid` parsing the prefixes it was written to keep out. `verify_script`'s
+`final` beside `verified` is the contrast that shows the rule is about
+direction and not about the engine: it demands a true stack, so a non-bool
+there fails a script rather than passing one.
+
 **Which of the two a flag is, is written down for every one of them.**
 `tests/bool_parameter_test.py` is the census: two tables, a kind driven
 until it refuses `"no"`, `0` and `1`, a truth driven until it accepts all

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -77,7 +77,15 @@ full year, short month, short day (YYYY-M-D)
   being what made the type check no check at all. The flags that decide
   only whether a check runs — `check_validity`, `check_root_xkey`,
   `verify_checksum`, `strict`, `bip380_enforced` and the rest, listed in
-  `tests/bool_parameter_test.py` — are still read for their truth.
+  `tests/bool_parameter_test.py` — are still read for their truth, on the
+  one condition issue #884 added: a truth's `True` has to be its
+  conservative value. Every wrong value is true, so the misreading is
+  always the flag's `True`, and three whose `True` was the permissive one
+  are refused with the kinds above — the script engine's `verified`,
+  which suppressed the NULLFAIL rule for a signature that failed to
+  verify; `assert_signed`'s `allow_partial`, which accepted an input
+  nobody signed; and `point_from_octets`'s `hybrid`, which parsed the
+  0x06 and 0x07 prefixes it was written to keep out.
 
 - **the serialization boundary refuses what it used to take, and reports
   through the exception contract.** A `from_dict` handed a mapping

--- a/btclib/curves/sec_point.py
+++ b/btclib/curves/sec_point.py
@@ -105,8 +105,12 @@ def point_from_octets(
     hybrid form to render, and nothing in bitcoin produces one. Consensus
     has to accept what was mined instead: Core rejects hybrid keys only
     under STRICTENC, so the script engine is the one caller that asks for
-    them (issue #129).
+    them (issue #129). It is refused rather than read for its truth: its
+    `True` is the permissive value, and a non-bool is true, so
+    `hybrid="no"` would parse the very prefixes it was written down to
+    keep out.
     """
+    assert_type(hybrid, bool, "hybrid")
     _assert_valid_ec(ec)
     pub_key = bytes_from_octets(pub_key, (ec.p_size + 1, 2 * ec.p_size + 1))
 

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -2874,7 +2874,11 @@ def assert_signed(psbt: Psbt, *, allow_partial: bool = False) -> None:
     of a signing session still going round: a device holding keys for
     some inputs only -- one psbt spanning several wallets -- leaves the
     others untouched, and which of the two a psbt is is the caller's to
-    say and not this function's to guess.
+    say and not this function's to guess. It is refused rather than read
+    for its truth: its `True` is the permissive value, so the misreading
+    a non-bool always makes -- `allow_partial="false"` out of a
+    configuration file -- is the one that stores as complete a psbt with
+    an input nobody signed.
 
     What neither half asks is whether an input is *satisfied*: one
     signature of a 2-of-2 is an input signed, and whether a spend can be
@@ -2899,6 +2903,7 @@ def assert_signed(psbt: Psbt, *, allow_partial: bool = False) -> None:
     refused with that said rather than reported unsigned, what it now
     carries being a spend for the script engine to verify.
     """
+    assert_type(allow_partial, bool, "allow_partial")
     if not psbt.inputs:
         raise BTClibValueError("nothing is signed: no inputs")
     psbt.assert_valid()

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -353,7 +353,19 @@ def op_code_name(op_code: int) -> str:
 def assert_nullfail(
     flags: ScriptFlag, verified: bool, signatures: list[bytes], op: str
 ) -> None:
-    """Reject a signature that failed to verify and was not empty."""
+    """Reject a signature that failed to verify and was not empty.
+
+    `verified` is refused rather than read for its truth, which is what
+    separates it from `verify_script`'s `final` next door: every wrong
+    value is true, so the misreading a non-bool makes is always the one
+    the flag's `True` stands for. `final=True` demands a true stack, so
+    a non-bool there fails a script that would have passed; `True` here
+    *suppresses* this refusal, so `verified="false"` lets a non-empty
+    signature that failed to verify through a consensus rule.
+    CONTRIBUTING.md has that as the polarity a truth needs and this one
+    has not (issue #884).
+    """
+    assert_type(verified, bool, "verified")
     if ScriptFlag.NULLFAIL in flags and not verified and any(signatures):
         raise BTClibValueError(f"non-empty signature for a failed {op}")
 

--- a/tests/bool_parameter_test.py
+++ b/tests/bool_parameter_test.py
@@ -22,6 +22,24 @@ A **kind** decides what a non-refusing call computes, returns or writes.
 answer -- the other signature, the other address, the other script code --
 and that is what the refusal is for.
 
+## The polarity a truth has to have
+
+`"no"` is true, and so is every other wrong value, so the misreading is
+never "the flag was off": it is always the one the flag's `True` stands
+for. That is what makes a truth safe rather than the fact that it changes
+no answer -- `verify_checksum="no"` checks the checksum, `strict="no"` is
+strict, `forbid_zero_size="no"` forbids. The wrong value falls on the side
+that refuses more, which is the side that cannot accept what was to be
+refused.
+
+So a truth's `True` has to be its conservative value, and a flag whose
+`True` is the permissive one is a kind however little it computes. Three
+were: `verified`, `allow_partial` and `hybrid`, each waiving the very
+refusal it was written to make. They are in `_KINDS` under a comment of
+their own, and issue #884 is the one that asked, over `verified` and over
+`verify_script`'s `final` beside it -- which stays a truth, its `True`
+being the one that demands the true stack.
+
 The two tests below are that line, one each:
 
 - a kind refuses `"no"`, `0`, `1` and (where the annotation does not
@@ -246,8 +264,10 @@ class _Case:
     # `bool | None` declares None, so it is not a wrong value there. Read
     # off the annotation, not an exemption from anything
     optional: bool = False
-    # a truth's classification, which is prose because it is a judgement:
-    # what the flag turns on, and what it therefore cannot change
+    # the classification, which is prose because it is a judgement: for a
+    # truth what the flag turns on and what it therefore cannot change,
+    # and for a kind only where the kind is the polarity rather than the
+    # answer, three flags below being that
     reason: str = ""
 
 
@@ -670,6 +690,43 @@ _KINDS = (
         {},
         valid=INSTALLED,
     ),
+    # The three below decide no answer, which every kind above does, and
+    # are here for the other half of the line: their `True` is the
+    # permissive value. A truth is safe because a non-bool is true and
+    # its `True` is the conservative one -- `verify_checksum="no"` checks
+    # the checksum, `forbid_zero_size="no"` forbids, `final="no"` demands
+    # the true stack -- so the one misreading a non-bool can make is the
+    # one that refuses more. These read the other way, and each is the
+    # refusal it was written to make, waived
+    _Case(
+        "btclib.script.engine.script.assert_nullfail",
+        "verified",
+        engine.assert_nullfail,
+        {
+            "flags": ScriptFlag.NULLFAIL,
+            "signatures": [b""],
+            "op": "OP_CHECKSIG",
+        },
+        reason="`True` suppresses the NULLFAIL refusal, so a non-bool lets"
+        " a non-empty signature that failed to verify through a consensus"
+        " rule; `verify_script`'s `final` beside it tightens instead",
+    ),
+    _Case(
+        "btclib.psbt.psbt.assert_signed",
+        "allow_partial",
+        assert_signed,
+        {"psbt": _SIGNED_PSBT},
+        reason="`True` accepts an input still unsigned, so a non-bool"
+        " stores as complete a psbt nobody finished signing",
+    ),
+    _Case(
+        "btclib.curves.sec_point.point_from_octets",
+        "hybrid",
+        point_from_octets,
+        {"pub_key": _SEC},
+        reason="`True` accepts the 0x06 and 0x07 prefixes, so a non-bool"
+        " parses the very forms it was written down to keep out",
+    ),
 )
 
 _TRUTHS = (
@@ -816,13 +873,6 @@ _TRUTHS = (
         reason="whether the signature is checked before it is answered with",
     ),
     _Case(
-        "btclib.psbt.psbt.assert_signed",
-        "allow_partial",
-        assert_signed,
-        {"psbt": _SIGNED_PSBT},
-        reason="whether an input still unsigned is allowed",
-    ),
-    _Case(
         "btclib.var_bytes.parse",
         "forbid_zero_size",
         var_bytes.parse,
@@ -927,14 +977,6 @@ _TRUTHS = (
         " spelling that answers the keys rather than their text",
     ),
     _Case(
-        "btclib.curves.sec_point.point_from_octets",
-        "hybrid",
-        point_from_octets,
-        {"pub_key": _SEC},
-        reason="whether the 0x06 and 0x07 prefixes are accepted; the point"
-        " read out of octets both accept is the same point",
-    ),
-    _Case(
         "btclib.mnemonic.mnemonic.WordLists.__init__",
         "power_of_two",
         WordLists,
@@ -964,19 +1006,10 @@ _TRUTHS = (
             "segwit": False,
         },
         reason="whether the script is required to end on a true stack,"
-        " which is the caller saying no script runs after this one",
-    ),
-    _Case(
-        "btclib.script.engine.script.assert_nullfail",
-        "verified",
-        engine.assert_nullfail,
-        {
-            "flags": ScriptFlag.NULLFAIL,
-            "signatures": [b""],
-            "op": "OP_CHECKSIG",
-        },
-        reason="whether the NULLFAIL refusal fires, an empty signature"
-        " being what it demands of a check that failed",
+        " which is the caller saying no script runs after this one; it"
+        " stays here where `verified` did not, being the flag whose"
+        " `True` refuses more -- a non-bool fails a script instead of"
+        " passing one, and that is nobody's money",
     ),
 )
 


### PR DESCRIPTION
Closes #884.

The issue asked whether the script engine's `verified` and `final` are
truths or kinds, and offered three answers: leave both, move both, or
split them. The answer this takes is the split, on a criterion the issue
did not name and that turns out to decide the whole table.

## The rule

Every wrong value is true — `"no"`, `"false"`, `0`, `1` — so the
misreading a non-bool makes is never "the flag was off". It is always the
one the flag's `True` stands for. That, and not the fact that a truth
changes no answer, is what has been making the truths safe:
`verify_checksum="no"` checks the checksum, `strict="no"` is strict,
`forbid_zero_size="no"` forbids. The wrong value falls on the side that
refuses more, which is the side that cannot accept what was to be
refused.

So the classifying question is the polarity of the flag's own name, and
**a flag whose `True` is the permissive value is a kind however little it
computes**. That is why this is not the third category the issue
anticipated: it is a constraint on the truths, in the shape this library
already reaches for — CONTRIBUTING.md's "a shape that cannot go wrong
beats a checker that catches it going wrong", applied to a parameter
instead of a function name.

## What moved

Reading the census against the rule, three flags failed it, not one:

```text
assert_nullfail(flags, verified="no", sigs, op)  -> NULLFAIL never fires
assert_signed(psbt, allow_partial="no")          -> an input nobody signed
point_from_octets(sec, hybrid="no")              -> 0x06 and 0x07 parsed
```

`verified` is the one that costs money, and it is the issue's own
argument: it suppresses NULLFAIL, so a non-bool lets a non-empty
signature that failed to verify through a consensus rule — btclib calling
valid a transaction the network rejects. `allow_partial` and `hybrid` are
the same shape one severity down, and they are here because leaving them
would have made the new sentence an exemption list, which is the state
CONTRIBUTING.md says not to keep.

Each is `utils.assert_type` now. No rename and no default flipped: kinds
carry no polarity constraint, so the names stay as they read best.

## What stayed

`verify_script`'s `final` stays a truth, which is the contrast that shows
the rule is about direction and not about the engine: it demands the
script end on a true stack, so a non-bool there fails a script rather
than passing one, and a script that fails is nobody's money. `segwit`
beside it is a kind for picking a digest. The issue reported the two as
an asymmetry inside one signature; they are the same rule read twice now,
and the docstring says so.

For the same reason `check_amounts` stays a truth, which is what ruled
out option 2 of the issue: it is more consensus-relevant than `final` by
any measure, and moving `final` for being consensus-relevant would have
had to move it too, and then the line the census is built on would be
gone.

## Also here

The CHANGELOG.md census bullet stated the split as counts — "seventy-eight
`bool` parameters, fifty-three kinds and twenty-five truths". They had
already drifted before this branch (the tree measures 93/60/33 today), so
rather than update a number that goes stale again the bullet now carries
the command that re-derives it, per CLAUDE.md.

## Gates

`uv run pytest` (28264 passed, coverage ratchet included),
`uv run pre-commit run --all-files`, and the sphinx `-W` build all green.

## Summary by Sourcery

Enforce boolean types for permissive flags and formalize the rule that truth parameters must default to the conservative behavior.

Bug Fixes:
- Prevent non-boolean values from weakening NULLFAIL enforcement, accepting incomplete PSBTs, or enabling hybrid public-key parsing.

Enhancements:
- Refine the boolean parameter classification rule so truths must represent the conservative behavior, while permissive flags are treated as strict kinds.
- Keep script verification's `final` flag as a truth because incorrect values fail scripts rather than bypassing safety checks.
- Replace stale boolean-parameter census counts with a command that derives current counts from the test tables.

Documentation:
- Document the conservative-value rule for truth parameters and update the changelog and history with the revised classification.

Tests:
- Update the boolean parameter census to classify `verified`, `allow_partial`, and `hybrid` as kinds and verify their type enforcement.