### PR TITLE
A re-run rehearsal mints its own version (issue #1156)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,10 +275,20 @@ jobs:
       - name: Pin the build timestamp to the commit
         run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
       # TestPyPI refuses a version it has already seen: the rehearsal
-      # appends .dev<run number>, unique per dispatch and sorted before
-      # the release it rehearses (PEP 440). Re-running a finished
-      # rehearsal would reuse its run number and collide on TestPyPI:
-      # dispatch a fresh run instead
+      # appends .dev<run*100+attempt>, unique per dispatch and per re-run
+      # of one, and sorted before the release it rehearses (PEP 440).
+      # A re-run keeps the run's own id and number and only raises
+      # run_attempt, so .dev<run number> alone -- the previous shape of
+      # this suffix -- was identical across every re-run of one dispatch
+      # and collided with itself on TestPyPI the moment a rehearsal was
+      # re-run rather than freshly dispatched. Multiplying the run number
+      # by 100 and adding the attempt keeps both properties at once:
+      # every attempt of every run is still unique, and, because the
+      # attempt never reaches the run number's own place value, attempt 2
+      # of run 7 (702) still sorts after every attempt of run 6 (600-699)
+      # -- the ordering .dev<run><attempt> concatenation would have kept
+      # only while the two numbers' digit counts happened to line up.
+      # The two digits reserved for the attempt are checked, not assumed
       - name: Make the version unique for TestPyPI (rehearsal only)
         if: github.event_name == 'workflow_dispatch'
         # Python and tomllib, not sed: the value is parsed and only then
@@ -297,6 +307,12 @@ jobs:
           import tomllib
           from pathlib import Path
 
+          run_number = int(os.environ["GITHUB_RUN_NUMBER"])
+          run_attempt = int(os.environ["GITHUB_RUN_ATTEMPT"])
+          if run_attempt > 99:
+              msg = f"attempt {run_attempt} exceeds the two digits reserved for it"
+              raise SystemExit(msg)
+
           path = Path("pyproject.toml")
           text = path.read_text(encoding="utf-8")
           declared = tomllib.loads(text)["project"]["version"]
@@ -304,7 +320,7 @@ jobs:
           if match is None:
               msg = f"pyproject.toml declares {declared}, which is not a literal in it"
               raise SystemExit(msg)
-          suffixed = declared + ".dev" + os.environ["GITHUB_RUN_NUMBER"]
+          suffixed = declared + ".dev" + str(run_number * 100 + run_attempt)
           line = match.group().replace(declared, suffixed, 1)
           path.write_text(text[: match.start()] + line + text[match.end() :], encoding="utf-8")
           PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,24 @@ documented at release-notes length in the first place, and are still in
   and checked. Reaching that shape here needs `test.yml`'s artifact
   published instead of rebuilt, which is a larger change than this one;
   the issue is the record of it.
+- **A re-run of a finished TestPyPI rehearsal now gets a version of its
+  own** (issue #1156): the suffix was `.dev<run number>`, and a re-run
+  keeps `github.run_number` and only raises `github.run_attempt`, so
+  re-running a finished rehearsal rebuilt the identical version and
+  TestPyPI refused the upload. RELEASING.md's answer had been a warning
+  to dispatch a fresh run instead of re-running one — a rule to remember
+  at the moment a failed rehearsal is least likely to leave room for it.
+  Fixed the way `btclib-secp256k1`'s `release.yml` already was, and the
+  way `bitcoin-core-rpc` fixed the identical defect in its own issue
+  #157: the suffix is now `.dev<run*100+attempt>`, the multiplier
+  keeping every attempt of every run both unique and PEP 440 ordered —
+  attempt 2 of run 7 still sorts after every attempt of run 6, which
+  plain concatenation only kept while the two numbers' digit counts
+  happened to line up. The step refuses outright past the two digits it
+  reserves for the attempt rather than silently wrapping into another
+  run's range. RELEASING.md's warning goes with it, the rule it stated
+  no longer being true, and every other place in that file naming the
+  old `.dev<run number>` template is updated to the new one.
 
 ## v2026.8.21
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,14 +46,21 @@ Telling these apart is most of what can go wrong when cutting a release.
 - **`v2026.8.4`**, the tag, carries no version of its own: it picks the
   index, PyPI rather than TestPyPI, and `version-check` exists to
   confirm it says what `pyproject.toml` says
-- **`2026.8.4.dev7`** is a rehearsal, and nobody types it either half at
-  a time: `.dev<run number>` is the template the `build` job patches into
-  `pyproject.toml` when `workflow_dispatch` starts the workflow, the
-  number being `github.run_number` counted for `release.yml` alone, so
-  the seventh such run rehearsing `2026.8.4` produces exactly that. The
-  count is what makes a rehearsal's version unique, and what makes
-  re-running a finished one collide with itself rather than mint a new
-  one. Nothing commits the result: `uv lock` runs straight after, so the
+- **`2026.8.4.dev701`** is a rehearsal, and nobody types it either half
+  at a time: `.dev<run*100+attempt>` is the template the `build` job
+  patches into `pyproject.toml` when `workflow_dispatch` starts the
+  workflow, `github.run_number` counted for `release.yml` alone and
+  `github.run_attempt` counted for one dispatch of it, so the seventh
+  such run's first attempt rehearsing `2026.8.4` produces exactly that.
+  The multiplier is what makes a re-run a version of its own rather than
+  a collision: a re-run keeps the run's own number and only raises the
+  attempt, so the run number alone was identical across every re-run of
+  one dispatch and PEP 440 could not tell them apart. Placing the
+  attempt below the run number's own place value keeps a run's later
+  attempts sorting after its earlier ones and before the next run's, the
+  attempt therefore capped at two digits and the step refusing a
+  hundredth rather than silently wrapping into the next run's range.
+  Nothing commits the result: `uv lock` runs straight after, so the
   lockfile the sdist ships agrees with the version it is named for
 - **`2026.8.4rc1`**, and a `v2026.8.4rc1` tag, have no place in this
   scheme: there is no pre-release here, only a version not yet tagged.
@@ -63,7 +70,7 @@ Telling these apart is most of what can go wrong when cutting a release.
   comparison against it burning a version `--pre` installs would then
   resolve
 
-PEP 440 sorts `2026.8.4.dev7` before `2026.8.4`, so a rehearsal never
+PEP 440 sorts `2026.8.4.dev701` before `2026.8.4`, so a rehearsal never
 shadows the release it rehearses. `git tag` on its own does not read
 the numbers the same way: measured, `v2026.10` lists before `v2026.7`,
 alphabetically rather than chronologically. `git tag --sort=v:refname`
@@ -110,10 +117,12 @@ it is about to publish), wheel smoke test — and publishes to
    to be dispatched at all, which is the paragraph at the top of this
    file, but it runs against whichever branch is picked.
 
-1. The workflow appends `.dev<run number>` to the version, so every
+1. The workflow appends `.dev<run*100+attempt>` to the version, so every
    rehearsal is unique on TestPyPI and sorts before the release it
-   rehearses. Re-running a finished rehearsal would reuse its run
-   number and be refused by TestPyPI: dispatch a fresh run instead.
+   rehearses, re-runs included: a re-run raises only
+   `github.run_attempt`, which the run number is multiplied by 100 to
+   make room for, so re-running a failed or finished rehearsal mints its
+   own version instead of colliding with the one it repeats.
 
 1. Check the upload on <https://test.pypi.org/project/btclib/>, and
    optionally install it (its dependencies come from the real PyPI):
@@ -122,7 +131,7 @@ it is about to publish), wheel smoke test — and publishes to
    uv run --isolated --no-project \
      --index https://test.pypi.org/simple/ \
      --index-strategy unsafe-best-match \
-     --with btclib==<version>.dev<run number> \
+     --with btclib==<version>.dev<run*100+attempt> \
      python -c "import btclib; print(btclib.__version__)"
    ```
 
@@ -393,7 +402,7 @@ to `latest`'s own result.
    whose claims do not match fails there having uploaded nothing, and
    the version survives — delete the tag, fix the registration, tag
    again. The same holds for a rehearsal failing the same way on
-   TestPyPI: its `.dev<run number>` is not consumed either, and `gh run
+   TestPyPI: its `.dev<run*100+attempt>` is not consumed either, and `gh run
    rerun --failed` re-runs the publish job alone, against the artifacts
    already built, rather than the whole matrix again. The upload itself
    is the point of no return, PyPI accepting no file name twice even
@@ -538,7 +547,7 @@ a mismatch as tampering:
   saw. A mismatch dates the rebuild before it accuses anyone; pinning the
   backend to a version is the fix, and the cost is a floor that ages.
 - **the rehearsal is a different version, by construction.** A TestPyPI
-  dispatch appends `.dev<run number>` to the version, so its files are not
+  dispatch appends `.dev<run*100+attempt>` to the version, so its files are not
   a second build of the release's — they are their own artifact, published
   where they say they are. The attestation the rehearsal writes covers
   those, and no digest is shared with the release.


### PR DESCRIPTION
## Summary

Closes #1156.

- `release.yml`'s `build` job patched a rehearsal's version as
  `.dev<run number>`. A run number is per workflow and does not change
  on a re-run, so re-running a finished rehearsal rebuilt the identical
  version and TestPyPI refused the upload, after the whole matrix had
  run again. `RELEASING.md`'s answer had been a warning to dispatch a
  fresh run instead of re-running one — a rule to remember at the
  moment a failed rehearsal is least likely to leave room for it.
- Fixed the way `btclib-secp256k1`'s `release.yml` already does it
  (read first, per the task): the suffix is now
  `.dev<run*100+attempt>`. The multiplier keeps every attempt of every
  run unique *and* keeps the PEP 440 ordering — attempt 2 of run 7
  (`702`) still sorts after every attempt of run 6 (`600`-`699`), which
  plain concatenation only kept while the two numbers' digit counts
  happened to line up. The step refuses outright past the two digits
  reserved for the attempt rather than silently wrapping into another
  run's range.
- `bitcoin-core-rpc` fixed the identical defect the same way for its
  own issue #157 (btclib-org/bitcoin-core-rpc#169, merged): this PR
  carries the same shape of fix, adapted to this repository's own
  Python/tomllib patching step rather than `bitcoin-core-rpc`'s plain
  shell one.
- `RELEASING.md`'s warning goes with the defect it was covering for,
  and every other place naming the old `.dev<run number>` template —
  the version-string bullet, the rehearsal steps, the `uv run --with`
  example, and the attestation paragraph — is updated to the new one.

### Why `GITHUB_RUN_ATTEMPT` alone does not work

`GITHUB_RUN_ATTEMPT` is not swapped in for `GITHUB_RUN_NUMBER`, or used
bare beside it: attempt alone repeats across runs (every run's first
attempt is `1`), and `<run>.<attempt>` or `<run>-<attempt>` are not
valid PEP 440 in the position after `.dev`, which accepts digits only.
Concatenating the two digit strings breaks PEP 440 ordering the moment
their digit counts stop lining up (`.dev6` then `.dev71` looks
increasing lexically-adjacent but is not the guarantee this exists
for). `run*100+attempt` is the smallest arithmetic that keeps both
properties — uniqueness per attempt and monotonic ordering — at once,
which is what `btclib-secp256k1` already does and what
`bitcoin-core-rpc` adopted for the same reason.

## Verified

- `uv run pre-commit run --all-files` — exit 0, `actionlint` and
  `zizmor` both report zero findings
- `uv run pytest` — exit 0, 29393 passed, 11 skipped, 100.00% coverage
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` — exit 0, "build
  succeeded"
- The patching arithmetic itself, standalone: `run*100+attempt` against
  four cases (run 7 attempt 1 twice, run 7 attempt 2, run 8 attempt 1)
  compared with `packaging.version.Version` — the two same-attempt
  calls are equal, and `(7,1) < (7,2) < (8,1)` holds. The guard was
  exercised at `attempt=100` and raises.
- The file-patching step's own logic, standalone against a copy of this
  repository's actual `pyproject.toml`: `2026.9` becomes
  `2026.9.dev701` for `run=7, attempt=1`.

**Not verified**: the real path, end to end — a `workflow_dispatch` of
this workflow, a re-run of it, and the second upload actually being
accepted by TestPyPI. That needs a rehearsal dispatch, which is outside
this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao774JtUq6tF3SnK359Krm

## Summary by Sourcery

Ensure every TestPyPI rehearsal attempt receives a unique, correctly ordered development version, including workflow re-runs.

New Features:
- Assign unique PEP 440-compatible development versions to TestPyPI rehearsal re-runs using both the workflow run number and attempt number.

Bug Fixes:
- Prevent TestPyPI upload collisions when a release rehearsal is re-run.

Enhancements:
- Reject workflow attempts beyond the reserved two-digit attempt range to preserve version ordering and uniqueness.

Documentation:
- Update release guidance and version examples to document the new rehearsal versioning scheme and re-run behavior.

Chores:
- Record the rehearsal versioning fix in the changelog.