### PR TITLE
Add the CHANGELOG.md entry issue #1052 landed without

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6149,6 +6149,20 @@ documented at release-notes length in the first place, and are still in
   against. The zkp reference also moved: the fork is
   `BlockstreamResearch`'s now, and the constant lives in its
   `generator` module rather than `rangeproof`.
+- **`ecc.musig2`'s module docstring states the history behind "the
+  earlier commit-then-reveal defence"** (issue #1052). MuSig was first
+  proposed with two rounds and no nonce commitment; it was withdrawn
+  once a signer choosing its nonce adaptively, after seeing everyone
+  else's, was shown to defeat the proof. The docstring already named
+  the revision that fixed it -- three rounds, a commitment round in
+  front -- without saying why it existed, and it renders on the
+  website through `docs/source/btclib.ecc.rst`'s autodoc, so a reader
+  meets the correction there.
+
+  `tests/ecc/ssa_test.py`'s MuSig demo is that three-round scheme now,
+  not the withdrawn one: `test_musig` is `test_musig1`, a round-1
+  commitment precedes the round-2 nonce reveal, and a forged nonce is
+  asserted to fail the commitment check rather than pass silently.
 
 ### Performance
 


### PR DESCRIPTION
## Summary

PR #1061 (issue #1052) landed as f6a8210c without a CHANGELOG.md
entry. The claude-review bot asked about it on `btclib/ecc/musig2.py`:
https://github.com/btclib-org/btclib/pull/1061#discussion_r3824483833

The docstring change renders on the docs website
(`docs/source/btclib.ecc.rst`'s autodoc), which is the same kind of
change the `ndata` renaming (issue #928) got an entry for under
"Documentation and the website" — CLAUDE.md's threshold for
CHANGELOG.md is "anything a user would notice", not only a correction.

This PR adds that one entry, covering the whole of #1052: the
`ecc.musig2` docstring addition and the `tests/ecc/ssa_test.py` MuSig
demo rewrite that landed alongside it. Nothing else changes — no
source, no tests, no RELEASE_NOTES.md, since nothing a caller does is
different.

## Test plan

- [x] `uv run pytest` (28541 passed, 9 skipped, coverage gate included)
- [x] `uv run pre-commit run --all-files` (all hooks passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Document the MuSig2 security-history clarification and three-round demonstration changes in the changelog.