### PR TITLE
Declare shell: bash on published.yml's steps (issue #1141)

### DIFF
--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -99,6 +99,18 @@ jobs:
         python: ["3.10", "3.14", "3.14t"]
     timeout-minutes: 20
     steps:
+      # every run step below declares `shell: bash`, and the matrix is why:
+      # the default shell on a Windows runner is PowerShell, which parses
+      # none of this. The wait step went in without the line (issue #1141)
+      # and took every Windows cell of v2026.8.21's release run with it --
+      # "Missing opening '(' after keyword 'for'" -- having never run
+      # before that tag, the release path being the only one that reaches
+      # it. A step whose script happens to be a couple of plain commands
+      # survives PowerShell unchanged, which is what makes an omission
+      # invisible on review; declaring it on every step is what makes the
+      # absence of one visible instead. Both siblings' copies of this file
+      # already do
+      #
       # the index does not serve a new file the instant the upload returns,
       # and this workflow installs whatever the resolver picks: a run that
       # starts too early tests the *previous* version and reports a pass for
@@ -108,6 +120,7 @@ jobs:
       # every other trigger
       - name: Wait for the index to serve the released version
         if: inputs.version != ''
+        shell: bash
         env:
           TAG: ${{ inputs.version }}
         run: |
@@ -156,6 +169,7 @@ jobs:
       # it: there is no checkout, so nothing of this repository is on the
       # path either way, and that is the property the header claims
       - name: Install btclib from PyPI
+        shell: bash
         run: |
           uv venv --python ${{ matrix.python }}
           uv pip install --verbose btclib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,44 @@ documented at release-notes length in the first place, and are still in
   while a skipped job is neither, which is why it left this one skipped on
   both attempts.
 
+### Packaging, linting and CI
+
+- **`published.yml`'s steps declare `shell: bash`** (issue #1141). The
+  matrix includes `windows-latest` and `windows-11-arm`, where the default
+  shell is PowerShell, and the step that waits for the index to serve the
+  released version is POSIX shell: it died at `Missing opening '(' after
+  keyword 'for'` on every Windows cell of `v2026.8.21`'s release run and
+  on no other cell of it. Those cells never reached the install this
+  workflow exists to make, so they verified nothing at all. Nothing
+  reached a user — PyPI has the wheel and the sdist, and the published
+  version installs and answers — but the sentinel was mute exactly where
+  it was meant to speak. The fix lands here rather than under that
+  release: `v2026.8.21` is tagged, and the tree that tag names does not
+  contain it.
+
+  It reached a release having never run. The step carries `if:
+  inputs.version != ''`, only `release.yml`'s call passes a version, and
+  `published.yml` is otherwise `schedule`/`workflow_dispatch`, so no pull
+  request and no scheduled run takes that branch: the tag was the step's
+  first execution in its life. Whether a run should be able to exercise
+  the release path deliberately is the issue's other half and is left to a
+  decision of its own; this changes no trigger.
+
+  `Install btclib from PyPI` gets the line too, the last step here without
+  one. That step is two plain commands, PowerShell runs it correctly and
+  has on every dispatched run — which is precisely what made the omission
+  invisible on review, since whether a shell-less step works depends on
+  whether its script happens to be portable rather than on anything
+  visible in the diff. With the line on every step, a missing one is
+  visible by its absence, which is the only review signal this file has:
+  `actionlint` reports nothing for a shell-less POSIX script on a Windows
+  runner, measured both under a literal `runs-on: windows-latest` and
+  under a matrix naming it. `btclib-secp256k1` and `bitcoin-core-rpc` both
+  declare it on every run step of their copies of this file, and this one
+  now matches them: the step was written correctly there and lost the line
+  on the way in here, its paragraph of reasoning arriving verbatim and
+  sound without the one declarative line that made it run.
+
 ## v2026.8.21
 
 ### Repository


### PR DESCRIPTION
Closes [ISS #1141](https://github.com/btclib-org/btclib/issues/1141).

## The defect

`published.yml`'s **Wait for the index to serve the released version** is
POSIX shell and declares no `shell:`. The `install-published` matrix
includes `windows-latest` and `windows-11-arm`, where the default shell
is PowerShell, so on those cells the script was handed to
`pwsh.EXE -command ". '{0}'"` and died before its first statement:

```
ParserError: D:\a\_temp\34ad999c-....ps1:3
   3 |  for attempt in $(seq 20); do
     |      ~
     | Missing opening '(' after keyword 'for'.
```

Every Windows cell of `v2026.8.21`'s release run failed there, and no
other cell of it did. Those cells never reached the install this workflow
exists to make. Nothing reached a user — PyPI has the wheel and the
sdist, and the published version installs and answers — but the sentinel
was mute exactly where it was meant to speak.

## The change

`shell: bash` on that step, between `if:` and `env:`, and on **Install
btclib from PyPI**, which was the last step here without the line.

That second one is not a bug fix: it is two plain commands, PowerShell
runs it correctly, and it has on every dispatched run. That is the point.
Whether a shell-less step works depends on whether its script happens to
be portable, which is not visible in the diff — which is how this
omission passed review. With the line on every step, a missing one is
visible by its absence, and the comment added above the steps says so.

Both siblings already declare `shell: bash` on **every** run step of
their copy of this file, in the same position:

| | wait step | install step | verify steps |
| --- | --- | --- | --- |
| `btclib-secp256k1` | `shell: bash` | `shell: bash` | `shell: bash` |
| `bitcoin-core-rpc` | `shell: bash` | `shell: bash` | `shell: bash` |
| `btclib`, before | — | — | `shell: bash` |
| `btclib`, after | `shell: bash` | `shell: bash` | `shell: bash` |

The two siblings do not differ from each other on this, so there was no
choice to make: the spelling and placement here are theirs. The step was
written correctly there and lost the line on the way in, its paragraph of
reasoning arriving verbatim and sound without the one declarative line
that made it run.

## This cannot be checked by CI on this pull request

`published.yml` is `schedule` / `workflow_dispatch` / `workflow_call`
only, so no pull request run exercises it, and the changed step is
additionally `if: inputs.version != ''`, which only `release.yml`'s call
satisfies. **Nothing in this PR's checks touches the changed lines.** The
evidence is local and from the failed run:

- the failed run's log, quoted above, is job `96744808603` of run
  `32471596505` — `Install 3.10 from PyPI on windows-latest` — and its
  `##[group]Run` block shows
  `shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"`
- the step's script, extracted verbatim from `main`, invoked locally the
  way the runner invokes it — `pwsh -command ". '<file>'"`, PowerShell
  7.7.0-preview.3 — reproduces `Missing opening '(' after keyword 'for'.`
  and exits 1
- the same script under `bash` with `TAG=v2026.8.21` prints
  `the index serves 2026.8.21` and exits 0

`actionlint` and `zizmor` stay at zero findings; `uv run pytest`,
`uv run pre-commit run --all-files` and the `-W` sphinx build all exit 0.

## Deliberately not in this diff

**A sweep of every workflow** for a `run:` step with no `shell:` on a
job that can land on a Windows runner found four Windows-capable jobs:
`published.yml::install-published`, `windows.yml::suite-windows` and
`latest.yml`'s two. Outside this file every such step is a single plain
command invocation — `uv lock --upgrade`, `uv run ... pytest`, one
`python -c` — which PowerShell runs identically and does, green, today.
So there is no second instance of this defect. There is the same latent
hazard, though, and for the same reason: neither `latest.yml` nor
`windows.yml` runs on a pull request either, so a POSIX construct added
to one of their steps would also first be seen by a schedule or a tag.
That is a separate issue rather than a wider diff here.

**The issue's second half** — whether a `workflow_dispatch` `version`
input should let the release path be exercised deliberately — is not
implemented, and the reasoning is in the review comment below. No trigger
changes here.

## CHANGELOG placement

**Corrected since the first push, and the correction matters.** The entry
originally sat under `## v2026.8.21`, on the argument that the defect
belongs to that release's run. The defect does; the *fix* does not.
`v2026.8.21` is tagged and published, and the tree that tag names does
not contain this change — an entry there would tell a reader the fix
shipped in a release that cannot carry it, and the tag is immutable, so
it never will.

This branch is now rebased onto [PR #1149](https://github.com/btclib-org/btclib/pull/1149),
which opened the next cycle, and the entry sits under **v2026.9 →
Packaging, linting and CI**. That group rather than "Repository" because
workflow *behaviour* is what it already records — `latest.yml`,
`test.yml`, `codeql.yml` — while "Repository" holds rulesets and process
documents.

**No release heading is added by this diff.** `## v2026.9 (work in
progress, not released yet)` comes from PR #1149 and appears in the hunk
as context, not as an addition; only `### Packaging, linting and CI` and
the bullet are new. Checked after the rebase by eye rather than by the
absence of a conflict marker, `merge=union` never producing one: the file
holds exactly one `## v2026.9` heading and exactly one group heading
under it, and `git diff origin/main -- CHANGELOG.md` is a single purely
additive hunk. `RELEASE_NOTES.md` is untouched — a CI workflow is in no
distribution and there is nothing for a user to act on.

## Summary by Sourcery

Declare Bash for every run step in the published-package validation workflow so Windows matrix jobs can reliably verify released packages.

Bug Fixes:
- Ensure the published-package validation workflow executes its POSIX shell steps correctly on Windows runners by explicitly selecting Bash.

Enhancements:
- Make shell selection consistent across all run steps in the published-package workflow to improve reviewability and prevent future cross-platform omissions.

Documentation:
- Document the published workflow shell correction and its release-cycle placement in the changelog.
