### PR TITLE
Refuse a BIP144 superfluous witness record in Tx.parse (issue #1104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1411,6 +1411,49 @@ documented at release-notes length in the first place, and are still in
 
 ### Transactions, blocks and PSBT
 
+- **`Tx.parse` refuses a BIP144 marker over witnesses that are all
+  empty** (issue #1104). The marker and the flag were read, one witness
+  was read per input, and nothing asked afterwards whether any of them
+  carried anything. `serialize` writes the marker only when `is_segwit`
+  is true, so those octets came back stripped: the transaction parsed
+  equal to the one without them, re-serialized to different bytes with a
+  different `hash`, and a caller relaying what it parsed sent something
+  other than what it received.
+
+  Bitcoin Core refuses the same octets rather than normalising them.
+  `UnserializeTransaction`, of `src/primitives/transaction.h`, reads the
+  witnesses and then throws `std::ios_base::failure("Superfluous witness
+  record")` -- "It's illegal to encode witnesses when all witness stacks
+  are empty" -- and refusing what it cannot reproduce is what this
+  library does everywhere else: `btclib.p2p.inventory`'s module docstring
+  states the property, and `Headers.parse` and `Verack.parse` refuse for
+  it. A marker over no inputs at all is refused too, `HasWitness` being
+  false there as well.
+
+  The refusal does not answer to `check_validity`, and the reason is not
+  the p2p envelope's -- there the checksum and the length are outside the
+  flag because a defence a caller can turn off is not one. Here the flag
+  has nothing to gate: it decides whether `assert_valid` runs, which asks
+  about the transaction, and the transaction is valid. What is malformed
+  is the encoding, which no field records and no later call could ask
+  about. `assert_no_trailing`, five lines below it, is the same shape for
+  the same reason.
+
+  `Block.parse` inherits the rule, a block's marker being per
+  transaction, and inherits it for nothing: every block under
+  `tests/block/_data/` parses unchanged, which is what a chain Core
+  validated has to do.
+
+  Two of BIP174's invalid-psbt vectors are refused by it now, ahead of
+  what they used to be refused by -- the witness-serialization one for
+  the encoding rather than for the round trip `psbt_utils.deserialize_tx`
+  compares, and the invalid-value-data one for its transaction's marker
+  rather than for the octets left after it. That leaves
+  `deserialize_tx`'s "wrong tx serialization format" one shape to catch
+  instead of two, a transaction that parses whole and re-serializes to
+  something else, which now needs a witness carrying something; a test
+  builds one.
+
 - **`tx.input_weight` answers what an input will weigh before the input
   exists** (issue #1067). A fee is chosen before the transaction is
   signed, so the weight it is computed from cannot be read off the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1442,7 +1442,9 @@ documented at release-notes length in the first place, and are still in
   `Block.parse` inherits the rule, a block's marker being per
   transaction, and inherits it for nothing: every block under
   `tests/block/_data/` parses unchanged, which is what a chain Core
-  validated has to do.
+  validated has to do. `btclib.p2p.data`'s module docstring named this
+  the one encoding its two payload types could not reproduce, and now
+  names where it is refused instead.
 
   Two of BIP174's invalid-psbt vectors are refused by it now, ahead of
   what they used to be refused by -- the witness-serialization one for

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -72,6 +72,20 @@ full year, short month, short day (YYYY-M-D)
   for. CHANGELOG.md has why the rule is not gated on
   `unsigned_template`.
 
+- **`Tx.parse` refuses a BIP144 marker over witnesses that are all
+  empty.** It used to take such octets and answer the transaction without
+  them, which re-serialized to the stripped encoding -- a different
+  `hash`, so a caller relaying what it had parsed sent something other
+  than what it received. It raises `BTClibValueError("superfluous witness
+  record")` now, which is Bitcoin Core's own refusal of the same bytes,
+  and `Block.parse` inherits it, a block's marker being per transaction.
+  `check_validity=False` does not get past it: that flag gates
+  `assert_valid`, and what is malformed here is the encoding rather than
+  the transaction, which no field records. No transaction on any chain is
+  affected -- Core has never accepted one -- so what changes is what a
+  caller may be handed by a peer or read out of a file. CHANGELOG.md has
+  the reasoning, and what it cost two of BIP174's vectors.
+
 - **`TxOut.from_dict` refuses a `null` value.** It used to build an output
   of zero satoshi, `valid_sats_amount` reading `None` as zero for the
   caller it was written for; a stored dict carrying `{"value": null}` now

--- a/btclib/p2p/data.py
+++ b/btclib/p2p/data.py
@@ -48,11 +48,11 @@ with no witness is a payload that parses back as `False`. The
 package keeps; the object round-trips exactly wherever the wire can tell
 the two apart, and where it cannot there is nothing to keep.
 
-The one encoding neither class reproduces is BIP144's superfluous witness
-record -- a marker over witnesses that are all empty, which `Tx.parse`
-accepts and re-serializes without the marker, and which Core refuses
-outright (issue #1104). It is `btclib.tx`'s to answer and is not answered
-here.
+BIP144's superfluous witness record -- a marker over witnesses that are
+all empty -- is the encoding neither class could reproduce, and neither
+has to: `Tx.parse` refuses it where it is read, as Core's
+`UnserializeTransaction` does, so no payload here holds one (issue
+#1104). It is `btclib.tx`'s answer and is not repeated here.
 
 **The flag is stored as it was given, never reduced against the
 object.** `include_witness=True` over a transaction with no witness could

--- a/btclib/psbt/psbt_utils.py
+++ b/btclib/psbt/psbt_utils.py
@@ -831,12 +831,11 @@ def deserialize_tx(
     transaction and gets the full check.
 
     The parse itself is unvalidated and assert_valid called afterwards:
-    validating on the way in would make the serialization comparison below
-    unreachable for a value the parse rejects. The BIP174 vector named "an
-    invalid value data due to its size being not the stated size" is
-    exactly such a value -- 51 bytes whose transaction re-serializes to 10
-    -- to be refused for its size, not for having no inputs, which is true
-    of it but not the fault.
+    validating on the way in would report what is wrong with the
+    transaction where what is wrong is the value. A witness serialization
+    of a transaction with no outputs is such a value -- to be refused for
+    the encoding this could not write back, where a validating parse
+    answers "Missing outputs", which is true of it but not the fault.
     """
     # None is a declared value for include_witness -- "either encoding" --
     # and every other non-bool decides which one is accepted

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -440,7 +440,23 @@ class Tx:  # noqa: PLW1641
         *,
         check_validity: bool = True,
     ) -> Tx:
-        """Return a Tx by parsing binary data."""
+        """Return a Tx by parsing binary data.
+
+        A BIP144 marker and flag over witnesses that are all empty is
+        refused, which is Core's "Superfluous witness record" of
+        `UnserializeTransaction` in src/primitives/transaction.h. The
+        refusal is what keeps the property this library holds every wire
+        class to -- `btclib.p2p.inventory`'s module docstring states it,
+        `Headers.parse` and `Verack.parse` refuse for it: `serialize`
+        writes the marker only when some input carries a witness, so
+        those octets are ones this class could not write back.
+
+        It does not answer to `check_validity`, and `assert_no_trailing`
+        beside it is the shape being copied: that flag gates
+        `assert_valid`, which asks about the transaction, and the
+        transaction here is valid -- what is malformed is the encoding,
+        which no field records and nothing downstream could ask about.
+        """
         stream = bytesio_from_binarydata(data)
 
         # version is a signed int (int32_t) in bitcoin_core
@@ -485,6 +501,14 @@ class Tx:  # noqa: PLW1641
                 tx_in.script_witness = Witness.parse(
                     stream, check_validity=check_validity
                 )
+            # Core's "Superfluous witness record": the marker said a witness
+            # would follow and none did, and `serialize` drops a marker over
+            # empty witnesses, so these octets do not serialize back. Asked
+            # after the loop and not before, the witnesses being what the
+            # question is about; the docstring has why `check_validity` does
+            # not reach it
+            if not any(tx_in.is_segwit for tx_in in vin):
+                raise BTClibValueError("superfluous witness record")
 
         lock_time = int.from_bytes(
             read_exactly(stream, 4, "lock time"), byteorder="little", signed=False

--- a/tests/psbt/_data/bip174_test_vectors.json
+++ b/tests/psbt/_data/bip174_test_vectors.json
@@ -92,12 +92,12 @@
         },
         {
             "description": "PSBT with unsigned tx serialized with witness serialization format",
-            "error message": "wrong tx serialization format",
+            "error message": "superfluous witness record",
             "encoded psbt": "cHNidP8BAHgCAAAAAAEBJoFxNx7f8oXpN63upLN7eAAMBWbLs61kZBcTykIXG/YAAAAAAP7///8C09/1BQAAAAAZdqkU0MWZA8W6woaHYOkP1SGkZlqnZSCIrADh9QUAAAAAF6kUNUXm4zuDLEcFDyTT7rk8nAOUi8eHALMuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAAAA"
         },
         {
             "description": "PSBT with an invalid value data due to its size being not the stated size",
-            "error message": "39 bytes after the transaction",
+            "error message": "superfluous witness record",
             "encoded psbt": "cHNidP8BADN0Af8HAAEAAAABAP8BAApzMXQo/wAAAAAB/wEDAQAAAQAAAAAAAAAAdgEAAABBAAkAAAAAAA=="
         }
     ],

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -39,6 +39,7 @@ from btclib.psbt.psbt import (
     HAS_SIG_HASH_SINGLE,
     INPUTS_MODIFIABLE,
     OUTPUTS_MODIFIABLE,
+    PSBT_GLOBAL_UNSIGNED_TX,
     PSBT_GLOBAL_VERSION,
     _sig_hash_from_psbt_in,
     _sort_or_shuffle,
@@ -86,10 +87,12 @@ def test_invalid_psbt_bip174(test_vector: dict[str, str]) -> None:
     """Each case must be refused, with the message this file records.
 
     The message is btclib's, not the BIP's, so the assert is what pins a
-    rejection to its reason, and each of the twenty is pinned to its own:
-    the `invalid value data` case is the transaction parser refusing the
-    thirty-nine octets left after the transaction its unsigned-tx value
-    holds, which is the malformation the description names.
+    rejection to its reason rather than to the fact of one. Two cases
+    share "superfluous witness record": the one the BIP describes as a
+    witness serialization, and the one it describes as a value whose size
+    is not the stated size -- whose transaction carries a marker over no
+    witness, which `Tx.parse` stops on before the size is anything
+    (issue 1104).
     """
     with pytest.raises(BTClibValueError) as excinfo:
         Psbt.b64decode(test_vector["encoded psbt"])
@@ -2101,20 +2104,72 @@ def test_the_global_unsigned_tx_is_mandatory() -> None:
         Psbt.b64decode(no_tx)
 
 
+def _psbt_from_unsigned_tx_value(value: bytes) -> bytes:
+    """Return the smallest psbt carrying `value` as PSBT_GLOBAL_UNSIGNED_TX.
+
+    The two tests below hand it octets no encoder would write, which is
+    what a vector file usually holds; built here instead because what
+    each of them is about is a length, and a base64 string states one
+    where these state where it came from.
+    """
+    return (
+        b"psbt\xff"
+        + var_int.serialize(len(PSBT_GLOBAL_UNSIGNED_TX))
+        + PSBT_GLOBAL_UNSIGNED_TX
+        + var_bytes.serialize(value)
+        + PSBT_SEPARATOR
+    )
+
+
 def test_a_value_that_is_not_the_stated_size_says_so() -> None:
     """The size mismatch is what is reported, and by the parser itself.
 
     The value announces more octets than its transaction holds, and a
     value is one whole transaction: the thirty-nine left over are refused
-    where they are read. Were the length taken on trust, this vector would
-    be reported as "Missing inputs" -- true of it, and not what is wrong
-    with it. The round-trip comparison in deserialize_tx still has the
-    other shape to catch, a transaction that parses whole and
-    re-serializes to something else.
+    where they are read, rather than the length being taken on trust and
+    the remainder dropped in silence.
+
+    BIP174's "invalid value data due to its size being not the stated
+    size" is such a value and no longer reaches this refusal: its
+    transaction carries a witness marker over no witness at all, so
+    `Tx.parse` stops on that first (issue 1104). The shape is what this
+    test is about, so it builds one whose transaction is otherwise
+    well-formed.
     """
-    bad_size = "cHNidP8BADN0Af8HAAEAAAABAP8BAApzMXQo/wAAAAAB/wEDAQAAAQAAAAAAAAAAdgEAAABBAAkAAAAAAA=="
+    tx = Tx(
+        1,
+        0,
+        [TxIn(OutPoint(b"\x11" * 32, 0), b"", 0xFFFFFFFF)],
+        [TxOut(1, ScriptPubKey(b"\x51"))],
+    )
+    value = tx.serialize(include_witness=False) + b"\x00" * 39
     with pytest.raises(BTClibValueError, match="39 bytes after the transaction"):
-        Psbt.b64decode(bad_size)
+        Psbt.parse(_psbt_from_unsigned_tx_value(value))
+
+
+def test_an_unsigned_tx_that_re_serializes_to_something_else_is_refused() -> None:
+    """`deserialize_tx` compares the parse against the octets it read.
+
+    BIP174's global unsigned transaction is the stripped serialization,
+    which is why `deserialize_tx` is called with `include_witness` False
+    and compares: a value holding a witness serialization is a value the
+    psbt could not write back.
+
+    A witness carrying something is what reaches that comparison. A
+    template written in witness format has empty stacks by construction
+    -- it is unsigned -- so `Tx.parse` refuses it one layer down for the
+    encoding (issue 1104), and what is left here is the transaction that
+    parses whole and re-serializes to something else.
+    """
+    tx = Tx(
+        1,
+        0,
+        [TxIn(OutPoint(b"\x11" * 32, 0), b"", 0xFFFFFFFF, Witness([b"\x03" * 64]))],
+        [TxOut(1, ScriptPubKey(b"\x51"))],
+    )
+    value = tx.serialize(include_witness=True)
+    with pytest.raises(BTClibValueError, match="wrong tx serialization format"):
+        Psbt.parse(_psbt_from_unsigned_tx_value(value))
 
 
 # issue 249: the finalizer against btclib's own script engine

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -87,10 +87,10 @@ def test_invalid_psbt_bip174(test_vector: dict[str, str]) -> None:
     """Each case must be refused, with the message this file records.
 
     The message is btclib's, not the BIP's, so the assert is what pins a
-    rejection to its reason rather than to the fact of one. Two cases
-    share "superfluous witness record": the one the BIP describes as a
-    witness serialization, and the one it describes as a value whose size
-    is not the stated size -- whose transaction carries a marker over no
+    rejection to its reason rather than to the fact of one. The case the
+    BIP describes as a witness serialization and the one it describes as
+    a value whose size is not the stated size share "superfluous witness
+    record": the second one's transaction carries a marker over no
     witness, which `Tx.parse` stops on before the size is anything
     (issue 1104).
     """

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -1004,3 +1004,77 @@ def test_the_size_and_the_serialization_agree() -> None:
         assert tx.weight == 3 * len(
             tx.serialize(include_witness=False, check_validity=False)
         ) + len(tx.serialize(include_witness=True, check_validity=False))
+
+
+def test_a_marker_over_empty_witnesses_is_refused() -> None:
+    """Core's "Superfluous witness record", and the round trip it keeps.
+
+    `serialize` writes the marker and the flag only when some input
+    carries a witness, so octets carrying them over witnesses that are
+    all empty are octets `Tx` cannot write back: the transaction they
+    parse to re-serializes to the stripped encoding, with a different
+    `hash`, and a caller relaying what it parsed would send something
+    other than what it received (issue 1104).
+
+    `UnserializeTransaction` in Bitcoin Core's src/primitives/transaction.h
+    reads the witnesses and then throws for the same reason -- "It's
+    illegal to encode witnesses when all witness stacks are empty" -- so
+    a peer sending these is a peer whose message does not deserialize
+    there either.
+    """
+    tx = Tx(
+        1,
+        0,
+        [TxIn(OutPoint(b"\x11" * 32, 0), b"", 0xFFFFFFFF)],
+        [TxOut(1, ScriptPubKey(b"\x51"))],
+    )
+    stripped = tx.serialize(include_witness=False)
+    assert Tx.parse(stripped) == tx
+
+    # the same transaction, with a marker, a flag and one empty witness
+    superfluous = stripped[:4] + b"\x00\x01" + stripped[4:-4] + b"\x00" + stripped[-4:]
+    with pytest.raises(BTClibValueError, match="superfluous witness record"):
+        Tx.parse(superfluous)
+
+    # the refusal is about the octets and not about the transaction, so
+    # check_validity -- which gates assert_valid -- does not reach it
+    with pytest.raises(BTClibValueError, match="superfluous witness record"):
+        Tx.parse(superfluous, check_validity=False)
+
+    # no input at all is refused too, Core's HasWitness being false there
+    # as well: the marker still announces what the encoding then lacks
+    no_inputs = (
+        (1).to_bytes(4, "little")
+        + b"\x00\x01"
+        + var_int.serialize(0)
+        + var_int.serialize(0)
+        + (0).to_bytes(4, "little")
+    )
+    with pytest.raises(BTClibValueError, match="superfluous witness record"):
+        Tx.parse(no_inputs, check_validity=False)
+
+
+def test_a_marker_over_one_non_empty_witness_is_accepted() -> None:
+    """The other side of the bound: one witness is enough for the marker.
+
+    The refusal above asks whether *any* input carries a witness, which
+    is `is_segwit` and so is what `serialize` writes the marker for. A
+    transaction of two inputs where only the second is signed is the
+    case that separates the two readings, and it is an ordinary
+    encoding: Core writes an empty stack for the unsigned one.
+    """
+    tx = Tx(
+        1,
+        0,
+        [
+            TxIn(OutPoint(b"\x11" * 32, 0), b"", 0xFFFFFFFF),
+            TxIn(OutPoint(b"\x22" * 32, 1), b"", 0xFFFFFFFF, Witness([b"\x03" * 64])),
+        ],
+        [TxOut(1, ScriptPubKey(b"\x51"))],
+    )
+    assert tx.is_segwit
+
+    wire = tx.serialize(include_witness=True)
+    parsed = Tx.parse(wire)
+    assert parsed == tx
+    assert parsed.serialize(include_witness=True) == wire


### PR DESCRIPTION
Closes #1104

`Tx.parse` read a BIP144 marker and flag, read one witness per input, and
never asked whether any of them carried anything. `serialize` writes the
marker only when `is_segwit` is true, so those octets came back stripped:
the transaction parsed equal to the one without them and re-serialized to
different bytes, with a different `hash`. A caller relaying what it
parsed sent something other than what it received.

The issue's reproduction, confirmed on `main` before the change:

```text
parsed == tx: True
round trips: False
```

## The refusal

One condition after the witness loop, where Bitcoin Core puts it:
`UnserializeTransaction` in `src/primitives/transaction.h` reads the
witnesses and throws `std::ios_base::failure("Superfluous witness
record")`. Refusing what it cannot reproduce is what this library does
everywhere else -- `btclib.p2p.inventory`'s module docstring states the
property, `Headers.parse` and `Verack.parse` refuse for it.

A marker over no inputs at all is refused too, Core's `HasWitness` being
false there as well.

## It does not answer to `check_validity`

Not for the p2p envelope's reason -- there the checksum and the length
checks are outside the flag because a defence a caller can turn off is
not one. Here the flag has nothing to gate: it decides whether
`assert_valid` runs, which asks about the *transaction*, and the
transaction is valid. What is malformed is the *encoding*, which no field
records and no later call could ask about, so there is no object a
caller could legitimately hold in the state the flag exists to allow.
`assert_no_trailing`, five lines below, is the same shape.

## `Block.parse` inherits it

A block's marker is per transaction. Every block under
`tests/block/_data/` parses unchanged, which is what a chain Core
validated has to do -- `block_481824_complete.bin` included, whose seven
segwit transactions all carry real witnesses.

## What it cost in fixtures

Two of BIP174's own invalid-psbt vectors, both pinned to a message
`Tx.parse` no longer gets to give:

- *"PSBT with unsigned tx serialized with witness serialization format"*
  is the refused case itself -- an unsigned template has empty witness
  stacks by construction. It was caught a layer up by the round-trip
  comparison in `psbt_utils.deserialize_tx`; the vector file's recorded
  message moves.
- *"PSBT with an invalid value data due to its size being not the stated
  size"* holds a transaction with a marker over no inputs, so it stops on
  that ahead of the thirty-nine octets left after it.
  `test_a_value_that_is_not_the_stated_size_says_so` is about the size
  and not about that vector, so it now builds a value whose transaction
  is otherwise well-formed.

That left `deserialize_tx`'s `"wrong tx serialization format"` with one
shape to catch instead of two -- a transaction that parses whole and
re-serializes to something else, which now needs a witness carrying
something -- and no test reaching it, which the 100% ratchet reported.
`test_an_unsigned_tx_that_re_serializes_to_something_else_is_refused` is
that test, and it is what the branch was always for.

Two docstrings named that vector as the example of a rule and neither is
true of it now: `deserialize_tx`'s, on why the parse is unvalidated, and
`test_invalid_psbt_bip174`'s, on what each vector is pinned to.

## Gates

All three run on this head, exit codes read:

| gate | exit |
| --- | --- |
| `uv run pytest` (29280 passed, 100% coverage) | 0 |
| `uv run pre-commit run --all-files` | 0 |
| `sphinx-build -W --keep-going` (plus the `href="#./"` grep) | 0 |

## Summary by Sourcery

Reject superfluous BIP144 witness records so parsed transactions preserve the exact wire encoding accepted by the library.

Bug Fixes:
- Reject transactions containing a BIP144 witness marker when every witness stack is empty, preventing the parser from silently normalizing bytes that cannot be re-serialized identically.

Enhancements:
- Propagate the encoding validation through block transaction parsing while preserving acceptance of valid SegWit transactions.
- Clarify PSBT parsing documentation and update affected BIP174 fixtures and tests for the new transaction parsing behavior.

Documentation:
- Document the superfluous witness-record rejection and its independence from the transaction validity flag in the changelog, release notes, and relevant API documentation.

Tests:
- Add coverage for empty-witness and no-input marker rejection, valid partially witnessed transactions, and the remaining PSBT serialization-mismatch case.