### PR TITLE
Record the decision on MuSig2's secret half, the key class and int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2094,6 +2094,28 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **`musig2.nonce_gen` and `sign` are not delegated to the bindings,
+  btclib grows no private-key class, and curve arithmetic stays on
+  `int`** (issue #1050). The three reduce to one: delegating MuSig2's
+  secret half would put `musig_nonce_gen`'s opaque, implementation-defined
+  secnonce in `btclib.ecc.musig2`'s public API, against
+  `btclib/psbt/musig2.py`'s own decision to hold no session state at
+  all, and buy only that `k_1` and `k_2` stop being Python `int`s --
+  `int_from_prv_key` already produces an unzeroizable one from the
+  private key on the delegated path too, so neither arm can zeroize it
+  either way. That gain is measured against `sign`'s own line, `s =
+  (k_1_ + values.b * k_2_ + values.e * a * d) % secp256k1.n`
+  (`btclib/ecc/musig2.py:812`): 1.016x over uniform scalars in
+  `[1, n-1]`, the point-multiplication side having been regular since
+  #254 already -- not worth the API shape, and the same reasoning is
+  why the library holds no private-key class and no `bytes`-backed
+  curve arithmetic either, both needing exactly the delegation declined
+  here. `SECURITY.md` carries the full reasoning where it already
+  publishes the Python arm's other limitations, including why
+  `btclib_secp256k1` itself takes the equivalent opaque handle for
+  `musig_keyagg_cache` and `musig_session` without landing on a
+  different answer -- those have no octets form at all, where an `int`
+  here already does the job. No behaviour changes.
 - **`btclib.kdf` is the key derivation functions, and it holds RFC
   5869's HKDF beside SEC 1's `ansi_x9_63_kdf`** (issue #1080).
   `hkdf_extract` concentrates the entropy of input keying material into

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -106,6 +106,36 @@ used to teach and to prototype as much as to build:
     or xpub string handed to `derive` or `derive_from_account`: the
     decoded key stays reachable from that cache, bounded by its
     `maxsize`, past whatever reference the caller itself still holds
+- **`musig2.nonce_gen` and `sign` stay on this arithmetic by decision,
+    not merely by default** (issue #1050). Delegating them would put
+    `musig_nonce_gen`'s secnonce -- an opaque 132-byte struct the
+    header calls "implementation defined and not guaranteed to be
+    portable between different platforms or versions" -- into
+    `btclib.ecc.musig2`'s public API, against `btclib/psbt/musig2.py`'s
+    own decision to hold no session state at all. What it would buy is
+    measured rather than assumed: the point-multiplication side has
+    been regular since #254, and `sign`'s own line, `s = (k_1_ +
+    values.b * k_2_ + values.e * a * d) % secp256k1.n`
+    (`btclib/ecc/musig2.py:812`), spreads 1.016x over uniform scalars
+    in `[1, n-1]` -- the magnitude leak that remains shows only for
+    scalars with zero high bits, keys already lost for other reasons.
+    The gain left is narrower than that figure suggests: delegating
+    would only keep `k_1` and `k_2` from becoming Python `int`s, and
+    the bullet above already covers why that does not decide anything
+    -- `int_from_prv_key` produces an unzeroizable `int` from the
+    private key on the delegated path too. `btclib_secp256k1` itself
+    takes the equivalent opaque handle for `musig_keyagg_cache` and
+    `musig_session` without this reasoning landing on a different
+    answer there: those have no octets form to begin with, where an
+    `int` here already does the job. The same reasoning answers two
+    more questions this library has never separately decided: it grows
+    no private-key class, because zeroization needs exactly the
+    delegation declined above -- a class that hands out an `int` the
+    moment anything uses it has a session object's ergonomics and none
+    of its guarantee -- and curve arithmetic stays on `int` rather than
+    `bytes`, `bytes` being immutable exactly like `int` while only
+    `bytearray` zeroizes, and bignum arithmetic on a `bytearray` still
+    allocating `int` intermediates at every step
 - the bindings also let a caller own the buffer a secret is written
     into: a keyword-only `into=`, on every entry point that produces
     one — `keys.prvkey_negate`, `keys.prvkey_tweak_add`,

--- a/btclib/ecc/musig2.py
+++ b/btclib/ecc/musig2.py
@@ -498,6 +498,9 @@ def nonce_gen_(
         msg_prefixed = b"\x01" + len(msg).to_bytes(8, "big") + msg
     extra = b"" if extra_in is None else bytes_from_octets(extra_in)
 
+    # k_1, k_2 become ints here rather than staying inside a delegated
+    # secnonce: SECURITY.md records why, beside sign's own line (issue
+    # #1050)
     k_1 = _nonce_hash(rand, pk, agg_pk, 0, msg_prefixed, extra) % secp256k1.n
     k_2 = _nonce_hash(rand, pk, agg_pk, 1, msg_prefixed, extra) % secp256k1.n
     # k_1 or k_2 zero would be a hash landing on a multiple of n, and the
@@ -803,6 +806,9 @@ def sign(sec_nonce: bytearray, prv_key: PrvKey, session_ctx: SessionContext) -> 
     a = _session_key_agg_coeff(session_ctx, pk)
     g = 1 if values.Q[1] % 2 == 0 else secp256k1.n - 1
     d = g * values.gacc * d_ % secp256k1.n
+    # this line's timing across k_1_, k_2_ is measured rather than
+    # assumed constant: SECURITY.md records the spread and why MuSig2's
+    # secret half stays undelegated (issue #1050)
     s = (k_1_ + values.b * k_2_ + values.e * a * d) % secp256k1.n
     return s.to_bytes(_SCALAR_SIZE, "big")
 


### PR DESCRIPTION
## Summary

Closes #1050. Three questions that reduce to one, all answered no:

- `musig2.nonce_gen` and `sign` are not delegated to the bindings
- btclib grows no private-key class
- curve arithmetic stays on `int`, not `bytes`

The reasoning is recorded in `SECURITY.md`, beside the existing
paragraph on Python objects holding secret material without being
zeroized: the 1.016x timing spread measured on `sign`'s own line
(`s = (k_1_ + values.b * k_2_ + values.e * a * d) % secp256k1.n`), the
opaque-handle cost against `btclib/psbt/musig2.py`'s own decision to
hold no session state, and why `int_from_prv_key` already produces an
unzeroizable `int` on the delegated path too, so neither arm can
zeroize the key regardless of this decision.

`btclib/ecc/musig2.py` gets a short comment at each site the decision
touches -- `nonce_gen_` where `k_1`/`k_2` become ints, and `sign`'s own
line -- pointing back at `SECURITY.md` rather than restating the
reasoning, per this tree's "one fact in one place" convention.
`CHANGELOG.md` gets an entry in "Curves, signatures and keys",
following #1029's precedent for what a decision record does there.

**No behaviour changes.** This is prose only: no code in `btclib/`
changed the arithmetic it does.

## Test plan

- [x] `uv run pytest` -- 100% coverage, all green
- [x] `uv run pre-commit run --all-files` -- all hooks passed
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html` -- build
      succeeded, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the security-driven decision to retain MuSig2 secret handling and curve arithmetic in btclib without changing behavior.

Enhancements:
- Document the security and API rationale for keeping MuSig2 secret operations local, without introducing a private-key class or bytes-backed curve arithmetic.
- Add targeted comments in MuSig2 nonce generation and signing code linking the implementation decisions to the security record.

Documentation:
- Record the MuSig2 delegation, private-key representation, and curve-arithmetic decisions in SECURITY.md and CHANGELOG.md.