### PR TITLE
Check release.yml's build job on the files it is about to publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,11 +314,10 @@ jobs:
           # --locked -- which is all of them, by convention -- then fails
           # with "the lockfile needs to be updated". Measured: without this
           # re-lock, "uv run --locked --only-group check" on a patched tree
-          # exits non-zero. Nothing after this step in this job happens to
-          # pass --locked today, so the rehearsal works by the arrangement
-          # of the jobs rather than by construction, and moving a packaging
-          # check back in here would break it silently -- silently
-          # because the rehearsal runs by hand, rarely.
+          # exits non-zero. This step now has three --locked consumers
+          # downstream in this same job -- the twine, check-wheel-contents
+          # and pyroma steps added for issue #1154 -- and the re-lock is
+          # what keeps every one of them working.
           # The re-lock is also what makes the sdist coherent: it ships
           # uv.lock, which otherwise declared the unsuffixed version inside
           # a distribution named for the suffixed one

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,26 +323,24 @@ jobs:
           # uv.lock, which otherwise declared the unsuffixed version inside
           # a distribution named for the suffixed one
           uv lock
-      # one thing the rehearsal does not cover, deliberately: dist, in
-      # the workflow this one calls, validates the tree as committed, while
-      # this job ships the suffixed version, so twine and pyroma never see
-      # the metadata that reaches TestPyPI. What they judge is metadata
-      # syntax, README rendering and metadata quality, and a .dev<N> suffix
-      # is valid PEP 440 that changes none of them. The smoke test below is
-      # the exception, and the reason it is below rather than left to
-      # dist: it installs the suffixed wheel itself. Should a packaging
-      # check ever become version-sensitive, the suffix has to be plumbed
-      # into test.yml as a workflow_call input instead
+      # what a rehearsal does differently from a tag: test.yml's dist job,
+      # called by this workflow's own `test` job above, validates the tree
+      # as committed, while the twine/check-wheel-contents/pyroma steps
+      # below run on the version this step just suffixed. Neither minds:
+      # what the three judge is metadata syntax, README rendering, wheel
+      # layout and metadata quality, none of which a .dev<N> suffix
+      # changes. The smoke test further down is the one check that does
+      # depend on the suffix -- it installs the wheel this job built,
+      # suffix and all -- which is why it could never have been left to
+      # test.yml's dist job and needed no plumbing to avoid it
       # uv build builds the sdist first and then the wheel from it, not
       # both from the source tree: the packaging path a user installing
       # from source takes is therefore the one that produced the wheel,
       # which is why no separate "install from the sdist" job is needed.
-      # What this job does not do is inspect what it builds: twine,
-      # check-wheel-contents and pyroma run in the dist job of the
-      # test workflow, which this workflow calls, so they gate every
-      # pull request as well as this one tag. check-manifest is a
-      # pre-commit hook, gated by the lint workflow, which this one calls
-      # too
+      # check-manifest stays out of this job: it is a pre-commit hook,
+      # gated by the lint workflow, which this one also calls, and its
+      # question is about the tree uv build reads rather than the files
+      # this job goes on to publish
       - name: Build the distribution files
         run: uv build
       # SOURCE_DATE_EPOCH reaches every entry of the wheel and nothing at
@@ -405,6 +403,24 @@ jobs:
         with:
           name: sbom
           path: sbom/
+      # the same three checks test.yml's dist job runs, and for the same
+      # reason given there: a release is the one place where finding a
+      # packaging problem is too late. They run in both places because
+      # dist builds its own copy of the distribution files rather than
+      # this job's -- issue #1154 -- so passing there was never a
+      # guarantee about the files this job is about to publish; this is
+      # the run that judges those files themselves. After the two uploads
+      # above rather than between them and the build: each of the three is
+      # a dependency this job has to install to run, and the comment on
+      # the first upload above already freezes what the publish jobs will
+      # download before anything is installed, a boundary these steps
+      # keep rather than move
+      - name: Check the metadata and the long description
+        run: uv run --locked --only-group check twine check --strict dist/*
+      - name: Check the wheel contents
+        run: uv run --locked --only-group check check-wheel-contents dist/*.whl
+      - name: Rate the packaging metadata
+        run: uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz
       # dist installs a wheel too, but not this one: it builds its own
       # copy, on another runner and -- in a rehearsal -- from another
       # version, the step above having patched pyproject.toml and

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -495,8 +495,11 @@ jobs:
   # the tag that ships it: a release is the one place where finding a
   # problem is too late, a version being consumed by the upload that
   # carries it, and then only yankable. The release workflow calls this
-  # one, so it runs these checks too, and its build job builds only what
-  # it publishes.
+  # one, so it runs these checks too, here on the files this job's own
+  # `uv build` produces. Its `build` job builds a second, separate copy
+  # -- the one it actually publishes -- and runs the same three checks on
+  # that copy as well (issue #1154), because passing here said nothing
+  # about files this job never saw.
   # Installing the wheel is the last of them (issue #131), and it is a
   # gate here rather than in the release workflow alone because the
   # bindings it resolves are published: while they were not, the step

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,26 @@ documented at release-notes length in the first place, and are still in
   non-zero, with `` error: Group `build` is not defined in the project's
   dependency-groups table `` — a copied step stops instead of running
   against four packages it did not mean to check.
+- **`release.yml`'s `build` job runs `twine check --strict`,
+  `check-wheel-contents` and `pyroma --min 10` on the files it is about to
+  publish** (issue #1154). Those three already gated every pull request,
+  in `test.yml`'s `dist` job, but `release.yml`'s own `build` job rebuilds
+  the distribution files from the same tree rather than reusing `dist`'s
+  artifact, and ran none of the three on its own copy — so a tag that
+  passed every check still published files nobody had checked, "usually"
+  identical to the checked ones being the whole of the guarantee. The
+  fix adds the three steps to `build`, after the two `upload-artifact`
+  steps rather than before them: each check installs a dependency of its
+  own, and the comment on the first upload already establishes that
+  nothing gets installed before `dist/` is frozen for the publish jobs to
+  download, a boundary these steps keep rather than move. Left undone,
+  and deliberately: `release.yml` still builds the distribution files
+  twice, once in the `test` job it calls and once in `build`, where
+  sibling `btclib-secp256k1` has no such seam — its `release.yml` has no
+  `build` job at all, publishing the artifact its called `test.yml` built
+  and checked. Reaching that shape here needs `test.yml`'s artifact
+  published instead of rebuilt, which is a larger change than this one;
+  the issue is the record of it.
 
 ## v2026.8.21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -491,16 +491,26 @@ uv lock --check
 uv version --short
 ```
 
-Its build job then repeats the smoke test above on the wheel it uploads,
-which is not the one `dist` built, and repeats it without the
-constraints. No pull request waits on that job and no branch rule names
-it, where `publish-testpypi` and `publish-pypi` both have it in `needs`:
-so it is the place to ask whether the newest published bindings satisfy
-the artifact, and a release stopping on that answer is the outcome
-wanted. It runs after the upload rather than before, the artifact being
-what the publish jobs download: installing a dependency executes its
-code, and a compromised one must not reach a `dist/` that has still to
-be handed on.
+Its `build` job runs the same twine, check-wheel-contents and pyroma
+commands above again too, on the files it is about to publish rather
+than on `dist`'s own copy (issue #1154):
+
+```shell
+uv run --locked --only-group check twine check --strict dist/*
+uv run --locked --only-group check check-wheel-contents dist/*.whl
+uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz
+```
+
+It then repeats the smoke test above on the wheel it uploads, which is
+not the one `dist` built, and repeats it without the constraints. No
+pull request waits on that job and no branch rule names it, where
+`publish-testpypi` and `publish-pypi` both have it in `needs`: so it is
+the place to ask whether the newest published bindings satisfy the
+artifact, and a release stopping on that answer is the outcome wanted.
+Both run after the upload rather than before, the artifact being what
+the publish jobs download: installing a dependency executes its code,
+and a compromised one must not reach a `dist/` that has still to be
+handed on.
 
 What that job builds is reproducible, and the two steps that make it so
 are the two lines below — the first is why two checkouts of one commit

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -100,7 +100,8 @@ Already done for btclib-org/btclib; kept here for the record.
 
 A rehearsal runs the identical pipeline — lint gate, test matrix, the
 packaging checks of the `dist` job (twine, check-wheel-contents,
-pyroma), build, wheel smoke test — and publishes to
+pyroma), build (which runs those same three checks again, on the files
+it is about to publish), wheel smoke test — and publishes to
 [TestPyPI](https://test.pypi.org/project/btclib/) instead of PyPI.
 
 1. On GitHub, Actions → release → Run workflow, and pick the branch to


### PR DESCRIPTION
## Summary

`twine check --strict`, `check-wheel-contents` and `pyroma --min 10`
already gate every pull request, in `test.yml`'s `dist` job. `release.yml`
then rebuilds the distribution files in its own `build` job and uploads
those — running none of the three on that copy. The files that reach PyPI
were not the files those checks passed; the two builds are from the same
tree by the same command, so they will usually be identical, and
"usually" was the whole of the guarantee. Closes #1154.

## The cheap form, not the full one

The issue offers two shapes. `btclib-secp256k1` has none of this seam at
all: its `release.yml` has no `build` job, publishing the artifact its
called `test.yml` built and checked. Reaching that shape here means
publishing `test.yml`'s artifact and deleting the second build — a larger
change, needing a composite action and two `workflow_call` inputs when
`btclib-secp256k1` did it.

This PR takes the cheap form instead: add the three check steps to
`build`, after it builds and before it publishes. After this, the
uploaded files are the checked files, which is the whole of what the
issue's title claims is wrong. **Left undone**: `build` still rebuilds
what `test`'s own `dist` job already built and checked — the redundant
rebuild itself is not removed, only the seam it left uncovered. That is
a structural change to the release path, and two defects were found in
that path this week; the small correct fix lands now, not the larger one.

## Placement inside `build`

The three new steps run after both `upload-artifact` steps rather than
between them and `uv build`. Each check installs a dependency of its own
(`twine`, `check-wheel-contents`, `pyroma`, via the `check` dependency
group), and the existing comment on the first upload step already
establishes an invariant: nothing gets installed before `dist/` is
uploaded, so a compromised dependency can at worst fail the job rather
than tamper with the files about to be published. The new steps keep that
boundary rather than moving it.

They run correctly against a rehearsal's suffixed `.dev<N>` version too:
what they judge is metadata syntax, README rendering, wheel layout and
metadata quality, none of which the suffix changes — the same argument
the existing comment already made for why `twine`/`pyroma` don't need the
suffix plumbed through as a `workflow_call` input.

## Verification

`release.yml` cannot run on a pull request, so CI does not exercise these
steps directly. Compensated locally:

```shell
uv run pytest                                      # 29393 passed, 100% coverage
uv run pre-commit run --all-files                   # all hooks passed, actionlint/zizmor included
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html   # build succeeded
```

And the three commands themselves, verbatim as added to the workflow,
against a real `uv build` output:

```shell
uv build                                                       # exit 0
uv run --locked --only-group check twine check --strict dist/* # PASSED, exit 0
uv run --locked --only-group check check-wheel-contents dist/*.whl  # OK, exit 0
uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz    # 10/10, exit 0
```

## Test plan

- [x] `uv run pytest` — green, 100% coverage
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] sphinx `-W` build — succeeds
- [x] the three added commands run by hand against a real distribution —
      all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uNzuzag82WGhvznByjFDH

## Summary by Sourcery

Ensure release builds are checked directly before publication so PyPI receives artifacts that have passed packaging validation.

Bug Fixes:
- Validate the distribution files produced by the release build with Twine, check-wheel-contents, and Pyroma before they are published.

Enhancements:
- Update release workflow comments and contributor-facing release documentation to reflect that packaging checks run on both test and release-built artifacts.

Documentation:
- Document the additional release-build validation in the changelog, contributing guide, and release instructions.