### PR TITLE
Drop the count of shimmed files from conf.py's comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -571,6 +571,21 @@ documented at release-notes length in the first place, and are still in
   hand, a vendored schema and a validator being what a test of it would
   cost.
 
+### Documentation and the website
+
+- **`docs/source/conf.py`'s `RootFileLinks` comment no longer states a
+  count of the root markdown files a build-time copy would duplicate**
+  (issue #1195). The paragraph rejecting that alternative said the
+  copies would be "a second definition of ... files that already
+  exist," a number sitting beside the very code that reads the true
+  set from `docs/source`'s `*_link.md` shims rather than from a
+  hand-maintained figure — and it had drifted, a shim having joined the
+  set since the sentence was written. The introductory paragraph
+  above it already names every one of those shims without a count,
+  which is what makes the fix a subtraction rather than a
+  correction: the reasoning about a redundant definition survives,
+  and only the number that could go stale again is gone.
+
 ## v2026.8.21
 
 ### Repository

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -135,7 +135,7 @@ html_theme = "sphinx_rtd_theme"
 # CONTRIBUTING.md links to CODE_OF_CONDUCT.md and tests/README.md, neither
 # of which is part of the documentation, so copies leave those two dead
 # however many are made; and the copies are generated files in a source
-# tree, which is a second definition of five files that already exist.
+# tree, which is a second definition of files that already exist.
 
 # a shim is one myst include fence, and everything after the directive
 # name on that line is the directive's argument: the path of the file the


### PR DESCRIPTION
A comment in `docs/source/conf.py` stated how many files the shim mechanism
covers, and the set had grown past it.

The fix is not the right number. `CONTRIBUTING.md` states the rule against
writing a count into prose and says why: it is a line every future change has
to remember to edit, and nobody remembers — replacing a wrong number with a
right one leaves the defect armed for the next edit.

Here the number goes and nothing replaces it. The introductory paragraph three
above already names the shims by title, so a list at this point would be a
second copy of the same fact to keep in step — which is what let the set grow
past the count in the first place. The sentence now rests on the reasoning
that survives the set's size.

Gates: lint, the suite at its coverage gate, and `sphinx-build -W
--keep-going`, each exit 0; the unresolved-link grep finds nothing.

Closes #1195.

## Summary by Sourcery

Remove the hard-coded shim file count so the documentation guidance cannot become outdated as the set changes.

Bug Fixes:
- Remove the stale count of documentation shim files from the `RootFileLinks` comment in `docs/source/conf.py`.

Documentation:
- Record the documentation comment correction in the changelog.