### PR TITLE
Open the v2026.9 development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Only v2026.8.7 and what follows it are here. The releases before it were
 documented at release-notes length in the first place, and are still in
 [RELEASE_NOTES.md](./RELEASE_NOTES.md) rather than duplicated here.
 
+## v2026.9 (work in progress, not released yet)
+
 ## v2026.8.21
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,8 @@ Notable changes to the codebase are documented here.
 Release names follow *[calendar versioning](https://calver.org/)*:
 full year, short month, short day (YYYY-M-D)
 
+## v2026.9 (work in progress, not released yet)
+
 ## v2026.8.21
 
 ### Breaking changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ name = "btclib"
 # file. Not a literal in btclib/__init__.py for setuptools to import and
 # conf.py to repeat: two declarations are two things a release workflow
 # has to compare before trusting either
-version = "2026.8.21"
+version = "2026.9"
 description = "A library for 'bitcoin cryptography'"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "btclib"
-version = "2026.8.21"
+version = "2026.9"
 source = { editable = "." }
 dependencies = [
     { name = "bitcoin-core-rpc" },


### PR DESCRIPTION
RELEASING.md's last step: the placeholder version and the two work-in-progress sections that the next cycle's entries accumulate into.

`pyproject.toml` goes to `2026.9` — two components, month only, which is the shape `version-check` refuses a tag on, so a checkout of `main` cannot be mistaken for a release. `CHANGELOG.md` and `RELEASE_NOTES.md` each gain `## v2026.9 (work in progress, not released yet)` above the section just released, and `uv.lock` is re-locked for the version it carries.

Nothing else moves. The preamble sentence naming v2026.8.7 as the oldest release documented in full is still true.

**Gates**, exit codes read directly: `uv run pytest` → 0, coverage 100.00% · `uv run pre-commit run --all-files` → 0, no in-place rewrites · `sphinx-build -W --keep-going` → 0.

This unblocks the three pull requests in flight for ISS #1141, #1142 and #1143's neighbours, each of which had to argue where its CHANGELOG entry goes with no work-in-progress section to put it under.

## Summary by Sourcery

Open the v2026.9 development cycle for upcoming changes.

Enhancements:
- Open the v2026.9 development cycle with work-in-progress sections in the changelog and release notes.
- Set the project and lockfile versions to the unreleased 2026.9 development version.