### PR TITLE
Give a re-run of a TestPyPI rehearsal a version of its own (issue #1156)

### DIFF
--- a/.github/scripts/generate_sbom.py
+++ b/.github/scripts/generate_sbom.py
@@ -13,7 +13,7 @@ metadata declares.
 
 **The wheel's metadata is the source, not pyproject.toml.** They agree on
 a release and not in a rehearsal, where the `build` job appends
-`.dev<run number>` to the version before building: the document has to
+`.dev<run*100+attempt>` to the version before building: the document has to
 describe the files beside it, so it reads the archive it is given. Which
 also means the only version it can report for a dependency is the one the
 metadata pins, and that is deliberate -- what a user's installer resolves
@@ -299,7 +299,7 @@ def main(argv: list[str]) -> int:
 
     # named after the wheel's own first two fields, {distribution} and
     # {version}, so the caller needs to know neither -- which in a
-    # rehearsal, where the version carries a `.dev<run number>` the
+    # rehearsal, where the version carries a `.dev<run*100+attempt>` the
     # workflow patched in, it does not
     distribution, version = wheel.name.split("-")[:2]
     output = Path(argv[2]) / f"{distribution}-{version}.cdx.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,10 +275,20 @@ jobs:
       - name: Pin the build timestamp to the commit
         run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
       # TestPyPI refuses a version it has already seen: the rehearsal
-      # appends .dev<run number>, unique per dispatch and sorted before
-      # the release it rehearses (PEP 440). Re-running a finished
-      # rehearsal would reuse its run number and collide on TestPyPI:
-      # dispatch a fresh run instead
+      # appends .dev<run*100+attempt>, unique per dispatch and per re-run
+      # of one, and sorted before the release it rehearses (PEP 440).
+      # A re-run keeps the run's own id and number and only raises
+      # run_attempt, so .dev<run number> alone -- the previous shape of
+      # this suffix -- was identical across every re-run of one dispatch
+      # and collided with itself on TestPyPI the moment a rehearsal was
+      # re-run rather than freshly dispatched. Multiplying the run number
+      # by 100 and adding the attempt keeps both properties at once:
+      # every attempt of every run is still unique, and, because the
+      # attempt never reaches the run number's own place value, attempt 2
+      # of run 7 (702) still sorts after every attempt of run 6 (600-699)
+      # -- the ordering .dev<run><attempt> concatenation would have kept
+      # only while the two numbers' digit counts happened to line up.
+      # The two digits reserved for the attempt are checked, not assumed
       - name: Make the version unique for TestPyPI (rehearsal only)
         if: github.event_name == 'workflow_dispatch'
         # Python and tomllib, not sed: the value is parsed and only then
@@ -297,6 +307,12 @@ jobs:
           import tomllib
           from pathlib import Path
 
+          run_number = int(os.environ["GITHUB_RUN_NUMBER"])
+          run_attempt = int(os.environ["GITHUB_RUN_ATTEMPT"])
+          if run_attempt > 99:
+              msg = f"attempt {run_attempt} exceeds the two digits reserved for it"
+              raise SystemExit(msg)
+
           path = Path("pyproject.toml")
           text = path.read_text(encoding="utf-8")
           declared = tomllib.loads(text)["project"]["version"]
@@ -304,7 +320,7 @@ jobs:
           if match is None:
               msg = f"pyproject.toml declares {declared}, which is not a literal in it"
               raise SystemExit(msg)
-          suffixed = declared + ".dev" + os.environ["GITHUB_RUN_NUMBER"]
+          suffixed = declared + ".dev" + str(run_number * 100 + run_attempt)
           line = match.group().replace(declared, suffixed, 1)
           path.write_text(text[: match.start()] + line + text[match.end() :], encoding="utf-8")
           PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,24 @@ documented at release-notes length in the first place, and are still in
   and checked. Reaching that shape here needs `test.yml`'s artifact
   published instead of rebuilt, which is a larger change than this one;
   the issue is the record of it.
+- **A re-run of a finished TestPyPI rehearsal now gets a version of its
+  own** (issue #1156). The suffix was `.dev<run number>`, and a re-run
+  keeps `github.run_number` and only raises `github.run_attempt`,
+  so re-running a rehearsal rebuilt the same version and TestPyPI
+  refused the upload after the whole matrix ran again. `RELEASING.md`'s
+  answer had been a warning to dispatch a fresh run instead of
+  re-running one — a rule to remember at the moment a failed rehearsal
+  is least likely to leave room for it. Fixed the way both sibling
+  repositories' `release.yml` already were (`btclib-secp256k1` first,
+  then `bitcoin-core-rpc`'s issue #157): the suffix is
+  `.dev<run*100+attempt>`, the multiplier keeping every attempt of
+  every run both unique and PEP 440-ordered — attempt 2 of run 7 still
+  sorts after every attempt of run 6 — and the step refuses outright
+  past the two digits it reserves for the attempt rather than wrapping
+  into another run's range. `RELEASING.md`'s warning goes with it, the
+  rule it stated no longer being true, and every other place stating
+  the old template — `generate_sbom.py` and its test among them — now
+  states the new one.
 
 ## v2026.8.21
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,15 +46,23 @@ Telling these apart is most of what can go wrong when cutting a release.
 - **`v2026.8.4`**, the tag, carries no version of its own: it picks the
   index, PyPI rather than TestPyPI, and `version-check` exists to
   confirm it says what `pyproject.toml` says
-- **`2026.8.4.dev7`** is a rehearsal, and nobody types it either half at
-  a time: `.dev<run number>` is the template the `build` job patches into
-  `pyproject.toml` when `workflow_dispatch` starts the workflow, the
-  number being `github.run_number` counted for `release.yml` alone, so
-  the seventh such run rehearsing `2026.8.4` produces exactly that. The
-  count is what makes a rehearsal's version unique, and what makes
-  re-running a finished one collide with itself rather than mint a new
-  one. Nothing commits the result: `uv lock` runs straight after, so the
-  lockfile the sdist ships agrees with the version it is named for
+- **`2026.8.4.dev701`** is a rehearsal, and nobody types it either half
+  at a time: `.dev<run*100+attempt>` is the template the `build` job
+  patches into `pyproject.toml` when `workflow_dispatch` starts the
+  workflow, `github.run_number` counted for `release.yml` alone and
+  `github.run_attempt` counted for one dispatch of it, so the seventh
+  such run's first attempt, rehearsing `2026.8.4`, produces exactly
+  that. The multiplier is what makes a re-run a version of its own
+  rather than a collision: a re-run keeps the run's own number and only
+  raises the attempt, so the run number alone was identical across
+  every re-run of one dispatch and PEP 440 could not tell them apart.
+  Placing the attempt below the run number's own place value keeps a
+  run's later attempts sorting after its earlier ones and before the
+  next run's, the attempt therefore capped at two digits and the
+  workflow refusing a hundredth rather than silently wrapping into the
+  next run's range. Nothing commits the result: `uv lock` runs straight
+  after, so the lockfile the sdist ships agrees with the version it is
+  named for
 - **`2026.8.4rc1`**, and a `v2026.8.4rc1` tag, have no place in this
   scheme: there is no pre-release here, only a version not yet tagged.
   `version-check` refuses anything that is not digits and dots, which
@@ -63,7 +71,7 @@ Telling these apart is most of what can go wrong when cutting a release.
   comparison against it burning a version `--pre` installs would then
   resolve
 
-PEP 440 sorts `2026.8.4.dev7` before `2026.8.4`, so a rehearsal never
+PEP 440 sorts `2026.8.4.dev701` before `2026.8.4`, so a rehearsal never
 shadows the release it rehearses. `git tag` on its own does not read
 the numbers the same way: measured, `v2026.10` lists before `v2026.7`,
 alphabetically rather than chronologically. `git tag --sort=v:refname`
@@ -110,10 +118,12 @@ it is about to publish), wheel smoke test — and publishes to
    to be dispatched at all, which is the paragraph at the top of this
    file, but it runs against whichever branch is picked.
 
-1. The workflow appends `.dev<run number>` to the version, so every
-   rehearsal is unique on TestPyPI and sorts before the release it
-   rehearses. Re-running a finished rehearsal would reuse its run
-   number and be refused by TestPyPI: dispatch a fresh run instead.
+1. The workflow appends `.dev<run*100+attempt>` to the version, so
+   every rehearsal is unique on TestPyPI and sorts before the release
+   it rehearses, re-runs included: a re-run raises only
+   `github.run_attempt`, which the run number is multiplied by 100 to
+   make room for, so re-running a failed or finished rehearsal mints
+   its own version instead of colliding with the one it repeats.
 
 1. Check the upload on <https://test.pypi.org/project/btclib/>, and
    optionally install it (its dependencies come from the real PyPI):
@@ -122,7 +132,7 @@ it is about to publish), wheel smoke test — and publishes to
    uv run --isolated --no-project \
      --index https://test.pypi.org/simple/ \
      --index-strategy unsafe-best-match \
-     --with btclib==<version>.dev<run number> \
+     --with btclib==<version>.dev<run*100+attempt> \
      python -c "import btclib; print(btclib.__version__)"
    ```
 
@@ -393,7 +403,7 @@ to `latest`'s own result.
    whose claims do not match fails there having uploaded nothing, and
    the version survives — delete the tag, fix the registration, tag
    again. The same holds for a rehearsal failing the same way on
-   TestPyPI: its `.dev<run number>` is not consumed either, and `gh run
+   TestPyPI: its `.dev<run*100+attempt>` is not consumed either, and `gh run
    rerun --failed` re-runs the publish job alone, against the artifacts
    already built, rather than the whole matrix again. The upload itself
    is the point of no return, PyPI accepting no file name twice even
@@ -552,10 +562,10 @@ a mismatch as tampering:
   saw. A mismatch dates the rebuild before it accuses anyone; pinning the
   backend to a version is the fix, and the cost is a floor that ages.
 - **the rehearsal is a different version, by construction.** A TestPyPI
-  dispatch appends `.dev<run number>` to the version, so its files are not
-  a second build of the release's — they are their own artifact, published
-  where they say they are. The attestation the rehearsal writes covers
-  those, and no digest is shared with the release.
+  dispatch appends `.dev<run*100+attempt>` to the version, so its files
+  are not a second build of the release's — they are their own artifact,
+  published where they say they are. The attestation the rehearsal
+  writes covers those, and no digest is shared with the release.
 
 `btclib_secp256k1` is not a third bound. It is a runtime dependency,
 resolved by whoever installs the wheel, and the only trace of it in either

--- a/tests/generate_sbom_test.py
+++ b/tests/generate_sbom_test.py
@@ -364,8 +364,8 @@ def test_main_names_the_file_after_the_wheel(
     """The caller passes a directory and needs to know no version.
 
     Which in a rehearsal it does not: the `build` job patches a
-    `.dev<run number>` into the version before building, so the name the
-    workflow would have to construct is not the one in pyproject.toml.
+    `.dev<run*100+attempt>` into the version before building, so the name
+    the workflow would have to construct is not the one in pyproject.toml.
     """
     monkeypatch.setenv("SOURCE_DATE_EPOCH", str(_EPOCH))
     write_dist(tmp_path, version="2026.9.dev7")


### PR DESCRIPTION
## Summary

The `build` job patched the rehearsal's version as `declared +
".dev" + os.environ["GITHUB_RUN_NUMBER"]`. A run number is per
workflow and does not change on a re-run, so re-running a finished
rehearsal rebuilt the same version and TestPyPI refused the upload —
after the whole matrix had run again. `RELEASING.md` warned the reader
to dispatch a fresh run instead of re-running one, a rule to remember
at the moment a failed rehearsal is least likely to leave room for it.

Fixed the way both sibling repositories' `release.yml` already are
(`btclib-secp256k1` first, then `bitcoin-core-rpc`'s
[#169](https://github.com/btclib-org/bitcoin-core-rpc/pull/169),
closing [#157](https://github.com/btclib-org/bitcoin-core-rpc/issues/157)):
the suffix is `.dev<run*100+attempt>`. The multiplier keeps every
attempt of every run both unique and PEP 440-ordered — attempt 2 of
run 7 still sorts after every attempt of run 6, which a
`.dev<run><attempt>` concatenation would only have kept while the two
numbers' digit counts happened to line up — and the step refuses
outright past the two digits it reserves for the attempt rather than
wrapping silently into another run's range.

`RELEASING.md`'s warning goes with the fix rather than standing beside
it, the rule it stated no longer being true. Every other place stating
the old `.dev<run number>` template now states the new one:
`generate_sbom.py` and its test, and `release.yml`'s own inline
comment (the generic `.dev<N>` placeholders in the header comment and
the packaging-checks comment stay as they were — they never named
`run number` specifically and remain true).

Closes #1156.

## What was checked before implementing

- **What parses the suffix downstream**: nothing does. `generate_sbom.py`
  reads the version out of the built wheel's own filename rather than
  reconstructing it, and the smoke test only asserts
  `btclib.__version__ != "unknown"`. The comparison against the tag in
  `version-check`'s "release only" step never runs in a rehearsal.
- **The re-lock**: `build` already runs `uv lock` right after patching
  `pyproject.toml`, to keep `uv.lock`'s declared version in step with
  the patched one (every later `--locked` call depends on it). That
  re-lock runs on whatever value the patch step wrote, so it needed no
  change of its own.

## Verification

`release.yml` cannot run on a pull request, so the arithmetic is
verified standalone: the patch step's exact source was extracted
from the workflow file and run, unmodified, against a real copy of
`pyproject.toml` (declared version `2026.9`), for a first attempt, a
re-run of the same run, the next run's first attempt, and an attempt
past the guard:

| case | `GITHUB_RUN_NUMBER` | `GITHUB_RUN_ATTEMPT` | result |
|---|---|---|---|
| first attempt of run 7 | 7 | 1 | `2026.9.dev701` |
| re-run of run 7 | 7 | 2 | `2026.9.dev702` |
| first attempt of run 8 | 8 | 1 | `2026.9.dev801` |
| attempt past the guard | 7 | 100 | exit 1, `pyproject.toml` untouched |

Ordering was checked with `packaging.version.Version`, not by eye:
`Version("2026.9.dev701") < Version("2026.9.dev702") <
Version("2026.9.dev801")` holds.

## Test plan

- [x] `uv run pytest` — 100% coverage, exit 0
- [x] `uv run pre-commit run --all-files` — every hook `Passed`, exit 0
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html` — build
      succeeded, exit 0
- [x] The extracted patch step run standalone for the four cases above,
      order checked with `packaging.version.Version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uNzuzag82WGhvznByjFDH

## Summary by Sourcery

Make TestPyPI rehearsal re-runs publishable by incorporating the workflow attempt into their development version suffix while preserving release ordering.

Bug Fixes:
- Generate unique TestPyPI rehearsal versions for workflow re-runs so repeated attempts no longer collide with an existing upload.
- Reject rehearsal attempts beyond the reserved version range instead of allowing suffixes to wrap into another run’s range.

Enhancements:
- Update release guidance, SBOM references, tests, and changelog entries to document the new rehearsal version format.

Documentation:
- Revise release documentation to explain version uniqueness and ordering across workflow runs and re-runs.
