### PR TITLE
test.yml's dist job is the one build a release publishes (issue #1166)

### DIFF
--- a/.github/actions/dev-version/action.yml
+++ b/.github/actions/dev-version/action.yml
@@ -1,0 +1,64 @@
+---
+# issue #1166: the release workflow used to compute this suffix and
+# rewrite pyproject.toml inline, inside the job that then built the
+# files it published -- the only build in the pipeline that ever saw a
+# rehearsal version. Moving the rewrite here is what lets test.yml's
+# `dist` job apply the same suffix before its own `uv build`, which is
+# what makes that job's build the one and only build a rehearsal
+# publishes too, rather than a second copy neither the packaging checks
+# nor the smoke test had inspected.
+#
+# Referenced by path (`uses: ./.github/actions/dev-version`) and not by
+# commit SHA, which is the rule for every third-party action: this one is
+# the repository's own file, read from the same commit as the workflow
+# that calls it, so there is no owner who could move it.
+name: Append a dev suffix to the version
+description: >-
+  Rewrites the version in pyproject.toml, appending the given suffix, and
+  re-locks so uv.lock agrees -- what a rehearsal needs before it builds a
+  version no index has already seen.
+
+inputs:
+  suffix:
+    description: What to append, e.g. .dev42
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Python and tomllib, not sed: the value is parsed and only then
+    # located in the text, because a regex for a version key on its own
+    # line would find whichever table came first. The assignment is
+    # rewritten whole, which leaves its spelling as the file had it.
+    # --no-project, so this runs on the interpreter uv already fetched
+    # and installs nothing into the tree the caller is about to build
+    - shell: bash
+      env:
+        SUFFIX: ${{ inputs.suffix }}
+      run: |
+        uv run --no-project --python 3.14 python - <<'PY'
+        import os
+        import re
+        import tomllib
+        from pathlib import Path
+
+        path = Path("pyproject.toml")
+        text = path.read_text(encoding="utf-8")
+        declared = tomllib.loads(text)["project"]["version"]
+        match = re.search(rf'(?m)^version\s*=\s*"{re.escape(declared)}"\s*$', text)
+        if match is None:
+            msg = f"pyproject.toml declares {declared}, which is not a literal in it"
+            raise SystemExit(msg)
+        suffixed = declared + os.environ["SUFFIX"]
+        line = match.group().replace(declared, suffixed, 1)
+        path.write_text(text[: match.start()] + line + text[match.end() :], encoding="utf-8")
+        PY
+        grep -m1 '^version' pyproject.toml
+        # uv.lock carries the project version, so patching pyproject.toml
+        # leaves the two disagreeing, and every uv command that passes
+        # --locked -- which is all of them, by convention -- then fails
+        # with "the lockfile needs to be updated". The re-lock is also
+        # what makes the sdist coherent: it ships uv.lock, which
+        # otherwise declared the unsuffixed version inside a
+        # distribution named for the suffixed one
+        uv lock

--- a/.github/scripts/generate_sbom.py
+++ b/.github/scripts/generate_sbom.py
@@ -12,7 +12,7 @@ licence, the two files and their digests, and every dependency their
 metadata declares.
 
 **The wheel's metadata is the source, not pyproject.toml.** They agree on
-a release and not in a rehearsal, where the `build` job appends
+a release and not in a rehearsal, where test.yml's `dist` job appends
 `.dev<run*100+attempt>` to the version before building: the document has to
 describe the files beside it, so it reads the archive it is given. Which
 also means the only version it can report for a dependency is the one the
@@ -22,8 +22,8 @@ be a claim the wheel does not make. A requirement pinned with `==` gets a
 `version`; anything else gets the specifier as a property and no version.
 
 **It is reproducible, like the files it describes.** The timestamp is
-`SOURCE_DATE_EPOCH`, which the `build` job exports from the commit date
-for the wheel and the sdist normalizer, and the serial number is a UUID5
+`SOURCE_DATE_EPOCH`, which test.yml's `dist` job exports from the commit
+date for the wheel and the sdist normalizer, and the serial number is a UUID5
 over the purl and the two digests -- so a rebuild of a tag writes the same
 bytes here too, and the attestation over the release assets covers this
 file as well. Nothing is read from the clock, and nothing is random:

--- a/.github/scripts/verify_dist_contents.py
+++ b/.github/scripts/verify_dist_contents.py
@@ -60,9 +60,9 @@ Run it on a freshly built dist directory, after `uv build`:
     uv run --no-project --python 3.14 \
         .github/scripts/verify_dist_contents.py dist/
 
-The `dist` job of test.yml runs it on every pull request and the `build`
-job of release.yml on what it is about to publish, which are the same
-command on two trees.
+The `dist` job of test.yml runs it on every pull request, and the same
+job -- reached through release.yml's `test` call -- on the files it is
+about to publish.
 """
 
 from __future__ import annotations

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,6 +267,11 @@ jobs:
       # only this call sets it: see the input's own description in
       # test.yml
       check-newest-bindings: true
+      # only this call sets it too: this is the run whose dist job
+      # builds what a tag or a rehearsal actually publishes, so its
+      # Setup uv step must not trust a cache another run wrote. See the
+      # input's own description in test.yml
+      disable-dist-cache: true
 
   # and the same checks a pull request lints with: without this, a tag
   # push could publish code the pre-commit hooks reject. Not gated on

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,8 @@ jobs:
     name: Check the tag and the declared versions
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      version-suffix: ${{ steps.suffix.outputs.version-suffix }}
     steps:
       # every action is pinned to a commit SHA, the tag in the comment: a
       # tag, let alone a branch, is a name its owner can move, and these
@@ -90,12 +92,12 @@ jobs:
             exit 1
           fi
           echo "$commit is an ancestor of $DEFAULT_BRANCH"
-      # caching off in this workflow, unlike every other: a cache entry is
-      # written by whichever run populated it, and read here through the
-      # scoping that gives a tag push the caches of the default branch. This
-      # is the workflow that builds what gets uploaded and whose jobs hold
-      # an OIDC token PyPI accepts, so it downloads its dependencies afresh
-      # every time. It costs seconds, once per release.
+      # caching off in this job, unlike every other in these workflows: a
+      # cache entry is written by whichever run populated it, and read here
+      # through the scoping that gives a tag push the caches of the default
+      # branch. This is the workflow whose jobs hold an OIDC token PyPI
+      # accepts, so this one downloads its dependencies afresh every time.
+      # It costs seconds, once per release.
       # Spelled out rather than left off: the input defaults to "auto",
       # which means enabled on a GitHub-hosted runner
       - name: Setup uv
@@ -197,8 +199,43 @@ jobs:
               }
             ' "$file"
           done
+      # TestPyPI refuses a version it has already seen: the rehearsal
+      # appends .dev<run*100+attempt>, unique per dispatch and per re-run
+      # of one, and sorted before the release it rehearses (PEP 440).
+      # A re-run keeps the run's own id and number and only raises
+      # run_attempt, so .dev<run number> alone -- the previous shape of
+      # this suffix -- was identical across every re-run of one dispatch
+      # and collided with itself on TestPyPI the moment a rehearsal was
+      # re-run rather than freshly dispatched (issue #1156). Multiplying
+      # the run number by 100 and adding the attempt keeps both
+      # properties at once: every attempt of every run is still unique,
+      # and, because the attempt never reaches the run number's own
+      # place value, attempt 2 of run 7 (702) still sorts after every
+      # attempt of run 6 (600-699) -- the ordering .dev<run><attempt>
+      # concatenation would have kept only while the two numbers' digit
+      # counts happened to line up. The two digits reserved for the
+      # attempt are checked, not assumed.
+      # Computed here rather than inside test.yml's `dist` job, which is
+      # what applies it (issue #1166): every job this workflow dispatches
+      # during one run has to agree on the same suffix, and this is the
+      # one job every one of them already depends on, directly or through
+      # `test`
+      - name: Compute the rehearsal version suffix
+        id: suffix
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "$GITHUB_RUN_ATTEMPT" -gt 99 ]; then
+            echo "::error::attempt $GITHUB_RUN_ATTEMPT exceeds the two digits reserved for it"
+            exit 1
+          fi
+          suffix=".dev$((GITHUB_RUN_NUMBER * 100 + GITHUB_RUN_ATTEMPT))"
+          echo "run $GITHUB_RUN_NUMBER attempt $GITHUB_RUN_ATTEMPT: $suffix"
+          echo "version-suffix=$suffix" >> "$GITHUB_OUTPUT"
 
-  # the whole build/test matrix, exactly as a pull request runs it
+  # the whole build/test matrix, exactly as a pull request runs it, and
+  # now the build too: test.yml's `dist` job builds the distribution
+  # files, checks them and uploads them, so this call is what makes them
+  # exist for the publish jobs below to download (issue #1166)
   test:
     name: Run the test workflow
     needs: version-check
@@ -223,6 +260,13 @@ jobs:
       # what keeps this run out of the branch concurrency groups: see the
       # group in test.yml
       concurrency-suffix: "-release"
+      # empty on the tag path, where the step above is skipped and a
+      # skipped step's output is the empty string: a release ships the
+      # version the tree declares
+      version-suffix: ${{ needs.version-check.outputs.version-suffix }}
+      # only this call sets it: see the input's own description in
+      # test.yml
+      check-newest-bindings: true
 
   # and the same checks a pull request lints with: without this, a tag
   # push could publish code the pre-commit hooks reject. Not gated on
@@ -254,247 +298,9 @@ jobs:
     name: Run the windows workflow
     uses: ./.github/workflows/windows.yml
 
-  build:
-    name: Build the wheel and the sdist
-    needs: version-check
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      # caching off, for the reason given in the version-check job: this is
-      # the job whose output is published
-      - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-        with:
-          enable-cache: false
-      # what makes the wheel this job publishes reproducible: without it
-      # setuptools stamps the zip entries with the mtimes of the checkout,
-      # so the same commit built twice gives two digests and the
-      # attestation below vouches for bytes nobody else can obtain. The
-      # commit date, not the tag's: `git log -1` on a shallow clone reads
-      # the tip, which is the commit the tag points at, and a lightweight
-      # tag has no date of its own to prefer.
-      # RELEASING.md has the command that rebuilds a released tag and
-      # verifies it against the attestation
-      - name: Pin the build timestamp to the commit
-        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
-      # TestPyPI refuses a version it has already seen: the rehearsal
-      # appends .dev<run*100+attempt>, unique per dispatch and per re-run
-      # of one, and sorted before the release it rehearses (PEP 440).
-      # A re-run keeps the run's own id and number and only raises
-      # run_attempt, so .dev<run number> alone -- the previous shape of
-      # this suffix -- was identical across every re-run of one dispatch
-      # and collided with itself on TestPyPI the moment a rehearsal was
-      # re-run rather than freshly dispatched. Multiplying the run number
-      # by 100 and adding the attempt keeps both properties at once:
-      # every attempt of every run is still unique, and, because the
-      # attempt never reaches the run number's own place value, attempt 2
-      # of run 7 (702) still sorts after every attempt of run 6 (600-699)
-      # -- the ordering .dev<run><attempt> concatenation would have kept
-      # only while the two numbers' digit counts happened to line up.
-      # The two digits reserved for the attempt are checked, not assumed
-      - name: Make the version unique for TestPyPI (rehearsal only)
-        if: github.event_name == 'workflow_dispatch'
-        # Python and tomllib, not sed: the value is parsed and only then
-        # located in the text, because a regex for a version key on its own
-        # line would find whichever table came first. The assignment is
-        # rewritten whole, which leaves its spelling as the file had it.
-        # The interpreter comes from uv, --no-project so that nothing is
-        # installed and no lock is consulted: this job sets up no Python of
-        # its own, and tomllib needs 3.11. 3.14 is what .python-version
-        # pins, so this asks for a version uv has already fetched for the
-        # other jobs rather than a second one
-        run: |
-          uv run --no-project --python 3.14 python - <<'PY'
-          import os
-          import re
-          import tomllib
-          from pathlib import Path
-
-          run_number = int(os.environ["GITHUB_RUN_NUMBER"])
-          run_attempt = int(os.environ["GITHUB_RUN_ATTEMPT"])
-          if run_attempt > 99:
-              msg = f"attempt {run_attempt} exceeds the two digits reserved for it"
-              raise SystemExit(msg)
-
-          path = Path("pyproject.toml")
-          text = path.read_text(encoding="utf-8")
-          declared = tomllib.loads(text)["project"]["version"]
-          match = re.search(rf'(?m)^version\s*=\s*"{re.escape(declared)}"\s*$', text)
-          if match is None:
-              msg = f"pyproject.toml declares {declared}, which is not a literal in it"
-              raise SystemExit(msg)
-          suffixed = declared + ".dev" + str(run_number * 100 + run_attempt)
-          line = match.group().replace(declared, suffixed, 1)
-          path.write_text(text[: match.start()] + line + text[match.end() :], encoding="utf-8")
-          PY
-          grep -m1 '^version' pyproject.toml
-          # uv.lock carries the project version, so patching pyproject.toml
-          # leaves the two disagreeing, and every uv command that passes
-          # --locked -- which is all of them, by convention -- then fails
-          # with "the lockfile needs to be updated". Measured: without this
-          # re-lock, "uv run --locked --only-group check" on a patched tree
-          # exits non-zero. This step now has three --locked consumers
-          # downstream in this same job -- the twine, check-wheel-contents
-          # and pyroma steps added for issue #1154 -- and the re-lock is
-          # what keeps every one of them working.
-          # The re-lock is also what makes the sdist coherent: it ships
-          # uv.lock, which otherwise declared the unsuffixed version inside
-          # a distribution named for the suffixed one
-          uv lock
-      # what a rehearsal does differently from a tag: test.yml's dist job,
-      # called by this workflow's own `test` job above, validates the tree
-      # as committed, while the twine/check-wheel-contents/pyroma steps
-      # below run on the version this step just suffixed. Neither minds:
-      # what the three judge is metadata syntax, README rendering, wheel
-      # layout and metadata quality, none of which a .dev<N> suffix
-      # changes. The smoke test further down is the one check that does
-      # depend on the suffix -- it installs the wheel this job built,
-      # suffix and all -- which is why it could never have been left to
-      # test.yml's dist job and needed no plumbing to avoid it
-      # uv build builds the sdist first and then the wheel from it, not
-      # both from the source tree: the packaging path a user installing
-      # from source takes is therefore the one that produced the wheel,
-      # which is why no separate "install from the sdist" job is needed.
-      # check-manifest stays out of this job: it is a pre-commit hook,
-      # gated by the lint workflow, which this one also calls, and its
-      # question is about the tree uv build reads rather than the files
-      # this job goes on to publish
-      - name: Build the distribution files
-        run: uv build
-      # SOURCE_DATE_EPOCH reaches every entry of the wheel and nothing at
-      # all in the sdist: setuptools honours it in the wheel writer it
-      # vendors and in no other place, so each member of the .tar.gz keeps
-      # a clock -- the checkout's for a file, the build's for the directory
-      # setuptools stages them in -- to sub-second precision, in a PAX
-      # record whose length changes with it. The script rewrites member
-      # metadata and no content, and its docstring has the measurement.
-      # --no-project, so this runs on the interpreter uv already fetched
-      # and installs nothing into the tree it is about to publish
-      - name: Make the sdist reproducible too
-        run: |
-          uv run --no-project --python 3.14 \
-            .github/scripts/normalize_sdist.py dist/
-          sha256sum dist/*
-      # what the packaging checks of the dist job do not look at: the
-      # members of the two archives. They read metadata -- whether it is
-      # valid, whether the long description renders, whether the
-      # classifiers are the ones a package should declare -- and the
-      # allowlist in the script is about what is *in* the files. It runs in
-      # that job too, so a pull request is told before a tag is; here it
-      # judges the files that get uploaded, which in a rehearsal are a
-      # different version built from a re-locked tree.
-      # After the normalizer rather than before: that rewrites member
-      # metadata, and this reads member names
-      - name: Check what the distribution files contain
-        run: |
-          uv run --no-project --python 3.14 \
-            .github/scripts/verify_dist_contents.py dist/
-      # and what nothing said at all: what the files contain, as a document
-      # rather than as a check. The bill of materials is reproducible for
-      # the reason the two steps above are -- SOURCE_DATE_EPOCH is its
-      # timestamp and the two digests its serial number -- so a rebuild of
-      # the tag writes this file too, and the attest job below signs it
-      # beside the distribution files.
-      # Into a directory of its own and not dist/: that directory is
-      # uploaded as the artifact the publish jobs hand to an index, and an
-      # index takes distribution files
-      - name: Write the bill of materials
-        run: |
-          uv run --no-project --python 3.14 \
-            .github/scripts/generate_sbom.py dist/ sbom/
-      # before anything is installed, and that ordering is the point: the
-      # step below runs third-party code -- a `.pth` file in a dependency
-      # executes at interpreter startup, before the first import -- while
-      # dist/ is a writable directory on the same runner. Uploading first
-      # freezes what the publish jobs will download, so the worst a
-      # compromised dependency can do here is fail the job, which stops
-      # them: both name this one in `needs`
-      - name: Upload the distribution files
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: dist
-          path: dist/
-      # an artifact of its own, for the reason the step that writes it gives:
-      # the two jobs that download `dist` hand every file in it to an index
-      - name: Upload the bill of materials
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: sbom
-          path: sbom/
-      # the same three checks test.yml's dist job runs, and for the same
-      # reason given there: a release is the one place where finding a
-      # packaging problem is too late. They run in both places because
-      # dist builds its own copy of the distribution files rather than
-      # this job's -- issue #1154 -- so passing there was never a
-      # guarantee about the files this job is about to publish; this is
-      # the run that judges those files themselves. After the two uploads
-      # above rather than between them and the build: each of the three is
-      # a dependency this job has to install to run, and the comment on
-      # the first upload above already freezes what the publish jobs will
-      # download before anything is installed, a boundary these steps
-      # keep rather than move
-      - name: Check the metadata and the long description
-        run: uv run --locked --only-group check twine check --strict dist/*
-      - name: Check the wheel contents
-        run: uv run --locked --only-group check check-wheel-contents dist/*.whl
-      - name: Rate the packaging metadata
-        run: uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz
-      # dist installs a wheel too, but not this one: it builds its own
-      # copy, on another runner and -- in a rehearsal -- from another
-      # version, the step above having patched pyproject.toml and
-      # re-locked. What reaches an index is this artifact, so this one is
-      # imported, from an empty directory so the import resolves to the
-      # wheel and not to the btclib/ source tree.
-      # Unconstrained, where dist pins the runtime dependencies to
-      # uv.lock: no pull request waits on this job, so it can afford the
-      # question a required check cannot -- whether the newest published
-      # btclib_secp256k1 satisfies the wheel about to be published,
-      # which is what a user installing it resolves. A release stopping
-      # on that answer is the outcome wanted.
-      # The assertions are dist's, and there for the same reasons:
-      # metadata can be missing (issue #150), `import btclib` runs only
-      # __init__.py and touches no binding, the extra can resolve to a
-      # release this tree cannot import, and a bindings release can
-      # install and still answer wrongly.
-      # The serving assertion is what makes the resolution above a
-      # question at all (issue #1117): a bindings release btclib fails
-      # to import lands in `_libsecp256k1`'s `except ImportError`, and
-      # the Python arithmetic then answers the version and the signature
-      # correctly -- that arm being supported and tested is what
-      # test.yml's `no-bindings` job exists for -- so without it this
-      # step goes green on exactly the resolution it is asked about.
-      # `is_libsecp256k1_serving` and not `INSTALLED`: serving is
-      # installed and not refused, so it implies the other, and it is
-      # the public reading of the seam every dispatch consults. It is
-      # asserted before the signature because it is what gives that
-      # signature its meaning -- verified by libsecp256k1 here rather
-      # than by the Python arm it would otherwise silently be
-      - name: Smoke-test the wheel, with its dependencies from PyPI
-        run: |
-          cd "$RUNNER_TEMP"
-          # `set --` for the reason dist's copy of this states: the
-          # positional parameters are sh, bash and zsh alike, where a
-          # named array is 0-indexed in one and 1-indexed in another
-          set -- "$GITHUB_WORKSPACE"/dist/*.whl
-          uv run --isolated --no-project --with "$1[secp256k1]" \
-            python -c "import btclib; \
-              from btclib.curves import is_libsecp256k1_serving; \
-              from btclib.ecc import dsa; \
-              from btclib.to_pub_key import pub_keyinfo_from_prv_key; \
-              print(btclib.__version__); \
-              assert btclib.__version__ != 'unknown'; \
-              assert is_libsecp256k1_serving(), \
-                'the secp256k1 extra resolved, the bindings do not serve'; \
-              assert dsa.verify(b'btclib', pub_keyinfo_from_prv_key(1)[0], \
-                dsa.sign(b'btclib', 1))"
-
   publish-testpypi:
     name: Publish to TestPyPI
-    needs: [test, lint, docs, macos, windows, build]
+    needs: [test, lint, docs, macos, windows]
     if: github.event_name == 'workflow_dispatch' && github.repository == 'btclib-org/btclib'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -518,7 +324,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [test, lint, docs, macos, windows, build]
+    needs: [test, lint, docs, macos, windows]
     if: github.event_name == 'push' && github.repository == 'btclib-org/btclib'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -565,10 +371,10 @@ jobs:
   # what the others contain.
   # A job of its own rather than two more permissions on github-release:
   # this workflow elevates one job at a time, and the one that writes
-  # releases has no reason to also hold an OIDC token. It is not in the
-  # build job for the stronger form of the same reason -- that job runs the
-  # build backend and installs the wheel it just built, and a token minted
-  # there would be minted beside third-party code.
+  # releases has no reason to also hold an OIDC token. It is not in
+  # test.yml's `dist` job for the stronger form of the same reason -- that
+  # job runs the build backend and installs the wheel it just built, and a
+  # token minted there would be minted beside third-party code.
   # After a publish and not after the build, so that a run reaching here is
   # a run the environment approval already let through: without that, a
   # dispatch from any branch would sign whatever that branch built.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,29 @@ on:
           the only caller that passes one. See the group below.
         type: string
         default: ""
+      version-suffix:
+        description: >
+          Appended to the version in pyproject.toml before the `dist`
+          job builds anything, by the dev-version composite action
+          (issue #1166: this is what lets that job's own build be the
+          one a rehearsal publishes, rather than a second build neither
+          the packaging checks nor the smoke test had inspected). A
+          release passes nothing and ships the version the tree
+          declares; the rehearsal passes a .dev suffix, which is how it
+          reaches TestPyPI with a version that index has not already
+          consumed.
+        type: string
+        default: ""
+      check-newest-bindings:
+        description: >
+          Whether the `dist` job's smoke test also asks about the newest
+          published btclib_secp256k1, unconstrained by uv.lock. Only
+          release.yml sets this: the question is not one a required
+          check can afford (a released binding would redden every open
+          pull request), so a direct trigger of this workflow leaves it
+          at the default and runs the deterministic smoke test alone.
+        type: boolean
+        default: false
   # the escape hatch: the matrix on demand for a branch whose pull
   # request is not open yet
   workflow_dispatch:
@@ -525,8 +548,21 @@ jobs:
   # gate here rather than in the release workflow alone because the
   # bindings it resolves are published: while they were not, the step
   # could only be red, for a reason nobody could fix from a branch
+  # issue #1166: this job used to build a copy that was checked and then
+  # thrown away, while release.yml's own `build` job built a second,
+  # separate copy -- from the same tree but with no SOURCE_DATE_EPOCH and
+  # no sdist normalization -- and published that one. Passing here said
+  # nothing about the files a tag actually shipped. This job now does what
+  # that job used to: pin the timestamp, apply a rehearsal's version
+  # suffix, build once, and upload what it built before installing
+  # anything. release.yml no longer has a `build` job at all; its publish
+  # jobs download this job's `dist` artifact, its `attest` job signs the
+  # digests this job's upload already fixed, and its `github-release` job
+  # attaches the same files. What used to be two builds checked twice is
+  # one build checked once and shipped unchanged -- btclib-secp256k1 has
+  # had this shape from the start, for the same reason
   dist:
-    name: Build the distribution and install it
+    name: Build the distribution files, check them, install one
     if: >-
       ${{ !github.event.pull_request.draft
           && github.event.action != 'closed'
@@ -543,35 +579,104 @@ jobs:
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
+      # what makes the wheel this job publishes reproducible: without it
+      # setuptools stamps the zip entries with the mtimes of the checkout,
+      # so the same commit built twice gives two digests and the
+      # attestation release.yml's `attest` job signs would vouch for bytes
+      # nobody else can obtain. The commit date, not the tag's: `git log
+      # -1` on a shallow clone reads the tip, which is the commit the tag
+      # points at, and a lightweight tag has no date of its own to prefer.
+      # RELEASING.md has the command that rebuilds a released tag and
+      # verifies it against the attestation
+      - name: Pin the build timestamp to the commit
+        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
+      # empty on every trigger but a release rehearsal: `inputs` is unset
+      # outside a workflow_call, so a direct run of this workflow -- the
+      # matrix a pull request or a push to main gets -- skips this and
+      # ships the version the tree declares, same as a real release does.
+      # TestPyPI refuses a version it has already seen, which is what the
+      # suffix is for; release.yml's `version-check` job computes it once
+      # and passes it down, so every job this workflow runs during one
+      # dispatch agrees on it
+      - name: Make the version unique for TestPyPI (rehearsal only)
+        if: inputs.version-suffix != ''
+        uses: ./.github/actions/dev-version
+        with:
+          suffix: ${{ inputs.version-suffix }}
       # uv build builds the sdist first and then the wheel from it, not
       # both from the source tree, so what is checked below is what a user
-      # installing from source would get. That the sdist is complete in the
-      # first place is check-manifest's job, a pre-commit hook, gated by
-      # the lint workflow
+      # installing from source would get, and what a rehearsal ships is
+      # built from the tree the step above just re-locked. That the sdist
+      # is complete in the first place is check-manifest's job, a
+      # pre-commit hook, gated by the lint workflow
       - name: Build the distribution files
         run: uv build
-      # what the three checks below do not look at: the members of the two
-      # archives, which is what a user installs. The allowlist and the
-      # reasoning are in the script; release.yml's build job runs the same
-      # command on the files it is about to publish, and this is the copy
-      # that answers before a tag rather than after one.
-      # --no-project, so it runs on the interpreter uv already fetched and
-      # installs nothing: the script imports the standard library only
+      # SOURCE_DATE_EPOCH reaches every entry of the wheel and nothing at
+      # all in the sdist: setuptools honours it in the wheel writer it
+      # vendors and in no other place, so each member of the .tar.gz keeps
+      # a clock -- the checkout's for a file, the build's for the
+      # directory setuptools stages them in -- to sub-second precision, in
+      # a PAX record whose length changes with it. The script rewrites
+      # member metadata and no content, and its docstring has the
+      # measurement. --no-project, so this runs on the interpreter uv
+      # already fetched and installs nothing into the tree it is about to
+      # publish
+      - name: Make the sdist reproducible too
+        run: |
+          uv run --no-project --python 3.14 \
+            .github/scripts/normalize_sdist.py dist/
+          sha256sum dist/*
+      # what the packaging checks further down do not look at: the
+      # members of the two archives, which is what a user installs. The
+      # allowlist and the reasoning are in the script.
+      # After the normalizer rather than before: that rewrites member
+      # metadata, and this reads member names
       - name: Check what the distribution files contain
         run: |
           uv run --no-project --python 3.14 \
             .github/scripts/verify_dist_contents.py dist/
-      # and the bill of materials release.yml attaches to a release. Written
-      # here and thrown away, into $RUNNER_TEMP rather than the workspace:
-      # what this gates is that the script still reads a real wheel, which
-      # otherwise nothing would say until a tag ran it for the first time
+      # and what nothing said at all: what the files contain, as a
+      # document rather than as a check. The bill of materials is
+      # reproducible for the reason the two steps above are --
+      # SOURCE_DATE_EPOCH is its timestamp and the two digests its serial
+      # number -- so a rebuild of a released tag writes this file too, and
+      # release.yml's `attest` job signs it beside the distribution files.
+      # Into a directory of its own and not dist/: that directory is
+      # uploaded as the artifact the publish jobs hand to an index, and an
+      # index takes distribution files
       - name: Write the bill of materials
         run: |
-          SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) \
-            uv run --no-project --python 3.14 \
-            .github/scripts/generate_sbom.py dist/ "$RUNNER_TEMP"/sbom/
+          uv run --no-project --python 3.14 \
+            .github/scripts/generate_sbom.py dist/ sbom/
+      # before anything is installed, and that ordering is the point: a
+      # step below runs third-party code -- twine, check-wheel-contents
+      # and pyroma come from a group uv installs, and a `.pth` file in a
+      # dependency executes at interpreter startup, before the first
+      # import -- while dist/ is a writable directory on the same runner.
+      # Uploading first freezes what release.yml's publish jobs will
+      # download, so the worst a compromised dependency can do here is
+      # fail this job, which stops them from ever seeing what it built
+      - name: Upload the distribution files
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+      # an artifact of its own, for the reason the step that writes it
+      # gives: release.yml's `attest` and `github-release` jobs both hand
+      # every file in it to a signature or a release, the same way they
+      # do dist's
+      - name: Upload the bill of materials
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom
+          path: sbom/
       # the same validation PyPI applies on upload: broken metadata, or a
-      # README that does not render, cannot be fixed by reuploading
+      # README that does not render, cannot be fixed by reuploading. After
+      # the two uploads above rather than between them and the build: each
+      # of the three checks below is a dependency this job has to install
+      # to run, and the comment on the first upload already freezes what
+      # the publish jobs will download before anything is installed, a
+      # boundary these steps keep rather than move
       - name: Check the metadata and the long description
         run: uv run --locked --only-group check twine check --strict dist/*
       # what twine does not look at: where the files land once installed,
@@ -615,39 +720,43 @@ jobs:
       # refuses as conflicting once the branch has moved past it. A floor
       # resolves to a release, and a release does not move.
       # Whether the newest bindings still work is asked on a schedule by
-      # latest.yml, and again by the release workflow before it publishes.
-      # Each assertion catches what the others miss: the version is
-      # asserted and not merely printed, since btclib.__version__ falls
-      # back to "unknown" with no metadata installed (issue #150), so a
-      # wheel shipping none would print that and pass; `btclib.ecc.dsa`
-      # is imported because `import btclib` runs only __init__.py, which
-      # reads that metadata and touches no binding, so the bindings could
-      # be missing entirely; the bindings are asserted to be serving
-      # because nothing else here notices when they are not; and a
-      # signature is verified because an installable release of them with
-      # an incompatible API imports fine and answers wrongly.
+      # latest.yml, and again below, release-only. Each assertion catches
+      # what the others miss: the version is asserted and not merely
+      # printed, since btclib.__version__ falls back to "unknown" with no
+      # metadata installed (issue #150), so a wheel shipping none would
+      # print that and pass; `btclib.ecc.dsa` is imported because `import
+      # btclib` runs only __init__.py, which reads that metadata and
+      # touches no binding, so the bindings could be missing entirely; the
+      # bindings are asserted to be serving because nothing else here
+      # notices when they are not; and a signature is verified because an
+      # installable release of them with an incompatible API imports fine
+      # and answers wrongly.
       # The serving one is issue #1117, and what it guards here is not
-      # what it guards in release.yml's unconstrained copy. The
-      # constraints bind a version and request no package, so the only
-      # thing that installs the bindings at all is the wheel's own
-      # `Requires-Dist` for the extra: a wheel that stopped declaring it
-      # resolves nothing, and a btclib_secp256k1 the lock pins that this
-      # tree cannot import lands in `_libsecp256k1`'s `except
-      # ImportError`. Either way `is_libsecp256k1_serving` is False while
-      # the Python arithmetic answers the version and the signature
-      # correctly -- that arm being supported is what the `no-bindings`
-      # job above exists for -- so both would pass unnoticed. Both are
-      # the tree's own state and not the index's, which is what makes the
-      # assertion fit for a required check: what it cannot say is whether
-      # the *newest* bindings serve, which is release.yml's copy and
-      # latest.yml's job.
+      # what it guards in the unconstrained step below. The constraints
+      # bind a version and request no package, so the only thing that
+      # installs the bindings at all is the wheel's own `Requires-Dist`
+      # for the extra: a wheel that stopped declaring it resolves
+      # nothing, and a btclib_secp256k1 the lock pins that this tree
+      # cannot import lands in `_libsecp256k1`'s `except ImportError`.
+      # Either way `is_libsecp256k1_serving` is False while the Python
+      # arithmetic answers the version and the signature correctly --
+      # that arm being supported is what the `no-bindings` job above
+      # exists for -- so both would pass unnoticed. Both are the tree's
+      # own state and not the index's, which is what makes the assertion
+      # fit for a required check: what it cannot say is whether the
+      # *newest* bindings serve, which is the step below and latest.yml's
+      # job.
       # `is_libsecp256k1_serving` and not `INSTALLED`: serving is
       # installed and not refused, so it implies the other, and it is the
       # public reading of the seam every dispatch consults -- the same
       # name the `no-bindings` job asserts the negative of. Asserted
       # before the signature because it is what gives that signature its
       # meaning: verified by libsecp256k1 here rather than by the Python
-      # arm it would otherwise silently be
+      # arm it would otherwise silently be.
+      # After the two uploads, for the reason the twine step's comment
+      # gives: installing a dependency executes its code, and a
+      # compromised one must not reach a `dist/` that still has to be
+      # handed on
       - name: Smoke-test the wheel, with its dependencies from PyPI
         run: |
           uv export --locked --no-dev --extra secp256k1 \
@@ -673,6 +782,38 @@ jobs:
               'the secp256k1 extra resolved, the bindings do not serve'; \
             assert dsa.verify(b'btclib', pub_keyinfo_from_prv_key(1)[0], \
               dsa.sign(b'btclib', 1))"
+      # release.yml's own copy of this question, moved here now that
+      # there is only one build for it to ask about. Unconstrained, where
+      # the step above pins the runtime dependencies to uv.lock: gated on
+      # `inputs.check-newest-bindings`, which only release.yml sets, so
+      # no pull request and no ordinary push to main waits on it -- it can
+      # afford the question a required check cannot, whether the newest
+      # published btclib_secp256k1 satisfies the wheel about to be
+      # published, which is what a user installing it resolves. A release
+      # stopping on that answer is the outcome wanted.
+      # `github.event_name != 'pull_request'` was the alternative
+      # considered and rejected: inside a called workflow that context is
+      # the *caller's* trigger, so it reads the same 'push' or
+      # 'workflow_dispatch' whether release.yml called this job or a bare
+      # push to main did, and this step running on every push to main
+      # would add a run this issue was never asked to add. The explicit
+      # input says only release.yml opts in
+      - name: Smoke-test the wheel against the newest bindings (release only)
+        if: inputs.check-newest-bindings
+        run: |
+          cd "$RUNNER_TEMP"
+          set -- "$GITHUB_WORKSPACE"/dist/*.whl
+          uv run --isolated --no-project --with "$1[secp256k1]" \
+            python -c "import btclib; \
+              from btclib.curves import is_libsecp256k1_serving; \
+              from btclib.ecc import dsa; \
+              from btclib.to_pub_key import pub_keyinfo_from_prv_key; \
+              print(btclib.__version__); \
+              assert btclib.__version__ != 'unknown'; \
+              assert is_libsecp256k1_serving(), \
+                'the secp256k1 extra resolved, the bindings do not serve'; \
+              assert dsa.verify(b'btclib', pub_keyinfo_from_prv_key(1)[0], \
+                dsa.sign(b'btclib', 1))"
 
   # the single check main's branch protection requires from this
   # workflow, and it exists because that rule names its checks as literal

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -557,10 +557,9 @@ jobs:
   # problem is too late, a version being consumed by the upload that
   # carries it, and then only yankable. The release workflow calls this
   # one, so it runs these checks too, here on the files this job's own
-  # `uv build` produces. Its `build` job builds a second, separate copy
-  # -- the one it actually publishes -- and runs the same three checks on
-  # that copy as well (issue #1154), because passing here said nothing
-  # about files this job never saw.
+  # `uv build` produces -- the same files a tag publishes, issue #1166
+  # below being why there is no second, separate copy of them left to
+  # miss (issue #1154).
   # Installing the wheel is the last of them (issue #131), and it is a
   # gate here rather than in the release workflow alone because the
   # bindings it resolves are published: while they were not, the step

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,23 @@ on:
           at the default and runs the deterministic smoke test alone.
         type: boolean
         default: false
+      disable-dist-cache:
+        description: >
+          Whether the `dist` job's own `Setup uv` step fetches its
+          dependencies afresh instead of from cache. Only release.yml's
+          call sets this: a cache entry written by one run is read by
+          another through GitHub's branch/PR cache scoping, so the job
+          whose output actually reaches an index -- a tag's upload or a
+          rehearsal's TestPyPI one, both routed through this same call --
+          is the one build that must not risk a poisoned cache reaching
+          the wheel it ships. An ordinary pull request or push to main
+          builds a copy this job throws away, so caching it is harmless,
+          and a flat `enable-cache: false` here would only cache-penalize
+          every one of them for a property only release.yml's call needs
+          -- the same asymmetry `check-newest-bindings` above expresses
+          for the unconstrained smoke test, applied to caching instead.
+        type: boolean
+        default: false
   # the escape hatch: the matrix on demand for a branch whose pull
   # request is not open yet
   workflow_dispatch:
@@ -575,10 +592,21 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # caching off only when release.yml calls this workflow: this dist
+      # job is then the one whose output is published -- a tag's upload
+      # or a rehearsal's TestPyPI one -- and the reasoning is
+      # version-check's own: a cache entry written by one run is read by
+      # another through GitHub's branch/PR cache scoping, so the build
+      # that actually ships is the one that must fetch its dependencies
+      # afresh rather than risk a poisoned cache reaching the wheel an
+      # index receives. An ordinary pull request's or push's build is
+      # thrown away, so caching it is harmless; `disable-dist-cache`
+      # defaults to false for exactly that reason, the same asymmetry
+      # `check-newest-bindings` above expresses for the smoke test
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          enable-cache: true
+          enable-cache: ${{ !inputs.disable-dist-cache }}
       # what makes the wheel this job publishes reproducible: without it
       # setuptools stamps the zip entries with the mtimes of the checkout,
       # so the same commit built twice gives two digests and the

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ parts/
 sdist/
 var/
 wheels/
+# test.yml's `dist` job writes the bill of materials here, alongside
+# dist/ above (issue #1166): both are build output, not source
+sbom/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -336,6 +336,13 @@ documented at release-notes length in the first place, and are still in
   the wheel — moved here from `build`, and gated on a new
   `check-newest-bindings` input only `release.yml`'s call sets, so no
   pull request pays for a question it cannot afford a red answer to.
+  `dist`'s own `Setup uv` step carries `build`'s caching-off forward the
+  same way, through a new `disable-dist-cache` input rather than a flat
+  `enable-cache: false`: a cache entry written by one run is read by
+  another through GitHub's branch/PR scoping, so the build whose output
+  actually reaches an index must fetch its dependencies afresh, where an
+  ordinary pull request's build is thrown away and caching it costs
+  nothing.
   `release.yml`'s `publish-testpypi`, `publish-pypi` and `attest` jobs
   download `dist`'s artifacts unchanged; nothing downloads a second copy
   because there is no second copy. A rehearsal's `.dev<run*100+attempt>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,18 +324,19 @@ documented at release-notes length in the first place, and are still in
   above gives, `dist`'s copy being thrown away and `build`'s own copy
   being what got checked and shipped a second time — but two builds
   still meant the checked files and the published files were only
-  "usually" the same object, "usually" being the whole of divergence 9's
-  gap: a defect only the actual build step introduces, and not the tree,
-  can pass the copy that gets checked and ship in the copy that does
-  not. `dist` now pins `SOURCE_DATE_EPOCH` from the commit and normalizes
-  the sdist — both previously `build`-only — uploads the `dist` and
-  `sbom` artifacts before installing anything, and only then runs twine,
-  check-wheel-contents and pyroma once, plus two smoke tests: the
-  existing one, pinned by `uv.lock`, and a second, unconstrained one that
-  asks whether the newest published `btclib_secp256k1` still satisfies
-  the wheel — moved here from `build`, and gated on a new
-  `check-newest-bindings` input only `release.yml`'s call sets, so no
-  pull request pays for a question it cannot afford a red answer to.
+  "usually" the same object, "usually" being the whole of that
+  divergence's gap: a defect only the actual build step introduces, and
+  not the tree, can pass the copy that gets checked and ship in the copy
+  that does not. `dist` now pins `SOURCE_DATE_EPOCH` from the commit and
+  normalizes the sdist — both previously `build`-only — uploads the
+  `dist` and `sbom` artifacts before installing anything, and only then
+  runs twine, check-wheel-contents and pyroma once, plus two smoke
+  tests: the existing one, pinned by `uv.lock`, and a second,
+  unconstrained one that asks whether the newest published
+  `btclib_secp256k1` still satisfies the wheel — moved here from `build`,
+  and gated on a new `check-newest-bindings` input only `release.yml`'s
+  call sets, so no pull request pays for a question it cannot afford a
+  red answer to.
   `dist`'s own `Setup uv` step carries `build`'s caching-off forward the
   same way, through a new `disable-dist-cache` input rather than a flat
   `enable-cache: false`: a cache entry written by one run is read by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,39 @@ documented at release-notes length in the first place, and are still in
   --keep-going` passes on both unchanged, since neither is the broken
   *reference* `-W` already catches — a link myst resolves happily and is
   dead anyway is the whole reason this second check exists.
+- **`release.yml` no longer has a `build` job, and `test.yml`'s `dist`
+  job is now the one build a release publishes** (issue #1166). Two
+  builds from the same tree were checked twice for the reason the entry
+  above gives, `dist`'s copy being thrown away and `build`'s own copy
+  being what got checked and shipped a second time — but two builds
+  still meant the checked files and the published files were only
+  "usually" the same object, "usually" being the whole of divergence 9's
+  gap: a defect only the actual build step introduces, and not the tree,
+  can pass the copy that gets checked and ship in the copy that does
+  not. `dist` now pins `SOURCE_DATE_EPOCH` from the commit and normalizes
+  the sdist — both previously `build`-only — uploads the `dist` and
+  `sbom` artifacts before installing anything, and only then runs twine,
+  check-wheel-contents and pyroma once, plus two smoke tests: the
+  existing one, pinned by `uv.lock`, and a second, unconstrained one that
+  asks whether the newest published `btclib_secp256k1` still satisfies
+  the wheel — moved here from `build`, and gated on a new
+  `check-newest-bindings` input only `release.yml`'s call sets, so no
+  pull request pays for a question it cannot afford a red answer to.
+  `release.yml`'s `publish-testpypi`, `publish-pypi` and `attest` jobs
+  download `dist`'s artifacts unchanged; nothing downloads a second copy
+  because there is no second copy. A rehearsal's `.dev<run*100+attempt>`
+  suffix (issue #1156, the entry above) moves too, from an inline step
+  in `build` to a `.github/actions/dev-version` composite action `dist`
+  runs before its own `uv build`, with the suffix itself computed once
+  in `version-check` and passed down as a `workflow_call` input — every
+  job the release dispatches during one run has to agree on it, and
+  `version-check` is the one job all of them already depend on. The
+  arithmetic is carried over unchanged, not re-derived: this entry
+  moves where it runs, not what it computes.
+  `btclib-secp256k1` has had this shape from the start; `bitcoin-core-rpc`
+  gets its own pull request, and its own gap turns out larger — its
+  `build` job never ran the packaging checks on the files it published at
+  all, only `dist`'s throwaway copy ever saw them.
 
 - **Coverage measures branches and not only statements**
   (`btclib-org/.github#7`). `branch = true` in `[tool.coverage.run]`, the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -429,38 +429,54 @@ that way in the first place. The two commands above run in two passes
 either way, one `.venv` not being able to hold and lack the bindings at
 once.
 
-The `dist` job, which inspects what would be published and then
-installs it. The first two commands after the build read the *members* of
-the two archives, which the three that follow do not: an allowlist of what
-may be in a wheel and an sdist, and the bill of materials a release
-attaches — written here into a temporary directory and thrown away, this
-being the copy that says the script still reads a real wheel. That
-allowlist is stated in prose in
+The `dist` job, which builds the distribution files, checks them and
+then installs one. This is the one build there is (issue #1166):
+`release.yml`'s `test` job calls this workflow, so a tag runs the very
+same job, and its own `publish-testpypi` and `publish-pypi` jobs download
+the `dist` artifact this job uploads rather than building a second copy —
+so what the checks below judge is what an index ends up serving, byte for
+byte. The first two commands after the build are what make the wheel and
+the sdist reproducible — the first is why two checkouts of one commit
+produce the same wheel, the second why they produce the same sdist — and
+`sha256sum` after them is the digest a rebuild from the tag is compared
+against. The two after that read the *members* of the two archives,
+which the three checks further down do not: an allowlist of what may be
+in a wheel and an sdist, and the bill of materials a release attaches.
+That allowlist is stated in prose in
 [the package-content policy](./docs/source/package-content-policy.md),
 which the suite compares against the script's own constants, so changing
-a rule means changing both. The last
-commands ask for the wheel and nothing else, so
-what pulls btclib_secp256k1 in is the `Requires-Dist` the wheel carries
-for the `secp256k1` extra — which those commands name on both sides, a
-wheel installed without it declaring nothing to resolve. The lock
-arrives as constraints, which bind a version without
-requesting a package, so a release of the bindings cannot turn a required
-check red while the wheel's own metadata still does the work. That the
-bindings then *serve* is asserted rather than assumed: with the extra
+a rule means changing both. Both are written before anything is
+installed and uploaded before anything below reads `dist/` — installing
+a dependency executes its code, and a compromised one must not reach a
+`dist/` that still has to be handed on, so what the publish jobs will
+download is frozen before the twine, check-wheel-contents and pyroma
+steps below install anything at all. The two smoke tests ask for the
+wheel and nothing else, so what pulls btclib_secp256k1 in is the
+`Requires-Dist` the wheel carries for the `secp256k1` extra — which they
+name on both sides, a wheel installed without it declaring nothing to
+resolve. The first pins the lock as constraints, which bind a version
+without requesting a package, so a release of the bindings cannot turn a
+required check red while the wheel's own metadata still does the work;
+the second is unconstrained and release-only, asking instead whether the
+*newest* published bindings still satisfy the wheel, which is what a
+user installing it resolves — no pull request waits on it, only
+`release.yml`'s call sets the input that turns it on. That the bindings
+then *serve* is asserted rather than assumed in both: with the extra
 resolving to nothing, or to a release this tree cannot import, btclib
 falls back to the Python arithmetic and answers the version and the
 signature correctly — the supported configuration `no-bindings` runs the
 whole suite in — so the assertion is the only thing between that
-resolution and a green check. They run
-from an empty directory, or the import finds the source tree instead of
-the wheel:
+resolution and a green check. They run from an empty directory, or the
+import finds the source tree instead of the wheel:
 
 ```shell
+export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 uv build
+uv run --no-project --python 3.14 .github/scripts/normalize_sdist.py dist/
+sha256sum dist/*
 uv run --no-project --python 3.14 \
     .github/scripts/verify_dist_contents.py dist/
-SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) uv run --no-project \
-    --python 3.14 .github/scripts/generate_sbom.py dist/ "$(mktemp -d)"
+uv run --no-project --python 3.14 .github/scripts/generate_sbom.py dist/ sbom/
 uv run --locked --only-group check twine check --strict dist/*
 uv run --locked --only-group check check-wheel-contents dist/*.whl
 uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz
@@ -480,10 +496,33 @@ cd "$tmp" && uv venv &&
         'the secp256k1 extra resolved, the bindings do not serve'; \
       assert dsa.verify(b'btclib', pub_keyinfo_from_prv_key(1)[0], \
         dsa.sign(b'btclib', 1))"
+cd "$OLDPWD" &&
+    uv run --isolated --no-project --with "$(echo dist/*.whl)[secp256k1]" \
+    python -c "import btclib; \
+      from btclib.curves import is_libsecp256k1_serving; \
+      from btclib.ecc import dsa; \
+      from btclib.to_pub_key import pub_keyinfo_from_prv_key; \
+      print(btclib.__version__); \
+      assert btclib.__version__ != 'unknown'; \
+      assert is_libsecp256k1_serving(), \
+        'the secp256k1 extra resolved, the bindings do not serve'; \
+      assert dsa.verify(b'btclib', pub_keyinfo_from_prv_key(1)[0], \
+        dsa.sign(b'btclib', 1))"
 ```
 
-The checks the `release` workflow runs before building anything, the
-first of them being where the tag came from rather than what it says:
+A rehearsal (`workflow_dispatch`) runs one command ahead of the block
+above, which the tag path skips: `.github/actions/dev-version` rewrites
+`pyproject.toml`'s version with the `.dev<run*100+attempt>` suffix
+`release.yml`'s `version-check` job computed and re-locks, so that
+`uv build` above ships a version TestPyPI has not already seen. Neither
+of the two checks minds — what they judge is metadata syntax, README
+rendering, wheel layout and metadata quality, none of which a `.dev<N>`
+suffix changes — and both smoke tests do mind, installing the wheel that
+suffix names.
+
+The checks `release.yml`'s `version-check` job runs before anything is
+built, the first of them being where the tag came from rather than what
+it says:
 
 ```shell
 git merge-base --is-ancestor HEAD origin/main
@@ -491,43 +530,10 @@ uv lock --check
 uv version --short
 ```
 
-Its `build` job runs the same twine, check-wheel-contents and pyroma
-commands above again too, on the files it is about to publish rather
-than on `dist`'s own copy (issue #1154):
-
-```shell
-uv run --locked --only-group check twine check --strict dist/*
-uv run --locked --only-group check check-wheel-contents dist/*.whl
-uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz
-```
-
-It then repeats the smoke test above on the wheel it uploads, which is
-not the one `dist` built, and repeats it without the constraints. No
-pull request waits on that job and no branch rule names it, where
-`publish-testpypi` and `publish-pypi` both have it in `needs`: so it is
-the place to ask whether the newest published bindings satisfy the
-artifact, and a release stopping on that answer is the outcome wanted.
-Both run after the upload rather than before, the artifact being what
-the publish jobs download: installing a dependency executes its code,
-and a compromised one must not reach a `dist/` that has still to be
-handed on.
-
-What that job builds is reproducible, and the two steps that make it so
-are the two lines below — the first is why two checkouts of one commit
-produce the same wheel, the second why they produce the same sdist:
-
-```shell
-export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
-uv run --no-project --python 3.14 .github/scripts/normalize_sdist.py dist/
-```
-
-The bill of materials that job writes is reproducible for the same reason,
-that variable being its timestamp, so a rebuild verifies against the
-attestation exactly as the two distribution files do.
-
-RELEASING.md's "Rebuild a release from its tag" has them in the order a
-verifier runs them, with the `gh attestation verify` that gives the
-rebuild a verdict and the two bounds on what that verdict means.
+RELEASING.md's "Rebuild a release from its tag" has the reproducibility
+commands above in the order a verifier runs them, with the
+`gh attestation verify` that gives the rebuild a verdict and the two
+bounds on what that verdict means.
 
 The `latest` workflow, which upgrades every dependency uv resolves before
 running the suite, the lint gate and the packaging checks. The upgrade

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -47,22 +47,23 @@ Telling these apart is most of what can go wrong when cutting a release.
   index, PyPI rather than TestPyPI, and `version-check` exists to
   confirm it says what `pyproject.toml` says
 - **`2026.8.4.dev701`** is a rehearsal, and nobody types it either half
-  at a time: `.dev<run*100+attempt>` is the template the `build` job
-  patches into `pyproject.toml` when `workflow_dispatch` starts the
+  at a time: `.dev<run*100+attempt>` is the template `version-check`
+  computes and the `dev-version` action patches into `pyproject.toml`
+  in test.yml's `dist` job when `workflow_dispatch` starts the
   workflow, `github.run_number` counted for `release.yml` alone and
   `github.run_attempt` counted for one dispatch of it, so the seventh
   such run's first attempt, rehearsing `2026.8.4`, produces exactly
   that. The multiplier is what makes a re-run a version of its own
-  rather than a collision: a re-run keeps the run's own number and only
-  raises the attempt, so the run number alone was identical across
-  every re-run of one dispatch and PEP 440 could not tell them apart.
-  Placing the attempt below the run number's own place value keeps a
-  run's later attempts sorting after its earlier ones and before the
-  next run's, the attempt therefore capped at two digits and the
-  workflow refusing a hundredth rather than silently wrapping into the
-  next run's range. Nothing commits the result: `uv lock` runs straight
-  after, so the lockfile the sdist ships agrees with the version it is
-  named for
+  rather than a collision (issue #1156): a re-run keeps the run's own
+  number and only raises the attempt, so the run number alone was
+  identical across every re-run of one dispatch and PEP 440 could not
+  tell them apart. Placing the attempt below the run number's own place
+  value keeps a run's later attempts sorting after its earlier ones and
+  before the next run's, the attempt therefore capped at two digits and
+  the workflow refusing a hundredth rather than silently wrapping into
+  the next run's range. Nothing commits the result: `uv lock` runs
+  straight after, so the lockfile the sdist ships agrees with the
+  version it is named for
 - **`2026.8.4rc1`**, and a `v2026.8.4rc1` tag, have no place in this
   scheme: there is no pre-release here, only a version not yet tagged.
   `version-check` refuses anything that is not digits and dots, which
@@ -107,9 +108,9 @@ Already done for btclib-org/btclib; kept here for the record.
 ## Rehearse on TestPyPI
 
 A rehearsal runs the identical pipeline — lint gate, test matrix, the
-packaging checks of the `dist` job (twine, check-wheel-contents,
-pyroma), build (which runs those same three checks again, on the files
-it is about to publish), wheel smoke test — and publishes to
+`dist` job's build, its packaging checks (twine, check-wheel-contents,
+pyroma) and its two wheel smoke tests, one pinned by `uv.lock` and one
+unconstrained — and publishes the very files those checks passed to
 [TestPyPI](https://test.pypi.org/project/btclib/) instead of PyPI.
 
 1. On GitHub, Actions → release → Run workflow, and pick the branch to
@@ -514,9 +515,11 @@ to `latest`'s own result.
 
 ## Rebuild a release from its tag
 
-The `build` job exports `SOURCE_DATE_EPOCH` from the commit date and
+test.yml's `dist` job exports `SOURCE_DATE_EPOCH` from the commit date and
 normalizes the sdist, so a rebuild of a released tag is the same bytes as
-what was published. Anyone can check that, and the check is one command
+what was published — that job's own upload is what `publish-pypi`
+publishes, unchanged, so "what was published" and "what that job built"
+are the same files (issue #1166). Anyone can check that, and the check is one command
 short of the provenance one above: verify the *rebuilt* file rather than a
 downloaded one, and it can only pass if the digests agree. A release whose
 assets carry `<tag>.attestation.jsonl` has the signed statement on disk

--- a/docs/source/package-content-policy.md
+++ b/docs/source/package-content-policy.md
@@ -7,9 +7,10 @@ are read before either is published.
 
 `.github/scripts/verify_dist_contents.py` enforces every rule down to the
 last section — the `dist` job of `test.yml` runs it on a build of every
-pull request, and the `build` job of `release.yml` on the files it is
-about to upload. The last section is the rules nothing here enforces,
-which say so one by one rather than leaving the list looking complete.
+pull request, and the same job, reached through `release.yml`'s `test`
+call, on the files it is about to upload. The last section is the rules
+nothing here enforces, which say so one by one rather than leaving the
+list looking complete.
 
 The script's constants are those rules, and the paragraph introducing
 each list below names the ones the list states.

--- a/tests/generate_sbom_test.py
+++ b/tests/generate_sbom_test.py
@@ -363,9 +363,10 @@ def test_main_names_the_file_after_the_wheel(
 ) -> None:
     """The caller passes a directory and needs to know no version.
 
-    Which in a rehearsal it does not: the `build` job patches a
-    `.dev<run*100+attempt>` into the version before building, so the name
-    the workflow would have to construct is not the one in pyproject.toml.
+    Which in a rehearsal it does not: test.yml's `dist` job patches a
+    `.dev<run*100+attempt>` into the version, through
+    `.github/actions/dev-version`, before building, so the name the
+    workflow would have to construct is not the one in pyproject.toml.
     """
     monkeypatch.setenv("SOURCE_DATE_EPOCH", str(_EPOCH))
     write_dist(tmp_path, version="2026.9.dev7")

--- a/tests/verify_dist_contents_test.py
+++ b/tests/verify_dist_contents_test.py
@@ -5,8 +5,9 @@
 """Tests for the distribution-content check of `.github/scripts`.
 
 What CI can show is that a real build passes: the `dist` job of test.yml
-runs the script on every pull request, and the `build` job of release.yml
-on the files it is about to publish. What CI cannot show is that anything
+runs the script on every pull request, and the same job -- reached
+through release.yml's `test` call -- on the files it is about to
+publish. What CI cannot show is that anything
 *fails* -- a wheel with a shared object in it is not something a workflow
 can produce on purpose -- so the archives here are synthetic, one member
 planted per rule, and the assertion is the complaint.


### PR DESCRIPTION
Closes #1166.

**Rebased once, by hand, after a review finding.** This branch was cut
before issue #1156 (PR #1168) merged, so when the rehearsal-suffix
computation moved into the new `version-check` step below, it was
re-derived from `release.yml`'s `build` job as it then stood — the
pre-#1168, uncollision-fixed `.dev<run number>` formula, not the
`.dev<run*100+attempt>` one #1168 landed an hour later. A cross-review
by the worker who fixed that collision caught it. Rebased onto `main`
(now carrying #1168), the suffix step carries `run_number * 100 +
run_attempt` and the two-digit attempt guard forward from #1168
unchanged rather than re-derived, and five prose sites that had
propagated the stale template — three in `RELEASING.md`, one in
`CONTRIBUTING.md`, one in the `CHANGELOG.md` entry — are fixed to
match. Every gate below and the reproducibility digests were re-run
against the post-rebase head.

## What each of the three actually does (before this PR)

| | btclib | btclib-secp256k1 | bitcoin-core-rpc |
|---|---|---|---|
| builds | `test.yml`'s `dist` job (thrown away) **and** `release.yml`'s `build` job (published) — two builds | `test.yml`'s `build-*` jobs, once | `test.yml`'s `dist` job (thrown away) **and** `release.yml`'s `build` job (published) — two builds |
| checks | both builds checked (twine/check-wheel-contents/pyroma), since issue #1154 | the one build, in `test.yml`'s `check-dist` | both builds checked, since issue btclib-org/bitcoin-core-rpc#155, landed today while this PR was in flight |
| published artifact | `release.yml`'s `build` job's own copy | `test.yml`'s `build-*` artifacts, downloaded unchanged | `release.yml`'s `build` job's own copy |
| inspected == published, byte for byte | **no** — two independent builds of the same tree, `release.yml`'s missing `SOURCE_DATE_EPOCH`/normalization on top | **yes**, by construction — one artifact, uploaded once | **no** — same shape as btclib |

btclib-secp256k1 needed no change: it already has the target shape, and
issue #1166 names it as the model. bitcoin-core-rpc gets its own PR,
referencing this one, rather than being folded in here — its starting
point turned out to differ mid-flight (see "Collision note" below).

## What this PR does

`test.yml`'s `dist` job now does everything `release.yml`'s `build`
job used to, and `release.yml` no longer has a `build` job:

- pins `SOURCE_DATE_EPOCH` from the commit and normalizes the sdist
  (previously only in `build`, so `dist`'s own build was not
  reproducible)
- applies a rehearsal's version suffix through a new
  `.github/actions/dev-version` composite action, so `dist` can build
  the suffixed tree too — the suffix itself is now computed once in
  `version-check` and passed down as a `workflow_call` input, so every
  job the release dispatches during one run agrees on it
- uploads the `dist` and `sbom` artifacts **before** installing
  anything (twine/check-wheel-contents/pyroma, the smoke tests) —
  preserved exactly, not reordered: installing a dependency executes
  its code, and a compromised one must not reach a `dist/` still to be
  handed on
- runs twine, check-wheel-contents and pyroma once, not twice
- runs two smoke tests: the existing one, pinned by `uv.lock` (what a
  required check can afford); and a new one carried over from
  `release.yml`'s `build` job, unconstrained, asking whether the
  *newest* published `btclib_secp256k1` still satisfies the wheel —
  gated on a new `check-newest-bindings` boolean input only
  `release.yml`'s call sets to `true`, so no pull request and no
  ordinary push to `main` pays for a question a required check cannot
  afford a red answer to (see "Alternative considered" below)

`release.yml`'s `publish-testpypi`, `publish-pypi` and `attest` jobs
are otherwise unchanged: they already downloaded artifacts named
`dist`/`sbom` by name, which now come from `test.yml`'s `dist` job
instead of `release.yml`'s own `build` job — nothing downstream had to
change to start receiving the one true build.

### Alternative considered and rejected: `github.event_name != 'pull_request'`

Inside a called workflow, `github.event_name` reflects the *caller's*
trigger, not `workflow_call` — so it is `'push'` or `'workflow_dispatch'`
whether `release.yml` called `test.yml` or a bare push to `main` /
manual dispatch of `test.yml` did. Gating the unconstrained smoke test
on `!= 'pull_request'` would therefore also run it on every ordinary
push to `main`, which the issue never asked for and which the original
code (only in `release.yml`) never did. The explicit
`check-newest-bindings` input, set only by `release.yml`'s call, keeps
the exact same trigger surface as before.

## Verifying inspected == published, byte for byte

The property now holds **by construction**, not by comparison: there is
exactly one `uv build` invocation anywhere in the release path, in
`test.yml`'s `dist` job, and `release.yml`'s publish/attest/github-release
jobs all download the `dist`/`sbom` artifacts *that job* uploaded, by
name, never rebuilding.

```shell
$ grep -n 'run: uv build' .github/workflows/release.yml .github/workflows/test.yml
.github/workflows/test.yml:593:        run: uv build
```

One build, in `test.yml`'s `dist` job; `release.yml` has none.

```shell
$ grep -n 'name: dist$\|name: sbom$' .github/workflows/test.yml .github/workflows/release.yml
.github/workflows/test.yml:642:          name: dist
.github/workflows/test.yml:651:          name: sbom
.github/workflows/release.yml:293:          name: dist
.github/workflows/release.yml:319:          name: dist
.github/workflows/release.yml:381:          name: dist
.github/workflows/release.yml:388:          name: sbom
.github/workflows/release.yml:471:          name: dist
.github/workflows/release.yml:483:          name: sbom
```

`test.yml`'s two are the `dist` job's own `upload-artifact` steps
(`Upload the distribution files`, `Upload the bill of materials`);
`release.yml`'s six are `download-artifact` steps in
`publish-testpypi`, `publish-pypi`, `attest` (both) and
`github-release` (both). One upload of each name, no upload of either
name anywhere else in the release path.

Reproducibility of that one build — the property `SOURCE_DATE_EPOCH`
and the sdist normalizer exist for — verified by building the pushed
commit twice, independently, from two fresh `git archive` checkouts.
**Updated after a rebase onto `main`** (see the note at the top of
this body): the numbers below are against `3ce09853`, the current
head, not the sha this section originally quoted.

```shell
$ git archive 3ce09853145811178912f8aa994a193405049227 | tar -x -C /tmp/checkout-a
$ git archive 3ce09853145811178912f8aa994a193405049227 | tar -x -C /tmp/checkout-b
$ export SOURCE_DATE_EPOCH=1787321760   # git log -1 --pretty=%ct, the pushed commit
$ cd /tmp/checkout-a
$ uv build && uv run --no-project --python 3.14 \
    .github/scripts/normalize_sdist.py dist/ && sha256sum dist/*
d35d0523b75cc9233694b17691d39f1539b58bbc049ade356a723c4f9e8a7f81  btclib-2026.9-py3-none-any.whl
e2186cda0878fc9d005c5c1bcd060f6cae7c22e90416e8ccd69a3d7e2b23ab4c  btclib-2026.9.tar.gz
$ cd /tmp/checkout-b && <same three commands>
d35d0523b75cc9233694b17691d39f1539b58bbc049ade356a723c4f9e8a7f81  btclib-2026.9-py3-none-any.whl
e2186cda0878fc9d005c5c1bcd060f6cae7c22e90416e8ccd69a3d7e2b23ab4c  btclib-2026.9.tar.gz
```
Both digests identical across two independent `git archive` checkouts
of the pushed commit, both files.

## Constraints preserved

- **Reproducibility**: `SOURCE_DATE_EPOCH` from the tagged commit and
  the sdist normalization step both moved into `test.yml`'s `dist` job
  unchanged — verified above.
- **Smoke test after upload**: both smoke tests (the existing
  `uv.lock`-pinned one and the new unconstrained one) run after the two
  `upload-artifact` steps, exactly where `release.yml`'s `build` job
  had them, for the same reason its comment gave: installing a
  dependency executes its code, and a compromised one must not reach a
  `dist/` still to be handed on. Not reordered.

## Verified locally (`uv sync --locked`, this repo's worktree)

| check | command | exit |
|---|---|---|
| pre-commit (includes actionlint, zizmor, yamllint on the workflow files) | `uv run --locked --only-group lint pre-commit run --all-files` | 0 |
| tests | `uv run pytest` | 0 (29393 passed, 11 skipped) |
| docs | `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html` | 0 |
| `dist` job — build | `SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) uv build` | 0 |
| `dist` job — sdist normalize | `uv run --no-project --python 3.14 .github/scripts/normalize_sdist.py dist/` | 0 |
| `dist` job — contents | `uv run --no-project --python 3.14 .github/scripts/verify_dist_contents.py dist/` | 0 |
| `dist` job — SBOM | `uv run --no-project --python 3.14 .github/scripts/generate_sbom.py dist/ sbom/` | 0 |
| `dist` job — twine | `uv run --locked --only-group check twine check --strict dist/*` | 0 |
| `dist` job — wheel contents | `uv run --locked --only-group check check-wheel-contents dist/*.whl` | 0 |
| `dist` job — pyroma | `uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz` | 0 |
| `dist` job — constrained smoke test | (`uv.lock`-pinned install + import/verify) | 0 |
| `dist` job — unconstrained smoke test | (`--isolated --with` install + import/verify) | 0 |
| reproducibility | two independent `git archive` builds, digests compared | identical |

## Not verified

The release path itself — a real tag push or an actual
`workflow_dispatch` rehearsal against `release.yml` — was **not**
exercised. Standing collision-warning rule against dispatching
`release.yml` while other workers hold it (issues #1156, #1158,
#1165); this PR's diff is scoped to the build/publish seam and the
commands above reproduce every step of `dist` and the pre-build checks
of `version-check` outside CI. `actionlint` and `zizmor` (both in the
pre-commit run above) validate the workflow YAML itself, including the
`workflow_call` input plumbing and the composite action reference.

## Collision note

Touches `release.yml` and `test.yml`, named in the standing collision
warning as held by workers on issues #1156, #1158, #1160 and #1165.
Rebased onto `origin/main` immediately before pushing (last picked up:
#1154's follow-on cache-comment fix and #1159's SBOM RELEASING.md
note, both merged in the meantime, neither touching the same lines).

## Summary by Sourcery

Make test.yml's dist job build, validate, and upload the exact reproducible artifacts that release workflows publish.

New Features:
- Route release distribution builds through test.yml's dist job so the checked artifacts are the exact files published and attested.
- Add release-only validation against the newest published btclib_secp256k1 bindings.

Bug Fixes:
- Ensure rehearsal version suffixes are applied to the single published build and remain consistent across the release workflow.
- Make release distribution and SBOM artifacts reproducible by preserving commit-based timestamps and sdist normalization.

Enhancements:
- Remove the duplicate release.yml build job and centralize packaging checks, smoke tests, and artifact uploads in test.yml's dist job.
- Compute rehearsal suffixes once in version-check and pass them into the called workflow through explicit inputs.
- Upload distribution artifacts before installing packaging and runtime dependencies, while disabling dependency caching for release builds.

Documentation:
- Update release, contribution, changelog, and package-content guidance to describe the single-build release flow and reproducibility checks.
