### PR TITLE
docs/source/package-content-policy.md records why check-wheel-contents runs unconfigured here (issue #1160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,8 +115,8 @@ documented at release-notes length in the first place, and are still in
   [ISS #1152](https://github.com/btclib-org/btclib/issues/1152), and this
   change made that fix wrong a second time.
 - **`docs/source/package-content-policy.md` records why
-  `check-wheel-contents` runs unconfigured here**, closing issue #1160.
-  The survey behind it found two half-measures split across the three
+  `check-wheel-contents` runs unconfigured here** (issue #1160). The
+  survey behind it found two half-measures split across the three
   publishing repositories: this project's `verify_dist_contents.py`, and
   `btclib-secp256k1`'s configured `[tool.check-wheel-contents]`
   (`ignore = ["W003", "W009"]`, for the shared library its dynamic wheel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,38 @@ documented at release-notes length in the first place, and are still in
   `head_ref` form, by the survey behind
   [ISS #1152](https://github.com/btclib-org/btclib/issues/1152), and this
   change made that fix wrong a second time.
+- **`docs/source/package-content-policy.md` records why
+  `check-wheel-contents` runs unconfigured here**, closing issue #1160.
+  The survey behind it found two half-measures split across the three
+  publishing repositories: this project's `verify_dist_contents.py`, and
+  `btclib-secp256k1`'s configured `[tool.check-wheel-contents]`
+  (`ignore = ["W003", "W009"]`, for the shared library its dynamic wheel
+  legitimately ships beside the package). `bitcoin-core-rpc` had
+  neither, and gained a configured `check-wheel-contents` of its own in
+  its own pull request (btclib-org/bitcoin-core-rpc#178) rather than a
+  ported script — a single-module, dependency-free package with no data
+  directory has nothing a completeness diff against its own source tree
+  does not already answer. `btclib-secp256k1` gained a wheel-only
+  script, `verify_wheel_contents.py`, tailored to two wheel kinds
+  (btclib-org/btclib-secp256k1#312): its wheels are not one package
+  tree, so `check-wheel-contents --package` cannot be configured into
+  correctness there the way it could for `bitcoin-core-rpc` — it reports
+  the compiled artifact every one of its wheels legitimately carries at
+  the wheel's own root as "not in package tree".
+
+  Nothing here ships outside `btclib/`, so `W003`/`W009` could never
+  fire, and configuring `check-wheel-contents --package btclib` would be
+  a third way of asking a question this project's own two-hop chain
+  already answers: `check-manifest` diffs the sdist against this
+  checkout, `verify_dist_contents.py`'s completeness check diffs the
+  wheel against the sdist, and chained the two give checkout tree ==
+  sdist == wheel, which is what `--package` would assert directly and
+  in one hop over the same ground. This entry is the whole of what
+  changed in this repository: `verify_dist_contents.py` already ran on
+  the files `release.yml` uploads as well as on every pull request
+  (issue #1154, #1164), so the decision above closes #1160 with no
+  script or workflow change here, only the record of why one was not
+  needed.
 
 - **`published.yml`'s steps declare `shell: bash`** (issue #1141). The
   matrix includes `windows-latest` and `windows-11-arm`, where the default

--- a/docs/source/package-content-policy.md
+++ b/docs/source/package-content-policy.md
@@ -125,13 +125,13 @@ one installing the wheel, or the reverse.
 
 ## check-wheel-contents needs no configuration here
 
-`check-wheel-contents` runs unconfigured, in both jobs `verify_dist_
-contents.py` runs in, and btclib-org/btclib#1160 is where that was
-decided rather than merely left alone. `btclib-secp256k1` configures
-`[tool.check-wheel-contents]` — `ignore = ["W003", "W009"]`, for the
-shared library its dynamic wheel ships beside the package — because its
-wheel is not one package tree: a legitimate top-level member outside
-`btclib_secp256k1/` is exactly what those two checks exist to flag.
+`check-wheel-contents` runs unconfigured, in both jobs `verify_dist_contents.py`
+runs in, and btclib-org/btclib#1160 is where that was decided rather than merely
+left alone. `btclib-secp256k1` configures `[tool.check-wheel-contents]` —
+`ignore = ["W003", "W009"]`, for the shared library its dynamic wheel ships
+beside the package — because its wheel is not one package tree: a legitimate
+top-level member outside `btclib_secp256k1/` is exactly what those two checks
+exist to flag.
 Nothing here ships outside `btclib/`, so neither check would ever fire,
 and an `ignore` list naming codes that can never trigger would be a line
 asserting a fact instead of preventing one.

--- a/docs/source/package-content-policy.md
+++ b/docs/source/package-content-policy.md
@@ -125,10 +125,12 @@ one installing the wheel, or the reverse.
 
 ## check-wheel-contents needs no configuration here
 
-`check-wheel-contents` runs unconfigured, in both jobs `verify_dist_contents.py`
-runs in, and btclib-org/btclib#1160 is where that was decided rather than merely
-left alone. `btclib-secp256k1` configures `[tool.check-wheel-contents]` —
-`ignore = ["W003", "W009"]`, for the shared library its dynamic wheel ships
+`check-wheel-contents` runs unconfigured, in the one job
+`verify_dist_contents.py` runs in — `test.yml`'s `dist` job, on every pull
+request and, through `release.yml`'s `test` call, on the files a release
+publishes — and btclib-org/btclib#1160 is where that was decided rather than
+merely left alone. `btclib-secp256k1` configures `[tool.check-wheel-contents]`
+— `ignore = ["W003", "W009"]`, for the shared library its dynamic wheel ships
 beside the package — because its wheel is not one package tree: a legitimate
 top-level member outside `btclib_secp256k1/` is exactly what those two checks
 exist to flag.

--- a/docs/source/package-content-policy.md
+++ b/docs/source/package-content-policy.md
@@ -123,6 +123,35 @@ from it, so `btclib/` is the same set of files in both; a difference
 either way is a file that reaches a user installing from source and not
 one installing the wheel, or the reverse.
 
+## check-wheel-contents needs no configuration here
+
+`check-wheel-contents` runs unconfigured, in both jobs `verify_dist_
+contents.py` runs in, and btclib-org/btclib#1160 is where that was
+decided rather than merely left alone. `btclib-secp256k1` configures
+`[tool.check-wheel-contents]` — `ignore = ["W003", "W009"]`, for the
+shared library its dynamic wheel ships beside the package — because its
+wheel is not one package tree: a legitimate top-level member outside
+`btclib_secp256k1/` is exactly what those two checks exist to flag.
+Nothing here ships outside `btclib/`, so neither check would ever fire,
+and an `ignore` list naming codes that can never trigger would be a line
+asserting a fact instead of preventing one.
+
+The stronger question is whether `check-wheel-contents --package btclib`
+would catch something this script does not: a full diff of the wheel's
+`btclib/` against this checkout's own, the same completeness
+`bitcoin-core-rpc` gained by configuring `package = ["bitcoin_core_rpc"]`
+in that repository's own pull request (btclib-org/bitcoin-core-rpc#178),
+for a project with no second check standing behind it. This project
+already has two: `check-manifest`, a pre-commit hook gated by the lint
+workflow, diffs the sdist against this same tree, and the completeness
+check above — `uv build` builds the sdist and then the wheel from it, so
+`btclib/` is the same set of files in both, and a difference either way
+is reported — diffs the wheel against the sdist. Chained, checkout tree
+== sdist == wheel, which is what `--package` would assert directly and
+in one hop; configuring it here would be a third way of asking a question
+two already answer, watching the same failure from a different angle
+rather than closing a gap neither covers.
+
 ## The rules nothing here enforces
 
 Three rules of the policy `diybitcoinhardware/embit` publishes beside its


### PR DESCRIPTION
## Summary

Closes #1160, filed from the release-machinery survey
(#1152, divergence 11, "right: decide"). Two half-measures for one
question, split across the organization's three publishing
repositories: `btclib` runs a hand-written script comparing a built
wheel and sdist, member for member, against an allowlist;
`btclib-secp256k1` configures `[tool.check-wheel-contents]`.
`bitcoin-core-rpc` had neither.

## Current state (established before deciding)

| repository | member-listing script | configured `check-wheel-contents` | runs on |
| --- | --- | --- | --- |
| `btclib` (this repository) | `verify_dist_contents.py`, paired with this page via a test comparing the two in both directions | not configured (defaults) | `test.yml`'s `dist` job **and** `release.yml`'s `build` job — the exact files it uploads (issue #1154, #1164) |
| `btclib-secp256k1` | none, before #312 | `ignore = ["W003", "W009"]`, for the shared library a dynamic wheel ships beside the package | `test.yml`'s `check-dist` job, which `release.yml`'s `test` job calls and whose artifacts the publish jobs upload |
| `bitcoin-core-rpc` | none | not configured, before #178 | `test.yml`'s `dist` job only (`release.yml`'s `build` job rebuilds without inspecting, tracked separately as bitcoin-core-rpc#155) |

This repository already has both mechanisms, on both artifacts: the
"which artifact" half of divergence 9 (checks running on the files
`release.yml` uploads, not just the files `dist` builds) was closed
here in #1164, before this issue was filed. What #1160 asks is
one-mechanism-or-two, and this PR is where that gets decided and
recorded, across all three repositories.

## Decision: two mechanisms, one per shape, and no change to this one

Each repository gets the check that fits what it ships, not a copy of
another repository's:

- **`bitcoin-core-rpc`** is a single module, zero dependencies, no data
  directory — its own PR (btclib-org/bitcoin-core-rpc#178) configures
  `check-wheel-contents` directly (`package = ["bitcoin_core_rpc"]`),
  measured to catch what unconfigured `check-wheel-contents` misses (a
  wheel built with `py.typed` stripped out and `RECORD` edited to
  match passes unconfigured and fails configured, `W101`). No script
  ported for symmetry: `check-manifest`, already gating the sdist,
  plus that one configuration line give the same `git tree == sdist ==
  wheel` guarantee this repository's two-hop chain gives, over a
  package with nothing a second check would add.
- **`btclib-secp256k1`** ships wheels that are not one package tree — a
  compiled artifact sits beside `btclib_secp256k1/` rather than inside
  it, which `check-wheel-contents --package` reports as "not in
  package tree" whether or not it belongs, measured against a real
  static wheel. Its own PR (btclib-org/btclib-secp256k1#312) adds a
  wheel-only script, `verify_wheel_contents.py`, tailored to its two
  wheel kinds, with its own policy page
  (`docs/source/package-content-policy.md` there) and its own pairing
  test — the pairing mechanism carried across, not the constants,
  which describe a different shape. Its sdist is explicitly out of
  scope there: an *exclude*-based sdist (`~300` members, mostly the
  vendored `secp256k1/` submodule) inverts the failure mode this class
  of check exists for, and modelling it would be an allowlist nobody
  could maintain.
- **This repository** needs no change to `verify_dist_contents.py` or
  to how it runs. What this PR adds is the answer to the one open
  question — does `check-wheel-contents` want configuring here too —
  in a new section of `docs/source/package-content-policy.md`:
  nothing here ships outside `btclib/`, so `W003`/`W009` can never
  fire, and `--package btclib` (the flag `bitcoin-core-rpc` configured)
  would be a third way of asking what this project's own two-hop chain
  already answers — `check-manifest` diffs the sdist against the
  checkout, `verify_dist_contents.py`'s completeness check diffs the
  wheel against the sdist, and chained the two give checkout tree ==
  sdist == wheel directly.

`tests/verify_dist_contents_test.py`'s pairing tests
(`test_the_page_states_what_the_script_enforces`,
`test_the_page_states_every_rule_the_script_has`) still pass: the new
section names no script constant in its lead paragraph, so it is
prose the pairing test does not examine, same as the existing "rules
nothing here enforces" section.

## Verification

- `uv run --locked --only-group lint pre-commit run --all-files`:
  exit 0 (includes `check-manifest` and `Check package with Pyroma`)
- `uv run --locked --no-default-groups --group test pytest`: exit 0,
  29393 passed, 11 skipped (all `BTCLIB_INTEGRATION`/hardware/vector
  skips, none related to this change;
  `tests/verify_dist_contents_test.py` alone: 38 passed)
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html`: exit 0

`dist`'s own commands, from CONTRIBUTING.md, run by hand:

- `uv build`: exit 0
- `uv run --no-project --python 3.14
  .github/scripts/verify_dist_contents.py dist/`: exit 0, "carry what
  they may and no more", one payload of 155 files in both
- `SOURCE_DATE_EPOCH=... uv run --no-project --python 3.14
  .github/scripts/generate_sbom.py dist/ <tmp>`: exit 0
- `uv run --locked --only-group check twine check --strict dist/*`:
  exit 0, `PASSED` on both files
- `uv run --locked --only-group check check-wheel-contents
  dist/*.whl`: exit 0, `OK` — confirms the "needs no configuration"
  decision against a real build
- `uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz`:
  exit 0, 10/10
- installed the wheel with the `secp256k1` extra, constrained, into an
  empty directory, and ran the smoke test CONTRIBUTING.md gives: exit
  0, `2026.9`, bindings serving, a signature made and verified

## Summary by Sourcery

Document the decision to retain the existing package-content validation approach without changing scripts or workflows.

Enhancements:
- Document why this repository keeps `check-wheel-contents` unconfigured: its existing sdist and wheel checks already establish equivalent package-content coverage, while the package layout does not trigger the relevant warnings.

Documentation:
- Record the package-content policy decision and its relationship to the differing validation strategies used by the organization's publishing repositories.