### PR TITLE
Test silent_payments.scan_outputs's Python arm against the bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7092,6 +7092,25 @@ documented at release-notes length in the first place, and are still in
   conventions; the trailing-underscore spelling is untouched, its defaults
   being a promise to its plain sibling rather than a convenience.
 
+- **`silent_payments.scan_outputs`'s Python arm is now tested directly
+  against `btclib_secp256k1.silentpayments.scan_outputs`**, issue #910's
+  fourth decision, the authority comparison `tests/ecc/dsa_test.py` and
+  `tests/ecc/ssa_test.py` already carry for the rest of the library and
+  `output_keys`'s own cross-arm tests now carry for BIP352's sender half.
+  `scan_outputs` still does not delegate -- the mismatch between the
+  `tweak: PubKey` a light client holds and the `prevouts_summary` the
+  bindings want, built from the raw outpoints and input public keys such
+  a client never sees, is unchanged -- so there is no
+  `_libsecp256k1_serves` guard to flip the way those tests do. Instead
+  `test_scan_outputs_matches_the_bindings` builds the summary a full node
+  *could* hand the bindings, from the same outpoints and input public
+  keys `test_receiving_vectors` already reads out of BIP352's own
+  vectors, and asks whether the two arms answer the same set of outputs
+  and spend tweaks. `label_lookup`'s `dict[bytes, int]` is reshaped to
+  the bindings' `Mapping[bytes, bytes]` for this one call -- issue #910's
+  third decision, which stays test-local because production code never
+  reaches it.
+
 ## v2026.8.9
 
 ### Descriptors and miniscript

--- a/tests/silent_payments_test.py
+++ b/tests/silent_payments_test.py
@@ -36,8 +36,11 @@ from btclib.curves import bytes_from_point, mult, secp256k1
 from btclib.ecc import ssa
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
+from btclib.script.script_pub_key import is_p2tr
 from btclib.script.witness import Witness
+from btclib.to_prv_key import int_from_prv_key
 from btclib.tx.out_point import OutPoint
+from btclib.utils import bytes_from_octets
 from tests import load, needs_bindings, vector_id
 
 _VECTORS = load("_data", "send_and_receive_test_vectors.json", encoding="utf-8")
@@ -609,6 +612,91 @@ def test_output_keys_wraps_a_delegated_refusal(monkeypatch: pytest.MonkeyPatch) 
         silent_payments.output_keys(
             [(_B_SCAN_PRV, script_pub_key)], outpoints, [_address()]
         )
+
+
+@needs_bindings
+@pytest.mark.parametrize("index,test", _RECEIVING, ids=_RECEIVING_IDS)
+def test_scan_outputs_matches_the_bindings(index: int, test: dict[str, Any]) -> None:
+    """The Python scan agrees with the bindings', given the same inputs.
+
+    `scan_outputs` has no `_libsecp256k1_serves` guard to flip the way
+    `output_keys`'s cross-arm tests do above: it stays Python regardless
+    of the bindings, because `tweak` is the already-reduced tweak data a
+    light client holds under BIP352's Appendix A, where
+    `silentpayments.scan_outputs` wants a `prevouts_summary` built from
+    the transaction's own outpoints and input public keys -- exactly the
+    data a light client never has, and exactly why this tree's dispatch
+    does not reach the bindings for this half of BIP352 (see the module
+    docstring and `SECURITY.md`). That mismatch is a reason not to
+    dispatch, not a reason to leave the arithmetic unchecked against the
+    bindings: this builds the summary a full node *could* hand them, from
+    the outpoints and input public keys `test_receiving_vectors` already
+    reads out of this same vector, and asks whether the two answer the
+    same set of outputs and spend tweaks.
+
+    The label cache is the one value reshaped for this call alone:
+    `label_lookup` returns `dict[bytes, int]`, where the bindings want
+    each tweak as 32 bytes -- decision 3 of issue #910, which stays a
+    test-local conversion because `scan_outputs` does not delegate.
+    """
+    given = test["given"]
+    b_scan = given["key_material"]["scan_priv_key"]
+    b_spend = given["key_material"]["spend_priv_key"]
+    B_spend = mult(b_spend)
+
+    pub_keys = []
+    taproot_pubkeys_bytes = []
+    pubkeys_bytes = []
+    for v in given["vin"]:
+        pub_key = _pub_key_of(v)
+        if pub_key is None:
+            continue
+        pub_keys.append(pub_key)
+        script_pub_key = bytes_from_octets(v["prevout"]["scriptPubKey"]["hex"])
+        if is_p2tr(script_pub_key):
+            taproot_pubkeys_bytes.append(bytes_from_point(pub_key)[1:])
+        else:
+            pubkeys_bytes.append(bytes_from_point(pub_key))
+    if not pub_keys:
+        pytest.skip("nothing eligible to derive a shared secret from")
+
+    outpoints = _outpoints(given["vin"])
+    try:
+        A_sum = silent_payments.pub_key_sum(pub_keys)
+    except BTClibValueError:
+        pytest.skip("input public keys sum to infinity")
+
+    outpoint_smallest36 = min(outpoint.serialize() for outpoint in outpoints)
+    summary = libsecp256k1_silentpayments.prevouts_summary(
+        outpoint_smallest36, taproot_pubkeys_bytes, pubkeys_bytes
+    )
+    labels = silent_payments.label_lookup(b_scan, given["labels"])
+    bindings_labels = {
+        label: tweak.to_bytes(32, "big") for label, tweak in labels.items()
+    }
+    tx_outputs_bytes = [bytes.fromhex(output) for output in given["outputs"]]
+
+    bindings_found = libsecp256k1_silentpayments.scan_outputs(
+        tx_outputs_bytes,
+        int_from_prv_key(b_scan),
+        summary,
+        bytes_from_point(B_spend),
+        bindings_labels,
+    )
+    tweak = silent_payments.tweak_data(outpoints, A_sum)
+    python_found = silent_payments.scan_outputs(
+        b_scan, B_spend, tweak, given["outputs"], labels
+    )
+
+    bindings_set = {
+        (pub_key.hex(), spend_tweak.hex())
+        for pub_key, spend_tweak, _label in bindings_found
+    }
+    python_set = {
+        (output.pub_key.hex(), output.prv_key_tweak.to_bytes(32, "big").hex())
+        for output in python_found
+    }
+    assert bindings_set == python_set
 
 
 def test_the_whole_round_trip_without_a_vector() -> None:


### PR DESCRIPTION
Addresses #910. Does not close it: `scan_outputs`, the recipient's half
of BIP352, still does not delegate -- only issue #910's fourth decision
lands here, on top of PR #1035, which delegated `output_keys`, the
sender's half, and left `scan_outputs` Python-only for a documented
reason. What is missing to close #910 is listed under "What is left"
below.

## Decision 1 revisited: is `scan_outputs` delegatable after all?

No, confirmed rather than assumed. `btclib.silent_payments.scan_outputs`
takes `tweak: PubKey` -- the already-reduced `input_hash * A_sum` a light
client gets from a server under BIP352's Appendix A, with no outpoints or
input public keys in sight. `btclib_secp256k1.silentpayments.scan_outputs`
takes a `prevouts_summary` instead, and that summary is built by
`prevouts_summary()` from exactly the outpoints and input public keys a
light client never has -- there is no bindings entry point that accepts
an already-reduced tweak, and the summary itself is an opaque,
version-specific blob (`silentpayments.py`'s own docstring: "not a
serialization... portable across neither platforms nor versions"), so
there is nothing to construct it from by hand either. Widening
`scan_outputs`'s public signature to always demand data a light client
does not have would break every caller relying on Appendix A today. This
is the same conclusion PR #1035's "Scope" section already reached; this
PR does not relitigate it, it measures it: a scratch script fed BIP352's
own `send_and_receive_test_vectors.json` through both arms, building the
bindings' summary from the vectors' raw outpoints and input keys (data a
*full node* has, unlike a light client). Every one of the 27 receiving
vectors with something to scan agreed exactly, pubkeys and spend tweaks
both -- so the blocker is the precondition mismatch, not a difference in
what the two arithmetics compute.

## Decision 4: the Python arm tested against the bindings

`test_scan_outputs_matches_the_bindings`, parametrized over
`send_and_receive_test_vectors.json`'s receiving vectors the same way
`test_receiving_vectors` is, does what the measurement above did as a
permanent test: builds the `prevouts_summary` a full node could hand the
bindings from the vector's own outpoints and input public keys, calls
`btclib_secp256k1.silentpayments.scan_outputs` directly, and asserts it
finds the same set of `(output, spend tweak)` pairs as
`silent_payments.scan_outputs` does. Unlike `output_keys`'s own cross-arm
tests, there is no `_libsecp256k1_serves` guard to monkeypatch --
`scan_outputs` has none, being Python on both arms -- so this calls the
bindings module directly rather than flipping a dispatch flag, the same
shape `tests/ecc/dsa_test.py` and `tests/ecc/ssa_test.py` established for
validating a Python-only path against libsecp256k1 as the reference
implementation.

## Decision 3: the label cache type

Reshaped for this one call, not in production. `label_lookup` returns
`dict[bytes, int]`; the bindings want `Mapping[bytes, bytes]`, so the
test converts each tweak with `.to_bytes(32, "big")` before calling the
bindings' `scan_outputs`. `label_lookup`'s own return type is unchanged
-- `scan_outputs` never reaches the bindings in production, so there is
no caller for the wider type there.

## What is left to close #910

`scan_outputs` reaching the bindings at all needs a design decision this
PR does not make: either a second, full-node-shaped entry point beside
today's light-client `scan_outputs`, or accepting that BIP352's
recipient side stays Python regardless of the bindings. PR #1035 already
left that decision for "a separate, focused issue rather than folded
into this one silently," and nothing measured here changes that
judgment -- it confirms it.

## Verification

```
$ uv run pre-commit run --all-files   # exit 0, every hook
$ uv run pytest                       # exit 0, 28291 passed, 100% coverage
$ uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html   # exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Validate the Python silent-payment output scanner against the libsecp256k1 bindings without changing its existing delegation behavior.

Enhancements:
- Add cross-implementation coverage confirming that Python `silent_payments.scan_outputs` produces the same discovered outputs and spend tweaks as the libsecp256k1 bindings when given equivalent full-node input data.

Documentation:
- Document that `scan_outputs` remains Python-only because its light-client tweak input does not match the bindings' full-node prevouts summary requirement.

Tests:
- Add parameterized BIP352 receiving-vector tests comparing Python scanning results with the bindings implementation.