### PR TITLE
Assert the bindings serve in the wheel smoke tests (issue #1117)

### DIFF
--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -159,10 +159,18 @@ jobs:
         run: |
           uv venv --python ${{ matrix.python }}
           uv pip install --verbose btclib
-      # BIP340 vector 0 for the ecc surface, exactly what dist and
-      # release.yml already assert; a signature round trip is the one
-      # thing an import cannot get wrong by itself, and a bindings release
-      # that installs and answers incorrectly is what this catches
+      # the ecc surface, as dist and release.yml assert it: a signature
+      # round trip is the one thing an import cannot get wrong by itself,
+      # and a bindings release that installs and answers incorrectly is
+      # what this catches.
+      # Those two assert one thing more, that the bindings are serving
+      # (issue #1117), and this deliberately does not: the install above
+      # names btclib and no extra, so the bindings are not asked for and
+      # nothing here is entitled to them. That is the supported
+      # configuration of issues #990, #991 and #992 -- the one
+      # `no-bindings` runs the suite in -- and what it makes this step
+      # answer is that the published wheel works on the Python arithmetic
+      # alone, which is the question a bare `pip install btclib` asks
       - name: Verify a signature, round tripped
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -417,10 +417,24 @@ jobs:
       # btclib_secp256k1 satisfies the wheel about to be published,
       # which is what a user installing it resolves. A release stopping
       # on that answer is the outcome wanted.
-      # The three assertions are dist's, and there for the same
-      # reasons: metadata can be missing (issue #150), `import btclib`
-      # runs only __init__.py and touches no binding, and a bindings
-      # release can install and still answer wrongly
+      # The assertions are dist's, and there for the same reasons:
+      # metadata can be missing (issue #150), `import btclib` runs only
+      # __init__.py and touches no binding, the extra can resolve to a
+      # release this tree cannot import, and a bindings release can
+      # install and still answer wrongly.
+      # The serving assertion is what makes the resolution above a
+      # question at all (issue #1117): a bindings release btclib fails
+      # to import lands in `_libsecp256k1`'s `except ImportError`, and
+      # the Python arithmetic then answers the version and the signature
+      # correctly -- that arm being supported and tested is what
+      # test.yml's `no-bindings` job exists for -- so without it this
+      # step goes green on exactly the resolution it is asked about.
+      # `is_libsecp256k1_serving` and not `INSTALLED`: serving is
+      # installed and not refused, so it implies the other, and it is
+      # the public reading of the seam every dispatch consults. It is
+      # asserted before the signature because it is what gives that
+      # signature its meaning -- verified by libsecp256k1 here rather
+      # than by the Python arm it would otherwise silently be
       - name: Smoke-test the wheel, with its dependencies from PyPI
         run: |
           cd "$RUNNER_TEMP"
@@ -430,10 +444,13 @@ jobs:
           set -- "$GITHUB_WORKSPACE"/dist/*.whl
           uv run --isolated --no-project --with "$1[secp256k1]" \
             python -c "import btclib; \
+              from btclib.curves import is_libsecp256k1_serving; \
               from btclib.ecc import dsa; \
               from btclib.to_pub_key import pub_keyinfo_from_prv_key; \
               print(btclib.__version__); \
               assert btclib.__version__ != 'unknown'; \
+              assert is_libsecp256k1_serving(), \
+                'the secp256k1 extra resolved, the bindings do not serve'; \
               assert dsa.verify(b'btclib', pub_keyinfo_from_prv_key(1)[0], \
                 dsa.sign(b'btclib', 1))"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -592,15 +592,38 @@ jobs:
       # resolves to a release, and a release does not move.
       # Whether the newest bindings still work is asked on a schedule by
       # latest.yml, and again by the release workflow before it publishes.
-      # The assertions are three, because each catches what the others
-      # miss: the version is asserted and not merely printed, since
-      # btclib.__version__ falls back to "unknown" with no metadata
-      # installed (issue #150), so a wheel shipping none would print that
-      # and pass; `btclib.ecc.dsa` is imported because `import btclib`
-      # runs only __init__.py, which reads that metadata and touches no
-      # binding, so the bindings could be missing entirely; and a
+      # Each assertion catches what the others miss: the version is
+      # asserted and not merely printed, since btclib.__version__ falls
+      # back to "unknown" with no metadata installed (issue #150), so a
+      # wheel shipping none would print that and pass; `btclib.ecc.dsa`
+      # is imported because `import btclib` runs only __init__.py, which
+      # reads that metadata and touches no binding, so the bindings could
+      # be missing entirely; the bindings are asserted to be serving
+      # because nothing else here notices when they are not; and a
       # signature is verified because an installable release of them with
-      # an incompatible API imports fine and answers wrongly
+      # an incompatible API imports fine and answers wrongly.
+      # The serving one is issue #1117, and what it guards here is not
+      # what it guards in release.yml's unconstrained copy. The
+      # constraints bind a version and request no package, so the only
+      # thing that installs the bindings at all is the wheel's own
+      # `Requires-Dist` for the extra: a wheel that stopped declaring it
+      # resolves nothing, and a btclib_secp256k1 the lock pins that this
+      # tree cannot import lands in `_libsecp256k1`'s `except
+      # ImportError`. Either way `is_libsecp256k1_serving` is False while
+      # the Python arithmetic answers the version and the signature
+      # correctly -- that arm being supported is what the `no-bindings`
+      # job above exists for -- so both would pass unnoticed. Both are
+      # the tree's own state and not the index's, which is what makes the
+      # assertion fit for a required check: what it cannot say is whether
+      # the *newest* bindings serve, which is release.yml's copy and
+      # latest.yml's job.
+      # `is_libsecp256k1_serving` and not `INSTALLED`: serving is
+      # installed and not refused, so it implies the other, and it is the
+      # public reading of the seam every dispatch consults -- the same
+      # name the `no-bindings` job asserts the negative of. Asserted
+      # before the signature because it is what gives that signature its
+      # meaning: verified by libsecp256k1 here rather than by the Python
+      # arm it would otherwise silently be
       - name: Smoke-test the wheel, with its dependencies from PyPI
         run: |
           uv export --locked --no-dev --extra secp256k1 \
@@ -617,10 +640,13 @@ jobs:
           set -- "$GITHUB_WORKSPACE"/dist/*.whl
           uv pip install --constraints constraints.txt "$1[secp256k1]"
           .venv/bin/python -c "import btclib; \
+            from btclib.curves import is_libsecp256k1_serving; \
             from btclib.ecc import dsa; \
             from btclib.to_pub_key import pub_keyinfo_from_prv_key; \
             print(btclib.__version__); \
             assert btclib.__version__ != 'unknown'; \
+            assert is_libsecp256k1_serving(), \
+              'the secp256k1 extra resolved, the bindings do not serve'; \
             assert dsa.verify(b'btclib', pub_keyinfo_from_prv_key(1)[0], \
               dsa.sign(b'btclib', 1))"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -641,6 +641,44 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **The wheel smoke test asserts that the bindings are serving** (issue
+  #1117). `test.yml`'s `dist` job and `release.yml`'s `build` job each
+  install the wheel with its `secp256k1` extra and then check the version
+  and a signature round trip — both of which the Python arithmetic
+  answers correctly, that arm being supported and run in full by the
+  `no-bindings` job. So an extra resolving to nothing, or to a
+  `btclib_secp256k1` release this tree cannot import, landed in
+  `_libsecp256k1`'s `except ImportError`, set `INSTALLED = False` and
+  went green. Issue #1116 was exactly that state on `main`, and neither
+  step would have said so: what the two exist to ask was the one thing
+  they could not answer. `btclib.curves.is_libsecp256k1_serving` is that
+  question in one call, and both now assert it — before the signature,
+  which is what gives that signature its meaning, verified by
+  libsecp256k1 rather than by the Python arm it would otherwise silently
+  be.
+
+  Both and not one, because they guard different things. `dist` exports
+  the lock as constraints, which bind a version and request no package,
+  so what it asks is whether the wheel's own `Requires-Dist` still
+  declares the extra and whether the version `uv.lock` pins is one this
+  tree can import — the tree's own state, deterministic, which is what
+  makes it fit for a required check. `release.yml` installs
+  unconstrained, so it asks what a user installing the published wheel
+  resolves: whether the *newest* published bindings serve it. A release
+  stopping on that answer is the outcome that step was written for, and
+  no pull request waits on it.
+
+  `published.yml` deliberately does not get the assertion, and its
+  comment now says why: that workflow installs `btclib` with no extra, so
+  the bindings are not asked for and nothing there is entitled to them.
+  Asserting it would contradict the supported no-bindings configuration
+  of issues #990, #991 and #992 — which `test.yml`'s `no-bindings` job
+  and `python-arm-authority.yml` assert the negative of, through the same
+  `is_libsecp256k1_serving` call. `INSTALLED` is not asserted beside it:
+  serving is installed and not refused, so it implies the other, and it
+  is the public reading of the seam every dispatch consults.
+  CONTRIBUTING.md's copy of the `dist` commands moves with the step.
+
 - **The bindings floor is `btclib_secp256k1>=0.8.0.4`, and
   `[tool.uv.sources]` goes with it** (issue #1116). The module that
   moves the floor is `musig`, btclib-secp256k1#282: `_libsecp256k1`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -441,7 +441,13 @@ for the `secp256k1` extra — which those commands name on both sides, a
 wheel installed without it declaring nothing to resolve. The lock
 arrives as constraints, which bind a version without
 requesting a package, so a release of the bindings cannot turn a required
-check red while the wheel's own metadata still does the work. They run
+check red while the wheel's own metadata still does the work. That the
+bindings then *serve* is asserted rather than assumed: with the extra
+resolving to nothing, or to a release this tree cannot import, btclib
+falls back to the Python arithmetic and answers the version and the
+signature correctly — the supported configuration `no-bindings` runs the
+whole suite in — so the assertion is the only thing between that
+resolution and a green check. They run
 from an empty directory, or the import finds the source tree instead of
 the wheel:
 
@@ -461,10 +467,13 @@ cd "$tmp" && uv venv &&
     set -- "$OLDPWD"/dist/*.whl &&
     uv pip install --constraints constraints.txt "$1[secp256k1]" &&
     .venv/bin/python -c "import btclib; \
+      from btclib.curves import is_libsecp256k1_serving; \
       from btclib.ecc import dsa; \
       from btclib.to_pub_key import pub_keyinfo_from_prv_key; \
       print(btclib.__version__); \
       assert btclib.__version__ != 'unknown'; \
+      assert is_libsecp256k1_serving(), \
+        'the secp256k1 extra resolved, the bindings do not serve'; \
       assert dsa.verify(b'btclib', pub_keyinfo_from_prv_key(1)[0], \
         dsa.sign(b'btclib', 1))"
 ```


### PR DESCRIPTION
Closes [ISS #1117](https://github.com/btclib-org/btclib/issues/1117).

The wheel smoke test of `test.yml`'s `dist` job and of `release.yml`'s
`build` job asserted the version and a signature round trip, and both of
those pass on the pure Python arm — that arm answering correctly with no
bindings at all is what `tests/no_bindings_test.py` and the
`no-bindings` job exist to keep true. So an extra resolving to nothing,
or to a `btclib_secp256k1` release this tree cannot import, landed in
`_libsecp256k1`'s `except ImportError`, set `INSTALLED = False`, and the
step went green on exactly the resolution it exists to ask about.
[ISS #1116](https://github.com/btclib-org/btclib/issues/1116) was that
state on `main` until `d7a390cf`, and neither step would have said so.

`btclib.curves.is_libsecp256k1_serving()` is that question in one call.
Both steps now assert it, before the signature — which is what gives
that signature its meaning, verified by libsecp256k1 rather than by the
Python arm it would otherwise silently be.

## Both copies, for different reasons

The issue asked whether `dist`'s copy should get it too rather than
treating it as given. It should, and what it guards there is not what
`release.yml`'s guards:

- **`dist`** exports the lock as constraints, which bind a version and
  request no package, so the only thing that installs the bindings at
  all is the wheel's own `Requires-Dist` for the extra. What the
  assertion asks there is whether the wheel still declares that extra,
  and whether the version `uv.lock` pins is importable by this tree.
  Both are the tree's own state and not the index's, so the answer is
  deterministic — which is what makes it fit for a required check that
  must never wait on an upstream release.
- **`release.yml`** installs unconstrained, so it asks what a user
  installing the published wheel resolves: whether the *newest*
  published bindings serve it. A release stopping on that answer is the
  outcome that step was written for, and no pull request waits on it.

## Where it deliberately does not go

`published.yml` installs `btclib` with no extra, so the bindings are not
asked for and nothing there is entitled to them; asserting it would
contradict the supported no-bindings configuration of
[ISS #990](https://github.com/btclib-org/btclib/issues/990),
[ISS #991](https://github.com/btclib-org/btclib/issues/991) and
[ISS #992](https://github.com/btclib-org/btclib/issues/992), which
`test.yml`'s `no-bindings` job and `python-arm-authority.yml` assert the
negative of through this same call. That workflow's comment claimed
parity with the other two smoke tests, which stops being true here, so
it moves with them and now states why it is the exception.

`is_libsecp256k1_serving` and not `INSTALLED`: serving is installed and
not refused, so it implies the other, and it is the public reading of
the seam every dispatch consults.

## `release.yml` does not run on this pull request

It triggers on `workflow_dispatch` and on a `v*` tag, so CI here cannot
exercise the copy that matters most before a release. Both copies were
reproduced locally against a wheel built from this branch
(`btclib-2026.9-py3-none-any.whl`), in both directions:

| what was run | old assertions | with the serving assertion |
| --- | --- | --- |
| `dist`'s copy, constraints from `uv.lock` | exit 0 | exit 0 |
| `release.yml`'s copy, unconstrained | exit 0 | exit 0 |
| the same venv with `btclib_secp256k1/musig.py` removed — ISS #1116's exact shape | exit 0 | exit 1 |
| the wheel installed without the `secp256k1` extra | exit 0 | exit 1 |

Both failures print `AssertionError: the secp256k1 extra resolved, the
bindings do not serve`, and the third row is the one the issue is about:
the assertion that could not fail, failing on the state that shipped.

## Gates

`uv run pytest`, `uv run pre-commit run --all-files` and the `-W` sphinx
build all exit 0.

## Not touched

`RELEASE_NOTES.md`: this is a CI gate, with no API, packaging or install
behaviour a user has to act on. `RELEASING.md`: its two sentences about
the wheel smoke test stay true word for word, and
[PR #1134](https://github.com/btclib-org/btclib/pull/1134) is open
against the surrounding lines.

## Summary by Sourcery

Ensure wheel smoke tests verify that the secp256k1 bindings actually serve requests instead of silently passing through Python fallback arithmetic.

Bug Fixes:
- Make wheel smoke tests fail when the secp256k1 bindings resolve but are unavailable, preventing supported Python-only fallback behavior from masking broken binding installations.

Enhancements:
- Apply the serving check to constrained distribution validation and unconstrained release validation while preserving the no-bindings published-wheel test.
- Clarify workflow comments and contributor guidance around binding-serving validation and the intentional no-bindings configuration.

CI:
- Strengthen the `test.yml` distribution and `release.yml` wheel smoke tests by asserting `is_libsecp256k1_serving()` before signature verification.

Documentation:
- Document the new binding-serving smoke-test requirement in the changelog and contributor instructions.