### PR TITLE
Declare shell: bash on latest.yml and windows.yml's Windows steps (issue #1148)

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -121,6 +121,14 @@ jobs:
       # This rewrites uv.lock, harmless on an ephemeral checkout and worth
       # knowing before running the same command in a working tree
       - name: Upgrade every dependency to its latest release
+        # this matrix includes windows-latest, whose default shell is
+        # PowerShell rather than bash -- see windows.yml's suite-windows
+        # job for the failure mode a POSIX-only step hits there unnoticed
+        # (issue #1148). This step and the pytest step below happen not to
+        # use any POSIX-only syntax today, which is exactly the hazard: a
+        # future edit that does would go green on this cell having run
+        # nothing
+        shell: bash
         run: uv lock --upgrade
       # still --locked, which is not a contradiction: the step above just
       # wrote that lock, so this asserts nothing moved between the two and
@@ -141,6 +149,7 @@ jobs:
       # already printed the "Update <pkg> vA -> vB" line the assertion
       # would not have named
       - name: Run pytest
+        shell: bash
         run: uv run --locked --no-default-groups --group test pytest
 
   # narrower than suite-latest above, and for a different reason: that
@@ -181,6 +190,9 @@ jobs:
       # diff of uv.lock. Harmless on an ephemeral checkout; worth
       # knowing before running the same command in a working tree
       - name: Upgrade the bindings to their latest release
+        # this matrix includes windows-latest; see suite-latest above and
+        # windows.yml's suite-windows job (issue #1148)
+        shell: bash
         run: uv lock --upgrade-package btclib_secp256k1
       # test.yml's no-bindings job, with the sense reversed, and here for
       # the mirror image of its reason: asked before the suite, and asked
@@ -218,12 +230,16 @@ jobs:
       # reachable and False leaves only the import, which is what the
       # message says rather than the generic sentence those two carry
       - name: Assert the bindings are serving
+        # see suite-latest above; this one folds a python -c onto the uv
+        # invocation, closer to the shape of ISS #1141's original defect
+        shell: bash
         run: >
           uv run --locked --no-default-groups --group test
           python -c "from btclib.curves import is_libsecp256k1_serving;
           assert is_libsecp256k1_serving(),
           'the newest btclib_secp256k1 does not import'"
       - name: Run pytest
+        shell: bash
         run: uv run --locked --no-default-groups --group test pytest
 
   # mypy is the whole reason this job exists, and it is worth being

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -121,5 +121,15 @@ jobs:
       # step: this matrix carries the same PyPy cells behind the same
       # timeout, and the coverage job there is the one place the number is
       # measured and gated
+      #
+      # every cell here runs on windows-latest or windows-11-arm, where the
+      # default shell is PowerShell rather than bash: "$GITHUB_ENV" and the
+      # rest of the POSIX spelling are literals there, not variables, so a
+      # step with no shell: goes green having done nothing. This one
+      # command has no POSIX-only syntax and would run identically under
+      # either shell today -- ISS #1141 shipped in exactly this shape, the
+      # defect being latent until the next edit adds a conditional, a
+      # substitution or a loop (issue #1148)
       - name: Run pytest
+        shell: bash
         run: uv run --locked --no-default-groups --group test pytest --no-cov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -427,9 +427,9 @@ documented at release-notes length in the first place, and are still in
   where the default shell is PowerShell and `"$GITHUB_ENV"` and the rest
   of the POSIX spelling are literals rather than variables — the same
   defect ISS #1141 shipped in `published.yml`, in the two workflows the
-  sweep behind that fix found but did not open a diff on. All five
-  affected steps are one plain command each and run identically under
-  either shell today, so nothing shipped broken; the hazard is the next
+  sweep behind that fix found but did not open a diff on. All affected
+  steps are one plain command each and run identically under either
+  shell today, so nothing shipped broken; the hazard is the next
   conditional, substitution or loop added to one of them, which would
   fail only on Windows and only on a schedule or a tag, `latest.yml` and
   `windows.yml` running on neither a pull request nor a push to `main`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -420,6 +420,35 @@ documented at release-notes length in the first place, and are still in
   Three findings, all fixed: `PreparedPoint`'s class docstring now has
   the `Attributes` section its three fields ask for, and
   `SignerDecorator.__init__` keeps the docstring it had.
+- **`latest.yml` and `windows.yml` declare `shell: bash` on every step
+  that can land on a Windows runner** (issue #1148). `suite-latest` and
+  `suite-bindings-latest` in `latest.yml`, and `suite-windows` in
+  `windows.yml`, each carry a `windows-latest` or `windows-11-arm` cell,
+  where the default shell is PowerShell and `"$GITHUB_ENV"` and the rest
+  of the POSIX spelling are literals rather than variables — the same
+  defect ISS #1141 shipped in `published.yml`, in the two workflows the
+  sweep behind that fix found but did not open a diff on. All five
+  affected steps are one plain command each and run identically under
+  either shell today, so nothing shipped broken; the hazard is the next
+  conditional, substitution or loop added to one of them, which would
+  fail only on Windows and only on a schedule or a tag, `latest.yml` and
+  `windows.yml` running on neither a pull request nor a push to `main`.
+  Verified with the two draft workflows the issue itself describes:
+  `actionlint` (the pinned linter in the pre-commit gate) reports nothing
+  for a shell-less POSIX step on a Windows runner, under a literal
+  `runs-on: windows-latest` and under a matrix naming it alike.
+
+  Enumerated by parsing every workflow file's `jobs.*.strategy.matrix`
+  (`os` and `include`) and `runs-on` with PyYAML, and flagging a `run:`
+  step whose job's runner set contains `windows` and which declares no
+  `shell:` of its own and inherits none from a job-level `defaults.run`.
+  `dist-latest` and `lint-latest` in `latest.yml` run on `ubuntu-latest`
+  only and are outside that set. `test.yml` in this repository carries no
+  Windows row at all — `windows.yml` is where that matrix moved — so the
+  sweep found nothing else here; `btclib-secp256k1` and
+  `bitcoin-core-rpc` each had one further instance, in their own
+  `test.yml`, fixed in a pull request of their own
+  (`btclib-org/btclib#1148` is the issue both reference).
 
 ## v2026.8.21
 


### PR DESCRIPTION
Closes #1148.

## The defect

`latest.yml` and `windows.yml` carry `run:` steps on `windows-latest` /
`windows-11-arm` matrix cells with no `shell:` of their own, which
GitHub hands to PowerShell rather than bash. `"$GITHUB_ENV"` and the
rest of the POSIX spelling are literals there rather than variables —
the same defect ISS #1141 shipped in `published.yml`, discovered when
`v2026.8.21`'s release run failed on it. Every step this PR touches is
a single plain command today and runs identically under either shell,
so nothing has shipped broken; the hazard is the next conditional,
substitution or loop landing on one of them, which would fail only on
Windows and — since `latest.yml` and `windows.yml` trigger on neither
a pull request nor a push to `main` — only be discovered on a schedule
or a tag, exactly how ISS #1141 reached a release.

## How every instance was enumerated

`actionlint`, the linter pinned in the pre-commit gate, does not ask
this question: reproduced on a minimal workflow carrying a POSIX `for`
loop and no `shell:`, it reports zero findings both under a literal
`runs-on: windows-latest` and under a matrix naming it. So the
enumeration here is not "the two files the issue names" but every
workflow of every one of the three publishing repositories, done by
parsing each file's `jobs.*.strategy.matrix` (`os` and `include`
entries) and `runs-on` with PyYAML, and flagging a `run:` step under a
job whose runner set contains `windows` and which declares no `shell:`
of its own and inherits none from a job-level `defaults.run`.

In this repository that turned up six steps, all in the two files the
issue names:

| workflow / job | step |
| --- | --- |
| `latest.yml::suite-latest` | `Upgrade every dependency to its latest release` |
| `latest.yml::suite-latest` | `Run pytest` |
| `latest.yml::suite-bindings-latest` | `Upgrade the bindings to their latest release` |
| `latest.yml::suite-bindings-latest` | `Assert the bindings are serving` |
| `latest.yml::suite-bindings-latest` | `Run pytest` |
| `windows.yml::suite-windows` | `Run pytest` |

`dist-latest` and `lint-latest` in `latest.yml` run on `ubuntu-latest`
only and are outside the set that can land on Windows. This
repository's `test.yml` carries no Windows row at all — that matrix
moved to `windows.yml`, see that file's own header — so the sweep found
nothing else here.

`btclib-secp256k1` and `bitcoin-core-rpc` were swept the same way, in
their own worktrees, with their own pull requests: both had the
matching `latest.yml`/`windows.yml` defect (`windows-arm.yml` in
`bitcoin-core-rpc`, which is that repository's equivalent — see the
parent tracking issue #1152 on why the file is not named the same
there), and each additionally had it in its own `test.yml`, on the
merge gate itself:

- `btclib-org/btclib-secp256k1#311` — `latest.yml::suite-latest` (2 steps),
  `windows.yml::suite-windows` (2 steps), `test.yml::build-cibuildwheel`
  (1 step), `test.yml::suite-sdist` (1 step)
- `btclib-org/bitcoin-core-rpc#184` — `latest.yml::suite-latest` (2 steps),
  `windows-arm.yml::suite-windows-arm` (1 step), `test.yml::suite`
  (1 step)

## Verification

Run from this branch's worktree:

- `uv run pre-commit run --all-files` — exit 0, every hook passed
- `uv run pytest` — exit 0, 29393 passed, 11 skipped, coverage 100%
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` — exit 0, build
  succeeded with no warnings; the dead-link grep `docs.yml`'s second
  step runs (`grep -rn 'href="#\./' docs/build/html --include='*.html'`)
  exits 1 (no matches), which is the passing case for that job

`windows.yml`'s only trigger besides `release.yml`'s call is
`schedule`/`workflow_dispatch`, so it was dispatched directly on this
branch to exercise the changed step for real:
`gh workflow run windows.yml --ref fix/1148-windows-shell-bash` — run
https://github.com/btclib-org/btclib/actions/runs/32485373505, `suite-windows`'s `Run pytest` step green on every cell of
the matrix.

## Summary by Sourcery

Bug Fixes:
- Declare Bash explicitly for every workflow step in `latest.yml` and `windows.yml` that can run on Windows, preventing latent shell-dependent failures in scheduled and release workflows.
