### PR TITLE
Skip test.yml's matrix on a prose-only pull request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,22 @@ jobs:
     name: Run the test workflow
     needs: version-check
     uses: ./.github/workflows/test.yml
+    # a called workflow's jobs are capped at what the caller grants here,
+    # not at what the called workflow's own top-level default declares:
+    # this workflow's contents: read alone would leave test.yml's
+    # `changes` job, which asks for pull-requests: read to list a pull
+    # request's files, refused before a single job starts, version-check
+    # included -- `changes` never actually reads a file list on a
+    # release, answering code=true unconditionally off anything that is
+    # not a pull_request event, but the check is against what the job
+    # declares, not against what it goes on to do. contents: read is
+    # repeated rather than left to test.yml's own default for the same
+    # reason: a caller's grant replaces the callee's default outright, so
+    # anything this list leaves off becomes none for every job over
+    # there, not only for the one this comment names
+    permissions:
+      contents: read
+      pull-requests: read
 
   # and the same checks a pull request lints with: without this, a tag
   # push could publish code the pre-commit hooks reject. Not gated on

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,86 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # the cheapest job in the workflow, and the one that decides whether the
+  # rest of it runs at all: a pull request that edits only prose changes
+  # nothing the five jobs below build or test, and running the whole
+  # matrix to prove it was the cost. Each of `suite`, `coverage`,
+  # `no-bindings` and `dist` takes this job as a `needs` and reads its
+  # output in its own `if`; `coverage-union` does too, rather than
+  # relying on `coverage` and `no-bindings` skipping under it, because a
+  # job's own `if` here replaces the implicit "needs succeeded" check
+  # rather than adding to it, and its two `needs` would otherwise be
+  # skipped, not failed, leaving it to try downloading artifacts neither
+  # produced
+  #
+  # Three things this must not get wrong:
+  #
+  # - it runs on every trigger, and answers `true` on all but
+  #   `pull_request`: a push to main, the release workflow's call, and a
+  #   manual dispatch have no base to diff against, and a `changes` that
+  #   skipped itself there would leave every dependent reading an empty
+  #   output, not 'true', and the whole workflow -- the release path
+  #   included -- would skip
+  # - README.md is not prose for this purpose: pyproject.toml reads it as
+  #   the package's long description, which the `dist` job's twine and
+  #   pyroma checks actually render and rate. Nor is anything under
+  #   docs/, which the sdist carries (MANIFEST.in) and which
+  #   tests/docs_test.py and tests/docs_examples_test.py read directly.
+  #   Nor are CHANGELOG.md or RELEASE_NOTES.md: tests/release_notes_test.py
+  #   parses and validates their format, in the very suite this job would
+  #   otherwise skip
+  # - test-passed takes this job as a `needs` too, so a failure here
+  #   fails the gate instead of skipping every job below and being read
+  #   as a pass. So does every job that reads its output, `coverage-union`
+  #   included, for the same reason: `needs.changes.outputs.code` is
+  #   undefined in an expression unless the job is named in its own
+  #   `needs`
+  changes:
+    name: Decide whether the matrix has anything to check
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # the file list of a pull request, which contents: read does not carry
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.decide.outputs.code }}
+
+    steps:
+      - name: Ask which files the pull request touches
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # a push to main, a release call and a dispatch build
+          # everything: only a pull request has a base to be a diff
+          # against
+          if [ "$EVENT" != pull_request ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "$EVENT is not a pull request: everything runs"
+            exit 0
+          fi
+          gh api "repos/$REPO/pulls/$NUMBER/files" --paginate \
+            --jq '.[].filename' > files.txt
+          echo "files changed:"
+          cat files.txt
+          # the allowlist is what nothing built or tested reads: the
+          # prose files of the root and of .github, none of README.md,
+          # CHANGELOG.md or RELEASE_NOTES.md among them. An empty list is not
+          # a documentation change, it is a question this could not
+          # answer, so the count is checked before the pattern
+          prose='^(AUTHORS|CLAUDE|CODE_OF_CONDUCT|CONTRIBUTING|RELEASING|REPOSITORY|REVIEWING|SECURITY)\.md$|^\.github/[^/]*\.md$'
+          if [ ! -s files.txt ] || grep -qvE "$prose" files.txt; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "something the matrix reads changed: everything runs"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            echo "prose only: the matrix has nothing to check"
+          fi
+
   # what the matrix buys: every (os, architecture, interpreter) triple
   # selects a different published wheel of btclib_secp256k1, each with
   # its own compiled libsecp256k1 inside, and the pure Python code meets a
@@ -93,7 +173,10 @@ jobs:
     # the closed event only to supersede a run this ref's group is still
     # holding, and every job here carries the same skip for the reason
     # the draft one already does
-    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
+    if: >-
+      ${{ !github.event.pull_request.draft
+          && github.event.action != 'closed'
+          && needs.changes.outputs.code == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -144,6 +227,7 @@ jobs:
     # far above what a run of the suite needs: what it bounds is a hung
     # job holding a runner for six hours
     timeout-minutes: 30
+    needs: changes
     steps:
       # every action is pinned to a commit SHA, the tag in the comment: a
       # tag, let alone a branch, is a name its owner can move, and these
@@ -198,9 +282,13 @@ jobs:
   # reports before it reads a number, so the pair needs no job of its own
   coverage:
     name: Measure coverage, gated at 100%
-    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
+    if: >-
+      ${{ !github.event.pull_request.draft
+          && github.event.action != 'closed'
+          && needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: changes
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -282,9 +370,13 @@ jobs:
   # makes this a suite and not a smoke test
   no-bindings:
     name: Run the suite with no bindings installed
-    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
+    if: >-
+      ${{ !github.event.pull_request.draft
+          && github.event.action != 'closed'
+          && needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: changes
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -349,8 +441,16 @@ jobs:
   # more
   coverage-union:
     name: Combine coverage from both runs, gated at 100% too
-    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
-    needs: [coverage, no-bindings]
+    # needs.changes.outputs.code, not reliance on coverage/no-bindings
+    # skipping under it: a job's own `if` here replaces the implicit
+    # "needs succeeded" check, so without this a prose-only pull request
+    # would still run this job -- straight into two "Download coverage
+    # data" steps with nothing uploaded to download
+    if: >-
+      ${{ !github.event.pull_request.draft
+          && github.event.action != 'closed'
+          && needs.changes.outputs.code == 'true' }}
+    needs: [changes, coverage, no-bindings]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -403,9 +503,13 @@ jobs:
   # could only be red, for a reason nobody could fix from a branch
   dist:
     name: Build the distribution and install it
-    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
+    if: >-
+      ${{ !github.event.pull_request.draft
+          && github.event.action != 'closed'
+          && needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: changes
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -540,7 +644,7 @@ jobs:
     # day either grows a second one, this pattern and a change to the rule
     # are what that costs
     name: "test: every job passed"
-    needs: [suite, coverage, no-bindings, coverage-union, dist]
+    needs: [changes, suite, coverage, no-bindings, coverage-union, dist]
     # !cancelled(), not always(): a run superseded by the concurrency
     # group above -- the next push landing on this ref, or a re-run
     # cancelled from the UI -- cancels every job still in flight, and
@@ -579,14 +683,26 @@ jobs:
       # always runs and the log always carries what `needs` actually
       # held, whether or not that matches a run's own conclusion; and it
       # is what makes a job added to `needs` above covered without
-      # touching this loop, the same as the expression it replaces
-      - name: Fail unless every job above succeeded
+      # touching this loop, the same as the expression it replaces.
+      # `skipped` is an allowed result now, not just `success`: `changes`
+      # makes `suite`, `coverage`, `no-bindings`, `dist` and
+      # `coverage-union` conditional on its own output, so a prose-only
+      # pull request means every one of them reports `skipped` on
+      # purpose. `changes` itself is not conditional, and a job that
+      # fails outright still reports `failure`, never `skipped` -- an
+      # allowlist rather than a denylist of the two, since an
+      # unanticipated result (empty string included, issue #1001's own
+      # failure mode) is exactly what this step exists to catch
+      - name: Fail unless every job above succeeded or was legitimately skipped
         run: |
           results='${{ join(needs.*.result, ' ') }}'
           echo "results: $results"
           for result in $results; do
-            [ "$result" = success ] || {
-              echo "::error::a job this gate depends on reported $result"
-              exit 1
-            }
+            case "$result" in
+              success | skipped) ;;
+              *)
+                echo "::error::a job this gate depends on reported $result"
+                exit 1
+                ;;
+            esac
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1372,6 +1372,42 @@ documented at release-notes length in the first place, and are still in
   running, uploading code quality results rather than security ones. Code
   quality is a separate setting, which `code-scanning/default-setup` does
   not report.
+- **A pull request that changes only prose no longer runs the whole
+  matrix** (issue #1044, porting `btclib-secp256k1`'s own #189).
+  `changes` is one ubuntu job that lists a pull request's files through
+  the API and answers whether anything the matrix builds or tests
+  changed; `suite`, `coverage`, `no-bindings`, `dist` and `coverage-union`
+  each take it as a `needs` and read its output in their own `if`, so a
+  job whose needs did not run is skipped in turn rather than spending a
+  runner to prove nothing changed. `test-passed` takes `changes` as a
+  `needs` too, so a failure listing the files fails the gate instead of
+  skipping everything and reporting a pass; its own aggregate step, which
+  issue #1001 made loop over `needs.*.result` and demand `success` from
+  every one of them, now allows `skipped` beside it for exactly this
+  reason, an unanticipated result still failing it the same as before.
+
+  The allowlist this job answers off is not `btclib-secp256k1`'s own:
+  `README.md` is excluded there too, being the package's long
+  description, which the `dist` job's twine and pyroma checks render and
+  rate; but unlike that repository, `CHANGELOG.md` and `RELEASE_NOTES.md`
+  cannot be, `tests/release_notes_test.py` parsing and validating their
+  format in the very suite a prose-only skip would leave unrun. Nor is
+  anything under `docs/`, which `MANIFEST.in` carries into the sdist and
+  which `tests/docs_test.py` and `tests/docs_examples_test.py` read
+  directly.
+
+  `release.yml`'s call into `test.yml` grants `pull-requests: read` now,
+  `contents: read` beside it (issue #1044's other half, filed alongside
+  the port itself after it broke a tag push in `btclib-secp256k1`,
+  `v0.8.0.3` there returning `startup_failure` with zero jobs scheduled).
+  A called workflow's jobs are capped at what the caller grants, not at
+  what the called workflow's own top-level default declares, and a
+  caller's grant replaces the callee's default outright rather than
+  adding to it -- so leaving this list at `contents: read` alone would
+  have refused `changes` before a single job started, `version-check`
+  included, even though `changes` never actually reads a file list on a
+  release, answering `code=true` unconditionally off any event that is
+  not `pull_request`.
 
 ### Transactions, blocks and PSBT
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -22,13 +22,17 @@ workflows with a job named the same thing produce one ambiguous check.
 That aggregate skips, rather than fails, when the run itself was
 cancelled by the concurrency group superseding it -- a skip satisfies a
 required check, the same as this very job's own draft/closed condition
-already relies on -- and fails hard on anything else a dependency
-reports that is not success, checked
-by name in a shell loop that always runs rather than a boolean
-expression a skipped step could leave unevaluated. (Issue #1025 and
-issue #1001.) Read the cells, not the aggregate, when a run's own
-conclusion and this check disagree:
-`gh api repos/btclib-org/btclib/actions/runs/<id>/jobs`.
+already relies on. A `changes` job gates `suite`, `coverage`,
+`no-bindings`, `dist` and `coverage-union` on whether a pull request
+touched anything the matrix reads, so `skipped` from any one of those
+five is legitimate too, on purpose, whenever the diff is prose alone
+(issue #1044) -- not only the whole-run-cancelled case. The aggregate
+fails hard on anything else a dependency reports, `success` or
+`skipped` and nothing besides, checked by name in a shell loop that
+always runs rather than a boolean expression a skipped step could
+leave unevaluated. (Issues #1025, #1001 and #1044.) Read the cells,
+not the aggregate, when a run's own conclusion and this check
+disagree: `gh api repos/btclib-org/btclib/actions/runs/<id>/jobs`.
 
 `main` requires four checks, and only four:
 
@@ -435,20 +439,33 @@ asking.
 ## Token permissions
 
 **The default `GITHUB_TOKEN` is read-only repository-wide**, so a job
-needing more must declare it. Four of those declarations are in
+needing more must declare it. Most of those declarations are in
 `release.yml`: `contents: write` on `github-release`, `id-token: write` on
-the two publish jobs, and `id-token: write` with `attestations: write` on
-`attest`. The fifth is `codeql.yml`'s `analyze`, whose
-`security-events: write` is what uploading a SARIF to code scanning takes,
-with `actions: read` beside it — redundant while this repository is public,
-and written down so that the file does not quietly stop working the day it
-is not. Its aggregate job needs none of that and declares none of it: one
+the two publish jobs, `id-token: write` with `attestations: write` on
+`attest`, and `contents: read` with `pull-requests: read` on `test` — that
+last one there because `test` calls `test.yml`, and a caller's
+`permissions:` block replaces the callee's default outright rather than
+adding to it, so it has to grant what `test.yml`'s own jobs declare, not
+only what `release.yml` itself needs. `test.yml` has one such declaration
+of its own, on `changes`: `pull-requests: read`, to list a pull request's
+files. And `codeql.yml`'s `analyze` has one: `security-events: write` is
+what uploading a SARIF to code scanning takes, with `actions: read` beside
+it — redundant while this repository is public, and written down so that
+the file does not quietly stop working the day it is not. Every
+workflow's aggregate job needs none of that and declares none of it: one
 elevation per job is the shape to keep — the job that writes releases holds
 no OIDC token, and the job that signs writes no release — and
 `vendored-vectors.yml` is the one place that departs from it, declaring
 `issues: write` at the workflow level where its only job would do.
 The workflow-level `permissions: contents: read` is belt and braces; keep
 it, it is what makes the intent readable in the file.
+
+```shell
+git grep -n "permissions:$" -- .github/workflows/*.yml
+```
+
+re-derives the current list, whenever it's wanted, rather than a count
+here going stale the next time a job's own needs change.
 
 ## Publishing
 


### PR DESCRIPTION
Closes #1044

Ports [btclib-secp256k1#189](https://github.com/btclib-org/btclib-secp256k1/pull/189):
a `changes` job lists a pull request's files through the API and
answers whether anything `suite`, `coverage`, `no-bindings`, `dist` or
`coverage-union` reads changed. Each of those five takes `changes` as
a `needs` and reads its output in its own `if`, so a prose-only pull
request skips every one of them rather than spending a runner to prove
nothing changed. `test-passed` takes `changes` as a `needs` too, so a
failure listing the files fails the gate instead of skipping
everything and reporting a pass; its own aggregate step (issue #1001)
now allows `skipped` beside `success` for that reason, still failing
on anything else.

The allowlist is not a copy of `btclib-secp256k1`'s own. Both exclude
`README.md`, the package's long description that the `dist` job's
twine and pyroma checks render and rate, and anything under `docs/`,
which `MANIFEST.in` carries into the sdist and which `tests/docs_test.py`
and `tests/docs_examples_test.py` read directly. This repository's list
additionally excludes `CHANGELOG.md` and `HISTORY.md`, which
`btclib-secp256k1` treats as prose but which
`tests/release_notes_test.py` here parses and validates the format
of — in the very suite a prose-only skip would otherwise leave unrun.

`coverage-union`, which this repository has and `btclib-secp256k1`'s
matrix does not, needed its own explicit gate rather than relying on
`coverage`/`no-bindings` skipping under it: a job's own `if` replaces
the implicit "needs succeeded" check rather than adding to it, so
without `needs.changes.outputs.code == 'true'` it would still run on a
prose-only pull request and fail trying to download two artifacts
neither upstream job produced.

Also applies issue #1044 itself: `release.yml`'s call into `test.yml`
now grants `pull-requests: read` beside `contents: read`, which the new
`changes` job needs and which a caller's `permissions:` block, once
present, grants in place of the callee's own default rather than in
addition to it — the gap issue #1044 documents `btclib-secp256k1`
hitting as a `startup_failure` on `v0.8.0.3`.

## Test plan

- [x] `uv run pre-commit run --all-files` — exit 0
- [x] `uv run pytest` (full suite, 100% coverage gate) — exit 0,
      100.00%
- [x] `uv run pytest tests/release_notes_test.py` — 3 passed
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html` — build
      succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Skip the test matrix for pull requests that change only files outside the code and test surface while preserving reliable aggregate status reporting.

New Features:
- Add a workflow change-detection job that skips the test matrix for pull requests containing only non-functional prose changes.

Bug Fixes:
- Grant reusable test workflows the pull-request permission required to inspect changed files, including release-triggered runs.
- Prevent the aggregate test gate from incorrectly passing when change detection fails while allowing intentionally skipped matrix jobs.

Enhancements:
- Update repository guidance to document the new workflow gating behavior and permission requirements.

CI:
- Gate suite, coverage, bindings, distribution, and coverage-union jobs on whether relevant files changed.

Documentation:
- Document the prose-only test optimization and workflow token permissions in the changelog and repository guide.