### PR TITLE
Constrain published.yml's install and add a sdist cell (issue #1153)

### DIFF
--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -110,15 +110,16 @@ jobs:
           # not a build failure -- and btclib was the only one of the
           # three publishing repositories with no cell that exercised it
           # (issue #1153). A single extra cell rather than a second axis
-          # over the base matrix: doubling it to watch the sdist path on
-          # every os and python would add eighteen more jobs to sample a
-          # risk that does not vary by platform or interpreter, being the
-          # same sdist everywhere. Pure Python, so nothing here compiles --
-          # measured by hand against the published 2026.8.21, building it
-          # took under two seconds, not the minutes btclib_secp256k1's
-          # cffi extension would cost its own sdist cell. Python 3.13
-          # rather than a version already in the base matrix, so this adds
-          # a job rather than a property to an existing one
+          # over the base matrix: a `["", "--no-binary"]` axis would
+          # multiply the base matrix to watch the sdist path on every os
+          # and python, sampling a risk that does not vary by platform or
+          # interpreter, being the same sdist everywhere. Pure Python, so
+          # nothing here compiles -- measured by hand against the
+          # published 2026.8.21, this is a packaging step and nothing
+          # more, unlike btclib_secp256k1's own sdist cell, which compiles
+          # a C library. Python 3.13 rather than a version already in the
+          # base matrix, so this adds a job rather than a property to an
+          # existing one
           - os: ubuntu-latest
             python: "3.13"
             no-binary: true

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -80,7 +80,9 @@ concurrency:
 
 jobs:
   install-published:
-    name: "Install ${{ matrix.python }} from PyPI on ${{ matrix.os }}"
+    name: >-
+      ${{ matrix.no-binary && 'Build' || 'Install' }}
+      ${{ matrix.python }} from PyPI on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -94,9 +96,32 @@ jobs:
           - windows-11-arm
         # the two ends of the supported range, plus the free-threaded
         # interpreter: btclib itself ships one universal wheel, so what
-        # varies across this matrix is entirely which wheel of
+        # varies across the base matrix is entirely which wheel of
         # btclib_secp256k1 each cell resolves to
         python: ["3.10", "3.14", "3.14t"]
+        include:
+          # the one cell where the sdist is what gets built, not merely
+          # what a missing wheel would silently fall back to: btclib ships
+          # data files opened by path rather than imported (see the
+          # header), and a wheel built from an sdist that lost one of them
+          # installs and imports cleanly, failing only at the BIP39 check
+          # below. No wheel-only cell can see that kind of drift -- the
+          # risk is MANIFEST.in or [tool.setuptools] listing what ships,
+          # not a build failure -- and btclib was the only one of the
+          # three publishing repositories with no cell that exercised it
+          # (issue #1153). A single extra cell rather than a second axis
+          # over the base matrix: doubling it to watch the sdist path on
+          # every os and python would add eighteen more jobs to sample a
+          # risk that does not vary by platform or interpreter, being the
+          # same sdist everywhere. Pure Python, so nothing here compiles --
+          # measured by hand against the published 2026.8.21, building it
+          # took under two seconds, not the minutes btclib_secp256k1's
+          # cffi extension would cost its own sdist cell. Python 3.13
+          # rather than a version already in the base matrix, so this adds
+          # a job rather than a property to an existing one
+          - os: ubuntu-latest
+            python: "3.13"
+            no-binary: true
     timeout-minutes: 20
     steps:
       # every run step below declares `shell: bash`, and the matrix is why:
@@ -164,15 +189,37 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       # --verbose so the log names the btclib_secp256k1 wheel this cell
-      # resolved to, which is the whole of what varies across the matrix.
-      # A venv of its own, and every step below runs --no-project against
-      # it: there is no checkout, so nothing of this repository is on the
-      # path either way, and that is the property the header claims
+      # resolved to, and on the include cell above where btclib itself is
+      # built from its sdist, what that build did too. --only-binary
+      # btclib on every other cell: without it a yanked or missing wheel
+      # demotes a cell to an sdist build silently, and the run stays green
+      # while testing the wrong thing -- the failure mode issue #1153
+      # named, and now the one thing a wheel cell here cannot become by
+      # accident. Only btclib is constrained either way, never its
+      # dependencies: this install names no extra, so btclib_secp256k1 is
+      # one of them and is left to resolve however pip normally would
+      # (issue #1143 is the open question of asking for it at all,
+      # unaffected by either flag here since neither names that package --
+      # adding the extra later would need its own --only-binary
+      # btclib_secp256k1 alongside this one, the same flag applied a
+      # second time rather than a reason to change this one). An
+      # environment variable and a shell conditional rather than a ${{ }}
+      # expression inside run, as both siblings already do: matrix values
+      # are not attacker-controlled, but the pattern is worth keeping
+      # uniform. A venv of its own, and every step below runs --no-project
+      # against it: there is no checkout, so nothing of this repository is
+      # on the path either way, and that is the property the header claims
       - name: Install btclib from PyPI
         shell: bash
+        env:
+          NO_BINARY: ${{ matrix.no-binary || false }}
         run: |
           uv venv --python ${{ matrix.python }}
-          uv pip install --verbose btclib
+          if [ "$NO_BINARY" = "true" ]; then
+            uv pip install --verbose --no-binary btclib btclib
+          else
+            uv pip install --verbose --only-binary btclib btclib
+          fi
       # the ecc surface, as dist and release.yml assert it: a signature
       # round trip is the one thing an import cannot get wrong by itself,
       # and a bindings release that installs and answers incorrectly is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,12 +98,13 @@ documented at release-notes length in the first place, and are still in
   named in this workflow's own header — and a wheel built from an sdist
   that lost one installs and imports cleanly, failing only at the BIP39
   check already in this file. The new cell adds `python: "3.13"` with
-  `no-binary: true` to the `include` list rather than doubling the base
-  matrix over a `["", "--no-binary"]` axis, since the sdist path does not
-  vary by platform or interpreter and one cell exercises it; measured by
-  hand against the published `2026.8.21`, building it from source took
-  under two seconds, btclib carrying no compiled extension to slow it
-  down. Not carried over from `btclib-secp256k1`: its cell also asserts
+  `no-binary: true` to the `include` list rather than a second axis over
+  the base matrix, since the sdist path does not vary by platform or
+  interpreter and one cell exercises it; measured by hand against the
+  published `2026.8.21`, building btclib from source is a packaging step
+  and nothing more, btclib carrying no compiled extension for it to
+  build — unlike `btclib_secp256k1`'s own sdist cell, which compiles a C
+  library. Not carried over from `btclib-secp256k1`: its cell also asserts
   which kind of artifact pip selected, `static` against `dynamic`, a
   property of its wheel layout that btclib has no equivalent of, shipping
   one universal wheel — recorded as a should-differ in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,36 @@ documented at release-notes length in the first place, and are still in
   on the way in here, its paragraph of reasoning arriving verbatim and
   sound without the one declarative line that made it run.
 
+- **`published.yml` installs the wheel cells with `--only-binary btclib`,
+  and one cell now builds the sdist** (issue #1153). The install step used
+  to run `uv pip install --verbose btclib` unconstrained, so a yanked or
+  missing wheel silently demoted a cell to an sdist build and the run
+  stayed green while testing something other than what it reported: both
+  sibling repositories already constrain this install, and
+  `btclib-secp256k1`'s header names exactly this failure mode. btclib was
+  also the only one of the three publishing repositories with no cell that
+  exercised the sdist at all, and the case for one is stronger here than
+  in `bitcoin-core-rpc`, whose comment raised it: btclib ships data files
+  opened by path rather than imported — the BIP39 wordlists among them,
+  named in this workflow's own header — and a wheel built from an sdist
+  that lost one installs and imports cleanly, failing only at the BIP39
+  check already in this file. The new cell adds `python: "3.13"` with
+  `no-binary: true` to the `include` list rather than doubling the base
+  matrix over a `["", "--no-binary"]` axis, since the sdist path does not
+  vary by platform or interpreter and one cell exercises it; measured by
+  hand against the published `2026.8.21`, building it from source took
+  under two seconds, btclib carrying no compiled extension to slow it
+  down. Not carried over from `btclib-secp256k1`: its cell also asserts
+  which kind of artifact pip selected, `static` against `dynamic`, a
+  property of its wheel layout that btclib has no equivalent of, shipping
+  one universal wheel — recorded as a should-differ in
+  [ISS #1152](https://github.com/btclib-org/btclib/issues/1152). Neither
+  flag names `btclib_secp256k1`, so this leaves ISS #1143 — whether to
+  install the `secp256k1` extra here at all — untouched; if that lands,
+  constraining the extra the same way is its own `--only-binary
+  btclib_secp256k1`, the same flag applied a second time rather than a
+  reason to revisit this one.
+
 ## v2026.8.21
 
 ### Repository


### PR DESCRIPTION
## Summary

- `--only-binary btclib` on every wheel cell of `published.yml`'s
  matrix, so a yanked or missing wheel is a failure rather than a
  silent demotion to an sdist build that keeps the run green.
- One new cell (`ubuntu-latest`, `python: "3.13"`, `no-binary: true`)
  that installs with `--no-binary btclib`, so the sdist path is
  exercised at all — btclib was the only one of the three publishing
  repositories with no cell that did.

Closes #1153.

## Why a single extra cell, not a doubled matrix

The sdist path does not vary by platform or interpreter — it is the
same sdist everywhere — so one cell samples the risk. Doubling the
base matrix over a `["", "--no-binary"]` axis would add eighteen more
jobs to answer a question that does not change across them. Both
sibling repositories (`btclib-secp256k1`, `bitcoin-core-rpc`) made the
same choice: one extra `include` cell, not a second axis.

## Where the two siblings differ from each other, and from this change

- `bitcoin-core-rpc` already does exactly what this PR does to
  `btclib`: `--only-binary`/`--no-binary` on the same install step via
  an env var + shell conditional, and one `no-binary: true` cell in
  `include` with a python version (3.13) not in the base matrix "so
  this adds a job rather than a property to an existing one." This PR
  follows that template closely.
- `btclib-secp256k1` additionally asserts *which kind* of artifact pip
  selected (`static` vs `dynamic`) — a property of its wheel layout
  (multiple platform-specific wheels vs. one PyPy/Windows fallback).
  btclib ships one universal wheel and has no such distinction to
  assert, so that check is **not** copied here — this is the
  should-differ already recorded in #1152.
- Neither sibling's matrix currently installs an "extra"
  (`btclib[secp256k1]` is #1143's open question); this PR doesn't
  touch that. `--only-binary btclib` names only the `btclib` package,
  never its dependencies, so `btclib_secp256k1` is left to resolve
  however pip normally would. If #1143 lands, constraining the extra
  the same way is its own `--only-binary btclib_secp256k1` alongside
  this one — the same flag applied a second time, not a reason to
  revisit this change.

## This cannot run in CI on this PR

`published.yml` triggers on `schedule` / `workflow_dispatch` /
`workflow_call` only, so this diff cannot execute via a pull-request
run. Compensating, I ran both install forms locally against the
published `btclib==2026.8.21`:

```console
$ uv pip install --python venv_wheel --verbose --only-binary btclib "btclib==2026.8.21"
...
Selecting: btclib==2026.8.21 [compatible] (btclib-2026.8.21-py3-none-any.whl)
Installed 2 packages in 4ms
 + bitcoin-core-rpc==2026.8.20
 + btclib==2026.8.21
# total wall time (venv create + install): ~0.29s

$ uv pip install --python venv_sdist --verbose --no-binary btclib "btclib==2026.8.21"
...
Built `btclib==2026.8.21` into `btclib-2026.8.21-py3-none-any.whl`
Prepared 1 package in 1.52s
Installed 2 packages in 1ms
 + bitcoin-core-rpc==2026.8.20
 + btclib==2026.8.21
# total wall time (venv create + install + sdist build): ~1.58s
```

Both venvs then passed this workflow's own checks (BIP340 vector 0
round trip, and the trezor BIP39 seed derived from the shipped word
lists), confirming the sdist build is cheap here (btclib is pure
Python, no compiled extension) and produces a working install.

## Test plan

- [x] `uv run pytest` — exit 0, 100% coverage
- [x] `uv run pre-commit run --all-files` — exit 0 (`actionlint`,
      `zizmor` included, zero findings)
- [x] `uv run --locked --no-default-groups --group docs sphinx-build
      -W --keep-going -b html docs/source docs/build/html` — exit 0
- [x] Local install runs against published `btclib==2026.8.21` in both
      `--only-binary` and `--no-binary` forms (above)
- [ ] `published.yml` itself only runs on `schedule` /
      `workflow_dispatch` / `workflow_call`, so a maintainer dispatch
      after merge is the only way to see this matrix run for real

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uNzuzag82WGhvznByjFDH

## Summary by Sourcery

Ensure published-package CI distinguishes wheel validation from source-distribution validation and fails when expected wheels are unavailable.

New Features:
- Add a published-package CI matrix cell that explicitly builds and validates btclib from its source distribution.

Bug Fixes:
- Prevent wheel validation jobs from silently falling back to source distributions when a btclib wheel is unavailable or yanked.

CI:
- Constrain btclib installation to wheels in existing published-package matrix cells and use an explicit source-distribution install for the new cell.