### PR TITLE
Rename the inspection dependency group from build to check (issue #1155)

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -266,7 +266,7 @@ jobs:
           uv run --locked --only-group lint
           pre-commit run --all-files --show-diff-on-failure
 
-  # the build group, for the same reason the packaging checks live in
+  # the check group, for the same reason the packaging checks live in
   # test.yml rather than in the release workflow: a release is the one place
   # where finding a problem is too late, a version being consumed by the
   # upload that carries it. twine, check-wheel-contents and pyroma are
@@ -294,8 +294,8 @@ jobs:
       - name: Build the distribution files
         run: uv build
       - name: Check the metadata and the long description
-        run: uv run --locked --only-group build twine check --strict dist/*
+        run: uv run --locked --only-group check twine check --strict dist/*
       - name: Check the wheel contents
-        run: uv run --locked --only-group build check-wheel-contents dist/*.whl
+        run: uv run --locked --only-group check check-wheel-contents dist/*.whl
       - name: Rate the packaging metadata
-        run: uv run --locked --only-group build pyroma --min 10 dist/*.tar.gz
+        run: uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,7 +313,7 @@ jobs:
           # leaves the two disagreeing, and every uv command that passes
           # --locked -- which is all of them, by convention -- then fails
           # with "the lockfile needs to be updated". Measured: without this
-          # re-lock, "uv run --locked --only-group build" on a patched tree
+          # re-lock, "uv run --locked --only-group check" on a patched tree
           # exits non-zero. Nothing after this step in this job happens to
           # pass --locked today, so the rehearsal works by the arrangement
           # of the jobs rather than by construction, and moving a packaging

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -549,11 +549,11 @@ jobs:
       # the same validation PyPI applies on upload: broken metadata, or a
       # README that does not render, cannot be fixed by reuploading
       - name: Check the metadata and the long description
-        run: uv run --locked --only-group build twine check --strict dist/*
+        run: uv run --locked --only-group check twine check --strict dist/*
       # what twine does not look at: where the files land once installed,
       # a test package shipped by accident, a stray top-level module
       - name: Check the wheel contents
-        run: uv run --locked --only-group build check-wheel-contents dist/*.whl
+        run: uv run --locked --only-group check check-wheel-contents dist/*.whl
       # and what twine cannot see either: metadata that is valid but poor,
       # a missing classifier or url, a version PyPI would sort in a way
       # nobody meant. The pyroma pre-commit hook rates the source tree, for
@@ -561,7 +561,7 @@ jobs:
       # that would actually be shipped. --min 10 is a ratchet, the score
       # being 10 today
       - name: Rate the packaging metadata
-        run: uv run --locked --only-group build pyroma --min 10 dist/*.tar.gz
+        run: uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz
       # what none of the three above does: install the wheel, and install
       # it alone, from an empty directory. The wheel is the only thing
       # asked for, so what pulls btclib_secp256k1 in is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,17 @@ documented at release-notes length in the first place, and are still in
   constraining the extra the same way is its own `--only-binary
   btclib_secp256k1`, the same flag applied a second time rather than a
   reason to revisit this one.
+- **The dependency group that inspects a distribution is `check`, not
+  `build`** (issue #1155). `btclib-secp256k1` builds wheels for many
+  platforms and keeps that work in its own `build` group, separate from
+  the `check` group that holds `check-manifest`, `check-wheel-contents`,
+  `pyroma` and `twine`; this repository named the same four packages
+  `build` instead, so `--only-group build` installed the tools that
+  inspect a distribution here and the tools that build one there — a step
+  copied between the two trees installed the wrong four packages and
+  failed obscurely. `pyproject.toml`'s group and every `--only-group
+  build` call site in `CONTRIBUTING.md`, `test.yml`, `latest.yml` and
+  `release.yml` now say `check`, matching `btclib-secp256k1` throughout.
 
 ## v2026.8.21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,11 @@ documented at release-notes length in the first place, and are still in
   failed obscurely. `pyproject.toml`'s group and every `--only-group
   build` call site in `CONTRIBUTING.md`, `test.yml`, `latest.yml` and
   `release.yml` now say `check`, matching `btclib-secp256k1` throughout.
+  A step still asking for the old name no longer installs anything wrong
+  under it: `uv run --locked --only-group build ...` here now exits
+  non-zero, with `` error: Group `build` is not defined in the project's
+  dependency-groups table `` — a copied step stops instead of running
+  against four packages it did not mean to check.
 
 ## v2026.8.21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -458,9 +458,9 @@ uv run --no-project --python 3.14 \
     .github/scripts/verify_dist_contents.py dist/
 SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) uv run --no-project \
     --python 3.14 .github/scripts/generate_sbom.py dist/ "$(mktemp -d)"
-uv run --locked --only-group build twine check --strict dist/*
-uv run --locked --only-group build check-wheel-contents dist/*.whl
-uv run --locked --only-group build pyroma --min 10 dist/*.tar.gz
+uv run --locked --only-group check twine check --strict dist/*
+uv run --locked --only-group check check-wheel-contents dist/*.whl
+uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz
 tmp=$(mktemp -d)
 uv export --locked --no-dev --extra secp256k1 --no-emit-project \
     --no-hashes -o "$tmp"/constraints.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,8 +168,11 @@ harness = [
 test = [{ include-group = "harness" }, { include-group = "bindings" }]
 lint = [{ include-group = "bindings" }, "mypy", "pre-commit", "ruff"]
 # the distribution files are built and published by uv itself: what this
-# group holds is what inspects them, before an upload consumes the version
-build = ["check-manifest", "check-wheel-contents", "pyroma", "twine"]
+# group holds is what inspects them, before an upload consumes the
+# version. Named `check`, not `build`, so `--only-group build` means the
+# same thing here as in btclib-secp256k1, which already has both names:
+# the tools that build a distribution, not the ones that inspect one
+check = ["check-manifest", "check-wheel-contents", "pyroma", "twine"]
 mutation = ["cosmic-ray"]
 docs = [
     { include-group = "bindings" },
@@ -180,7 +183,7 @@ docs = [
 dev = [
     { include-group = "test" },
     { include-group = "lint" },
-    { include-group = "build" },
+    { include-group = "check" },
     { include-group = "docs" },
     { include-group = "mutation" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ secp256k1 = [
 bindings = [
     { name = "btclib-secp256k1" },
 ]
-build = [
+check = [
     { name = "check-manifest" },
     { name = "check-wheel-contents" },
     { name = "pyroma" },
@@ -399,7 +399,7 @@ provides-extras = ["secp256k1"]
 
 [package.metadata.requires-dev]
 bindings = [{ name = "btclib-secp256k1", specifier = ">=0.8.0.4" }]
-build = [
+check = [
     { name = "check-manifest" },
     { name = "check-wheel-contents" },
     { name = "pyroma" },


### PR DESCRIPTION
## Summary

`--only-group build` installs the inspection tools here
(`check-manifest`, `check-wheel-contents`, `pyroma`, `twine`) and the
building tools in `btclib-secp256k1` (`build`, `cibuildwheel`,
`auditwheel`, `delocate`). The split across the two repositories is
right; the name collision is the defect — a step copied between these
trees under the ongoing alignment work installs the wrong four
packages and fails obscurely.

`btclib-secp256k1` already keeps two groups with these names right: a
`build` group that builds wheels for its many platforms, and a
separate `check` group holding the same four inspection packages this
repository calls `build`. This PR renames this repository's group to
`check` to match, so `--only-group build` means "the tools that build
a distribution" and `--only-group check` means "the tools that inspect
one" across both repositories. Nothing changes in
`btclib-secp256k1`.

- `pyproject.toml`: the group itself, and the `dev` group's
  `include-group` reference to it
- `uv.lock`: re-locked, the group name being part of the resolved
  dependency-groups table
- Every `--only-group build` call site: `CONTRIBUTING.md`,
  `test.yml`, `latest.yml`, `release.yml` (the last two only in a
  comment quoting the same command)
- One workflow comment in `latest.yml` naming "the build group" in
  prose, not in a command

## Test plan

- [x] `uv run pytest` — 29393 passed, 11 skipped, 100.00% coverage
- [x] `uv run pre-commit run --all-files` — every hook passed
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html` — build
      succeeded
- [x] Ran the renamed commands directly against a built distribution:
      `uv run --locked --only-group check twine check --strict dist/*`,
      `... check-wheel-contents dist/*.whl`, `... pyroma --min 10
      dist/*.tar.gz` — all exit 0
- [x] `uv run --locked --only-group build ...` now fails with `Group
      'build' is not defined in the project's dependency-groups table`,
      confirming the old name is gone rather than duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uNzuzag82WGhvznByjFDH

## Summary by Sourcery

Rename the distribution-inspection dependency group to `check` and update all references to distinguish it from tools that build distributions.

Bug Fixes:
- Rename the distribution-inspection dependency group from `build` to `check` so copied `--only-group build` commands fail clearly instead of selecting the wrong tools.

Enhancements:
- Align dependency-group naming with `btclib-secp256k1` and update development, documentation, and workflow references accordingly.

Build:
- Re-lock dependencies with the renamed dependency group.

Documentation:
- Document the renamed `check` dependency group and update contributor commands and workflow references.