### PR TITLE
Comment why pub_key's length check runs before pub_nonce's parsing

### DIFF
--- a/btclib/ecc/musig2.py
+++ b/btclib/ecc/musig2.py
@@ -953,6 +953,16 @@ def partial_sig_verify_(
     if s >= secp256k1.n:
         return False
     pub_nonce = bytes_from_octets(pub_nonce, _NONCE_SIZE)
+    # ahead of pub_nonce's own point-parsing below: the delegated branch
+    # needs pub_key as validated-length bytes before it can hand it to
+    # the bindings, and this length check is the one line both arms
+    # share, so it runs once here rather than once per arm. The only
+    # input this ordering affects is a direct partial_sig_verify_ call
+    # carrying both a wrong-length pub_key and a malformed pub_nonce at
+    # once -- unreachable through partial_sig_verify, which screens both
+    # first -- where pub_key's length is what raises rather than
+    # pub_nonce's parse; the exception type is the same either way, and
+    # no vector pins which one a caller sees
     pub_key = bytes_from_octets(pub_key, _PK_SIZE)
     if (
         _libsecp256k1_serves(secp256k1, sha256)


### PR DESCRIPTION
## What this answers

A follow-up to #1096 (issue #1049): a non-blocking review question on
that PR asked whether `partial_sig_verify_`'s `pub_key` length check
running ahead of `pub_nonce`'s point-parsing was deliberate. It was, and
the answer was only recorded in the (now resolved) review thread — not
in the source, where the next reader who tidies the check order back
would find it. This adds the one-line reasoning at the call site.

No behavior change: comment-only diff.

## No CHANGELOG.md entry

Nothing a user of the library notices — the exception type and message
for every documented input are unchanged from #1096. CONTRIBUTING.md's
CHANGELOG rule is "anything a user would notice"; this is not that.

## Gates, all three, on this sha

```
uv run pytest                                          # 28711 passed, 11 skipped, 100.00% coverage
uv run pre-commit run --all-files                       # clean
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html   # build succeeded, no broken relative links
```

## Outside this diff's scope

Nothing filed.

## Summary by Sourcery

Enhancements:
- Document why public-key length validation precedes public-nonce parsing in partial signature verification, preserving the intentional validation order.