### PR TITLE
Refuse a borromean ring shape that disagrees with pubk_rings, and drop a dead seed byte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4481,6 +4481,37 @@ documented at release-notes length in the first place, and are still in
   never handed back an object that looks like a signature and signs
   nothing.
 
+- **`borromean.assert_as_valid` refuses a `sig` whose ring shape
+  disagrees with `pubk_rings`, and `verify` answers `False` for one
+  rather than raising** (issue #1088). Nothing checked that `sig.s` and
+  `pubk_rings` described the same shape before the walk indexed
+  `sig.s[i][j]` against `pubk_ring[j]`: a mismatched signature -- fewer
+  rings than `pubk_rings`, or a ring with fewer s-values than it has
+  keys -- reached a bare `IndexError`, which is neither a
+  `BTClibValueError` nor a `BTClibRuntimeError`, so it escaped `verify`'s
+  `except (ValueError, BTClibRuntimeError)` and `verify` raised where it
+  is documented to answer `False`. The check is a `BTClibValueError`
+  naming the ring and the counts -- not `BorromeanRingError`, which is a
+  `BTClibRuntimeError` for a check that ran and failed, where a shape
+  mismatch is two arguments that never described the same object in the
+  first place -- and it runs once, before the walk, in both
+  `assert_as_valid` and `sign`: `sign` had the same exposure through
+  `sign_keys`, left out of its own existing ring-count check and
+  reaching `sign_keys[i]` in step 2 as the same bare `IndexError`.
+  `verify`'s `except` clause is unchanged and does not add `IndexError`
+  to it: the existing `BTClibValueError` arm already catches the new
+  check, and widening the clause would hide this class of bug rather
+  than fix it.
+
+- **The `r = b"\0x00"` seed at the top of `assert_as_valid`'s per-ring
+  loop is gone** (issue #1089). It was never a null byte: `\0` is
+  Python's own NUL escape, so the literal read as the four bytes
+  `b"\x00x00"`, not the placeholder it looked like. It was also dead --
+  the loop below is the only reader of `r`, and always assigns it in
+  the same iteration before that read -- so nothing depended on the
+  four stray bytes it briefly held; only the initializer is removed,
+  and it cost no test.
+
 ### Security
 
 - **`SECURITY.md` says the bindings offer a buffer for a secret, and

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -473,18 +473,20 @@ full year, short month, short day (YYYY-M-D)
 
 - **`borromean.verify` answers `False`, not a bare `IndexError`, for a
   `sig` whose ring shape disagrees with `pubk_rings`; `assert_as_valid`
-  refuses one with `BTClibValueError`, not the same `IndexError`.**
-  Before: a `sig` with fewer rings than `pubk_rings`, or a ring with
-  fewer s-values than it has keys, indexed past the end of a ring's
-  tuple in both, and the plain `IndexError` that raised was neither
-  caught by `verify`'s `except (ValueError, BTClibRuntimeError)` nor
-  documented by either function. Now: `assert_as_valid` raises
+  and `sign` refuse one with `BTClibValueError`, not the same
+  `IndexError`.** Before: a `sig` with fewer rings than `pubk_rings`, or
+  a ring with fewer s-values than it has keys, indexed past the end of a
+  ring's tuple in `assert_as_valid`; a `sign_keys` shorter than
+  `pubk_rings` indexed past its own end in `sign`'s step 2 the same way.
+  Both reached a plain `IndexError`, neither caught by `verify`'s
+  `except (ValueError, BTClibRuntimeError)` nor documented by any of the
+  three functions. Now: `assert_as_valid` and `sign` both raise
   `BTClibValueError` naming the ring and the counts, and `verify`
   answers `False` for it, the same as any other invalid signature. A
-  caller catching `IndexError` around either call to detect this case
-  has to catch `BTClibValueError`, or nothing at all against `verify`,
-  which no longer raises here. CHANGELOG.md has why the check is a
-  `BTClibValueError` and not `BorromeanRingError`.
+  caller catching `IndexError` around any of the three calls to detect
+  either case has to catch `BTClibValueError`, or nothing at all against
+  `verify`, which no longer raises here. CHANGELOG.md has why the check
+  is a `BTClibValueError` and not `BorromeanRingError`.
 
 ### Worth knowing, though nothing raises
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -471,6 +471,21 @@ full year, short month, short day (YYYY-M-D)
   catching `ValueError` around that one corner case catches nothing
   now. CHANGELOG.md has why, for both.
 
+- **`borromean.verify` answers `False`, not a bare `IndexError`, for a
+  `sig` whose ring shape disagrees with `pubk_rings`; `assert_as_valid`
+  refuses one with `BTClibValueError`, not the same `IndexError`.**
+  Before: a `sig` with fewer rings than `pubk_rings`, or a ring with
+  fewer s-values than it has keys, indexed past the end of a ring's
+  tuple in both, and the plain `IndexError` that raised was neither
+  caught by `verify`'s `except (ValueError, BTClibRuntimeError)` nor
+  documented by either function. Now: `assert_as_valid` raises
+  `BTClibValueError` naming the ring and the counts, and `verify`
+  answers `False` for it, the same as any other invalid signature. A
+  caller catching `IndexError` around either call to detect this case
+  has to catch `BTClibValueError`, or nothing at all against `verify`,
+  which no longer raises here. CHANGELOG.md has why the check is a
+  `BTClibValueError` and not `BorromeanRingError`.
+
 ### Worth knowing, though nothing raises
 
 - **Signing on the Python arm now checks the signature before answering

--- a/btclib/ecc/borromean.py
+++ b/btclib/ecc/borromean.py
@@ -372,10 +372,11 @@ def sign(
     # BTClibValueError's class with none of its content, naming "argument
     # 3" and no parameter of this function; strict=True stays, as the
     # assertion that this check and those loops cannot drift apart.
-    # sign_keys used to be left out of this: a short one is the same
-    # shape mismatch _assert_matches_pubk_rings refuses on the
-    # verification side, and was reaching `sign_keys[i]` in step 2 as a
-    # bare IndexError instead (issue #1088)
+    # sign_keys is part of this check for the same reason as the other
+    # three: step 2 indexes it per ring (`sign_keys[i]`), so a shorter
+    # sequence there is the same shape exposure _assert_matches_pubk_rings
+    # refuses on the verification side, one ring's worth of tuple away
+    # from a bare IndexError instead of this message
     if not len(pubk_rings) == len(sign_key_idx) == len(ks) == len(sign_keys):
         err_msg = f"{len(pubk_rings)} rings, {len(sign_key_idx)} signing indexes, "
         err_msg += f"{len(ks)} nonces and {len(sign_keys)} signing keys"
@@ -536,14 +537,6 @@ def assert_as_valid(
         if e[i][0] == 0:
             err_msg = "implausible signature failure"
             raise BorromeanRingError(err_msg, i, 0)
-        # no seed value: the loop below is the only reader of r, always
-        # assigning it in the same iteration before that read -- `else:
-        # e0bytes += r` fires on the loop's own last iteration, never
-        # before its first -- so a dead placeholder had nothing to seed
-        # (issue #1089). What used to be here, `b"\0x00"`, was not even
-        # an honest one: `\0` is Python's own NUL escape, so the literal
-        # read as the four bytes b"\x00x00", not the single null byte
-        # it looked like
         for j in range(keys_size):
             t = double_mult_var(-e[i][j], pubk_ring[j], sig.s[i][j], ec.G, ec)
             r = _bytes_from_ring_point(t, ec, i, j)

--- a/btclib/ecc/borromean.py
+++ b/btclib/ecc/borromean.py
@@ -291,6 +291,42 @@ def _initialize(
     return msg_, m, e
 
 
+def _assert_matches_pubk_rings(
+    pubk_rings: Sequence[PubkeyRing], s: Sequence[Sequence[int]]
+) -> None:
+    """Refuse an s whose ring shape disagrees with pubk_rings.
+
+    `sign` and `assert_as_valid` both walk `s[i][j]` against
+    `pubk_rings[i][j]` -- `_initialize` is where the two already meet,
+    building `e` in that same shape from `pubk_rings` alone. Unless `s`
+    describes the identical shape, one ring per pubkey ring and one
+    value per key, that walk runs past the end of a ring's tuple and a
+    bare `IndexError` escapes where `verify` is documented to answer
+    `False` (issue #1088). Checked once, here, before the walk -- not as
+    each index into `s` is taken, which is what let the `IndexError`
+    through in the first place.
+
+    `sign` has no such argument to check: its own `s` is built from
+    `pubk_rings` two lines below its call into this module, so it cannot
+    disagree with it by construction. What `sign` takes instead is one
+    flat, per-ring index (`sign_key_idx`) and one flat, per-ring key
+    (`sign_keys`) -- checked where they are declared, against the same
+    `pubk_rings` and for the same reason.
+    """
+    if len(s) != len(pubk_rings):
+        pubk_word = "ring" if len(pubk_rings) == 1 else "rings"
+        s_word = "ring" if len(s) == 1 else "rings"
+        err_msg = f"{len(pubk_rings)} pubkey {pubk_word} and {len(s)} s-value {s_word}"
+        raise BTClibValueError(err_msg)
+    for i, (pubk_ring, s_ring) in enumerate(zip(pubk_rings, s, strict=True)):
+        if len(s_ring) != len(pubk_ring):
+            s_word = "s-value" if len(s_ring) == 1 else "s-values"
+            key_word = "key" if len(pubk_ring) == 1 else "keys"
+            err_msg = f"ring {i} has {len(s_ring)} {s_word} for {len(pubk_ring)}"
+            err_msg += f" {key_word}"
+            raise BTClibValueError(err_msg)
+
+
 def sign(
     msg: Octets,
     ks: Sequence[int],
@@ -328,17 +364,21 @@ def sign(
         for pubk_ring in pubk_rings
     ]
 
-    # one entry per ring in each of the three, checked here rather than
+    # one entry per ring in each of the four, checked here rather than
     # left to the `strict=True` of the two loops below: a short ks would
     # truncate them silently and sign a subset of the rings -- a signature
     # over fewer rings than the caller asked for, which is the one thing a
     # ring signature must not do quietly. zip's own message is a
     # BTClibValueError's class with none of its content, naming "argument
     # 3" and no parameter of this function; strict=True stays, as the
-    # assertion that this check and those loops cannot drift apart
-    if not len(pubk_rings) == len(sign_key_idx) == len(ks):
-        err_msg = f"{len(pubk_rings)} rings, {len(sign_key_idx)} signing indexes"
-        err_msg += f" and {len(ks)} nonces"
+    # assertion that this check and those loops cannot drift apart.
+    # sign_keys used to be left out of this: a short one is the same
+    # shape mismatch _assert_matches_pubk_rings refuses on the
+    # verification side, and was reaching `sign_keys[i]` in step 2 as a
+    # bare IndexError instead (issue #1088)
+    if not len(pubk_rings) == len(sign_key_idx) == len(ks) == len(sign_keys):
+        err_msg = f"{len(pubk_rings)} rings, {len(sign_key_idx)} signing indexes, "
+        err_msg += f"{len(ks)} nonces and {len(sign_keys)} signing keys"
         raise BTClibValueError(err_msg)
 
     # step 1
@@ -442,7 +482,12 @@ def assert_as_valid(
     The rings are walked forward from `sig.e0` and must close on the
     `e0` they started from; errors carry the reason and which ring and
     position it happened at (`BorromeanRingError`), `verify` being the
-    boolean answer.
+    boolean answer. A `sig` whose ring shape disagrees with
+    `pubk_rings` -- a different number of rings, or a ring with a
+    different number of s-values than it has keys -- is refused first,
+    as a plain `BTClibValueError` naming the ring and the counts: two
+    arguments that do not describe the same object is not a check that
+    ran and failed, so it is not a `BorromeanRingError` (issue #1088).
 
     `sig` as octets is parsed with `BorromeanSig.parse`, which reads
     secp256k1 and sha256 always -- `ec` and `hf` are then not what
@@ -472,6 +517,13 @@ def assert_as_valid(
     # on the octets path just taken
     ec = sig.ec
 
+    # the octets path above cannot disagree with pubk_rings -- rsizes,
+    # read off pubk_rings itself, is what BorromeanSig.parse built sig.s
+    # from -- but a BorromeanSig handed in directly carries no such
+    # guarantee, and the walk below indexes sig.s[i][j] against
+    # pubk_ring[j] without ever re-checking it (issue #1088)
+    _assert_matches_pubk_rings(pubk_rings, sig.s)
+
     msg, m, e = _initialize(msg, pubk_rings, ec, hf)
     e0bytes = m
 
@@ -484,7 +536,14 @@ def assert_as_valid(
         if e[i][0] == 0:
             err_msg = "implausible signature failure"
             raise BorromeanRingError(err_msg, i, 0)
-        r = b"\0x00"
+        # no seed value: the loop below is the only reader of r, always
+        # assigning it in the same iteration before that read -- `else:
+        # e0bytes += r` fires on the loop's own last iteration, never
+        # before its first -- so a dead placeholder had nothing to seed
+        # (issue #1089). What used to be here, `b"\0x00"`, was not even
+        # an honest one: `\0` is Python's own NUL escape, so the literal
+        # read as the four bytes b"\x00x00", not the single null byte
+        # it looked like
         for j in range(keys_size):
             t = double_mult_var(-e[i][j], pubk_ring[j], sig.s[i][j], ec.G, ec)
             r = _bytes_from_ring_point(t, ec, i, j)

--- a/tests/ecc/borromean_test.py
+++ b/tests/ecc/borromean_test.py
@@ -425,6 +425,11 @@ def test_one_nonce_and_one_signing_index_per_ring() -> None:
     `zip` and no parameter of `sign`. The check is `sign`'s own now, and
     `strict=True` stays as the assertion that the two cannot drift
     apart.
+
+    `sign_keys` used to be left out of this check (issue #1088): a short
+    one reached `sign_keys[i]` in step 2 as a bare `IndexError`, the same
+    ring-count exposure `assert_as_valid` has for a mismatched `s` --
+    checked here now, before either walk, for the same reason.
     """
     ring_sizes = [3, 4]
     sign_key_idx = [2, 1]
@@ -437,12 +442,48 @@ def test_one_nonce_and_one_signing_index_per_ring() -> None:
         borromean.sign(msg, [1, 2], sign_key_idx, sign_keys, pubk_rings), BorromeanSig
     )
 
-    err_msg = "2 rings, 2 signing indexes and 1 nonces"
+    err_msg = "2 rings, 2 signing indexes, 1 nonces and 2 signing keys"
     with pytest.raises(BTClibValueError, match=err_msg):
         borromean.sign(msg, [1], sign_key_idx, sign_keys, pubk_rings)
-    err_msg = "2 rings, 1 signing indexes and 2 nonces"
+    err_msg = "2 rings, 1 signing indexes, 2 nonces and 2 signing keys"
     with pytest.raises(BTClibValueError, match=err_msg):
         borromean.sign(msg, [1, 2], sign_key_idx[:1], sign_keys, pubk_rings)
+    err_msg = "2 rings, 2 signing indexes, 2 nonces and 1 signing keys"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        borromean.sign(msg, [1, 2], sign_key_idx, sign_keys[:1], pubk_rings)
+
+
+def test_a_ring_shape_that_disagrees_with_pubk_rings_is_refused() -> None:
+    """A caller-built BorromeanSig whose shape disagrees with pubk_rings.
+
+    Before this fix, nothing checked that `sig.s` and `pubk_rings`
+    described the same shape before the walk indexed `sig.s[i][j]`
+    against `pubk_ring[j]`: a mismatch reached a bare `IndexError`,
+    neither a `BTClibValueError` nor a `BTClibRuntimeError`, so it
+    escaped `verify`'s `except (ValueError, BTClibRuntimeError)` too --
+    `verify` raised where it is documented to answer `False` (issue
+    #1088). The two cases named separately, as the issue's decision
+    asked: a ring with fewer scalars than keys, and fewer rings than
+    `pubk_rings` -- "the same defect one level up" -- each asserted
+    through both `assert_as_valid` and `verify`, since the escaping
+    `IndexError` was visible only through the second.
+    """
+    ec = secp256k1
+    q1 = mult(1, ec.G, ec)
+    q2 = mult(2, ec.G, ec)
+
+    # one ring, two keys, one s-value: fewer scalars than keys
+    sig = BorromeanSig((0).to_bytes(32, "big"), [[5]], ec)
+    err_msg = "ring 0 has 1 s-value for 2 keys"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        borromean.assert_as_valid(b"msg", sig, [[q1, q2]])
+    assert not borromean.verify(b"msg", sig, [[q1, q2]])
+
+    # one ring in the signature, two in pubk_rings: fewer rings
+    err_msg = "2 pubkey rings and 1 s-value ring"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        borromean.assert_as_valid(b"msg", sig, [[q1], [q2]])
+    assert not borromean.verify(b"msg", sig, [[q1], [q2]])
 
 
 # each maps an s-value to a key `_guess_signer` maximizes over the ring: a

--- a/tests/ecc/borromean_test.py
+++ b/tests/ecc/borromean_test.py
@@ -426,10 +426,10 @@ def test_one_nonce_and_one_signing_index_per_ring() -> None:
     `strict=True` stays as the assertion that the two cannot drift
     apart.
 
-    `sign_keys` used to be left out of this check (issue #1088): a short
-    one reached `sign_keys[i]` in step 2 as a bare `IndexError`, the same
-    ring-count exposure `assert_as_valid` has for a mismatched `s` --
-    checked here now, before either walk, for the same reason.
+    `sign_keys` is part of the same check: step 2 indexes it per ring
+    (`sign_keys[i]`), so a short one is the same ring-count exposure
+    `assert_as_valid` refuses for a mismatched `s`, checked here before
+    either walk for the same reason.
     """
     ring_sizes = [3, 4]
     sign_key_idx = [2, 1]
@@ -456,17 +456,14 @@ def test_one_nonce_and_one_signing_index_per_ring() -> None:
 def test_a_ring_shape_that_disagrees_with_pubk_rings_is_refused() -> None:
     """A caller-built BorromeanSig whose shape disagrees with pubk_rings.
 
-    Before this fix, nothing checked that `sig.s` and `pubk_rings`
-    described the same shape before the walk indexed `sig.s[i][j]`
-    against `pubk_ring[j]`: a mismatch reached a bare `IndexError`,
-    neither a `BTClibValueError` nor a `BTClibRuntimeError`, so it
-    escaped `verify`'s `except (ValueError, BTClibRuntimeError)` too --
-    `verify` raised where it is documented to answer `False` (issue
-    #1088). The two cases named separately, as the issue's decision
-    asked: a ring with fewer scalars than keys, and fewer rings than
-    `pubk_rings` -- "the same defect one level up" -- each asserted
-    through both `assert_as_valid` and `verify`, since the escaping
-    `IndexError` was visible only through the second.
+    `assert_as_valid` raises `BTClibValueError`, naming the ring and the
+    counts, for a `sig.s` whose shape does not match `pubk_rings`: the
+    two cases issue #1088 names separately, a ring with fewer scalars
+    than keys and fewer rings than `pubk_rings` -- "the same defect one
+    level up". `verify` is asserted for each case too, and not only
+    `assert_as_valid`: it is documented to answer `False` for an invalid
+    signature, and only calling it exercises that promise for this
+    input.
     """
     ec = secp256k1
     q1 = mult(1, ec.G, ec)


### PR DESCRIPTION
## What this answers

Closes #1088, closes #1089. Both are in `btclib/ecc/borromean.py`'s
verification walk, on top of PR #1079 (`26361234`), which landed first
per the issue's own ordering note.

**#1088.** `assert_as_valid` walked `sig.s[i][j]` straight against
`pubk_ring[j]` with nothing checking the two arguments describe the same
shape. A signature with fewer rings than `pubk_rings`, or a ring with
fewer s-values than it has keys, indexed past the end of a tuple and let
a bare `IndexError` escape — neither a `BTClibValueError` nor a
`BTClibRuntimeError`, so it escaped `verify`'s own
`except (ValueError, BTClibRuntimeError)` too, making `verify` raise
where it is documented to answer `False`.

Per the issue's decided comment:

- The check is a plain `BTClibValueError` naming the ring and the
  counts (e.g. `"ring 0 has 1 s-value for 2 keys"`), not
  `BorromeanRingError` — that class is a `BTClibRuntimeError` for a
  check that *ran and failed*; a shape mismatch is two arguments that
  never described the same object, so nothing was verified at all.
- `verify`'s `except` clause is unchanged. It already catches
  `BTClibValueError`, so `verify` becomes the documented boolean with no
  change of its own. `IndexError` is **not** added to that clause —
  doing so would hide this class of bug rather than fix it.
- The check runs once, before the walk, in both entry points.
  `assert_as_valid` gets a new `_assert_matches_pubk_rings(pubk_rings,
  sig.s)` call. `sign` had the same exposure through `sign_keys`, which
  was missing from its existing `len(pubk_rings) == len(sign_key_idx)
  == len(ks)` check and reached `sign_keys[i]` in step 2 as the same
  bare `IndexError` — folded into that check now.
- The test names the two cases separately (fewer scalars than keys;
  fewer rings than `pubk_rings`) and asserts what `verify` *returns*,
  not only what `assert_as_valid` raises.

**#1089.** The `r = b"\0x00"` seed at the top of `assert_as_valid`'s
per-ring loop was never a null byte — `\0` is Python's own NUL escape,
so the literal was the four bytes `b"\x00x00"` — and it was dead besides:
the loop is the only reader of `r`, and always assigns it in the same
iteration before that read. Dropped, with the reason in a comment.

## Verified against the tree, not assumed

- Reproduced the issue's exact snippet against `26361234` before
  fixing: both `assert_as_valid` calls and both `verify` calls raised a
  bare `IndexError`. After the fix, `assert_as_valid` raises
  `BTClibValueError` naming the ring and counts, and `verify` returns
  `False`, for both cases.
- Also checked a case the issue didn't name: a ring with zero keys
  (shapes agreeing on both sides) still reaches a bare `IndexError` in
  `assert_as_valid` (indexing `e[i][0]` on an empty list) and a
  `ZeroDivisionError` in `sign` (`(j_star + 1) % keys_size` with
  `keys_size == 0`). This predates PR #1079 same as #1088 did, is a
  different trigger than a shape *mismatch* between two arguments, and
  is outside this diff's decided scope — filed separately as #1094, not
  a finding against this PR.

## Gates, on the rebased tip

```
$ uv run pytest
28604 passed, 9 skipped, 100.00% coverage

$ uv run pre-commit run --all-files
all hooks passed

$ uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
build succeeded, 0 warnings
$ grep -rn 'href="#\./' docs/build/html --include='*.html'
(no matches, exit 1)
```

## CHANGELOG.md / RELEASE_NOTES.md

Two separate CHANGELOG.md entries, one fact each: the fixed defect
(#1088) and the dead literal (#1089). #1088 is source-breaking — an
escaping `IndexError` becomes `BTClibValueError`, and `verify` returns
`False` where it used to raise — so it has its own
RELEASE_NOTES.md breaking-changes bullet, with a before/after. #1089 is
dead-code removal with no behavior change and gets no RELEASE_NOTES.md
entry.

## Summary by Sourcery

Validate Borromean ring shapes before signing and verification so malformed inputs produce the documented errors and boolean verification result.

Bug Fixes:
- Reject Borromean signatures whose ring structure does not match the supplied public-key rings, returning False from verification instead of allowing an IndexError to escape.
- Normalize signing validation so incomplete signing-key inputs raise BTClibValueError rather than failing with an IndexError.

Enhancements:
- Remove the unused Borromean verification seed initializer.

Documentation:
- Document the changed Borromean validation and verification behavior, including the breaking exception change.

Tests:
- Add coverage for mismatched signature ring shapes and incomplete signing-key inputs.