### PR TITLE
Name the two bindings states where _libsecp256k1 introduces them (issue #1137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7021,6 +7021,33 @@ documented at release-notes length in the first place, and are still in
 
 ### Documentation and the website
 
+- **`_libsecp256k1`'s docstring names the two states the module
+  publishes** (issue #1137). It said the question "are the bindings
+  installed" is answered by `AVAILABLE`, and there is no `AVAILABLE` in
+  the package: what answers is `INSTALLED`, and `ENABLED` is that answer
+  with `BTCLIB_NO_LIBSECP256K1` applied. The same paragraph named
+  `curves.curve`'s `_libsecp256k1_available` correctly two sentences
+  later, which is the likeliest source of the wrong one — and the one
+  sentence telling a reader what to look for sent them after a symbol
+  they could not find.
+
+  Both names are now introduced where the module publishes them, with
+  why it keeps two where `is_libsecp256k1_serving` publishes one:
+  `ENABLED` is only the state the seam starts in and
+  `set_libsecp256k1_serving` may have moved it since, while `INSTALLED`
+  is settled at that import and stays — which is what that function
+  reads to refuse `serving=True` where there is nothing to serve, and
+  what the suite skips its `bindings` marker on. Neither symbol is
+  renamed: issue #1117's smoke tests chose `is_libsecp256k1_serving`
+  over `INSTALLED` because serving is the public reading of the seam,
+  and that is untouched — a caller still has no use for the difference
+  the module needs.
+
+  The count of `try` blocks the single import replaced goes with the
+  rewrite, and so does the second copy of it: a number describing a tree
+  that no longer exists is neither checkable against this one nor of use
+  to a reader of it.
+
 - **Where a measured timing lives is written down** (issue #940).
   CONTRIBUTING.md's "Documentation and comments" already asked for the
   command beside a number, so that a reader can re-measure "instead of

--- a/btclib/_libsecp256k1.py
+++ b/btclib/_libsecp256k1.py
@@ -6,17 +6,30 @@
 
 The modules that delegate to the bindings import none of them directly:
 they import from here, so the question "are the bindings installed" is
-asked once, at one import, and answered by `AVAILABLE` rather than by
-eleven `try` blocks that could drift apart. `curves.curve` reads that
-answer into `_libsecp256k1_available`, which is the seam every dispatch
-in the package consults, so an absent binding is a dispatch that declines
-rather than an `ImportError` raised before any dispatch is reached.
+asked once, at one import, and answered by `INSTALLED` rather than by a
+`try` block in each of them, which could drift apart. `ENABLED` is that
+answer with `BTCLIB_NO_LIBSECP256K1` applied -- installed, and not
+refused -- and `curves.curve` reads it into `_libsecp256k1_available`,
+which is the seam every dispatch in the package consults, so an absent
+binding is a dispatch that declines rather than an `ImportError` raised
+before any dispatch is reached.
+
+Two names because the seam moves and this import does not. `ENABLED` is
+only the state `curves.curve` starts in, and `set_libsecp256k1_serving`
+may have moved it since; `INSTALLED` is settled here and stays, so it is
+what that function reads to refuse `serving=True` where there is nothing
+to serve, and what the suite skips its `bindings` marker on. The
+difference is this module's and the seam's, not a caller's:
+`curves.is_libsecp256k1_serving` publishes one answer -- whether the next
+call goes to libsecp256k1 or to the Python arithmetic -- which is the
+only difference a caller can act on.
 
 A module that imports nothing of btclib, and is therefore below every
 package that reads it -- the placement `consensus.py` has and for its
 reason. What it does import is the whole of the surface btclib uses, so
 this file is also the answer to "what does btclib need these bindings
-for", which was previously spread over the eleven import blocks.
+for", which no reader has to assemble from the delegating modules' own
+imports.
 
 The names are re-exported under the bindings' own spelling and the caller
 aliases them as it always did: a caller holding `keys` and reaching


### PR DESCRIPTION
Closes [ISS #1137](https://github.com/btclib-org/btclib/issues/1137).

`btclib/_libsecp256k1.py`'s docstring said the question "are the
bindings installed" is answered by `AVAILABLE`. There is no `AVAILABLE`
in the package — `git grep -n AVAILABLE origin/main -- btclib tests
docs` names that one line and nothing else but `exceptions.py`'s
unrelated `UNAVAILABLE_ACTION`. What the module publishes is
`INSTALLED`, the answer its single `try` reaches, and `ENABLED`, that
answer with `BTCLIB_NO_LIBSECP256K1` applied.

The typo is the smaller half. The module distinguishes two states and
introduced neither, so a reader arriving from
`is_libsecp256k1_serving`'s "installed, and not refused" had nothing in
this docstring to attach that to. Both are now named where they are
published, with why the module keeps two where the public call
publishes one: `ENABLED` is only the state `curves.curve` starts in and
`set_libsecp256k1_serving` may have moved it since, while `INSTALLED`
is settled at that import and stays — which is what that function reads
to refuse `serving=True` where there is nothing to serve, and what
`tests/conftest.py` skips the `bindings` marker on, `INSTALLED` being
"not something a test can fake in-process".

Nothing is renamed. [PR #1135](https://github.com/btclib-org/btclib/pull/1135)
chose `is_libsecp256k1_serving` over `INSTALLED` for the wheel smoke
tests because serving is what a caller can act on; the new paragraph
says the same thing from this side — the difference between the two
names is the module's and the seam's, not a caller's.

The "eleven `try` blocks" count goes with the rewrite, in both places
it appeared: it counts a tree that no longer exists, nothing here
re-derives it, and what the sentence was carrying — one `try` rather
than one per delegating module, which could drift apart — survives
without it.

No other copy of the wrong name or of the gap: `CONTRIBUTING.md` names
`INSTALLED` correctly, and `SECURITY.md`, `README.md` and
`docs/source/guide.rst` describe the seam through the public
`is_libsecp256k1_serving`, which is the right name for a reader who
cannot import a private module.

RELEASE_NOTES.md gets nothing: it moves for a change a user has to act
on, and no spelling a caller writes changes here.

Gates on this tree, exit codes:

- `uv run pytest` — 0
- `uv run pre-commit run --all-files` — 0
- `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html` — 0

## Summary by Sourcery

Clarify the libsecp256k1 binding-state documentation and replace obsolete terminology with the module's published names.

Enhancements:
- Clarify the `_libsecp256k1` module documentation by accurately naming and distinguishing the `INSTALLED` and `ENABLED` binding states and their relationship to the public serving status.
- Remove outdated references to the nonexistent `AVAILABLE` symbol and obsolete try-block counts from the documentation.

Documentation:
- Update the changelog to document the corrected binding-state terminology and explanation.