### PR TITLE
Point what would reopen the SBOM decision at an issue that is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,20 @@ documented at release-notes length in the first place, and are still in
   release wound up with four assets, not the two the old bullet would
   have produced.
 
+- **RELEASING.md's bill-of-materials step separates the evaluation from
+  what would change it** (btclib-org/.github#24). "See issue #1159 for
+  the evaluation and what would change it" sent both halves of that
+  answer to one issue, and #1159 is no longer open, so the half a reader
+  would come back for sat where nothing watches it. That half is the one
+  that matters, and its premise is a script in this tree rather than
+  anything either sibling ships: `generate_sbom.py` builds `components`
+  from `Requires-Dist`, so what it cannot express is what those releases
+  would have to omit, and a tool limitation is the kind of premise that
+  gets lifted. The evaluation still points at #1159, where it happened;
+  what would reopen the question points at btclib-org/.github#24, which
+  is open. Both siblings gain the same trigger in their own
+  `RELEASING.md`.
+
 ### Packaging, linting and CI
 
 - **`test.yml`'s and `lint.yml`'s concurrency groups take a

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -483,8 +483,11 @@ to `latest`'s own result.
    Python dependency. A bill of materials built the way this one is
    would name `cffi` and say nothing about the pin a verifier of that
    package would most want described, which is worse than omitting the
-   document. See issue #1159 for the evaluation and what would change
-   it.
+   document. Issue #1159 has the evaluation. What would change it is
+   btclib-org/.github#24, open because the premise is this repository's
+   own script: `generate_sbom.py` learning to describe a component
+   `Requires-Dist` cannot express would put the asymmetry above back in
+   question.
 
 1. Read the release run's `published` job, which is this workflow called
    with the tag rather than a dispatch to remember: it has no checkout, so


### PR DESCRIPTION
`btclib-org/btclib#1159` — "Decide whether a release SBOM is a three-repository
property or a btclib one" — closed at `2026-08-21T13:15:39Z`. All three
`RELEASING.md` files still send the reader who asks "why is no bill of
materials attached here?" to that issue, and none names
[btclib-org/.github#24](https://github.com/btclib-org/.github/issues/24), which
is the open successor holding the conditional half of the decision.

A completed evaluation cited at a closed issue is a legitimate record. A
condition that would reopen the decision, pointing at a closed issue, is a
decision quietly becoming permanent — which is what `.github#24` was opened to
prevent, and its third box is exactly this: the trigger written down.

So the evaluation still points where it happened, and what would reopen it now
points somewhere a person is watching. The three sentences are not identical
prose: each paragraph sits in a different argument, and this repository's says
what is its own. What is true in all three afterwards is the same.

This does **not** close `.github#24` — that issue has boxes these changes do
not satisfy.

Gates: `pre-commit run --all-files`, the suite with its coverage gate, and
`sphinx-build -W --keep-going`, each exit 0.

## Summary by Sourcery

Clarify SBOM release guidance by keeping the historical evaluation linked to its closed issue while directing future decision changes to the open tracking issue.

Enhancements:
- Update release documentation to distinguish the completed SBOM evaluation from the open issue that would trigger revisiting the decision.

Documentation:
- Align the repository and sibling release guides with the new SBOM decision references and document the condition that would reopen the question.

Chores:
- Record the SBOM documentation correction in the changelog.