### PR TITLE
Name the bindings failure in latest.yml (issue #1136)

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -125,7 +125,21 @@ jobs:
       # still --locked, which is not a contradiction: the step above just
       # wrote that lock, so this asserts nothing moved between the two and
       # keeps the convention that no uv command in these workflows
-      # installs from a lock it has not checked
+      # installs from a lock it has not checked.
+      # No "assert the bindings are serving" in front of it, which
+      # suite-bindings-latest below does have (issue #1136), and the
+      # difference is what these two jobs are for. There the bindings are
+      # the only thing that moved, so they are the answer and stopping on
+      # them costs nothing; here everything moved, so they are one
+      # suspect among the dozen this job exists to net, and an assertion
+      # ahead of pytest would trade the list of failures that names the
+      # others for one line about the one the job below already asks
+      # precisely, on this same matrix, from this same newest release.
+      # The case the two answers differ in is a package moving *under*
+      # the bindings and breaking their import while the bindings
+      # themselves are fine -- and there the upgrade step above has
+      # already printed the "Update <pkg> vA -> vB" line the assertion
+      # would not have named
       - name: Run pytest
         run: uv run --locked --no-default-groups --group test pytest
 
@@ -168,6 +182,47 @@ jobs:
       # knowing before running the same command in a working tree
       - name: Upgrade the bindings to their latest release
         run: uv lock --upgrade-package btclib_secp256k1
+      # test.yml's no-bindings job, with the sense reversed, and here for
+      # the mirror image of its reason: asked before the suite, and asked
+      # of the interpreter rather than of the resolver, because the step
+      # above resolves and installs whatever the newest release is
+      # whether or not this tree can import it. `btclib._libsecp256k1`
+      # imports the whole surface in one `try` whose `except ImportError`
+      # sets `INSTALLED = False`, so a release missing one name of it --
+      # issue #1116, where the name was `musig` -- leaves the suite below
+      # answering on the Python arithmetic, tests/conftest.py's
+      # `pytest_collection_modifyitems` skipping every `bindings`-marked
+      # test, and the run answering the one question this job exists to
+      # ask as a coverage shortfall against the 100% ratchet -- the whole
+      # bindings half of the suite having skipped itself. Reproduce it
+      # with the bindings out of reach and read what it says:
+      #
+      #   UV_PROJECT_ENVIRONMENT=.venv-nobind uv run --locked \
+      #       --no-default-groups --group harness pytest
+      #
+      # Red, so nothing shipped on it, but only by accident and saying
+      # nothing -- and RELEASING.md reads this workflow per job, where a
+      # coverage shortfall is the shape of "a dependency moved and this
+      # tree has not caught up", which does not block a release, while
+      # what happened is the one shape that does (issue #1136).
+      # The ratchet is not what is wrong and is deliberately untouched:
+      # it measures a suite that really did skip those tests, and
+      # lowering it would turn this failure green. What was missing is a
+      # step in front of it that says which suite ran.
+      # `is_libsecp256k1_serving` and not `INSTALLED`: serving is
+      # installed and not refused, so it implies the other, and it is the
+      # public reading of the seam every dispatch consults -- the name
+      # the wheel smoke tests assert (issue #1117) and the one
+      # `no-bindings` and python-arm-authority.yml assert the negative
+      # of. Nothing here sets BTCLIB_NO_LIBSECP256K1, so refusal is not
+      # reachable and False leaves only the import, which is what the
+      # message says rather than the generic sentence those two carry
+      - name: Assert the bindings are serving
+        run: >
+          uv run --locked --no-default-groups --group test
+          python -c "from btclib.curves import is_libsecp256k1_serving;
+          assert is_libsecp256k1_serving(),
+          'the newest btclib_secp256k1 does not import'"
       - name: Run pytest
         run: uv run --locked --no-default-groups --group test pytest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -641,6 +641,42 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **`latest.yml`'s `suite-bindings-latest` asserts that the bindings are
+  serving** (issue #1136). That job upgrades `btclib_secp256k1` alone to
+  its newest release and runs the suite, and RELEASING.md names it as
+  the one worth reading closely before a tag: what it exists to answer
+  is "did my own other release just break this one". It could not answer
+  it. A release this tree cannot import — issue #1116's shape, where
+  `btclib._libsecp256k1` imports the whole surface in one `try` and one
+  missing name lands the lot in `except ImportError` — set `INSTALLED =
+  False`, `tests/conftest.py` skipped every `bindings`-marked test, and
+  the run went red on coverage with the remaining suite passing. Red, so
+  nothing shipped on it, but by accident and mute: RELEASING.md reads
+  that workflow per job, and a coverage shortfall there is the shape of
+  "a dependency moved and this tree has not caught up", which does not
+  block a release, while what had happened is the one shape that does.
+  The step `no-bindings` and `python-arm-authority.yml` already carry,
+  with the sense reversed, now runs before the suite and says so by
+  name. Its message names the import rather than the seam in general:
+  serving is installed and not refused, and nothing in that job sets
+  `BTCLIB_NO_LIBSECP256K1`, so refusal is not reachable there.
+
+  The 100% ratchet is deliberately untouched, and lowering it would have
+  been the wrong fix: it measures a suite that really did skip those
+  tests, and a floor that tolerated the skip would turn this failure
+  green rather than legible. `suite-latest` deliberately does not get
+  the assertion either, and its comment now says why — there everything
+  moved, so the bindings are one suspect among the dozen that job exists
+  to net, and stopping ahead of pytest would trade the failures naming
+  the others for one line about the question the sibling job now asks
+  precisely, on the same matrix and of the same release. `lint-latest`
+  and `dist-latest` are not entitled to it at all: neither runs the
+  suite, mypy names a `btclib_secp256k1` submodule it cannot find in its
+  own words, and nothing in the distribution checks imports btclib.
+  RELEASING.md's "read it per job" paragraph gains the sentence that
+  makes the new failure legible from the run page, and CONTRIBUTING.md's
+  copy of that job's commands moves with the step.
+
 - **The wheel smoke test asserts that the bindings are serving** (issue
   #1117). `test.yml`'s `dist` job and `release.yml`'s `build` job each
   install the wheel with its `secp256k1` extra and then check the version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -528,10 +528,19 @@ uv lock --upgrade
 That workflow has a second job, `suite-bindings-latest`, upgrading only
 the bindings and re-running the suite — narrower than the upgrade above,
 which moves every dependency, so a red run here names the one responsible
-instead of burying it behind a dozen others:
+instead of burying it behind a dozen others. That the newest release
+then *serves* is asserted before the suite rather than assumed: a release
+this tree cannot import leaves btclib on the Python arithmetic, the
+suite skipping every `bindings`-marked test, and the run failing on
+coverage — which reads as a dependency this tree has not caught up with
+rather than as the answer the job was asked for:
 
 ```shell
 uv lock --upgrade-package btclib_secp256k1
+uv run --locked --no-default-groups --group test python -c \
+    "from btclib.curves import is_libsecp256k1_serving; \
+     assert is_libsecp256k1_serving(), \
+       'the newest btclib_secp256k1 does not import'"
 uv run --locked --no-default-groups --group test pytest
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -141,11 +141,17 @@ dependency moved and this tree has not caught up" or "the bindings are
 broken against it", and only the second is a reason to stop — so which
 job failed is the question, and a run that is red overall while
 `bindings at latest` is green on every runner is saying the pin is
-sound. Open the failure rather than inferring it from a sibling: on
-v2026.8.7 seven jobs were red, six tests and the lint one, and reading
-a single test log and generalising happened to be right — the lint job
-was mypy reporting the same four errors — but nothing said so until it
-was checked.
+sound. The second says which it is now (issue #1136): a newest release
+this tree cannot import fails that job's **Assert the bindings are
+serving** step, by name and before the suite, where it used to reach you
+as a coverage shortfall under a suite that passed — the shape of the
+first, and the reading that does not stop a release. Red on a test
+below that step is the other blocking shape, the bindings importing and
+answering differently. Open the failure rather than inferring it from a
+sibling: on v2026.8.7 seven jobs were red, six tests and the lint one,
+and reading a single test log and generalising happened to be right —
+the lint job was mypy reporting the same four errors — but nothing said
+so until it was checked.
 
 **Usually a red run is future work, and sometimes it blocks.** A release
 ships what `uv.lock` pins, so drift against a newer version of some


### PR DESCRIPTION
Closes [ISS #1136](https://github.com/btclib-org/btclib/issues/1136).

`latest.yml`'s `suite-bindings-latest` upgrades `btclib_secp256k1` alone
to its newest release and runs the suite. RELEASING.md names it as the
job worth reading closely before a tag, because what it exists to answer
is "did my own other release just break this one" — and it could not
answer it. A release this tree cannot import
([ISS #1116](https://github.com/btclib-org/btclib/issues/1116)'s shape)
sets `INSTALLED = False`, `tests/conftest.py` skips every
`bindings`-marked test, and the run goes red on **coverage** with the
remaining suite passing. Red, so nothing ships on it, but by accident
and mute: RELEASING.md reads that workflow per job, where a coverage
shortfall is the shape of "a dependency moved and this tree has not
caught up" — the reading that does *not* block a release — while what
happened is the one shape that does.

The step `no-bindings` and `python-arm-authority.yml` already carry,
with the sense reversed, now runs before the suite.

## The four decisions

1. **Placement: before `pytest`.** Nothing else moved in that job, so
   its suite result is entirely about the bindings — stopping early
   loses no answer the run could otherwise have given. `fail-fast:
   false` is unchanged, so each (os, python) cell still reports on its
   own, which matters when a bindings release ships a wheel for some
   platforms and not others.

2. **The message names the import, not the seam.**
   `is_libsecp256k1_serving` is installed *and not refused*, matching the
   wheel smoke tests of
   [ISS #1117](https://github.com/btclib-org/btclib/issues/1117) rather
   than inventing a third spelling. Nothing in that job sets
   `BTCLIB_NO_LIBSECP256K1`, so refusal is not reachable there and False
   leaves only the import — hence `'the newest btclib_secp256k1 does not
   import'` rather than the generic sentence `no-bindings` carries.
   Confirmed by measurement: in the broken environment `INSTALLED` and
   `ENABLED` are both False.

3. **The coverage floor is deliberately untouched.** It is not what is
   wrong: it measures a suite that really did skip those tests, and a
   floor that tolerated the skip would turn this failure *green* rather
   than legible. What was missing is the step in front of it.

4. **Siblings.** `suite-bindings-latest` only.
   - `suite-latest` deliberately does **not** get it, against the
     issue's own leaning, and its comment now records why: there
     *everything* moved, so the bindings are one suspect among the dozen
     that job exists to net, and an assertion ahead of `pytest` would
     trade the failures naming the others for one line about the
     question `suite-bindings-latest` now asks precisely, on the same
     matrix and of the same release. The one case the two answers differ
     in — a package moving *under* the bindings and breaking their
     import while the bindings themselves are fine — is already named by
     that job's own `Update <pkg> vA -> vB` line, which the assertion
     would not have named.
   - `lint-latest` and `dist-latest` are not entitled to it at all:
     neither runs the suite, mypy names a `btclib_secp256k1` submodule
     it cannot find in its own words, and nothing in the distribution
     checks imports btclib.
   - `published.yml` remains the worked example of a job that must not
     have it, for PR #1135's reason (no extra, the supported no-bindings
     configuration of ISS #990/#991/#992). Untouched here.

## This does not run in CI on this pull request

`latest.yml` is `schedule` / `workflow_dispatch` only. Reproduced
locally instead, with the job's own dependency group and its command
verbatim.

Baseline, bindings serving:

```
$ uv run --locked --no-default-groups --group test python -c \
    "from btclib.curves import is_libsecp256k1_serving; \
     assert is_libsecp256k1_serving(), 'the newest btclib_secp256k1 does not import'"
EXIT=0
```

ISS #1116's exact shape — `btclib_secp256k1/musig.py` removed from the
environment, which is one name missing from `_libsecp256k1`'s single
`try`:

```
$ python -c "from btclib._libsecp256k1 import INSTALLED, ENABLED; ..."
INSTALLED False ENABLED False

$ uv run --locked --no-default-groups --group test pytest
ERROR: Coverage failure: total of 97.67 is less than fail-under=100.00
TOTAL 46665 1088 97.67%
FAIL Required test coverage of 100.0% not reached. Total coverage: 97.67%
23454 passed, 5950 skipped in 44.23s
PYTEST_EXIT=1          # today's illegible failure, the issue's own numbers
                       # reproduced under --group test rather than --group harness

$ <the new step, verbatim>
AssertionError: the newest btclib_secp256k1 does not import
EXIT=1                 # what the job says instead, before the suite runs
```

So the assertion fires on exactly the state the job was blind to, and
does not misfire on the normal one.

## Gates

| gate | exit |
| --- | --- |
| `uv run pytest` | 0 (29393 passed) |
| `uv run pre-commit run --all-files` | 0 (`actionlint`, `zizmor` clean) |
| `sphinx-build -W --keep-going` | 0 |

## Documentation

- CHANGELOG.md gets an entry under the existing work-in-progress
  heading, in "Packaging, linting and CI".
- **RELEASE_NOTES.md gets nothing**, deliberately: it moves only for a
  change a user has to *act* on, and this is a scheduled sentinel
  workflow's diagnostic — no API, no install, no behaviour a caller can
  observe changes.
- RELEASING.md's "read it per job" paragraph gains the sentence that
  makes the new failure legible from the run page. Written against the
  current text, which includes PR #1134's rewrite (`680365cc`); no
  collision with it.
- CONTRIBUTING.md copies `suite-bindings-latest`'s commands verbatim, so
  it moves with the step — the same obligation PR #1135 discharged for
  `dist`. Its spelling of the command (backslash-continued inside the
  double quotes) was run verbatim in both directions too, not just the
  workflow's folded-scalar one.

Rebased onto `b1d0a874` (ISS #1137, which names `INSTALLED` and
`ENABLED` where `_libsecp256k1` publishes them). Both CHANGELOG.md and
RELEASE_NOTES.md re-read by eye after the rebase for the `merge=union`
hazard: one `## v2026.9 (work in progress, not released yet)` heading in
each, unmodified, and RELEASE_NOTES.md untouched.

## Summary by Sourcery

Make the bindings-only latest-release workflow identify incompatible btclib_secp256k1 releases before running the test suite.

New Features:
- Add an explicit pre-suite check to the latest-bindings workflow that reports when the newest bindings release cannot be imported.

Bug Fixes:
- Make incompatible btclib_secp256k1 releases fail with a clear, actionable diagnostic instead of an opaque coverage failure.

Enhancements:
- Clarify why the bindings check is limited to the bindings-only workflow and document how to interpret the resulting failure.

CI:
- Update the latest dependency workflow and related contributor guidance to run and explain the bindings-serving assertion.

Documentation:
- Document the new bindings import check and its release-readiness implications in the changelog, contributing guide, and release guide.
