### PR TITLE
Delegate silent_payments.scan_transaction_outputs (issue #910)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4085,6 +4085,16 @@ documented at release-notes length in the first place, and are still in
   `into=` a decision on the record rather than something nobody
   noticed.
 
+- **`SECURITY.md` and `README.md`'s enumeration of what reaches the
+  bindings with a secret gains `silent_payments.scan_transaction_outputs`**
+  (issue #910). Both files already said `scan_outputs` -- the light
+  client's entry point -- is Python-only regardless, which stays true;
+  neither said anything about `scan_transaction_outputs`, the full-node
+  sibling this cycle adds, and a caller reading either for what is and
+  is not constant-time would have found no answer for it. It reaches
+  `silentpayments.scan_outputs` with `b_scan` wherever the bindings
+  serve secp256k1, the same as `output_keys` above it in both lists.
+
 ### The public API and the module layout
 
 - **`hashes.siphash` implements SipHash-2-4** (issue #373), the keyed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4013,6 +4013,57 @@ documented at release-notes length in the first place, and are still in
   composes those steps and exposes none of them separately, so there is
   nothing here for them to delegate to.
 
+- **`silent_payments.scan_transaction_outputs` reaches
+  `btclib_secp256k1.silentpayments.scan_outputs` where the bindings serve
+  secp256k1** (issue #910), the recipient's half joining `output_keys` on
+  the delegated path -- through a new sibling function, not `scan_outputs`
+  itself. `scan_outputs` takes `tweak`, the already-reduced
+  `input_hash * A_sum` a light client holds under BIP352's Appendix A,
+  and stays exactly as it was: `silentpayments.scan_outputs` wants a
+  `prevouts_summary` built from the transaction's outpoints and input
+  public keys, which a light client never has, and widening
+  `scan_outputs`'s own signature to demand that of every caller was the
+  option the issue's own follow-up comment declined.
+  `scan_transaction_outputs` is the shape that data does fit --
+  `pub_keys` pairs each eligible input's public key with the
+  script_pub_key it spends, exactly as `output_keys`'s `prv_keys` does on
+  the sending side -- and reaches the delegated arm with a
+  `prevouts_summary` computed once, the shape a wallet scanning a block
+  needs.
+
+  The issue's own measurement is why a second entry point was worth
+  writing rather than folding into the first: without a label the two
+  arms are close, the Python one ahead at a hundred outputs (44.3 us
+  against 277.7); with the change label BIP352 asks every wallet to
+  check (m = 0), the bindings are 6.4x faster (341.9 us against 2190.7 at
+  a hundred outputs) -- and the labelled case is the normal one, not the
+  first row of that table. The Python arm is unchanged, and is still
+  what `scan_outputs` and every caller holding only a light client's
+  tweak runs.
+
+  `label_lookup` answers `dict[bytes, bytes]` now, 33-byte label to
+  32-byte tweak -- `silentpayments.scan_outputs`'s own spelling of a
+  label cache, which refuses a `bytearray` or a `memoryview` as a key
+  and is what `scan_transaction_outputs` hands the delegated arm
+  unconverted. `scan_outputs`'s own `labels` parameter takes the same
+  shape now; its Python loop reads the tweak through `int_from_prv_key`,
+  which already accepts 32-octet input, so neither arm pays a conversion
+  this function did not already do once, per wallet rather than per
+  scan. This is issue #910's third decision, and it is a signature
+  change with nothing in RELEASE_NOTES.md to show for it: `silent_payments`
+  (#640) is itself new in this unreleased cycle, `label_lookup` included,
+  so there is no prior release whose callers this could break.
+
+  What this does not do: touch `output_keys`. PR #1035 delegated it to
+  `silentpayments.create_outputs` before this issue's own measurement
+  comment was posted, and that comment's first decision reads the
+  opposite way -- `scan_outputs` yes, `output_keys` no, the sender's side
+  having no measured gain and `psbt.silent_payments` unable to use
+  `create_outputs` at all. This pull request does not revert what
+  already shipped; the discrepancy is named here for the maintainer to
+  resolve -- keep it, revert it, or declare the first decision
+  superseded -- rather than resolved by this change.
+
 ### Security
 
 - **`SECURITY.md` says the bindings offer a buffer for a secret, and

--- a/README.md
+++ b/README.md
@@ -216,10 +216,14 @@ validates against the bindings but which is not constant-time. So a caller
 whose threat model includes timing should stay on the delegated paths, or
 keep the key out of the process altogether: `btclib.hwi` drives a hardware
 wallet through HWI, behind the same `PsbtSigner` contract a software
-signer answers. `silent_payments.scan_outputs`, the recipient's half of
-BIP352, is Python-only regardless: it accepts the shared secret already
+signer answers. `silent_payments.scan_outputs`, BIP352's light-client
+scan, is Python-only regardless: it accepts the shared secret already
 reduced, the shape a light client has and the bindings have no entry
-point for.
+point for. `scan_transaction_outputs`, its full-node sibling, is not:
+where the bindings serve secp256k1 it reaches them with `b_scan`, the
+recipient's scan private key, the same as `output_keys` above — a
+caller holding the transaction itself gets the delegated path a light
+client cannot reach.
 
 What that path does about it is in the names, and it is worth knowing
 before calling one. **A function whose duration follows the value it is

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -207,11 +207,17 @@ used to teach and to prototype as much as to build:
     `silentpayments.create_outputs` for every private key an eligible
     input carries, a keypair built and wiped per taproot input and a
     scalar buffer per other one, exactly as `dsa.sign` and `ssa.sign`
-    build and wipe theirs. `scan_outputs`, the recipient's half, is not
-    delegated — it takes the shared secret already reduced, which is the
-    shape a BIP352 light client has and the bindings' own `scan_outputs`
+    build and wipe theirs. `scan_outputs`, BIP352's light-client scan, is
+    not delegated — it takes the shared secret already reduced, which is
+    the shape a light client has and the bindings' own `scan_outputs`
     does not accept, wanting the raw inputs to derive it from instead —
     so every secret that function meets is still Python's alone.
+    `scan_transaction_outputs`, the full-node sibling a wallet holding
+    the transaction itself can call, is a fourth case: where the
+    bindings serve secp256k1 it reaches `silentpayments.scan_outputs`
+    with `b_scan`, the recipient's scan private key, built once for a
+    whole transaction rather than once per input; off that path it falls
+    back to `scan_outputs` above and stays Python's alone.
     Anything else — another
     curve, another hash function, a nonce of your own — runs the Python
     implementation, whose scalar multiplication is

--- a/btclib/silent_payments.py
+++ b/btclib/silent_payments.py
@@ -933,14 +933,18 @@ def scan_transaction_outputs(
     through `int_from_prv_key`.
     """
     A_sum = pub_key_sum([pub_key for pub_key, _script_pub_key in pub_keys])
-    input_hash(outpoints, A_sum)
+    h = input_hash(outpoints, A_sum)
 
     if _libsecp256k1_serves(secp256k1, None):
         return _delegated_scan_outputs(
             b_scan, outpoints, pub_keys, B_spend, outputs_to_check, labels
         )
 
-    tweak = tweak_data(outpoints, A_sum)
+    # `tweak_data` would recompute `input_hash`, redoing the outpoint sort
+    # and the tagged hash over the same data: `h` is already this
+    # transaction's, same as `output_keys` reuses its own `h` rather than
+    # letting a helper derive it again
+    tweak = mult(h, A_sum)
     return scan_outputs(b_scan, B_spend, tweak, outputs_to_check, labels)
 
 

--- a/btclib/silent_payments.py
+++ b/btclib/silent_payments.py
@@ -40,7 +40,11 @@ The pieces, bottom-up:
   (BIP352's Appendix A) and all a scanner needs.
 - `shared_secret` is the multiplication both parties do, from either end.
 - `output_keys` is the sender's whole operation, and `scan_outputs` the
-  recipient's.
+  recipient's -- for a caller holding a light client's `tweak`, per
+  BIP352's Appendix A; `scan_transaction_outputs` is the same recipient's
+  operation for a caller holding the transaction itself, outpoints and
+  input public keys, which is what lets it reach the bindings the way
+  `output_keys` does.
 - `label_tweak`, `labeled_address_from_keys` and `label_lookup` are the
   optional third piece: one published address per purpose, all sharing
   one scan key, at the cost of a subtraction per output while scanning.
@@ -104,6 +108,7 @@ __all__ = [
     "pub_key_from_input",
     "pub_key_sum",
     "scan_outputs",
+    "scan_transaction_outputs",
     "shared_secret",
     "tweak_data",
 ]
@@ -323,7 +328,7 @@ def labeled_address_from_keys(
     return address_from_keys(B_scan, B_m, network)
 
 
-def label_lookup(b_scan: PrvKey, m_values: Iterable[int]) -> dict[bytes, int]:
+def label_lookup(b_scan: PrvKey, m_values: Iterable[int]) -> dict[bytes, bytes]:
     """Precompute the {label point: label tweak} map a scan reads.
 
     Once per wallet, not once per transaction, which is the point of it:
@@ -332,9 +337,21 @@ def label_lookup(b_scan: PrvKey, m_values: Iterable[int]) -> dict[bytes, int]:
     multiplications here instead of M point additions per output for
     ever. Include 0 among the values unless the wallet is certain it
     never paid itself.
+
+    The tweak is 32 bytes, big-endian -- `silentpayments.scan_outputs`'s
+    own spelling of a label cache, `Mapping[bytes, bytes]`, which refuses
+    a `bytearray` or a `memoryview` as a key and is what
+    `scan_transaction_outputs` hands the bindings unconverted where they
+    serve. `scan_outputs`'s Python loop reads the same bytes through
+    `int_from_prv_key`, which already accepts 32-octet SEC input, so
+    neither arm pays a conversion this function did not already do once,
+    per wallet rather than per scan.
     """
     tweaks = [label_tweak(b_scan, m) for m in m_values]
-    return {bytes_from_point(mult(t), secp256k1): t for t in tweaks}
+    return {
+        bytes_from_point(mult(t), secp256k1): t.to_bytes(secp256k1.n_size, "big")
+        for t in tweaks
+    }
 
 
 def _pub_key_from_p2pkh(script_pub_key: bytes, script_sig: bytes) -> Point | None:
@@ -711,7 +728,7 @@ class SilentPaymentOutput:
 
 
 def _labelled(
-    output: bytes, P_k: Point, labels: Mapping[bytes, int]
+    output: bytes, P_k: Point, labels: Mapping[bytes, bytes]
 ) -> tuple[Point, int] | None:
     """Return (P_k + label, label tweak) if the difference is a label.
 
@@ -750,16 +767,20 @@ def scan_outputs(
     B_spend: PubKey,
     tweak: PubKey,
     outputs_to_check: Sequence[Octets],
-    labels: Mapping[bytes, int] | None = None,
+    labels: Mapping[bytes, bytes] | None = None,
 ) -> list[SilentPaymentOutput]:
     """Return the outputs of one transaction that belong to this wallet.
 
-    `tweak` is the tweak data of `tweak_data`, input_hash*A_sum;
-    `outputs_to_check` are the x-only keys of every taproot output of the
-    transaction, spent ones included -- a wallet recovering its history
-    is looking for outputs it has already spent. `labels` is
-    `label_lookup`'s map, and BIP352 asks for the change label m = 0 in
-    it whatever else the wallet used.
+    `tweak` is the tweak data of `tweak_data`, input_hash*A_sum -- the
+    light client's entry point, BIP352's Appendix A: a server hands a
+    light client exactly this and nothing else about the transaction,
+    which is why this stays the Python arithmetic below whatever the
+    bindings serve. `scan_transaction_outputs` is the counterpart for a
+    caller holding the transaction itself. `outputs_to_check` are the
+    x-only keys of every taproot output of the transaction, spent ones
+    included -- a wallet recovering its history is looking for outputs it
+    has already spent. `labels` is `label_lookup`'s map, and BIP352 asks
+    for the change label m = 0 in it whatever else the wallet used.
 
     The scan walks k upwards and stops at the first k that matches
     nothing, which is what makes it one multiplication per transaction
@@ -807,6 +828,120 @@ def scan_outputs(
         remaining.remove(match[0])
         found.append(match[1])
     return found
+
+
+def _delegated_scan_outputs(
+    b_scan: PrvKey,
+    outpoints: Sequence[OutPoint],
+    pub_keys: Sequence[tuple[PubKey, Octets]],
+    B_spend: PubKey,
+    outputs_to_check: Sequence[Octets],
+    labels: Mapping[bytes, bytes] | None,
+) -> list[SilentPaymentOutput]:
+    """`scan_transaction_outputs` over `silentpayments.scan_outputs`.
+
+    `prevouts_summary` is built from the same split `_delegated_output_keys`
+    builds on the sending side -- `is_p2tr` of the script a key spends
+    decides whether it is folded in x-only or in full, and the even-y
+    normalization of the x-only ones is libsecp256k1's own, not repeated
+    here. Unlike that function, this one's caller is not required to have
+    validated the group already: `pub_key_sum` and `input_hash` already
+    ran in `scan_transaction_outputs`, above, for the refusal an infinite
+    sum or an empty outpoint sequence has a specific message for.
+
+    `labels` reaches the bindings unconverted: it is `label_lookup`'s own
+    map, 33-byte label to 32-byte tweak, which is the bindings' own
+    spelling and not this tree's legacy one. The label element of each
+    returned triple is discarded -- the tweak the bindings answer already
+    has it folded in, the same combined scalar `_labelled` returns on the
+    Python arm.
+    """
+    outpoint_smallest36 = min(outpoint.serialize() for outpoint in outpoints)
+    taproot_pubkeys_bytes = []
+    pubkeys_bytes = []
+    for pub_key, script_pub_key in pub_keys:
+        point = point_from_pub_key(pub_key)
+        if is_p2tr(bytes_from_octets(script_pub_key)):
+            taproot_pubkeys_bytes.append(_x_only(point))
+        else:
+            pubkeys_bytes.append(bytes_from_point(point, secp256k1))
+
+    try:
+        summary = libsecp256k1_silentpayments.prevouts_summary(
+            outpoint_smallest36, taproot_pubkeys_bytes, pubkeys_bytes
+        )
+        outputs_bytes = [
+            bytes_from_octets(output, secp256k1.p_size) for output in outputs_to_check
+        ]
+        found = libsecp256k1_silentpayments.scan_outputs(
+            outputs_bytes,
+            int_from_prv_key(b_scan),
+            summary,
+            bytes_from_point(point_from_pub_key(B_spend), secp256k1),
+            labels,
+        )
+    except ValueError as e:
+        # mirrors `_delegated_output_keys`'s own wrapping: the specific
+        # refusals already ran above, so what reaches here is
+        # libsecp256k1's coarser message for whatever else it refuses
+        raise BTClibValueError(str(e)) from e
+
+    return [
+        SilentPaymentOutput(pub_key, int.from_bytes(tweak, "big"))
+        for pub_key, tweak, _label in found
+    ]
+
+
+def scan_transaction_outputs(
+    b_scan: PrvKey,
+    B_spend: PubKey,
+    outpoints: Sequence[OutPoint],
+    pub_keys: Sequence[tuple[PubKey, Octets]],
+    outputs_to_check: Sequence[Octets],
+    labels: Mapping[bytes, bytes] | None = None,
+) -> list[SilentPaymentOutput]:
+    """Return the outputs of one transaction, from data a full node has.
+
+    `scan_outputs` is the light client's entry point, `tweak` the one
+    value BIP352's Appendix A hands it. A full node holds the transaction
+    itself instead: `pub_keys` pairs each eligible input's public key
+    with the script_pub_key it spends, exactly as `output_keys`'s
+    `prv_keys` does on the sending side, and every eligible input must be
+    there for the same reason `pub_key_sum` there needs all of them.
+    `outpoints` is the transaction's, eligible or not: what the input
+    hash binds to is the transaction, precisely as `output_keys` reads it.
+
+    Where the bindings serve secp256k1, this reaches
+    `silentpayments.scan_outputs` with a `prevouts_summary` computed once
+    from `pub_keys` and `outpoints` -- the shape a wallet scanning a block
+    needs, and the one issue #910's own measurement found 6.4x faster
+    than the Python loop at a hundred outputs once a label is in play,
+    which BIP352 asks every wallet to check (m = 0, the change label).
+    Without a label the two arms are close, the Python one ahead at a
+    hundred outputs, but that case is not what decided this: see the
+    issue's own comments for the numbers.
+
+    `pub_key_sum` and `input_hash` run unconditionally, before either arm
+    is chosen, for the same reason `output_keys` computes `a` and `h`
+    either way: a zero-sum refusal or an empty outpoint sequence gets the
+    specific message those two functions already give it, rather than
+    libsecp256k1's coarser one.
+
+    `labels` is `label_lookup`'s map -- 33-byte label to 32-byte tweak,
+    the bindings' own spelling -- and reaches the delegated arm
+    unconverted; the Python arm, `scan_outputs`, reads the same bytes
+    through `int_from_prv_key`.
+    """
+    A_sum = pub_key_sum([pub_key for pub_key, _script_pub_key in pub_keys])
+    input_hash(outpoints, A_sum)
+
+    if _libsecp256k1_serves(secp256k1, None):
+        return _delegated_scan_outputs(
+            b_scan, outpoints, pub_keys, B_spend, outputs_to_check, labels
+        )
+
+    tweak = tweak_data(outpoints, A_sum)
+    return scan_outputs(b_scan, B_spend, tweak, outputs_to_check, labels)
 
 
 def prv_key_from_tweak(b_spend: PrvKey, prv_key_tweak: int) -> int:

--- a/tests/python_arm_authority_test.py
+++ b/tests/python_arm_authority_test.py
@@ -332,6 +332,7 @@ _AUTHORITY: dict[str, tuple[str, ...]] = {
         "script_engine/transactions_test.py",
     ),
     "silent_payments.output_keys": ("silent_payments_test.py",),
+    "silent_payments.scan_transaction_outputs": ("silent_payments_test.py",),
 }
 
 # the ones the measurement found nothing for, named so that closing one

--- a/tests/silent_payments_test.py
+++ b/tests/silent_payments_test.py
@@ -36,11 +36,8 @@ from btclib.curves import bytes_from_point, mult, secp256k1
 from btclib.ecc import ssa
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
-from btclib.script.script_pub_key import is_p2tr
 from btclib.script.witness import Witness
-from btclib.to_prv_key import int_from_prv_key
 from btclib.tx.out_point import OutPoint
-from btclib.utils import bytes_from_octets
 from tests import load, needs_bindings, vector_id
 
 _VECTORS = load("_data", "send_and_receive_test_vectors.json", encoding="utf-8")
@@ -217,6 +214,24 @@ def test_receiving_vectors(index: int, test: dict[str, Any]) -> None:
     found = silent_payments.scan_outputs(
         b_scan, B_spend, tweak, given["outputs"], labels
     )
+
+    # the full-node entry point, given the same transaction data rather
+    # than the already-reduced tweak: `scan_outputs`'s light-client
+    # answer is what it has to match, on whichever arm this environment
+    # runs -- delegated where the bindings serve, `scan_outputs` itself
+    # otherwise, which is what makes this the vector this arm's own
+    # entry in `tests/python_arm_authority_test.py` cites
+    pub_keys_with_scripts = [
+        (pub_key, v["prevout"]["scriptPubKey"]["hex"])
+        for v in given["vin"]
+        if (pub_key := _pub_key_of(v)) is not None
+    ]
+    transaction_found = silent_payments.scan_transaction_outputs(
+        b_scan, B_spend, outpoints, pub_keys_with_scripts, given["outputs"], labels
+    )
+    assert {(o.pub_key, o.prv_key_tweak) for o in transaction_found} == {
+        (o.pub_key, o.prv_key_tweak) for o in found
+    }
 
     if "n_outputs" in expected:
         # the K_MAX case, where the file counts rather than lists: the
@@ -616,87 +631,97 @@ def test_output_keys_wraps_a_delegated_refusal(monkeypatch: pytest.MonkeyPatch) 
 
 @needs_bindings
 @pytest.mark.parametrize("index,test", _RECEIVING, ids=_RECEIVING_IDS)
-def test_scan_outputs_matches_the_bindings(index: int, test: dict[str, Any]) -> None:
-    """The Python scan agrees with the bindings', given the same inputs.
+def test_scan_transaction_outputs_matches_across_arms(
+    index: int, test: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The delegated and the Python arm of the full-node scan agree.
 
-    `scan_outputs` has no `_libsecp256k1_serves` guard to flip the way
-    `output_keys`'s cross-arm tests do above: it stays Python regardless
-    of the bindings, because `tweak` is the already-reduced tweak data a
-    light client holds under BIP352's Appendix A, where
-    `silentpayments.scan_outputs` wants a `prevouts_summary` built from
-    the transaction's own outpoints and input public keys -- exactly the
-    data a light client never has, and exactly why this tree's dispatch
-    does not reach the bindings for this half of BIP352 (see the module
-    docstring and `SECURITY.md`). That mismatch is a reason not to
-    dispatch, not a reason to leave the arithmetic unchecked against the
-    bindings: this builds the summary a full node *could* hand them, from
-    the outpoints and input public keys `test_receiving_vectors` already
-    reads out of this same vector, and asks whether the two answer the
-    same set of outputs and spend tweaks.
-
-    The label cache is the one value reshaped for this call alone:
-    `label_lookup` returns `dict[bytes, int]`, where the bindings want
-    each tweak as 32 bytes -- decision 3 of issue #910, which stays a
-    test-local conversion because `scan_outputs` does not delegate.
+    `scan_transaction_outputs`'s own dispatch is `_libsecp256k1_serves(
+    secp256k1, None)`, exactly `output_keys`'s, so a vector is run twice
+    with the predicate patched between the two --
+    `test_output_keys_matches_across_arms`'s own shape, now available
+    because `scan_transaction_outputs` gives the recipient's side a
+    dispatch to flip. `test_receiving_vectors` already checks the light
+    client's `scan_outputs` against the vector file directly; this asks
+    whether the full-node entry point's two arms agree with each other
+    and with that same file.
     """
-    given = test["given"]
+    given, expected = test["given"], test["expected"]
     b_scan = given["key_material"]["scan_priv_key"]
     b_spend = given["key_material"]["spend_priv_key"]
     B_spend = mult(b_spend)
 
-    pub_keys = []
-    taproot_pubkeys_bytes = []
-    pubkeys_bytes = []
-    for v in given["vin"]:
-        pub_key = _pub_key_of(v)
-        if pub_key is None:
-            continue
-        pub_keys.append(pub_key)
-        script_pub_key = bytes_from_octets(v["prevout"]["scriptPubKey"]["hex"])
-        if is_p2tr(script_pub_key):
-            taproot_pubkeys_bytes.append(bytes_from_point(pub_key)[1:])
-        else:
-            pubkeys_bytes.append(bytes_from_point(pub_key))
+    pub_keys = [
+        (pub_key, v["prevout"]["scriptPubKey"]["hex"])
+        for v in given["vin"]
+        if (pub_key := _pub_key_of(v)) is not None
+    ]
     if not pub_keys:
         pytest.skip("nothing eligible to derive a shared secret from")
 
     outpoints = _outpoints(given["vin"])
-    try:
-        A_sum = silent_payments.pub_key_sum(pub_keys)
-    except BTClibValueError:
-        pytest.skip("input public keys sum to infinity")
-
-    outpoint_smallest36 = min(outpoint.serialize() for outpoint in outpoints)
-    summary = libsecp256k1_silentpayments.prevouts_summary(
-        outpoint_smallest36, taproot_pubkeys_bytes, pubkeys_bytes
-    )
     labels = silent_payments.label_lookup(b_scan, given["labels"])
-    bindings_labels = {
-        label: tweak.to_bytes(32, "big") for label, tweak in labels.items()
-    }
-    tx_outputs_bytes = [bytes.fromhex(output) for output in given["outputs"]]
 
-    bindings_found = libsecp256k1_silentpayments.scan_outputs(
-        tx_outputs_bytes,
-        int_from_prv_key(b_scan),
-        summary,
-        bytes_from_point(B_spend),
-        bindings_labels,
-    )
-    tweak = silent_payments.tweak_data(outpoints, A_sum)
-    python_found = silent_payments.scan_outputs(
-        b_scan, B_spend, tweak, given["outputs"], labels
-    )
+    def _scan(*, delegated: bool) -> list[silent_payments.SilentPaymentOutput] | None:
+        with monkeypatch.context() as arm:
+            if not delegated:
+                arm.setattr(silent_payments, "_libsecp256k1_serves", lambda *_a: False)
+            try:
+                return silent_payments.scan_transaction_outputs(
+                    b_scan, B_spend, outpoints, pub_keys, given["outputs"], labels
+                )
+            except BTClibValueError:
+                return None
 
-    bindings_set = {
-        (pub_key.hex(), spend_tweak.hex())
-        for pub_key, spend_tweak, _label in bindings_found
-    }
-    python_set = {
-        (output.pub_key.hex(), output.prv_key_tweak.to_bytes(32, "big").hex())
-        for output in python_found
-    }
-    assert bindings_set == python_set
+    delegated_found = _scan(delegated=True)
+    python_found = _scan(delegated=False)
+    assert (delegated_found is None) == (python_found is None)
+    if delegated_found is None:
+        # the input public keys sum to infinity: BIP352 skips the
+        # transaction, which `test_receiving_vectors` already reads as
+        # an empty outputs list for this same vector
+        assert expected["outputs"] == []
+        return
+    assert python_found is not None
+
+    delegated_set = {(o.pub_key.hex(), o.prv_key_tweak) for o in delegated_found}
+    python_set = {(o.pub_key.hex(), o.prv_key_tweak) for o in python_found}
+    assert delegated_set == python_set
+
+    if "n_outputs" in expected:
+        # the K_MAX case, where the file counts rather than lists
+        assert len(delegated_found) == expected["n_outputs"]
+    else:
+        assert delegated_set == {
+            (o["pub_key"], int(o["priv_key_tweak"], 16)) for o in expected["outputs"]
+        }
+
+
+@needs_bindings
+def test_scan_transaction_outputs_wraps_a_delegated_refusal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`silentpayments.scan_outputs`'s own ValueError comes back wrapped.
+
+    `pub_key_sum` and `input_hash` already cover the two refusals a real
+    transaction can trigger -- infinite input key sum, no outpoint -- the
+    same pair `test_output_keys_wraps_a_delegated_refusal` names, so this
+    is not a case the vector file has either: the bindings' own message
+    for whatever else `secp256k1_silentpayments_receiver_scan_outputs`
+    refuses is substituted for rather than reproduced.
+    """
+
+    def _refuse(*_args: object, **_kwargs: object) -> list[tuple[bytes, bytes, None]]:
+        raise ValueError("silent payment scan failed")
+
+    monkeypatch.setattr(libsecp256k1_silentpayments, "scan_outputs", _refuse)
+    script_pub_key = "0014" + hash160(bytes_from_point(mult(_B_SCAN_PRV))).hex()
+    pub_keys = [(mult(_B_SCAN_PRV), script_pub_key)]
+    outpoints = [OutPoint("00" * 31 + "01", 0)]
+    with pytest.raises(BTClibValueError, match="silent payment scan failed"):
+        silent_payments.scan_transaction_outputs(
+            _B_SCAN_PRV, mult(_B_SPEND_PRV), outpoints, pub_keys, [_NOT_AN_X]
+        )
 
 
 def test_the_whole_round_trip_without_a_vector() -> None:

--- a/tests/silent_payments_test.py
+++ b/tests/silent_payments_test.py
@@ -698,6 +698,60 @@ def test_scan_transaction_outputs_matches_across_arms(
 
 
 @needs_bindings
+@pytest.mark.parametrize("index,test", _RECEIVING, ids=_RECEIVING_IDS)
+def test_scan_transaction_outputs_accepts_no_labels_on_the_real_bindings(
+    index: int, test: dict[str, Any]
+) -> None:
+    """`labels=None` reaches `silentpayments.scan_outputs` unconverted.
+
+    Every other real-bindings call in this file always builds a
+    `label_lookup(...)` map first -- `test_receiving_vectors` and
+    `test_scan_transaction_outputs_matches_across_arms` both do --  and
+    `test_scan_transaction_outputs_wraps_a_delegated_refusal` calls with
+    `labels=None` but monkeypatches `scan_outputs` itself, so the real
+    function never sees `None` in either case. This is the one test that
+    does, and it asks the same question `test_receiving_vectors` asks of
+    the filled-map case: that the full-node entry point's delegated arm
+    agrees with the light client's own Python arm, `scan_outputs`, on the
+    same input -- here, no labels at all.
+    """
+    given, expected = test["given"], test["expected"]
+    b_scan = given["key_material"]["scan_priv_key"]
+    b_spend = given["key_material"]["spend_priv_key"]
+    B_spend = mult(b_spend)
+
+    pub_keys = [
+        (pub_key, v["prevout"]["scriptPubKey"]["hex"])
+        for v in given["vin"]
+        if (pub_key := _pub_key_of(v)) is not None
+    ]
+    if not pub_keys:
+        pytest.skip("nothing eligible to derive a shared secret from")
+
+    outpoints = _outpoints(given["vin"])
+
+    try:
+        delegated_found = silent_payments.scan_transaction_outputs(
+            b_scan, B_spend, outpoints, pub_keys, given["outputs"], labels=None
+        )
+    except BTClibValueError:
+        # the input public keys sum to infinity: BIP352 skips the
+        # transaction, the same fact `test_receiving_vectors` reads as an
+        # empty outputs list for this same vector
+        assert expected["outputs"] == []
+        return
+
+    A_sum = silent_payments.pub_key_sum([pub_key for pub_key, _ in pub_keys])
+    tweak = silent_payments.tweak_data(outpoints, A_sum)
+    light_client_found = silent_payments.scan_outputs(
+        b_scan, B_spend, tweak, given["outputs"], labels=None
+    )
+    assert {(o.pub_key, o.prv_key_tweak) for o in delegated_found} == {
+        (o.pub_key, o.prv_key_tweak) for o in light_client_found
+    }
+
+
+@needs_bindings
 def test_scan_transaction_outputs_wraps_a_delegated_refusal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What this delegates, and why

Issue #910's own measured decision (two maintainer comments dated
2026-08-16, "What the delegation is worth, measured" and its
follow-up) reaches four explicit conclusions. This pull request acts
on decisions 1 and 3:

- **Decision 1: delegate `scan_outputs`, not `output_keys`.** Measured
  on a full-node shape (`prevouts_summary` computed once): without
  labels btclib's own Python path is the *faster* of the two (issue
  #937); with the change label (m = 0, which BIP352 asks every wallet
  to check, so it is the normal case) the bindings are 6.4x faster --
  341.9 us against 2190.7 us at a hundred outputs.
- **Decision 3: the label cache.** `label_lookup` now answers
  `dict[bytes, bytes]` -- the bindings' own spelling, 33-byte label to
  32-byte tweak -- rather than converting per call. The Python arm
  reads the same bytes through `int_from_prv_key`, which already
  accepts 32-octet input, so this is the "honest shape" option the
  maintainer's comment named: no conversion either arm did not already
  pay, once per wallet rather than once per scan.

## The API shape

`scan_outputs(b_scan, B_spend, tweak, outputs_to_check, labels=None)`
is unchanged in what it does: it takes `tweak`, the already-reduced
`input_hash * A_sum` a light client holds under BIP352's Appendix A,
and stays on the Python path regardless of the bindings, because the
bindings' own `scan_outputs` wants a `prevouts_summary` built from the
transaction's outpoints and input public keys -- data a light client
never has. Widening `scan_outputs`'s own signature to demand that of
every caller is the option PR #1040's body (and issue #910's own
comments) already declined.

Instead there is a new sibling, **`scan_transaction_outputs(b_scan,
B_spend, outpoints, pub_keys, outputs_to_check, labels=None)`**, for a
caller holding the transaction itself: `pub_keys` pairs each eligible
input's public key with the `script_pub_key` it spends, exactly the
shape `output_keys`'s own `prv_keys` already uses on the sending side.
`pub_key_sum` and `input_hash` run unconditionally before either arm
is chosen -- mirroring `output_keys`'s own `a`/`h` -- so a zero-sum or
empty-outpoint refusal keeps its specific message rather than
libsecp256k1's coarser one. Where the bindings serve secp256k1, this
builds a `prevouts_summary` once and reaches
`silentpayments.scan_outputs`; otherwise it derives `tweak_data` and
falls straight through to `scan_outputs`, so the Python arithmetic
stays the single implementation on that path (no second copy of the
scan loop).

No existing caller of `scan_outputs` has to change: it keeps its
signature and its behavior, labels shape aside (see below).

## Label cache resolution

`label_lookup(b_scan, m_values) -> dict[bytes, bytes]` -- previously
`dict[bytes, int]`. `scan_outputs`'s own `labels` parameter takes the
same `Mapping[bytes, bytes] | None` shape now. This is a signature
change, but **`btclib.silent_payments` is itself new in this
unreleased cycle** (issue #640, not present in any tagged release --
checked against `v2026.8.9`, which has no `btclib/silent_payments.py`
at all) so there is no prior release whose callers this could break,
and no RELEASE_NOTES.md breaking-changes bullet is warranted.

## The output_keys / PR #1035 tension -- named, not resolved

Issue #910's own decision 1 says **do not** delegate `output_keys`:
the sender's side has no measured gain, and `psbt.silent_payments`
cannot use `create_outputs` at all (the issue's limit 3). PR #1035
already delegated `output_keys` to `silentpayments.create_outputs`,
merged 2026-08-20 -- *after* the measurement comments were posted
(2026-08-16), so whoever wrote it did not have them in front of it.

This pull request does **not** revert PR #1035. That is a bigger call
than implementing #910 authorizes, and undoing shipped, tested, gated
functionality without being asked is not this change's job. The
discrepancy is named here for the maintainer to resolve: keep
`output_keys`'s delegation as a deliberate departure from decision 1,
revert it, or declare decision 1 superseded by whatever reasoning
justified PR #1035.

## Tests

- `tests/silent_payments_test.py::test_scan_transaction_outputs_matches_across_arms`
  replaces PR #1040's hand-built comparison (which called the bindings
  directly because production had no dispatch to flip) with a real
  cross-arm test through `scan_transaction_outputs` itself, patching
  `_libsecp256k1_serves` the way `test_output_keys_matches_across_arms`
  already does.
- `test_receiving_vectors` now also calls `scan_transaction_outputs`
  unconditionally (no `needs_bindings`) and checks it against
  `scan_outputs`'s own answer, so the new arm is reached by a
  third-party vector on both the delegated and the no-bindings run --
  what `tests/python_arm_authority_test.py`'s inventory now cites for
  `silent_payments.scan_transaction_outputs`.
- `test_scan_transaction_outputs_wraps_a_delegated_refusal` mirrors
  `test_output_keys_wraps_a_delegated_refusal` for the bindings'
  own `ValueError`.

## Gates

All green locally:

- `uv run pre-commit run --all-files`
- `uv run pytest` (100% coverage gate, 28511 passed)
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html`

## Status of issue 910

This only advances it, the same honesty PR #1040's own body used: it
does not finish the issue. Decisions 1 and 3 above are acted on;
decision 2 (`SilentPaymentOutput` stays the return type) was already
true and unchanged; decision 4 (Python arm tested against the
bindings) was PR #1040's. What is left open is the
`output_keys`/PR #1035 discrepancy named above -- issue 910 stays open
until the maintainer settles it, which is deliberately not automated
by any keyword in this description. PR #1040's own history is the
reason for the care: a negated closing keyword in its commit message,
naming the issue right after it, still closed the issue on merge --
GitHub's parser reads the keyword and the number and drops the
negation in front of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a full-node silent-payment scanning entry point with bindings delegation, byte-valued label caches, and comprehensive cross-arm coverage.

New Features:
- Add full-node silent-payment transaction scanning through a new `scan_transaction_outputs` API that delegates to secp256k1 bindings when available and falls back to the Python implementation otherwise.

Enhancements:
- Align silent-payment label caches with the bindings by using byte-valued tweaks while preserving the existing light-client scanning API.
- Document the delegated full-node scanning path and its security characteristics.

Documentation:
- Update the changelog, README, and security documentation to describe full-node scan delegation and label-cache behavior.

Tests:
- Add cross-arm, receiving-vector, no-label, refusal-wrapping, and Python-arm authority coverage for transaction scanning.