### PR TITLE
RELEASING.md records why the SBOM step stays btclib-only (issue #1159)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -461,6 +461,20 @@ to `latest`'s own result.
    Attested with the distribution files, so `gh attestation verify` below
    covers it too.
 
+   **Neither sibling repository carries one, on purpose.**
+   bitcoin-core-rpc declares `dependencies = []`, and `published.yml`
+   already asserts that against the installed package on every run; a
+   bill of materials there would be an empty `components` list restating
+   a fact CI checks more directly. btclib-secp256k1's interesting
+   dependency is the vendored, statically-linked libsecp256k1 C library
+   pinned in its `secp256k1` submodule, which this generator cannot
+   describe — it reads `Requires-Dist`, and the submodule is not a
+   Python dependency. A bill of materials built the way this one is
+   would name `cffi` and say nothing about the pin a verifier of that
+   package would most want described, which is worse than omitting the
+   document. See issue #1159 for the evaluation and what would change
+   it.
+
 1. Read the release run's `published` job, which is this workflow called
    with the tag rather than a dispatch to remember: it has no checkout, so
    it resolves to what PyPI actually serves rather than to a source tree,


### PR DESCRIPTION
## What

Documents, in `RELEASING.md`, that btclib carrying a CycloneDX bill of
materials while its two siblings do not is a decision rather than
drift, and states the reason for each sibling.

## Why

Issue #1159 asked whether the SBOM step is a three-repository property
or a btclib one. Evidence, posted as a comment on the issue:

- Generated an SBOM for each of the three repositories (built wheel +
  sdist from current `main`, ran btclib's own `generate_sbom.py` with
  `SOURCE_DATE_EPOCH` set as the workflow does).
- bitcoin-core-rpc's SBOM is `"components": []` -- it declares
  `dependencies = []`, and `published.yml` already asserts that
  against the installed package on every run.
- btclib-secp256k1's SBOM names `cffi` three times (once per
  environment-marker split) and nothing else -- the dependency it
  actually wraps, the vendored/statically-linked libsecp256k1 C
  library pinned in the `secp256k1` submodule, is invisible to a
  `Requires-Dist`-based generator.
- No consumer of the attached SBOM was found outside a human reader
  following `RELEASING.md`; `gh attestation verify` covers provenance
  (this file matches what the named workflow produced), not content
  accuracy.
- Carrying the generator to a sibling is not a copy-paste: 314 lines
  of script plus 417 of tests, ~10 workflow touch points, and for
  btclib-secp256k1 a `SOURCE_DATE_EPOCH`/reproducibility prerequisite
  it does not yet have (tracked separately as divergence #8 on #1152).

Recommendation posted on #1159: keep the asymmetry, write it down.
This PR is that write-down for btclib's own `RELEASING.md`; sibling
PRs (non-closing, referencing this issue) carry the matching note for
bitcoin-core-rpc and btclib-secp256k1.

Closes #1159

## Verification

```
$ uv run --locked pre-commit run --files RELEASING.md   # exit 0, all hooks passed
```

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Document the intentional SBOM asymmetry across the related repositories and the rationale for keeping the generator limited to btclib.

Enhancements:
- Document why the SBOM remains btclib-only and why bitcoin-core-rpc and btclib-secp256k1 intentionally do not carry one.

Documentation:
- Clarify the rationale for the sibling repositories' lack of SBOMs and reference issue #1159 for the evaluation.