### PR TITLE
Refuse a transaction spending one outpoint twice (issue #1073)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1480,8 +1480,7 @@ documented at release-notes length in the first place, and are still in
   would set needs a chain tip, so it is an argument here and defaults
   to none. An outpoint spent twice is refused, Core's
   `bad-txns-inputs-duplicate` and a double count in the fee arithmetic
-  both; `Tx.assert_valid` implements the rest of `CheckTransaction` and
-  not that rule, which is issue #1073.
+  both -- by `Tx.assert_valid`, which the entry below gave that rule.
 
   `tx.input_weight` of issue #1067 is not what the fee is computed
   from, and the two do not compose: that answers for one input, where a
@@ -1498,6 +1497,54 @@ documented at release-notes length in the first place, and are still in
   encoding: the size that was really signed is compared with the size
   the fee was bought at, the estimate being an upper bound and the
   transaction therefore never below the rate it was built for.
+
+- **`Tx.assert_valid` refuses a transaction naming one outpoint twice**
+  (issue #1073). Core's `CheckTransaction` rejects it as
+  `bad-txns-inputs-duplicate` -- the rule CVE-2018-17144 was the cost of
+  not applying -- and it was the one rule of that function missing here,
+  from a docstring that claimed the set and from the code under it: a
+  transaction spending one output twice was accepted, so anything
+  computing over its inputs, a fee or a total or an ancestor set,
+  answered for a transaction that cannot be mined. `OutPoint` is frozen
+  and hashable, so the rule is the set of the outpoints against their
+  count, and it is asked after the loop that judges each input on its
+  own -- a tx_id of the wrong length is then reported as that rather
+  than as a member of a set.
+
+  Unconditional, `unsigned_template` or not. That flag drops the two
+  rules a psbt's global unsigned transaction cannot satisfy, at least
+  one input and at least one output, and a duplicate is not one of them:
+  a psbt under construction has no duplicate inputs either, and a
+  Constructor adding an input already there builds a transaction no node
+  will accept, finished or not. So `Psbt.assert_valid` gains the rule
+  through the `tx.assert_valid(unsigned_template=True)` it already made,
+  and gains it in the right order: it checks the input maps first, so an
+  input carrying no PSBT_IN_OUTPUT_INDEX is still refused under its own
+  name rather than as a duplicate of whatever spends index 0 --
+  `PsbtIn.prev_out` reads a missing index as 0.
+
+  `tx_builder.build_psbt` loses the `_assert_spends_once` it carried
+  for itself, which is more than redundant now: `prevouts` validates the
+  psbt before the input total is summed, so the private check would have
+  been unreachable, and the message a caller gets is the one it gave.
+  What the builder's own test still pins is the order the fee arithmetic
+  needs -- the refusal before the sum it would corrupt.
+
+  Three test transactions were the duplicates this now refuses, none of
+  them meaning to be: `tests/tx/tx_in_test.py`'s weight sum built its
+  segwit transaction from two inputs of one outpoint, where the weight
+  is the same for any two; `tests/psbt/psbt_size_test.py` rebuilds the
+  psbt behind a block's spends and funded every legacy input from one
+  synthetic previous transaction, so two inputs paying the same
+  script_pub_key were given the same outpoint, and it now builds one per
+  input; and `tests/psbt/psbt_test.py`'s "common inputs" case duplicated
+  an input within one psbt, where what `join` refuses is an input two
+  *valid* psbts share, which is what it duplicates now.
+
+  Core's own `tx_invalid.json` carries one transaction with duplicate
+  inputs, marked `BADTX`, and it is now refused by `Tx.parse` rather
+  than by `verify_transaction` finding one prevout for two inputs. That
+  count check was covered by nothing else, and has a test of its own.
 
 - **`psbt.musig2.partial_sigs_agg` aggregates the participant list once,
   not four times** (issue #1046). Every public function of the module

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -52,6 +52,16 @@ full year, short month, short day (YYYY-M-D)
   also stops reporting the point at infinity as a recovered key, which
   CHANGELOG.md has.
 
+- **a transaction naming one outpoint twice is refused.**
+  `Tx.assert_valid` implements Core's `bad-txns-inputs-duplicate` now, so
+  building, parsing or serializing such a transaction raises
+  `BTClibValueError` where it used to go through, and so does validating
+  a psbt whose unsigned transaction is one. A caller that was holding a
+  duplicate on purpose -- to measure it, or to feed it to the script
+  engine -- passes `check_validity=False`, which is what that flag is
+  for. CHANGELOG.md has why the rule is not gated on
+  `unsigned_template`.
+
 - **`TxOut.from_dict` refuses a `null` value.** It used to build an output
   of zero satoshi, `valid_sats_amount` reading `None` as zero for the
   caller it was written for; a stored dict carrying `{"value": null}` now

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -96,9 +96,10 @@ class Tx:  # noqa: PLW1641
     `hash` are computed from the current state on every read, so they
     follow the edits. assert_valid checks what CheckTransaction checks
     of a lone transaction -- field ranges, the inputs and outputs one
-    by one, the coinbase script size, the MAX_MONEY bound on the
-    output sum; whether it spends what it claims needs the prevouts,
-    which is script.engine.verify_transaction's question.
+    by one, the coinbase script size, no outpoint spent twice, the
+    MAX_MONEY bound on the output sum; whether it spends what it claims
+    needs the prevouts, which is script.engine.verify_transaction's
+    question.
     """
 
     # 4 bytes, _signed_ little endian
@@ -320,8 +321,8 @@ class Tx:  # noqa: PLW1641
         unsigned_template=True drops the two rules a PSBT's global unsigned
         transaction cannot satisfy, and only those: at least one input and
         at least one output. Everything else still applies -- the version
-        and lock time ranges, each input and output on its own, the
-        MAX_MONEY bound on their sum.
+        and lock time ranges, each input and output on its own, no outpoint
+        spent twice, the MAX_MONEY bound on their sum.
 
         Those two rules are right for a transaction, Core's
         CheckTransaction rejecting an empty vin or vout, and wrong for a
@@ -348,6 +349,20 @@ class Tx:  # noqa: PLW1641
             raise BTClibValueError("Missing inputs")
         for tx_in in self.vin:
             tx_in.assert_valid()
+
+        # CheckTransaction's `bad-txns-inputs-duplicate` (CVE-2018-17144):
+        # an outpoint named twice would be spent twice, and every arithmetic
+        # over the inputs -- a fee, a total, an ancestor set -- counts what
+        # it names once. `OutPoint` is frozen and hashable for this, so the
+        # rule is the set, and the inputs are judged one by one above first,
+        # a tx_id of the wrong length being reported as that rather than as
+        # a member of a set. Unconditional, unsigned_template or not: the
+        # flag drops the two rules a psbt's transaction cannot satisfy while
+        # it is being built, and a Constructor adding an input already there
+        # builds a transaction no node accepts, incomplete or finished
+        outpoints = [tx_in.prev_out for tx_in in self.vin]
+        if len(set(outpoints)) != len(outpoints):
+            raise BTClibValueError("the same outpoint is spent twice")
 
         if not unsigned_template and not self.vout:
             raise BTClibValueError("Missing outputs")

--- a/btclib/tx_builder.py
+++ b/btclib/tx_builder.py
@@ -136,28 +136,6 @@ def _assert_arguments(
     assert_type(dust_fee_rate, FeeRate, "dust fee rate")
 
 
-def _assert_spends_once(inputs: Sequence[PsbtIn]) -> None:
-    """Refuse a set of inputs naming one outpoint twice.
-
-    Core's `CheckTransaction` refuses it as `bad-txns-inputs-duplicate`,
-    and what it costs here is not only that the transaction would be
-    rejected: the fee is computed from what the inputs are worth, and an
-    outpoint listed twice is counted twice, so the change would be an
-    amount the transaction does not have. `Tx.assert_valid` implements
-    the rest of `CheckTransaction` and not this rule (issue #1073), so
-    the psbt this returns would not be refused by its own validation.
-
-    Asked after the psbt has been validated, and that is the order rather
-    than an accident: `PsbtIn.prev_out` reads a missing output index as
-    0, so an input carrying none would be a duplicate of whatever else
-    spends index 0 of the same transaction -- where `Psbt.assert_valid`
-    refuses it under its own name, as a missing PSBT_IN_OUTPUT_INDEX.
-    """
-    outpoints = [psbt_in.prev_out for psbt_in in inputs]
-    if len(set(outpoints)) != len(outpoints):
-        raise BTClibValueError("the same outpoint is spent twice")
-
-
 def build_psbt(
     inputs: Sequence[PsbtIn],
     outputs: Sequence[TxOut],
@@ -237,9 +215,11 @@ def build_psbt(
         fallback_lock_time=lock_time,
         check_validity=False,
     )
+    # `prevouts` validates, and the psbt's transaction with it, so the
+    # outpoint spent twice this sum would double count is refused before
+    # the sum is made -- `Tx.assert_valid`'s rule, Core's
+    # `bad-txns-inputs-duplicate`, rather than one this function repeats
     total_in = sum(prev_out.value for prev_out in prevouts(psbt))
-    # after `prevouts`, which is what validates; its own docstring says why
-    _assert_spends_once(inputs)
     total_out = sum(tx_out.value for tx_out in outputs)
     remainder = total_in - total_out
 

--- a/tests/psbt/psbt_size_test.py
+++ b/tests/psbt/psbt_size_test.py
@@ -173,7 +173,7 @@ def psbt_from_spend(tx: Tx) -> Psbt | None:
     """
     tx = deepcopy(tx)
     inputs: list[PsbtIn] = []
-    for tx_in in tx.vin:
+    for i, tx_in in enumerate(tx.vin):
         built = psbt_input_from_spend(tx_in)
         if built is None:
             return None
@@ -183,11 +183,15 @@ def psbt_from_spend(tx: Tx) -> Psbt | None:
             # a psbt whose non_witness_utxo does not hash to the outpoint
             # is one assert_valid refuses -- so the outpoint is moved to
             # the transaction built here, which changes no size: an
-            # outpoint is 36 bytes whatever is in it
+            # outpoint is 36 bytes whatever is in it.
+            # One such transaction per input, told apart by the index it
+            # spends: two inputs paying the same script_pub_key would
+            # otherwise be funded by the same transaction and left naming
+            # one outpoint twice, which is `bad-txns-inputs-duplicate`
             prev_tx = Tx(
                 1,
                 0,
-                [TxIn(OutPoint(b"\x01" * 32, 0))],
+                [TxIn(OutPoint(b"\x01" * 32, i))],
                 [TxOut(1000, script_pub_key, check_validity=False)],
                 check_validity=False,
             )

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -1933,9 +1933,13 @@ def test_join() -> None:
             shuffle_out=False,
         )
 
-    # failure: common inputs
+    # failure: common inputs. The shared input comes from the other psbt,
+    # which is what this refusal is about: each psbt spends its outpoints
+    # once and is valid on its own, and only the join would spend one of
+    # them twice -- a psbt naming one outpoint twice by itself is refused
+    # by `Tx.assert_valid`, which `_ensure_consistency` reaches first
     psbt2 = Psbt.b64decode(psbt2_str)
-    psbt2.inputs.append(psbt2.inputs[0])
+    psbt2.inputs.append(deepcopy(psbt1.inputs[0]))
     err_msg = "common inputs"
     with pytest.raises(BTClibValueError, match=err_msg):
         join(

--- a/tests/script_engine/transactions_test.py
+++ b/tests/script_engine/transactions_test.py
@@ -319,13 +319,14 @@ def test_invalid_legacy(vector: list[Any]) -> None:
     """Reproduce Core's tx_invalid.json."""
     prevouts, check_amounts = prevouts_of(vector)
 
-    # Tx.parse inside the raises block, not before it: 8 of these
-    # transactions are malformed enough that btclib refuses them there,
-    # and refusing them there is refusing them -- parsed first and
-    # skipped on failure, those 8 would assert nothing at all.
-    # BTClibValueError alone, as above: all 93 leave through one,
-    # measured, so naming IndexError and KeyError too is width that buys
-    # nothing and would hide the next contract break
+    # Tx.parse inside the raises block, not before it: some of these
+    # transactions are refused there -- malformed, or invalid as a lone
+    # transaction, which is what Core's own BADTX marker says of the
+    # duplicate-input vector -- and refusing them there is refusing them;
+    # parsed first and skipped on failure, those would assert nothing at
+    # all. BTClibValueError alone, as above: every vector leaves through
+    # one, measured, so naming IndexError and KeyError too is width that
+    # buys nothing and would hide the next contract break
     with pytest.raises(BTClibValueError):
         tx = Tx.parse(vector[1])
         # the vector's own flags, and only those: an invalid transaction
@@ -345,3 +346,22 @@ def test_invalid_amount() -> None:
     # Output amount greater than sum of inputs
     with pytest.raises(BTClibValueError):
         verify_amounts([prevout], tx)
+
+
+def test_a_prevout_per_input() -> None:
+    """Verify each input against its own prevout: one list each, one length.
+
+    The caller brings the prevouts, an outpoint saying neither what it is
+    worth nor what it locks, so nothing but this check says they are the
+    prevouts of *this* transaction: one short and the loop below would
+    verify the inputs it has against the wrong outputs, or fall off the
+    list.
+    """
+    prevout = TxOut(10, ScriptPubKey(""))
+    tx = Tx(
+        vin=[TxIn(OutPoint(b"1" * 32, 1)), TxIn(OutPoint(b"1" * 32, 2))],
+        vout=[TxOut(10, ScriptPubKey(""))],
+    )
+
+    with pytest.raises(BTClibValueError, match="1 prevouts for 2 transaction inputs"):
+        verify_transaction([prevout], tx)

--- a/tests/tx/tx_in_test.py
+++ b/tests/tx/tx_in_test.py
@@ -303,6 +303,10 @@ def test_input_weight_sums_to_tx_weight() -> None:
     that byte.
     """
     prev_out = OutPoint(b"\x01" * 32, 0)
+    # the second output of that same transaction: one outpoint spent
+    # twice is a transaction `Tx.assert_valid` refuses, and an outpoint
+    # weighs what an outpoint weighs whichever output it names
+    other_prev_out = OutPoint(b"\x01" * 32, 1)
     tx_out = TxOut(1000, "0014" + "00" * 20)
     p2pkh_script_sig = b"\x00" * 107
     p2wpkh_witness = Witness(["00" * 72, "00" * 33])
@@ -312,7 +316,7 @@ def test_input_weight_sums_to_tx_weight() -> None:
     segwit = Tx(
         vin=[
             TxIn(prev_out, b"", 0xFFFFFFFF, p2wpkh_witness),
-            TxIn(prev_out, p2sh_p2wpkh_script_sig, 0xFFFFFFFF, Witness()),
+            TxIn(other_prev_out, p2sh_p2wpkh_script_sig, 0xFFFFFFFF, Witness()),
         ],
         vout=[tx_out],
     )

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -342,6 +342,47 @@ def test_output_total_is_bounded() -> None:
         Tx(vin=[tx_in], vout=[TxOut(max_money // 2 + 1, "")] * 2)
 
 
+def test_one_outpoint_is_spent_once() -> None:
+    """An outpoint named twice is refused, as `bad-txns-inputs-duplicate`.
+
+    Core's CheckTransaction has the rule and CVE-2018-17144 is what it
+    was worth: the transaction spends one output twice, so anything
+    computing over its inputs -- a fee, a total, an ancestor set --
+    answers for a transaction that cannot be mined.
+    """
+    out_point = OutPoint(b"\x01" * 32, 0)
+    tx_out = TxOut(1000, "")
+
+    err_msg = "the same outpoint is spent twice"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        Tx(vin=[TxIn(out_point), TxIn(out_point)], vout=[tx_out])
+
+    # the sequence is no part of the outpoint, so two inputs differing
+    # only there are the same double spend
+    with pytest.raises(BTClibValueError, match=err_msg):
+        Tx(vin=[TxIn(out_point, b"", 0), TxIn(out_point, b"", 1)], vout=[tx_out])
+
+    # a psbt's transaction is refused as well: `unsigned_template` drops
+    # the two rules that transaction cannot satisfy while it is being
+    # built, and nothing makes a duplicate one of them
+    tx = Tx(vin=[TxIn(out_point)], vout=[tx_out])
+    tx.vin.append(TxIn(out_point))
+    with pytest.raises(BTClibValueError, match=err_msg):
+        tx.assert_valid(unsigned_template=True)
+
+    # and what the refusal must not take with it: two outputs of one
+    # transaction, and one output index of two transactions, are two
+    # outpoints either way
+    Tx(
+        vin=[TxIn(out_point), TxIn(OutPoint(b"\x01" * 32, 1))],
+        vout=[tx_out],
+    ).assert_valid()
+    Tx(
+        vin=[TxIn(out_point), TxIn(OutPoint(b"\x02" * 32, 0))],
+        vout=[tx_out],
+    ).assert_valid()
+
+
 def test_standard() -> None:
     """Verify assert_standard refuses a version assert_valid accepts."""
     tx_bytes = "010000000001019bdea7abb2fa14dead47dd14d03cf82212a25b6096a8da6b14feec3658dbcf9d0100000000ffffffff02a02526000000000017a914f987c321394968be164053d352fc49763b2be55c874361610000000000220020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d04004730440220421fbbedf2ee096d6289b99973509809d5e09589040d5e0d453133dd11b2f78a02205686dbdb57e0c44e49421e9400dd4e931f1655332e8d078260c9295ba959e05d014730440220398f141917e4525d3e9e0d1c6482cb19ca3188dc5516a3a5ac29a0f4017212d902204ea405fae3a58b1fc30c5ad8ac70a76ab4f4d876e8af706a6a7b4cd6fa100f44016952210375e00eb72e29da82b89367947f29ef34afb75e8654f6ea368e0acdfd92976b7c2103a1b26313f430c4b15bb1fdce663207659d8cac749a0e53d70eff01874496feff2103c96d495bfdd5ba4145e3e046fee45e84a8a48ad05bd8dbb395c011a32cf9f88053ae00000000"

--- a/tests/tx_builder_test.py
+++ b/tests/tx_builder_test.py
@@ -272,17 +272,23 @@ def test_a_transaction_needs_an_input_and_an_output() -> None:
 
 
 def test_one_outpoint_is_spent_once() -> None:
-    """A double count in the fee arithmetic, and `bad-txns-inputs-duplicate`."""
+    """A double count in the fee arithmetic, and `bad-txns-inputs-duplicate`.
+
+    `Tx.assert_valid`'s rule, reached here through the `prevouts` that
+    reads what the inputs are worth: the fee is what that sum buys, so
+    the refusal comes before the number it would corrupt.
+    """
     with pytest.raises(BTClibValueError, match="spent twice"):
         build_psbt(
             [spendable(100_000), spendable(100_000)],
             [TxOut(60_000, PAY_SCRIPT)],
             TEN_SAT_PER_VBYTE,
         )
-    # an input naming no output index is refused under its own name, the
-    # psbt being validated before the duplicates are looked for: read the
-    # other way round it would be a duplicate of whatever spends index 0
-    # of the same transaction
+    # an input naming no output index is refused under its own name,
+    # `Psbt.assert_valid` checking the input fields before the transaction
+    # it builds out of them: `PsbtIn.prev_out` reads a missing index as 0,
+    # so read the other way round this would be a duplicate of whatever
+    # spends index 0 of the same transaction
     nameless = spendable(100_000)
     nameless.output_index = None
     with pytest.raises(BTClibValueError, match="missing PSBT_IN_OUTPUT_INDEX"):


### PR DESCRIPTION
Closes #1073.

`Tx.assert_valid` stated its scope as what `CheckTransaction` checks of
a lone transaction and implemented every one of those rules but the
duplicate-outpoint check Core rejects as `bad-txns-inputs-duplicate` —
the rule CVE-2018-17144 was the cost of not applying. The issue's
reproducer built and validated a transaction naming one outpoint twice
without a word.

## What it does

`OutPoint` is frozen and hashable, so the rule is the set of the
outpoints against their count. It sits after the loop that validates
each input on its own, so a `tx_id` of the wrong length is still
reported as that rather than as a member of a set, and it raises
`BTClibValueError("the same outpoint is spent twice")` — the message
`tx_builder` already gave for the same refusal.

## The placement question the issue left open

**Unconditional, not gated on `unsigned_template`**, which is the
issue's own reading and what the code says too. That flag drops the two
rules a psbt's global unsigned transaction cannot satisfy — at least one
input, at least one output — and a duplicate is not one of them: a psbt
under construction has no duplicate inputs either, and a Constructor
adding an input already present is building a transaction no node will
accept, finished or not.

Two things checked in the code rather than assumed:

- `Psbt.assert_valid` (`btclib/psbt/psbt.py:1133`) calls
  `self.tx.assert_valid(unsigned_template=True)`, so the psbt layer gets
  the rule for free.
- It gets it in the right order. `_assert_valid_input_fields` runs
  *before* that call, so an input carrying no `PSBT_IN_OUTPUT_INDEX` is
  still refused under its own name — `PsbtIn.prev_out` reads a missing
  index as 0, which would otherwise make it a duplicate of whatever
  spends index 0. That is exactly the ordering hazard
  `tx_builder._assert_spends_once` was placed around, and it is already
  handled where the rule now lives.

## The builder's own check

Removed. It is not merely redundant now: `build_psbt` calls
`prevouts(psbt)`, which calls `psbt.assert_valid()`, before it sums what
the inputs are worth — so `_assert_spends_once` after it would have been
unreachable, a dead branch the coverage gate would fail on. The message
a caller sees is unchanged, and `tests/tx_builder_test.py`'s test still
pins what the builder actually needs: the refusal before the sum it
would corrupt, and the missing-output-index input refused under its own
name.

## What else this newly refuses

The full suite found four, all of them test artifacts rather than
transactions that should be valid:

- `tests/tx/tx_in_test.py`'s weight sum built its segwit transaction
  from two inputs of one outpoint; the second now names the second
  output of that transaction, and an outpoint weighs the same either
  way.
- `tests/psbt/psbt_size_test.py`'s `psbt_from_spend` funded *every*
  legacy input of a real block's spends from one synthetic previous
  transaction, so two inputs paying the same `script_pub_key` were given
  the same outpoint. It builds one funding transaction per input now.
  No transaction in either vendored block has duplicate inputs.
- `tests/psbt/psbt_test.py`'s `join` "common inputs" case duplicated an
  input *within* one psbt, reaching join's own refusal through a psbt
  that was invalid on its own. It now shares an input between two psbts
  each valid by itself, which is what that refusal is about.
- Core's `tx_invalid.json` carries one transaction with duplicate
  inputs, marked `BADTX`, and it lists one prevout for its two inputs.
  It is now refused by `Tx.parse` — for the reason Core marks it —
  rather than by `verify_transaction` finding the prevout count wrong.
  That count check was covered by nothing else, so it has a test of its
  own now, and the comment stating how many vectors fail at parse (which
  this change moves from 8 to 9) no longer states a count.

## Gates

All three, on this sha, exit code 0:

- `uv run pytest` — 28589 passed, 9 skipped, coverage 100.00%
- `uv run pre-commit run --all-files`
- `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html`

`CHANGELOG.md` has an entry, and `RELEASE_NOTES.md` a breaking-changes
bullet: this refuses input a caller could previously pass, and the way
to act on it is `check_validity=False` where a caller legitimately holds
such a transaction. The `tx_builder` entry's closing clause, which said
`Tx.assert_valid` does not carry this rule, was corrected in place —
both entries are in the same unreleased release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uNzuzag82WGhvznByjFDH

## Summary by Sourcery

Reject transactions that spend an outpoint twice and apply the rule consistently across transaction, PSBT, and builder validation.

Bug Fixes:
- Reject transactions and PSBTs that spend the same outpoint more than once, matching Core's duplicate-input validation rule.

Enhancements:
- Centralize duplicate-outpoint validation in `Tx.assert_valid` and remove the now-redundant transaction-builder check.
- Preserve validation ordering so malformed PSBT input fields are reported under their specific validation errors.

Documentation:
- Document the duplicate-outpoint validation and the opt-out path for callers intentionally handling such transactions.
- Add changelog and release-note entries for the new breaking validation behavior.

Tests:
- Update transaction, PSBT, builder, and Core invalid-vector tests for duplicate-input rejection and add coverage for per-input prevout validation.