### PR TITLE
Remove counts nothing checks, and fix two that already drifted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7057,6 +7057,30 @@ documented at release-notes length in the first place, and are still in
 
 ### Documentation and the website
 
+- **Prose no longer states counts nothing checks, and two that had
+  already drifted are fixed** (issue #1144). CONTRIBUTING.md's own
+  "measure, don't assert" rule was not honored in 36 places across
+  CLAUDE.md, RELEASING.md, REPOSITORY.md, CONTRIBUTING.md, README.md
+  and SECURITY.md — a count of something that can grow or shrink,
+  asserted as present-tense fact with nothing guarding it from
+  drifting silently false. Most had the number dropped where the named
+  things already carried the count, or a live command pointed at
+  instead (`gh api ... --jq '.required_status_checks.checks'`,
+  `cosmic-ray baseline`); GitHub's own platform limits (twenty
+  concurrent jobs on the Free plan) kept their number, with a dated
+  qualifier, since that is their policy and not this repository's
+  history.
+
+  Two were already wrong, not just unguarded. README.md said Electrum's
+  mnemonic standard reads "the five wordlists Electrum reads" where
+  `electrum.py`'s own `ELECTRUM_WORDLISTS` reuses `BIP39_LANGUAGE_FILES`
+  entire — twelve languages, only Portuguese overridden. RELEASING.md
+  said "the two `publish-*` jobs are the only holders of `id-token:
+  write`" in `release.yml`, where `attest` holds it too, for its
+  Sigstore OIDC exchange; the review gate the sentence was arguing for
+  still holds, `attest` only running via `needs:` after a publish job
+  succeeds, but the sentence itself was false.
+
 - **`_libsecp256k1`'s docstring names the two states the module
   publishes** (issue #1137). It said the question "are the bindings
   installed" is answered by `AVAILABLE`, and there is no `AVAILABLE` in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,14 +68,13 @@ address encodings, beside `bip44`. `mnemonic/`, `script/`, `tx/`,
 holds the type aliases the public API accepts, and much of the surface
 takes "anything convertible" rather than one type.
 
-Three of those pairs are one idea split in two, and each split runs one
+Each of those pairs is one idea split in two, and each split runs one
 way only: `curves/` is arithmetic and `ecc/` is what is built on it;
 `base58` and `bech32` are codecs with no bitcoin in them, `b58` and `b32`
 the bitcoin semantics on top. `ecc` imports `curves`, `b58` imports
 `base58`, `b32` imports `bech32`, and never the reverse. The README
-carries the same layout as a table, and each of the six modules states
-its own direction in its docstring — six places, if the direction ever
-changes.
+carries the same layout as a table, and each of these modules states its
+own direction in its docstring, wherever that direction changes.
 
 ## The primary checkout is the maintainer's
 
@@ -179,7 +178,8 @@ Do not use Fable unless explicitly instructed.
   <version>` rebuilds `.venv`, and a group-restricted command then leaves
   pre-commit out of it: reproducing a matrix cell (`uv run --locked
   --no-default-groups --group test --python 3.10 pytest`) recreates the
-  environment with 15 packages where `uv sync` leaves 84 — and
+  environment with only the `test` group's packages where a plain `uv
+  sync` leaves the full dev set — and
   pre-commit's git hook `exec`s `.venv/bin/python -mpre_commit` by
   absolute path, which exists and lacks the module, so its "did you
   forget to activate your virtualenv" fallback never fires and the next

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,7 @@ uv run pre-commit run --all-files
 
 The suite writes nothing: it runs against a read-only checkout, and from an
 installed sdist. The one exception is deliberate and has to be asked for.
-Eleven modules compare a dataclass's `to_dict()` against a json file
+Several modules compare a dataclass's `to_dict()` against a json file
 committed beside them, under `tests/**/_generated_files/`, so that a change
 to a serialized form is a failing test rather than something to notice in a
 `git diff`. When such a change is the intended one:
@@ -284,8 +284,9 @@ read by every checkout of this repository.
 | `python-arm-authority` | monthly | the arm-to-vector-module table |
 | `release` | a tag | calls test, lint, docs, macos, windows, published |
 
-The first four rows are what a merge waits for, and between them they report
-the four required checks: `lint` and `docs` share a row and report one each.
+The `test`, `lint`/`docs`, `integration` and `website` rows are what a
+merge waits for, and between them they report the required checks: `lint`
+and `docs` share a row and report one each.
 
 What the other rows have in common is that a pull request does not wait for
 them, and the reason is one number: the ceiling GitHub Free puts on an
@@ -611,12 +612,14 @@ which is the one failure mode of a mutation run that looks like good news.
 excludes by operator, and is a no-op for one that excludes none, so the
 same five commands run any of them: `parsers.toml` is the one that
 excludes a family, and it states which and why. `sig_hash.toml` or
-`engine.toml` in place of it is the consensus profile, at 727 mutants and half
-an hour of cpu against 2768 and five and a half hours; the parser profile
-is 1034 mutants and minutes, so it is the one that finishes. Each
-configuration carries its own arithmetic. The report is `--surviving-only`,
-which is the whole of what anybody acts on: a killed mutant is the suite
-doing its job, and printing all 727 of them buries the dozen that are not.
+`engine.toml` in place of it is the consensus profile, minutes of cpu
+against hours; the parser profile is the one that finishes fastest. Each
+configuration carries its own arithmetic — `cosmic-ray baseline` reports
+the mutant count and the cpu cost for whichever one is run, rather than a
+figure fixed here that the source can grow past. The report is
+`--surviving-only`, which is the whole of what anybody acts on: a killed
+mutant is the suite doing its job, and printing every one of them buries
+the handful that are not.
 
 Three things to know before starting one. The session mutates the source
 file in place and restores it afterwards, so nothing else may read the
@@ -985,14 +988,14 @@ wrong values can build. `tests/built_object_contract_test.py` does the
 same for a function whose parameter is an object the caller already built
 — a `Psbt`, a `PsbtIn`, a sequence of extended keys — which is the family
 `check_validity=False` makes reachable, an invalid object being something a
-caller may legitimately hold. `tests/curve_parameter_test.py` is the
-fourth, over a parameter that carries a *default*: reaching one means every
-argument in front of it has to be valid, which is the table of valid values
-the automatic walk exists to do without, so `ec` is driven from a table
-there as `hf` and `network` are driven where their own checks live. None of
-the four has an exemption list, which is the state to keep: a finding is a
-red test, to be fixed or to be given a reason of its own beside the two
-families that have one.
+caller may legitimately hold. `tests/curve_parameter_test.py` drives
+the same rules over a parameter that carries a *default*: reaching one
+means every argument in front of it has to be valid, which is the table
+of valid values the automatic walk exists to do without, so `ec` is
+driven from a table there as `hf` and `network` are driven where their
+own checks live. None of these test files has an exemption list, which is
+the state to keep: a finding is a red test, to be fixed or to be given a
+reason of its own beside the two families that have one.
 
 **A `bool` parameter is a kind or a truth, and only the first is
 type-checked.** A flag that decides *what is computed* refuses a non-bool,
@@ -1079,17 +1082,17 @@ cannot go wrong beats a checker that catches it going wrong.
 
 What the four prefixes buy is a promise read off the name:
 
-- `assert_*` refuses and returns `None`. There are eighty-odd of them
-  and they are the reason half of the pair above.
+- `assert_*` refuses and returns `None`, and is the reason half of the
+  pair above.
 - `is_*` answers a `bool` about a value, and is total over the declared
   types: `is_p2sh` is False for bytes that are not a p2sh script.
 - `verify*` answers a `bool` about a signature or a proof, on the same
   terms. `assert_as_valid` beside it says why.
 - `check_*` answers a `bool` **and refuses what cannot be an answer** --
-  the one prefix that warns a caller it still needs an `except`. There
-  are two: `script.engine.script.check_pub_key`, where a wrong length is
+  the one prefix that warns a caller it still needs an `except`:
+  `script.engine.script.check_pub_key`, where a wrong length is
   False but a hybrid prefix under STRICTENC is the offence itself, which
-  is how Core's `CheckPubKeyEncoding` splits it; and
+  is how Core's `CheckPubKeyEncoding` splits it — and
   `script.taproot.check_output_pubkey`, where a malformed control block
   is no proof rather than a disproof.
 
@@ -1106,8 +1109,8 @@ name classifies what the call answers, and a caller passes this one
 rather than reading a result off it. What it gates is `assert_valid`, a
 refusal, so the vocabulary above would name it after that if it named it
 at all. It keeps the name it has: `validate` says no more, and the
-alternative is renaming a keyword on eighty-odd public signatures for a
-reading nobody has to make twice.
+alternative is renaming a keyword across every public signature that
+carries it, for a reading nobody has to make twice.
 
 `check_validity=False` is not an exemption from this. It says "do not
 check *now*", not "this object is exempt from here on": these are mutable
@@ -1206,10 +1209,11 @@ random operands of 256 bits down to 64, the ratio between the two ends:
 
 **The suffix is measured, never inherited, and that is what stops it.**
 Every function that *reaches* one of these through some chain of calls
-would otherwise take it: there are 636 of them, 344 public, which is
-`hex_string`, `ripemd160` and `p2pkh` — a suffix on the library, saying
-nothing. Two things break the chain, and both are facts about the caller
-rather than about the callee. Blinding is one: `mult` calls
+would otherwise take it: most of the library's own call graph, public
+functions included, right down to `hex_string`, `ripemd160` and
+`p2pkh` — a suffix on the library, saying nothing. Two things break
+the chain, and both are facts about the caller rather than about the
+callee. Blinding is one: `mult` calls
 `aff_from_jac_var` and is 0.99x in its scalar, because `_blinded_jac`
 randomized the `Z` that inverse is timed on. A public operand is the
 other: `point_from_octets` measures 1.05x, its `y_even_var` being one
@@ -1449,7 +1453,7 @@ notices that the pull request is not about becomes an issue rather than a
 comment. Read before opening a pull request, it is what the pull request
 will be answered against.
 
-**`main` enforces four things on every commit that reaches it, not only
+**`main` enforces this on every commit that reaches it, not only
 on review**: a verified signature, linear history, no force push, no
 branch deletion. These are a GitHub ruleset with no bypass actor, not a
 rule trusted to hold on its own — a commit that is unsigned or that

--- a/README.md
+++ b/README.md
@@ -103,10 +103,11 @@ Included features are:
 - [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
   hierarchical deterministic key chains
 - [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
-  mnemonic for generating deterministic keys, in the twelve wordlists of
-  the reference implementation, with the language read off the words
-- [Electrum](https://electrum.org/#home) standard for mnemonic, in the
-  five wordlists Electrum reads
+  mnemonic for generating deterministic keys, in the wordlists of the
+  reference implementation, with the language read off the words
+- [Electrum](https://electrum.org/#home) standard for mnemonic, reading
+  the same wordlists as BIP39 except for Portuguese, which is Electrum's
+  own list
 - [SLIP39](https://github.com/satoshilabs/slips/blob/master/slip-0039.md)
   Shamir backup: a master secret split into mnemonic shares, of which a
   threshold number recovers it
@@ -176,7 +177,7 @@ Included features are:
   owes for the unconfirmed ancestors it is mined with, and the dust
   threshold of any output type, computed as Bitcoin Core computes it
   rather than tabulated
-- wallets, three sources of addresses behind one vocabulary: an extended
+- wallets, several sources of addresses behind one vocabulary: an extended
   key at a BIP44 account or a set of individual keys, which also answer
   the private key that signs for an address — what `sign(address, msg)`
   needs — an output descriptor per chain, and a script template with
@@ -253,8 +254,8 @@ pointer to it.
 
 ## Module layout
 
-Three pairs of modules are one idea split in two, and each split runs one
-way only:
+Each pair of modules below is one idea split in two, and each split runs
+one way only:
 
 | the codec / the arithmetic | the bitcoin semantics on top |
 | --- | --- |
@@ -266,8 +267,8 @@ The right column imports the left one; the left never imports the right.
 
 So `from btclib.ecc import dsa` for a signature,
 `from btclib.curves import mult` for a point multiplication, `btclib.b58`
-for an address, `btclib.base58` for the encoding on its own. Each of the
-six modules says the same in its own docstring.
+for an address, `btclib.base58` for the encoding on its own. Each of
+these modules says the same in its own docstring.
 
 The rest, roughly bottom-up. `alias` holds the types the public API
 accepts, much of it taking anything convertible rather than one type, and

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -82,9 +82,11 @@ Already done for btclib-org/btclib; kept here for the record.
 
 1. In the GitHub repository settings, create the `pypi` and `testpypi`
    environments. Both require a review from `fametrano`, so neither
-   index is uploaded to without a human approving that run; the two
-   `publish-*` jobs are the only holders of `id-token: write`, and this
-   is the gate in front of them. `pypi` is additionally restricted to
+   index is uploaded to without a human approving that run; every job
+   holding `id-token: write` either runs under one of those two
+   environments directly, or — `attest` — only after one of them has
+   already succeeded, so nothing exchanges for an OIDC token ahead of
+   the review. `pypi` is additionally restricted to
    `v*` tags, which is the only ref its job runs on anyway — the
    restriction is what makes that true of the environment and not just
    of an `if:` in a file a pull request could change.
@@ -417,10 +419,10 @@ to `latest`'s own result.
 1. Install what was just published into an environment of its own,
    then exercise something that touches the shipped data rather than
    only importing it. `import btclib` runs `__init__.py` alone, and the
-   25 files under `_data/` — the twelve BIP39 wordlists among them —
-   are opened by path at the first call that needs one, not imported,
-   so a wheel missing `wordlist.txt` would install and import cleanly
-   and only fail there:
+   files under `_data/` — the BIP39 wordlists among them — are opened
+   by path at the first call that needs one, not imported, so a wheel
+   missing `wordlist.txt` would install and import cleanly and only
+   fail there:
 
    ```shell
    uv run --isolated --no-project --with btclib \

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -34,7 +34,9 @@ leave unevaluated. (Issues #1025, #1001 and #1044.) Read the cells,
 not the aggregate, when a run's own conclusion and this check
 disagree: `gh api repos/btclib-org/btclib/actions/runs/<id>/jobs`.
 
-`main` requires four checks, and only four:
+`main` requires these checks, and no others — `gh api
+repos/btclib-org/btclib/branches/main/protection --jq
+'.required_status_checks.checks'` reads the rule back live:
 
 | Check | Produced by |
 | --- | --- |
@@ -46,7 +48,7 @@ disagree: `gh api repos/btclib-org/btclib/actions/runs/<id>/jobs`.
 A workflow needs an aggregate when every one of its jobs has to gate: the
 matrix of `test.yml` is the one, and a context naming one cell of it would
 leave the rest outside the rule. Where a single job is what gates, that job
-*is* the context, which is why three of the four are job names.
+*is* the context, which is why most of the checks above are job names.
 `integration.yml` holds only the regtest job: the HWI jobs — `HWI against a
 Trezor emulator` and `HWI against a Ledger emulator` — live in
 `hwi-integration.yml`, a workflow with no `pull_request` trigger at all, so
@@ -75,7 +77,8 @@ a merge, where a skipped one satisfies it.
 
 `codeql: every job passed` is not among them, and that is the one place a
 check was traded for the wait it cost. GitHub Free gives an organization
-twenty concurrent jobs; a commit here asked for thirty-nine, and measured
+twenty concurrent jobs (as of 2026-08-21); a commit here asked for
+thirty-nine, and measured
 over a working afternoon the repository sat at nineteen or twenty running
 jobs for 1375 of 2100 seconds — so a pull request's wall clock was the wait
 for a slot and not the work. `codeql.yml` now runs on `main` and on its
@@ -224,7 +227,8 @@ gh api -X PATCH repos/btclib-org/btclib/code-quality/setup \
 ```
 
 What decided it is the concurrency ceiling and not the queries. GitHub
-Free gives an organization twenty concurrent jobs, a pull request here
+Free gives an organization twenty concurrent jobs (as of 2026-08-21), a
+pull request here
 asks for twenty-one on purpose, and `Analyze (python)` and `Analyze
 (ruby)` were two more on every pull request and every push to `main` —
 `Code Quality: PR #N` in the run list, 80 seconds and 32.
@@ -286,18 +290,19 @@ branch, and it is the only branch there is. Issue #158 was the other
 arrangement — two bots pushing through an integration branch that carried
 no protection at all — and one branch is what closed it.
 
-### Three rulesets beside the classic rule
+### The rulesets beside the classic rule
 
 `enforce_admins` off is one switch that exempts an administrator from
 every rule above at once — there is no way, inside the classic rule
 alone, to relax the review requirement for a solo merge while keeping
-signatures and linear history unconditional. Two rulesets carry that
-split, additive to the classic rule rather than replacing it: rules
-aggregate across rulesets and classic protection, taking the most
-restrictive combination wherever they overlap. A third targets tags
-rather than `main`, for an unrelated reason: `release.yml` publishes to
-PyPI on `push: tags: ["v*"]`, and that tag was the one unattested link
-in an otherwise fully-signed chain (issue #1022).
+signatures and linear history unconditional. `main-integrity` and
+`main-self-merge` carry that split, additive to the classic rule rather
+than replacing it: rules aggregate across rulesets and classic
+protection, taking the most restrictive combination wherever they
+overlap. `tag-integrity` targets tags rather than `main`, for an
+unrelated reason: `release.yml` publishes to PyPI on `push: tags:
+["v*"]`, and that tag was the one unattested link in an otherwise
+fully-signed chain (issue #1022).
 
 - `main-integrity`: required signatures, required linear history, no
   force pushes, no deletions. No bypass actor, for anyone, ever.
@@ -441,7 +446,8 @@ asking.
 **The default `GITHUB_TOKEN` is read-only repository-wide**, so a job
 needing more must declare it. Most of those declarations are in
 `release.yml`: `contents: write` on `github-release`, `id-token: write` on
-the two publish jobs, `id-token: write` with `attestations: write` on
+`publish-pypi` and `publish-testpypi`, `id-token: write` with
+`attestations: write` on
 `attest`, and `contents: read` with `pull-requests: read` on `test` — that
 last one there because `test` calls `test.yml`, and a caller's
 `permissions:` block replaces the callee's default outright rather than

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -142,7 +142,7 @@ used to teach and to prototype as much as to build:
     `keys.prvkey_tweak_mul`, `xonly.prvkey_tweak_add`,
     `ecdh.shared_secret`, `ellswift.xdh`, `dsa.nonce_rfc6979` and
     `ssa.nonce_bip340`. btclib passes none of them, and that is a
-    decision, not an oversight. Three call sites read one of those
+    decision, not an oversight. These call sites read one of those
     straight into a Python `int`: `bip32.derive`
     (`btclib/bip32/bip32.py:624`), `commit_nonce.commit_nonce_`
     (`btclib/ecc/commit_nonce.py:145`) and `taproot._tweaked_prvkey`


### PR DESCRIPTION
Closes #1144.

CONTRIBUTING.md's own "measure, don't assert" rule (lines 1323-1328) is
not honored in 36 places across the prescriptive docs — a count of
something that can grow or shrink, stated as present-tense fact, with
nothing guarding it from drifting silently false.

**Two were already wrong**, not just unguarded, found while fixing the
rest:
- README.md's "five wordlists Electrum reads" — `electrum.py`'s own
  `ELECTRUM_WORDLISTS` reuses `BIP39_LANGUAGE_FILES` entire (twelve
  languages), only Portuguese overridden. Now reads "the same wordlists
  as BIP39 except for Portuguese, which is Electrum's own list".
- RELEASING.md's "the two `publish-*` jobs are the only holders of
  `id-token: write`" — `attest` holds it too, for its Sigstore OIDC
  exchange. The security property still holds (`attest` only runs via
  `needs:` after a publish job succeeds), the sentence just didn't say
  that; it does now.

Three remediation shapes for the rest:
1. Where the named things are already listed in the same sentence, drop
   the redundant count.
2. Where a live command exists or fits naturally, point at it instead of
   a bare digit (`gh api ... --jq '.required_status_checks.checks'`,
   `cosmic-ray baseline`).
3. GitHub's own platform limits (twenty concurrent jobs on the Free
   plan) keep the number, with a dated qualifier — their policy, not
   this repository's history.

**Left alone, on purpose:**
- The CI workflow-matrix table in CONTRIBUTING.md ("N platforms × M
  interpreters") — that format is wanted as-is.
- "three checksum tables of `btclib.descriptors`" — `descriptors.py`'s
  own comment ties this to BIP380's fixed three-table checksum scheme,
  an external spec constant rather than this codebase's own count.
- Two minor, low-value cases (line-proximity of two functions in
  `dsa.py`; linter line-width figures already declared in config files)
  the original census itself flagged as judgment calls rather than
  clear findings.

Gate: `uv run pre-commit run --all-files`, clean.

## Summary by Sourcery

Remove unsupported documentation counts and correct the statements that had already drifted from the repository's current behavior.

Bug Fixes:
- Correct inaccurate documentation about Electrum wordlists and GitHub Actions OIDC token permissions.
- Remove or replace drifting present-tense counts throughout the prescriptive documentation.

Enhancements:
- Update repository guidance to reference live configuration or platform limits instead of hard-coded repository counts.
- Clarify documentation of workflow checks, module relationships, test coverage, mutation testing, release validation, and security-sensitive call sites.

Documentation:
- Revise documentation across CLAUDE.md, CONTRIBUTING.md, README.md, RELEASING.md, REPOSITORY.md, and SECURITY.md to avoid unsupported counts while preserving externally defined limits and intentional fixed-specification values.

Chores:
- Record the documentation corrections and count-removal work in the changelog.