### PR TITLE
Cache L, second and pub_keys_set on SessionValues (issue #1069)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7052,8 +7052,9 @@ documented at release-notes length in the first place, and are still in
   `L`, `second` and `pub_keys_set` -- what a coefficient is computed
   from -- are now three more fields on `SessionValues`, computed once
   by `session_values` the way `key_agg` already computes its own `L`
-  and `second` once, at `:300-301`, rather than recomputed by every
-  one of `_session_key_agg_coeff`'s 2n callers. Not threaded out of
+  and `second` once and reuses them for every key, rather than
+  recomputed by every one of `_session_key_agg_coeff`'s 2n callers.
+  Not threaded out of
   `key_agg_and_tweak` instead, which already computes the same `L` and
   `second` internally to aggregate Q: doing that would widen
   `KeyAggContext`, which `btclib/psbt/musig2.py` and callers outside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7039,6 +7039,59 @@ documented at release-notes length in the first place, and are still in
   Q, gacc, tacc, b, R and e are all public -- so nothing here changes
   what `SECURITY.md` publishes.
 
+- **A MuSig2 session's per-signer coefficient is O(1), not O(n)**
+  (issue #1069, the third quadratic path issue #1045 and #1046 did not
+  touch, all three raised by the review bot on PR #1060 and left each
+  time to a person to decide whether they became their own issue).
+  `_session_key_agg_coeff` ran three O(n) traversals of
+  `session_ctx.pub_keys` per call -- the membership test,
+  `_hash_pub_keys`'s join-and-hash and `_second_pub_key`'s scan -- and
+  `sign` and `partial_sig_verify_` each call it once per signer, so it
+  ran 2n times per session over inputs that never change.
+
+  `L`, `second` and `pub_keys_set` -- what a coefficient is computed
+  from -- are now three more fields on `SessionValues`, computed once
+  by `session_values` the way `key_agg` already computes its own `L`
+  and `second` once, at `:300-301`, rather than recomputed by every
+  one of `_session_key_agg_coeff`'s 2n callers. Not threaded out of
+  `key_agg_and_tweak` instead, which already computes the same `L` and
+  `second` internally to aggregate Q: doing that would widen
+  `KeyAggContext`, which `btclib/psbt/musig2.py` and callers outside
+  this module already read, for a value only the coefficient wants.
+  Not a second cached field on `SessionContext` beside `_values`
+  either, which issue #1069 posed as the alternative: both of
+  `_session_key_agg_coeff`'s callers already call `session_values`
+  first, so a `SessionValues` field costs nothing beyond what
+  assembling the session already paid for, where a second cache would
+  only earn its keep for a caller wanting the coefficient without the
+  rest of the session -- which neither `sign` nor `partial_sig_verify_`
+  is. The membership test stays a check of its own, answered by the
+  new `pub_keys_set` frozenset in O(1): `_SIGNER_PK_ERR` is one of
+  BIP327's verbatim messages, pinned byte for byte by the vectors, so
+  folding it into a dict lookup that raises something else was never
+  an option.
+
+  Measured the same way as the table above, on the same machine, best
+  of five:
+
+  | n | before | after | speedup |
+  | ---: | ---: | ---: | ---: |
+  | 2 | 0.35 ms | 0.34 ms | 1.02x |
+  | 5 | 0.78 ms | 0.77 ms | 1.01x |
+  | 10 | 1.50 ms | 1.48 ms | 1.02x |
+  | 20 | 2.93 ms | 2.89 ms | 1.02x |
+  | 50 | 7.33 ms | 7.16 ms | 1.02x |
+  | 100 | 14.81 ms | 14.21 ms | 1.04x |
+
+  A small, honest gain and not a mistake in the measurement: this path
+  does O(n) *byte* work per call -- a join, a tagged hash, a linear
+  scan -- where `session_values` did O(n) *curve* work, so removing it
+  buys a few percent rather than the multiples the table above
+  measures. It is worth doing anyway: what it removes is a quadratic,
+  and a quadratic built from byte operations is still the one a
+  large-enough `n` eventually notices, the constant being small today
+  and not forever.
+
 ### Tests
 
 - **A recorder per bindings signing call site asserts what `verify` it

--- a/btclib/ecc/musig2.py
+++ b/btclib/ecc/musig2.py
@@ -596,8 +596,9 @@ def session_values(session_ctx: SessionContext) -> SessionValues:
     `L`, `second` and `pub_keys_set` are computed here too, once, and
     not because deriving them needs anything above -- they are pure
     functions of `session_ctx.pub_keys` alone, the same as `key_agg`'s
-    own `L` and `second` at `:300-301`, computed again rather than
-    threaded out of `key_agg_and_tweak` above: doing that would widen
+    own `L` and `second`, which it likewise computes once and reuses
+    for every key. Computed again here rather than threaded out of
+    `key_agg_and_tweak` above: doing that would widen
     `KeyAggContext`, which `btclib/psbt/musig2.py` and callers outside
     this module already read, for a value only `_session_key_agg_coeff`
     wants. What earns them a place on `SessionValues` instead of a

--- a/btclib/ecc/musig2.py
+++ b/btclib/ecc/musig2.py
@@ -260,13 +260,6 @@ def _key_agg_coeff_(L: bytes, second: bytes, pub_key: bytes) -> int:
     )
 
 
-def _key_agg_coeff(pub_keys: tuple[bytes, ...], pub_key: bytes) -> int:
-    # the list hash and the second key are the same for every key in the
-    # list, so aggregation computes them once and calls the spelling
-    # above; this one is for the single coefficient a signer needs
-    return _key_agg_coeff_(_hash_pub_keys(pub_keys), _second_pub_key(pub_keys), pub_key)
-
-
 @dataclass(frozen=True)
 class KeyAggContext:
     """The aggregate public key, and what tweaking it has accumulated.
@@ -567,6 +560,11 @@ class SessionValues:
     - b is the coefficient combining the two halves of the nonce
     - R is the effective nonce point, R_1 + b*R_2
     - e is the BIP340 challenge, over R, Q and the message
+    - L, second and pub_keys_set are what a per-signer key-aggregation
+      coefficient is computed from -- issue #1069, the same shape #1045
+      solved for the fields above: fixed for the session, so computed
+      here once rather than by every one of `_session_key_agg_coeff`'s
+      2n callers
     """
 
     Q: Point
@@ -575,6 +573,9 @@ class SessionValues:
     b: int
     R: Point
     e: int
+    L: bytes
+    second: bytes
+    pub_keys_set: frozenset[bytes]
 
 
 def session_values(session_ctx: SessionContext) -> SessionValues:
@@ -591,6 +592,19 @@ def session_values(session_ctx: SessionContext) -> SessionValues:
     been used to sign; `object.__setattr__` reaches past `frozen=True`
     to set it, exactly as `SessionContext.__init__` already does for
     its declared fields.
+
+    `L`, `second` and `pub_keys_set` are computed here too, once, and
+    not because deriving them needs anything above -- they are pure
+    functions of `session_ctx.pub_keys` alone, the same as `key_agg`'s
+    own `L` and `second` at `:300-301`, computed again rather than
+    threaded out of `key_agg_and_tweak` above: doing that would widen
+    `KeyAggContext`, which `btclib/psbt/musig2.py` and callers outside
+    this module already read, for a value only `_session_key_agg_coeff`
+    wants. What earns them a place on `SessionValues` instead of a
+    second cached field on `SessionContext` is that every caller of
+    `_session_key_agg_coeff` -- `sign` and `partial_sig_verify_` --
+    already calls this function first, so a `SessionValues` field costs
+    nothing beyond what assembling the session already paid for.
     """
     if session_ctx._values is not None:
         return session_ctx._values
@@ -618,18 +632,37 @@ def session_values(session_ctx: SessionContext) -> SessionValues:
     # the one btclib's own BIP340 verifier recomputes, byte for byte and
     # for a message of any size
     e = ssa.challenge_(session_ctx.msg, Q[0], R[0], secp256k1, sha256)
-    values = SessionValues(Q, key_agg_ctx.gacc, key_agg_ctx.tacc, b, R, e)
-    # nothing cached here is secret -- Q, gacc, tacc, b, R, e are all
-    # public -- so caching them on the context changes no security
-    # property this module publishes
+    L = _hash_pub_keys(session_ctx.pub_keys)
+    second = _second_pub_key(session_ctx.pub_keys)
+    pub_keys_set = frozenset(session_ctx.pub_keys)
+    values = SessionValues(
+        Q, key_agg_ctx.gacc, key_agg_ctx.tacc, b, R, e, L, second, pub_keys_set
+    )
+    # nothing cached here is secret -- Q, gacc, tacc, b, R, e, L, second
+    # and pub_keys_set are all public -- so caching them on the context
+    # changes no security property this module publishes
     object.__setattr__(session_ctx, "_values", values)
     return values
 
 
 def _session_key_agg_coeff(session_ctx: SessionContext, pub_key: bytes) -> int:
-    if pub_key not in session_ctx.pub_keys:
+    # issue #1069: this used to be three O(n) traversals of pub_keys per
+    # call -- the membership test, `_hash_pub_keys`'s join-and-hash and
+    # `_second_pub_key`'s scan -- and ran 2n times per session, once per
+    # signer from `sign` and once per signer from `partial_sig_verify_`.
+    # `session_values` now derives `L`, `second` and `pub_keys_set` once
+    # per session instead, the same fixed-input shape issue #1045 solved
+    # for the curve arithmetic above; what is left here is an O(1)
+    # frozenset membership test and one hash of constant size.
+    #
+    # The membership test stays a check of its own rather than folding
+    # into the frozenset lookup below it: `_SIGNER_PK_ERR` is one of
+    # BIP327's verbatim messages, pinned byte for byte by the vectors,
+    # and a dict access raising `KeyError` would not produce it
+    values = session_values(session_ctx)
+    if pub_key not in values.pub_keys_set:
         raise BTClibValueError(_SIGNER_PK_ERR)
-    return _key_agg_coeff(session_ctx.pub_keys, pub_key)
+    return _key_agg_coeff_(values.L, values.second, pub_key)
 
 
 def sign(sec_nonce: bytearray, prv_key: PrvKey, session_ctx: SessionContext) -> bytes:

--- a/tests/ecc/musig2_test.py
+++ b/tests/ecc/musig2_test.py
@@ -656,6 +656,35 @@ def test_session_values_cache_is_invisible_to_equality() -> None:
     assert hash(session_ctx) == hash_before == hash(twin)
 
 
+def test_key_agg_coeff_cache_is_invisible_to_equality() -> None:
+    """A populated key-aggregation-coefficient cache must not perturb equality.
+
+    Issue #1069's `L`, `second` and `pub_keys_set` are folded into the
+    same `_values` `test_session_values_cache_is_invisible_to_equality`
+    above already pins, rather than a second cached field on
+    `SessionContext` -- so this is the same invariant, checked with two
+    signers so that `second` is a real key rather than the one-signer
+    placeholder, and populated through `partial_sig_verify_`,
+    `_session_key_agg_coeff`'s other caller.
+    """
+    pk_1 = musig2.individual_pub_key(_SK_1)
+    pk_2 = musig2.individual_pub_key(_SK_2)
+    pub_keys = musig2.key_sort([pk_1, pk_2])
+    sk_of = {pk_1: _SK_1, pk_2: _SK_2}
+    nonces = {pk: musig2.nonce_gen(sk_of[pk], pk, None, _MSG) for pk in pub_keys}
+    agg_nonce = musig2.nonce_agg([nonces[pk][1] for pk in pub_keys])
+    session_ctx = musig2.SessionContext(agg_nonce, pub_keys, [], [], _MSG)
+    twin = musig2.SessionContext(agg_nonce, pub_keys, [], [], _MSG)
+    hash_before = hash(session_ctx)
+
+    signer = pub_keys[0]
+    psig = musig2.sign(nonces[signer][0], sk_of[signer], session_ctx)
+    assert musig2.partial_sig_verify_(psig, nonces[signer][1], signer, twin)
+
+    assert session_ctx == twin
+    assert hash(session_ctx) == hash_before == hash(twin)
+
+
 def test_tweaks_and_is_xonly_pair_up() -> None:
     """Verify tweaks and is_xonly of unequal lengths are refused."""
     pk_1 = musig2.individual_pub_key(_SK_1)


### PR DESCRIPTION
## What

Closes #1069. `_session_key_agg_coeff` (`btclib/ecc/musig2.py`) ran
three O(n) traversals of `session_ctx.pub_keys` per call -- the
`pub_key not in session_ctx.pub_keys` membership test, `_hash_pub_keys`'s
join-and-hash and `_second_pub_key`'s scan -- and `sign` and
`partial_sig_verify_` each call it once per signer, so a full session
ran that work 2n times over inputs that never change. This is the
third quadratic path in `ecc/musig2.py`: issue #1045 fixed
`session_values`, issue #1046 fixed the psbt-layer aggregation, both
already on `main`, and this one is what the review bot on PR #1060
raised in all three of its rounds without it being a finding against
that PR.

## Design decision

The issue posed two shapes and asked for one, deliberately: `L` and
`second` -- what a coefficient is computed from -- either as two more
fields on `SessionValues`, or as a second cached field on
`SessionContext` beside `_values`. I went with the first, and added a
third field, `pub_keys_set`, for the O(1) membership test:

- **Not threaded out of `key_agg_and_tweak`.** It already computes
  the same `L` and `second` internally, inside `key_agg`, to aggregate
  Q. Routing them out would mean widening `KeyAggContext`'s public
  shape (it is read outside this module -- `btclib/psbt/musig2.py`'s
  `Session.key_agg_ctx`, and by tests) for a value only the
  per-signer coefficient wants. `session_values` recomputes `L` and
  `second` once per session instead -- redundant with `key_agg`'s own
  computation by a factor of two, but that is a constant on an O(n)
  once-per-session step, not a second quadratic.
- **Not a second cached field on `SessionContext`.** The issue framed
  the two shapes as differing in "whether a caller who wants only the
  coefficient has to assemble a whole session first." I checked: both
  of `_session_key_agg_coeff`'s callers, `sign` and
  `partial_sig_verify_`, already call `session_values` first, so
  today there is no caller who wants the coefficient without the rest
  of the session. A `SessionValues` field costs nothing beyond what
  assembling the session already pays for; a second `SessionContext`
  field would only earn its keep for a caller that does not exist.
- **The membership test stays separate.** `_SIGNER_PK_ERR` is one of
  BIP327's verbatim messages and the vectors pin it byte for byte, so
  it cannot be folded into a `pub_keys_set` lookup that would raise
  something else on a miss. `pub_keys_set` answers only "is this key
  in the session," in O(1); the `BTClibValueError(_SIGNER_PK_ERR)` is
  still raised by hand.

`_key_agg_coeff`, the tuple-of-`pub_keys` spelling `_session_key_agg_coeff`
used to call, is removed: nothing else called it, and it would have been
dead code once `_session_key_agg_coeff` reads `L`/`second` off
`SessionValues` instead.

## Measured

Reused the harness issue #1045's CHANGELOG entry was measured with
(same `session()` driver, same n = 2, 5, 10, 20, 50, 100, best of
five), swapping in an unpatched reimplementation of
`_session_key_agg_coeff` -- the three-traversal body -- as the
"before" arm, on the tree as it now stands (so #1045 and #1046's
fixes are in both arms; only this one function differs). My own
machine, not the issue's: Apple M5, macOS 26.6.2, arm64, CPython
3.14.6, `btclib_secp256k1` bindings serving.

| n | before | after | speedup |
| ---: | ---: | ---: | ---: |
| 2 | 0.35 ms | 0.34 ms | 1.02x |
| 5 | 0.78 ms | 0.77 ms | 1.01x |
| 10 | 1.50 ms | 1.48 ms | 1.02x |
| 20 | 2.93 ms | 2.89 ms | 1.02x |
| 50 | 7.33 ms | 7.16 ms | 1.02x |
| 100 | 14.81 ms | 14.21 ms | 1.04x |

As the issue predicted: a small, honest gain, not the multiples
#1045 measured, because this path does O(n) *byte* work per call
where `session_values` does O(n) *curve* work. The CHANGELOG entry
says this plainly rather than implying otherwise -- removing a
quadratic is worth doing at 1.02x, the constant being small today and
not forever.

## Verified

- `uv run pytest tests/ecc/musig2_test.py tests/psbt/musig2_test.py`
  -- all pass, eight vendored BIP327 vector files included: the
  coefficients the cache now returns are the same values the
  three-traversal path produced, or every vector's expected signature
  would fail to verify.
- Added `test_key_agg_coeff_cache_is_invisible_to_equality`, beside
  PR #1060's `test_session_values_cache_is_invisible_to_equality`
  rather than duplicating it: a two-signer session (so `second` is a
  real key, not the one-signer placeholder) whose cache is populated
  through `partial_sig_verify_` -- `_session_key_agg_coeff`'s other
  caller -- stays `==` and equally hashing to an untouched twin.
- `uv run pytest` -- full suite, 100% coverage gate, green.
- `uv run pre-commit run --all-files` -- green.
- `sphinx-build -W --keep-going -b html docs/source docs/build/html`
  (through `uv run --locked --no-default-groups --group docs`) --
  builds clean, no warnings.

## Test plan

- [x] `uv run pytest tests/ecc/musig2_test.py tests/psbt/musig2_test.py`
- [x] `uv run pytest` (full suite, 100% coverage)
- [x] `uv run pre-commit run --all-files`
- [x] sphinx `-W` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Cache MuSig2 session-invariant coefficient inputs to make per-signer coefficient calculation constant-time with respect to the participant count.

Bug Fixes:
- Eliminate repeated per-signer MuSig2 coefficient work by caching session-invariant aggregation values and public-key membership data.

Enhancements:
- Remove the obsolete tuple-based key aggregation coefficient helper and preserve SessionContext equality and hashing behavior when cached values are populated.

Tests:
- Add coverage verifying that populating the coefficient cache does not affect SessionContext equality or hashing.