### PR TITLE
Relock btclib_secp256k1 onto 9545ae5 and bitcoin-core-rpc to 2026.8.20

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -458,8 +458,8 @@ test = [
 
 [[package]]
 name = "btclib-secp256k1"
-version = "0.8.0.3"
-source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#bc36867fa1dc4901b5ccd6cf2b2d0240d6a07984" }
+version = "0.8.0.4"
+source = { git = "https://github.com/btclib-org/btclib-secp256k1.git?branch=main#9545ae59830d40ce3d321e5a9e656b5c4c6bea34" }
 dependencies = [
     { name = "cffi" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -301,11 +301,11 @@ wheels = [
 
 [[package]]
 name = "bitcoin-core-rpc"
-version = "2026.8.13"
+version = "2026.8.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/f8/bc602214490d47ed66f857a119e66d8c2788691d597024536d4c702a380f/bitcoin_core_rpc-2026.8.13.tar.gz", hash = "sha256:ab7c748457756982561a07bf699eda211fcfe99acbe6ef46cf4d43b311025d03", size = 368264, upload-time = "2026-08-13T17:18:08.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/7a/02580ed845cc0daa380f76e3b19be84e2d6de0a58d46fe5f71d2c5588798/bitcoin_core_rpc-2026.8.20.tar.gz", hash = "sha256:9e47e906ffeb09dc2c9a5fc5ce2f893794a069193f65af271621a04cd733d79a", size = 382663, upload-time = "2026-08-20T13:42:00.63Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/e9/ae5634c2c8ffd36c5013412e0450cff63db7138ba3c3a829a9f6a98d4e3e/bitcoin_core_rpc-2026.8.13-py3-none-any.whl", hash = "sha256:606285cc836780d55ac426d573dfe051c5fa9f0300b73e9cf4da695ea0215456", size = 44484, upload-time = "2026-08-13T17:18:07.39Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/3b/3ad6ebf51dcd6387b801f0a66da7451f25064c95b9718be659fa31aaf0c9/bitcoin_core_rpc-2026.8.20-py3-none-any.whl", hash = "sha256:34a7c1f406409872792d46155e8f3cc5e9f2671da0136120a181bced810a9b6b", size = 44521, upload-time = "2026-08-20T13:41:59.346Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Two relocks, `uv.lock` only, `pyproject.toml` unchanged in both:

1. **`btclib_secp256k1` onto its new tip, `9545ae5`.**
   `[tool.uv.sources]` already points at the bindings' `main`, so this
   is `uv lock --upgrade-package btclib_secp256k1`, not an edit.
   btclib-secp256k1#285 landed since the last relock and is what moves:
   a `musig.py` wrapper -- `KeyAggCache`, `Session` and `SecretNonce`.
2. **`bitcoin-core-rpc` to 2026.8.20, floor unchanged.** The lock
   resolved 2026.8.13; PyPI's latest is 2026.8.20.
   `uv lock --upgrade-package bitcoin-core-rpc`.

## Why the floor and the sources table don't move

**`btclib_secp256k1`'s floor stays `>=0.8.0.3`, and `[tool.uv.sources]`
stays.** Its own comment says to drop the table "once the floor names a
version PyPI serves", and `btclib_secp256k1` 0.8.0.3 *is* on PyPI now
(`info.version` is `0.8.0.3`). I kept it anyway: the musig wrapper
`#285` just landed is on the bindings' `main` and not in the 0.8.0.3
release PyPI serves, and btclib issues #1048 and #1049 are queued to
call it. Dropping the git pin now would cut btclib off from exactly
the entry points it is about to need. The table goes when a bindings
*release* carries `musig.py`, not before -- and the floor moves with
it, when #1048/#1049 land and actually call the wrapper. btclib does
not call it yet, so nothing here changes what the suite exercises.

**`bitcoin-core-rpc`'s floor stays `>=2026.8.13`.** v2026.8.20's own
release notes:

> Nothing to act on. Every change this cycle is repository tooling —
> workflows and CI configuration, recorded in CHANGELOG.md — and the
> library itself is unchanged since v2026.8.13.

Raising the floor would demand a version that offers btclib nothing,
and in this tree every floor carries the reason that decided it --
there is none to write here.

## CHANGELOG.md

No entry, deliberately. Checked what this repository has done for
previous pure relocks -- `uv.lock` only, no floor moved -- before
deciding, rather than reasoning from scratch: #946, #950, #960 and
#971 are all shaped exactly like this one (`git diff --stat` between
their base and merge commit shows `uv.lock` alone, sometimes with
`.pre-commit-config.yaml` beside it), and none of them touched
`CHANGELOG.md`. A relock a user never sees, behind a floor that does
not move, is not "something a user would notice" by that same
standard -- the bindings tip now carrying `musig.py` does not change
that, because nothing in this tree calls it yet. The entry belongs to
whichever of #1048/#1049 first calls the wrapper, where a user gets
something to notice.

## Verified

A relock changes what the suite runs against, so this is the evidence
and not a formality -- run once after each relock, and once more after
rebasing onto `origin/main` moving under this branch:

- `uv run pytest` -- full suite, 100% coverage gate, green every time,
  bindings tip included. No behaviour change the suite notices: btclib
  does not call the new `musig.py` wrapper, so nothing new is
  exercised, and the rest of the bindings' surface this tree does call
  is unchanged by `#285`.
- `uv run pre-commit run --all-files` -- green.
- `sphinx-build -W --keep-going -b html docs/source docs/build/html`
  (through `uv run --locked --no-default-groups --group docs`) --
  builds clean, no warnings.

## Test plan

- [x] `uv run pytest` (full suite, 100% coverage)
- [x] `uv run pre-commit run --all-files`
- [x] sphinx `-W` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Refresh the locked btclib_secp256k1 dependency to its latest bindings tip and update bitcoin-core-rpc to version 2026.8.20 without changing dependency floors or source configuration.