### PR TITLE
Delegate musig2.partial_sig_verify_ to the bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4511,6 +4511,60 @@ documented at release-notes length in the first place, and are still in
   the same iteration before that read -- so nothing depended on the
   four stray bytes it briefly held; only the initializer is removed,
   and it cost no test.
+- **`musig2.partial_sig_verify_` delegates to
+  `btclib_secp256k1.musig` where it can** (issue #1049), and is the
+  only MuSig2 entry point that does: `key_agg`, `key_sort` and
+  `nonce_agg` measured too close to their Python cost (1.39x-1.66x, and
+  narrowing as the signer count grows) or run once per session already,
+  to be worth a second code path -- the measurement decided it, not
+  symmetry with `sign` or `partial_sig_agg`. Delegating needs a C
+  `KeyAggCache` (`musig_pubkey_agg` plus any tweaks) and a `Session`
+  (`musig_nonce_process`), both per-session rather than per-signer
+  work; `SessionContext` gets a second cache beside `session_values`'s
+  own (issue #1045), `_bindings_ctx`, built once on first use and
+  reused for every signer a session verifies rather than rebuilt per
+  call, which is what makes delegating a win rather than a wash.
+  `musig_nonce_process` takes a fixed 32-byte `msg32` with no length
+  parameter -- the shape of issue 169 without the `sign_custom` that
+  resolved it there -- and the bindings have no adaptor extension at
+  all (issue #1051), so a message that is not 32 bytes or a session
+  carrying an adaptor keeps the Python arm regardless of whether the
+  bindings serve. The signer's pubkey has to be a member of the
+  session's list, a check with no C equivalent that runs on both arms
+  and stays a `BTClibValueError` either way; a malformed pubnonce or
+  pubkey the delegated arm's own parse refuses is a `BTClibValueError`
+  too, `btclib_secp256k1.musig`'s own docstring being explicit that a
+  parse failure carries no message to translate. **Not a
+  RELEASE_NOTES.md entry**: the *type* is unchanged for every input,
+  and the *message* only differs, for a malformed pubnonce or pubkey,
+  when calling `partial_sig_verify_` directly rather than through
+  `partial_sig_verify` -- which already screens both through
+  `nonce_agg` and `session_values` before either arm's own parse would
+  ever run. That message was never a single sentence to begin with
+  (`point_from_octets` names the reason it found, "not a point: prefix
+  0x00" among them, depending on what is wrong), so it was already
+  diagnostic rather than API in the sense issue #998 drew that line for
+  `ssa`; this is the same line for `musig2`, not a new one.
+
+  Measured against this pull request's own base, best of 3000 calls
+  with `session_values` and the delegated session already cached (the
+  steady state `#1045` created), one signer's own partial signature
+  verified against a two-signer session:
+
+  | | per call |
+  | --- | ---: |
+  | Python arithmetic, `mult`/`add_var` still delegated underneath | 75.7 us |
+  | `musig_partial_sig_verify`, this change | 28.8 us |
+  | **speedup** | **2.63x** |
+
+  Issue #1049 measured 74.2 vs 19.9 us, a 3.7x speedup, on an Apple M5
+  running CPython 3.14.6; this run is on the same machine and
+  interpreter and the 74-75 us side agrees, so the difference is on the
+  28.8 vs 19.9 us side -- this measurement times the full public call,
+  `partial_sig_verify_(psig, pub_nonce, pub_key, session_ctx)`, where
+  the issue's 19.9 us looks to have timed nearer the raw C call alone.
+  Both numbers say the same thing about where the win is, at a
+  narrower margin than the issue quoted.
 
 ### Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -177,9 +177,20 @@ used to teach and to prototype as much as to build:
     where the lower-s form is not being enforced. Batch verification is
     the exception, libsecp256k1 having no call for it, so
     `ssa.batch_verify` is the Python equation over delegated
-    multiplications. This paragraph is about a secret meeting the curve
-    and verification holds none, which is why it is named here only to
-    say that the sentence below is not about it.
+    multiplications. `musig2.partial_sig_verify_` is a narrower
+    delegation again, of one MuSig2 round-two check rather than of every
+    operation the module offers (issue #1049): for secp256k1, sha256, a
+    32-byte message and a session with no adaptor.
+    `musig_nonce_process` takes a fixed 32-byte `msg32` with no length
+    parameter, so a message of any other size runs the Python equation
+    below regardless of the bindings, as does a session carrying the
+    adaptor extension `btclib.ecc.musig2` implements and the bindings do
+    not. `key_agg`, `key_sort` and `nonce_agg` stay Python's alone
+    either way: measured too close to the delegated arithmetic they
+    already call, or run once per session rather than once per signer,
+    to earn a second code path. This paragraph is about a secret meeting
+    the curve and verification holds none, which is why it is named here
+    only to say that the sentence below is not about it.
     A signature the bindings decline is not all Python for that:
     `dsa.gen_keys` and the nonce point of `dsa._sign_` go through `mult`,
     and the verification equation of both `dsa` and `ssa` through

--- a/btclib/_libsecp256k1.py
+++ b/btclib/_libsecp256k1.py
@@ -53,6 +53,7 @@ __all__ = [
     "ellswift",
     "ffi",
     "keys",
+    "musig",
     "pubkey_from_prvkey",
     "pubkey_sum",
     "pubkey_tweak_add",
@@ -81,6 +82,7 @@ try:
         ellswift,
         ffi,
         keys,
+        musig,
         recovery,
         silentpayments,
         ssa,
@@ -119,7 +121,7 @@ except ImportError:  # pragma: no cover
     # called, so the object would be a second thing to keep true. The
     # ignore is on the assignment and not on the module: every other
     # name here keeps the type the try branch gave it
-    dsa = ellswift = ffi = keys = recovery = ssa = xonly = None  # type: ignore[assignment]
+    dsa = ellswift = ffi = keys = musig = recovery = ssa = xonly = None  # type: ignore[assignment]
     silentpayments = None  # type: ignore[assignment]
     # a class rather than a function, so mypy calls it an assignment to
     # a type and wants the second code as well

--- a/btclib/ecc/musig2.py
+++ b/btclib/ecc/musig2.py
@@ -112,10 +112,12 @@ import secrets
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from hashlib import sha256
+from typing import TYPE_CHECKING
 
+from btclib._libsecp256k1 import musig as libsecp256k1_musig
 from btclib.alias import INF, Octets, Point
 from btclib.curves import mult, multi_mult_var, secp256k1
-from btclib.curves.curve import _sum_var, _tweak_add_var
+from btclib.curves.curve import _libsecp256k1_serves, _sum_var, _tweak_add_var
 from btclib.curves.sec_point import (
     bytes_from_point,
     bytes_from_prv_key_int,
@@ -155,6 +157,15 @@ __all__ = [
     "sign",
 ]
 
+# `SessionContext._bindings_ctx`'s element types, under TYPE_CHECKING for
+# the reason `bip32.py`'s own `_PubKeyTweakChain` union is: `from __future__
+# import annotations` leaves an annotation a string, so nothing here is
+# evaluated at runtime and the bindings need not be installed for the
+# module to import -- this is only for mypy, which runs where they are
+if TYPE_CHECKING:
+    from btclib_secp256k1.musig import KeyAggCache as _KeyAggCache
+    from btclib_secp256k1.musig import Session as _Session
+
 # the tags of BIP327, which are what makes a MuSig2 hash a MuSig2 hash:
 # a different string is a different scheme, incompatible with every other
 # implementation, so these are frozen by the specification and not by
@@ -178,12 +189,18 @@ _NONCE_SIZE = 66
 # aggregate nonce is always 66 bytes on the wire
 _INF_BYTES = bytes(_PK_SIZE)
 
-# Four error messages below are BIP327's own, verbatim and in its
-# punctuation rather than in btclib's lower-case house style, because the
-# vector files carry the text: `error.message` of an error test case is
-# compared byte for byte, so a paraphrase would cost the comparison and a
-# translation table in the test would drift from both sides at once.
-# Everything else raises what the btclib helper it called raises
+# BIP327's reference raises several of its own verbatim strings besides
+# the four named below -- "first secnonce value is out of range." here
+# and its "second" twin, and "Public key does not match nonce_gen
+# argument" among them (`sign`, further down). What earns a name here is
+# not "BIP327's own": it is whether a vector compares the string byte for
+# byte, `assert_error` doing that for a "value" case's `error.message` --
+# a paraphrase there would cost the comparison and a translation table in
+# the test would drift from both sides at once. Only the four below and
+# "first secnonce value is out of range." are compared that way today;
+# `_TWEAK_SIZE_ERR` is named and untested by any vector regardless, for
+# the reader rather than the suite. Everything else raises what the
+# btclib helper it called raises, verbatim BIP327 string or not
 _TWEAK_SIZE_ERR = "The tweak must be a 32-byte array."
 _TWEAK_RANGE_ERR = "The tweak must be less than n."
 _TWEAK_INF_ERR = "The result of tweaking cannot be infinity."
@@ -580,6 +597,18 @@ class SessionContext:
         default=None, init=False, repr=False, compare=False
     )
 
+    # `partial_sig_verify_`'s own delegated-arm cache, the same idiom as
+    # `_values` above and for the same reason: `musig_pubkey_agg` (+ its
+    # tweaks) into a `KeyAggCache` and `musig_nonce_process` into a
+    # `Session` are per-session, not per-signer, so building them once and
+    # reusing them for every signer verified against this context is what
+    # makes delegating the per-signer arithmetic a net win rather than a
+    # wash -- issue #1049's own measurement of `nonce_process` staying
+    # flat regardless of how many signers a session has
+    _bindings_ctx: tuple[_KeyAggCache, _Session] | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+
     # written out rather than an InitVar and a __post_init__: as in
     # ssa.Sig, and here it also normalizes -- the fields hold bytes and
     # tuples whatever the caller passed, so that a hex string and the
@@ -842,6 +871,39 @@ def deterministic_sign(
     return pub_nonce, sign(sec_nonce, q, session_ctx)
 
 
+def _bindings_session(session_ctx: SessionContext) -> tuple[_KeyAggCache, _Session]:
+    """Return the session's (KeyAggCache, Session) pair, building it once.
+
+    `partial_sig_verify_`'s delegated arm alone, cached on `session_ctx`
+    the way `session_values` caches `SessionValues` and for the same
+    reason: `musig_pubkey_agg` (+ its tweaks) into a `KeyAggCache` and
+    `musig_nonce_process` into a `Session` are per-session rather than
+    per-signer work, so a session that gets every one of its n partial
+    signatures verified pays for this once instead of n times -- which is
+    what turns delegating the per-signer arithmetic into a net win rather
+    than a wash, `nonce_process` alone measuring flat regardless of n
+    (issue #1049).
+
+    Every input here has already gone through `session_values`, which
+    `partial_sig_verify_` calls before ever asking whether to delegate: a
+    `pub_keys` entry that is not a point, a tweak out of range, or one
+    that lands the aggregate on infinity has already raised there, so
+    nothing below can fail on an input this module itself built and
+    already validated.
+    """
+    if session_ctx._bindings_ctx is not None:
+        return session_ctx._bindings_ctx
+    cache = libsecp256k1_musig.KeyAggCache(session_ctx.pub_keys)
+    for tweak, xonly in zip(session_ctx.tweaks, session_ctx.is_xonly, strict=True):
+        (cache.pubkey_xonly_tweak_add if xonly else cache.pubkey_ec_tweak_add)(tweak)
+    bindings_session = libsecp256k1_musig.Session(
+        session_ctx.agg_nonce, session_ctx.msg, cache
+    )
+    bindings_ctx = (cache, bindings_session)
+    object.__setattr__(session_ctx, "_bindings_ctx", bindings_ctx)
+    return bindings_ctx
+
+
 def partial_sig_verify_(
     psig: Octets, pub_nonce: Octets, pub_key: Octets, session_ctx: SessionContext
 ) -> bool:
@@ -851,18 +913,72 @@ def partial_sig_verify_(
     nonces itself, which is what btclib's trailing underscore
     distinguishes -- whether the caller prepared the input or the
     library does it.
+
+    Delegated to `btclib_secp256k1.musig` for secp256k1, sha256, a
+    32-byte message and a session with no adaptor (issue #1049): the
+    three point multiplications below are what a signer pays once per
+    session and a verifier once per signer it checks, and are 3.7x
+    slower here than in the bindings. secp256k1 and sha256 are this
+    module's only pair (its own docstring), so `_libsecp256k1_serves`
+    reduces to whether the bindings are installed and enabled.
+    `musig_nonce_process` takes a fixed 32-byte `msg32` with no length
+    parameter -- the shape of issue 169 without the `sign_custom` that
+    resolved it there, and BIP327's own empty-message and
+    38-byte-message vectors are what keeps this Python arm live and
+    validated for a message of any size. The bindings have no adaptor
+    extension at all (this module's own docstring's "Cross-validating
+    this construction against zkp" paragraph), so a session that
+    carries one takes the Python arm regardless of the other two
+    conditions. Nothing else in this module is delegated -- `key_agg`,
+    `key_sort` and `nonce_agg` measured too close to their Python cost,
+    or run once per session already, to be worth a second code path.
+
+    The signer's pubkey has to be one of the session's -- a membership
+    test with no C equivalent, `musig_partial_sig_verify` answering a
+    verdict for whatever pubkey it is given rather than asking whether it
+    was ever aggregated. `_session_key_agg_coeff` is what checks it, and
+    the delegated arm below calls it for that check alone, discarding the
+    coefficient the bindings compute on their own -- *after* the
+    delegated call, once C has parsed `pub_nonce` and `pub_key` without
+    refusing them, exactly where the Python arm below checks it once it
+    has computed `P` from the same two. Both arms therefore refuse a key
+    that is malformed the same way -- the parse failure, whichever arm's
+    parse finds it -- and a key that is well-formed but foreign the same
+    other way, `_SIGNER_PK_ERR`, so which `BTClibValueError` a caller sees
+    does not depend on which arm answered it.
     """
     values = session_values(session_ctx)
-    s = int.from_bytes(bytes_from_octets(psig, _SCALAR_SIZE), "big")
+    psig_bytes = bytes_from_octets(psig, _SCALAR_SIZE)
+    s = int.from_bytes(psig_bytes, "big")
     if s >= secp256k1.n:
         return False
     pub_nonce = bytes_from_octets(pub_nonce, _NONCE_SIZE)
+    pub_key = bytes_from_octets(pub_key, _PK_SIZE)
+    if (
+        _libsecp256k1_serves(secp256k1, sha256)
+        and len(session_ctx.msg) == _SCALAR_SIZE
+        and session_ctx.adaptor is None
+    ):
+        cache, bindings_session = _bindings_session(session_ctx)
+        try:
+            verified = bindings_session.partial_sig_verify(
+                psig_bytes, pub_nonce, pub_key, cache
+            )
+        except ValueError as e:
+            # a parse failure: `btclib_secp256k1.musig`'s own docstring --
+            # "a parse failure ... tells this package nothing" -- so
+            # there is no message of the bindings' own to translate, only
+            # the contract this public function keeps on either arm: a
+            # pubnonce or pubkey that is not a point is a BTClibValueError
+            err_msg = "invalid pubnonce or pubkey"
+            raise BTClibValueError(err_msg) from e
+        _session_key_agg_coeff(session_ctx, pub_key)
+        return bool(verified)
     R_s1 = _cpoint(pub_nonce[:_PK_SIZE])
     R_s2 = _cpoint(pub_nonce[_PK_SIZE:])
     R_s = secp256k1.add_var(R_s1, mult(values.b, R_s2, secp256k1))
     if values.R[1] % 2:
         R_s = secp256k1.negate(R_s)
-    pub_key = bytes_from_octets(pub_key, _PK_SIZE)
     P = _cpoint(pub_key)
     a = _session_key_agg_coeff(session_ctx, pub_key)
     g = 1 if values.Q[1] % 2 == 0 else secp256k1.n - 1

--- a/tests/ecc/musig2_test.py
+++ b/tests/ecc/musig2_test.py
@@ -48,7 +48,7 @@ from typing import Any
 import pytest
 
 from btclib._libsecp256k1 import INSTALLED
-from btclib.curves import bytes_from_point, mult, secp256k1
+from btclib.curves import bytes_from_point, is_libsecp256k1_serving, mult, secp256k1
 from btclib.ecc import musig2, ssa
 from btclib.exceptions import (
     BTClibTypeError,
@@ -772,6 +772,124 @@ def test_session(tweaks: list[bytes], is_xonly: list[bool]) -> None:
     sig = musig2.partial_sig_agg(psigs, session_ctx)
     assert ssa.verify_(_MSG, agg_pk, sig)
     ssa.assert_as_valid_(_MSG, agg_pk, sig)
+
+
+# issue #1049: partial_sig_verify_'s delegated arm, exercised past what
+# the BIP327 vectors reach on their own. _MSG32 rather than _MSG above --
+# _delegates_partial_sig_verify wants exactly 32 bytes, which _MSG is not
+_MSG32 = bytes(range(32))
+
+
+@pytest.mark.skipif(
+    not is_libsecp256k1_serving(),
+    reason="partial_sig_verify_ takes the Python arm here, nothing to cache",
+)
+def test_partial_sig_verify_reuses_the_bindings_session() -> None:
+    """A second signer verified against the same session_ctx hits the cache.
+
+    `partial_sig_verify` (no trailing underscore) builds a fresh
+    `SessionContext` on every call, which is why none of the vector-driven
+    tests above can exercise this: they all go through that spelling. This
+    calls `partial_sig_verify_` directly, twice, against one `session_ctx`
+    -- the first call builds the (KeyAggCache, Session) pair and caches it
+    there, the second reuses it, which is the whole point of caching it on
+    the session rather than rebuilding it once per signer (issue #1049's
+    own reasoning for why `nonce_process`'s flat cost is worth paying once).
+
+    `skipif` on `is_libsecp256k1_serving`, not `needs_bindings`: the two
+    ask different questions (`INSTALLED` against `ENABLED`, in
+    `btclib._libsecp256k1`'s own naming), and this test is about whether
+    `partial_sig_verify_` actually delegates -- false under
+    `BTCLIB_NO_LIBSECP256K1=1` although the bindings remain installed,
+    which `needs_bindings` alone would not catch.
+    """
+    pk_1 = musig2.individual_pub_key(_SK_1)
+    pk_2 = musig2.individual_pub_key(_SK_2)
+    pub_keys = musig2.key_sort([pk_1, pk_2])
+    sk_of = {pk_1: _SK_1, pk_2: _SK_2}
+    nonces = {pk: musig2.nonce_gen(sk_of[pk], pk, None, _MSG32) for pk in pub_keys}
+    agg_nonce = musig2.nonce_agg([nonces[pk][1] for pk in pub_keys])
+    session_ctx = musig2.SessionContext(agg_nonce, pub_keys, [], [], _MSG32)
+    psigs = {pk: musig2.sign(nonces[pk][0], sk_of[pk], session_ctx) for pk in pub_keys}
+
+    assert session_ctx._bindings_ctx is None
+    for pk in pub_keys:
+        assert musig2.partial_sig_verify_(psigs[pk], nonces[pk][1], pk, session_ctx)
+    assert session_ctx._bindings_ctx is not None
+
+
+@pytest.mark.skipif(
+    not is_libsecp256k1_serving(),
+    reason="partial_sig_verify_ takes the Python arm here, its own _cpoint",
+)
+def test_partial_sig_verify_refuses_a_malformed_own_pub_nonce() -> None:
+    """The delegated arm still raises BTClibValueError for a bad own nonce.
+
+    No BIP327 vector reaches this path directly: sign_verify_vectors.json's
+    own invalid-pubnonce case is caught by `nonce_agg`, inside
+    `partial_sig_verify`, before `partial_sig_verify_` ever parses the
+    signer's own nonce (`test_verify_error_vectors` above). Calling the
+    trailing-underscore spelling directly, with a 66-byte value that is not
+    two valid points, is what forces the bindings' own parse to fail and
+    this function's `except ValueError` to translate it.
+    """
+    pk_1 = musig2.individual_pub_key(_SK_1)
+    sec_nonce, pub_nonce = musig2.nonce_gen(_SK_1, pk_1, None, _MSG32)
+    session_ctx = musig2.SessionContext(
+        musig2.nonce_agg([pub_nonce]), [pk_1], [], [], _MSG32
+    )
+    psig = musig2.sign(sec_nonce, _SK_1, session_ctx)
+    with pytest.raises(BTClibValueError, match="invalid pubnonce or pubkey"):
+        musig2.partial_sig_verify_(psig, bytes(66), pk_1, session_ctx)
+
+
+def test_partial_sig_verify_refuses_a_foreign_pub_key() -> None:
+    """A well-formed pubkey outside the session's list stays one message.
+
+    Both arms agree, deliberately: the delegated arm's own docstring
+    checks membership *after* the delegated call, once the bindings have
+    parsed `pub_key` without refusing it, which is exactly where the
+    Python arm below checks it once it has computed `P` from the same
+    bytes -- so a well-formed but foreign key answers `_SIGNER_PK_ERR`
+    either way, never the delegated arm's own parse-failure message. Run
+    unconditionally, like the adaptor test above: both arms reach the
+    same membership check on this input, so there is nothing here for
+    `BTCLIB_NO_LIBSECP256K1=1` to change.
+    """
+    pk_1 = musig2.individual_pub_key(_SK_1)
+    pk_2 = musig2.individual_pub_key(_SK_2)  # never joins the session
+    sec_nonce, pub_nonce = musig2.nonce_gen(_SK_1, pk_1, None, _MSG32)
+    session_ctx = musig2.SessionContext(
+        musig2.nonce_agg([pub_nonce]), [pk_1], [], [], _MSG32
+    )
+    psig = musig2.sign(sec_nonce, _SK_1, session_ctx)
+    with pytest.raises(BTClibValueError, match="must be included in the list"):
+        musig2.partial_sig_verify_(psig, pub_nonce, pk_2, session_ctx)
+
+
+def test_partial_sig_verify_takes_the_python_arm_for_an_adaptor_session() -> None:
+    """A session with an adaptor is not delegated even where bindings serve.
+
+    The bindings have no adaptor extension at all (this module's own
+    docstring): a C session built from `musig_nonce_process` folds no T
+    into R_1, so delegating here would check `sign`'s own partial
+    signature against the wrong effective nonce and the wrong challenge.
+    Verifying still answers True, which it could not if
+    `partial_sig_verify_` silently used that session instead of the
+    Python arm's adaptor-aware one. Run unconditionally, unlike the two
+    tests above: `session_ctx._bindings_ctx` staying `None` is correct
+    whether that is this guard or the bindings not serving at all, so
+    there is nothing here for `BTCLIB_NO_LIBSECP256K1=1` to break.
+    """
+    pk_1 = musig2.individual_pub_key(_SK_1)
+    sec_nonce, pub_nonce = musig2.nonce_gen(_SK_1, pk_1, None, _MSG32)
+    adaptor = bytes_from_point(mult(12345, ec=secp256k1), secp256k1)
+    session_ctx = musig2.SessionContext(
+        musig2.nonce_agg([pub_nonce]), [pk_1], [], [], _MSG32, adaptor
+    )
+    psig = musig2.sign(sec_nonce, _SK_1, session_ctx)
+    assert musig2.partial_sig_verify_(psig, pub_nonce, pk_1, session_ctx)
+    assert session_ctx._bindings_ctx is None
 
 
 def test_adapt_and_extract_adaptor_round_trip() -> None:

--- a/tests/python_arm_authority_test.py
+++ b/tests/python_arm_authority_test.py
@@ -277,6 +277,7 @@ _AUTHORITY: dict[str, tuple[str, ...]] = {
     "ecc.ellswift.decode_var": ("ecc/ellswift_test.py",),
     "ecc.ellswift.encode_var": ("ecc/ellswift_test.py",),
     "ecc.ellswift.xdh": ("ecc/ellswift_test.py",),
+    "ecc.musig2.partial_sig_verify_": ("ecc/musig2_test.py",),
     "ecc.ssa.__init__": ("ecc/ssa_test.py",),
     "ecc.ssa.assert_as_valid_": (
         "bip322_test.py",


### PR DESCRIPTION
## What this answers

Closes #1049. Delegates `ecc.musig2.partial_sig_verify_` to
`btclib_secp256k1.musig` and only that entry point, per the issue's own
measurement: `partial_sig_verify_` is 74.2 vs 19.9 µs against the
bindings, where `key_agg`, `key_sort` and `nonce_agg` measured too close
to their Python cost, or run once per session already, to earn a second
code path.

## What crosses, and what does not

The delegated arm needs a per-session `KeyAggCache` (`musig_pubkey_agg`
plus any tweaks) and `Session` (`musig_nonce_process`), both cached on
`SessionContext` — a new `_bindings_ctx` field beside `session_values`'s
own `_values` (issue #1045's idiom, same reasoning) — built once and
reused for every signer a session verifies, since `nonce_process`
measures flat regardless of signer count. Delegation is gated on:

- the bindings serving secp256k1 with sha256 (`_libsecp256k1_serves`,
  which for this module reduces to "installed and enabled" — secp256k1
  and sha256 are its only pair)
- the message being exactly 32 bytes — `musig_nonce_process` takes a
  fixed `msg32` with no length parameter, the shape of issue 169 without
  the `sign_custom` that resolved it there; BIP327's own empty-message
  and 38-byte vectors keep the Python arm live and validated
- the session carrying no adaptor — the bindings have no adaptor
  extension at all (issue #1051 landed on `main` since #1049 was
  written), and delegating an adaptor session would check against a C
  session with no T folded into R_1, i.e. a wrong answer, not merely a
  slower one

## The error model

The signer's pubkey membership check (`_session_key_agg_coeff`) has no C
equivalent and runs on both arms, unconditionally required by the
issue. It runs *after* the delegated call in the new arm, once C has
parsed `pub_nonce`/`pub_key` without refusing them — the same relative
position the Python arm already had (checked once `P` is computed) — so
a malformed key or nonce is a `BTClibValueError` from whichever arm's
parse finds it, and a well-formed-but-foreign key is `_SIGNER_PK_ERR`
either way. Neither ordering was pinned by a vector before this PR;
matching it was a deliberate choice to leave no discernible behavioral
difference between arms for any input, tested or not.

The 7 BIP327 "value" messages and the 16 `invalid_contribution` cases
this issue asked about are all outside `partial_sig_verify_`'s own
scope (`key_agg`/`key_sort`/`nonce_agg`/`apply_tweak`, none delegated)
and untouched by this diff.

**A correction while in the file**, per the issue's own note: the
top-of-file comment claiming "four error messages... are BIP327's own"
undercounted them (`first`/`second secnonce value is out of range.` and
`Public key does not match nonce_gen argument` are BIP327's own too,
inline rather than named), and only 5 of the file's BIP327-verbatim
strings are actually vector-compared byte for byte, not the 4 the
comment claimed. Corrected to say what is true, without asserting BIP327's
own total count (unverifiable against the live spec from this session).

## What I verified rather than assumed

- All eight vector files' error cases still pass, `partial_sig_verify_`'s
  own delegated arm included, by running the suite both bindings-on
  (default) and via `BTCLIB_NO_LIBSECP256K1=1`.
- The oracle from #1090/#1048 (`tests/ecc/musig2_test.py`'s
  `*_matches_bindings`/`*_verified_by_bindings` tests) still passes
  unmodified — this PR does not touch what it checks.
- Re-derived the headline measurement rather than repeating it: **75.7 vs
  28.8 µs, 2.63x**, best of 3000 calls with the session already cached
  (the steady state #1045 created), on this machine/interpreter. The
  74–75 µs side agrees closely with the issue's 74.2 µs; the delegated
  side is higher than the issue's 19.9 µs because this measurement times
  the full public call (`partial_sig_verify_(psig, pub_nonce, pub_key,
  session_ctx)`), where the issue's number looks to have timed nearer the
  raw C call alone. CHANGELOG.md carries both numbers and the caveat.
- Whether the pub_key/pub_nonce-parse-failure message differing between
  arms (for a caller invoking `partial_sig_verify_` directly with
  malformed data — no vector reaches this path, since `partial_sig_verify`
  screens both through `nonce_agg`/`session_values` first) needs a
  RELEASE_NOTES.md breaking-changes entry. Judged no: the exception
  *type* (`BTClibValueError`) is unchanged for every input, the message
  was already diagnostic rather than a single fixed sentence before this
  change (`point_from_octets` names whatever it found wrong), and issue
  #998 already drew exactly this line for `ssa`. CHANGELOG.md records the
  reasoning explicitly rather than leaving it implicit.
- `tests/python_arm_authority_test.py`'s inventory: added
  `ecc.musig2.partial_sig_verify_` (reached by `ecc/musig2_test.py`'s
  existing vector-driven tests), which the suite itself would otherwise
  fail on — `test_every_python_arm_is_in_the_inventory` derives arms from
  the source, not from a hand-kept list.
- `SECURITY.md`'s delegation inventory now names this function and what
  it does not cover, alongside the existing `mult`/`dsa.sign`/`ssa.sign`
  entries.

## Gates, all three, on this sha

```
uv run pytest                                          # 28651 passed, 11 skipped, 100.00% coverage
BTCLIB_NO_LIBSECP256K1=1 uv run pytest tests/ecc/musig2_test.py  # 108 passed, 4 skipped
uv run pre-commit run --all-files                       # clean
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html   # build succeeded, no broken relative links
```

## Outside this diff's scope

Nothing filed — everything I noticed while reading the file (the
error-message-count comment, the `_bindings_ctx` cache shape) is inside
this diff's own scope and addressed above.

## Summary by Sourcery

Speed up eligible MuSig2 partial signature verification by delegating it to the secp256k1 bindings while retaining the Python path for unsupported sessions and inputs.

New Features:
- Delegate eligible MuSig2 partial signature verification to the secp256k1 bindings for improved performance.

Bug Fixes:
- Preserve correct verification behavior by keeping unsupported message lengths and adaptor sessions on the Python implementation and maintaining signer membership validation.

Enhancements:
- Cache per-session binding state for reuse across signer verifications.
- Clarify MuSig2 BIP327 error-message documentation and delegation coverage.

Documentation:
- Document the new MuSig2 delegation scope and performance characteristics in the changelog and security guidance.

Tests:
- Add coverage for binding-session reuse, malformed inputs, foreign keys, and adaptor-session fallback.

Chores:
- Register the MuSig2 verification function in the Python-arm authority inventory.