### PR TITLE
documented's polling loop can no longer spend the whole job timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -730,6 +730,45 @@ jobs:
   # tag it refuses produces one verdict and not two; and nothing needs it:
   # a late documentation build is not a reason to withhold a wheel, and the
   # fix for a red run here is a build on their side, not a moved tag
+  #
+  # The loop below used to spend the same budget as the job's
+  # timeout-minutes: 30 attempts of a 10s curl (--max-time) plus a 30s
+  # sleep, on every attempt including the last, is 30 * 40 = 1200s -- and
+  # 20 minutes is 1200s too. A response slow enough to spend its own
+  # --max-time on every attempt without ever answering -- reachable, just
+  # never inside 10s -- ran the loop into that wall, and the job was
+  # killed before its `::error::` line, the one line it exists to print,
+  # ever ran (issue #1165). An ordinary fast failure never came close: RTD
+  # answers a 404 in well under a second while a build has not started,
+  # so 30 attempts at ~0s + 30s is 900s, five minutes under. The bug only
+  # bit the slow-response case, never the everyday one -- but it did bite,
+  # which is what made it worth fixing rather than a hypothetical. 20
+  # attempts at the same 10s/30s keeps the loop's worst case at
+  # 20 * 10 + 19 * 30 = 770s against the job's 1200s, a fixed 430s (36%)
+  # margin the loop can never spend into: the print always runs now. The
+  # last attempt no longer sleeps either, which used to buy nothing.
+  #
+  # What the loop cannot do is tell "still building" from "will never
+  # build": RTD's own webhook accepts a push that matches no version with
+  # a 200 and `{"build_triggered": false, "versions": []}` -- a green
+  # delivery with nothing behind it -- and /en/<tag>/ answers 404 in both
+  # that case and the ordinary "build not finished yet" one, so the
+  # rendered URL alone cannot separate them. The v3 API can (a build's
+  # `state.code` and `success`, queried straight, matched this tag's
+  # `v2026.8.21` build seconds after it finished) but the comment above
+  # already rules the API out for this job, for a reason that still
+  # holds and that testing here confirmed rather than assumed: RTD
+  # throttles an unauthenticated caller to 5 requests a minute and blocks
+  # a cloud-provider caller -- which a GitHub-hosted runner is -- outright
+  # without a token. Querying it from this loop would mean storing an RTD
+  # credential in a job that gates nothing, to buy a distinction the job
+  # already gestures at by naming the builds page. Scraping the builds
+  # *page* instead of the API was considered and dropped too: same
+  # bot-facing defenses, with an HTML shape nothing here would notice
+  # changing under it. What the fix below does instead is stop discarding
+  # the one signal the existing curl call already carries for free: the
+  # last HTTP status or transport failure it saw, which the final message
+  # now names instead of "is not served yet"
   documented:
     name: Check read the docs built the tag
     needs: version-check
@@ -742,14 +781,44 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           url="https://btclib.readthedocs.io/en/${TAG}/"
-          for attempt in $(seq 30); do
-            if curl -sf --max-time 10 -o /dev/null "$url"; then
+          builds_page="https://app.readthedocs.org/projects/btclib/builds/"
+          attempts=20
+          interval=30
+          last_seen="no attempt has run yet"
+          for attempt in $(seq "$attempts"); do
+            # no -f: a non-2xx response is read, not discarded, so a
+            # failure below can name it. curl_rc is 0 whenever a response
+            # arrived at all, including a 404 -- $status is what tells
+            # the two apart, and stays empty on a transport-level failure
+            # (timeout, DNS, connection refused), which curl_rc alone
+            # then names.
+            # The assignment is the condition of the if rather than a
+            # statement of its own: this script runs under the shell's
+            # default `set -e`, which a bare `status=$(curl ...)` is not
+            # exempt from -- a hung or unreachable server makes curl exit
+            # 28, and that would end the step right there, on the first
+            # slow response, before curl_rc is even read. Measured against
+            # this file's own extracted step, in isolation
+            if status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$url"); then
+              curl_rc=0
+            else
+              curl_rc=$?
+            fi
+            if [ "$curl_rc" -eq 0 ] && [ "$status" = "200" ]; then
               echo "${url} is served"
               exit 0
             fi
-            echo "attempt ${attempt}: ${url} is not served yet"
-            sleep 30
+            if [ "$curl_rc" -eq 0 ]; then
+              last_seen="HTTP ${status}"
+            else
+              last_seen="curl exit ${curl_rc} (no response within 10s)"
+            fi
+            echo "attempt ${attempt}/${attempts}: ${url} answered ${last_seen}"
+            if [ "$attempt" -lt "$attempts" ]; then
+              sleep "$interval"
+            fi
           done
-          echo "::error::${url} was never served: read the builds page on" \
-            "https://app.readthedocs.org/projects/btclib/builds/"
+          msg="tag ${TAG}: ${url} was never served after ${attempts} attempts;"
+          echo "::error::${msg} last seen: ${last_seen}. Read the builds page" \
+            "on ${builds_page} -- it says why, this job only says that"
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,34 @@ documented at release-notes length in the first place, and are still in
   published instead of rebuilt, which is a larger change than this one;
   the issue is the record of it.
 
+- **`documented`'s polling loop can no longer spend the whole job
+  timeout** (btclib-org/.github#18). The loop and `timeout-minutes: 20`
+  used to be the same budget — 30 attempts of a 10s `curl --max-time`
+  plus a 30s `sleep`, on every attempt including the last, is 1200s, and
+  20 minutes is 1200s too — so a response slow enough to spend its own
+  `--max-time` without ever answering ran the loop into the job's own
+  wall and lost the `::error::` line the job exists to print, to a
+  runner-issued "exceeded the maximum execution time" instead. An
+  ordinary fast failure never came close, RTD's 404 for "no build yet"
+  costing the loop well under a second per attempt; only the
+  slow-or-unreachable case bit, and it is the case a reader most needs
+  the pointer for. 20 attempts at the same 10s/30s brings the loop's
+  worst case to 770s against the job's 1200s, a fixed margin the loop
+  cannot spend into, and the last attempt no longer sleeps before giving
+  up. The final message also names what it last saw — the HTTP status
+  RTD answered with, or the transport failure if none came back within
+  10s — rather than repeating "is not served yet". What it still cannot
+  do is tell a build that has not started from one that never will:
+  Read the Docs' own v3 API carries that distinction, but querying it
+  from this job would mean storing an RTD credential for a check that
+  gates nothing, since the job's existing comment already rules the API
+  out for exactly that reason — confirmed here rather than re-litigated,
+  an unauthenticated call from a GitHub-hosted runner is throttled and
+  then blocked outright as a cloud-provider caller. `bitcoin-core-rpc`
+  carries the same job, ported byte-identical, and is not fixed here;
+  `btclib-secp256k1` will gain a third copy once its own Read the Docs
+  side lands.
+
 ## v2026.8.21
 
 ### Repository


### PR DESCRIPTION
Refs btclib-org/.github#18 (first filed as btclib#1165, closed and
refiled there per the cross-repository filing rule; this PR is
btclib's copy of the fix).

## The arithmetic

`documented`'s loop and the job's `timeout-minutes: 20` were the same
budget: 30 attempts, each an up-to-10s `curl --max-time 10` plus a
30s `sleep` — including after the *last* attempt, which bought
nothing — is `30 * (10 + 30) = 1200s`, and 20 minutes is 1200s too.

That equality only bites under a slow response. A fast failure (RTD
answering 404 in well under a second, the ordinary "no build yet"
case) costs the loop `30 * (~0 + 30) ≈ 900s`, five minutes under the
job's wall. It is specifically a response slow enough to spend its
own `--max-time` on every attempt without ever completing — reachable,
just never inside 10s — that pushes the loop to exactly 1200s, and the
runner kills the job at the top of that window rather than letting the
last `echo "::error::..."` run. So: the loop *can* outlast the
timeout, but only under a slow/unreachable response, not in the
everyday fast-fail case — matching the issue's own framing.

## The fix

- 20 attempts at the same 10s/30s, and no sleep after the last one:
  worst case is `20 * 10 + 19 * 30 = 770s` against the job's 1200s, a
  fixed 430s (36%) margin the loop can never spend into. The print
  always runs now.
- The final (and each attempt's) message now names what it was
  waiting for (the tag and URL) and what it last saw — the HTTP status
  RTD answered with, or the specific transport failure (e.g. `curl
  exit 28`, `--max-time` exceeded) if nothing came back within 10s —
  instead of repeating "is not served yet" either way.
- A real bug the isolated test below caught: a bare
  `status=$(curl ...)` is not exempt from this shell's default
  `set -e`. On a hung/unreachable server, curl's non-zero exit ended
  the step on the *first* slow response, before `curl_rc` was even
  read — silently defeating the whole point of this fix. Fixed by
  making the assignment the condition of an `if`, the same pattern the
  original script already used for the success check.

## The still-building vs. will-never-build distinction

Not implemented, and here is why. Read the Docs' v3 API does carry
this distinction — I queried it directly against btclib's real
project rather than assuming: `GET
.../versions/<tag>/builds/` returns each build's `state.code` and
`success`, so a finished-and-failed build is distinguishable from one
still queued or building. But the job's *existing* comment already
rules the API out for this job, for a reason I confirmed rather than
took on faith: an unauthenticated call from a GitHub-hosted runner is
throttled to 5 requests/minute and then blocked outright as a
cloud-provider caller (Read the Docs' own docs state this; I did not
have a way to reproduce the block itself from this environment, whose
egress is not a flagged cloud-provider range, but the throttle and the
documented block are consistent and both point the same way).
Querying it would mean storing an RTD API token in a job whose own
header says it "gates nothing" — a real cost for a job that exists
only to print a pointer. Scraping the public builds *page* instead of
the API was considered and dropped too: same bot-facing defenses
apply, for a brittler, HTML-shaped signal.

What the fix does instead, for free: the existing single curl call
already carries a real (if partial) signal, which the loop used to
discard — its HTTP status vs. a transport failure. A 404 still
conflates "no build triggered yet" and "will never build without
intervention" (matching the analogous ambiguity Read the Docs'
webhook itself documents for an unmatched branch push:
`{"build_triggered": false, "versions": []}`, a 200 with nothing
behind it), but a transport failure at least separates "RTD/the CDN is
unreachable" from "RTD answered and has nothing yet".

## The other two repositories

Per my original mandate, `bitcoin-core-rpc` and `btclib-secp256k1`
were believed to have no such job. **That premise is stale as of
btclib-org/.github#18**: `bitcoin-core-rpc` already carries this job,
ported byte-identical apart from its two URLs (its own issue #154);
`btclib-secp256k1` will gain a third copy once its Read the Docs side
lands (issue #295, blocked on #302). Fixing either is out of scope
for this PR — `bitcoin-core-rpc`'s copy needs the identical fix ported
by hand (it is a maintainer-owned repository I only read from), and
`btclib-secp256k1`'s does not exist yet to fix. This diff is scoped to
the `documented` job in btclib's `release.yml` alone, per the
collision warning on that file.

Whether the fixed version is worth carrying: yes, unchanged apart from
the two URLs, the same way the job itself was ported — nothing in the
fix is btclib-specific.

## Verification

- `uv run pre-commit run --all-files`: exit 0, all hooks passed,
  including `actionlint` and `zizmor` at zero findings.
- `uv run pytest`: exit 0, 29393 passed, 11 skipped (all
  environment-gated), 100.00% coverage.
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source <out>`: exit 0, `build succeeded.`

What I could not exercise: `documented` only runs on `push` of a `v*`
tag, so I did not run the job itself in CI, and did not tag a release
to do so. What I did instead: extracted the step's literal `run:`
script from the committed YAML (via a small script, not retyped) and
drove it under mocked `curl`/`sleep` binaries on `$PATH`, with a
scaled clock, against four recorded scenarios:

| scenario | attempts before exit | simulated elapsed | exit |
| --- | --- | --- | --- |
| immediate success (HTTP 200 on attempt 1) | 1 | 0.2s | 0 |
| success on attempt 5 (HTTP 404 ×4, then 200) | 5 | 121s | 0 |
| fast failure every attempt (HTTP 404 ×20) | 20 | 574s | 1 |
| every attempt hangs to `--max-time` (curl exit 28 ×20) | 20 | 770s | 1 |

The last row is the worst case the arithmetic above predicts (770s),
confirms it lands under the job's 1200s with the print intact, and is
the scenario that caught the `set -e` bug described above — the
un-fixed script exited 28 on the very first mocked hang instead of
completing all 20 attempts.

## Summary by Sourcery

Ensure the documented release check always reports a clear outcome within the workflow timeout.

Bug Fixes:
- Prevent the documented release check from exhausting the job timeout before reporting a failed Read the Docs build.
- Preserve and report HTTP statuses and curl transport failures so polling failures provide actionable context.

Enhancements:
- Simplify the polling budget by reducing retries and avoiding an unnecessary final delay while retaining the existing polling interval and request timeout.