### PR TITLE
Refuse a borromean ring with no keys, and a sign_key_idx out of range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4512,6 +4512,39 @@ documented at release-notes length in the first place, and are still in
   four stray bytes it briefly held; only the initializer is removed,
   and it cost no test.
 
+- **`BorromeanSig.assert_valid` refuses a ring with no keys** (issue
+  #1094). A ring of size zero proves nothing about any key, and nothing
+  checked for one: `BorromeanSig(e0, [[]], ec)` built silently, and a
+  zero-key ring that agreed on shape with `pubk_rings` -- so #1088's new
+  `_assert_matches_pubk_rings` had nothing to say about it -- still
+  reached `assert_as_valid` indexing `e[i][0]` on the empty list
+  `_initialize` builds for it, a bare `IndexError` that escaped
+  `verify`'s `except (ValueError, BTClibRuntimeError)` the same way
+  #1088's did. The new check sits beside `assert_valid`'s existing "no
+  rings" one, one ring's worth of nesting down, and runs wherever that
+  method already does: at construction (`check_validity`'s default is
+  `True`), from `BorromeanSig.parse`, and unconditionally inside
+  `assert_as_valid` -- so `verify` answers `False` for it like any other
+  invalid signature. It is not what fixes `sign`'s own exposure to the
+  same input, `(j_star + 1) % keys_size` being a `ZeroDivisionError` for
+  `keys_size == 0` reached long before any `BorromeanSig` is built: the
+  next entry's bound on `sign_key_idx[i]` is what closes that one, a
+  zero-size ring failing it for every value since no index is valid
+  there.
+
+- **`sign` refuses a `sign_key_idx[i]` that is not a position in its own
+  ring** (issue #1095). `sign_key_idx`, `ks`, `sign_keys` and
+  `pubk_rings` were checked to carry one entry per ring, and nothing
+  beyond that: a `sign_key_idx[i]` past the end of its own ring was not
+  bounded by that count, and step 2's inner loop then walked `s` and
+  `pubk_rings` past the end of the ring's tuple, a bare `IndexError`. A
+  negative value did not raise at all -- Python's own negative indexing
+  quietly read a different position than the one named, so `sign`
+  returned a `BorromeanSig` that silently does not verify. The new
+  `_assert_sign_key_idx_in_range` refuses both, once per ring before
+  either step, as a `BTClibValueError` naming the ring, its size and the
+  index.
+
 ### Security
 
 - **`SECURITY.md` says the bindings offer a buffer for a secret, and

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -488,6 +488,33 @@ full year, short month, short day (YYYY-M-D)
   `verify`, which no longer raises here. CHANGELOG.md has why the check
   is a `BTClibValueError` and not `BorromeanRingError`.
 
+- **`BorromeanSig(e0, [[]], ...)` -- a ring with no keys -- is refused,
+  where it used to build silently.** Before: `BorromeanSig.__init__` and
+  `BorromeanSig.parse`, both with `check_validity`'s default of `True`,
+  accepted it; `assert_as_valid` then reached a bare `IndexError`
+  indexing `e[i][0]` on the empty list built for that ring, escaping
+  `verify`'s `except (ValueError, BTClibRuntimeError)` the same way
+  issue #1088's did. Now: `BorromeanSig.assert_valid` refuses it as
+  `BTClibValueError`, so construction and `BorromeanSig.parse` raise it
+  directly, `assert_as_valid` raises it in place of the `IndexError`,
+  and `verify` answers `False` for it like any other invalid signature.
+  A caller building a `BorromeanSig` with `check_validity=False` to hold
+  one anyway still has it refused the moment `assert_as_valid`,
+  `serialize` or `assert_valid` itself runs. CHANGELOG.md has why the
+  check lives on `BorromeanSig` and not beside `_assert_matches_pubk_rings`.
+
+- **`borromean.sign` refuses a `sign_key_idx[i]` that is not a position
+  in its own ring.** Before: a value at or past the ring's size walked
+  `s[i][j - 1]` and `pubk_rings[i][j - 1]` past the end of the ring's
+  tuple in step 2, a bare `IndexError`; a negative value did not raise
+  at all, Python's own negative indexing quietly signing a different
+  position than the one named and returning a `BorromeanSig` that does
+  not verify. Both are `BTClibValueError` now, naming the ring, its size
+  and the index, raised once before step 1 -- which is also what refuses
+  a ring with no keys on the signing side, no index being valid into an
+  empty one. CHANGELOG.md has why this is a bound on `sign_key_idx` and
+  not a copy of the empty-ring check above.
+
 ### Worth knowing, though nothing raises
 
 - **Signing on the Python arm now checks the signature before answering

--- a/btclib/ecc/borromean.py
+++ b/btclib/ecc/borromean.py
@@ -192,7 +192,7 @@ class BorromeanSig:
             self.assert_valid()
 
     def assert_valid(self) -> None:
-        """Refuse a bad curve, no rings, or a scalar s outside 0..n-1."""
+        """Refuse a bad curve, no rings, an empty ring, or an out-of-range s."""
         # the curve first, as in dsa.Sig.assert_valid and ssa.Sig.assert_valid
         # and for their reason: every s below is read against it
         _assert_valid_ec(self.ec)
@@ -207,6 +207,19 @@ class BorromeanSig:
             raise BTClibValueError("no rings")
 
         for i, ring in enumerate(self.s):
+            # a ring with no keys proves nothing about any key, the same
+            # degeneracy as no rings at all, one level down: left
+            # unrefused here, `assert_as_valid` indexed e[i][0] on the
+            # empty list `_initialize` builds for it and a bare
+            # IndexError escaped where `verify` is documented to answer
+            # `False` (issue #1094). Checked here rather than in
+            # `assert_as_valid` or `_assert_matches_pubk_rings` because
+            # it holds for `self.s` alone, independent of whatever
+            # `pubk_rings` a caller later checks it against -- and this
+            # way `BorromeanSig(e0, [[]], ec)` is already refused at
+            # construction, check_validity's default being True
+            if not ring:
+                raise BTClibValueError(f"ring {i} has no keys")
             for j, value in enumerate(ring):
                 if not 0 <= value < self.ec.n:
                     err_msg = "scalar s not in 0..n-1: "
@@ -327,6 +340,33 @@ def _assert_matches_pubk_rings(
             raise BTClibValueError(err_msg)
 
 
+def _assert_sign_key_idx_in_range(
+    pubk_rings: Sequence[PubkeyRing], sign_key_idx: Sequence[int]
+) -> None:
+    """Refuse a sign_key_idx[i] that is not a position in pubk_rings[i].
+
+    Nothing bounded what a value of `sign_key_idx` pointed at: `sign`'s
+    own length check only compares the *counts* of `pubk_rings`,
+    `sign_key_idx`, `ks` and `sign_keys`, one entry per ring on all four,
+    and says nothing about what a value inside `sign_key_idx` names.
+    Unchecked, step 1's `(j_star + 1) % keys_size` is a ZeroDivisionError
+    for a ring with no keys (issue #1094, on the signing side --
+    `BorromeanSig.assert_valid`'s own check cannot reach this walk, which
+    runs before any `BorromeanSig` is built), and step 2's `range(1,
+    j_star + 1)` walks past the end of a ring's tuple for a value at or
+    past its size (issue #1095); a negative value does not raise at all,
+    Python's own negative indexing quietly reading a different position
+    than the one named. `0 <= sign_key_idx[i] < len(pubk_rings[i])`
+    refuses all three, checked here once before either step.
+    """
+    for i, (pubk_ring, j_star) in enumerate(zip(pubk_rings, sign_key_idx, strict=True)):
+        if not 0 <= j_star < len(pubk_ring):
+            key_word = "key" if len(pubk_ring) == 1 else "keys"
+            err_msg = f"ring {i} has {len(pubk_ring)} {key_word}, "
+            err_msg += f"sign_key_idx {j_star} is not a valid index"
+            raise BTClibValueError(err_msg)
+
+
 def sign(
     msg: Octets,
     ks: Sequence[int],
@@ -345,6 +385,11 @@ def sign(
     key in each ring, `sign_keys` the real private key of each ring --
     `sign_keys[i]` signs at `pubk_rings[i][sign_key_idx[i]]` -- and
     `pubk_rings` the full public rings, real key included.
+    `sign_key_idx[i]` must be a valid index into `pubk_rings[i]`, refused
+    with `BTClibValueError` naming the ring, the index and the ring's
+    size otherwise -- a ring with no keys has none, whatever the index
+    (issue #1094), and a value the ring's size does not reach either
+    (issue #1095).
 
     A `BorromeanSig`, because that is what it is: the result verifies
     with `assert_as_valid`/`verify`, serializes with
@@ -381,6 +426,14 @@ def sign(
         err_msg = f"{len(pubk_rings)} rings, {len(sign_key_idx)} signing indexes, "
         err_msg += f"{len(ks)} nonces and {len(sign_keys)} signing keys"
         raise BTClibValueError(err_msg)
+
+    # sign_key_idx[i] is the real signer's position in pubk_rings[i], and
+    # nothing checked it was one before step 1 read it -- see the
+    # docstring above for the two ways that went wrong (issues #1094,
+    # #1095). Checked once here, before either step, the same shape as
+    # the length check just above and #1088's decision on the
+    # verification side
+    _assert_sign_key_idx_in_range(pubk_rings, sign_key_idx)
 
     # step 1
     for i, (pubk_ring, j_star, k) in enumerate(
@@ -488,7 +541,11 @@ def assert_as_valid(
     different number of s-values than it has keys -- is refused first,
     as a plain `BTClibValueError` naming the ring and the counts: two
     arguments that do not describe the same object is not a check that
-    ran and failed, so it is not a `BorromeanRingError` (issue #1088).
+    ran and failed, so it is not a `BorromeanRingError` (issue #1088). A
+    `sig` carrying a ring with no keys is refused too, by `sig.assert_valid`
+    below rather than here -- it proves nothing about any key regardless
+    of what `pubk_rings` says, so `BorromeanSig`'s own invariant is what
+    refuses it (issue #1094).
 
     `sig` as octets is parsed with `BorromeanSig.parse`, which reads
     secp256k1 and sha256 always -- `ec` and `hf` are then not what

--- a/tests/ecc/borromean_test.py
+++ b/tests/ecc/borromean_test.py
@@ -483,6 +483,65 @@ def test_a_ring_shape_that_disagrees_with_pubk_rings_is_refused() -> None:
     assert not borromean.verify(b"msg", sig, [[q1], [q2]])
 
 
+def test_a_ring_with_no_keys_is_refused() -> None:
+    """A ring of size zero signs nothing, even where every shape agrees.
+
+    `_assert_matches_pubk_rings` only compares the *counts* of two
+    arguments, so `sig.s == [[]]` against `pubk_rings == [[]]` passes it
+    -- both are one ring of zero. The walk still cannot run: `sign`'s
+    step 1 divides by `keys_size` (`ZeroDivisionError`), and
+    `assert_as_valid` indexes `e[i][0]` on the empty list `_initialize`
+    builds for it (`IndexError`), neither a `BTClibValueError` nor a
+    `BTClibRuntimeError`, so the second escaped `verify`'s own
+    `except (ValueError, BTClibRuntimeError)` (issue #1094).
+
+    The fix is `BorromeanSig.assert_valid`'s own new check, so it holds
+    at construction already -- before `assert_as_valid` or `verify` are
+    even reached -- and `sign`'s new bound on `sign_key_idx[i]`, which a
+    zero-size ring fails for every value since no index is valid there.
+    """
+    ec = secp256k1
+
+    with pytest.raises(BTClibValueError, match="ring 0 has no keys"):
+        BorromeanSig((0).to_bytes(32, "big"), [[]], ec)
+
+    sig = BorromeanSig((0).to_bytes(32, "big"), [[]], ec, check_validity=False)
+    with pytest.raises(BTClibValueError, match="ring 0 has no keys"):
+        borromean.assert_as_valid(b"msg", sig, [[]])
+    assert not borromean.verify(b"msg", sig, [[]])
+
+    err_msg = "ring 0 has 0 keys, sign_key_idx 0 is not a valid index"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        borromean.sign(b"msg", [1], [0], [1], [[]])
+
+
+def test_sign_key_idx_out_of_range_is_refused() -> None:
+    """A sign_key_idx[i] that is not a position in its own ring.
+
+    `sign`'s existing shape check compares the *counts* of `pubk_rings`,
+    `sign_key_idx`, `ks` and `sign_keys`, which all agree here -- one
+    entry each. Nothing bounded what `sign_key_idx[0]` itself pointed
+    at: too large a value walked `s[i][j - 1]` and `pubk_rings[i][j - 1]`
+    past the end of the ring's tuple in step 2, a bare `IndexError`
+    (issue #1095); a negative one wrapped to a Python-legal index and
+    signed a position other than the one it named, silently producing a
+    signature that does not verify rather than raising anything at all.
+    Both are now `BTClibValueError`, naming the ring, its size and the
+    index, before either step runs.
+    """
+    ec = secp256k1
+    q1 = mult(1, ec.G, ec)
+    q2 = mult(2, ec.G, ec)
+
+    err_msg = "ring 0 has 2 keys, sign_key_idx 5 is not a valid index"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        borromean.sign(b"msg", [1], [5], [1], [[q1, q2]])
+
+    err_msg = "ring 0 has 2 keys, sign_key_idx -1 is not a valid index"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        borromean.sign(b"msg", [1], [-1], [1], [[q1, q2]])
+
+
 # each maps an s-value to a key `_guess_signer` maximizes over the ring: a
 # published signature must not let any of them recover which position was
 # the real signer. "bit_length" and "value" are the two the unreduced real


### PR DESCRIPTION
## What this answers

Closes #1094, closes #1095. Both are in `btclib/ecc/borromean.py`, on
top of PR #1093 (`bcf81ccd`), which fixed #1088 minutes before this
branch started.

**#1094.** A ring of size zero agrees on shape with `pubk_rings`, so
#1093's new `_assert_matches_pubk_rings` -- which only compares the
*counts* on both sides -- has nothing to say about it, and the walk
still crashed: `assert_as_valid` indexed `e[i][0]` on the empty list
`_initialize` builds for a zero-key ring, a bare `IndexError` that
escaped `verify`'s `except (ValueError, BTClibRuntimeError)`; `sign`'s
step 1 divided by `keys_size`, a `ZeroDivisionError`.

**#1095.** `sign_key_idx[i]` was never bounds-checked against its own
ring's size. A value at or past the ring's size walked `s[i][j - 1]`
and `pubk_rings[i][j - 1]` past the end of the ring's tuple in step 2,
a bare `IndexError`, reachable even when every sequence's *length*
agreed with every other.

## The design question

#1088, #1094 and #1095 are three triggers of one class -- a caller's
arguments do not describe a signable/verifiable configuration, and the
walk discovers it by indexing off the end -- but they did not collapse
into one check. They split along the two entry points instead, because
`assert_as_valid` and `sign` do not share an argument for either
question:

- **The verification side (`assert_as_valid`/`verify`).** A ring with
  no keys proves nothing about any key, independent of whatever
  `pubk_rings` a caller later checks it against -- it is a fact about
  `sig.s` alone. So the check lives on `BorromeanSig.assert_valid`
  itself, beside its existing "no rings" refusal, one ring's worth of
  nesting down, rather than in `_assert_matches_pubk_rings` or
  `assert_as_valid`. That single check now runs at construction
  (`check_validity`'s default is `True`), from `BorromeanSig.parse`,
  and unconditionally inside `assert_as_valid`, so `verify` answers
  `False` for it like any other invalid signature.

- **The signing side (`sign`).** `BorromeanSig.assert_valid` cannot
  reach `sign`'s crash: it happens long before any `BorromeanSig` is
  built. But `sign`'s own zero-key-ring exposure (#1094) and its
  out-of-range `sign_key_idx` exposure (#1095) turn out to be the exact
  same question asked one way: is `sign_key_idx[i]` a valid position in
  `pubk_rings[i]`? A ring of size zero fails `0 <=
  sign_key_idx[i] < len(pubk_rings[i])` for every possible value, so
  one bound, `_assert_sign_key_idx_in_range`, closes both issues at
  once. It also refuses a *negative* `sign_key_idx`, which used to be
  silently accepted through Python's own negative indexing and sign a
  different ring position than the one named -- not one of the two
  issues' own repros, but the same defect the bound exists to close,
  found while writing it.

So: two checks, not three and not one. Bolting a third guard beside
#1093's would have missed that #1094 and #1095 are the same question on
the signing side; merging everything into `_assert_matches_pubk_rings`
would have made it answer a question (`sign_key_idx` validity) it has
no arguments to answer, and would have missed that the verification
side needs no `pubk_rings` at all.

Per #1088's settled decisions, carried over: `BTClibValueError`, not
`BorromeanRingError` -- neither check is "ran and failed", both are
arguments that never described a signable/verifiable object.
`verify`'s `except` clause is unchanged; it already catches
`BTClibValueError`. Both checks run once, before any walk.

## Tests

`test_a_ring_with_no_keys_is_refused` reproduces #1094's exact repro
(construction, `assert_as_valid`, `verify`, `sign`) and asserts what
`verify` *returns*, not only what `assert_as_valid` raises.
`test_sign_key_idx_out_of_range_is_refused` reproduces #1095's, plus
the negative-index case found while fixing it.

## Gates, on the rebased tip

```
$ uv run pytest
28649 passed, 11 skipped, 100.00% coverage

$ uv run pre-commit run --all-files
all hooks passed

$ uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
build succeeded, 0 warnings
$ grep -rn 'href="#\./' docs/build/html --include='*.html'
(no matches, exit 1)
```

## CHANGELOG.md / RELEASE_NOTES.md

Two CHANGELOG.md entries, one fact each -- the two issues are different
defects even though their signing-side fix is shared code. Both are
source-breaking, each with its own RELEASE_NOTES.md breaking-changes
bullet naming every affected call site:

- #1094: `BorromeanSig.__init__`, `BorromeanSig.parse`,
  `assert_as_valid`, `verify` (a `BorromeanSig` with a zero-key ring
  used to build/parse silently and only crash downstream; now refused
  at the point it is built or first validated).
- #1095: `sign` (an out-of-range or negative `sign_key_idx[i]` used to
  reach a bare `IndexError` or sign silently at the wrong position; now
  a `BTClibValueError` before either step).

## Summary by Sourcery

Validate Borromean ring contents and signing-key indexes before processing to prevent invalid configurations from causing crashes or silently selecting the wrong key.

Bug Fixes:
- Reject Borromean signatures containing empty rings with a BTClibValueError instead of allowing downstream failures.
- Reject negative or out-of-range signing-key indexes, including indexes for empty rings, before signing begins.

Tests:
- Add coverage for empty-ring validation across construction, verification, and signing, plus invalid positive and negative signing-key indexes.