### PR TITLE
Implement MuSig2 adaptor signatures in python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4123,6 +4123,45 @@ documented at release-notes length in the first place, and are still in
   resolve -- keep it, revert it, or declare the first decision
   superseded -- rather than resolved by this change.
 
+- **`ecc.musig2` answers MuSig2 adaptor signatures** (issue #1051).
+  `SessionContext` takes an optional `adaptor`, a public point T;
+  `partial_sig_agg` on a session that carries one now answers a
+  `PreSignature` rather than an `ssa.Sig` -- the sum is the same
+  arithmetic, but the result does not verify, and returning an
+  `ssa.Sig` for it would claim otherwise. `adapt` turns a pre-signature
+  into a real one given the secret behind T, and `extract_adaptor`
+  recovers that secret from a pre-signature and the signature `adapt`
+  produced from it, which is the other half of what makes an adaptor
+  signature useful: releasing the signature releases the secret. This
+  is what a DLC's contract execution transaction, an atomic swap and a
+  payment channel's revocation all build on.
+
+  There is no BIP for this and no vector file -- BIP327 does not cover
+  adaptor signatures -- so the construction is read off
+  secp256k1-zkp's `src/modules/musig/session_impl.h` and
+  `adaptor_impl.h`, the de facto specification. Two details are where
+  an implementation goes wrong and zkp does not: T is folded into R_1
+  *before* the nonce coefficient b is hashed, not into the final R
+  afterward, so the challenge itself commits to T; and completing a
+  pre-signature negates the secret exactly when the final nonce has
+  odd y, because the pre-signature's nonce is then really -(r+t)*G
+  rather than (r+t)*G. `session_values` now reserializes the two nonce
+  halves before hashing b instead of reading `agg_nonce` verbatim,
+  which is what folding T in ahead of the hash requires; with no
+  adaptor the reserialization round-trips to the same bytes, so all
+  eight BIP327 vector files still answer byte for byte what they did
+  before this.
+
+  Cross-validating the construction against secp256k1-zkp is
+  btclib-org/btclib#156's open question and stays open: mainline
+  `bitcoin-core/secp256k1`, the vendored library, has no adaptor
+  support at all -- `musig_adapt`, `musig_extract_adaptor` and
+  `musig_nonce_parity` are absent, and `musig_nonce_process` takes five
+  arguments where zkp's takes six -- so this is delegated to nothing
+  and checked by its own round-trip tests, both parities of the final
+  nonce exercised in the same run rather than pinned for one and
+  pragma'd for the other.
+
 ### Security
 
 - **`SECURITY.md` says the bindings offer a buffer for a secret, and

--- a/btclib/ecc/musig2.py
+++ b/btclib/ecc/musig2.py
@@ -68,6 +68,34 @@ One rule outlives every abstraction here: **a secret nonce signs once**.
 Two signatures under one secnonce hand out the private key by
 elementary algebra, which is why `sign` zeroes the bytearray it is given
 rather than merely reading it.
+
+Adaptor signatures are the one capability BIP327 does not cover:
+`SessionContext.adaptor` carries a public point T, and `partial_sig_agg`
+then answers a *pre-signature* -- a `PreSignature`, not an `ssa.Sig`,
+because it does not verify -- that `adapt` turns into a real signature
+given the secret t behind T, or that `extract_adaptor` recovers t from,
+given both the pre-signature and the signature `adapt` produced. A DLC's
+contract execution transaction, an atomic swap across two chains and a
+payment channel's revocation all build on the same trade: whoever
+completes the signature is whoever knew t, and revealing the signature
+beside its pre-signature reveals t to anyone holding both.
+
+There is no BIP for this and no vector file, so the construction is read
+off secp256k1-zkp, the de facto specification:
+https://github.com/BlockstreamResearch/secp256k1-zkp/blob/master/src/modules/musig/session_impl.h
+and .../adaptor_impl.h beside it. Two details are where an
+implementation goes wrong and zkp does not: T is added to R_1 *before*
+b is hashed, not to the final R afterward, so the challenge itself
+commits to T and it cannot be swapped in once b is fixed; and `adapt`
+negates t exactly when the final nonce has odd y, because the
+pre-signature's nonce is then really -(r+t)*G rather than (r+t)*G --
+`adaptor_impl.h`'s own comment gives this reasoning in full.
+
+Cross-validating this construction against zkp is
+btclib-org/btclib#156's open question, not answered here: the vendored
+library, mainline `bitcoin-core/secp256k1`, has no adaptor support at
+all, so the round-trip tests below are this module's only check for
+now.
 """
 
 from __future__ import annotations
@@ -97,10 +125,13 @@ from btclib.utils import assert_type, bytes_from_octets
 
 __all__ = [
     "KeyAggContext",
+    "PreSignature",
     "SessionContext",
     "SessionValues",
+    "adapt",
     "apply_tweak",
     "deterministic_sign",
+    "extract_adaptor",
     "individual_pub_key",
     "key_agg",
     "key_agg_and_tweak",
@@ -518,6 +549,13 @@ class SessionContext:
     the tweaks with their kinds, and the message. Two signers with
     different session contexts produce partial signatures that do not
     add up, which `partial_sig_verify` is there to catch.
+
+    `adaptor` is `None` for an ordinary session and a 33-byte compressed
+    point T for an adaptor one -- session data every party signs under,
+    not an argument to `sign`, since a signer that did not agree to T
+    must not sign a pre-signature it becomes valid for. Optional and
+    last, so an existing positional call is still five arguments and
+    still means what it meant.
     """
 
     agg_nonce: bytes
@@ -525,6 +563,7 @@ class SessionContext:
     tweaks: tuple[bytes, ...]
     is_xonly: tuple[bool, ...]
     msg: bytes
+    adaptor: bytes | None
 
     # `session_values`'s memoized answer, PreparedPoint.fixed's idiom for
     # a derived value on an otherwise-frozen dataclass: `compare=False`
@@ -550,12 +589,18 @@ class SessionContext:
         tweaks: Sequence[Octets],
         is_xonly: Sequence[bool],
         msg: Octets,
+        adaptor: Octets | None = None,
     ) -> None:
         object.__setattr__(self, "agg_nonce", bytes_from_octets(agg_nonce, _NONCE_SIZE))
         object.__setattr__(self, "pub_keys", _pub_keys(pub_keys))
         object.__setattr__(self, "tweaks", _tweaks(tweaks))
         object.__setattr__(self, "is_xonly", _flags(is_xonly))
         object.__setattr__(self, "msg", bytes_from_octets(msg))
+        object.__setattr__(
+            self,
+            "adaptor",
+            None if adaptor is None else bytes_from_octets(adaptor, _PK_SIZE),
+        )
         _require_same_length(self.tweaks, self.is_xonly)
 
 
@@ -599,13 +644,27 @@ def session_values(session_ctx: SessionContext) -> SessionValues:
     )
     Q = key_agg_ctx.Q
     x_Q = key_agg_ctx.x_only_pub_key
-    t = tagged_hash(_NONCE_COEFF_TAG, session_ctx.agg_nonce + x_Q + session_ctx.msg)
-    b = int.from_bytes(t, "big") % secp256k1.n
     try:
         R_1 = _cpoint_ext(session_ctx.agg_nonce[:_PK_SIZE])
         R_2 = _cpoint_ext(session_ctx.agg_nonce[_PK_SIZE:])
     except BTClibValueError as err:
         raise InvalidContributionError(None, "aggnonce") from err
+    # the adaptor point, folded into R_1 before b is hashed and not into
+    # the final R afterward: b must commit to T, or an adaptor could be
+    # swapped in once the pre-signature is already fixed. With no
+    # adaptor R_1 is unchanged and _cbytes_ext round-trips it back to
+    # exactly the bytes session_ctx.agg_nonce already carried, which is
+    # what keeps every BIP327 vector byte-identical to before this
+    if session_ctx.adaptor is not None:
+        try:
+            T = _cpoint(session_ctx.adaptor)
+        except BTClibValueError as err:
+            raise InvalidContributionError(None, "adaptor") from err
+        R_1 = secp256k1.add_var(R_1, T)
+    t = tagged_hash(
+        _NONCE_COEFF_TAG, _cbytes_ext(R_1) + _cbytes_ext(R_2) + x_Q + session_ctx.msg
+    )
+    b = int.from_bytes(t, "big") % secp256k1.n
     R = secp256k1.add_var(R_1, mult(b, R_2, secp256k1))
     # an aggregate nonce of infinity is a session the signers can still
     # complete: G stands in for R, the resulting signature is invalid
@@ -799,13 +858,40 @@ def partial_sig_verify(
     return partial_sig_verify_(psig, pub_nonces[i], pub_keys[i], session_ctx)
 
 
-def partial_sig_agg(psigs: Sequence[Octets], session_ctx: SessionContext) -> ssa.Sig:
-    """Aggregate the partial signatures into one BIP340 signature.
+@dataclass(frozen=True)
+class PreSignature:
+    """A MuSig2 pre-signature: (x_R, s_pre), over a session with an adaptor.
 
-    An `ssa.Sig`, because that is what it is: the result verifies under
-    the x-only aggregate key with `btclib.ecc.ssa.verify_` and with
-    every other BIP340 verifier, and handing back 64 bytes would only
-    make the caller parse them again to find out.
+    `partial_sig_agg` answers one of these instead of an `ssa.Sig`
+    whenever `session_ctx.adaptor` is set. The two share `ssa.Sig`'s
+    shape -- r an x-coordinate, s a scalar reduced mod n -- and nothing
+    else: `ssa.Sig`'s whole point is a value that verifies, and a
+    pre-signature does not, until `adapt` supplies the secret behind the
+    adaptor. Keeping it a different class is what stops a caller from
+    handing this to `ssa.verify_` and reading a failure as "bad
+    signature" rather than "not adapted yet", and it carries no
+    `serialize`/`parse` of its own: BIP373 has no field for a
+    pre-signature (`btclib.ecc.musig2`'s own docstring says so), so
+    there is no wire format to answer to yet, and one invented here would
+    have no caller to check it against.
+    """
+
+    r: int
+    s: int
+
+
+def partial_sig_agg(
+    psigs: Sequence[Octets], session_ctx: SessionContext
+) -> ssa.Sig | PreSignature:
+    """Aggregate the partial signatures into one signature, or pre-signature.
+
+    An `ssa.Sig` for an ordinary session: the result verifies under the
+    x-only aggregate key with `btclib.ecc.ssa.verify_` and with every
+    other BIP340 verifier, and handing back 64 bytes would only make the
+    caller parse them again to find out. For a session carrying an
+    adaptor, a `PreSignature` instead -- the arithmetic is the same sum,
+    but the result does not verify, and returning an `ssa.Sig` for it
+    would claim otherwise.
     """
     values = session_values(session_ctx)
     s = 0
@@ -818,4 +904,54 @@ def partial_sig_agg(psigs: Sequence[Octets], session_ctx: SessionContext) -> ssa
     # signer adds: the group tweaked the key, no single signer did
     g = 1 if values.Q[1] % 2 == 0 else secp256k1.n - 1
     s = (s + values.e * g * values.tacc) % secp256k1.n
-    return ssa.Sig(values.R[0], s, secp256k1)
+    if session_ctx.adaptor is None:
+        return ssa.Sig(values.R[0], s, secp256k1)
+    return PreSignature(values.R[0], s)
+
+
+def adapt(pre_sig: PreSignature, t: PrvKey, session_ctx: SessionContext) -> ssa.Sig:
+    """Complete a pre-signature into a signature, given the secret adaptor.
+
+    `session_ctx` is the session `pre_sig` was built from -- the same
+    one `partial_sig_agg` took -- because the one bit this needs and
+    does not carry on its own is the parity `session_values` already
+    derived, `R[1] % 2` on the final nonce R = R_1 + T + b*R_2.
+
+    BIP340 signs the even-y nonce; when the parity is odd, the
+    pre-signature's x-only nonce is really that of -(r+t)*G rather than
+    (r+t)*G, so completing it needs -t rather than t.
+    `secp256k1_musig_adapt` (`adaptor_impl.h`) is the source of this and
+    negates the same way, and is also this function's authority: no
+    BIP or vector file covers adaptor signatures.
+
+    Nothing here re-verifies the result: a wrong `t` returns a `Sig`
+    that fails `ssa.assert_as_valid_`, which is the caller's to run
+    against the aggregate key it already has.
+    """
+    values = session_values(session_ctx)
+    t_ = int_from_prv_key(t, secp256k1)
+    if values.R[1] % 2:
+        t_ = secp256k1.n - t_
+    s = (pre_sig.s + t_) % secp256k1.n
+    return ssa.Sig(pre_sig.r, s, secp256k1)
+
+
+def extract_adaptor(
+    sig: ssa.Sig, pre_sig: PreSignature, session_ctx: SessionContext
+) -> bytes:
+    """Return the secret adaptor a signature reveals against its pre-signature.
+
+    The inverse of `adapt`, over the same `session_ctx`: whoever holds a
+    valid signature and the pre-signature it was adapted from recovers
+    exactly the `t` that `adapt` consumed. That is the second half of
+    what makes an adaptor signature useful -- releasing the signature is
+    releasing the secret -- and it is why `sig` is not checked against
+    the aggregate key here: extraction is arithmetic on two scalars, and
+    a `sig` that does not verify still yields the `t` that would make it
+    the one `adapt` would have produced from a matching `pre_sig`.
+    """
+    values = session_values(session_ctx)
+    t = (sig.s - pre_sig.s) % secp256k1.n
+    if values.R[1] % 2:
+        t = -t % secp256k1.n
+    return t.to_bytes(_SCALAR_SIZE, "big")

--- a/btclib/exceptions.py
+++ b/btclib/exceptions.py
@@ -324,11 +324,11 @@ class InvalidContributionError(BTClibRuntimeError):
     Which party, and which of its contributions: `signer` is the index
     in the list the caller passed, None for the aggregator -- who has no
     index, having no key -- and `contrib` names what was wrong, one of
-    "pubkey", "pubnonce", "aggnonce", "aggothernonce" or "psig". That is
-    the whole point of the class: a multi-round protocol that merely
-    fails leaves every participant a suspect, and the answer a caller
-    needs is who to hold accountable and to exclude from the next
-    attempt.
+    "pubkey", "pubnonce", "aggnonce", "aggothernonce", "psig" or
+    "adaptor". That is the whole point of the class: a multi-round
+    protocol that merely fails leaves every participant a suspect, and
+    the answer a caller needs is who to hold accountable and to exclude
+    from the next attempt.
 
     A BTClibRuntimeError and not a BTClibValueError, which is the other
     obvious base and the one BIP327 keeps separate: its reference

--- a/btclib/psbt/musig2.py
+++ b/btclib/psbt/musig2.py
@@ -65,7 +65,7 @@ from btclib.bip32 import BIP328_CHAIN_CODE, pub_key_derivation_tweaks
 from btclib.curves import secp256k1
 from btclib.curves.sec_point import bytes_from_point
 from btclib.ecc import musig2, ssa
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.hashes import hash160, tagged_hash
 from btclib.psbt.psbt import (
     Psbt,
@@ -518,6 +518,13 @@ def partial_sigs_agg(
     sig = musig2.partial_sig_agg(
         [partial_sigs[key] for key in session.context.pub_keys], session.context
     )
+    if not isinstance(sig, ssa.Sig):
+        # unreachable: session_context (above) never sets
+        # SessionContext.adaptor, BIP373 having no field for one yet
+        # (btclib-org/btclib#1051), so partial_sig_agg cannot answer a
+        # PreSignature here. The check is what tells mypy that, since
+        # nothing in the type system does
+        raise BTClibRuntimeError("unexpected musig2 pre-signature")  # pragma: no cover
     x_only_pub_key = session.key_agg_ctx.x_only_pub_key
     if not ssa.verify_(session.context.msg, x_only_pub_key, sig):
         # a partial signature that verifies on its own and does not add

--- a/tests/ecc/musig2_test.py
+++ b/tests/ecc/musig2_test.py
@@ -12,11 +12,12 @@ error case is checked against the exception the file names -- which
 party misbehaved and how, or the message of a plain value error.
 """
 
+import secrets
 from typing import Any
 
 import pytest
 
-from btclib.curves import bytes_from_point, mult
+from btclib.curves import bytes_from_point, mult, secp256k1
 from btclib.ecc import musig2, ssa
 from btclib.exceptions import (
     BTClibTypeError,
@@ -461,6 +462,9 @@ def test_sig_agg_valid_vectors(case: dict[str, Any]) -> None:
 
     session_ctx = musig2.SessionContext(agg_nonce, pub_keys, tweaks, is_xonly, _SA_MSG)
     sig = musig2.partial_sig_agg(psigs, session_ctx)
+    # no adaptor on this session_ctx, so partial_sig_agg answers an
+    # ssa.Sig rather than a PreSignature
+    assert isinstance(sig, ssa.Sig)
     assert sig.serialize() == bytes.fromhex(case["expected"])
     # the aggregate is an ordinary BIP340 signature, and btclib's own
     # verifier is what says so
@@ -554,8 +558,101 @@ def test_session(tweaks: list[bytes], is_xonly: list[bool]) -> None:
     )
 
     sig = musig2.partial_sig_agg(psigs, session_ctx)
+    # no adaptor on this session_ctx, so partial_sig_agg answers an
+    # ssa.Sig rather than a PreSignature
+    assert isinstance(sig, ssa.Sig)
     assert ssa.verify_(_MSG, agg_pk, sig)
     ssa.assert_as_valid_(_MSG, agg_pk, sig)
+
+
+def test_adapt_and_extract_adaptor_round_trip() -> None:
+    """A pre-signature does not verify; adapt and extract_adaptor invert.
+
+    No vector file covers adaptor signatures, so this is the round trip
+    the module docstring calls the floor: `partial_sig_agg` on a session
+    carrying an adaptor answers a `PreSignature` that fails
+    `ssa.verify_`; `adapt` with the secret behind it answers an `ssa.Sig`
+    that passes `ssa.assert_as_valid_`; and `extract_adaptor` on that
+    pair answers exactly the secret `adapt` consumed.
+
+    Both parities of the final nonce R are exercised in the same run,
+    fresh keys and adaptor each time, rather than pinned offline for one
+    parity and pragma'd for the other as `ssa_test.test_musig1` pins
+    randomness against the coverage gate: `adapt` and `extract_adaptor`
+    each negate on the odd parity, which is exactly where a sign error
+    would hide, and this is the test the issue asks be strong enough to
+    catch one.
+    """
+    pk_1 = musig2.individual_pub_key(_SK_1)
+    pk_2 = musig2.individual_pub_key(_SK_2)
+    pub_keys = musig2.key_sort([pk_1, pk_2])
+    agg_pk = musig2.key_agg(pub_keys).x_only_pub_key
+    sk_of = {pk_1: _SK_1, pk_2: _SK_2}
+
+    parities_seen: set[int] = set()
+    for _ in range(64):
+        t = 1 + secrets.randbelow(secp256k1.n - 1)
+        adaptor = bytes_from_point(mult(t, ec=secp256k1), secp256k1)
+
+        sec_nonce_of = {}
+        pub_nonce_of = {}
+        for pk, sk in ((pk_1, _SK_1), (pk_2, _SK_2)):
+            sec_nonce_of[pk], pub_nonce_of[pk] = musig2.nonce_gen(sk, pk, agg_pk, _MSG)
+        agg_nonce = musig2.nonce_agg([pub_nonce_of[pk] for pk in pub_keys])
+        session_ctx = musig2.SessionContext(agg_nonce, pub_keys, [], [], _MSG, adaptor)
+        parities_seen.add(musig2.session_values(session_ctx).R[1] % 2)
+
+        psigs = [
+            musig2.sign(sec_nonce_of[pk], sk_of[pk], session_ctx) for pk in pub_keys
+        ]
+        pre_sig = musig2.partial_sig_agg(psigs, session_ctx)
+        assert isinstance(pre_sig, musig2.PreSignature)
+        assert not ssa.verify_(_MSG, agg_pk, ssa.Sig(pre_sig.r, pre_sig.s, secp256k1))
+
+        sig = musig2.adapt(pre_sig, t, session_ctx)
+        ssa.assert_as_valid_(_MSG, agg_pk, sig)
+
+        extracted = musig2.extract_adaptor(sig, pre_sig, session_ctx)
+        assert extracted == t.to_bytes(32, "big")
+
+    assert parities_seen == {0, 1}
+
+
+def test_a_pre_signature_needs_the_matching_adaptor() -> None:
+    """Verify adapt with the wrong secret answers a signature that fails."""
+    pk_1 = musig2.individual_pub_key(_SK_1)
+    sec_nonce, pub_nonce = musig2.nonce_gen(_SK_1, pk_1, None, _MSG)
+    agg_nonce = musig2.nonce_agg([pub_nonce])
+    t = 1 + secrets.randbelow(secp256k1.n - 1)
+    adaptor = bytes_from_point(mult(t, ec=secp256k1), secp256k1)
+    session_ctx = musig2.SessionContext(agg_nonce, [pk_1], [], [], _MSG, adaptor)
+    psig = musig2.sign(sec_nonce, _SK_1, session_ctx)
+    pre_sig = musig2.partial_sig_agg([psig], session_ctx)
+    assert isinstance(pre_sig, musig2.PreSignature)
+
+    agg_pk = musig2.key_agg([pk_1]).x_only_pub_key
+    wrong_t = 1 + secrets.randbelow(secp256k1.n - 1)
+    sig = musig2.adapt(pre_sig, wrong_t, session_ctx)
+    assert not ssa.verify_(_MSG, agg_pk, sig)
+
+
+def test_adaptor_must_be_a_valid_point() -> None:
+    """Verify a malformed adaptor is InvalidContributionError, not a crash.
+
+    The all-zero placeholder is what `_cpoint_ext` reads as infinity for
+    an aggregate nonce; the adaptor point is parsed with the plain
+    `_cpoint` instead, which refuses it -- a public adaptor, unlike a
+    nonce half, is never the infinity point.
+    """
+    pk_1 = musig2.individual_pub_key(_SK_1)
+    sec_nonce, pub_nonce = musig2.nonce_gen(_SK_1, pk_1, None, _MSG)
+    del sec_nonce
+    agg_nonce = musig2.nonce_agg([pub_nonce])
+    session_ctx = musig2.SessionContext(agg_nonce, [pk_1], [], [], _MSG, bytes(33))
+    with pytest.raises(InvalidContributionError) as exc_info:
+        musig2.session_values(session_ctx)
+    assert exc_info.value.signer is None
+    assert exc_info.value.contrib == "adaptor"
 
 
 def test_sec_nonce_signs_once() -> None:


### PR DESCRIPTION
## Summary

Implements MuSig2 adaptor signatures (issue #1051): a pre-signature
that does not verify, and that a secret adaptor `t` turns into one
that does -- or that a completed signature, held beside its
pre-signature, reveals `t` from. This is what DLCs, atomic swaps and
payment channels build on, and it is the last MuSig2-shaped item in
btclib-org/btclib-secp256k1#156.

- `SessionContext` gains an optional trailing `adaptor: Octets | None`
  (a 33-byte compressed point T) -- session data every party signs
  under, not an argument to `sign`. Optional and last, so every
  existing positional call is unaffected.
- `session_values` folds T into R_1 **before** the nonce coefficient
  `b` is hashed, not into the final R afterward, so the challenge
  itself commits to T and it cannot be swapped in once `b` is fixed.
  With no adaptor, R_1 is unchanged and the reserialization
  round-trips to exactly the bytes `agg_nonce` already carried, so all
  eight BIP327 vector files still answer byte for byte what they did
  before this.
- `partial_sig_agg` answers a new `PreSignature` (r, s) instead of an
  `ssa.Sig` whenever the session carries an adaptor: the arithmetic is
  the same sum, but the result does not verify, and returning an
  `ssa.Sig` for it would claim otherwise. `PreSignature` carries no
  `serialize`/`parse` -- BIP373 has no wire field for a pre-signature
  yet, so there is nothing to answer to.
- `adapt(pre_sig, t, session_ctx) -> ssa.Sig` and
  `extract_adaptor(sig, pre_sig, session_ctx) -> bytes` are the two new
  functions. Both take the session context rather than a bare parity
  bool, so the parity (`session_values(session_ctx).R[1] % 2`) is
  derived once and cannot be passed inconsistently. `adapt` negates
  the secret exactly on odd parity, because the pre-signature's x-only
  nonce is then really that of `-(r+t)*G` rather than `(r+t)*G`.

## The construction and its authority

There is no BIP and no vector file for this -- BIP327 does not cover
adaptor signatures -- so the construction is read off secp256k1-zkp,
the de facto specification:
https://github.com/BlockstreamResearch/secp256k1-zkp/blob/10366dbbbfeb11457f2aae3b23e154ab7d6a1fe4/src/modules/musig/session_impl.h
and
https://github.com/BlockstreamResearch/secp256k1-zkp/blob/10366dbbbfeb11457f2aae3b23e154ab7d6a1fe4/src/modules/musig/adaptor_impl.h
(commit `10366dbbbfeb11457f2aae3b23e154ab7d6a1fe4`, the tip of `master`
at the time this was read; the module docstring cites the `blob/master`
URL instead, matching this repository's existing convention for zkp
references in `ecc.pedersen`).

`secp256k1_musig_nonce_process` folds the adaptor into
`aggnonce_pts[0]` before calling `secp256k1_musig_nonce_process_internal`,
which is where `b` is hashed -- matching this PR's `session_values`
exactly. `secp256k1_musig_adapt` and `secp256k1_musig_extract_adaptor`
in `adaptor_impl.h` negate the secret adaptor on odd
`nonce_parity`, for the reason the file's own comment gives (the
pre-signature's nonce is really `-(r+t)*G` on odd parity) -- matching
this PR's `adapt`/`extract_adaptor` exactly, verified against zkp's
source line by line rather than against the issue's prose summary
alone.

## The oracle is deferred, on purpose

**Cross-validating this python implementation against secp256k1-zkp is
not done here.** Mainline `bitcoin-core/secp256k1`, the vendored
library, has no adaptor support at all:

```python
import btclib_secp256k1 as b
[n for n in dir(b.lib) if "adapt" in n or "parity" in n]   # []
```

`musig_adapt`, `musig_extract_adaptor` and `musig_nonce_parity` are
absent, and `musig_nonce_process` takes five arguments where zkp's
takes six (the `adaptor` parameter). Supplying an oracle needs the zkp
decision btclib-org/btclib-secp256k1#283 is waiting on, which is
blocked. Nothing here vendors zkp or adds a submodule; the round-trip
tests (below) are this module's only check for now, and the module
docstring says so and names btclib-org/btclib#156 as the open question.

## Tests

No vector file exists, so the properties pinned are the strong ones
the issue asks for:

- a pre-signature never verifies as a signature (`ssa.verify_` is
  `False` on it);
- `adapt` with the right `t` answers a signature that
  `ssa.assert_as_valid_` accepts;
- `extract_adaptor` on that pair answers exactly the `t` that went in;
- `adapt` with the *wrong* `t` answers a signature that fails to
  verify;
- a malformed adaptor point is `InvalidContributionError(None,
  "adaptor")`, not a crash;
- **both parities of the final nonce are exercised in the same test
  run** (fresh keys and adaptor per iteration, looped until both are
  seen) -- `adapt`/`extract_adaptor` each negate on the odd one, which
  is exactly where a sign error hides, and this is deliberately not
  pinned-for-one-parity-and-pragma'd-for-the-other the way
  `ssa_test.test_musig1`'s coin flip is.

All eight existing BIP327 vector files and the full suite pass
unchanged. `btclib/psbt/musig2.py`'s one call site into
`partial_sig_agg` gets a narrowing check (`# pragma: no cover`,
genuinely unreachable: its own `session_context()` never sets an
adaptor, BIP373 having no field for one yet) purely to satisfy mypy
--strict over the new union return type.

## Documentation

- `btclib/ecc/musig2.py`'s module docstring gains a paragraph on
  adaptor signatures: what they are for, the construction's authority,
  and the two parity-sensitive details.
- `CHANGELOG.md` gets an entry under "Curves, signatures and keys" --
  this is a new public capability, squarely "anything a user would
  notice".
- **No `RELEASE_NOTES.md` entry.** This is purely additive: the new
  `SessionContext.adaptor` field is optional and last, so every
  existing positional call is unaffected, and `partial_sig_agg`'s
  return type only becomes a union for a session that sets the new
  field -- nothing an existing caller does today changes or needs to
  change. `RELEASE_NOTES.md` is "what a user has to act on"
  (source-breaking changes); this is new API a user may choose to use,
  not one that makes anyone act.
- No `btclib/ecc/musig1.py` and no submodule, per the issue's own
  decision.

## Test plan

- [x] `uv run pytest tests/ecc/musig2_test.py` and `tests/psbt/`
- [x] `uv run pytest` (28545 passed, 9 skipped, 100.00% coverage)
- [x] `uv run pre-commit run --all-files` (all hooks passed)
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html` (build
      succeeded, no warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extend MuSig2 with parity-safe adaptor signature workflows for DLCs, atomic swaps, and payment channels.

New Features:
- Add MuSig2 adaptor signature support, including session adaptors, pre-signatures, signature adaptation, and adaptor secret extraction.

Bug Fixes:
- Reject malformed adaptor points with a structured contribution error.

Enhancements:
- Preserve existing BIP327 behavior for ordinary sessions while committing adaptor points before nonce coefficient calculation.
- Keep PSBT MuSig2 aggregation compatible with the new pre-signature return type.

Documentation:
- Document MuSig2 adaptor signatures and record the new public capability in the changelog.

Tests:
- Add round-trip, wrong-secret, malformed-point, and nonce-parity coverage for adaptor signatures while retaining existing vector assertions.