### PR TITLE
Point CHANGELOG.md and musig2.py's #156 refs at btclib-secp256k1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4379,14 +4379,16 @@ documented at release-notes length in the first place, and are still in
   before this.
 
   Cross-validating the construction against secp256k1-zkp is
-  btclib-org/btclib#156's open question and stays open: mainline
-  `bitcoin-core/secp256k1`, the vendored library, has no adaptor
-  support at all -- `musig_adapt`, `musig_extract_adaptor` and
+  btclib-org/btclib-secp256k1#156's open question and stays open:
+  mainline `bitcoin-core/secp256k1`, the vendored library, has no
+  adaptor support at all -- `musig_adapt`, `musig_extract_adaptor` and
   `musig_nonce_parity` are absent, and `musig_nonce_process` takes five
   arguments where zkp's takes six -- so this is delegated to nothing
   and checked by its own round-trip tests, both parities of the final
   nonce exercised in the same run rather than pinned for one and
-  pragma'd for the other.
+  pragma'd for the other. What would supply that delegation,
+  btclib-org/btclib-secp256k1#283, is decided and waits on
+  secp256k1-zkp#330 upstream.
 - **`borromean`'s challenge hash now matches secp256k1-zkp's, at the
   cost of every signature this module ever produced** (issue #1070).
   `_hash`'s four-part preimage was `m || R || ring || position` since

--- a/btclib/ecc/musig2.py
+++ b/btclib/ecc/musig2.py
@@ -100,10 +100,12 @@ pre-signature's nonce is then really -(r+t)*G rather than (r+t)*G --
 `adaptor_impl.h`'s own comment gives this reasoning in full.
 
 Cross-validating this construction against zkp is
-btclib-org/btclib#156's open question, not answered here: the vendored
-library, mainline `bitcoin-core/secp256k1`, has no adaptor support at
-all, so the round-trip tests below are this module's only check for
-now.
+btclib-org/btclib-secp256k1#156's open question, not answered here:
+the vendored library, mainline `bitcoin-core/secp256k1`, has no
+adaptor support at all, so the round-trip tests below are this
+module's only check for now. What would supply that delegation,
+btclib-org/btclib-secp256k1#283, is decided and waits on
+secp256k1-zkp#330 upstream.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Two prose sites cite `btclib-org/btclib#156` for an open
cross-validation question about MuSig2 adaptor signatures against
secp256k1-zkp:

- `CHANGELOG.md`, in the entry for issue #1051
- `btclib/ecc/musig2.py`'s module docstring

`btclib-org/btclib#156` is real but unrelated: a closed issue titled
"Nothing advances the bindings git pin, and test.yml has no schedule".
The question both sites actually describe — whether to reach for
secp256k1-zkp at all, and cross-validate adaptor signatures against
it — is [btclib-org/btclib-secp256k1#156](https://github.com/btclib-org/btclib-secp256k1/issues/156),
"Evaluate secp256k1-zkp for s2c, generator and rangeproof; and musig
is already compiled in and unwrapped".

I confirmed this by fetching both issues' bodies with `gh api`:
`btclib-org/btclib#156` is the closed, unrelated one; `btclib-org/
btclib-secp256k1#156` is open and is exactly the "whether to reach for
the zkp fork" question the surrounding prose is describing at both
sites. A repo-wide sweep
(`git grep -ohE "btclib-org/btclib#[0-9]+" origin/main`) shows `156`
was the only reference of its shape pointing at the wrong repository —
982, 993, 1005 and 1048 are correct, and the bindings-prefixed
references (282, 283) were already correct.

Each site also now names
[btclib-org/btclib-secp256k1#283](https://github.com/btclib-org/btclib-secp256k1/issues/283)
as what would supply the delegation this cross-validation is
currently missing — that issue is decided and waiting on
`secp256k1-zkp#330` upstream, and its own body lists unblocking
`btclib-org/btclib#1051` (this MuSig2 adaptor-signature work) as one
of the things it settles. This mirrors phrasing already used for the
same situation in `btclib/ecc/borromean.py` ("Issue #1072 is that
remaining distance, filed and decided wanted -- after
btclib-org/btclib-secp256k1#283 gives it something to check the
answer against").

No behaviour changes: this is a prose-only fix inside an existing
CHANGELOG.md entry and a docstring, so no new CHANGELOG.md entry and
no RELEASE_NOTES.md change.

## Test plan

- [x] `uv run pytest` — 29277 passed, 11 skipped, coverage 100.00%
- [x] `uv run pre-commit run --all-files` — all hooks passed
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html` — build
      succeeded, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct the MuSig2 adaptor-signature documentation to reference the relevant btclib-secp256k1 issues and clarify the pending cross-validation path.

Bug Fixes:
- Correct references to the MuSig2 adaptor-signature cross-validation question from btclib#156 to btclib-secp256k1#156.

Enhancements:
- Document btclib-secp256k1#283 and its dependency on secp256k1-zkp#330 as the pending delegation path for cross-validation.