### PR TITLE
published.yml checks the secp256k1 extra actually serves (issue #1143)

### DIFF
--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -32,6 +32,22 @@ name: published
 # yet published, asked before publication rather than after, and asking
 # it here would be asking it one step too late to matter to what gets
 # published next
+#
+# Two jobs, not one job asking both questions or one matrix carrying an
+# extra axis, because they are entitled to different answers.
+# install-published names no extra, so it is answering whether the
+# supported no-bindings configuration -- issues #990, #991 and #992 --
+# installs and works; it has not asked the index for the bindings and
+# cannot ask whether they serve. install-published-secp256k1 names the
+# extra a user who wants the bindings actually types, and is the one this
+# workflow lacked until issue #1143: `btclib/_libsecp256k1.py` answers a
+# resolution it cannot import with `INSTALLED = False`, no error and no
+# warning, so a pair broken on the index degrades silently to the Python
+# arithmetic -- tens of times slower, not constant-time -- rather than
+# failing here. An axis over the base matrix would ask that question on
+# every (os, python) cell the no-bindings question already uses; a job of
+# its own asks it on the cells that actually vary for it instead, which
+# is argued where that job's own matrix is
 
 on:
   schedule:
@@ -259,3 +275,104 @@ jobs:
               '8e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c8' \
               '1b2f001698e7463b04'); \
             assert seed == expected, seed"
+
+  install-published-secp256k1:
+    name: >-
+      Install ${{ matrix.python }}[secp256k1] from PyPI on
+      ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-26-intel
+          - macos-latest
+          - windows-latest
+          - windows-11-arm
+        # one interpreter, where install-published samples three: the
+        # bindings publish a wheel per (platform, interpreter) pair, so a
+        # broken pair can in principle hide behind either axis, but the
+        # two are not equally likely to hide one. Measured against
+        # https://pypi.org/pypi/btclib-secp256k1/json for the newest
+        # release, 0.8.0.4: every platform below has a wheel for every
+        # supported interpreter, cp310 through cp315(t), so trying a
+        # second interpreter on a platform that already has one answers
+        # the same "does a wheel exist and import here" question again.
+        # A missing wheel is where the two publishing pipelines actually
+        # differ per platform -- a manylinux build, a macOS universal2
+        # build and a Windows build are three independent jobs in the
+        # bindings' own release workflow -- which is why the platform axis
+        # stays install-published's own instead of shrinking to one, the
+        # thing issue #1143 asks to be argued rather than assumed.
+        # 3.14 and not install-published's 3.10 floor: the same JSON API
+        # answer says btclib_secp256k1 ships no win_arm64 wheel below
+        # cp311, which is what makes install-published fetch an emulated
+        # win_amd64 interpreter for its 3.10 cell on windows-11-arm (see
+        # that job's own comment). 3.14 has a native win_arm64 wheel, so
+        # this job resolves the bindings this platform actually ships
+        # rather than exercising that workaround a second time
+        python: ["3.14"]
+    timeout-minutes: 20
+    steps:
+      # the same wait, for the same reason install-published's copy
+      # states: a run started by release.yml's call must not measure the
+      # version the tag is replacing
+      - name: Wait for the index to serve the released version
+        if: inputs.version != ''
+        shell: bash
+        env:
+          TAG: ${{ inputs.version }}
+        run: |
+          version="${TAG#v}"
+          for attempt in $(seq 20); do
+            if curl -sf --max-time 10 -o /dev/null \
+                "https://pypi.org/pypi/btclib/${version}/json"; then
+              echo "the index serves ${version}"
+              exit 0
+            fi
+            echo "attempt ${attempt}: ${version} is not served yet"
+            sleep 15
+          done
+          echo "::error::${version} never appeared on the index"
+          exit 1
+      - name: Setup uv with Python ${{ matrix.python }}
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          python-version: ${{ matrix.python }}
+      # --only-binary on both packages: btclib for the reason
+      # install-published's own comment gives, and btclib_secp256k1 for
+      # the same one applied to the package this job adds. Without it, a
+      # wheel the bindings have not published for this cell demotes the
+      # install to a source build -- a C toolchain question a hosted
+      # runner may or may not answer -- and the run would stay green
+      # while never having asked whether a published wheel imports
+      - name: Install btclib[secp256k1] from PyPI
+        shell: bash
+        run: |
+          uv venv --python ${{ matrix.python }}
+          uv pip install --verbose \
+            --only-binary btclib --only-binary btclib_secp256k1 \
+            "btclib[secp256k1]"
+      # is_libsecp256k1_serving is the assertion install-published's own
+      # comment says it is not entitled to, that job's install naming no
+      # extra. This job names the extra, so it is entitled to the
+      # question and asks it before the signature, which is what gives
+      # that signature its meaning: verified by libsecp256k1 rather than,
+      # unnoticed, by the Python arithmetic it would otherwise silently
+      # be -- issue #1116, live on main once already, is exactly the
+      # failure a passing signature alone cannot distinguish from this
+      - name: Verify the bindings serve, with a signature round tripped
+        shell: bash
+        run: |
+          uv run --no-project python -c "import btclib; \
+            from btclib.curves import is_libsecp256k1_serving; \
+            from btclib.ecc import dsa; \
+            from btclib.to_pub_key import pub_keyinfo_from_prv_key; \
+            print(btclib.__version__); \
+            assert btclib.__version__ != 'unknown'; \
+            assert is_libsecp256k1_serving(), \
+              'the secp256k1 extra resolved, the bindings do not serve'; \
+            assert dsa.verify(b'btclib', pub_keyinfo_from_prv_key(1)[0], \
+              dsa.sign(b'btclib', 1))"

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -214,12 +214,12 @@ jobs:
       # named, and now the one thing a wheel cell here cannot become by
       # accident. Only btclib is constrained either way, never its
       # dependencies: this install names no extra, so btclib_secp256k1 is
-      # one of them and is left to resolve however pip normally would
-      # (issue #1143 is the open question of asking for it at all,
-      # unaffected by either flag here since neither names that package --
-      # adding the extra later would need its own --only-binary
-      # btclib_secp256k1 alongside this one, the same flag applied a
-      # second time rather than a reason to change this one). An
+      # one of them and is left to resolve however pip normally would,
+      # and neither flag here names it. install-published-secp256k1,
+      # below, is the job that names the extra and is entitled to
+      # constrain btclib_secp256k1 too, with its own --only-binary --
+      # the same flag applied a second time rather than a reason to
+      # change this one. An
       # environment variable and a shell conditional rather than a ${{ }}
       # expression inside run, as both siblings already do: matrix values
       # are not attacker-controlled, but the pattern is worth keeping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,46 @@ documented at release-notes length in the first place, and are still in
   rule it stated no longer being true, and every other place stating
   the old template — `generate_sbom.py` and its test among them — now
   states the new one.
+- **`published.yml` gets a second job that installs `btclib[secp256k1]`
+  from the index and checks the bindings serve** (issue #1143).
+  `install-published` names no extra, deliberately: it answers whether
+  the supported no-bindings configuration of issues #990, #991 and #992
+  installs and works, and asserting the bindings there would contradict
+  that configuration. Nothing else asked the question a user who wants
+  the bindings actually types, and its failure is silent —
+  `btclib/_libsecp256k1.py` answers a resolution it cannot import with
+  `INSTALLED = False`, no error and no warning, so a pair broken on the
+  index degrades to the Python arithmetic, tens of times slower and not
+  constant-time, while every check `install-published` runs still
+  passes. Issue #1116 was exactly that state, live on `main`, and only
+  the pre-upload smoke tests of `test.yml`'s `dist` job and `release.yml`'s
+  `build` job — issue #1117 — catch the version *about to be* published;
+  nothing watched the pair afterwards, and it can break on either side's
+  release day without this repository changing at all.
+
+  A job of its own, not a second cell of the existing matrix: doubling
+  the base matrix's os and python axes asks a question that does not
+  vary by interpreter on every cell the no-bindings question already
+  uses, where a job scoped to its own matrix asks it on the cells that
+  do vary for it. Measured against
+  `https://pypi.org/pypi/btclib-secp256k1/json` for the newest release,
+  0.8.0.4: every platform `install-published` already covers has a wheel
+  for every supported interpreter, so the new job keeps that job's full
+  platform axis — a broken pair can hide behind a platform the bindings
+  build independently, a manylinux, a macOS universal2 and a Windows
+  build each being their own job in the bindings' own release workflow —
+  and drops the interpreter axis to one value, 3.14, which also
+  sidesteps `install-published`'s own Windows-arm64-below-3.11 workaround
+  rather than exercising it a second time. `--only-binary` on both
+  `btclib` and `btclib_secp256k1`, for the same reason `install-published`
+  already constrains `btclib` alone (issue #1153): without it, a wheel the
+  bindings have not published for a cell demotes the install to a source
+  build — a C toolchain question a hosted runner may or may not answer —
+  and the run would stay green while never having asked whether a
+  published wheel imports. Both triggers, the schedule and the call from
+  `release.yml`, are inherited from the workflow rather than argued
+  separately: the pair can break on the bindings' release day as well as
+  on btclib's, and a job added to `published.yml` gets both for free.
 
 ## v2026.8.21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -559,14 +559,19 @@ uv run --locked --no-default-groups --group test pytest
 ```
 
 The `published` workflow, monthly, on demand and as part of a release,
-installs btclib itself
-from PyPI, nothing checked out, and asks whether it works rather than
-whether it installs: `import btclib` runs `__init__.py` alone, and the
-files under `btclib/*/_data/` — the wordlists among them — are opened by
-path at the first call that needs one, not imported, so a wheel missing
-one would pass the import and fail only here. Both checks are
-version-independent, a BIP340 vector and a BIP39 one whose values are
-fixed forever:
+has two jobs, entitled to different answers about what the index
+serves.
+
+`install-published` installs btclib itself from PyPI, nothing checked
+out, and asks whether it works rather than whether it installs:
+`import btclib` runs `__init__.py` alone, and the files under
+`btclib/*/_data/` — the wordlists among them — are opened by path at the
+first call that needs one, not imported, so a wheel missing one would
+pass the import and fail only here. This install names no extra, so the
+bindings are not asked for and the job is not entitled to assert they
+serve — the supported no-bindings configuration of issues #990, #991
+and #992. The first two checks below are version-independent, a BIP340
+vector and a BIP39 one whose values are fixed forever:
 
 ```shell
 python -m pip install btclib
@@ -582,6 +587,29 @@ python -c "from btclib.mnemonic.bip39 import seed_from_mnemonic; \
       'c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53' \
       '495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f0016' \
       '98e7463b04')"
+```
+
+`install-published-secp256k1` installs `btclib[secp256k1]` instead,
+wheels only for both `btclib` and `btclib_secp256k1`, so a wheel the
+index does not have for a platform fails the job rather than falling
+back to a source build that answers a different question. Naming the
+extra is what entitles it to the assertion the other job cannot make: a
+resolution that installs and imports but does not serve — issue #1116,
+live on `main` once already — is invisible to a signature check alone,
+so this one asks `is_libsecp256k1_serving()` first, and the signature
+after it is meaningful because of that:
+
+```shell
+python -m pip install --only-binary btclib --only-binary btclib_secp256k1 \
+    "btclib[secp256k1]"
+python -c "import btclib; \
+    from btclib.curves import is_libsecp256k1_serving; \
+    from btclib.ecc import dsa; \
+    from btclib.to_pub_key import pub_keyinfo_from_prv_key; \
+    assert is_libsecp256k1_serving(), \
+      'the secp256k1 extra resolved, the bindings do not serve'; \
+    assert dsa.verify(b'btclib', pub_keyinfo_from_prv_key(1)[0], \
+      dsa.sign(b'btclib', 1))"
 ```
 
 The `links` workflow, weekly and on demand, which is the one that needs a


### PR DESCRIPTION
## What was wrong

`published.yml` is the only workflow whose subject is what PyPI actually
serves, and its `install-published` job installs bare `btclib` — never
`btclib[secp256k1]`. So nothing checked that the published pair
(`btclib` + `btclib_secp256k1`) resolves to a combination this tree can
import. `btclib/_libsecp256k1.py` imports the whole bindings surface in
one `try` whose `except ImportError` sets `INSTALLED = False`, so a
broken pair silently degrades to the Python arithmetic — no error, no
warning, tens of times slower, and not constant-time. Issue #1116 was
exactly that state, live on `main`, and the pre-upload smoke tests added
for issue #1117 (`test.yml`'s `dist` job, `release.yml`'s `build` job)
only catch the version *about to be* published — nothing watched the pair
afterwards, and it can break on either side's release day without this
repository changing at all.

## What was decided, and on what evidence

1. **A second job, not a second matrix cell.** `install-published`'s
   base matrix already varies over 6 OSes × 3 interpreters, plus an
   `include` cell for the sdist path. Doubling that base matrix with an
   `extra` axis would ask the bindings question on every cell the
   no-bindings question already uses; a job scoped to its own matrix asks
   it only on the cells that actually vary for it. New job:
   `install-published-secp256k1`.

2. **Platforms: the same six as `install-published`; interpreters:
   one (3.14), not three.** Measured against
   `https://pypi.org/pypi/btclib-secp256k1/json` for the newest release
   on PyPI (0.8.0.4 at the time of writing): every one of
   `install-published`'s six OS labels has a wheel for every supported
   interpreter (cp310 through cp315/cp315t). So sampling a second
   interpreter on a platform that already has one answers the same
   "does a wheel exist and import here" question again, while a missing
   wheel is exactly where the two publishing pipelines differ — a
   manylinux build, a macOS universal2 build and a Windows build are
   separate jobs in the bindings' own release workflow, so a broken pair
   on one platform and not the others is a real, not hypothetical, risk.
   3.14 rather than `install-published`'s 3.10 floor: the same JSON API
   answer shows `btclib_secp256k1` ships no `win_arm64` wheel below
   cp311 (confirmed — this is what makes `install-published` fetch an
   emulated `win_amd64` interpreter for its 3.10 cell on
   `windows-11-arm`), so 3.14 resolves the platform's own native wheel
   instead of exercising that workaround a second time.

3. **`--only-binary` on both `btclib` and `btclib_secp256k1`.**
   Verified the exact `uv pip install` spelling empirically (real venv,
   real PyPI, python 3.14, macOS arm64):
   `uv pip install --verbose --only-binary btclib --only-binary
   btclib_secp256k1 "btclib[secp256k1]"` resolves and installs cleanly.
   Without the second flag, a cell where the bindings have not published
   a wheel would silently fall back to a source build — a C toolchain
   question a hosted runner may or may not answer, and a different
   question from the one this job asks — and stay green while answering
   it. This mirrors `install-published`'s own `--only-binary btclib`
   (issue #1153), whose own comment already anticipated this exact
   follow-up flag.

4. **Both triggers.** `install-published-secp256k1` is a job inside
   `published.yml`, so it inherits the workflow's `schedule` and the
   `workflow_call` from `release.yml` for free — no separate wiring
   needed. The pair can break on the bindings' release day (argument for
   the monthly run) as well as on btclib's (argument for the post-release
   call), so both apply.

My reading going in matched all four of the above; none of the
measurements contradicted it.

## What was checked before implementing

- Read `.github/workflows/published.yml` in full, including its
  `--only-binary`/`no-binary` include cell (PR #1162) and the comment
  recording the Windows-arm64-below-3.11 wheel gap.
- Read `test.yml`'s `dist` job and `release.yml`'s `build` job, and
  copied their `is_libsecp256k1_serving` assertion spelling verbatim
  (`from btclib.curves import is_libsecp256k1_serving`, with the same
  failure message) rather than inventing a new one.
- Read `btclib/_libsecp256k1.py` and `btclib/curves/curve.py` for
  `is_libsecp256k1_serving`.
- Queried `https://pypi.org/pypi/btclib-secp256k1/json` for the wheel
  filenames of the newest release to determine platform/interpreter
  wheel coverage (see decision 2).
- Checked `pyproject.toml`'s `secp256k1` extra: `btclib_secp256k1>=0.8.0.3`,
  no ceiling — an unconstrained install from the index always resolves to
  the newest release satisfying that floor.
- Checked `CONTRIBUTING.md`'s "Reproducing what CI runs" section: its
  description of the `published` workflow was not updated for PR #1162's
  own new matrix cell either, so this PR follows the same precedent and
  leaves that narrative section alone — the sentence it states about
  `install-published` remains true.
- Verified empirically, in a real venv against the real index (not just
  that the workflow parses): `uv pip install --only-binary btclib
  --only-binary btclib_secp256k1 "btclib[secp256k1]"` on Python 3.14
  installs `btclib==2026.8.21` + `btclib_secp256k1==0.8.0.4`, and running
  the exact assertion script from the new step
  (`is_libsecp256k1_serving()` + a signature round trip) exits 0.

## RELEASE_NOTES.md

Not touched: this is a CI-only sentinel with no API change and nothing a
user has to act on.

## Test plan

```shell
uv run pytest
# 29393 passed, 11 skipped, TOTAL coverage 100.00%, exit 0

uv run pre-commit run --all-files
# every hook Passed, including actionlint and zizmor, exit 0

uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
# build succeeded, exit 0
```

Also, since none of the above can execute the new job's shell logic
end-to-end without a release:

- `uv run pre-commit run actionlint --files .github/workflows/published.yml`
  and `... zizmor ...` — both Passed in isolation, before the full run
  above.
- Ran the new job's install and assertion steps standalone, against the
  real index, in a real 3.14 venv (see "What was checked" above) — both
  exited 0.

Closes #1143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uNzuzag82WGhvznByjFDH

## Summary by Sourcery

Add post-publication CI coverage for validating that the PyPI secp256k1 package pairing resolves, imports, and uses the native bindings.

New Features:
- Add a published-package CI job that installs the secp256k1 extra from PyPI across supported platforms and verifies the bindings are actually serving.

Enhancements:
- Ensure published validation uses binary distributions for both packages and exercises the extra configuration separately from the base installation checks.

CI:
- Run the secp256k1 publication check on scheduled and release-triggered published workflow runs.

Documentation:
- Document the two published-package validation jobs and how to reproduce the secp256k1 check.