### PR TITLE
Say when github-release runs instead of relying on no `if` (issue #1142)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -600,17 +600,39 @@ jobs:
           path: attestation.jsonl
 
   # only after PyPI has accepted the files: a GitHub release announces what
-  # users can already install. Both jobs above it and not attest alone:
-  # attest runs in a rehearsal too, so naming it by itself would make this
-  # job -- which has no `if` of its own -- cut a release from a dispatch,
-  # where publish-pypi is skipped and a skipped need is what keeps this to
-  # the tag. attest earns its place in the list by producing the bundle
-  # attached below; a failure there leaves the version published and no
-  # release cut, which `gh run rerun --failed` finishes without rebuilding
-  # anything
+  # users can already install. Both jobs in `needs` and not attest alone:
+  # attest runs in a rehearsal too, so naming it by itself would cut a
+  # release from a dispatch, where publish-pypi is skipped; asking below
+  # for publish-pypi's success is what keeps this job to the tag. attest
+  # earns its place in the list by producing the bundle attached here.
+  # The `if` is spelled out, and it opens with always(), because the
+  # absence of one does not mean "whatever my own needs did": a job with a
+  # skipped job anywhere in its ancestry is force-skipped whatever its
+  # condition says, unless that condition opens with a status function --
+  # and attest's own always(), which is what lets attest run past the
+  # skipped publish-testpypi, does not clear that skip for whoever needs
+  # attest in turn. Every job crossing a skip has to opt out for itself.
+  # Measured on v2026.8.21, the first tag with attest standing between
+  # publish-pypi and here: both needs green, this job skipped in the same
+  # second attest finished, the version on PyPI and no GitHub release cut
+  # at all (issue #1142). That run was also failing an unrelated install
+  # job (issue #1141), which looks like the cause and is not -- sibling
+  # btclib-secp256k1 lost v0.8.0.2 to the same skip on a run with nothing
+  # failing in it, and carries this exact condition as the fix.
+  # A skip is neither a failure nor within that flag's blast radius, so
+  # `gh run rerun --failed` does not recover it: it re-runs failed jobs
+  # and their dependents, and this job is a dependent of neither -- tried
+  # twice on the v2026.8.21 run, skipped both times. What does recover it
+  # is RELEASING.md's other option, the release created by hand from the
+  # run's own dist, sbom and attestation artifacts, with the distribution
+  # files checked against the digests PyPI publishes before they are
+  # attached
   github-release:
     name: Attach the files to the GitHub release
     needs: [publish-pypi, attest]
+    if: >-
+      always() && needs.publish-pypi.result == 'success' &&
+      needs.attest.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,30 @@ documented at release-notes length in the first place, and are still in
 
 ## v2026.9 (work in progress, not released yet)
 
+### Repository
+
+- **A tagged release cuts its GitHub release again** (issue #1142).
+  `release.yml`'s `github-release` job carried no `if` of its own, which
+  reads as "run when my needs succeeded" and is not what GitHub does with
+  it: a job with a skipped job anywhere in its ancestry is force-skipped
+  whatever its condition says, unless that condition opens with a status
+  function such as `always()`. `attest`, added for v2026.8.21 between
+  `publish-pypi` and this job, needs `publish-testpypi` — skipped on a tag
+  — and its own `always()` keeps `attest` itself running without clearing
+  that skip for whoever needs `attest` in turn. v2026.8.21 was the first
+  tag under that shape: the version reached PyPI, both of this job's needs
+  were green, and no GitHub release was created at all, the release being
+  recreated by hand from the run's artifacts. The job now asks
+  `always() && needs.publish-pypi.result == 'success' && needs.attest.result
+  == 'success'`, which is what sibling btclib-secp256k1 already carried
+  after losing three releases to the same skip. A rehearsal still cuts
+  nothing, by the condition rather than by omission: `workflow_dispatch`
+  skips `publish-pypi`, so the first `.result` test is false. The comment's
+  other claim goes with it — `gh run rerun --failed` does not finish an
+  interrupted release, that flag reaching failed jobs and their dependents
+  while a skipped job is neither, which is why it left this one skipped on
+  both attempts.
+
 ## v2026.8.21
 
 ### Repository


### PR DESCRIPTION
Closes #1142.

`release.yml`'s `github-release` job gains the condition
btclib-secp256k1's `release.yml` already carries, word for word:

```yaml
    if: >-
      always() && needs.publish-pypi.result == 'success' &&
      needs.attest.result == 'success'
```

and the comment above it is rewritten rather than left standing beside
the fix.

## What the issue got wrong, and why it changes the fix

[ISS #1142](https://github.com/btclib-org/btclib/issues/1142) blames the
skip on the unrelated `published` failure the same run carried
([ISS #1141](https://github.com/btclib-org/btclib/issues/1141)). It is
not the cause. A job whose ancestry contains a *skipped* job is
force-skipped whatever its own condition says, unless that condition
opens with a status function; `attest`'s `always()` lets `attest` itself
run past the skipped `publish-testpypi`, and does not clear the skip for
whoever needs `attest` in turn.

The skip is therefore deterministic, not a race: it happens on every
tagged release under this shape, whatever else the run did. Three
measurements say so, none of them involving a failure:

- bitcoin-core-rpc, which carries the same defect
  ([bitcoin-core-rpc #149](https://github.com/btclib-org/bitcoin-core-rpc/issues/149)),
  released twice with `conclusion=success` and nothing failing at all —
  [32375425517](https://github.com/btclib-org/bitcoin-core-rpc/actions/runs/32375425517)
  (v2026.8.20) and
  [31724290757](https://github.com/btclib-org/bitcoin-core-rpc/actions/runs/31724290757)
  (v2026.8.13). Each has exactly two jobs not green, and they are the
  same two: `Publish to TestPyPI` skipped, and `Attach the files to the
  GitHub release` skipped behind it.

- sibling btclib-secp256k1's v0.8.0.2 run
  ([31832396617](https://github.com/btclib-org/btclib-secp256k1/actions/runs/31832396617))
  is green in every job but the skipped `Publish to TestPyPI`, its
  `github-release` carried an `if` asking exactly the two `.result`
  questions **without** `always()`, and it never ran. That is what makes
  the `always()` prefix load-bearing rather than decorative.
- here, v2026.8.7 and v2026.8.9 cut their releases because
  `github-release` then needed `publish-pypi` alone, with nothing skipped
  in its ancestry. `attest` arrived after v2026.8.9, and v2026.8.21 is
  the first tag since — so under the shape on `main` today **no tag would
  cut a release**, failure or no failure. This is not a regression in
  `github-release`, which has not changed: it started the day `attest`
  was added between it and `publish-pypi`.

The comment's `gh run rerun --failed` promise is dropped: the flag
re-runs failed jobs and their dependents, this job is a dependent of
neither, and attempts 2 and 3 of run 32471596505 left it skipped both
times. The comment now names the recovery that worked — RELEASING.md's
other option, the release created by hand from the run's own `dist`,
`sbom` and `attestation` artifacts, with the distribution files checked
against PyPI's published digests first.

## This cannot be exercised in CI

`release.yml` triggers on `push: tags: ["v*"]` and `workflow_dispatch`
only, so no pull request runs it and the pull-request checks say nothing
about this change. `actionlint` and `zizmor` (both pre-commit hooks) pass
at zero findings, and the reasoning below is against the file rather than
against a run. A `workflow_dispatch` rehearsal from this branch would
exercise the dispatch column for real, and is the maintainer's call.

## Trigger table, every `if` quoted

The conditions in play, verbatim from the file:

- `publish-testpypi`: `github.event_name == 'workflow_dispatch' &&
  github.repository == 'btclib-org/btclib'`
- `publish-pypi`: `github.event_name == 'push' && github.repository ==
  'btclib-org/btclib'`
- `attest`: `always() && (needs.publish-pypi.result == 'success' ||
  needs.publish-testpypi.result == 'success')`
- `github-release`, new: `always() && needs.publish-pypi.result ==
  'success' && needs.attest.result == 'success'`

`publish-testpypi` is skipped on every one of the tag rows, and that one
cell is what tainted `github-release` through `attest` before this
change: the last column read `skipped` on every row of the table,
including the first.

| trigger | `publish-pypi` | `publish-testpypi` | `attest` | `github-release`, before | `github-release`, after |
| --- | --- | --- | --- | --- | --- |
| `v*` tag push, all green | success | skipped | success | skipped | **runs** |
| `v*` tag push, unrelated job fails (`published`, `documented`) | success | skipped | success | skipped | **runs** |
| `v*` tag push, `attest` fails | success | skipped | failure | skipped | skipped |
| `v*` tag push, `publish-pypi` fails | failure | skipped | skipped (`or` false) | skipped | skipped |
| `workflow_dispatch` rehearsal | skipped | success | success | skipped | skipped — `.result` is `skipped` |
| either trigger on a fork | skipped | skipped | skipped | skipped | skipped |

The first row is the whole defect: nothing wrong anywhere and no release.
The rehearsal row is the property the old comment achieved by omission —
for the wrong reason, since that column was `skipped` whatever happened —
and the new condition states outright: `publish-pypi` is `push`-only, so
a dispatch leaves `needs.publish-pypi.result == 'skipped'`, the first
`.result` test is false, and no release is cut.

## Anything else with the same shape

One job, and it is sound today: `published` has `needs: publish-pypi` and
no `if`, and relies on the same skipped-need rule to stay off a
rehearsal. The difference is its ancestry — `publish-pypi`, `build`,
`test`, `lint`, `docs`, `macos`, `windows`, `version-check` — which holds
nothing skipped on a tag push, so it runs when it should. It is fragile
in the way `github-release` was, in that the day anything skipped enters
that ancestry it dies silently, but adding `always()` to it today is a
no-op guard against a hypothesis, so the diff stays off it.

`attest` already opens with `always()`. `documented`, `publish-pypi` and
`publish-testpypi` carry explicit conditions. The remaining jobs
(`version-check`, `test`, `lint`, `docs`, `macos`, `windows`, `build`)
are meant to run on both triggers and have no skipped ancestor.

## Where the CHANGELOG entry went

The entry sits under `## v2026.9 (work in progress, not released yet)`,
which [PR #1149](https://github.com/btclib-org/btclib/pull/1149) opened
along with `pyproject.toml`'s month-only placeholder, `uv.lock` and
RELEASE_NOTES.md's matching section. Nothing goes in RELEASE_NOTES.md
here: this asks nothing of a user.

**Corrected since the first push.** The commit at `68d9b902` opened that
heading itself — `main` then had none, v2026.8.21 being the top one — and
its message said so. #1149 landed the same line, and this branch was
rebased onto it and the heading dropped, so the commit at `6fbb5258` adds
the entry alone and its message says *that*. The earlier claim is gone
from the branch, and this paragraph is where it is on the record.

The rebase merged the two without duplicating anything, and not because
`merge=union` protected it: both sides had added the *identical* line at
the *identical* place, which an ordinary three-way merge records once.
Union would have kept both copies had either differed — a different
wording, a different offset — with no conflict marker to show it, which
is why the diff was re-read by eye rather than believed on the strength
of a clean rebase. `main` has one `## v2026.9` heading; so does this
branch.

## Gates

| gate | exit |
| --- | --- |
| `uv run pytest` | 0 |
| `uv run pre-commit run --all-files` | 0 |
| `sphinx-build -W --keep-going` | 0 |

## Related, not fixed here

RELEASING.md's "Only the `github-release` job failed" bullet says to
create the release "by hand from the `dist` artifact of the run", which
is now short by two: the release also carries the SBOM and the
attestation bundle. Filed as [ISS #1150](https://github.com/btclib-org/btclib/issues/1150) rather than widened into this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uNzuzag82WGhvznByjFDH

## Summary by Sourcery

Restore automatic GitHub release creation for tagged releases by explicitly requiring successful PyPI publication and artifact attestation.

Bug Fixes:
- Ensure tagged releases create the GitHub release after PyPI publication and attestation succeed, even when unrelated workflow jobs are skipped or fail.

Enhancements:
- Make the release job's execution conditions explicit while preserving the behavior that workflow rehearsals do not create GitHub releases.
- Update release workflow guidance to document skipped-job behavior and the supported manual recovery path.

Documentation:
- Add a v2026.9 work-in-progress changelog entry describing the release workflow fix and recovery behavior.

