### PR TITLE
docs.yml's unresolved-link grep carries both known shapes (issue #1157)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -109,14 +109,33 @@ jobs:
         run: >
           uv run --locked --no-default-groups --group docs
           sphinx-build -W --keep-going -b html docs/source docs/build/html
-      # the one defect the build above cannot report on itself: a relative
-      # link myst cannot resolve is rendered as an anchor on the page it is
-      # already on -- href="#./CONTRIBUTING.md", an id nothing has -- so
-      # -W passes over a dead link (issue 195). conf.py resolves those
-      # links and no longer suppresses myst.xref_missing, which makes the
-      # build fail on the next one; this step is the same claim made about
-      # the artifact rather than about the configuration, and it is what
-      # would catch a suppression added back.
+      # the one defect the build above cannot report on itself: a link
+      # myst cannot resolve is rendered as an anchor on the page it is
+      # already on -- an id nothing has -- so -W passes over a dead link
+      # (issue 195). conf.py resolves every link the included root files
+      # carry and no longer suppresses myst.xref_missing, which makes the
+      # build fail on the one myst still cannot place; this step is the
+      # same claim made about the artifact rather than about the
+      # configuration, and it is what would catch a suppression added
+      # back.
+      #
+      # Two greps, not one, because myst's fallback renders the target
+      # verbatim and a target is written one of two ways across this
+      # organization's three publishing repositories (issue #1157):
+      # "./CONTRIBUTING.md", every relative link this repository's own
+      # root files use, which becomes href="#./CONTRIBUTING.md" if it
+      # breaks -- the first grep -- and a bare "SECURITY.md" with no
+      # "./", the convention btclib-secp256k1 uses instead, which
+      # becomes href="#SECURITY.md" and only the second grep catches.
+      # Each repository used to run one of the two, on the strength of
+      # the convention its own root files happened to follow, which
+      # left it blind to a broken link written the other way -- this
+      # repository's own links are all the first shape today, but
+      # nothing enforces that, and bitcoin-core-rpc ran the very same
+      # single grep on the same assumption. A survey across all three
+      # found no third shape among the links these pages actually
+      # carry, so two greps is the union rather than a guess at how far
+      # to generalize.
       #
       # Not lychee: links.yml reads the sources, where "./CONTRIBUTING.md"
       # is a correct path, and pointing it at docs/build/html would mean
@@ -134,7 +153,13 @@ jobs:
       # on the built html
       - name: Check the built pages for unresolved links
         run: |
+          status=0
           if grep -rn 'href="#\./' docs/build/html --include='*.html'; then
-            echo "::error::the links above resolve to no page"
-            exit 1
+            echo "::error::the links above resolve to no page (unresolved relative path)"
+            status=1
           fi
+          if grep -rn 'href="#[A-Za-z0-9_.-]*\.md"' docs/build/html --include='*.html'; then
+            echo "::error::the links above resolve to no page (unresolved bare .md target)"
+            status=1
+          fi
+          exit $status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,21 @@ documented at release-notes length in the first place, and are still in
   carries the same job, ported byte-identical, and is not fixed here;
   `btclib-secp256k1` will gain a third copy once its own Read the Docs
   side lands.
+- **`docs.yml`'s unresolved-link grep now carries both known shapes**,
+  closing issue #1157. MyST renders a link its `RootFileLinks` transform
+  cannot resolve as `href="#<target>"` verbatim, so what the grep
+  matches depends on how the target was written — `href="#\./` for
+  `./CONTRIBUTING.md`, this repository's own convention throughout its
+  root files, and `href="#[A-Za-z0-9_.-]*\.md"` for a bare
+  `SECURITY.md` with no `./`, the convention `btclib-secp256k1` uses
+  instead. This repository ran only the first, `bitcoin-core-rpc` ran
+  the same one, and `btclib-secp256k1` ran only the second — each blind
+  to the shape it had not yet been bitten by. Built the documentation
+  with a deliberately unresolved link of each shape and confirmed the
+  added grep reports it before removing it; `sphinx-build -W
+  --keep-going` passes on both unchanged, since neither is the broken
+  *reference* `-W` already catches — a link myst resolves happily and is
+  dead anyway is the whole reason this second check exists.
 
 ## v2026.8.21
 


### PR DESCRIPTION
## What

Both greps `docs.yml` needs are now in every one of `btclib`,
`btclib-secp256k1` and `bitcoin-core-rpc`'s `docs.yml`, closing #1157.
This repository's own step was extended; the other two are companion
PRs.

## The two failure modes, enumerated

`docs/source/conf.py`'s `RootFileLinks` transform resolves every
repository-relative link the included root files (README, CONTRIBUTING,
REVIEWING, SECURITY, RELEASE_NOTES, CHANGELOG) carry, to either an
in-doc reference or a GitHub blob link. What it cannot resolve — a
target that exists nowhere in the tree — it leaves to myst, and myst's
fallback for an unresolved target is not a warning: it renders the
target verbatim as `href="#<target>"`, an anchor on the page it is
already on, to an id nothing has. `sphinx-build -W` does not see this;
it is not a broken *reference*, it is a link myst resolved (to a
same-page anchor, wrongly) and is dead anyway. That is what this grep
step exists to catch, and it is why the fix belongs here rather than in
`conf.py` or in `-W`.

The two greps this organization has run, before this PR, each catch one
shape of that verbatim target and miss the other:

| | pattern | catches | misses |
| --- | --- | --- | --- |
| btclib, bitcoin-core-rpc | `href="#\./` | any target beginning `./`, whatever follows — extension included | a target with no leading `./` (`href="#SECURITY.md"`) |
| btclib-secp256k1 | `href="#[A-Za-z0-9_.-]*\.md"` | a bare target ending `.md`, no `/` before it | a `./`-prefixed target, of any extension |

Neither is a superset: `href="#./SECURITY.md"` contains a `/`
immediately after `#`, which the bare-name pattern's character class
excludes, so it does not match; `href="#SECURITY.md"` never contains
`./`, so the relative-path pattern does not match it either. Two
distinct MyST failure modes, and each repository's grep was built
against the convention its own root files happened to follow —
`./CONTRIBUTING.md` throughout this repository's and
bitcoin-core-rpc's, a bare `SECURITY.md`/`RELEASE_NOTES.md`/etc.
through most of btclib-secp256k1's, mixed with a `./REVIEWING.md` and a
`./RELEASE_NOTES.md` its CONTRIBUTING.md and CHANGELOG.md write the
other way. A repository that ran only one grep was never blind to a
link it had — it was blind to the other repository's shape breaking,
if that shape ever appeared in its own tree by accident or convention
drift.

## The fix is the union

Each `docs.yml` now runs both greps, matching the shim's own
`RootFileLinks` docstring reasoning: the check answers what myst
actually emits, not what a repository's current link style happens to
be. `# 1157`'s tracking issue names the "right" column for this
divergence as **neither repository alone** — this PR, and its two
companions, are that union rather than a pick of one side.

## Is there a third shape?

Checked rather than assumed. Appended a link of five additional
shapes to a scratch copy of `CONTRIBUTING.md` in each of the three
repositories and built:

- `./DOES_NOT_EXIST.md` — the relative-path shape, caught
- `DOES_NOT_EXIST.md` — the bare-`.md` shape, caught
- `DOES_NOT_EXIST.txt` — bare, non-`.md` extension
- `sub/DOES_NOT_EXIST.md` — nested path, no leading `./`
- `DOES_NOT_EXIST` — bare, no extension at all

MyST's fallback is generic — it renders whatever string the link
carried, so all five produced an `href="#..."`. The union above catches
the first two and misses the last three: none of the observed link
conventions across the three repositories' six included root files
today use any of those three shapes, so no dead link ships from them
right now, but the grep would not catch one if it did. That is a real
gap in the check, not a hypothetical one — filed as a new finding
rather than folded into this PR: #1175.

## Verification

```shell
$ uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
build succeeded.
$ uv run pre-commit run --all-files
... all hooks Passed, exit 0
```

`docs.yml` dispatched on this branch: https://github.com/btclib-org/btclib/actions/runs/32486357052, job green.

Reference: this PR closes #1157. Companions:
btclib-org/bitcoin-core-rpc#182,
btclib-org/btclib-secp256k1#310.

Closes #1157

## Summary by Sourcery

Make the documentation workflow catch both known forms of unresolved links emitted in the built HTML.

Bug Fixes:
- Extend the documentation build check to detect both known MyST unresolved-link output shapes, preventing dead links from escaping CI.

CI:
- Update the docs workflow to run both unresolved-link greps and report either failure while preserving the build status.

Documentation:
- Document the expanded unresolved-link validation and its coverage in the changelog.