### PR TITLE
Drop the Slack badge and the Slack bullet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **The Slack badge is gone from README.md and CONTRIBUTING.md**, and
+  with it the "come find us on Slack" bullet that opened the second. A
+  badge reports state, which is the criterion the badge block's own
+  comment states and the one that keeps "we use ruff" out of it; this
+  one reported a route, to a channel of the course workspace the library
+  was first taught in. What answers a question today is the issue
+  tracker and a pull request, and CONTRIBUTING.md now names those two
+  instead — a reader arriving at that bullet is told where to write
+  something the next reader of the file can find, which a chat message
+  is not. The word survives elsewhere in CONTRIBUTING.md, where "no
+  slack" is the coverage ratchet having none. `bitcoin-core-rpc` and
+  `btclib-secp256k1` carry the same badge and are not touched here: one
+  repository's badge block is not the others' to edit from inside a pull
+  request about this one.
+
 - **A tagged release cuts its GitHub release again** (issue #1142).
   `release.yml`'s `github-release` job carried no `if` of its own, which
   reads as "run when my needs succeeded" and is not what GitHub does with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,6 @@ or a place to go. The README keeps the ones that can turn red. -->
 [![lint: markdownlint-cli2](https://img.shields.io/badge/lint-markdownlint--cli2-yellowgreen.svg?logo=markdown)](https://github.com/DavidAnson/markdownlint-cli2)
 [![pre-commit enabled](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![GitHub repository: btclib-org/btclib](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib-181717?logo=github)](https://github.com/btclib-org/btclib/)
-[![slack: btclib_dev](https://img.shields.io/badge/slack-btclib_dev-white.svg?logo=slack)](https://bbt-training.slack.com/messages/C01CCJ85AES)
 
 Thank you for investing your time in contributing to our project.
 We are glad you are reading this, because we need volunteer developers
@@ -22,7 +21,11 @@ If you haven't already:
 - see the [README](./README.md) file to get an overview of the project
 - read our [Code of Conduct](./CODE_OF_CONDUCT.md) to keep our community
   approachable and respectable
-- come find us on [Slack](https://bbt-training.slack.com/archives/C01CCJ85AES).
+- open an [issue](https://github.com/btclib-org/btclib/issues) to ask
+  about something, and a
+  [pull request](https://github.com/btclib-org/btclib/pulls) to propose
+  it: both are read, and both leave a record the next reader of this
+  file can find.
 
 In this guide you will get an overview of the contribution workflow from
 opening an issue, creating a PR, reviewing, and merging the PR.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ kramdown having hard_wrap off. -->
 [![documentation build](https://app.readthedocs.org/projects/btclib/badge/?version=latest)](https://btclib.readthedocs.io)
 
 [![GitHub repository: btclib-org/btclib](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib-181717?logo=github)](https://github.com/btclib-org/btclib/)
-[![slack: btclib_dev](https://img.shields.io/badge/slack-btclib_dev-white.svg?logo=slack)](https://bbt-training.slack.com/messages/C01CCJ85AES)
 
 ---
 


### PR DESCRIPTION
## What this changes

The Slack badge goes from `README.md` and `CONTRIBUTING.md`, and with it
the "come find us on Slack" bullet that opened the second.

The badge block's own comment states the criterion — a badge reports
state, which is why "we use ruff" is not one. This badge reported a
route rather than state, to a channel of the course workspace btclib was
first taught in, and it was the third thing a new contributor was told
to do before they were told anything about the gates.

`CONTRIBUTING.md`'s bullet names the issue tracker and pull requests
instead. The difference is not the medium: a question asked in an issue
leaves an answer the next reader of that file can find, where a chat
message leaves one only for whoever was in the channel.

The word survives in `CONTRIBUTING.md`'s coverage paragraph, where "no
slack" is the ratchet having none, and throughout `CHANGELOG.md`. Both
are the English word.

## How it was verified

```text
uv run pre-commit run --all-files                    exit 0
uv run pytest                                        exit 0
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html \
    docs/source docs/build/html                      exit 0
```

`README.md` is what `pyproject.toml` declares as the long description,
so `check-manifest` and `pyroma` in the gate above are reading the
edited file, and `twine check --strict` renders it in the `dist` job.

## Checks

- [x] `uv run pre-commit run --all-files` is clean
- [x] `uv run pytest` passes
- [x] `CHANGELOG.md` has an entry, under `### Repository`. Nothing in
      `RELEASE_NOTES.md`: this asks nothing of a user

## Anything the reviewer should know

`bitcoin-core-rpc` and `btclib-secp256k1` carry the same badge in the
same two files and are untouched here — a pull request against this
repository is not where another repository's badge block is edited.
Each takes its own if that is wanted.

The organization profile page, `btclib-org/.github`, no longer names
Slack either.

## Summary by Sourcery

Replace the obsolete Slack-based contribution route with persistent GitHub issue and pull request channels.

Enhancements:
- Remove the Slack badge from the README and contributor guide and direct contributors to the issue tracker and pull requests instead.

Chores:
- Document the repository communication guidance change in the changelog.