### PR TITLE
Aggregate a musig2 psbt session's keys once, not four times (issue #1046)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1375,6 +1375,29 @@ documented at release-notes length in the first place, and are still in
 
 ### Transactions, blocks and PSBT
 
+- **`psbt.musig2.partial_sigs_agg` aggregates the participant list once,
+  not four times** (issue #1046). Every public function of the module
+  built a fresh `SessionContext` from the psbt, so issue #1045's own
+  memoization on that class never had an instance to attach to, and
+  `partial_sigs_agg` paid for `key_agg_and_tweak` four times over: once in
+  `_session_parts` for the tweaked key, again inside `session_context`,
+  again inside `musig2.partial_sig_agg`'s own `session_values`, and a
+  fourth time to read `key_agg_ctx.x_only_pub_key` back -- a value
+  `_session_parts` had already returned as `tweaked_pub_key`.
+
+  `session_context` now returns `Session`, a `NamedTuple` of the
+  `SessionContext` it built and the `KeyAggContext` behind it, rather than
+  the `SessionContext` alone: `partial_sigs_agg` takes the tweaked key from
+  `.key_agg_ctx` instead of aggregating the participants a second time, and
+  the Finalizer's own check at what was `:497` still verifies against a key
+  `_session_parts` computed and validated, not one carried along untested.
+  `partial_sign` and `partial_sig_verify` unpack `.context` and sign or
+  verify exactly as before. The alternative -- a cache on `_session_parts`,
+  keyed off the psbt -- was the one to distrust: `partial_sigs_agg` writes
+  to the very psbt fields a cache would key on, in the same call, so
+  nothing would own invalidating it. `RELEASE_NOTES.md` has the
+  source-breaking shape
+
 - **BIP158 basic compact block filters** (issue #374, on the SipHash-2-4
   of issue #373). `btclib.block.block_filter` is the new module and
   `BasicBlockFilter` the type: `from_block` builds the filter of a block,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,16 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **`psbt.musig2.session_context` returns `Session`, not a bare
+  `SessionContext`.** `session_context(psbt, vin_i, aggregate_pub_key) ->
+  musig2.SessionContext` is now `-> Session`, a `NamedTuple` of
+  `.context` (the `SessionContext` it used to return alone) and
+  `.key_agg_ctx` (the `KeyAggContext` it built the session on). A caller
+  reading the result as a `SessionContext` -- passing it to
+  `btclib.ecc.musig2.sign` or `partial_sig_verify_`, or reading
+  `.pub_keys`, `.tweaks`, `.is_xonly`, `.msg` or `.agg_nonce` off it --
+  takes `.context` first. CHANGELOG.md has why.
+
 - **`pip install btclib` no longer installs `btclib_secp256k1`.** The
   bindings are the `secp256k1` extra now — `pip install
   "btclib[secp256k1]"` — and an install that does not ask for them gets a

--- a/btclib/psbt/musig2.py
+++ b/btclib/psbt/musig2.py
@@ -49,6 +49,10 @@ publishes a vector for each:
 `session_context` is where those four are read off the psbt, and it is
 public because a signer needs it for what BIP327 asks beyond signing:
 `btclib.ecc.musig2.partial_sig_verify_` against another signer's nonce.
+It returns the `KeyAggContext` it built the session on, alongside the
+session itself: `partial_sigs_agg` is a caller that needs the tweaked
+key, and the alternative -- aggregating the participants over again to
+get it -- is the quadratic shape issue #1046 fixed.
 """
 
 from __future__ import annotations
@@ -81,6 +85,7 @@ from btclib.to_prv_key import PrvKey
 from btclib.utils import assert_type, bytes_from_octets
 
 __all__ = [
+    "Session",
     "add_participant_pub_keys",
     "assert_valid_participants",
     "nonce_gen",
@@ -207,6 +212,11 @@ class _SessionParts(NamedTuple):
     the aggregate key carried through the derivation and the taproot
     tweak (`SignMuSig2` in script/sign.cpp), and a psbt keyed either
     other way is one no other implementation reads.
+
+    `key_agg_ctx` is the `KeyAggContext` `tweaked_pub_key` was read off of
+    -- carried along rather than dropped, so that a caller needing it
+    (`session_context`, on to `partial_sigs_agg`) does not aggregate the
+    participants a second time to get it back.
     """
 
     participants: list[bytes]
@@ -214,6 +224,7 @@ class _SessionParts(NamedTuple):
     is_xonly: list[bool]
     msg: bytes
     tweaked_pub_key: bytes
+    key_agg_ctx: musig2.KeyAggContext
 
 
 def _session_parts(
@@ -250,6 +261,7 @@ def _session_parts(
         is_xonly,
         msg,
         bytes_from_point(key_agg_ctx.Q, secp256k1),
+        key_agg_ctx,
     )
 
 
@@ -267,10 +279,24 @@ def _script_key(psbt_in: PsbtIn, leaf_hash: bytes) -> bytes:
     return single_leaf_key(script)
 
 
+class Session(NamedTuple):
+    """A BIP327 session, and the `KeyAggContext` it was built on.
+
+    `context` is what `btclib.ecc.musig2.sign` and `partial_sig_verify_`
+    take. `key_agg_ctx` is the aggregation `_session_parts` already did to
+    reach it -- handed back rather than left for a caller that needs the
+    tweaked key, `x_only_pub_key` included, to aggregate the participants
+    a second time.
+    """
+
+    context: musig2.SessionContext
+    key_agg_ctx: musig2.KeyAggContext
+
+
 def session_context(
     psbt: Psbt, vin_i: int, aggregate_pub_key: Octets, *, leaf_hash: Octets = b""
-) -> musig2.SessionContext:
-    """Return the BIP327 session the psbt describes for one aggregate key.
+) -> Session:
+    """Return the BIP327 session the psbt describes, and its key aggregation.
 
     The aggregate nonce is the sum of the public nonces the input carries
     for this session, so every signer that has published one is in it: a
@@ -296,9 +322,10 @@ def session_context(
     agg_nonce = musig2.nonce_agg(
         [pub_nonces[key] for key in parts.participants if key in pub_nonces]
     )
-    return musig2.SessionContext(
+    context = musig2.SessionContext(
         agg_nonce, parts.participants, parts.tweaks, parts.is_xonly, parts.msg
     )
+    return Session(context, parts.key_agg_ctx)
 
 
 def _key_data(
@@ -407,9 +434,9 @@ def partial_sign(
         err_msg += aggregate_pub_key.hex()
         raise BTClibValueError(err_msg)
 
-    session_ctx = session_context(psbt, vin_i, aggregate_pub_key, leaf_hash=leaf_hash)
-    psig = musig2.sign(sec_nonce, prv_key, session_ctx)
-    if not musig2.partial_sig_verify_(psig, pub_nonce, pub_key, session_ctx):
+    session = session_context(psbt, vin_i, aggregate_pub_key, leaf_hash=leaf_hash)
+    psig = musig2.sign(sec_nonce, prv_key, session.context)
+    if not musig2.partial_sig_verify_(psig, pub_nonce, pub_key, session.context):
         # unreachable short of a defect in either this module or `sign`:
         # the context is the one the signature was just made against.
         # It stays because what it costs is one verification against a
@@ -450,8 +477,10 @@ def partial_sig_verify(
         err_msg = f"no musig2 partial signature of {participant_pub_key.hex()} "
         err_msg += f"for aggregate key {aggregate_pub_key.hex()}"
         raise BTClibValueError(err_msg)
-    session_ctx = session_context(psbt, vin_i, aggregate_pub_key, leaf_hash=leaf_hash)
-    return musig2.partial_sig_verify_(psig, pub_nonce, participant_pub_key, session_ctx)
+    session = session_context(psbt, vin_i, aggregate_pub_key, leaf_hash=leaf_hash)
+    return musig2.partial_sig_verify_(
+        psig, pub_nonce, participant_pub_key, session.context
+    )
 
 
 def partial_sigs_agg(
@@ -477,29 +506,25 @@ def partial_sigs_agg(
     aggregate_pub_key = bytes_from_octets(aggregate_pub_key, MUSIG2_PUB_KEY_SIZE)
     leaf_hash = bytes_from_octets(leaf_hash)
     psbt_in = psbt.inputs[vin_i]
-    tweaked_pub_key = _session_parts(
-        psbt, vin_i, aggregate_pub_key, leaf_hash
-    ).tweaked_pub_key
-    session_ctx = session_context(psbt, vin_i, aggregate_pub_key, leaf_hash=leaf_hash)
+    session = session_context(psbt, vin_i, aggregate_pub_key, leaf_hash=leaf_hash)
+    tweaked_pub_key = bytes_from_point(session.key_agg_ctx.Q, secp256k1)
     partial_sigs = _session_partial_sigs(psbt_in, tweaked_pub_key, leaf_hash)
-    missing = [key for key in session_ctx.pub_keys if key not in partial_sigs]
+    missing = [key for key in session.context.pub_keys if key not in partial_sigs]
     if missing:
         err_msg = "missing musig2 partial signature of "
         err_msg += ", ".join(key.hex() for key in missing)
         raise BTClibValueError(err_msg)
 
     sig = musig2.partial_sig_agg(
-        [partial_sigs[key] for key in session_ctx.pub_keys], session_ctx
+        [partial_sigs[key] for key in session.context.pub_keys], session.context
     )
-    key_agg_ctx = musig2.key_agg_and_tweak(
-        session_ctx.pub_keys, session_ctx.tweaks, session_ctx.is_xonly
-    )
-    if not ssa.verify_(session_ctx.msg, key_agg_ctx.x_only_pub_key, sig):
+    x_only_pub_key = session.key_agg_ctx.x_only_pub_key
+    if not ssa.verify_(session.context.msg, x_only_pub_key, sig):
         # a partial signature that verifies on its own and does not add
         # up is what a peer sending one of another session produces, so
         # this is the Finalizer's check and not a belt-and-braces one
         err_msg = "the musig2 partial signatures do not add up to a signature "
-        err_msg += f"of {key_agg_ctx.x_only_pub_key.hex()}"
+        err_msg += f"of {x_only_pub_key.hex()}"
         raise BTClibValueError(err_msg)
 
     signature = sig.serialize()
@@ -507,9 +532,7 @@ def partial_sigs_agg(
         # BIP341: the type is appended, and its absence is SIGHASH_DEFAULT
         signature += psbt_in.sig_hash_type.to_bytes(1, "big")
     if leaf_hash:
-        psbt_in.taproot_script_spend_signatures[
-            key_agg_ctx.x_only_pub_key + leaf_hash
-        ] = signature
+        psbt_in.taproot_script_spend_signatures[x_only_pub_key + leaf_hash] = signature
     else:
         psbt_in.taproot_key_spend_signature = signature
 


### PR DESCRIPTION
Closes #1046.

## What was open

`partial_sigs_agg` (`btclib/psbt/musig2.py`) aggregated the same
participant list up to four times per call: once in `_session_parts`
for the tweaked key, again inside `session_context`'s own call to
`_session_parts`, again inside `musig2.partial_sig_agg`'s
`session_values`, and a fourth time at what was line 494 to read
`key_agg_ctx.x_only_pub_key` back -- a value `_session_parts` had
already returned as `tweaked_pub_key`.

## The design decision

The issue laid out two shapes for the half that needed one:

- **`session_context` returns both** the `SessionContext` and the
  `KeyAggContext` it built it on, source-breaking on a public
  function's return type.
- **`_session_parts` grows a cache**, keyed on what it reads off the
  psbt, leaving the public surface untouched but the invalidation
  unowned.

I took the first shape, as the issue recommended. The second was the
one to distrust: `partial_sigs_agg` mutates the very psbt fields
(`musig2_pub_nonces`, `musig2_partial_sigs`,
`musig2_participant_pub_keys`) a cache would key on, in the same call
(`_drop_session` at the end of `partial_sigs_agg`) -- so a cache and
the write that invalidates it would race inside one function, with
nobody watching the invariant.

`session_context` now returns `Session`, a `NamedTuple` of `.context`
(the `SessionContext` it used to return alone) and `.key_agg_ctx` (the
`KeyAggContext` it built the session on). `partial_sign` and
`partial_sig_verify` unpack `.context` and are otherwise unchanged.
`partial_sigs_agg` takes the tweaked key from `.key_agg_ctx` instead of
aggregating the participants a second time, and the Finalizer's own
check verifies against a key `_session_parts` computed and validated
once -- not one carried along untested and not one rebuilt from
scratch.

Net effect: `partial_sigs_agg` now aggregates the participant list
twice (once in `session_context`'s own `_session_parts` call, once
inside `musig2.partial_sig_agg`'s `session_values`, which is issue
#1045's separate, ecc-layer concern) instead of four times.

## What I checked

- The four BIP373 vectors (one per way the aggregate key reaches the
  output being spent) still pass -- `tests/psbt/musig2_test.py`
  parametrizes over all four.
- `_drop_session` still runs on exactly the same `tweaked_pub_key` it
  did before: it is now computed via `bytes_from_point(session.key_agg_ctx.Q,
  secp256k1)` rather than via a separate `_session_parts` call, but
  it's the same aggregation, same inputs.
- The Finalizer's check (`ssa.verify_` against `x_only_pub_key`) still
  verifies against a key computed by `_session_parts` inside
  `session_context`, not against a value merely carried along.

Since `session_context` did not exist at `v2023.7.12` (the module was
added later, in #297), there is no historical "before" spelling to
preserve beyond the current signature, which `RELEASE_NOTES.md`
records.

## Gates run locally

- `uv run pytest` -- 28539 passed, 9 skipped, 100.00% coverage
- `uv run pre-commit run --all-files` -- all hooks passed
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` -- build succeeded,
  no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Reuse MuSig2 session key aggregation results to eliminate redundant participant aggregation during PSBT signature finalization.

Enhancements:
- Reduce MuSig2 PSBT partial-signature aggregation by reusing the key aggregation context created for the session instead of recomputing participant aggregation.
- Expose the session context and its associated key aggregation context together through the PSBT MuSig2 session API.

Documentation:
- Document the breaking change to the MuSig2 session API and the resulting aggregation optimization.