### PR TITLE
RELEASING.md: the github-release recovery names all three artifacts (issue #1150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,32 @@ documented at release-notes length in the first place, and are still in
   while a skipped job is neither, which is why it left this one skipped on
   both attempts.
 
+- **RELEASING.md's `github-release` recovery bullet names the full
+  asset set** (issue #1150). "create the release by hand from the
+  `dist` artifact of the run" named one artifact where the job
+  downloads three — `dist`, `sbom` and `attestation`, each uploaded by
+  a step of its own earlier in the same workflow — and a release built
+  by that instruction would carry the wheel and the sdist while
+  missing the bill of materials and the signed attestation bundle,
+  which the "Rebuild a release from its tag" section a few dozen lines
+  below already assumes with `--bundle <tag>.attestation.jsonl`. The
+  bullet now downloads and attaches all three, the distribution files
+  and the bill of materials in the order the "Rebuild" section's own
+  `gh attestation verify` calls check them — wheel, sdist, bill of
+  materials — with the bundle renamed as `github-release` renames it.
+  It also has the reader check the two distribution files against the
+  digests PyPI already published for them before attaching anything,
+  which is what makes "the release carries what the index serves" a
+  fact rather than an assumption, and states the limit of the other
+  recovery this same bullet names: `gh run rerun --failed` reaches a
+  job the run marks failed, not one it marks skipped, which is why it
+  did not recover `github-release` on either of the runs issue #1142
+  measured. Issue #1148's fix stops that skip from recurring; the
+  flag's reach is worth stating where a reader is sent to it anyway.
+  Measured while recreating v2026.8.21 by hand after issue #1142: the
+  release wound up with four assets, not the two the old bullet would
+  have produced.
+
 ### Packaging, linting and CI
 
 - **`published.yml`'s steps declare `shell: bash`** (issue #1141). The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,9 @@ documented at release-notes length in the first place, and are still in
   recovery this same bullet names: `gh run rerun --failed` reaches a
   job the run marks failed, not one it marks skipped, which is why it
   did not recover `github-release` on either of the runs issue #1142
-  measured. Issue #1148's fix stops that skip from recurring; the
-  flag's reach is worth stating where a reader is sent to it anyway.
+  measured. That issue's own `if: always()` fix stops the skip from
+  recurring; the flag's reach is worth stating where a reader is sent
+  to it anyway.
   Measured while recreating v2026.8.21 by hand after issue #1142: the
   release wound up with four assets, not the two the old bullet would
   have produced.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -591,5 +591,51 @@ above needs no `uv sync` to produce the published bytes.
   and publish a new patch version (`2026.8.4` → `2026.8.4.1`).
 
 - Only the `github-release` job failed: the PyPI upload is already
-  done; re-run the failed job, or create the release by hand from the
-  `dist` artifact of the run.
+  done. `gh run rerun <run id> --failed` reaches it when the run marks
+  it *failed* — a dependent of a failed job is reached too, which is
+  what usually gets `github-release` from `attest` or `publish-pypi`
+  failing under it. It does not reach a job the run marks *skipped*:
+  a skip is neither a failure nor within that flag's blast radius,
+  which is how v2026.8.21 kept a version on PyPI and no release at
+  all through two reruns (issue #1142; the comment on
+  `github-release`'s `if` in `release.yml` has the measurement). A
+  skipped job needs the recovery below, same as a failed one
+  `--failed` did not reach.
+
+  Either way, the recovery is a release built from the run's own
+  artifacts by hand — three of them, `dist`, `sbom` and `attestation`,
+  not the one `dist` alone:
+
+  ```shell
+  run_id=<the release.yml run>
+  version=<the released version, e.g. 2026.8.4>
+  tag="v$version"
+  gh run download "$run_id" -n dist -n sbom -n attestation
+  ```
+
+  Check the distribution files against the digests PyPI already
+  published for them, before attaching anything: it is what makes
+  "the release carries what the index serves" a fact rather than an
+  assumption, and PyPI accepts no second upload to compare them
+  against.
+
+  ```shell
+  for f in dist/*.whl dist/*.tar.gz; do
+    sha=$(curl -sf "https://pypi.org/pypi/btclib/$version/json" |
+      jq -r --arg n "$(basename "$f")" \
+        '.urls[] | select(.filename==$n) | .digests.sha256')
+    echo "$sha  $f" | sha256sum -c -
+  done
+  ```
+
+  Then attach the same three: the bundle renamed as the job renames
+  it, and every file in the order the "Rebuild a release from its
+  tag" section above verifies them in — wheel, sdist, bill of
+  materials:
+
+  ```shell
+  mv attestation/attestation.jsonl "$tag.attestation.jsonl"
+  gh release create "$tag" dist/*.whl dist/*.tar.gz \
+    sbom/*.cdx.json "$tag.attestation.jsonl" \
+    --title "$tag" --notes-file <the tag's RELEASE_NOTES.md section>
+  ```


### PR DESCRIPTION
## What

RELEASING.md's "If something goes wrong" section, the "Only the
`github-release` job failed" bullet, said to create the release by
hand from the `dist` artifact of the run. `release.yml`'s
`github-release` job downloads `dist`, `sbom` and `attestation` and
attaches all three, renaming the bundle to `<tag>.attestation.jsonl`.
A release built from `dist` alone carries the wheel and the sdist with
no bill of materials and no signed attestation bundle, and "Rebuild a
release from its tag" a few dozen lines below already assumes one is
there to `--bundle` against.

## Established before writing

Read `release.yml`'s `github-release` job: it downloads all three
artifacts and runs `gh release create "$GITHUB_REF_NAME" dist/*
sbom/* "$bundle" ...`. Checked a release cut without hand repair —
`gh release view v2026.8.9 --repo btclib-org/btclib --json assets`
lists only the wheel and the sdist, because that tag predates the
`sbom` and `attest` jobs entirely; no tag has ever completed
`github-release` automatically since attest was inserted ahead of it
(`v2026.8.21` is the first, and it was skipped — issue #1142 — then
recreated by hand). So the source of truth here is the job's own
script, corroborated by the hand-repaired `v2026.8.21`, which now
carries all four assets (wheel, sdist, `.cdx.json`, `.attestation.jsonl`).

## What changed

The bullet now:

- downloads and attaches all three artifacts, the distribution files
  and the bill of materials in the order the "Rebuild a release from
  its tag" section's own `gh attestation verify` calls check them —
  wheel, sdist, bill of materials — with the bundle renamed the way
  the job renames it, `gh` commands spelled out;
- checks the two distribution files against the digests PyPI already
  published for them before attaching anything, so "the release
  carries what the index serves" is a fact rather than an assumption;
- states that `gh run rerun --failed` reaches a job the run marks
  *failed*, not one it marks *skipped*, which is why it did not
  recover `github-release` on either of the runs issue #1142
  measured — issue #1148's fix stops that skip from recurring, but
  the flag's reach is worth stating where the bullet sends a reader
  to it.

A `CHANGELOG.md` entry records the fix under "Repository" for
v2026.9. No `RELEASE_NOTES.md` entry: nothing here is something a
package user has to act on.

## Finding, filed rather than fixed here

Nothing exercises this recovery procedure — no test, no CI step, no
rehearsal path runs the `gh run download` / digest-check / `gh
release create` sequence RELEASING.md now spells out for any of the
three publishing repositories. Filed as
[btclib#1172](https://github.com/btclib-org/btclib/issues/1172)
rather than widened into this diff.

## Verification

Run in a worktree off `origin/main`:

```
uv run pre-commit run --all-files   # exit 0, every hook Passed
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
                                     # exit 0, "build succeeded"
```

Both re-run clean after rebasing onto a concurrent `release.yml`
change (issue #1154's PR #1164, unrelated to this file).

Closes #1150

## Summary by Sourcery

Ensure GitHub release recovery produces complete, verified releases from the workflow’s artifacts.

Bug Fixes:
- Correct the release recovery instructions to preserve distribution files, software bills of materials, and signed attestation bundles when rebuilding a GitHub release.
- Document that failed-job reruns do not recover jobs marked as skipped.

Enhancements:
- Add PyPI digest verification to ensure manually rebuilt releases match the published package artifacts.

Documentation:
- Expand RELEASING.md with explicit commands for downloading, validating, and attaching all release artifacts during recovery.