### PR TITLE
Fix concurrency group collisions in test.yml and lint.yml (issue #1158)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,15 +34,22 @@ on:
     # what makes it do, cancel-in-progress above turning the landing
     # into the cancellation. A closed pull request has nothing left to
     # ask this workflow, the merge commit being main's own push
-    # trigger's question. The group below keys on github.head_ref rather
-    # than plain github.ref for exactly this event: a merged pull
-    # request's closed event sets github.ref to the base branch, not the
-    # merge ref, which used to land it in main's own push group and race
-    # the merge commit's run for cancellation (PR 1023's bug) instead of
-    # the PR's own group as intended
+    # trigger's question. The group below keys on the pull request's own
+    # number rather than plain github.ref for exactly this event: a
+    # merged pull request's closed event sets github.ref to the base
+    # branch, not the merge ref, which used to land it in main's own
+    # push group and race the merge commit's run for cancellation
+    # (PR 1023's bug) instead of the PR's own group as intended
     types: [opened, reopened, synchronize, ready_for_review, closed]
   # lets the release workflow gate publication on these same checks
   workflow_call:
+    inputs:
+      concurrency-suffix:
+        description: >
+          Appended to the concurrency group, and the release workflow is
+          the only caller that passes one. See the group below.
+        type: string
+        default: ""
   # the escape hatch: a run on demand for a branch whose pull request is
   # not open yet
   workflow_dispatch:
@@ -58,13 +65,27 @@ permissions:
 # a called workflow is the caller's name: the release workflow calls both
 # this and test.yml, and with that expression the two would share a group
 # and cancel each other.
-# head_ref falls back to ref rather than being used bare: it is set only
-# for pull_request events, to the PR's head branch, so a push run (ref
-# refs/heads/main) still gets its own group -- and a pull_request event
-# always groups by the PR's branch, closed and merged ones included, so
-# it never collides with a push's group the way bare ref did
+# github.ref has the same shape of problem one level down, and it is why
+# the suffix is there. Inside a called workflow that context is the
+# caller's ref, so a rehearsal -- a workflow_dispatch of release.yml on a
+# branch, which is what RELEASING.md prescribes -- computes
+# lint-refs/heads/<branch>, the very group a push to that branch or a
+# direct dispatch of this workflow computes. One then kills the other:
+# either the rehearsal dies mid-build, or it cancels the run of the push.
+# A tag run is unaffected, refs/tags/v* being a ref nothing else uses.
+# release.yml passes a suffix of its own, which keeps the release path
+# out of the branch groups while still letting a second rehearsal of the
+# same branch supersede the first.
+# github.event.pull_request.number, not github.ref alone, is a third
+# problem with the same shape: for a closed, merged pull request's run,
+# github.ref resolves to the base branch's ref rather than
+# refs/pull/N/merge, colliding with the push trigger's own group --
+# PR 1023's bug, recorded in the pull_request trigger's own comment
+# above. A pull_request run of any action, closed included, now groups
+# by the pull request's own number instead, which a push never carries
+# and so still groups by github.ref, unchanged
 concurrency:
-  group: lint-${{ github.head_ref || github.ref }}
+  group: lint-${{ github.event.pull_request.number || github.ref }}${{ inputs.concurrency-suffix }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,10 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+    with:
+      # what keeps this run out of the branch concurrency groups: see the
+      # group in test.yml
+      concurrency-suffix: "-release"
 
   # and the same checks a pull request lints with: without this, a tag
   # push could publish code the pre-commit hooks reject. Not gated on
@@ -226,6 +230,9 @@ jobs:
   lint:
     name: Run the lint workflow
     uses: ./.github/workflows/lint.yml
+    with:
+      # see the test job above
+      concurrency-suffix: "-release"
 
   # and the documentation build, for the reason the lint call above gives: a
   # tag publishes the docstrings read the docs will render from it, so the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,15 +44,22 @@ on:
     # what makes it do, cancel-in-progress above turning the landing
     # into the cancellation. A closed pull request has nothing left to
     # ask this workflow, the merge commit being main's own push
-    # trigger's question. The group below keys on github.head_ref rather
-    # than plain github.ref for exactly this event: a merged pull
-    # request's closed event sets github.ref to the base branch, not the
-    # merge ref, which used to land it in main's own push group and race
-    # the merge commit's run for cancellation (PR 1023's bug) instead of
-    # the PR's own group as intended
+    # trigger's question. The group below keys on the pull request's own
+    # number rather than plain github.ref for exactly this event: a
+    # merged pull request's closed event sets github.ref to the base
+    # branch, not the merge ref, which used to land it in main's own
+    # push group and race the merge commit's run for cancellation
+    # (PR 1023's bug) instead of the PR's own group as intended
     types: [opened, reopened, synchronize, ready_for_review, closed]
   # allows the release workflow to reuse the whole build/test pipeline
   workflow_call:
+    inputs:
+      concurrency-suffix:
+        description: >
+          Appended to the concurrency group, and the release workflow is
+          the only caller that passes one. See the group below.
+        type: string
+        default: ""
   # the escape hatch: the matrix on demand for a branch whose pull
   # request is not open yet
   workflow_dispatch:
@@ -68,13 +75,27 @@ permissions:
 # a called workflow is the caller's name: the release workflow calls both
 # this and lint.yml, and with that expression the two would share a group
 # and cancel each other.
-# head_ref falls back to ref rather than being used bare: it is set only
-# for pull_request events, to the PR's head branch, so a push run (ref
-# refs/heads/main) still gets its own group -- and a pull_request event
-# always groups by the PR's branch, closed and merged ones included, so
-# it never collides with a push's group the way bare ref did
+# github.ref has the same shape of problem one level down, and it is why
+# the suffix is there. Inside a called workflow that context is the
+# caller's ref, so a rehearsal -- a workflow_dispatch of release.yml on a
+# branch, which is what RELEASING.md prescribes -- computes
+# test-refs/heads/<branch>, the very group a push to that branch or a
+# direct dispatch of this workflow computes. One then kills the other:
+# either the rehearsal dies mid-build, or it cancels the run of the push.
+# A tag run is unaffected, refs/tags/v* being a ref nothing else uses.
+# release.yml passes a suffix of its own, which keeps the release path
+# out of the branch groups while still letting a second rehearsal of the
+# same branch supersede the first.
+# github.event.pull_request.number, not github.ref alone, is a third
+# problem with the same shape: for a closed, merged pull request's run,
+# github.ref resolves to the base branch's ref rather than
+# refs/pull/N/merge, colliding with the push trigger's own group --
+# PR 1023's bug, recorded in the pull_request trigger's own comment
+# above. A pull_request run of any action, closed included, now groups
+# by the pull request's own number instead, which a push never carries
+# and so still groups by github.ref, unchanged
 concurrency:
-  group: test-${{ github.head_ref || github.ref }}
+  group: test-${{ github.event.pull_request.number || github.ref }}${{ inputs.concurrency-suffix }}
   cancel-in-progress: true
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,31 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **`test.yml`'s and `lint.yml`'s concurrency groups take a
+  `concurrency-suffix` input, and `release.yml` passes `-release` at both
+  call sites; the key changes from `github.head_ref || github.ref` to
+  `github.event.pull_request.number || github.ref`** (issue #1158). Two
+  divergences, in the same lines. First: `release.yml` calls both
+  workflows, and inside a called workflow `github.ref` is the ref of the
+  release run itself — a `workflow_dispatch` rehearsal from `main`
+  computes `refs/heads/main`, the same group a push to `main` holds, with
+  `cancel-in-progress: true`, so one cancelled the other. Not exercised
+  directly — reproducing it costs an actual rehearsal race — but
+  `btclib-secp256k1` had already fixed it with the same
+  `concurrency-suffix` mechanism this copies. Second: `head_ref` is set
+  only for `pull_request` events and is the branch name, so two forks
+  each pushing a branch called, say, `patch-1` collide under it; the pull
+  request number does not repeat across forks. `head_ref` still beat a
+  bare `github.ref` on one count the surviving comment keeps: a closed,
+  merged pull request's event sets `github.ref` to the base branch, not
+  the merge ref, so the fallback still has to be something that gives a
+  closed `pull_request` event its own group, and the pull request number
+  does that too. `CLAUDE.md` is corrected in the same pull request: it
+  had been fixed once already, from `test-${{ github.ref }}` to the
+  `head_ref` form, by the survey behind
+  [ISS #1152](https://github.com/btclib-org/btclib/issues/1152), and this
+  change made that fix wrong a second time.
+
 - **`published.yml`'s steps declare `shell: bash`** (issue #1141). The
   matrix includes `windows-latest` and `windows-11-arm`, where the default
   shell is PowerShell, and the step that waits for the index to serve the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,10 +139,12 @@ Do not use Fable unless explicitly instructed.
   pre-commit.ci's included, neither of them naming a branch. Branch
   protection, and why it is what it is, is `REPOSITORY.md`.
 - **A branch's CI run can be `cancelled` rather than green.** `test.yml`'s
-  concurrency group is `test-${{ github.ref }}` with cancel-in-progress,
-  so the next push kills the run for the previous commit. The local gates
-  below are the evidence; `cancelled` is not `failure`, and waiting for a
-  busy afternoon to settle is waiting for nothing.
+  concurrency group is
+  `test-${{ github.event.pull_request.number || github.ref }}` (plus a
+  release-only suffix) with cancel-in-progress, so the next push kills
+  the run for the previous commit. The local gates below are the
+  evidence; `cancelled` is not `failure`, and waiting for a busy
+  afternoon to settle is waiting for nothing.
 - **A bare `uv run pytest` is the coverage gate too**: `--cov` is in
   addopts, so the 100% ratchet fails locally instead of only in the
   `coverage` job. A run that selects a subset — paths, `-k`, `-m` — is
@@ -196,8 +198,9 @@ Do not use Fable unless explicitly instructed.
 - **Workflows**: every action pinned to a commit SHA with the tag in a
   trailing comment; every workflow declares `permissions: contents: read`
   and `timeout-minutes`; concurrency groups are named literally
-  (`test-${{ github.ref }}`), never through `github.workflow`, which in a
-  called workflow is the caller's name; `checkout` passes
+  (`test-${{ github.event.pull_request.number || github.ref }}`), never
+  through `github.workflow`, which in a called workflow is the caller's
+  name; `checkout` passes
   `persist-credentials: false`; uv commands pass `--locked`, never
   `--frozen`. `actionlint` and `zizmor` are hooks, and both must stay at
   zero findings.


### PR DESCRIPTION
## Summary

Two divergences in the `concurrency:` block of `test.yml` and
`lint.yml`, both filed as issue #1158 out of the release-machinery
survey (btclib-org/btclib#1152):

1. **A release rehearsal collides with the branch's own runs.**
   `release.yml` calls `test.yml` and `lint.yml`, and `github.ref`
   inside a called workflow is the *caller's* ref, not the called
   workflow's own. A `workflow_dispatch` rehearsal of `release.yml`
   from `main` computed `test-refs/heads/main` /
   `lint-refs/heads/main` -- the same group a push to `main` holds --
   with `cancel-in-progress: true`, so one run cancelled the other. A
   tag push is unaffected (`refs/tags/v*` collides with nothing), so
   this bit the rehearsal specifically: the run that happens rarely,
   by hand, with somebody watching it.
2. **The key was `github.head_ref`, not the pull request number.**
   `head_ref` is set only for `pull_request` events and is the
   branch's *name*, so two forks each pushing a branch called, say,
   `patch-1` collide under it and cancel each other's runs. The pull
   request number does not repeat across forks.

## Comparison across the three repositories (read before this PR)

| | btclib (before) | btclib-secp256k1 | bitcoin-core-rpc |
| --- | --- | --- | --- |
| defect 1 (rehearsal collision) | present | fixed: `concurrency-suffix` input, `release.yml` passes `-release` | present (companion PR) |
| defect 2 (key) | `github.head_ref \|\| github.ref` | `github.event.pull_request.number \|\| github.ref` | `github.event.pull_request.number \|\| github.ref` |

`btclib-secp256k1` already had both right and needs no change. This PR
brings `btclib` to the same shape `btclib-secp256k1` has. The
companion fix in `bitcoin-core-rpc` needs only defect 1 -- its key was
already right: btclib-org/bitcoin-core-rpc#181.

## Two traps avoided (both already recorded in the file's own comments)

- The group stays named literally (`test-${{ ... }}`), never through
  `github.workflow`, which inside a called workflow is the *caller's*
  name -- `release.yml` calls both `test.yml` and `lint.yml`, and that
  expression would have them share a group.
- The key keeps a `|| github.ref` fallback: `head_ref` (now
  `pull_request.number`) is set only for `pull_request` events, so a
  push needs its own term to fall back to. And a `closed` pull-request
  event sets `github.ref` to the *base* branch, not the merge ref --
  the bug PR 1023 fixed, which is why the fallback has to be a
  pull-request-scoped key first (now `pull_request.number` instead of
  `head_ref`) and only then `github.ref`, never `github.ref` alone.

## What changed

- `test.yml`, `lint.yml`: `workflow_call` gains a `concurrency-suffix`
  input (default `""`); the group becomes
  `${job}-${{ github.event.pull_request.number || github.ref }}${{ inputs.concurrency-suffix }}`.
- `release.yml`: the `test` and `lint` call sites pass
  `concurrency-suffix: "-release"`. Diff confined to those two `with:`
  blocks -- `release.yml` is also held by workers on #1156, #1165 and
  #1166.
- `CLAUDE.md`: the two mentions of `test.yml`'s group are corrected
  from `test-${{ github.ref }}` (already stale once, per #1152's
  survey, which found the real group was the `head_ref` form) to the
  current expression.

## Which defect was exercised

Neither is exercised by an actual GitHub Actions run in this PR --
reproducing either costs a real rehearsal race or two same-named fork
branches, and this is diff review, not a live drill. The expression
change is confirmed by `actionlint`/`zizmor` parsing it cleanly and by
reading the `workflow_call` schema against GitHub's documented context
availability (`github.event.pull_request.number` is unset outside
`pull_request`, matching the existing `|| github.ref` fallback's
purpose).

## Verification

Run from a worktree off `origin/main`, `uv sync --locked` first.

- `uv run pre-commit run --all-files`: exit 0, all hooks green,
  `actionlint` and `zizmor` at zero findings.
- `uv run pytest`: exit 0, 29393 passed, 11 skipped.
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html`: exit 0, build
  succeeded.

Closes #1158

## Summary by Sourcery

Fix test and lint concurrency grouping to isolate pull requests and release rehearsals from unrelated workflow runs.

Bug Fixes:
- Prevent test and lint workflow runs from colliding across pull requests from different forks by grouping pull request events by number.
- Prevent release rehearsals from cancelling branch test and lint runs by isolating release workflow concurrency groups.

Enhancements:
- Add configurable concurrency suffixes to reusable test and lint workflows while preserving branch-based grouping for non-pull-request runs.
- Update workflow guidance and changelog entries to document the corrected concurrency behavior.