### PR TITLE
Measure branch coverage and add a pydoclint hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -454,6 +454,25 @@ repos:
         args: [--fix]
       - id: ruff-format
         name: ruff format (in place fixes)
+  # what ruff's D rules do not reach: they ask that a docstring exists,
+  # and this asks that it documents the arguments and the return value --
+  # the half that goes wrong in silence, a signature growing a parameter
+  # while the prose above it still describes the old one. The
+  # configuration is in pyproject.toml, beside the ruff one.
+  #
+  # Scoped to btclib/, which is the published surface: a caller reading
+  # help() or an IDE tooltip has that docstring and nothing else. A test
+  # function documents what it claims rather than its fixtures -- which
+  # is why the D rules are not in per-file-ignores for tests/ and this is
+  # not run over them -- and .github/scripts is read from the tree by
+  # whoever changes it
+  - repo: https://github.com/jsh9/pydoclint
+    rev: 0.9.1
+    hooks:
+      - id: pydoclint
+        name: pydoclint (arguments and return values)
+        args: [--config=pyproject.toml]
+        files: ^btclib/.*\.py$
   # the other half of pyproject.toml's unspecified-encoding, which reads
   # `open` and the pathlib and tempfile spellings and stops there. A child
   # process decoded through `text=True` takes the locale's encoding by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,6 +304,108 @@ documented at release-notes length in the first place, and are still in
   `btclib-secp256k1` will gain a third copy once its own Read the Docs
   side lands.
 
+- **Coverage measures branches and not only statements**
+  (`btclib-org/.github#7`). `branch = true` in `[tool.coverage.run]`, the
+  setting the organization standard's section 8 states and the one this
+  repository was missing. Statement coverage calls a half-tested `if`
+  fully covered: the line ran, one of its two ways out never did, and the
+  ways out that go unexercised in a library like this one are exactly the
+  ones it exists to get right — a validation that refuses, a serialization
+  path a shorter input takes. The tree was at 100.00% of statements
+  before this and stayed there; what turning branches on found was 29
+  partial branches, and the gate is red until every one of them is either
+  a test or a branch no input can reach.
+
+  Eighteen were a test. Nine of those are one shape repeated: an
+  `if check_validity:` whose flag was never passed false, so nothing ran
+  the call that skips the check — `Bip21`'s constructor and `serialize`,
+  `BasicBlockFilter`'s constructor, `Network`'s constructor and
+  `to_dict`, `BorromeanSig.serialize`,
+  `TimestampedNetworkAddress.serialize`, `Message.serialize` and
+  `Psbt.to_dict`. Each now builds an object its own `assert_valid`
+  refuses and asks the boundary twice, which is what
+  `check_validity_test.py` already does for the transaction classes.
+  Which invalidity a fixture can carry is not free, and two of these say
+  why: an amount out of MoneyRange is refused by `btc_from_sats` on the
+  way into the json whatever the flag says, and a fallback lock time out
+  of range by the `"tx"` entry `Psbt.to_dict` derives, so what stands in
+  is a `bool` timestamp, a short magic, a genesis block of the wrong
+  length, a v0 psbt carrying `PSBT_GLOBAL_TX_MODIFIABLE`.
+
+  The other nine tests are nine gaps of their own, and three of them are
+  answers this library had never been asked for: `_pub_key_from_p2pkh`
+  walking past a window whose hash160 matches and whose 33 octets are no
+  public key, which its own comment describes and nothing exercised; a
+  taproot script-path input whose internal key is *not* BIP341's NUMS,
+  where every vector had the NUMS case that is skipped; and
+  `_pub_key_size` reading past an `hd_key_paths` entry that does not
+  hash to the script's payload, an input having as many keys as an
+  Updater put there. The rest are `bms.gen_keys` taking a network name,
+  `deserialize_tx`'s `include_witness=None`, `_prv_keyinfo_from_xprvwif`
+  handed a parsed `BIP32KeyData`, a v2 output map with a script and no
+  amount, `find_all_points` on a curve with a point of order two — `b = 0`
+  puts one at the origin, and no curve in `CURVES` has one, being of
+  prime order — and a `ValueError` from the delegated `dsa.sign` that is
+  about neither of the two things it can complain about, which only a
+  patched binding can raise and which must still leave as a
+  `BTClibValueError`.
+
+  Eleven branches were not a test. Three were a guard over data that
+  cannot take the other way: `electrum_test`'s `if mnemonic:` over
+  vectors that all carry one, `script_test`'s check that Core writes the
+  amount as the last element of a witness array, and
+  `sig_hash_taproot_test`'s test of whether one transcribed signature is
+  65 octets. Each is now an `assert` instead, which measures the same
+  fact and fails loudly where the guard silently skipped the work below
+  it. The remaining eight carry `# pragma: no branch` with the reason
+  beside them — not `# pragma: no cover`, which would exclude the
+  statement and its whole block where what is unreachable is one arc out
+  of it. Two are in the package: `merkle_proof`'s round-trip comparison,
+  false only for 64 octets that parse and that btclib writes back
+  differently, which var_int's canonical widths and `Tx.parse`'s refusal
+  of a marker over empty witnesses leave no room for; and
+  `number_theory`'s Tonelli-Shanks inner loop, which the legendre symbol
+  above it stops from ever running out of exponents. Six are in the
+  suite, where a walk that visits nothing twice, a blocking dict asked
+  about one language, a helper called only inside `pytest.raises`, an
+  exhaustive `elif` chain over three local vectors and a markdown reader
+  that MD012 keeps from seeing two blank lines are each a loop or a
+  branch with one way out. No `exclude_also` pattern was added: none of
+  these is the same shape at several sites, which is the criterion for
+  one.
+
+- **A `pydoclint` hook holds a docstring to the signature above it**
+  (`btclib-org/.github#7`). Section 4 of the standard names it, and it is
+  the check ruff's `D` family does not make: those ask that a docstring
+  exists, this asks that the `Args`, `Returns` and `Attributes` sections
+  it carries describe what the function actually takes and gives back,
+  which is the half that goes wrong in silence when a signature grows a
+  parameter. Scoped to `btclib/`, the published surface, a caller reading
+  `help()` having that docstring and nothing else; the configuration is
+  in `pyproject.toml` beside ruff's.
+
+  `skip-checking-short-docstrings` is left at pydoclint's default, which
+  is where this differs from sibling `btclib-secp256k1` and from the
+  standard's reference configuration. There the `false` is right: every
+  docstring of a wrapper is one summary line, so switching the skip off
+  is what makes the check reach any of them. Here it reaches 4404
+  findings over 111 files — sections that do not exist, rather than
+  sections that disagree with a signature — which is a rewrite of the
+  package's prose and not a lint fix. Issue #1178 is that measurement,
+  the command that produced it and the count per file.
+  `allow-init-docstring` is on for the same kind of reason: pep257,
+  ruff's convention here, neither asks for a docstring on `__init__` nor
+  forbids one, and this package writes its constructors out by hand
+  wherever a frozen dataclass validates itself. `skip-checking-raises`
+  is on, as in `btclib-secp256k1`: a btclib call refuses mostly through
+  what it delegates to, so what a caller catches is not what the body
+  raises, and the hierarchy that is caught is written down once in
+  `btclib/exceptions.py`.
+
+  Three findings, all fixed: `PreparedPoint`'s class docstring now has
+  the `Attributes` section its three fields ask for, and
+  `SignerDecorator.__init__` keeps the docstring it had.
+
 ## v2026.8.21
 
 ### Repository

--- a/btclib/block/merkle_proof.py
+++ b/btclib/block/merkle_proof.py
@@ -72,7 +72,16 @@ def _assert_inner_node_is_not_a_tx(inner_node: bytes) -> None:
         # in every block, and anything else is a bug worth propagating
         return
 
-    if is_a_tx:
+    # `no branch` rather than a test: a false `is_a_tx` would be 64 octets
+    # that parse and that btclib writes back differently, and there are
+    # none. Every field is read as it was written -- the counts and the
+    # lengths are var_ints, and `var_int.parse` takes only the canonical
+    # width of each -- and the one encoding that would not round-trip, a
+    # BIP144 marker over empty witnesses, is what `Tx.parse` refuses on
+    # its own. The comparison stays because that is a property of the
+    # parser rather than of this module, and a parser that stopped
+    # refusing that shape would need it here
+    if is_a_tx:  # pragma: no branch
         err_msg = "inner node of the merkle branch is a valid transaction"
         raise BTClibValueError(err_msg)
 

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -922,6 +922,13 @@ class PreparedPoint:
     built rather than found. A working desktop rather than a quiesced
     machine: a ratio, not a figure to quote.
 
+    Attributes:
+        point: the point, as the constructor validated it.
+        ec: the curve it was validated against.
+        fixed: the Jacobian set a verification hands straight down,
+            derived by the constructor from the two above; the comment
+            beside the field is what it holds and why it is derived.
+
     Args:
         point: the point to prepare, on the curve and not infinity.
         ec: the curve it belongs to.

--- a/btclib/number_theory.py
+++ b/btclib/number_theory.py
@@ -410,7 +410,14 @@ def tonelli_var(a: int, p: int) -> int:
     while t != 1:
         # Find the lowest i such that t^(2^i) = 1
         t2i = t
-        for i in range(1, s):
+        # `no branch` on the exhausted loop, which cannot happen: the
+        # legendre symbol above is what rules it out, `a` being a
+        # quadratic residue making `t = a**q` an element of the subgroup
+        # of order 2**(s-1), so squaring it reaches 1 at some i < s. The
+        # bound is the loop's termination and not a fallback -- there is
+        # no value of i to take past it -- which is why nothing follows
+        # the loop but the `while` that reads the new t
+        for i in range(1, s):  # pragma: no branch
             t2i = t2i * t2i % p
             if t2i == 1:
                 # Update next value to iterate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -553,6 +553,17 @@ source = ["btclib", "tests"]
 # defect. What covers them is the opt-in run, and the module docstrings
 # carry the command
 omit = ["*/site-packages/*", "tests/integration/*"]
+# statement coverage alone calls a half-tested `if` fully covered: the
+# line ran, one of its two ways out never did, and the ways out that go
+# unexercised here are exactly the ones the library exists to get right
+# -- a validation that refuses, a curve special case, a serialization
+# path a shorter input takes. Measuring branches costs the ratchet
+# nothing where a test already drives both sides, and where it does not
+# the miss is a real one: it is either a test to write or a branch no
+# input can reach, and the second carries its reason beside it. Not left
+# at statements on the grounds that the total already reads 100.00%: a
+# total that cannot fall is a total that measures less than it says
+branch = true
 
 [tool.coverage.report]
 show_missing = true
@@ -927,3 +938,45 @@ parametrize-names-type = "csv"
 # No file here opens with a shebang, so nothing legitimate sits between
 # byte zero and the notice for the anchor to exclude
 notice-rgx = "^# Copyright \\(c\\) The btclib developers\\n# Distributed under the MIT software license, see the accompanying\\n# LICENSE file or https://opensource\\.org/license/mit for the full text\\."
+
+# what keeps the docstrings of the public surface complete, ruff having
+# no rule for a missing argument: the D family below asks that a
+# docstring exists, and this asks that it says what the call takes and
+# what it hands back. Run as a hook over btclib/ only; the comment on
+# the hook has why that is the scope
+[tool.pydoclint]
+# napoleon renders it, which is what docs/source/conf.py enables, so the
+# sections asked for here are the ones sphinx already understands
+style = "google"
+# the types are in the signature, and mypy is strict: repeating them in
+# the docstring is a second place to be wrong, and the one nothing checks
+arg-type-hints-in-docstring = false
+check-return-types = false
+# the default, and not the false sibling btclib-secp256k1 sets. There it
+# is right: every docstring of a wrapper is a line, so switching the skip
+# off is what makes the check reach any of them at all. Here what it
+# reaches is `Args` and `Returns` sections that do not exist rather than
+# sections that disagree with a signature, which is a rewrite of the
+# whole package's prose and not a lint fix. Left at the default, this
+# gates the docstrings that do carry sections, which is where the silent
+# drift is: a signature grows a parameter and the section above it still
+# lists the old ones. Issue #1178 is the stricter setting, how many
+# findings it reaches, and the command that counts them -- no figure is
+# repeated here, a count beside no way of re-measuring it being a line
+# every change to the package can falsify in silence
+skip-checking-short-docstrings = true
+# pep257 -- ruff's convention here -- neither asks for a docstring on
+# __init__ nor forbids one, and this package writes its constructors out
+# by hand wherever a frozen dataclass validates itself. So a constructor
+# that has something of its own to say keeps it, rather than folding it
+# into a class docstring that is about the class
+allow-init-docstring = true
+# and this one is off, deliberately. It compares the Raises section with
+# the `raise` statements of the body, and a btclib call refuses mostly
+# through what it delegates to -- bytes_from_octets, assert_valid, the
+# curve and network lookups -- so what a caller catches is not what this
+# body raises. Kept on, every docstring would document its own body
+# instead of its contract, which is the opposite of what these sections
+# are for; the hierarchy a caller does catch is btclib/exceptions.py's,
+# written down once there
+skip-checking-raises = true

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -703,8 +703,10 @@ def test_the_export_tree_is_walkable_to_its_leaves() -> None:
             )
             # the set is the frontier's filter rather than a check on the
             # way out: one module reachable from two parents would be
-            # walked twice, and nothing here is
-            if value.__name__ not in seen:
+            # walked twice, and nothing here is -- which is what the
+            # `no branch` says, the tree being one and the filter being
+            # what would keep a future re-export from doubling the walk
+            if value.__name__ not in seen:  # pragma: no branch
                 seen.add(value.__name__)
                 frontier.append(value)
     # the root, the nine packages, the nested one, and the modules they

--- a/tests/bip21_test.py
+++ b/tests/bip21_test.py
@@ -315,3 +315,20 @@ def test_built_rather_than_parsed() -> None:
         Bip21("not an address", None, None, None)
     with pytest.raises(BTClibValueError, match="missing address"):
         Bip21("", None, None, None)
+
+
+def test_the_flag_still_switches_the_check_off() -> None:
+    """Verify check_validity=False builds and writes an addressless URI.
+
+    Every URI above is built checked, so `if check_validity:` was a line
+    that ran one way only, which is what branch coverage reports and
+    statement coverage does not. The empty address is the invalidity to
+    carry here because it is the one a serialization can still write: a
+    bad amount is refused by `valid_btc_amount` on the way in, before the
+    flag is read, so it could not stand in for it.
+    """
+    uri = Bip21("", None, None, None, check_validity=False)
+    assert uri.address == ""
+    assert uri.serialize(check_validity=False) == "bitcoin:"
+    with pytest.raises(BTClibValueError, match="missing address"):
+        uri.serialize()

--- a/tests/block/block_filter_test.py
+++ b/tests/block/block_filter_test.py
@@ -270,3 +270,20 @@ def test_an_unresolved_previous_output_is_refused() -> None:
     block = _block_170()
     with pytest.raises(BTClibValueError, match="unresolved previous output: "):
         prevout_scripts_from_utxos(block, {})
+
+
+def test_the_flag_still_switches_the_check_off() -> None:
+    """Verify check_validity=False builds a filter of the wrong block hash.
+
+    Every filter above is built checked, so the constructor's
+    `if check_validity:` ran one way only: the default is what the
+    refusal below states, and the flag's own effect is what the line
+    before it does. A hash of the wrong length is the invalidity to
+    carry, `block_hash` being a field rather than something read back out
+    of the coded set.
+    """
+    err_msg = "invalid block hash length: 1 bytes instead of 32"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        BasicBlockFilter(b"\x00", 0, b"")
+
+    assert BasicBlockFilter(b"\x00", 0, b"", check_validity=False).block_hash == b"\x00"

--- a/tests/curves/curve_group_f_test.py
+++ b/tests/curves/curve_group_f_test.py
@@ -64,3 +64,22 @@ def test_ecf_exceptions() -> None:
         # p (10007) is too big to count all subgroup points
         G = (2, 3265)
         find_subgroup_points(ec, G)
+
+
+def test_a_point_whose_y_is_zero_is_listed_once() -> None:
+    """A point of order two is its own negative, and the walk knows it.
+
+    `y != 0` is what stops `(x, p - y)` being appended beside `(x, y)`
+    where the two are the same point, and F_9739 above has no such point
+    to take that branch with. `b = 0` puts one at the origin -- the roots
+    of `y**2 = x**3 + x` include x = 0 -- and the curve is non-singular
+    there all the same, `4a**3 + 27b**2` being 4.
+    """
+    ec = CurveGroup(11, 1, 0)
+    points = find_all_points(ec)
+
+    ec.require_on_curve((0, 0))
+    assert points.count((0, 0)) == 1
+    # the ordinary case beside it: two distinct roots, both listed
+    assert points.count((9, 1)) == points.count((9, 10)) == 1
+    assert len(points) == len(set(points))

--- a/tests/ecc/bms_test.py
+++ b/tests/ecc/bms_test.py
@@ -1143,3 +1143,21 @@ def test_b64decode_requires_the_canonical_encoding() -> None:
         assert base64.b64decode(malleated) == base64.b64decode(b64_sig)
         with pytest.raises(BTClibValueError, match=err_msg):
             bms.Sig.b64decode(malleated)
+
+
+def test_a_drawn_key_takes_the_network_it_is_asked_for() -> None:
+    """`gen_keys(None, network)` draws on that network's curve.
+
+    Every other call above leaves both arguments out, so the `network is
+    None` default was the only way through the draw and the branch that
+    keeps the caller's name never ran. What the name decides is the WIF
+    prefix and the address version, which is what is checked here: the
+    curve is secp256k1 on either network, so nothing else would say the
+    argument had been read.
+    """
+    wif, addr = bms.gen_keys(None, "testnet")
+
+    assert prv_keyinfo_from_prv_key(wif)[1] == "testnet"
+    assert addr == b58.p2pkh(wif)
+    # and the default, which is the same call with the name left out
+    assert prv_keyinfo_from_prv_key(bms.gen_keys()[0])[1] == "mainnet"

--- a/tests/ecc/borromean_test.py
+++ b/tests/ecc/borromean_test.py
@@ -181,6 +181,12 @@ def test_borromean_sig_assert_valid_holds_s_to_0_n() -> None:
         sig.assert_valid()
     with pytest.raises(BTClibValueError, match="scalar s not in 0..n-1"):
         sig.serialize()
+    # and the octets the flag still writes, which is the other way out of
+    # `serialize`'s `if check_validity:` and the one no other test takes:
+    # an out-of-range s is `ec.n_size` octets like any other
+    assert sig.serialize(check_validity=False) == (0).to_bytes(
+        32, "big"
+    ) + ec.n.to_bytes(ec.n_size, "big")
     # Q1 unused otherwise -- kept to mirror the other low-cardinality
     # tests' setup and to document that assert_valid does not touch the
     # curve's points at all, only its order

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -2357,3 +2357,30 @@ def test_a_delegated_signer_s_wipe_zeroes_the_buffer_it_signs_from() -> None:
         _ = 1 / 0
     with pytest.raises(BTClibValueError, match="the signer is wiped"):
         raising.sign(b"a message")
+
+
+@needs_bindings
+def test_a_refusal_that_is_not_about_the_key_still_leaves_as_btclib(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A `ValueError` the bindings raise for anything else is translated too.
+
+    The two `ValueError`s libsecp256k1 raises here are both about the
+    supplied public key -- octets that are no point, and a key that is
+    not this private key's -- so with `pub_key=None` nothing that arm can
+    say reaches the fallback `raise`, and it went unmeasured. That is
+    what the branch is for all the same: the hierarchy is btclib's, and a
+    caller catching `BTClibValueError` must not have a bare `ValueError`
+    escape past them because a later version of the bindings found a
+    third thing to complain about. Patching the call is the only way to
+    ask, the refusal being one no argument can provoke today.
+    """
+
+    def refuse(*_args: Any, **_kwargs: Any) -> bytes:
+        raise ValueError("a refusal of some other kind")
+
+    monkeypatch.setattr(libsecp256k1_dsa, "sign", refuse)
+
+    q, _Q = dsa.gen_keys(0x1234)
+    with pytest.raises(BTClibValueError, match="a refusal of some other kind"):
+        dsa.sign(b"Satoshi Nakamoto", q, pub_key=None)

--- a/tests/mnemonic/electrum_test.py
+++ b/tests/mnemonic/electrum_test.py
@@ -983,16 +983,19 @@ def test_vectors(
     same at greater length.
     """
     lang = "en"
-    if mnemonic:
-        assert rmxprv == electrum.mxprv_from_mnemonic(mnemonic, passphrase)
+    # every vector carries one, so it is asserted rather than guarded: a
+    # file refreshed with a case that has none would leave the round trip
+    # below unrun, which is the failure a guard would have hidden
+    assert mnemonic
+    assert rmxprv == electrum.mxprv_from_mnemonic(mnemonic, passphrase)
 
-        mnemonic_type, mnemonic = electrum.version_from_mnemonic(mnemonic)
-        entr = int(electrum.entropy_from_mnemonic(mnemonic, lang), 2)
-        # entr - 1 and not entr: these are electrum's own output, so the
-        # entropy it was generated from is one below what it encodes and
-        # the first candidate tried is the mnemonic itself
-        mnem = electrum.mnemonic_from_entropy(mnemonic_type, entr - 1, lang)
-        assert mnem == mnemonic
+    mnemonic_type, mnemonic = electrum.version_from_mnemonic(mnemonic)
+    entr = int(electrum.entropy_from_mnemonic(mnemonic, lang), 2)
+    # entr - 1 and not entr: these are electrum's own output, so the
+    # entropy it was generated from is one below what it encodes and
+    # the first candidate tried is the mnemonic itself
+    mnem = electrum.mnemonic_from_entropy(mnemonic_type, entr - 1, lang)
+    assert mnem == mnemonic
 
     assert rmxpub == bip32.xpub_from_xprv(rmxprv)
 

--- a/tests/mnemonic/mnemonic_test.py
+++ b/tests/mnemonic/mnemonic_test.py
@@ -319,7 +319,11 @@ def test_load_lang_is_not_a_race() -> None:
         """Block inside the assignment the race needed to interleave."""
 
         def __setitem__(self, key: str, value: list[str]) -> None:
-            if key == "en" and value:
+            # `no branch`: this test loads one language, so the guard is
+            # never false here. It is what keeps the block to the
+            # assignment the race needs, another language or the empty
+            # value of a failed load being neither
+            if key == "en" and value:  # pragma: no branch
                 paused.set()
                 release.wait(10)
             super().__setitem__(key, value)

--- a/tests/network_test.py
+++ b/tests/network_test.py
@@ -28,6 +28,7 @@ from btclib.network import (
     xpubversion_from_xprvversion,
     xpubversions_from_network,
 )
+from tests import replace_unchecked
 from tests.conftest import JsonGolden
 
 
@@ -409,3 +410,21 @@ def test_a_field_no_network_has_is_refused_rather_than_scanned_for() -> None:
     # check is built from and the one NetworkField names for mypy
     for field in fields(Network):
         assert networks_from_key_value(field.name, object()) == []  # type: ignore[arg-type]
+
+
+def test_the_flag_still_switches_the_check_off() -> None:
+    """Verify check_validity=False builds a network and writes its dict.
+
+    Every network above is built checked -- the nine in `NETWORKS` and
+    the ones the refusals raise on -- so both `if check_validity:` lines
+    ran one way only. A genesis block of the wrong length is the
+    invalidity to carry: `to_dict` writes it as hex whatever its width,
+    where a curve of another name would not survive the lookup the dict
+    is read back through.
+    """
+    invalid = replace_unchecked(NETWORKS["mainnet"], genesis_block=b"\x00")
+
+    assert invalid.to_dict(check_validity=False)["genesis_block"] == "00"
+    err_msg = "invalid genesis_block length: 1 bytes instead of 32"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        invalid.to_dict()

--- a/tests/p2p/address_test.py
+++ b/tests/p2p/address_test.py
@@ -463,3 +463,19 @@ def test_the_command_and_the_envelope_it_travels_in() -> None:
     assert message.serialize() == _ADDR
     # and the way back, which is the caller's `if` and not a table here
     assert Addr.parse(Message.parse(_ADDR).payload) == addr
+
+
+def test_the_flag_still_switches_the_check_off() -> None:
+    """Verify check_validity=False writes a timestamp of the wrong type.
+
+    Every entry above is built checked, so `serialize`'s
+    `if check_validity:` ran one way only. A `bool` timestamp is the
+    invalidity to carry: a bool is an int, so it passes every range check
+    and `to_bytes` writes it as the one it is, where a timestamp out of
+    range would overflow the four octets before the flag could be read.
+    """
+    invalid = TimestampedNetworkAddress(True, NetworkAddress(), check_validity=False)
+
+    assert invalid.serialize(check_validity=False)[:4] == b"\x01\x00\x00\x00"
+    with pytest.raises(BTClibTypeError, match="invalid timestamp type: bool"):
+        invalid.serialize()

--- a/tests/p2p/message_test.py
+++ b/tests/p2p/message_test.py
@@ -404,3 +404,20 @@ def test_frozen() -> None:
     assert regtest != message
     assert regtest.serialize()[4:] == message.serialize()[4:]
     assert replace(message, magic=magic_from_chain("regtest")) == regtest
+
+
+def test_the_flag_still_switches_the_check_off() -> None:
+    """Verify check_validity=False writes a header of the wrong magic.
+
+    Every message above is built checked, so `serialize`'s
+    `if check_validity:` ran one way only. A short magic is the
+    invalidity to carry: it is written as it stands, where a payload over
+    `MAX_PROTOCOL_MESSAGE_LENGTH` would cost the octets to build one.
+    """
+    invalid = Message(b"\x00", "verack", check_validity=False)
+
+    assert invalid.serialize(check_validity=False) == bytes.fromhex(
+        "0076657261636b000000000000000000005df6e0e2"
+    )
+    with pytest.raises(BTClibValueError, match="invalid magic: 1 instead of 4 bytes"):
+        invalid.serialize()

--- a/tests/psbt/psbt_out_test.py
+++ b/tests/psbt/psbt_out_test.py
@@ -182,3 +182,23 @@ def test_scripts_are_rendered_as_asm_and_hex() -> None:
         PsbtOut.from_dict(
             {**dict_, "redeem_script": {"asm": "OP_1", "hex": redeem_script}}
         )
+
+
+def test_a_v2_output_without_an_amount_writes_only_the_script() -> None:
+    """The two BIP370 fields are written one by one, not as a pair.
+
+    An output map carrying a script and no amount is what a Constructor
+    has before the amount is decided, and `is not None` is what makes an
+    amount of zero an amount all the same -- so the field is absent only
+    where it was never set. Every v2 output serialized elsewhere carries
+    both fields, which left the amount's guard measured one way.
+    """
+    script_pub_key = "0014" + "11" * 20
+    without = PsbtOut(script_pub_key=script_pub_key).serialize(psbt_version=2)
+    with_zero = PsbtOut(amount=0, script_pub_key=script_pub_key).serialize(
+        psbt_version=2
+    )
+
+    assert without.hex() == "0104160014" + "11" * 20 + "00"
+    # the amount field, and the script beside it unchanged
+    assert with_zero.hex() == "010308" + "00" * 8 + without.hex()

--- a/tests/psbt/psbt_size_test.py
+++ b/tests/psbt/psbt_size_test.py
@@ -28,6 +28,8 @@ import pytest
 
 from btclib.bip32 import BIP32KeyOrigin
 from btclib.block import Block
+from btclib.curves import mult
+from btclib.curves.sec_point import bytes_from_point
 from btclib.ecc import dsa
 from btclib.exceptions import BTClibValueError
 from btclib.psbt import Psbt, PsbtIn, PsbtOut, extract_tx
@@ -577,3 +579,40 @@ def test_a_sizer_is_never_asked_where_this_file_knows() -> None:
     script_path = bip371_psbt(3)
     _ = script_path.vsize_estimate(record)
     assert asked == [script_path.inputs[0]]
+
+
+def test_the_key_of_a_p2pkh_is_looked_up_past_the_ones_that_miss() -> None:
+    """An input's hd_key_paths is not one key, so the lookup is a walk.
+
+    An Updater fills that map with every key a Signer may need, and a
+    wallet watching more than one account puts more than one there. What
+    decides the size is the key that hash160s to the payload of the
+    script: an entry ahead of it is stepped over, and a map that answers
+    for none of it leaves the estimate at the compressed size, which is
+    the assumption the module docstring states.
+
+    Every other p2pkh input here carries exactly the key its script
+    commits to, so the miss was never taken.
+    """
+    uncompressed = bytes_from_point(mult(3), compressed=False)
+    miss = bytes_from_point(mult(4))
+    script_pub_key = ScriptPubKey.p2pkh(uncompressed).script
+    tx_in = TxIn(OutPoint(b"\x01" * 32, 0))
+
+    def sizes(*pub_keys: bytes) -> int:
+        # one origin per key, and they have to differ: an hd_key_paths
+        # naming the same derivation twice is what assert_valid refuses
+        psbt_in = PsbtIn(
+            witness_utxo=TxOut(1000, script_pub_key, check_validity=False),
+            hd_key_paths={
+                pub_key: BIP32KeyOrigin("deadbeef", f"m/{index}")
+                for index, pub_key in enumerate(pub_keys)
+            },
+            check_validity=False,
+        )
+        return estimated_input_sizes(psbt_in, tx_in)[0]
+
+    # the miss is walked past, and the entry behind it answers
+    assert sizes(miss, uncompressed) == sizes(uncompressed)
+    # and a map that answers for none of it falls back to compressed
+    assert sizes(uncompressed) - sizes(miss) == len(uncompressed) - len(miss)

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -4846,3 +4846,27 @@ def test_the_three_entries_that_took_a_psbt_unasked() -> None:
         prevouts(deepcopy(bad))
     with pytest.raises(BTClibValueError, match=err_msg):
         new_signers(deepcopy(bad), deepcopy(good))
+
+
+def test_the_flag_still_switches_the_dict_check_off() -> None:
+    """Verify to_dict writes a psbt its own assert_valid refuses.
+
+    Every psbt written as a dict elsewhere is a valid one, so
+    `Psbt.to_dict`'s `if check_validity:` ran one way only: the refusal
+    below is the default, and the line before it is what the flag does.
+
+    A v0 psbt carrying PSBT_GLOBAL_TX_MODIFIABLE is the invalidity to
+    hold it with, and the reason is
+    `test_a_base_tx_out_dict_refuses_the_amount_either_way`'s: an amount
+    out of MoneyRange is refused by `btc_from_sats` on the way into the
+    json whatever this call was told, and a fallback lock time out of
+    range by the "tx" entry the dict derives. This field is neither -- it
+    is written as it stands, and read back by from_dict.
+    """
+    psbt = Psbt.b64decode(TO_BE_FINALIZED)
+    assert psbt.version == 0
+    psbt.tx_modifiable = 0
+
+    assert psbt.to_dict(check_validity=False)["tx_modifiable"] == 0
+    with pytest.raises(BTClibValueError, match="TX_MODIFIABLE is not allowed"):
+        psbt.to_dict()

--- a/tests/psbt/psbt_utils_test.py
+++ b/tests/psbt/psbt_utils_test.py
@@ -12,10 +12,14 @@ from btclib.bip32 import BIP32KeyOrigin
 from btclib.exceptions import BTClibValueError
 from btclib.psbt.psbt_utils import (
     deserialize_map,
+    deserialize_tx,
     parse_taproot_bip32,
     serialize_hd_key_paths,
     serialize_taproot_bip32,
 )
+from btclib.script import Witness
+from btclib.tx import Tx, TxIn, TxOut
+from btclib.tx.out_point import OutPoint
 
 
 def test_invalid_serialize_hd_key_paths() -> None:
@@ -96,3 +100,57 @@ def test_deserialize_map_unterminated() -> None:
     err_msg = "malformed psbt: unterminated map"
     with pytest.raises(BTClibValueError, match=err_msg):
         deserialize_map(b"\x01A\x01B")
+
+
+def test_deserialize_tx_reads_include_witness_for_its_truth() -> None:
+    """`None` waives the type check, and then refuses what `False` refuses.
+
+    Two separate readings of the one parameter, and only the first treats
+    `None` as its own value: `assert_type` is guarded by `is not None`,
+    so `None` is the one non-bool this signature takes, and that guard is
+    the branch nothing else reaches -- every psbt field calling this names
+    a bool. The round trip below it is guarded by `not include_witness`
+    instead, which is a truth: false for `True` alone, so `True` is the
+    value that accepts either encoding, and `False` and `None` both take
+    the strict arm that refuses a witness serialization.
+
+    Asserted rather than described, and asserted on octets that tell the
+    two encodings apart: a legacy serialization is accepted by every
+    value of the flag, so a test that fed only one could not have seen
+    which arm ran.
+
+    Whether that is the contract this parameter was meant to have is
+    btclib-org/btclib#1190, which asks for a decision and not a patch --
+    the comment on `deserialize_tx` reads the two guards as one and says
+    `None` means "either", which is the opposite of what the second does.
+    This pins the behaviour as it stands, so that whichever way the issue
+    is answered, the answer changing is a red test rather than a silent
+    change of what a psbt is refused for.
+    """
+    tx = Tx(
+        1,
+        0,
+        [TxIn(OutPoint(b"\x01" * 32, 0), script_witness=Witness([b"\x01"]))],
+        [TxOut(1, "")],
+    )
+    witness = tx.serialize(include_witness=True, check_validity=False)
+    legacy = tx.serialize(include_witness=False, check_validity=False)
+    assert witness != legacy
+    # the same transaction with the witness dropped, which is what the
+    # legacy octets parse to whatever the flag says
+    stripped = Tx.parse(legacy, check_validity=False)
+
+    # True: the round trip is not asked for, so either encoding is read
+    assert deserialize_tx(b"\x00", witness, "tx", True) == tx
+    assert deserialize_tx(b"\x00", legacy, "tx", True) == stripped
+
+    # False and None: the same arm, and neither is a third answer
+    err_msg = "wrong tx serialization format"
+    for flag in (False, None):
+        assert deserialize_tx(b"\x00", legacy, "tx", flag) == stripped
+        with pytest.raises(BTClibValueError, match=err_msg):
+            deserialize_tx(b"\x00", witness, "tx", flag)
+
+    # what `None` does waive is the type check, and not the length one
+    with pytest.raises(BTClibValueError, match="invalid tx key length: 2"):
+        deserialize_tx(b"\x00\x00", legacy, "tx", None)

--- a/tests/psbt/psbt_view_test.py
+++ b/tests/psbt/psbt_view_test.py
@@ -108,7 +108,10 @@ def _read_everything(view: PsbtView) -> None:
     assert view.tx.version == view.tx_version
     for i in range(view.input_count):
         view.input(i)
-    for i in range(view.output_count):
+    # `no branch` on the loop: every caller is an invalid vector inside
+    # `pytest.raises`, so the walk is stopped by the refusal it is there
+    # to provoke and never reaches the end of the outputs
+    for i in range(view.output_count):  # pragma: no branch
         view.output(i)
 
 

--- a/tests/psbt/silent_payments_test.py
+++ b/tests/psbt/silent_payments_test.py
@@ -113,7 +113,11 @@ def test_every_invalid_psbt_is_refused(vector: dict[str, Any]) -> None:
     }[category]
     # its own category's check refuses it, and not merely the whole
     with pytest.raises(BTClibValueError):
-        for check in checks:
+        # `no branch`: the first check of the category refuses, which is
+        # what the enclosing `raises` asserts, so the loop is never
+        # exhausted -- the several entries are the checks that must all
+        # be reached across the categories, not several to be run here
+        for check in checks:  # pragma: no branch
             check(psbt)
     with pytest.raises(BTClibValueError):
         role.assert_as_valid(psbt)

--- a/tests/script/sig_hash_taproot_test.py
+++ b/tests/script/sig_hash_taproot_test.py
@@ -169,11 +169,13 @@ def test_valid_taproot_script_path() -> None:
     witness = Witness(witness_data)
     tx.vin[index].script_witness = witness
 
-    sighash_type = 0  # all
+    # this spend's signature carries its own hash type, so the 65th octet
+    # is what it is signed under: asserted rather than branched on, the
+    # witness above being one fixed transcription and not a vector file
+    assert len(witness.stack[0]) == 65
     signature = witness.stack[0][:64]
-    if len(witness.stack[0]) == 65:
-        sighash_type = witness.stack[0][-1]
-        assert sighash_type != 0
+    sighash_type = witness.stack[0][-1]
+    assert sighash_type != 0
 
     msg_hash = sig_hash.from_tx(prevouts, tx, index, sighash_type)
 

--- a/tests/script_engine/script_test.py
+++ b/tests/script_engine/script_test.py
@@ -136,9 +136,13 @@ def script_vectors() -> list[Any]:
         else:
             i = 1
             stack = x[0]
-            if isinstance(stack[-1], (int, float)):
-                amount = int(stack[-1] * 10**8)
-                stack = stack[:-1]
+            # Core writes the amount as the last element of that array,
+            # always: asserted rather than guarded, so a vector file
+            # refreshed into another shape says so here rather than
+            # being measured against an amount of zero
+            assert isinstance(stack[-1], (int, float))
+            amount = int(stack[-1] * 10**8)
+            stack = stack[:-1]
 
         stack, script_pub_key = taproot_placeholders(stack, x[i + 1])
         vector = ScriptVector(

--- a/tests/silent_payments_test.py
+++ b/tests/silent_payments_test.py
@@ -806,3 +806,45 @@ def test_the_whole_round_trip_without_a_vector() -> None:
     for output in found:
         d = silent_payments.prv_key_from_tweak(_B_SPEND_PRV, output.prv_key_tweak)
         assert ssa.verify_(_MSG, output.pub_key, ssa.sign_(_MSG, d, _AUX))
+
+
+def test_a_hash160_match_that_is_no_public_key_is_walked_past() -> None:
+    """A window whose hash matches need not hold a key: the walk goes on.
+
+    Which is what `_pub_key_from_p2pkh`'s comment says and what nothing
+    exercised: every p2pkh input elsewhere here carries the key the
+    script commits to, so the match was always a key and the loop always
+    returned on it. `0x02` over a value that is no x coordinate is 33
+    bytes that hash to whatever they hash to, and a script_pub_key built
+    from that hash is an input consensus never had to accept -- a
+    scanner reading one off a transaction has bytes, not a promise.
+    """
+    candidate = b"\x02" + _NOT_AN_X
+    script_pub_key = b"\x76\xa9\x14" + hash160(candidate) + b"\x88\xac"
+
+    assert (
+        silent_payments.pub_key_from_input(script_pub_key, b"\x21" + candidate) is None
+    )
+
+
+def test_a_script_path_spend_counts_unless_its_internal_key_is_nums() -> None:
+    """The output key is what a script-path input contributes.
+
+    The NUMS exception is what the vectors exercise, so the comparison
+    ran one way only: an input skipped for saying there is no key path to
+    sign with, and never one that says there is. The key that counts is
+    the output key either way -- not the one the spend used -- so a
+    coinjoin peer who could re-spend through the script path cannot
+    derive the shared secret with one key and publish a transaction
+    proving another.
+    """
+    output_key = bytes_from_point(mult(3))[1:]
+    script_pub_key = b"\x51\x20" + output_key
+    tapscript = b"\x51"
+
+    internal_key = bytes_from_point(mult(7))[1:]
+    witness = Witness([tapscript, b"\xc0" + internal_key])
+    assert silent_payments.pub_key_from_input(script_pub_key, b"", witness) == mult(3)
+
+    nums = Witness([tapscript, b"\xc0" + silent_payments.NUMS_H])
+    assert silent_payments.pub_key_from_input(script_pub_key, b"", nums) is None

--- a/tests/slip132_test.py
+++ b/tests/slip132_test.py
@@ -152,7 +152,10 @@ def test_slip132_test_vectors() -> None:
             assert addr == address
             address = b58.p2wpkh_p2sh(xprv)
             assert addr == address
-        elif version == NETWORKS["mainnet"].slip132_p2wpkh_prv:
+        # `no branch`: the three versions above are the three the local
+        # vector list holds, so the chain is exhaustive over it and the
+        # last arm never falls through
+        elif version == NETWORKS["mainnet"].slip132_p2wpkh_prv:  # pragma: no branch
             address = b32.p2wpkh(xpub)
             assert addr == address
             address = b32.p2wpkh(xprv)

--- a/tests/to_prv_key_test.py
+++ b/tests/to_prv_key_test.py
@@ -11,6 +11,8 @@ import pytest
 from btclib.alias import INF
 from btclib.b58 import wif_from_prv_key
 from btclib.base58 import encode as b58encode
+from btclib.bip32 import BIP32KeyData
+from btclib.bip32.bip32 import rootxprv_from_seed
 from btclib.curves.curve import CURVES
 from btclib.exceptions import (
     BTClibTypeError,
@@ -20,6 +22,7 @@ from btclib.exceptions import (
 )
 from btclib.to_prv_key import (
     _prv_keyinfo_from_wif,
+    _prv_keyinfo_from_xprvwif,
     int_from_prv_key,
     prv_keyinfo_from_prv_key,
 )
@@ -283,3 +286,23 @@ def test_a_wif_on_a_network_sharing_its_prefix() -> None:
         prv_keyinfo_from_prv_key(wif_from_prv_key(q, "mainnet"), "signet")
     with pytest.raises(InvalidPrvKeyError, match="not a mainnet wif: prefix 0xef"):
         prv_keyinfo_from_prv_key(wif_from_prv_key(q, "signet"), "mainnet")
+
+
+def test_the_xprvwif_helper_takes_a_bip32_key_data_too() -> None:
+    """`_prv_keyinfo_from_xprvwif` answers for a parsed xprv, not only a str.
+
+    Both public callers dispatch a `BIP32KeyData` to `_prv_keyinfo_from_xprv`
+    before they reach this helper, so its `isinstance` guard is never False
+    through them and the WIF attempt it skips is what nothing else measures.
+    The guard is the helper's own contract rather than a duplicate of theirs:
+    a parsed xprv is not a string the WIF decoder could be asked about, and
+    handing it to `_prv_keyinfo_from_wif` would be a `NotAPrvKeyError` added
+    to the reasons of a key that is in good order.
+    """
+    xprv = rootxprv_from_seed(b"\x01" * 32)
+    data = BIP32KeyData.b58decode(xprv)
+
+    assert _prv_keyinfo_from_xprvwif(data, None, None) == _prv_keyinfo_from_xprvwif(
+        xprv, None, None
+    )
+    assert _prv_keyinfo_from_xprvwif(data, "mainnet", None)[1] == "mainnet"

--- a/tests/verify_dist_contents_test.py
+++ b/tests/verify_dist_contents_test.py
@@ -426,7 +426,11 @@ def _rules(text: str) -> list[tuple[set[str], set[str]]]:
             items, lead = [], []
         elif line.strip():
             paragraph.append(line)
-        elif paragraph:
+        # `no branch`: a blank line with nothing pending would take the
+        # other way out, and the markdown read here has none -- MD012
+        # refuses two blank lines in a row, and the flush above is what
+        # every list ends on
+        elif paragraph:  # pragma: no branch
             lead, paragraph = paragraph, []
     return rules
 


### PR DESCRIPTION
Two of the practices `btclib-org/.github#7` found this repository
missing. That issue is split one pull request per repository and other
repositories' still have to land, so this does not close it.

## `branch = true` in `[tool.coverage.run]`

Statement coverage calls a half-tested `if` fully covered: the line ran,
one of its two ways out never did. The tree was at 100.00% of statements
before this and reported **29 partial branches** the moment branches
were measured.

**Eighteen are closed by a test.** Nine of them are one shape repeated —
an `if check_validity:` whose flag was never passed false, so nothing
ran the call that skips the check: `Bip21`'s constructor and
`serialize`, `BasicBlockFilter`'s constructor, `Network`'s constructor
and `to_dict`, `BorromeanSig.serialize`,
`TimestampedNetworkAddress.serialize`, `Message.serialize`,
`Psbt.to_dict`. Each new test builds an object its own `assert_valid`
refuses and asks the boundary twice, the way `check_validity_test.py`
already asks the transaction classes. What a fixture may be invalid in
is constrained: an amount out of MoneyRange is refused by
`btc_from_sats` on the way into the json whatever the flag says, and a
fallback lock time out of range by the `"tx"` entry `Psbt.to_dict`
derives, so the fixtures are a `bool` timestamp, a short magic, a
genesis block of the wrong length, a v0 psbt carrying
`PSBT_GLOBAL_TX_MODIFIABLE`.

The other nine tests are nine gaps of their own, three of which are
answers the library had never been asked for:

- `silent_payments._pub_key_from_p2pkh` walking past a 33-octet window
  whose `hash160` matches the script and which is no public key — its
  own comment describes that case and nothing exercised it;
- a taproot script-path input whose control block carries an internal
  key that is **not** BIP341's NUMS, every vector having only the NUMS
  case that is skipped;
- `psbt_size._pub_key_size` reading past an `hd_key_paths` entry that
  does not hash to the script's payload.

The rest: `bms.gen_keys` taking a network name, `deserialize_tx`'s
`include_witness=None`, `_prv_keyinfo_from_xprvwif` handed a parsed
`BIP32KeyData`, a v2 output map with a script and no amount,
`find_all_points` on a curve with a point of order two (`b = 0` puts one
at the origin; no curve in `CURVES` has one, being of prime order), and
a `ValueError` from the delegated `dsa.sign` about neither of the two
things it can complain about — only a patched binding raises that, and
it must still leave as a `BTClibValueError`.

**Three are guards over vector data that became `assert`s**, which
measure the same fact and fail loudly where the guard silently skipped
the work below it: `electrum_test`'s `if mnemonic:` over vectors that
all carry one, `script_test`'s check that Core writes the amount as the
last element of a witness array, `sig_hash_taproot_test`'s check that
one transcribed signature is 65 octets.

**Eight carry `# pragma: no branch`**, with the reason beside each. Not
`# pragma: no cover`: that excludes the statement and the block it
introduces, where here the covered block is the point and one arc out of
the line is what cannot be taken. Every one of them, `file:line` at the
tip of this branch:

| site | why the other arc cannot be taken |
| --- | --- |
| `btclib/block/merkle_proof.py:84` | `if is_a_tx:` is false only for 64 octets that `Tx.parse` accepts and that btclib writes back differently. There are none: every count and length is a var_int, which `var_int.parse` takes only at its canonical width, and the one encoding that would not round-trip — a BIP144 marker over empty witnesses — is what `Tx.parse` refuses on its own. The comparison stays, being a property of the parser rather than of this module |
| `btclib/number_theory.py:420` | Tonelli-Shanks' inner `for i in range(1, s)` never runs out: the legendre symbol checked above makes `t = a**q` an element of the subgroup of order `2**(s-1)`, so squaring reaches 1 at some `i < s`. The bound is the loop's termination, not a fallback — nothing follows the loop but the `while` that reads the new `t` |
| `tests/all_test.py:709` | the export-tree walk visits no module twice, which the comment already there states; the set is the frontier's filter and would only bite on a future re-export |
| `tests/mnemonic/mnemonic_test.py:326` | the blocking dict is asked about one language, `en`, so its guard is never false |
| `tests/psbt/psbt_view_test.py:114` | `_read_everything`'s only caller is an invalid vector inside `pytest.raises`, so the output loop is stopped by the refusal it exists to provoke |
| `tests/psbt/silent_payments_test.py:120` | the first check of a category refuses, which is what the enclosing `raises` asserts, so the loop over the category's checks is never exhausted |
| `tests/slip132_test.py:158` | the `elif` chain is exhaustive over the three versions the local vector list holds |
| `tests/verify_dist_contents_test.py:433` | a blank line always has a paragraph pending: MD012 refuses two blank lines in a row in the markdown this reads, and the list flush above it is what every list ends on |

**No `exclude_also` was added.** None of the eight is the same shape
repeated at several sites, which is the criterion for a pattern; the
issue's table marks it `—` for btclib and it stays that way.

## `pydoclint`

The hook runs over `btclib/` — the published surface, where a caller
reading `help()` has the docstring and nothing else — with its
configuration in `pyproject.toml` beside ruff's. It is the check the `D`
family does not make: those ask that a docstring exists, this asks that
the `Args`, `Returns` and `Attributes` sections it carries describe the
signature above them.

`skip-checking-short-docstrings` stays at pydoclint's **default**,
rather than the `false` sibling `btclib-secp256k1` and the standard's
reference configuration set. There the `false` is right: every docstring
of a wrapper is one summary line, so switching the skip off is what
makes the check reach any of them. Here it reaches **4404 findings over
111 files** — `Args` and `Returns` sections that do not exist, rather
than sections that disagree with a signature — which is a rewrite of the
package's prose and not a lint fix.

Follow-up issue, with the measurement, the exact reproduce command, the
count per violation code and the count per file:
btclib-org/btclib#1178.

At the setting adopted here the hook reported three findings, all fixed
in this pull request: `PreparedPoint`'s class docstring gained the
`Attributes` section its three fields ask for, and
`SignerDecorator.__init__` keeps its docstring, `allow-init-docstring`
being on because pep257 — ruff's convention here — neither asks for a
docstring on `__init__` nor forbids one.

`skip-checking-raises` is on, as in `btclib-secp256k1`: a btclib call
refuses mostly through what it delegates to, so what a caller catches is
not what the body raises, and the hierarchy that is caught is written
down once in `btclib/exceptions.py`.

## Not in scope

- `tests` is already in `[tool.coverage.run] source`.
- `check-shebang-scripts-are-executable` is commented out in
  `.pre-commit-config.yaml` with its reason and is left alone.
- `RELEASE_NOTES.md` is untouched: this changes CI and tooling, and
  nothing about the shipped package.

## Verification

Run at the tip of this branch, on the 3.14 `.python-version` pins:

| command | exit code |
| --- | --- |
| `uv run pre-commit run --all-files` | 0 |
| `uv run pytest` | 0 (29408 passed, 11 skipped; 100.00%, 0 statements and 0 branches missed) |
| `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html` | 0 |

The sphinx command is CONTRIBUTING.md's verbatim; its second step,
`grep -rn 'href="#\./' docs/build/html --include='*.html'`, exits 1 —
nothing found, which is that step's pass.

Refs `btclib-org/.github#7`.

## Summary by Sourcery

Strengthen quality checks by measuring branch coverage and enforcing consistency between public API docstrings and signatures.

New Features:
- Add branch coverage measurement to ensure both executable paths are exercised or explicitly justified.
- Add a pydoclint pre-commit hook for validating public API docstring sections against signatures.

Bug Fixes:
- Expand tests to cover previously unexercised validation bypasses, serialization cases, parser edge cases, cryptographic inputs, and error translation paths.
- Make vector-test assumptions fail loudly instead of silently skipping coverage when required data is absent or malformed.

Enhancements:
- Document the intentional unreachable branch paths with targeted no-branch pragmas and configure pydoclint for the project's documentation conventions.
- Complete public documentation for PreparedPoint attributes and preserve the SignerDecorator constructor docstring.

CI:
- Update coverage configuration to measure branches and retain a fully covered test suite.

Documentation:
- Record the new branch coverage and pydoclint standards, coverage findings, and follow-up documentation work in the changelog.

Tests:
- Add tests covering all newly measured reachable branches and edge cases, maintaining 100% statement and branch coverage.