### PR TITLE
Compose a transaction builder: tx_builder.build_psbt (issue #1068)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1444,6 +1444,7 @@ documented at release-notes length in the first place, and are still in
   `btclib.fee`, taking no rate and answering a weight; `fee_from_vsize`
   is what turns one into money. Coin selection and fee estimation are
   still not here, and what a caller does with the number is theirs.
+
 - **A transaction builder: `btclib.tx_builder.build_psbt`** (issue
   #1068). Every part of composing a spend was already here and nothing
   composed them, so every caller composed them again -- this repository
@@ -1481,6 +1482,14 @@ documented at release-notes length in the first place, and are still in
   `bad-txns-inputs-duplicate` and a double count in the fee arithmetic
   both; `Tx.assert_valid` implements the rest of `CheckTransaction` and
   not that rule, which is issue #1073.
+
+  `tx.input_weight` of issue #1067 is not what the fee is computed
+  from, and the two do not compose: that answers for one input, where a
+  fee is bought by a whole transaction, and `Psbt.weight_estimate`
+  already sums the per-input estimates into the one arithmetic
+  `Tx.weight` is. The per-input number is what the layer above wants --
+  coin selection pricing a candidate before there is a psbt to put it
+  in -- and the module docstring points there.
 
   The test module's oracles are `fee`'s own functions for the
   arithmetic -- on both sides of the dust threshold, to the satoshi --

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1444,6 +1444,51 @@ documented at release-notes length in the first place, and are still in
   `btclib.fee`, taking no rate and answering a weight; `fee_from_vsize`
   is what turns one into money. Coin selection and fee estimation are
   still not here, and what a caller does with the number is theirs.
+- **A transaction builder: `btclib.tx_builder.build_psbt`** (issue
+  #1068). Every part of composing a spend was already here and nothing
+  composed them, so every caller composed them again -- this repository
+  included, in `tests/integration/conftest.py`'s `spending_psbt`, which
+  takes one utxo, a hardcoded `fee: int = 1_000`, and splits the amount
+  in half. `build_psbt` takes the psbt input maps to spend, the outputs
+  to pay, a `FeeRate` and a change script, and answers a `FundedPsbt`:
+  the psbt, the `fee` it pays, and `change_index`, which is Bitcoin
+  Core's `fundrawtransaction` triple under btclib's names.
+
+  A psbt and not a transaction, because the fee cannot be priced off
+  something unsigned: `Tx.vsize` is read from a serialization the
+  signatures are not in yet, where `Psbt.vsize_estimate` sizes them from
+  each input's utxo and scripts. The unsigned transaction is
+  `built.psbt.tx`, so a second entry point answering with a `Tx` would
+  have been a second spelling rather than a second answer. An input is a
+  `PsbtIn` for the same reason it is not a pair of an outpoint and a
+  `TxOut`: what a wrapped or multisig input will push is in its redeem
+  or witness script, which the map carries and a pair does not, and
+  nothing here fetches anything -- an outpoint alone says neither what
+  it is worth nor what it spends, and a builder that fetches is a
+  builder with a node in it.
+
+  Change below `dust_threshold` for its own script is not created and
+  its value goes to the fee, which is the branch hand-written builders
+  get wrong; the transaction is then smaller than the one that was
+  priced, so what it owes is computed again rather than the larger
+  figure reused. The dust threshold is taken at Core's `-dustrelayfee`
+  default rather than at the transaction's own rate, `dust_fee_rate`
+  being where a caller says otherwise. Coin selection stays out, which
+  is what lets a caller bring its own, and so does everything
+  downstream of a network: the anti-fee-sniping `lock_time` a wallet
+  would set needs a chain tip, so it is an argument here and defaults
+  to none. An outpoint spent twice is refused, Core's
+  `bad-txns-inputs-duplicate` and a double count in the fee arithmetic
+  both; `Tx.assert_valid` implements the rest of `CheckTransaction` and
+  not that rule, which is issue #1073.
+
+  The test module's oracles are `fee`'s own functions for the
+  arithmetic -- on both sides of the dust threshold, to the satoshi --
+  and, for the whole flow, a psbt signed by `SoftwareSigner`, finalized,
+  extracted and run under btclib's script engine, once per BIP44
+  encoding: the size that was really signed is compared with the size
+  the fee was bought at, the estimate being an upper bound and the
+  transaction therefore never below the rate it was built for.
 
 - **`psbt.musig2.partial_sigs_agg` aggregates the participant list once,
   not four times** (issue #1046). Every public function of the module

--- a/btclib/__init__.py
+++ b/btclib/__init__.py
@@ -108,6 +108,7 @@ __all__ = [
     "to_prv_key",
     "to_pub_key",
     "tx",
+    "tx_builder",
     "tx_or_psbt",
     "utils",
     "var_bytes",

--- a/btclib/tx_builder.py
+++ b/btclib/tx_builder.py
@@ -146,6 +146,12 @@ def _assert_spends_once(inputs: Sequence[PsbtIn]) -> None:
     amount the transaction does not have. `Tx.assert_valid` implements
     the rest of `CheckTransaction` and not this rule (issue #1073), so
     the psbt this returns would not be refused by its own validation.
+
+    Asked after the psbt has been validated, and that is the order rather
+    than an accident: `PsbtIn.prev_out` reads a missing output index as
+    0, so an input carrying none would be a duplicate of whatever else
+    spends index 0 of the same transaction -- where `Psbt.assert_valid`
+    refuses it under its own name, as a missing PSBT_IN_OUTPUT_INDEX.
     """
     outpoints = [psbt_in.prev_out for psbt_in in inputs]
     if len(set(outpoints)) != len(outpoints):
@@ -200,7 +206,6 @@ def build_psbt(
     _assert_arguments(inputs, outputs, fee_rate, dust_fee_rate)
     if not inputs:
         raise BTClibValueError("no inputs")
-    _assert_spends_once(inputs)
     change_script = (
         None
         if change_script_pub_key is None
@@ -233,6 +238,8 @@ def build_psbt(
         check_validity=False,
     )
     total_in = sum(prev_out.value for prev_out in prevouts(psbt))
+    # after `prevouts`, which is what validates; its own docstring says why
+    _assert_spends_once(inputs)
     total_out = sum(tx_out.value for tx_out in outputs)
     remainder = total_in - total_out
 

--- a/btclib/tx_builder.py
+++ b/btclib/tx_builder.py
@@ -51,7 +51,11 @@ elsewhere too:
 
 - **coin selection**. Which utxos to spend is policy with a literature
   behind it, and keeping it out is what lets a caller bring its own;
-  this spends the ones it is given, all of them.
+  this spends the ones it is given, all of them. `tx.input_weight` is
+  the number that caller prices a candidate with -- one input, before
+  there is a psbt to put it in -- where what a fee is bought by here is
+  the whole transaction, which `Psbt.vsize_estimate` is the one arithmetic
+  for.
 - **a node, an rpc, or wallet state**. The same arguments give the same
   answer forever, which is `fee`'s own boundary: what is downstream of a
   network -- a fee estimate for a confirmation target, which utxos are

--- a/btclib/tx_builder.py
+++ b/btclib/tx_builder.py
@@ -1,0 +1,260 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Compose the psbt spending a set of outputs, at a fee rate, with change.
+
+Every part of this is elsewhere and nothing composes them, so every
+caller composes them again: `Psbt` holds what is being built,
+`psbt.prevouts` says what its inputs are worth, `Psbt.vsize_estimate`
+says how large the signed transaction will be, `fee.fee_from_vsize`
+prices that size and `fee.dust_threshold` says whether the change is
+worth creating. `build_psbt` is that composition, and the three
+decisions it makes are the ones a hand-written builder gets wrong.
+
+**The fee comes from the rate and the size, and the size comes from the
+psbt.** A transaction that is not signed has no size to be priced by --
+`Tx.vsize` is read off a serialization, and the signatures are not
+written yet -- so the object built here is a psbt: `Psbt.vsize_estimate`
+sizes the missing signatures from each input's utxo and scripts, which
+is the one thing in the tree that answers before there is anything to
+sign. The unsigned transaction is `built.psbt.tx`, a property away, so a
+second entry point answering with a `Tx` would be a second spelling of
+one answer rather than a second answer.
+
+**Change is an output or it is fee.** Below `dust_threshold` for its own
+script an output cannot be relayed, so it is not created and its value
+is left to the fee; and the transaction is then smaller than the one
+that was priced, so the fee it owes is computed again rather than
+reused. `change_index` is which output it is, or None for the branch
+that dropped it.
+
+**An input is a `PsbtIn`**: the outpoint it spends, the output that
+outpoint names -- `witness_utxo` or `non_witness_utxo`, whichever its
+kind of input takes -- and whatever else says how it will be unlocked, a
+redeem script or a witness script included. Two things follow from
+taking the psbt's own map rather than a pair of an outpoint and a
+`TxOut`. Nothing here fetches anything, an outpoint alone saying neither
+what it is worth nor what it spends, and a builder that fetches is a
+builder with a node in it; and an input whose script is wrapped or
+multisig is estimated exactly, its redeem or witness script being a
+field of the map that arrives rather than an argument this function
+would have to grow. The outputs are `TxOut` and not `PsbtOut` because
+the asymmetry is real: the input map is *read*, every byte a signature
+will take being computed from it, where nothing computed here reads an
+output map -- what a wallet writes into one, `descriptors`'
+`update_psbt_output` on the change output at `change_index` included, is
+written after this returns and changes no size.
+
+Explicitly not here, both of them boundaries this library draws
+elsewhere too:
+
+- **coin selection**. Which utxos to spend is policy with a literature
+  behind it, and keeping it out is what lets a caller bring its own;
+  this spends the ones it is given, all of them.
+- **a node, an rpc, or wallet state**. The same arguments give the same
+  answer forever, which is `fee`'s own boundary: what is downstream of a
+  network -- a fee estimate for a confirmation target, which utxos are
+  confirmed, the block height that would make an anti-fee-sniping lock
+  time -- is fed in rather than fetched.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from btclib.alias import Octets
+from btclib.exceptions import BTClibValueError
+from btclib.fee import DUST_RELAY_FEE_RATE, FeeRate, dust_threshold, fee_from_vsize
+from btclib.psbt.psbt import Psbt, prevouts
+from btclib.psbt.psbt_in import PsbtIn
+from btclib.psbt.psbt_out import PsbtOut
+from btclib.psbt.psbt_size import SolutionSizer
+from btclib.psbt.psbt_utils import PSBT_V0
+from btclib.tx import TxOut
+from btclib.utils import assert_type, bytes_from_octets
+
+__all__ = [
+    "FundedPsbt",
+    "build_psbt",
+]
+
+
+@dataclass(frozen=True)
+class FundedPsbt:
+    """A psbt whose fee is paid, and what paying it decided.
+
+    The three answers Bitcoin Core's `fundrawtransaction` gives, which
+    is the same triple under its own names: the transaction, `fee`, and
+    `changepos` -- spelled here as an index into the psbt's outputs, and
+    None where Core writes -1 for the transaction that has no change
+    output.
+
+    `fee` is what the inputs are worth less what the outputs hold. It is
+    at least what `fee_rate` asked of the estimated size and can exceed
+    it, by exactly the change that was too small to create.
+    """
+
+    psbt: Psbt
+    fee: int
+    change_index: int | None
+
+    @property
+    def change(self) -> int:
+        """Return the satoshi the change output holds, 0 where there is none."""
+        if self.change_index is None:
+            return 0
+        return self.psbt.outputs[self.change_index].amount or 0
+
+
+def _assert_arguments(
+    inputs: Sequence[PsbtIn],
+    outputs: Sequence[TxOut],
+    fee_rate: FeeRate,
+    dust_fee_rate: FeeRate,
+) -> None:
+    """Refuse an argument of the wrong type before a field is read off it.
+
+    The two sequences are checked as sequences and then element by
+    element, which is the shape `tests/built_object_contract_test.py`
+    calls a sequence walked before it is checked: `None` is not iterable
+    from underneath this library, and a `str` is a sequence of one-character
+    strings that would each be read for fields it has not got.
+    """
+    assert_type(inputs, Sequence, "inputs")
+    for psbt_in in inputs:
+        assert_type(psbt_in, PsbtIn, "psbt input")
+    assert_type(outputs, Sequence, "outputs")
+    for tx_out in outputs:
+        assert_type(tx_out, TxOut, "output")
+    assert_type(fee_rate, FeeRate, "fee rate")
+    assert_type(dust_fee_rate, FeeRate, "dust fee rate")
+
+
+def _assert_spends_once(inputs: Sequence[PsbtIn]) -> None:
+    """Refuse a set of inputs naming one outpoint twice.
+
+    Core's `CheckTransaction` refuses it as `bad-txns-inputs-duplicate`,
+    and what it costs here is not only that the transaction would be
+    rejected: the fee is computed from what the inputs are worth, and an
+    outpoint listed twice is counted twice, so the change would be an
+    amount the transaction does not have. `Tx.assert_valid` implements
+    the rest of `CheckTransaction` and not this rule (issue #1073), so
+    the psbt this returns would not be refused by its own validation.
+    """
+    outpoints = [psbt_in.prev_out for psbt_in in inputs]
+    if len(set(outpoints)) != len(outpoints):
+        raise BTClibValueError("the same outpoint is spent twice")
+
+
+def build_psbt(
+    inputs: Sequence[PsbtIn],
+    outputs: Sequence[TxOut],
+    fee_rate: FeeRate,
+    change_script_pub_key: Octets | None = None,
+    *,
+    tx_version: int = 2,
+    lock_time: int = 0,
+    dust_fee_rate: FeeRate = DUST_RELAY_FEE_RATE,
+    sizer: SolutionSizer | None = None,
+) -> FundedPsbt:
+    """Return the psbt spending these inputs at this rate, and its change.
+
+    `inputs` are the psbt's own input maps, each carrying the outpoint it
+    spends and the output that outpoint names; `outputs` are what is
+    being paid. What is left over pays the fee, and `change_script_pub_key`
+    is where the rest of it goes -- to an output of that script when it
+    would be worth more than `dust_threshold` asks, and to the fee when
+    it would not. No change script at all is every leftover satoshi to
+    the fee, which is what a caller sweeping an address means and what a
+    caller who forgot the argument gets, so it is spelled rather than
+    defaulted.
+
+    Raised, all as `BTClibValueError`: no inputs, no outputs left to pay,
+    an outpoint spent twice, an input carrying no utxo, an input whose
+    type the psbt does not determine -- `psbt_size`'s rule, and `sizer`
+    is where a caller answers for one -- and inputs that do not cover the
+    outputs and the fee.
+
+    `tx_version` and `lock_time` are the transaction's, defaulting to
+    Core's own 2 and to no lock time: the block height that would make a
+    lock time worth setting is a node's answer, and this function has no
+    node. Each input's sequence is its own `PsbtIn.sequence`, and an
+    input naming none spends with the final sequence -- no lock time and
+    no BIP125 replacement, which a caller wanting either sets on the
+    input rather than having overwritten here.
+
+    `dust_fee_rate` is the rate the dust threshold is computed at, Core's
+    `-dustrelayfee` default; it is not `fee_rate`, an output being dust
+    by what the network will relay rather than by what this transaction
+    chose to pay.
+
+    The psbt is version 0, which every Signer reads; `Psbt.to_v2` is the
+    other one.
+    """
+    _assert_arguments(inputs, outputs, fee_rate, dust_fee_rate)
+    if not inputs:
+        raise BTClibValueError("no inputs")
+    _assert_spends_once(inputs)
+    change_script = (
+        None
+        if change_script_pub_key is None
+        else bytes_from_octets(change_script_pub_key)
+    )
+
+    psbt_outputs = [
+        PsbtOut(amount=tx_out.value, script_pub_key=tx_out.script_pub_key.script)
+        for tx_out in outputs
+    ]
+    change_index: int | None = None
+    if change_script is not None:
+        change_index = len(psbt_outputs)
+        # the amount is what the fee leaves and the fee is what this
+        # psbt's size costs, so the output has to be in it before there
+        # is an amount to put in the output. A value is eight bytes
+        # whatever it holds, so the estimate does not move when the
+        # placeholder below is replaced by the answer computed from it
+        psbt_outputs.append(PsbtOut(amount=0, script_pub_key=change_script))
+
+    # not validated here: `prevouts` below validates, and it is the first
+    # thing that reads the psbt
+    psbt = Psbt(
+        tx_version,
+        inputs,
+        psbt_outputs,
+        PSBT_V0,
+        {},
+        fallback_lock_time=lock_time,
+        check_validity=False,
+    )
+    total_in = sum(prev_out.value for prev_out in prevouts(psbt))
+    total_out = sum(tx_out.value for tx_out in outputs)
+    remainder = total_in - total_out
+
+    if change_script is not None:
+        fee = fee_from_vsize(psbt.vsize_estimate(sizer), fee_rate)
+        change = remainder - fee
+        if change >= dust_threshold(change_script, dust_fee_rate):
+            # the last output, this having appended it
+            psbt.outputs[-1].amount = change
+            # the one state nothing else has judged: every other exit
+            # returns what `vsize_estimate` last validated
+            psbt.assert_valid()
+            return FundedPsbt(psbt, fee, change_index)
+        # dust cannot be created, so what would have been change is fee
+        psbt.outputs.pop()
+        change_index = None
+
+    if not psbt.outputs:
+        err_msg = "no outputs: nothing is paid, and there is no change to create"
+        raise BTClibValueError(err_msg)
+    # the whole leftover, which is at least what the rate asks: the
+    # transaction is smaller than the one priced above, so what it owes
+    # is computed again rather than the larger figure reused
+    owed = fee_from_vsize(psbt.vsize_estimate(sizer), fee_rate)
+    if remainder < owed:
+        err_msg = f"the inputs are worth {total_in} satoshi, "
+        err_msg += f"where the outputs and the fee need {total_out + owed}"
+        raise BTClibValueError(err_msg)
+    return FundedPsbt(psbt, remainder, change_index)

--- a/docs/source/btclib.rst
+++ b/docs/source/btclib.rst
@@ -190,6 +190,13 @@ btclib.to\_pub\_key module
    :members:
    :show-inheritance:
 
+btclib.tx\_builder module
+-------------------------
+
+.. automodule:: btclib.tx_builder
+   :members:
+   :show-inheritance:
+
 btclib.tx\_or\_psbt module
 --------------------------
 

--- a/tests/built_object_contract_test.py
+++ b/tests/built_object_contract_test.py
@@ -64,9 +64,12 @@ from btclib import slip132
 from btclib.bip32.bip32 import rootxprv_from_seed, xpub_from_xprv
 from btclib.descriptors.descriptors import miniscript_sizer, satisfaction_sizer
 from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.fee import FeeRate
 from btclib.psbt.psbt import Psbt, assert_signatures_only
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.psbt.psbt_size import estimated_input_sizes
+from btclib.tx import TxOut
+from btclib.tx_builder import build_psbt
 from btclib.wallet.script_wallet import KeyGroup
 from tests.psbt import psbt_cases
 
@@ -94,6 +97,9 @@ _CHANGED.unknown = {b"\x00": b"\x01"}
 
 _PSBT_IN = _SIGNED.inputs[0]
 _TX_IN = _SIGNED.tx.vin[0]
+# a payment small enough for that input to cover it at any rate, to the
+# script the vector's own first output pays
+_TX_OUT = TxOut(1_000, _SIGNED.tx.vout[0].script_pub_key)
 # the input's own keys, which is the caller a satisfaction sizer is for:
 # it sizes the branch these will take, so the quorum has to be theirs
 _SIGNER_KEYS = list(_PSBT_IN.hd_key_paths)
@@ -176,6 +182,17 @@ _CASES = (
         # an input carrying no utxo is a PsbtIn whose type cannot be read,
         # which is what this function raises about rather than guesses at
         {0: PsbtIn()},
+    ),
+    _Case(
+        "tx_builder.build_psbt",
+        build_psbt,
+        ([_PSBT_IN], [_TX_OUT], FeeRate(sats_per_kvbyte=1000)),
+        # an input carrying no utxo is worth nothing this can read, and a
+        # transaction with no output at all is one Core's CheckTransaction
+        # refuses: both are sequences of the declared type holding a value
+        # no valid call carries. The rate has no wrong value -- every
+        # FeeRate its own constructor admits is a price
+        {0: [PsbtIn()], 1: []},
     ),
     # the two SolutionSizers, which take the same pair and owe a caller the
     # same check. Neither has a wrong *value*: "not mine" is what a sizer

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -289,6 +289,12 @@ KEYWORD_ONLY: dict[str, list[str]] = {
     "btclib.tx:TxOut.parse": ["check_validity"],
     "btclib.tx:TxOut.serialize": ["check_validity"],
     "btclib.tx:TxOut.to_dict": ["check_validity"],
+    "btclib.tx_builder:build_psbt": [
+        "tx_version",
+        "lock_time",
+        "dust_fee_rate",
+        "sizer",
+    ],
     "btclib.tx_or_psbt:tx_or_psbt_from_any": ["check_validity"],
 }
 

--- a/tests/tx_builder_test.py
+++ b/tests/tx_builder_test.py
@@ -1,0 +1,449 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the `btclib.tx_builder` module.
+
+Two oracles, because a builder can be wrong in two ways that no
+assertion about its own numbers would catch.
+
+The first is arithmetic, and it is checked against `fee`'s own
+functions rather than against figures copied out of a run: what the
+transaction pays is what `fee_from_vsize` asks of the size the psbt
+estimates, and what the change is worth is measured against
+`dust_threshold` for the script it is paid to -- on both sides of it,
+the boundary being where a builder that rounds the wrong way stops
+relaying.
+
+The second is the network's, as far as this suite can reach it: the
+psbt is signed by `SoftwareSigner`, finalized, extracted, and the
+transaction that comes out is run under btclib's own script engine. The
+size a fee was bought at is then compared with the size that was really
+signed -- the estimate is an upper bound, so a transaction is never
+below the rate it was built for, and that is the one claim a builder
+exists to make.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from btclib.descriptors import Descriptor
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.fee import FeeRate, dust_threshold, fee_from_vsize
+from btclib.psbt.psbt import extract_tx, finalize
+from btclib.psbt.psbt_in import PsbtIn
+from btclib.psbt.psbt_size import SIG_SIZE
+from btclib.psbt_signer import SoftwareSigner, export_account, request_signatures
+from btclib.script import ScriptPubKey
+from btclib.script.engine import verify_transaction
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
+from btclib.tx_builder import build_psbt
+
+# BIP39's "abandon abandon ... about" root, which BIP84 publishes and
+# `tests/software_signer_test.py` signs with
+XPRV_ROOT = (
+    "xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRR"
+    "uL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu"
+)
+
+# two public keys of no private key anybody holds, which is all the
+# arithmetic below needs: nothing signs for these, the scripts being
+# there to be measured and to be dust-checked
+PAY_KEY = "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
+CHANGE_KEY = "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9"
+
+PAY_SCRIPT = ScriptPubKey.p2wpkh(PAY_KEY)
+CHANGE_SCRIPT = ScriptPubKey.p2wpkh(CHANGE_KEY)
+
+# a satoshi a virtual byte, so that a fee read against a size needs no
+# conversion in the head of whoever reads a failure here
+ONE_SAT_PER_VBYTE = FeeRate.from_sats_per_vbyte(1)
+TEN_SAT_PER_VBYTE = FeeRate.from_sats_per_vbyte(10)
+
+
+def spendable(
+    value: int, script: ScriptPubKey = PAY_SCRIPT, tx_id: bytes = b"\x06" * 32
+) -> PsbtIn:
+    """Return the input map spending one segwit output of that value."""
+    return PsbtIn(
+        witness_utxo=TxOut(value, script), previous_tx_id=tx_id, output_index=0
+    )
+
+
+def test_the_fee_is_what_the_rate_asks_of_the_estimated_size() -> None:
+    """The whole arithmetic, checked against `fee` rather than a figure.
+
+    Every satoshi of the inputs is an output or the fee, the fee is what
+    the rate asks of the size this psbt will be once signed, and the
+    change is the last output, which is where this appends it.
+    """
+    built = build_psbt(
+        [spendable(100_000)],
+        [TxOut(60_000, PAY_SCRIPT)],
+        TEN_SAT_PER_VBYTE,
+        CHANGE_SCRIPT.script,
+    )
+
+    assert built.fee == fee_from_vsize(built.psbt.vsize_estimate(), TEN_SAT_PER_VBYTE)
+    assert built.change_index == 1
+    assert built.change == 100_000 - 60_000 - built.fee
+    assert sum(tx_out.value for tx_out in built.psbt.tx.vout) + built.fee == 100_000
+    assert built.psbt.tx.vout[1].script_pub_key == CHANGE_SCRIPT
+    # what a Signer reads, and the version every Signer reads it in
+    assert built.psbt.version == 0
+    assert built.psbt.tx.version == 2
+    assert built.psbt.tx.lock_time == 0
+
+
+def test_the_transaction_fields_are_the_caller_s() -> None:
+    """`tx_version` and `lock_time` reach the transaction being built."""
+    built = build_psbt(
+        [spendable(100_000)],
+        [TxOut(60_000, PAY_SCRIPT)],
+        TEN_SAT_PER_VBYTE,
+        tx_version=3,
+        lock_time=800_000,
+    )
+    assert built.psbt.tx.version == 3
+    assert built.psbt.tx.lock_time == 800_000
+
+
+def test_an_input_spends_with_the_sequence_it_carries() -> None:
+    """The sequence is the input's own, and none of it is this builder's.
+
+    An input naming no sequence spends with the final one, which is what
+    `psbt.tx` puts there; a caller opting into BIP125 replacement says so
+    on the input rather than through an argument here.
+    """
+    psbt_in = spendable(100_000)
+    psbt_in.sequence = 0xFFFFFFFD
+    built = build_psbt([psbt_in], [TxOut(60_000, PAY_SCRIPT)], TEN_SAT_PER_VBYTE)
+    assert built.psbt.tx.vin[0].sequence == 0xFFFFFFFD
+
+    built = build_psbt(
+        [spendable(100_000)], [TxOut(60_000, PAY_SCRIPT)], TEN_SAT_PER_VBYTE
+    )
+    assert built.psbt.tx.vin[0].sequence == 0xFFFFFFFF
+
+
+def dust_boundary(fee_rate: FeeRate = TEN_SAT_PER_VBYTE) -> tuple[int, int, int]:
+    """Return the input value, the payment leaving exactly dust, and the fee.
+
+    Measured rather than tabulated: the amount that leaves the change at
+    its dust threshold to the satoshi is the value less the fee of the
+    transaction that has a change output less that threshold, and the
+    first two of those are what this asks the builder and `fee` for.
+    """
+    value = 100_000
+    # the fee of the shape that has a change output, which no payment
+    # amount moves: an output's value is eight bytes whatever it holds
+    probe = build_psbt(
+        [spendable(value)], [TxOut(1_000, PAY_SCRIPT)], fee_rate, CHANGE_SCRIPT.script
+    )
+    threshold = dust_threshold(CHANGE_SCRIPT.script)
+    return value, value - probe.fee - threshold, probe.fee
+
+
+def test_change_worth_exactly_the_dust_threshold_is_created() -> None:
+    """Exactly the threshold is not dust, which `dust_threshold` says."""
+    value, payment, fee = dust_boundary()
+    built = build_psbt(
+        [spendable(value)],
+        [TxOut(payment, PAY_SCRIPT)],
+        TEN_SAT_PER_VBYTE,
+        CHANGE_SCRIPT.script,
+    )
+    assert built.change_index == 1
+    assert built.change == dust_threshold(CHANGE_SCRIPT.script)
+    assert built.fee == fee
+
+
+def test_change_one_satoshi_below_the_threshold_becomes_fee() -> None:
+    """The branch a hand-written builder gets wrong.
+
+    The output is not created, so the whole leftover is the fee -- more
+    than the rate asked for, by what the change would have been -- and
+    the transaction that pays it is the smaller one, which is what makes
+    the leftover cover a fee it was not weighed against.
+    """
+    value, payment, fee_with_change = dust_boundary()
+    built = build_psbt(
+        [spendable(value)],
+        [TxOut(payment + 1, PAY_SCRIPT)],
+        TEN_SAT_PER_VBYTE,
+        CHANGE_SCRIPT.script,
+    )
+
+    assert built.change_index is None
+    assert built.change == 0
+    assert len(built.psbt.outputs) == 1
+    assert built.fee == value - (payment + 1)
+    # what the rate asks of the transaction that is really being made,
+    # which is smaller than the one priced at fee_with_change
+    owed = fee_from_vsize(built.psbt.vsize_estimate(), TEN_SAT_PER_VBYTE)
+    assert owed < fee_with_change
+    assert built.fee > owed
+
+
+def test_no_change_script_is_every_leftover_satoshi_to_the_fee() -> None:
+    """A sweep: nothing comes back, and the psbt says so with no output."""
+    built = build_psbt(
+        [spendable(100_000)], [TxOut(60_000, PAY_SCRIPT)], TEN_SAT_PER_VBYTE
+    )
+    assert built.change_index is None
+    assert built.change == 0
+    assert built.fee == 40_000
+    assert len(built.psbt.outputs) == 1
+
+
+def test_a_change_output_can_be_the_only_output() -> None:
+    """No payment at all is a self-send, and the change is what it pays."""
+    built = build_psbt(
+        [spendable(100_000)], [], TEN_SAT_PER_VBYTE, CHANGE_SCRIPT.script
+    )
+    assert built.change_index == 0
+    assert built.change == 100_000 - built.fee
+    assert built.fee == fee_from_vsize(built.psbt.vsize_estimate(), TEN_SAT_PER_VBYTE)
+
+
+def test_a_zero_rate_owes_nothing_and_the_change_is_the_whole_leftover() -> None:
+    """`fee_from_vsize` answers zero at every size for a zero rate."""
+    built = build_psbt(
+        [spendable(100_000)],
+        [TxOut(60_000, PAY_SCRIPT)],
+        FeeRate(sats_per_kvbyte=0),
+        CHANGE_SCRIPT.script,
+    )
+    assert built.fee == 0
+    assert built.change == 40_000
+
+
+def test_the_dust_rate_is_the_network_s_and_not_this_transaction_s() -> None:
+    """`dust_fee_rate` moves the threshold; `fee_rate` does not.
+
+    Core computes a dust threshold at `-dustrelayfee` rather than at
+    whatever the transaction chose to pay, so a node run with a higher
+    one refuses an output this would otherwise create.
+    """
+    value, payment, _ = dust_boundary()
+    ten_times = FeeRate(sats_per_kvbyte=10 * 3000)
+    built = build_psbt(
+        [spendable(value)],
+        [TxOut(payment, PAY_SCRIPT)],
+        TEN_SAT_PER_VBYTE,
+        CHANGE_SCRIPT.script,
+        dust_fee_rate=ten_times,
+    )
+    assert built.change_index is None
+    assert dust_threshold(CHANGE_SCRIPT.script, ten_times) > dust_threshold(
+        CHANGE_SCRIPT.script
+    )
+
+
+def test_inputs_that_do_not_cover_the_outputs_and_the_fee() -> None:
+    """Refused, with both totals in the message, and on either branch."""
+    with pytest.raises(BTClibValueError, match="the inputs are worth"):
+        build_psbt([spendable(60_000)], [TxOut(60_000, PAY_SCRIPT)], TEN_SAT_PER_VBYTE)
+    # the same shortfall reached through the change branch: the change is
+    # negative, which is below every threshold, so the output is dropped
+    # and what is left still does not pay for the smaller transaction
+    with pytest.raises(BTClibValueError, match="the inputs are worth"):
+        build_psbt(
+            [spendable(60_000)],
+            [TxOut(60_000, PAY_SCRIPT)],
+            TEN_SAT_PER_VBYTE,
+            CHANGE_SCRIPT.script,
+        )
+
+
+def test_a_transaction_needs_an_input_and_an_output() -> None:
+    """Core's CheckTransaction refuses an empty vin or vout; so does this."""
+    with pytest.raises(BTClibValueError, match="no inputs"):
+        build_psbt([], [TxOut(60_000, PAY_SCRIPT)], TEN_SAT_PER_VBYTE)
+
+    with pytest.raises(BTClibValueError, match="no outputs"):
+        build_psbt([spendable(100_000)], [], TEN_SAT_PER_VBYTE)
+
+    # nothing is paid and what would come back is dust, so dropping the
+    # change output would leave a transaction with no output at all
+    with pytest.raises(BTClibValueError, match="no outputs"):
+        build_psbt([spendable(400)], [], ONE_SAT_PER_VBYTE, CHANGE_SCRIPT.script)
+
+
+def test_one_outpoint_is_spent_once() -> None:
+    """A double count in the fee arithmetic, and `bad-txns-inputs-duplicate`."""
+    with pytest.raises(BTClibValueError, match="spent twice"):
+        build_psbt(
+            [spendable(100_000), spendable(100_000)],
+            [TxOut(60_000, PAY_SCRIPT)],
+            TEN_SAT_PER_VBYTE,
+        )
+    # the same output index of two different transactions is two utxos
+    built = build_psbt(
+        [spendable(100_000), spendable(100_000, tx_id=b"\x07" * 32)],
+        [TxOut(60_000, PAY_SCRIPT)],
+        TEN_SAT_PER_VBYTE,
+        CHANGE_SCRIPT.script,
+    )
+    assert built.change == 200_000 - 60_000 - built.fee
+
+
+def test_an_input_carrying_no_utxo_has_no_amount() -> None:
+    """`prevouts`' refusal, which is what reads the amounts here."""
+    psbt_in = PsbtIn(previous_tx_id=b"\x06" * 32, output_index=0)
+    with pytest.raises(BTClibValueError, match="no utxo for input 0"):
+        build_psbt([psbt_in], [TxOut(60_000, PAY_SCRIPT)], TEN_SAT_PER_VBYTE)
+
+
+def test_an_input_of_no_readable_type_is_answered_by_a_sizer() -> None:
+    """`psbt_size`'s rule, reached through the builder.
+
+    A witness script of no standard type has no estimate, so the fee has
+    none either; the caller who knows what will satisfy it says so, and
+    the fee follows what they said.
+    """
+    witness_script = b"\x51"  # OP_TRUE, which no classifier names
+    psbt_in = spendable(100_000, ScriptPubKey.p2wsh(witness_script))
+    psbt_in.witness_script = witness_script
+
+    with pytest.raises(BTClibValueError, match="no estimate"):
+        build_psbt([psbt_in], [TxOut(60_000, PAY_SCRIPT)], TEN_SAT_PER_VBYTE)
+
+    small = build_psbt(
+        [psbt_in],
+        [TxOut(60_000, PAY_SCRIPT)],
+        TEN_SAT_PER_VBYTE,
+        CHANGE_SCRIPT.script,
+        sizer=lambda _psbt_in, _tx_in: [],
+    )
+    large = build_psbt(
+        [psbt_in],
+        [TxOut(60_000, PAY_SCRIPT)],
+        TEN_SAT_PER_VBYTE,
+        CHANGE_SCRIPT.script,
+        sizer=lambda _psbt_in, _tx_in: [SIG_SIZE] * 3,
+    )
+    assert small.fee < large.fee
+    assert large.change == 100_000 - 60_000 - large.fee
+
+
+def test_a_legacy_input_is_priced_from_the_transaction_that_created_it() -> None:
+    """The other utxo field: a non-segwit output is not a witness utxo."""
+    prev_out = TxOut(100_000, ScriptPubKey.p2pkh(PAY_KEY))
+    prev_tx = Tx(vin=[TxIn(OutPoint(b"\x06" * 32, 0))], vout=[prev_out])
+    psbt_in = PsbtIn(
+        non_witness_utxo=prev_tx, previous_tx_id=prev_tx.id, output_index=0
+    )
+
+    built = build_psbt(
+        [psbt_in], [TxOut(60_000, PAY_SCRIPT)], TEN_SAT_PER_VBYTE, CHANGE_SCRIPT.script
+    )
+    assert built.fee == fee_from_vsize(built.psbt.vsize_estimate(), TEN_SAT_PER_VBYTE)
+    # no witness discount on either half of it, so it is dearer than the
+    # segwit spend of the same value
+    segwit = build_psbt(
+        [spendable(100_000)],
+        [TxOut(60_000, PAY_SCRIPT)],
+        TEN_SAT_PER_VBYTE,
+        CHANGE_SCRIPT.script,
+    )
+    assert built.fee > segwit.fee
+
+
+@pytest.mark.parametrize("wrong", [None, 1.5, "not a sequence"])
+def test_a_sequence_of_the_wrong_type(wrong: object) -> None:
+    """Refused before a field is read off anything it holds."""
+    with pytest.raises(BTClibTypeError):
+        build_psbt(wrong, [TxOut(60_000, PAY_SCRIPT)], TEN_SAT_PER_VBYTE)  # type: ignore[arg-type]
+    with pytest.raises(BTClibTypeError):
+        build_psbt([spendable(100_000)], wrong, TEN_SAT_PER_VBYTE)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("wrong", [None, 1.5])
+def test_an_argument_of_the_wrong_type(wrong: object) -> None:
+    """Each position refuses what its annotation does not declare."""
+    inputs = [spendable(100_000)]
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    with pytest.raises(BTClibTypeError):
+        build_psbt([wrong], outputs, TEN_SAT_PER_VBYTE)  # type: ignore[list-item]
+    with pytest.raises(BTClibTypeError):
+        build_psbt(inputs, [wrong], TEN_SAT_PER_VBYTE)  # type: ignore[list-item]
+    with pytest.raises(BTClibTypeError):
+        build_psbt(inputs, outputs, wrong)  # type: ignore[arg-type]
+    with pytest.raises(BTClibTypeError):
+        build_psbt(inputs, outputs, TEN_SAT_PER_VBYTE, dust_fee_rate=wrong)  # type: ignore[arg-type]
+
+
+def test_a_change_script_that_is_not_octets() -> None:
+    """`bytes_from_octets` is the refusal, as everywhere else taking them."""
+    with pytest.raises(BTClibValueError):
+        build_psbt(
+            [spendable(100_000)],
+            [TxOut(60_000, PAY_SCRIPT)],
+            TEN_SAT_PER_VBYTE,
+            "not hex at all",
+        )
+
+
+def account_input(
+    receive: Descriptor, purpose: int, index: int = 0
+) -> tuple[PsbtIn, TxOut]:
+    """Return the input map spending an address of this account, and its output.
+
+    The whole previous transaction, which is the answer for an input of
+    any type, BIP322's `to_sign_psbt` giving the same reason for the same
+    choice. The redeem script is the one field the psbt cannot work out
+    for itself: a p2sh-wrapped input is spent by what the wrapper hashes
+    to, so what a signature will cost is not in the script_pub_key, and
+    the caller who knows the account knows the script.
+    """
+    prev_out = TxOut(100_000, receive.script_pub_key(index))
+    prev_tx = Tx(vin=[TxIn(OutPoint(b"\x06" * 32, 0))], vout=[prev_out])
+    redeem_script = b""
+    if purpose == 49:
+        redeem_script = ScriptPubKey.p2wpkh(
+            receive.key_expressions[0].sec(index)
+        ).script
+    return (
+        PsbtIn(
+            non_witness_utxo=prev_tx,
+            previous_tx_id=prev_tx.id,
+            output_index=0,
+            redeem_script=redeem_script,
+        ),
+        prev_out,
+    )
+
+
+@pytest.mark.parametrize("purpose", [44, 49, 84, 86])
+def test_what_was_built_is_signed_spends_and_pays_the_rate(purpose: int) -> None:
+    """The whole flow, once per BIP44 encoding, with two oracles at the end.
+
+    The script engine says the transaction spends what it claims, and
+    the size it really took says the fee was not an underestimate: the
+    estimate is an upper bound, so the transaction that comes out pays at
+    least the rate it was built for. A signature sized wrong, or a change
+    output that took the fee with it, fails one of the two.
+    """
+    signer = SoftwareSigner(XPRV_ROOT)
+    receive, change = export_account(signer, f"m/{purpose}h/0h/0h")
+    psbt_in, prev_out = account_input(receive, purpose)
+
+    built = build_psbt(
+        [psbt_in],
+        [TxOut(60_000, receive.script_pub_key(1))],
+        TEN_SAT_PER_VBYTE,
+        change.script_pub_key(0).script,
+    )
+    estimate = built.psbt.vsize_estimate()
+    assert built.change_index is not None
+
+    psbt = receive.update_psbt_input(built.psbt, 0, 0)
+    psbt = change.update_psbt_output(psbt, built.change_index, 0)
+    tx = extract_tx(finalize(request_signatures(signer, psbt)))
+
+    verify_transaction([prev_out], tx)
+    assert tx.vsize <= estimate
+    assert fee_from_vsize(tx.vsize, TEN_SAT_PER_VBYTE) <= built.fee
+    assert 100_000 - sum(tx_out.value for tx_out in tx.vout) == built.fee

--- a/tests/tx_builder_test.py
+++ b/tests/tx_builder_test.py
@@ -279,6 +279,19 @@ def test_one_outpoint_is_spent_once() -> None:
             [TxOut(60_000, PAY_SCRIPT)],
             TEN_SAT_PER_VBYTE,
         )
+    # an input naming no output index is refused under its own name, the
+    # psbt being validated before the duplicates are looked for: read the
+    # other way round it would be a duplicate of whatever spends index 0
+    # of the same transaction
+    nameless = spendable(100_000)
+    nameless.output_index = None
+    with pytest.raises(BTClibValueError, match="missing PSBT_IN_OUTPUT_INDEX"):
+        build_psbt(
+            [nameless, spendable(100_000)],
+            [TxOut(60_000, PAY_SCRIPT)],
+            TEN_SAT_PER_VBYTE,
+        )
+
     # the same output index of two different transactions is two utxos
     built = build_psbt(
         [spendable(100_000), spendable(100_000, tx_id=b"\x07" * 32)],


### PR DESCRIPTION
Closes #1068.

`btclib.tx_builder.build_psbt` takes the psbt input maps to spend, the
outputs to pay, a `FeeRate` and a change script, and answers a
`FundedPsbt`: the psbt, the `fee` it pays, and `change_index` — Bitcoin
Core's `fundrawtransaction` triple (`hex`, `fee`, `changepos`) under
btclib's names, with `None` where Core writes `-1`.

## The design questions the issue left open

**`Tx` or `Psbt`: the psbt, and there is no second entry point.** A fee
cannot be priced off something unsigned — `Tx.vsize` is read from a
serialization the signatures are not in yet — and `Psbt.vsize_estimate`
is the one thing in the tree that answers before there is anything to
sign, sizing the missing signatures from each input's utxo and scripts.
So the object that can price itself is the object that is built. The
unsigned transaction is `built.psbt.tx`, a property away, so a
`build_tx` beside it would be a second spelling of one answer rather
than a second answer.

**An input is a `PsbtIn`, not a pair of an outpoint and a `TxOut`.** The
issue asks for "outpoints with their `TxOut`" and for it to be taken
"the way `psbt`'s own update path does" — which is `witness_utxo` and
`non_witness_utxo`, so the psbt's own input map already _is_ that pair,
in the type btclib has for it. Two things follow. Nothing here fetches
anything, which is the issue's boundary; and an input whose script is
wrapped or multisig is estimated exactly, its redeem or witness script
being a field of the map that arrives rather than an argument this
function would have to grow — a `sizer` cannot rescue it, since
`_p2wsh_witness_sizes` raises for a missing witness script before it
asks one. The outputs are `TxOut` and not `PsbtOut` because the
asymmetry is real: the input map is _read_ and every byte of the
estimate comes from it, where nothing computed here reads an output map.

**Where it lives: `btclib/tx_builder.py`, top level.** It composes
`fee`, `psbt` and `tx`, three peers, so it sits above all three —
`tx_or_psbt.py` is the precedent for exactly that placement, and putting
it under `psbt/` would put dust policy and fee rates inside the module
that is about the BIP174/BIP370 format.

## The two branches the issue names

The fee comes from `fee_from_vsize(psbt.vsize_estimate(sizer),
fee_rate)`, so the size a fee is bought at is the size of the psbt as
built, change output included — the provisional change output carries a
placeholder amount, and a value is eight bytes whatever it holds, so
replacing the placeholder with the answer computed from that estimate
does not move it.

Change below `dust_threshold` for its own script is not created and its
value goes to the fee. The transaction is then smaller than the one that
was priced, so what it owes is computed **again** rather than the larger
figure reused — reusing it would refuse transactions that pay their
rate. The threshold is taken at Core's `-dustrelayfee` default and not
at `fee_rate`: an output is dust by what the network will relay, not by
what this transaction chose to pay, and `dust_fee_rate` is where a
caller says otherwise.

## Scope held

No coin selection — it spends the inputs it is given, all of them. No
node, no rpc, no wallet state: the anti-fee-sniping `lock_time` a wallet
would set needs a chain tip, so it is an argument and defaults to none,
and each input's sequence is its own `PsbtIn.sequence` rather than
something overwritten here.

One refusal is beyond the arithmetic and is here because the arithmetic
is what it corrupts: an outpoint spent twice is counted twice in the
input total, so the change would be an amount the transaction does not
have. `Tx.assert_valid` implements the rest of `CheckTransaction` and
not Core's `bad-txns-inputs-duplicate`, which is #1073, filed rather
than fixed here.

## ISS #1067

It landed while this branch was open, as #1071 squashed onto `main` as
`c1fa8585`, and this branch is rebased past it. `tx.input_weight` is
**not** what the fee is computed from, because the two do not compose:
it answers for one input, where a fee is bought by a whole transaction,
and `Psbt.weight_estimate` already sums the per-input estimates into the
one arithmetic `Tx.weight` is — its own comment saying why that
arithmetic is written once, in the class whose serialization it is.
Summing `input_weight` here instead would mean re-deriving the version,
the lock time, the two counts, the marker and the outputs beside it: a
second implementation of a size, able to disagree with the transaction
actually built.

Nothing is duplicated either: no per-input weight arithmetic is in this
diff, and none is taken from the caller. The per-input number is what
the layer *above* wants — coin selection pricing a candidate input
before there is a psbt to put it in — and the module docstring points
there, under the bullet that keeps coin selection out.

## Tests

`tests/tx_builder_test.py`, with two oracles rather than figures copied
out of a run.

The arithmetic is checked against `fee`'s own functions, and the dust
branch on both sides of the threshold to the satoshi — the boundary
amount is measured from `dust_threshold` and a probe build rather than
tabulated, so it cannot go stale. Covered: change kept, change dropped,
no change script at all, a change-only self-send, a zero rate, a raised
`dust_fee_rate`, a shortfall on either branch, an empty vin or vout, the
duplicate outpoint, an input with no utxo, an input of no readable type
with and without a `sizer`, a legacy input priced from its
`non_witness_utxo`, and the wrong-type refusals.

The other oracle is the whole flow, once per BIP44 encoding (44, 49, 84,
86): build, update from the descriptors, sign with `SoftwareSigner`,
finalize, extract, and run under btclib's script engine. The size that
was really signed is then compared with the size the fee was bought at —
the estimate is an upper bound, so the transaction is never below the
rate it was built for, which is the one claim a builder exists to make.
Purpose 49 is the p2sh-wrapped case, and it is what checks that the
redeem script travelling in the input map is what makes a wrapped input
priceable.

`tests/keyword_only_test.py` and `tests/built_object_contract_test.py`
gain the entry each census wants; `btclib/__init__.py` and
`docs/source/btclib.rst` gain the new module. `CHANGELOG.md` has the
entry; `RELEASE_NOTES.md` has none, nothing here being a break a user
has to act on. The `merge=union` result in `CHANGELOG.md` was read
rather than trusted: the rebase joined this bullet to #1067's without
the blank line between them, which is fixed.

## Gates

All three, on `8d9c1871`, rebased onto `330b6b00`:

```text
uv run pytest                       exit 0  28586 passed, 9 skipped
                                            TOTAL 42759 0 100.00%
uv run pre-commit run --all-files   exit 0
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
                                    exit 0  build succeeded
```

## Summary by Sourcery

Add a transaction builder that funds supplied PSBT inputs and outputs with fee-rate-aware change handling.

New Features:
- Add `btclib.tx_builder.build_psbt` to compose funded PSBTs from supplied inputs and outputs at a specified fee rate.
- Return the constructed PSBT together with its fee and change output position through the new `FundedPsbt` result type.

Bug Fixes:
- Handle dust change by omitting the change output and recalculating the fee for the resulting transaction.
- Reject duplicate outpoints and insufficient input value before producing invalid fee or change calculations.

Enhancements:
- Support configurable transaction version, lock time, dust relay fee rate, and custom input size estimators while preserving caller-provided input sequences and excluding coin selection or network access.

Documentation:
- Expose the new transaction-builder module through the package and API documentation.
- Document the transaction builder in the changelog.

Tests:
- Add comprehensive transaction-builder coverage for fee and dust handling, validation, custom sizing, legacy and wrapped inputs, and end-to-end signing and script verification.