### PR TITLE
Give one bom-ref to one dependency, not to one Requires-Dist line

### DIFF
--- a/.github/scripts/generate_sbom.py
+++ b/.github/scripts/generate_sbom.py
@@ -53,7 +53,7 @@ import zipfile
 from email import message_from_bytes
 from email.message import Message
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 from urllib.parse import quote
 from uuid import NAMESPACE_URL, uuid5
 
@@ -131,8 +131,19 @@ def purl(name: str, version: str | None, url: str | None) -> str:
     return reference
 
 
-def component(requirement: str) -> dict[str, Any]:
-    """Return the component one `Requires-Dist` line describes."""
+class Reading(NamedTuple):
+    """What one `Requires-Dist` line says about the dependency it names."""
+
+    name: str
+    version: str | None
+    url: str | None
+    extras: str | None
+    optional: bool
+    line: str
+
+
+def reading(requirement: str) -> Reading:
+    """Return the reading of one `Requires-Dist` line."""
     match = REQUIREMENT.match(requirement.strip())
     if match is None:
         msg = f"cannot read the requirement {requirement!r}"
@@ -140,34 +151,81 @@ def component(requirement: str) -> dict[str, Any]:
 
     specifier = (match["specifier"] or "").strip()
     pinned = PINNED.match(specifier)
-    version = pinned["version"] if pinned is not None else None
     marker = match["marker"]
-    reference = purl(match["name"], version, match["url"])
-
-    entry: dict[str, Any] = {
-        "type": "library",
-        "bom-ref": reference,
-        "name": canonical_name(match["name"]),
-        "purl": reference,
+    return Reading(
+        name=canonical_name(match["name"]),
+        version=pinned["version"] if pinned is not None else None,
+        url=match["url"],
+        extras=match["extras"],
         # an extra names a dependency the wheel asks for only when the
         # extra is; nothing else in a marker makes a requirement optional
         # to a bill of materials, an interpreter version being a condition
         # on where it installs rather than on whether it is needed
-        "scope": (
-            "optional" if marker is not None and "extra ==" in marker else "required"
-        ),
+        optional=marker is not None and "extra ==" in marker,
+        line=requirement,
+    )
+
+
+def agreed(values: list[str | None]) -> str | None:
+    """Return the value every line carries, or None where they differ.
+
+    A field one line answers differently from the next is a fact about
+    one installation environment and not about the distribution, so the
+    document states none of it -- the lines are kept below as properties,
+    where each answer is read beside the marker it holds under.
+    """
+    first = values[0]
+    return first if all(value == first for value in values) else None
+
+
+def component(readings: list[Reading]) -> dict[str, Any]:
+    """Return the component the lines naming one dependency describe.
+
+    One component per dependency and not per `Requires-Dist` line. A
+    floor widened across interpreter versions is several lines differing
+    only by marker, and each reads as the same package url: a component
+    per line would give the document several sharing one `bom-ref`, which
+    CycloneDX 1.6 requires to be unique, and would leave `dependencies`
+    standing one package in the graph as several nodes. Minting a unique
+    reference per line instead -- a suffix, a qualifier -- satisfies the
+    schema and keeps that graph, at the price of a `bom-ref` that is no
+    longer the purl a consumer resolves the package by; the document is
+    read to resolve a dependency graph, so the graph is what has to be
+    right, and the lines survive as properties either way (issue #1194).
+    """
+    version = agreed([entry.version for entry in readings])
+    url = agreed([entry.url for entry in readings])
+    reference = purl(readings[0].name, version, url)
+
+    properties: list[dict[str, str]] = []
+    for entry in readings:
         # the line as the metadata carries it, which is the whole of what
         # this document knows about the dependency: the fields above are a
         # reading of it, and the reading is checkable against it
-        "properties": [{"name": "btclib:requires-dist", "value": requirement}],
+        properties.append({"name": "btclib:requires-dist", "value": entry.line})
+        if entry.extras is not None:
+            properties.append({"name": "btclib:extras", "value": entry.extras})
+
+    # optional only where every line naming it is under an extra: one line
+    # asking for it unconditionally is the wheel asking for it
+    optional = all(entry.optional for entry in readings)
+    result: dict[str, Any] = {
+        "type": "library",
+        "bom-ref": reference,
+        "name": readings[0].name,
+        "purl": reference,
+        "scope": "optional" if optional else "required",
+        "properties": properties,
     }
     if version is not None:
-        entry["version"] = version
-    if match["extras"] is not None:
-        entry["properties"].append({"name": "btclib:extras", "value": match["extras"]})
-    if match["url"] is not None:
-        entry["externalReferences"] = [{"type": "vcs", "url": match["url"]}]
-    return entry
+        result["version"] = version
+    # deduplicated and in the order the metadata declares them, a
+    # reference repeated once per line being noise rather than a second
+    # place to look
+    urls = dict.fromkeys(entry.url for entry in readings if entry.url is not None)
+    if urls:
+        result["externalReferences"] = [{"type": "vcs", "url": each} for each in urls]
+    return result
 
 
 def timestamp(epoch: int) -> str:
@@ -235,12 +293,16 @@ def build_sbom(wheel: Path, sdist: Path, epoch: int) -> dict[str, Any]:
             {"name": "btclib:requires-python", "value": requires_python}
         ]
 
+    # grouped by the name the lines normalize to, which is what makes the
+    # references below distinct: the dict keeps each dependency's lines in
+    # the order the metadata declares them
+    by_name: dict[str, list[Reading]] = {}
+    for requirement in metadata.get_all("Requires-Dist", []):
+        declared = reading(requirement)
+        by_name.setdefault(declared.name, []).append(declared)
     components = sorted(
-        (
-            component(requirement)
-            for requirement in metadata.get_all("Requires-Dist", [])
-        ),
-        key=lambda entry: str(entry["bom-ref"]),
+        (component(readings) for readings in by_name.values()),
+        key=lambda dependency: str(dependency["bom-ref"]),
     )
     serial = f"{reference}:{file_hash(wheel)}:{file_hash(sdist)}"
     return {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -523,6 +523,40 @@ documented at release-notes length in the first place, and are still in
   `test.yml`, fixed in a pull request of their own
   (`btclib-org/btclib#1148` is the issue both reference).
 
+- **`generate_sbom.py` writes one component per dependency, where it
+  wrote one per `Requires-Dist` line** (issue #1194). A component's
+  `bom-ref` and `purl` are the requirement's name, its `==` pin and its
+  direct-reference url, and a dependency declared across lines differing
+  only by environment marker — the ordinary way to widen a floor across
+  interpreter versions — reads as the same package url on every one of
+  them. So such a dependency produced components sharing a single
+  reference, which CycloneDX 1.6 requires to be unique, and
+  `dependencies` compounded it: the root's `dependsOn` named that one
+  reference once per line, each followed by an entry of its own, so a
+  single package stood in the graph as several nodes of it. The lines
+  are grouped by the name they normalize to now, and read together. Each
+  survives as a `btclib:requires-dist` property in the order the
+  metadata declares them, so the reading is still checkable against the
+  metadata; a version or a vcs url the lines disagree about is left out
+  rather than taken from whichever came first, being a fact about one
+  installation environment and not about the distribution; and the
+  dependency is `optional` only where every line naming it is under an
+  extra. The alternative was to keep a component per line and mint a
+  unique `bom-ref` for each — a suffix or a qualifier — which satisfies
+  the schema, leaves the graph naming one package as several, and costs
+  a `bom-ref` that is no longer the purl a consumer resolves the package
+  by; the document is read to resolve a dependency graph, so the graph
+  is what has to be right. Nothing published was malformed: no
+  requirement btclib's own metadata carries is split by a marker, so the
+  defect was a split away rather than in the documents attached to a
+  release — and `btclib-secp256k1` declares its `cffi` floor across
+  marker-separated lines already, that split being the routine change
+  rather than an exotic one. `tests/generate_sbom_test.py` asserts that
+  the references of a document are distinct, which is the one rule of the
+  schema the suite checks directly — the rest of it is validated by
+  hand, a vendored schema and a validator being what a test of it would
+  cost.
+
 ## v2026.8.21
 
 ### Repository

--- a/tests/generate_sbom_test.py
+++ b/tests/generate_sbom_test.py
@@ -13,7 +13,12 @@ Two properties are worth more than the field-by-field assertions, and are
 what the release pipeline depends on. The document validates against the
 CycloneDX 1.6 JSON schema, checked once against the published schema and
 its two `$ref` files -- not asserted here, that would need the schema
-vendored and a validator installed for one test. And it is reproducible:
+vendored and a validator installed for one test. The one rule of it a
+test does assert is that the references are distinct, a dependency
+declared across several marker-separated lines being the shape that
+reaches it: that assertion is a comparison over the document the script
+already returns, where the rest of the schema is not. And it is
+reproducible:
 `test_the_document_is_the_same_bytes_twice` is the one that fails if a
 clock or a `uuid4` ever reaches it, which would leave a rebuilt release
 differing from the published one in the one field nobody could check.
@@ -237,6 +242,114 @@ def test_the_extras_of_a_requirement_are_recorded(
 
     (component,) = document["components"]
     assert {"name": "btclib:extras", "value": "socks"} in component["properties"]
+
+
+def test_a_dependency_split_by_marker_is_one_component(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """One component per dependency, whatever it takes to declare it.
+
+    Widening a floor across interpreter versions is several
+    `Requires-Dist` lines differing only by marker, and each of them
+    reads as the same package url.
+    """
+    requirements = (
+        'cffi>=1.17; python_version >= "3.13"',
+        'cffi>=1.16; python_version == "3.12"',
+        'cffi>=1.15; python_version < "3.12"',
+    )
+    document = sbom(script, tmp_path, requirements=requirements)
+
+    (component,) = document["components"]
+    assert component["name"] == "cffi"
+    assert component["purl"] == "pkg:pypi/cffi"
+    # every line kept, in the order the metadata declares them: the
+    # component is a reading of them all and checkable against them
+    assert component["properties"] == [
+        {"name": "btclib:requires-dist", "value": requirement}
+        for requirement in requirements
+    ]
+
+
+def test_the_references_of_a_document_are_distinct(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """`bom-ref` identifies a component, so CycloneDX 1.6 asks it be unique.
+
+    Nothing here runs the schema, and a dependency split by marker is the
+    shape that reaches this rule of it -- in the graph as well as in the
+    components, `dependencies` being keyed by the same reference.
+    """
+    document = sbom(
+        script,
+        tmp_path,
+        requirements=(
+            'cffi>=1.17; python_version >= "3.13"',
+            'cffi>=1.15; python_version < "3.13"',
+            "btclib_secp256k1>=0.8.0",
+        ),
+    )
+
+    references = [document["metadata"]["component"]["bom-ref"]]
+    references += [c["bom-ref"] for c in document["components"]]
+    assert len(set(references)) == len(references)
+    root, *leaves = document["dependencies"]
+    graph = [root["ref"], *(leaf["ref"] for leaf in leaves)]
+    assert len(set(graph)) == len(graph)
+    assert len(set(root["dependsOn"])) == len(root["dependsOn"])
+
+
+def test_a_version_the_lines_disagree_about_is_left_out(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """A pin under a marker names a version for one environment.
+
+    Which is not what the wheel pins, so the document names none.
+    """
+    document = sbom(
+        script,
+        tmp_path,
+        requirements=(
+            'tomli==2.0.1; python_version < "3.11"',
+            'tomli==2.2.1; python_version >= "3.11"',
+        ),
+    )
+
+    (component,) = document["components"]
+    assert "version" not in component
+    assert component["purl"] == "pkg:pypi/tomli"
+
+
+def test_a_version_the_lines_agree_on_is_kept(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """Lines that pin the same version pin it for the distribution."""
+    document = sbom(
+        script,
+        tmp_path,
+        requirements=(
+            'tomli==2.2.1; python_version < "3.11"',
+            'tomli==2.2.1; python_version >= "3.11"',
+        ),
+    )
+
+    (component,) = document["components"]
+    assert component["version"] == "2.2.1"
+    assert component["purl"] == "pkg:pypi/tomli@2.2.1"
+
+
+def test_a_line_outside_an_extra_makes_the_dependency_required(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """Optional only where every line naming it is under an extra."""
+    document = sbom(
+        script,
+        tmp_path,
+        requirements=('coverage>=7; extra == "test"', 'coverage>=7; os_name == "nt"'),
+    )
+
+    (component,) = document["components"]
+    assert component["scope"] == "required"
 
 
 def test_the_dependency_graph_names_every_component(


### PR DESCRIPTION
`component()` derived a component's identity from the requirement's name, its
`==` pin and its direct-reference url, so a dependency declared across several
`Requires-Dist` lines differing only by environment marker collapsed onto one
identity — several components sharing a `bom-ref`, and a `dependencies` graph
standing one package as several nodes with the same ref.

Measured before the change, on three marker-split `cffi` lines:

```
['pkg:pypi/cffi', 'pkg:pypi/cffi', 'pkg:pypi/cffi']
unique refs: 1 of 3
```

**Merged by canonical name**, one component per dependency, each
`Requires-Dist` line kept as its own `btclib:requires-dist` property in
metadata order. The alternative — disambiguating the reference per line —
satisfies the schema's uniqueness rule without touching what the rule exists
for: the document would be well formed and still wrong at the level it is read
at, with references no tool resolves.

Where the lines disagree: version and vcs url are reported only when every
line carries the same one, a pin under a marker being a fact about one
installation environment rather than about the distribution — the same
reasoning the module docstring already uses to refuse a resolved version.
Scope is `optional` only when every line naming it is under an extra.

The suite gained a test asserting the references of a document are distinct,
over a marker-split requirement, across the root and component `bom-ref`s,
across the `dependencies` refs, and within the root's `dependsOn`. It fails on
the previous script and passes here.

This tree's own published document is unchanged: the `dist` job's command
produces output byte-identical to what `main`'s script writes, so "latent, not
live" is measured rather than asserted.

Gates: lint, the suite at its coverage gate, and the docs build, each exit 0.

Closes #1194.

## Summary by Sourcery

Make SBOM dependency identity represent one package rather than each individual Requires-Dist declaration.

Bug Fixes:
- Ensure SBOM dependencies declared across multiple marker-specific Requires-Dist lines receive one unique component and dependency-graph reference instead of duplicate bom-refs.

Enhancements:
- Preserve every grouped Requires-Dist declaration in metadata order while reporting versions, VCS URLs, and optional scope only when the declarations agree.
- Record distinct dependency references across SBOM components and dependency graphs.

Documentation:
- Document the corrected dependency grouping and reference behavior in the changelog.

Tests:
- Add coverage for marker-split dependencies, reference uniqueness, conflicting and matching versions, and mixed optionality.