### PR TITLE
Answer an input's weight before the input exists (issue #1067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1411,6 +1411,40 @@ documented at release-notes length in the first place, and are still in
 
 ### Transactions, blocks and PSBT
 
+- **`tx.input_weight` answers what an input will weigh before the input
+  exists** (issue #1067). A fee is chosen before the transaction is
+  signed, so the weight it is computed from cannot be read off the
+  transaction whose shape that fee decides, and `Tx.weight` needs a
+  transaction already built. `input_weight(script_sig, witness=None)` is
+  BIP141's rule applied to one input: the non-witness bytes -- the
+  36-byte outpoint, the script_sig behind its var_int length, the 4-byte
+  sequence -- weigh `WITNESS_SCALE_FACTOR` each, and the serialized
+  witness stack weighs one each. It is Bitcoin Core's
+  `calculate_input_weight`, of
+  `test/functional/test_framework/wallet_util.py`, whose
+  `TestFrameworkWalletUtil.test_calculate_input_weight` beside it is the
+  third-party vector set the test transcribes, at bitcoin/bitcoin
+  42330922: the two var_int boundaries, 252 bytes against 253 on the
+  script_sig and on the witness item count, and no witness against an
+  empty stack.
+
+  Those last two are a byte apart, and that is the subtlety the type
+  carries. An input of a transaction with no witness section contributes
+  nothing beyond its non-witness bytes; an empty stack in a segwit
+  transaction still serializes the var_int announcing no elements. Core
+  takes a list of hex items and has to document the difference as a rule
+  about its `None` default, where `Witness | None` makes it unspeakable
+  to get wrong. It is why this is a free function and not a `TxIn`
+  property: `TxIn.script_witness` is a `Witness` and never `None`, so an
+  input alone cannot say whether the transaction it will sit in has a
+  witness section at all -- an empty one there is both a legacy input
+  and an unsigned segwit one, and a property would have to pick.
+
+  It sits in `btclib.tx.tx_in` beside that input rather than in
+  `btclib.fee`, taking no rate and answering a weight; `fee_from_vsize`
+  is what turns one into money. Coin selection and fee estimation are
+  still not here, and what a caller does with the number is theirs.
+
 - **`psbt.musig2.partial_sigs_agg` aggregates the participant list once,
   not four times** (issue #1046). Every public function of the module
   built a fresh `SessionContext` from the psbt, so issue #1045's own

--- a/btclib/tx/__init__.py
+++ b/btclib/tx/__init__.py
@@ -2,11 +2,11 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Transactions: OutPoint, TxIn, TxOut, Tx, and join."""
+"""Transactions: OutPoint, TxIn, TxOut, Tx, join, and input_weight."""
 
 from btclib.tx.out_point import OutPoint
 from btclib.tx.tx import Tx, join
-from btclib.tx.tx_in import TxIn
+from btclib.tx.tx_in import TxIn, input_weight
 from btclib.tx.tx_out import TxOut
 
-__all__ = ["OutPoint", "Tx", "TxIn", "TxOut", "join"]
+__all__ = ["OutPoint", "Tx", "TxIn", "TxOut", "input_weight", "join"]

--- a/btclib/tx/tx_in.py
+++ b/btclib/tx/tx_in.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""The TxIn dataclass; the class docstring has the contract."""
+"""The TxIn dataclass and input_weight; the class docstring has the contract."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ from typing import Any
 
 from btclib import var_bytes
 from btclib.alias import BinaryData, Octets
+from btclib.consensus import WITNESS_SCALE_FACTOR
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.script import Witness, script_from_dict, script_to_dict
 from btclib.tx.out_point import OutPoint
@@ -27,6 +28,7 @@ from btclib.utils import (
 __all__ = [
     "TX_IN_COMPARES_WITNESS",
     "TxIn",
+    "input_weight",
 ]
 
 TX_IN_COMPARES_WITNESS = True
@@ -224,3 +226,40 @@ class TxIn:
         return cls(
             prev_out, script_sig, sequence, Witness(), check_validity=check_validity
         )
+
+
+def input_weight(script_sig: Octets, witness: Witness | None = None) -> int:
+    """Return the weight one input adds to a transaction, per BIP141.
+
+    Bitcoin Core's `calculate_input_weight`, of
+    test/functional/test_framework/wallet_util.py: the non-witness bytes
+    weigh WITNESS_SCALE_FACTOR each -- the 36-byte outpoint, the
+    script_sig behind its var_int length, the 4-byte sequence -- and the
+    serialized witness stack weighs one each. Which output is spent and
+    what the sequence says do not enter the answer, both fields being
+    fixed-width, so neither is an argument.
+
+    It is computable before the input exists, which is the point: a fee
+    is chosen before the transaction is signed, so the weight the fee is
+    computed from cannot be read off the finished transaction.
+    `Tx.weight` is the same arithmetic over one already built.
+
+    `witness` is `None` for an input of a transaction with no witness
+    section and a `Witness` for one of a transaction that has it --
+    `Witness()` being the empty stack a non-segwit input carries there.
+    The two differ by a byte, that stack still serializing the var_int
+    announcing no elements, and a caller that cannot tell them apart
+    misprices an input by one. Core, taking a list of hex items, has to
+    document the distinction as a rule about `None`; here it is the
+    type's.
+    """
+    # a TxIn measured rather than its fixed 40 bytes restated here: what
+    # an outpoint and a sequence weigh is _serialized_size's to know, and
+    # building the input is what Core does for the same reason
+    weight = TxIn(script_sig=script_sig)._serialized_size() * WITNESS_SCALE_FACTOR
+    # `is not None` and not a truth test: Witness defines __len__, so the
+    # empty stack is falsy, and it is exactly the case that must not be
+    # read as no witness at all
+    if witness is not None:
+        weight += witness._serialized_size()
+    return weight

--- a/tests/tx/tx_in_test.py
+++ b/tests/tx/tx_in_test.py
@@ -9,9 +9,11 @@ from pathlib import Path
 
 import pytest
 
+from btclib import var_int
+from btclib.consensus import WITNESS_SCALE_FACTOR
 from btclib.exceptions import BTClibValueError
 from btclib.script import Witness
-from btclib.tx import OutPoint, Tx, TxIn
+from btclib.tx import OutPoint, Tx, TxIn, TxOut, input_weight
 from tests.conftest import JsonGolden
 
 
@@ -205,3 +207,132 @@ def test_script_sig_is_not_validated_and_that_is_the_answer() -> None:
     tx = Tx(vin=[TxIn()], vout=[], check_validity=False)
     with pytest.raises(BTClibValueError, match="Invalid coinbase script size"):
         tx.assert_valid()
+
+
+def test_input_weight() -> None:
+    """Match Core's TestFrameworkWalletUtil.test_calculate_input_weight.
+
+    Its cases transcribed from
+    test/functional/test_framework/wallet_util.py at bitcoin/bitcoin
+    42330922, with Core's `witness_stack_hex=None` spelled `None` and its
+    `[]` spelled `Witness()`. They are chosen for the two boundaries the
+    arithmetic can be wrong at: a length of 252 against one of 253, where
+    a var_int grows from one byte to three, on the script_sig and on the
+    witness item count alike; and no witness against an empty stack.
+    """
+    SKELETON_BYTES = 32 + 4 + 4  # prevout-txid, prevout-index, sequence
+    SMALL_LEN_BYTES = 1  # a var_int announcing a length below 253
+    LARGE_LEN_BYTES = 3  # a var_int announcing 253 or more
+
+    # empty script_sig, no witness
+    assert (
+        input_weight(b"") == (SKELETON_BYTES + SMALL_LEN_BYTES) * WITNESS_SCALE_FACTOR
+    )
+    assert (
+        input_weight(b"", None)
+        == (SKELETON_BYTES + SMALL_LEN_BYTES) * WITNESS_SCALE_FACTOR
+    )
+    # small script_sig, no witness
+    script_sig_small = b"\x00" * 252
+    assert (
+        input_weight(script_sig_small, None)
+        == (SKELETON_BYTES + SMALL_LEN_BYTES + 252) * WITNESS_SCALE_FACTOR
+    )
+    # small script_sig, empty witness stack
+    assert (
+        input_weight(script_sig_small, Witness())
+        == (SKELETON_BYTES + SMALL_LEN_BYTES + 252) * WITNESS_SCALE_FACTOR
+        + SMALL_LEN_BYTES
+    )
+    # large script_sig, no witness
+    script_sig_large = b"\x00" * 253
+    assert (
+        input_weight(script_sig_large, None)
+        == (SKELETON_BYTES + LARGE_LEN_BYTES + 253) * WITNESS_SCALE_FACTOR
+    )
+    # large script_sig, empty witness stack
+    assert (
+        input_weight(script_sig_large, Witness())
+        == (SKELETON_BYTES + LARGE_LEN_BYTES + 253) * WITNESS_SCALE_FACTOR
+        + SMALL_LEN_BYTES
+    )
+    # empty script_sig, 5 small witness stack items
+    assert (
+        input_weight(b"", Witness(["00", "11", "22", "33", "44"]))
+        == (SKELETON_BYTES + SMALL_LEN_BYTES) * WITNESS_SCALE_FACTOR
+        + SMALL_LEN_BYTES
+        + 5 * SMALL_LEN_BYTES
+        + 5
+    )
+    # empty script_sig, 253 small witness stack items
+    assert (
+        input_weight(b"", Witness(["00"] * 253))
+        == (SKELETON_BYTES + SMALL_LEN_BYTES) * WITNESS_SCALE_FACTOR
+        + LARGE_LEN_BYTES
+        + 253 * SMALL_LEN_BYTES
+        + 253
+    )
+    # small script_sig, 3 large witness stack items
+    assert (
+        input_weight(script_sig_small, Witness(["00" * 253] * 3))
+        == (SKELETON_BYTES + SMALL_LEN_BYTES + 252) * WITNESS_SCALE_FACTOR
+        + SMALL_LEN_BYTES
+        + 3 * LARGE_LEN_BYTES
+        + 3 * 253
+    )
+    # large script_sig, 3 large witness stack items
+    assert (
+        input_weight(script_sig_large, Witness(["00" * 253] * 3))
+        == (SKELETON_BYTES + LARGE_LEN_BYTES + 253) * WITNESS_SCALE_FACTOR
+        + SMALL_LEN_BYTES
+        + 3 * LARGE_LEN_BYTES
+        + 3 * 253
+    )
+
+
+def test_input_weight_sums_to_tx_weight() -> None:
+    """Sum the inputs of a built transaction and land on Tx.weight.
+
+    Core's vectors above fix the answer against a third party; this fixes
+    it against btclib's own weight arithmetic, which is what a caller
+    composes it with -- and it is where the `None`/`Witness()` split is
+    load-bearing rather than merely documented. The second transaction is
+    segwit with one input carrying an empty stack: reading that input as
+    having no witness would lose the one byte of its var_int, and reading
+    the legacy transaction's input as having an empty one would invent
+    that byte.
+    """
+    prev_out = OutPoint(b"\x01" * 32, 0)
+    tx_out = TxOut(1000, "0014" + "00" * 20)
+    p2pkh_script_sig = b"\x00" * 107
+    p2wpkh_witness = Witness(["00" * 72, "00" * 33])
+    p2sh_p2wpkh_script_sig = b"\x16" + b"\x00" * 22
+
+    legacy = Tx(vin=[TxIn(prev_out, p2pkh_script_sig, 0xFFFFFFFF)], vout=[tx_out])
+    segwit = Tx(
+        vin=[
+            TxIn(prev_out, b"", 0xFFFFFFFF, p2wpkh_witness),
+            TxIn(prev_out, p2sh_p2wpkh_script_sig, 0xFFFFFFFF, Witness()),
+        ],
+        vout=[tx_out],
+    )
+
+    for tx in (legacy, segwit):
+        inputs = sum(
+            input_weight(
+                tx_in.script_sig, tx_in.script_witness if tx.is_segwit else None
+            )
+            for tx_in in tx.vin
+        )
+        # everything the inputs are not: version, the two counts, the
+        # outputs and the lock time, all of them non-witness bytes, plus
+        # the two bytes of the segwit marker and flag, which are witness
+        # bytes and weigh one each
+        rest = WITNESS_SCALE_FACTOR * (
+            4
+            + len(var_int.serialize(len(tx.vin)))
+            + len(var_int.serialize(len(tx.vout)))
+            + sum(tx_out_._serialized_size() for tx_out_ in tx.vout)
+            + 4
+        ) + (2 if tx.is_segwit else 0)
+        assert tx.weight == inputs + rest


### PR DESCRIPTION
Closes #1067.

`btclib.tx.input_weight(script_sig, witness=None)` is BIP141's rule
applied to one input: the non-witness bytes -- the 36-byte outpoint, the
script_sig behind its `var_int` length, the 4-byte sequence -- weigh
`WITNESS_SCALE_FACTOR` each, and the serialized witness stack weighs one
each. A fee is chosen before the transaction is signed, so the weight it
is computed from cannot be read off the transaction whose shape that fee
decides, which is what `Tx.weight` needs.

## The two decisions the issue left to the review

**A free function and not a `TxIn` property.** `TxIn.script_witness` is a
`Witness` and never `None`, so an input alone cannot say whether the
transaction it will sit in has a witness section: `Witness()` there is
both a legacy input and an unsigned segwit one, and a property would have
to pick one of the two. Core passes both in for the same reason, its
`CTxIn` not holding a witness at all.

**`btclib/tx/tx_in.py` and not `btclib/fee.py`**, which is the issue's own
argument: it is a property of an input, it takes no rate, and
`fee_from_vsize` is what turns a weight into money. It is exported from
`btclib.tx` beside `TxIn`.

`None` against `Witness()` is a byte, and the type carries it: no witness
section contributes nothing, an empty stack still serializes the `var_int`
announcing no elements. Core takes a list of hex items and documents that
as a rule about its `None` default.

## The authority

`TestFrameworkWalletUtil.test_calculate_input_weight`, of
[`test/functional/test_framework/wallet_util.py`](https://github.com/bitcoin/bitcoin/blob/42330922dd8d5f96dbc0cc6a8e4092500029f89d/test/functional/test_framework/wallet_util.py#L115-L151)
at bitcoin/bitcoin
[`42330922`](https://github.com/bitcoin/bitcoin/commit/42330922dd8d5f96dbc0cc6a8e4092500029f89d),
transcribed into `tests/tx/tx_in_test.py` with Core's own
`SKELETON_BYTES`/`SMALL_LEN_BYTES`/`LARGE_LEN_BYTES` arithmetic kept
verbatim so the port reads against the upstream line. They are code
upstream rather than a data file, so nothing is vendored and
`tests/_data/README.md` has nothing to say.

A second test sums the inputs of a built transaction and lands on
`Tx.weight`, which fixes the answer against btclib's own weight
arithmetic rather than only against Core's constants. It is where the
`None`/`Witness()` split is load-bearing: the segwit transaction there has
one input carrying an empty stack, and reading it as having no witness
loses that byte.

## Not here

Coin selection and fee estimation, per the issue's scope. `Tx.weight` is
unchanged.

## Gates

All three, on `5a12cc86`, exit code 0:

- `uv run pytest` -- 28546 passed, 9 skipped; total coverage 100.00%
- `uv run pre-commit run --all-files`
- `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html`

## Summary by Sourcery

Expose BIP141 input weight calculation for pre-signing transaction fee planning.

New Features:
- Add the public `btclib.tx.input_weight` helper for calculating an input’s BIP141 weight before transaction construction.

Enhancements:
- Clarify the distinction between absent witness data and an empty witness stack when estimating input weight.

Documentation:
- Document the new input weight calculation and its intended fee-estimation use in the changelog.

Tests:
- Add Bitcoin Core-derived boundary tests and verify that summed input weights align with complete transaction weights.