### PR TITLE
v2026.8.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Only v2026.8.7 and what follows it are here. The releases before it were
 documented at release-notes length in the first place, and are still in
 [RELEASE_NOTES.md](./RELEASE_NOTES.md) rather than duplicated here.
 
-## v2026.9 (work in progress, not released yet)
+## v2026.8.21
 
 ### Repository
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,7 +16,7 @@ Notable changes to the codebase are documented here.
 Release names follow *[calendar versioning](https://calver.org/)*:
 full year, short month, short day (YYYY-M-D)
 
-## v2026.9 (work in progress, not released yet)
+## v2026.8.21
 
 ### Breaking changes
 
@@ -39,6 +39,17 @@ full year, short month, short day (YYYY-M-D)
   `btclib.ecc.musig2.sign` or `partial_sig_verify_`, or reading
   `.pub_keys`, `.tweaks`, `.is_xonly`, `.msg` or `.agg_nonce` off it --
   takes `.context` first. CHANGELOG.md has why.
+
+- **`musig2.SessionValues` carries three more fields.** The frozen
+  dataclass gained `L`, `second` and `pub_keys_set` after `e`, so
+  `SessionValues(Q, gacc, tacc, b, R, e)` is a `TypeError` now. Reading
+  one is unaffected, and reading is what it is for: it is what
+  `session_values(session_ctx)` hands back, and every field it already
+  had answers the same thing. A caller that builds one itself passes the
+  three, which are what a per-signer key-aggregation coefficient is
+  computed from -- fixed for a session, so computed once here rather
+  than by each of `_session_key_agg_coeff`'s callers. CHANGELOG.md has
+  the measurement.
 
 - **`pip install btclib` no longer installs `btclib_secp256k1`.** The
   bindings are the `secp256k1` extra now — `pip install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ name = "btclib"
 # file. Not a literal in btclib/__init__.py for setuptools to import and
 # conf.py to repeat: two declarations are two things a release workflow
 # has to compare before trusting either
-version = "2026.9"
+version = "2026.8.21"
 description = "A library for 'bitcoin cryptography'"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "btclib"
-version = "2026.9"
+version = "2026.8.21"
 source = { editable = "." }
 dependencies = [
     { name = "bitcoin-core-rpc" },


### PR DESCRIPTION
## What this release is

The cycle since `v2026.8.9` is 299 commits, and RELEASE_NOTES.md's
section carries 41 entries across three groups. Two things dominate it,
and a user notices them in opposite ways.

**`btclib.p2p` is new**: Bitcoin's p2p message codecs, in a package that
opens no socket — the seven children of
[ISS #1083](https://github.com/btclib-org/btclib/issues/1083), from the
envelope through the handshake, inventory, tx and block payloads, BIP155
addrv2, BIP157 filters and BIP152 compact blocks. Purely additive: no
existing caller sees it unless it imports it. What is deliberately absent
is BIP324's v2 transport, by
[ISS #1066](https://github.com/btclib-org/btclib/issues/1066)'s rule.

**The breaking-changes list is long**, and the entry a user is most
likely to be bitten by is not an API change at all: `pip install btclib`
no longer installs the bindings, which are the `secp256k1` extra now. An
install that forgets the extra raises nothing and fails nothing — it
answers on the Python arithmetic, tens of times slower and not
constant-time. `btclib.curves.is_libsecp256k1_serving()` is the question,
and as of `741f4cdf` it is also what the wheel smoke tests assert.

The rest of the list is what it looks like: `bool` arguments that used to
be silently truthy now refused, native exceptions replaced by btclib
ones, `lower_s` and `ec` dropped from signatures that had no use for
them, several public names made private or prefixed, and low-R ECDSA.

## The steps nothing enforces

**griffe** — `griffe check btclib -a v2026.8.9`, exit 1, 164 differences.
Every one is named in RELEASE_NOTES.md already, as itself, as a rename,
or by the family bullet covering `curve_group`'s and `curve_group_2`'s
multiplication variants — **except one**, which this branch adds:
`musig2.SessionValues` is public in that module's `__all__` and gained
`L`, `second` and `pub_keys_set` as required fields
([ISS #1069](https://github.com/btclib-org/btclib/issues/1069)), so
`SessionValues(Q, gacc, tacc, b, R, e)` raises `TypeError`.

One finding is discounted, checked rather than assumed: hwi's
`executable` default reads as changed from `'hwi'` to
`DEFAULT_EXECUTABLE`, and `DEFAULT_EXECUTABLE` is `"hwi"` — the spelling
moved and the default did not.

**`latest`** — **not dispatched yet.** It gates nothing and reading it is
the point, so it belongs before the tag rather than before this pull
request. Read it per job when it runs, and know that its
`suite-bindings-latest` job currently answers the bindings question with
a coverage percentage:
[ISS #1136](https://github.com/btclib-org/btclib/issues/1136) — **fixed
in `ad6d3bae`, under this branch**, so that job now stops on a named
**Assert the bindings are serving** step before the suite rather than on
a coverage shortfall afterwards. Read it per job when it runs;
RELEASING.md's paragraph on doing so moved with the fix.

**Both btclib-org siblings, checked.** `btclib_secp256k1`'s floor moved
to `>=0.8.0.4` in `d7a390cf` and the `[tool.uv.sources]` table went with
it, so the lock resolves it from PyPI;
`griffe check btclib_secp256k1 -a v0.8.0.3` reports nothing, that release
being purely additive. `bitcoin-core-rpc`'s floor does **not** move: its
newest release is v2026.8.20 and its own notes say the library is
unchanged since v2026.8.13.

**A stranger dependency's drift, stated rather than defaulted by
omission**, as RELEASING.md asks since `680365cc`. `uv lock --upgrade`
would move five: `hypothesis`, `idna`, `pygments`, `ruff` and
`stevedore`. **Left for Dependabot.** None of the five ships in the
wheel — btclib's only runtime dependency is `bitcoin-core-rpc`, plus the
bindings behind the extra — so none of them is in what this release
publishes, and taking them here would re-run the whole matrix for
development tooling.

## Gates

Run on this branch after rebasing onto `741f4cdf`, exit codes read
directly rather than from filtered output:

| | |
| --- | --- |
| `uv run pytest` | **0** — 29393 passed, 11 skipped, `TOTAL 46665 0 100.00%` |
| `uv run pre-commit run --all-files` | **0**, no in-place rewrites |
| `sphinx-build -W --keep-going` | **0** |

## Landed under this branch since it was opened

- [ISS #1137](https://github.com/btclib-org/btclib/issues/1137) —
  `b1d0a874`, `_libsecp256k1`'s docstring naming `AVAILABLE`, a symbol
  the package does not define, and not naming the two states it does.
- [ISS #1136](https://github.com/btclib-org/btclib/issues/1136) —
  `ad6d3bae`, above.

Rebased onto `ad6d3bae` and all three gates re-run on that base, with the
results in the table.

## Still owed before the tag

- The Read the Docs **builds** page, read as the builds page and not as
  the rendered site — a site answering 200 may be serving the last build
  that succeeded, which for three years was v2023.7.12's
  ([ISS #484](https://github.com/btclib-org/btclib/issues/484)).
- `lint` and `test` read on the commit `main` ends up at, which is a
  different run from this pull request's.
- `latest`, then the TestPyPI rehearsal, then the tag.
