### PR TITLE
commit's docstring points at second_generator's instead of restating it

### DIFF
--- a/btclib/ecc/pedersen.py
+++ b/btclib/ecc/pedersen.py
@@ -103,9 +103,8 @@ def second_generator(ec: Curve = secp256k1, hf: HashF = sha256) -> Point:
 def commit(r: int, v: int, ec: Curve = secp256k1, hf: HashF = sha256) -> Point:
     """Commit to v under blinding factor r, returning rG+vH.
 
-    H is `second_generator`: opening the commitment to any (r, v) other
-    than the one committed to would need its discrete logarithm with
-    respect to G, which nobody has.
+    H is `second_generator`, whose docstring has why nobody can open
+    this to a different (r, v).
     """
     H = second_generator(ec, hf)
     Q = double_mult_var(v, H, r, ec.G, ec)


### PR DESCRIPTION
## Summary

Recovers a fix that missed #1059's merge window. #1059 (issue #1055,
landed as \`9f72a580\`) fixed \`pedersen.py\`'s dead zkp reference and
pinned that \`second_generator\` derives libsecp256k1-zkp's \`H\`. The
review bot's re-review, on the sha that fixed the last blocking finding
(the \`tests/ecc/pedersen_test.py\` path), landed one more non-blocking
observation -- still open on
[the pedersen.py:108 thread](https://github.com/btclib-org/btclib/pull/1059#discussion_r3824655449)
-- fifteen seconds after the maintainer merged. This PR is that
observation.

\`commit\`'s docstring restated \`second_generator\`'s "nobody has the
discrete logarithm relating H to G" reasoning instead of pointing at
it -- the same "one fact in one place" shape #1059 already fixed once,
between \`second_generator\`'s docstring and \`test_second_generator\`'s.
\`commit\`'s now does the same: it names \`second_generator\` and says its
docstring carries the why, rather than repeating the why itself.

## CHANGELOG.md

Deliberately unchanged. The entry \`9f72a580\` added under "Documentation
and the website" (issue #1055) already says: "The docstrings of
\`second_generator\`, \`commit\` and the test now say so" -- it already
describes \`commit\`'s docstring as part of #1055's documentation work.
This PR is that sentence's \`commit\` half actually landing on \`main\`;
a second bullet would restate the first bullet's own words about the
same change, which is the duplication CHANGELOG.md's rules exist to
prevent.

## Test plan

- [x] \`uv run pytest\` (full suite, 100% coverage gate)
- [x] \`uv run pre-commit run --all-files\`
- [x] \`uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Update the Pedersen commitment documentation to reference `second_generator` for the security rationale instead of duplicating it.