### PR TITLE
Count only a stanza as documentation, not a toctree line (issue #1091)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8305,6 +8305,25 @@ documented at release-notes length in the first place, and are still in
   stated, rather than left out of the parameter list where the gap would
   not be visible. `btclib/` does not change: this is validation of the
   existing Python arithmetic, not delegation to the bindings.
+- **A package is documented by its own stanza, not by its toctree line**
+  (issue #1091). `tests/docs_test.py` compares the modules under `btclib/`
+  against the automodule stanzas in `docs/source/*.rst`, and read a
+  toctree line as documentation too -- which is the one shape that made
+  the comparison lie, because every per-package page has both.
+  `btclib.psbt` is named in `btclib.rst`'s toctree and again by the
+  stanza that ends `btclib.psbt.rst`, so deleting that stanza left the
+  package's own `__init__` -- its docstring, and the names it re-exports
+  flat -- out of the published pages with the suite green and the
+  documentation build silent, autodoc having no idea a page was meant to
+  carry it. Measured by deleting it: `uv run pytest tests/docs_test.py`
+  passed and `docs.yml`'s `sphinx-build -W --keep-going` exited 0 with no
+  warning naming the package. Only the stanzas count now, and
+  `test_a_toctree_line_is_not_a_stanza` pins the distinction on a page
+  holding both shapes. The toctree loses no coverage by this: a page no
+  toctree includes is `toc.not_included`, which that same `-W` already
+  fails on. No page needed a stanza added -- every module and every
+  package under `btclib/` carries one -- so what changes is the gate and
+  not the documentation.
 
 ## v2026.8.9
 

--- a/tests/docs_test.py
+++ b/tests/docs_test.py
@@ -63,11 +63,12 @@ def _is_public(parts: tuple[str, ...]) -> bool:
     """Whether a module path names something a user is meant to import.
 
     `__init__` is the package itself and not a private name, which is the
-    only reason this is not a one-line `startswith("_")`. One module under
-    `btclib/` is private, `_ripemd160`, the pure Python fallback
-    `btclib.hashes` reaches where hashlib has no RIPEMD-160: it is not
-    API, so it takes no automodule stanza, and the underscore is what says
-    so. `_data` holds data and no Python.
+    only reason this is not a one-line `startswith("_")`. A module under a
+    private name is not API, so it takes no automodule stanza, and the
+    underscore is the whole of what says so -- `btclib._ripemd160`, the
+    pure Python fallback `btclib.hashes` reaches where hashlib has no
+    RIPEMD-160, and `btclib._libsecp256k1`, where the bindings are
+    imported once for the package. `_data` holds data and no Python.
     """
     return not any(part.startswith("_") for part in parts if part != "__init__")
 

--- a/tests/docs_test.py
+++ b/tests/docs_test.py
@@ -30,18 +30,32 @@ _DOCS_DIR = _ROOT / "docs" / "source"
 # what a documented module looks like to sphinx: ".. automodule:: name",
 # whatever indentation and options follow it
 _AUTOMODULE = re.compile(r"^\s*\.\.\s+automodule::\s+(\S+)\s*$", re.MULTILINE)
-# and what a documented subpackage looks like: a line of the toctree in
-# btclib.rst, which names the per-package page rather than a module
-_TOCTREE_ENTRY = re.compile(r"^\s{3}(btclib\.\S+)\s*$", re.MULTILINE)
+
+
+def _documented_in(text: str) -> set[str]:
+    """Every module one documentation page publishes the members of.
+
+    An automodule stanza and nothing else. A toctree line naming
+    `btclib.psbt` is not one: it makes the package's *page* reachable
+    from `btclib.rst`, which is what a toctree is for, and says nothing
+    about whether that page renders the package's own `__init__` -- the
+    docstring, and the names re-exported flat that a caller reads
+    `btclib.psbt` for. Counting it as documentation is what would let a
+    package keep its page, its submodules and its toctree line while
+    losing itself out of the middle of them.
+
+    Nothing is lost by not counting it, because the toctree is gated
+    where it belongs: a page no toctree includes is `toc.not_included`,
+    which the `-W` of the documentation workflow turns into a failure.
+    """
+    return set(_AUTOMODULE.findall(text))
 
 
 def _documented() -> set[str]:
-    """Every dotted name the documentation sources mention."""
+    """Every module the documentation sources carry a stanza for."""
     names: set[str] = set()
     for page in _DOCS_DIR.glob("*.rst"):
-        text = page.read_text(encoding="utf-8")
-        names.update(_AUTOMODULE.findall(text))
-        names.update(_TOCTREE_ENTRY.findall(text))
+        names.update(_documented_in(page.read_text(encoding="utf-8")))
     return names
 
 
@@ -126,6 +140,29 @@ def test_shipped_module_is_a_dotted_btclib_name(name: str) -> None:
     """
     assert name == "btclib" or name.startswith("btclib.")
     assert not any(part.startswith("_") for part in name.split("."))
+
+
+def test_a_toctree_line_is_not_a_stanza() -> None:
+    """A package page is documentation of the package only if it says so.
+
+    The two tests above are only as good as this scan, and the shape it
+    has to tell apart is the one every per-package page has: a toctree
+    line for `btclib.psbt` in `btclib.rst`, stanzas for the submodules in
+    `btclib.psbt.rst`, and the package's own stanza at the end of it. Read
+    the toctree as documentation and dropping that last stanza passes --
+    the suite finding the name in the toctree, and sphinx warning about
+    nothing, autodoc having no idea a page was meant to carry it.
+    """
+    source = (
+        ".. toctree::\n"
+        "   :maxdepth: 4\n"
+        "\n"
+        "   btclib.psbt\n"
+        "\n"
+        ".. automodule:: btclib.psbt.psbt_utils\n"
+        "   :members:\n"
+    )
+    assert _documented_in(source) == {"btclib.psbt.psbt_utils"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1091.

## The issue's premise is half stale, and the half that survives is the package

Issue #1091 says nothing derives the documented module list from the tree
and nothing fails when it is incomplete. The first clause was already
untrue when the issue was filed: `tests/docs_test.py` has existed since
`92c93f9` (2026-07-30), it walks `btclib/**/*.py` rather than listing
anything, and it asserts the correspondence in both directions.

The issue's own measurement is reproduced, and it is right about what it
measured — sphinx is silent. Deleting the `btclib.kdf` stanza from
`docs/source/btclib.rst` and running the documentation gate verbatim:

```shell
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
```

exits 0 on a build directory cleaned first, with no line of the log
naming `kdf` and no `module-btclib.kdf` anchor anywhere under
`docs/build/html/`. What the issue did not measure is the suite, and the
suite catches it:

```text
FAILED tests/docs_test.py::test_every_module_is_documented
AssertionError: not documented in docs/source: btclib.kdf -- add an
automodule stanza (...)
```

So the gate the issue asks for exists, and writing a second one would
have been a duplicate. What the issue's title claims is nonetheless true
of exactly one kind of module, and that is what this changes.

`_documented()` counted two shapes: an `automodule` stanza, and a line of
a toctree naming `btclib.<something>`. Every per-package page has both —
`btclib.rst`'s toctree names `btclib.psbt`, and `btclib.psbt.rst` ends
with the package's own stanza — so the package was the one thing the
comparison could not see. Deleting that closing stanza from
`btclib.psbt.rst`:

- `uv run pytest tests/docs_test.py` → `136 passed`
- `sphinx-build -W --keep-going` → exit 0, and
  `grep -o 'id="module-btclib\.psbt[^"]*"' docs/build/html/btclib.psbt.html`
  lists the eight submodules and not `module-btclib.psbt` itself

The package's `__init__` — its docstring, and the flat re-exports a
caller reads `btclib.psbt` for — is gone from the published page and
nothing says so. That is issue #1091's defect, in the one place it still
lives.

## The change

Only an `automodule` stanza counts as documentation now.

The toctree half loses no coverage by going. A page no toctree includes
is `toc.not_included`, which `docs.yml`'s `-W` already fails on, measured
by deleting `   btclib.psbt` from `btclib.rst`'s toctree:

```text
docs/source/btclib.psbt.rst: WARNING: document isn't included in any
toctree [toc.not_included]
build finished with problems, 1 warning (with warnings treated as errors)
```

The scan is factored into `_documented_in(text)` so it can be asserted
rather than assumed, and `test_a_toctree_line_is_not_a_stanza` drives it
over a synthetic page carrying both shapes — the shape every real
per-package page has. Without that test the distinction this change turns
on would be re-mergeable by accident.

No page needed a stanza added: the correspondence between the public
modules under `btclib/` and the stanzas in `docs/source/*.rst` is exact
in both directions today, `btclib/p2p/`'s eleven-module arrival included.
The issue's assertion that the tree is currently complete holds.

## The two questions the issue leaves open

**What must be documented.** Every `.py` under `btclib/` whose every path
component is public, a package counted as itself; `_shipped()` is that
walk and `_is_public()` states the exemption — a name opening with an
underscore is not API, so it takes no stanza, which is `btclib/_ripemd160.py`
and `btclib/_libsecp256k1.py` today. This is deliberately **not** the
`__all__`-derived set the issue proposes, and the reason is that the
`__all__` set is strictly smaller: `btclib.psbt.psbt_utils`,
`btclib.curves.curve_group`, `btclib.block.limits` and every other module
`tests/all_test.py`'s `CHILD_MODULES` records as `unpublished` are absent
from their parent's `__all__` and *are* documented — correctly, since
CONTRIBUTING.md's "The public surface" says such a module still declares
its own surface and a caller still imports it by name. Deriving the
documented set from `__all__` would have made deleting those stanzas
legal.

**Where the test lives.** In `tests/docs_test.py`, which already existed;
the issue's "beside `tests/all_test.py`'s walk" would have meant a second
definition of "public module" in a second file, free to drift from the
first. It needs no `docs` dependency group and does not get one: it reads
`docs/source/*.rst` as text with a regex and imports no sphinx — which is
why it runs on every interpreter of the matrix rather than on the one
runner that builds the documentation.

**`CHANGELOG.md`, and not `RELEASE_NOTES.md`.** A user notices nothing
and has nothing to act on: no published page changes, no API moves. What
changed is a gate, which is what the "Tests" group of the changelog is
for.

**One correction carried by the second commit.** `_is_public`'s docstring
said "One module under `btclib/` is private, `_ripemd160`".
`btclib/_libsecp256k1.py` is the second, so the sentence was false — and a
stated total is the shape CLAUDE.md's "Never state how many of anything a
file holds" is about. It is not collateral: it is the statement of the
exemption rule this pull request is asked to state, in the function the
rule lives in. It now states the underscore and names what it exempts,
with no total.

## Gates

All three run at `1de8249`, on `origin/main` at `11ee4545`:

- `uv run pytest` → `29278 passed, 11 skipped`, exit 0 (the coverage
  ratchet with it)
- `uv run pre-commit run --all-files` → exit 0
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uNzuzag82WGhvznByjFDH

## Summary by Sourcery

Count only explicit autodoc stanzas when verifying that public modules are documented, while leaving toctree reachability to Sphinx’s documentation build checks.

Bug Fixes:
- Ensure documentation validation recognizes package modules only when they have their own autodoc stanza, preventing package-level documentation from being silently omitted.

Enhancements:
- Refine the documentation scan to distinguish autodoc stanzas from toctree entries and clarify the public-module detection rules.
- Add regression coverage proving that a toctree entry alone does not document a package.

Tests:
- Update documentation tests to validate the corrected module-to-stanza correspondence and public-module exemptions.

Chores:
- Record the documentation validation correction in the changelog.