### PR TITLE
Align borromean's challenge hash preimage with secp256k1-zkp's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4195,6 +4195,41 @@ documented at release-notes length in the first place, and are still in
   and checked by its own round-trip tests, both parities of the final
   nonce exercised in the same run rather than pinned for one and
   pragma'd for the other.
+- **`borromean`'s challenge hash now matches secp256k1-zkp's, at the
+  cost of every signature this module ever produced** (issue #1070).
+  `_hash`'s four-part preimage was `m || R || ring || position` since
+  `v2023.7.12`, the message hash before the point; secp256k1-zkp's
+  `rangeproof` module -- `secp256k1_borromean_hash`,
+  `src/modules/rangeproof/borromean_impl.h`, the only other
+  implementation of this construction anything reads, Elements and
+  Confidential Transactions among its callers -- builds `e || m ||
+  ring || pos`, the point first. Found while researching #1054's wire
+  format and checked against zkp's source rather than inferred: same
+  four components, same widths, same big-endian counters, the message
+  and the point swapped. `_hash` now writes them in zkp's order.
+  This is a hard break with no migration: `sign` and `assert_as_valid`
+  compute the same hash every time, there is no version byte in the
+  wire format to switch on, and a signature made before this change
+  does not verify after it. The recommendation #1070 recorded was to
+  keep the old order and only document the divergence -- cheaper, and
+  it breaks nothing already stored -- but the maintainer chose to pay
+  the break instead, because a verifiable-nowhere hash is not worth
+  having a wire format for at all (#1054), and interoperating with the
+  one other implementation anyone reads is. `_get_msg_format` was
+  checked in the same issue and left alone: zkp's rangeproof never
+  hashes a caller's message together with caller-supplied pubkey
+  rings, reconstructing its rings from a value commitment instead, so
+  there is no zkp preimage for this one to diverge from or agree with.
+  `tests/ecc/borromean_test.py` pins the new preimage order against a
+  construction computed by hand from zkp's documented source, there
+  being no vendored zkp in this tree to call.
+  **Aligning the challenge hash is not the same as producing a CT
+  rangeproof**: `rangeproof_impl.h` wraps the borromean signature in
+  mantissa/exponent, min-value, sign bits and x-only pubkey recovery
+  that `btclib.ecc.borromean` has no counterpart for, taking explicit
+  pubkey rings where zkp reconstructs them from a commitment. What
+  agrees now is the primitive underneath, not the whole of what
+  Elements calls a rangeproof.
 
 ### Security
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -413,6 +413,16 @@ full year, short month, short day (YYYY-M-D)
   where it read `non-minimal encoding of zero`, the general check now
   answering for it too.
 
+- **`borromean.sign` and `borromean.assert_as_valid` compute a
+  different challenge hash.** The four-part preimage has been `m || R
+  || ring || position` since `v2023.7.12`, the message hash before the
+  point or the closing `e0`; it is `R || m || ring || position` now,
+  matching secp256k1-zkp's `rangeproof` module. Every borromean
+  signature this module ever produced was made with the old order and
+  does not verify under the new one, and there is no version byte in
+  the wire format to switch on -- CHANGELOG.md has why the break was
+  worth paying.
+
 ### Worth knowing, though nothing raises
 
 - **Signing on the Python arm now checks the signature before answering

--- a/btclib/ecc/borromean.py
+++ b/btclib/ecc/borromean.py
@@ -11,6 +11,27 @@ References:
 Both are also cited inside `sign`, which is not where a reader looks
 first; they are here because the module is what one arrives at.
 
+`_hash`'s challenge preimage matches secp256k1-zkp's `rangeproof`
+module -- `secp256k1_borromean_hash`,
+`src/modules/rangeproof/borromean_impl.h` -- which is the only other
+implementation of this construction anything reads, Elements and
+Confidential Transactions among its callers: `e || m || ring || pos`,
+the point or `e0` bytes first, then the message hash, then the ring
+index and the position each as 4 bytes big-endian. It did not always:
+issue #1070 found the message and the point swapped, and every
+signature this module produced before that fix does not verify after
+it and never will -- there is no version byte in the wire format to
+switch on, `sign` and `assert_as_valid` compute this hash the same way
+every time, and RELEASE_NOTES.md's breaking-changes list has the
+"before" and "after" this cost.
+
+`_get_msg_format` was checked against zkp too, in the same issue, and
+has nothing to align with: zkp's rangeproof never hashes a caller's
+message together with caller-supplied pubkey rings the way this
+function does, because it reconstructs its rings from a value
+commitment and hashes that commitment, the generator point and the
+proof's own header bytes instead. There is no zkp construction here to
+diverge from or to match, so this one is untouched.
 """
 
 from __future__ import annotations
@@ -46,8 +67,15 @@ __all__ = [
 
 
 def _hash(m: bytes, R: bytes, i: int, j: int, hf: HashF) -> bytes:
+    # R (the nonce point, or e0 closing the rings) before m: zkp's
+    # secp256k1_borromean_hash writes e || m || ring || pos, and this
+    # used to write m || R -- the two swapped, a byte-for-byte different
+    # preimage over identical inputs (issue #1070). Aligning it is a
+    # hard break with no migration: every signature this module ever
+    # produced was made with the old order and stops verifying under
+    # this one
     temp = b"".join(
-        [m, R, i.to_bytes(4, "big", signed=False), j.to_bytes(4, "big", signed=False)]
+        [R, m, i.to_bytes(4, "big", signed=False), j.to_bytes(4, "big", signed=False)]
     )
     hasher = hf()
     hasher.update(temp)
@@ -60,6 +88,9 @@ PubkeyRing = Sequence[Point]
 def _get_msg_format(
     msg: bytes, pubk_rings: Sequence[PubkeyRing], ec: Curve, hf: HashF
 ) -> bytes:
+    # unlike _hash, nothing to align here: zkp never hashes a message
+    # together with caller-supplied pubkey rings, so there is no zkp
+    # preimage this one could diverge from (issue #1070)
     t = b"".join(
         b"".join(bytes_from_point(Q, ec) for Q in pubk_ring) for pubk_ring in pubk_rings
     )

--- a/tests/ecc/borromean_test.py
+++ b/tests/ecc/borromean_test.py
@@ -62,6 +62,37 @@ def test_borromean() -> None:
         borromean.assert_as_valid(b"another message", sig[0], sig[1], pubk_rings)
 
 
+def test_challenge_hash_matches_zkps_preimage_order() -> None:
+    """`_hash`'s preimage order, pinned against secp256k1-zkp's by hand.
+
+    secp256k1-zkp's rangeproof module builds this challenge as `e || m
+    || ring || pos` (`secp256k1_borromean_hash`,
+    `src/modules/rangeproof/borromean_impl.h`, read at its current tip
+    on 2026-08-20): the point -- or the `e0` closing the rings -- first,
+    then the message hash, then the ring index and the position each as
+    4 bytes big-endian (issue #1070). There is no vendored zkp in this
+    tree to call, so this pins that order computed by hand from zkp's
+    documented source rather than from any live cross-check against
+    zkp's own code -- and pins it against a `m || R || i || j` order,
+    which is what this function computed, and what this test would have
+    caught, before #1070.
+    """
+    m = hashlib.sha256(b"message hash, pretending to be one").digest()
+    r = hashlib.sha256(b"nonce point, or e0, pretending to be one").digest()
+    ring, position = 3, 7
+    expected = hashlib.sha256(
+        r + m + ring.to_bytes(4, "big") + position.to_bytes(4, "big")
+    ).digest()
+
+    assert borromean._hash(m, r, ring, position, sha256) == expected
+    # the order the preimage used to have, and would still equal if
+    # #1070 had not been fixed
+    swapped = hashlib.sha256(
+        m + r + ring.to_bytes(4, "big") + position.to_bytes(4, "big")
+    ).digest()
+    assert borromean._hash(m, r, ring, position, sha256) != swapped
+
+
 def test_the_curve_and_the_hash_function_are_parameters() -> None:
     """As module globals, selecting either would be process-wide.
 
@@ -174,26 +205,28 @@ def test_a_zero_e_is_a_one_in_n_event_on_a_low_cardinality_curve() -> None:
 
     # step 2, the e derived from e0
     with pytest.raises(BTClibRuntimeError, match=err_msg):
-        borromean.sign(b"\x00\x00\x00\x00", [1], [0], [1], [[Q1]], ec=ec)
+        borromean.sign(b"\x00\x00\x00\x00", [3], [0], [1], [[Q1]], ec=ec)
 
     # step 1, the e derived from the nonce's own point
     with pytest.raises(BTClibRuntimeError, match=err_msg):
-        borromean.sign(b"\x00\x00\x00\x01", [3], [0], [1], [[Q1, Q2]], ec=ec)
+        borromean.sign(b"\x00\x00\x00\x00", [1], [0], [1], [[Q1, Q2]], ec=ec)
 
     # and both guards in verification, where nothing is random: the first
-    # e of a ring, and one derived from a preceding r
+    # e of a ring, and one derived from a preceding r. Both e0 values are
+    # specific to #1070's preimage order -- e || m || ring || pos -- and
+    # were found by searching, not derived
     with pytest.raises(BTClibRuntimeError, match=err_msg):
         borromean.assert_as_valid(
-            b"\x00\x00\x00\x00", (8).to_bytes(32, "big"), [[1]], [[Q1]], ec=ec
+            b"\x00\x00\x00\x00", (0).to_bytes(32, "big"), [[1]], [[Q1]], ec=ec
         )
     with pytest.raises(BTClibRuntimeError, match=err_msg):
         borromean.assert_as_valid(
-            b"\x00\x00\x00\x00", (0).to_bytes(32, "big"), [[1, 1]], [[Q1, Q2]], ec=ec
+            b"\x00\x00\x00\x00", (47).to_bytes(32, "big"), [[1, 1]], [[Q1, Q2]], ec=ec
         )
     # verify answers False, as it does for any input that is not a valid
     # signature: BTClibRuntimeError is one of the two it catches
     assert not borromean.verify(
-        b"\x00\x00\x00\x00", (8).to_bytes(32, "big"), [[1]], [[Q1]], ec=ec
+        b"\x00\x00\x00\x00", (0).to_bytes(32, "big"), [[1]], [[Q1]], ec=ec
     )
 
 
@@ -209,13 +242,15 @@ def test_the_point_at_infinity_is_the_other_corner_case() -> None:
     ec = low_card_curves["ec13_11"]
     Q1 = mult(1, ec.G, ec)
 
+    # this e0, like the ones above, is specific to #1070's preimage
+    # order and was found by searching
     with pytest.raises(BTClibValueError, match="no bytes representation"):
         borromean.assert_as_valid(
-            b"\x00\x00\x00\x00", (21).to_bytes(32, "big"), [[1]], [[Q1]], ec=ec
+            b"\x00\x00\x00\x00", (14).to_bytes(32, "big"), [[1]], [[Q1]], ec=ec
         )
     # ValueError being the other exception verify catches
     assert not borromean.verify(
-        b"\x00\x00\x00\x00", (21).to_bytes(32, "big"), [[1]], [[Q1]], ec=ec
+        b"\x00\x00\x00\x00", (14).to_bytes(32, "big"), [[1]], [[Q1]], ec=ec
     )
 
 


### PR DESCRIPTION
## What was open

`btclib/ecc/borromean.py`'s challenge hash and secp256k1-zkp's
`rangeproof` module built byte-for-byte different preimages over
identical inputs, and nothing in the tree said so. Found while
researching #1054's wire format (checked against zkp's source rather
than inferred) and filed separately as #1070, since a signature-value
change riding inside an encoding-only PR is not something anyone can
bisect later.

- zkp, `src/modules/rangeproof/borromean_impl.h` (`secp256k1_borromean_hash`):
  `e || m || ring || pos` -- the point (or `e0` closing the rings) first,
  then the message hash.
- btclib, `ecc/borromean.py::_hash`, unchanged since `v2023.7.12`:
  `m || R || ring || pos` -- the message first.

Same four components, same widths, same big-endian counters on the two
counters; only the message and the point are swapped.

#1070 recorded two options and recommended the cheaper one (keep the
order, document the divergence). The maintainer chose the other one:
adopt zkp's order, because a wire format (#1054) for a signature that
verifies nowhere else is not worth having, and interoperating with the
one other implementation anyone reads is.

## The fix

One line: `_hash`'s preimage join reorders `[m, R, ...]` to `[R, m,
...]`. `_get_msg_format`, the module's other preimage, was checked
against zkp too and left alone -- zkp's rangeproof never hashes a
caller's message together with caller-supplied pubkey rings, since it
reconstructs its rings from a value commitment instead, so there is no
zkp construction for this one to diverge from or agree with. That
finding is recorded in the module docstring and the PR is why the next
reader does not have to re-check it.

## This is a hard break, on purpose

Every borromean signature this module has ever produced was made with
the old preimage order and does not verify under the new one. There is
no version byte in the wire format to switch on -- `sign` and
`assert_as_valid` compute this hash the same way every time.
`RELEASE_NOTES.md`'s breaking-changes list and `CHANGELOG.md` both
carry the detail, with the "before" spelling checked against the
`v2023.7.12` tag.

**What this does not claim**: aligning the challenge hash primitive is
not the same as producing a CT rangeproof. `rangeproof_impl.h` wraps
the signature in mantissa/exponent, min-value, sign bits and x-only
pubkey recovery that `btclib.ecc.borromean` has no counterpart for,
taking explicit pubkey rings where zkp reconstructs them from a
commitment. What agrees now is the primitive underneath, not the whole
of what Elements calls a rangeproof.

## Evidence

`tests/ecc/borromean_test.py::test_challenge_hash_matches_zkps_preimage_order`
pins the new preimage order against a construction computed *by hand*
from zkp's documented source (`R || m || ring(4B BE) || pos(4B BE)`,
hashed independently with `hashlib.sha256` rather than through `_hash`
itself) and asserts it disagrees with the old `m || R || ...` order.
There is no vendored zkp in this tree to call, so this is a pinned
hand-computation, not a live cross-check -- stated as such in the test
docstring.

The four low-cardinality-curve regression tests in the same file
(`test_a_zero_e_is_a_one_in_n_event_on_a_low_cardinality_curve`,
`test_the_point_at_infinity_is_the_other_corner_case`) hardcode
specific `e0`/nonce values chosen to trip particular guards on
`ec13_11`; those values were specific to the old preimage order and
are updated to new ones found by search, still tripping the same four
guards (and the point-at-infinity corner case) under the new order.

## Verification run

```
uv run pytest                     # 100% coverage, full suite green
uv run pre-commit run --all-files # all hooks pass
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
```

Closes #1070. Precedes #1054, which is rebased on this once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align Borromean challenge hashing with secp256k1-zkp and clearly communicate the resulting signature-format break.

Bug Fixes:
- Align the Borromean challenge-hash preimage with secp256k1-zkp by placing the nonce point before the message hash.
- Update regression coverage to validate the interoperable preimage order and preserve low-cardinality curve edge cases.

Enhancements:
- Document the challenge-hash alignment and its intentional breaking impact on previously generated signatures.

Documentation:
- Add release and changelog notes describing the hash-order change, migration impact, and its distinction from full CT rangeproof compatibility.

Tests:
- Add an independent test that pins the challenge hash against secp256k1-zkp's documented preimage order.