### PR TITLE
Enforce the link-destination rule where the link is written

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -119,31 +119,35 @@ jobs:
       # configuration, and it is what would catch a suppression added
       # back.
       #
-      # Two greps, not one, because myst's fallback renders the target
-      # verbatim and a target is written one of two ways across this
-      # organization's three publishing repositories (issue #1157):
-      # "./CONTRIBUTING.md", every relative link this repository's own
-      # root files use, which becomes href="#./CONTRIBUTING.md" if it
-      # breaks -- the first grep -- and a bare "SECURITY.md" with no
-      # "./", the convention btclib-secp256k1 uses instead, which
-      # becomes href="#SECURITY.md" and only the second grep catches.
-      # Each repository used to run one of the two, on the strength of
-      # the convention its own root files happened to follow, which
-      # left it blind to a broken link written the other way -- this
-      # repository's own links are all the first shape today, but
-      # nothing enforces that, and bitcoin-core-rpc ran the very same
-      # single grep on the same assumption. A survey across all three
-      # found no third shape among the links these pages actually
-      # carry, so two greps is the union rather than a guess at how far
-      # to generalize.
+      # One grep, because there is one spelling to look for. myst's
+      # fallback renders the destination verbatim, so what this can
+      # match is decided upstream of here, in how the link was written
+      # -- and the local-link-prefix hook in .pre-commit-config.yaml
+      # refuses a local destination that does not begin "./", in the
+      # commit that writes it. Every destination the included root files
+      # carry therefore renders href="#./<destination>" when it breaks,
+      # anchor, extension and nested path alike (issue
+      # btclib-org/.github#20; the hook's own comment has the
+      # measurement behind that).
+      #
+      # Not a second grep for a bare destination beside it. It would be
+      # unreachable with the hook in place, and it is no superset of
+      # this one even without: a character class of name characters
+      # stops at the "#" of an anchor, so href="#README.md#build" is a
+      # shape both patterns pass over. That is the argument for the hook
+      # rather than for a third pattern -- a check downstream of the
+      # rendering has to anticipate every way a link can be written, and
+      # a rule upstream of it permits one.
       #
       # Not lychee: links.yml reads the sources, where "./CONTRIBUTING.md"
       # is a correct path, and pointing it at docs/build/html would mean
       # building the documentation inside a workflow that gates nothing
       # and re-requesting every external url these pages carry.
-      # Not a pre-commit hook either: it would have to build the
-      # documentation, which is the very reason this job exists apart from
-      # the lint one.
+      # Not the local-link-prefix hook in place of this step either, for
+      # all that it is what settles the spelling: it reads the markdown, and
+      # the claim made here is about the built artifact -- that no page
+      # sphinx wrote carries an anchor to an id nothing has, whatever
+      # emitted it and whatever conf.py is configured to warn about.
       #
       # Not narrowed to myst's own class="xref myst" either. The defect is
       # an href to an id no page has, whoever emitted it, and the prose
@@ -153,13 +157,7 @@ jobs:
       # on the built html
       - name: Check the built pages for unresolved links
         run: |
-          status=0
           if grep -rn 'href="#\./' docs/build/html --include='*.html'; then
             echo "::error::the links above resolve to no page (unresolved relative path)"
-            status=1
+            exit 1
           fi
-          if grep -rn 'href="#[A-Za-z0-9_.-]*\.md"' docs/build/html --include='*.html'; then
-            echo "::error::the links above resolve to no page (unresolved bare .md target)"
-            status=1
-          fi
-          exit $status

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -282,6 +282,71 @@ repos:
       - id: markdownlint-cli2
         name: markdownlint-cli2 (in place fixes)
         args: [--fix]
+  # how a link destination is spelled, which markdownlint has no rule for
+  # and the documentation build depends on. docs.yml greps the built html
+  # for `href="#./`: that is what myst renders in place of a link the
+  # RootFileLinks transform in docs/source/conf.py cannot resolve -- an
+  # anchor to an id no page has, which -W reports today and would stop
+  # reporting the day suppress_warnings took myst.xref_missing back. A
+  # grep can key on one spelling, so the destinations are spelled one way
+  # and this hook is what keeps them that way, in the commit that writes
+  # the link rather than in the artifact built from it.
+  #
+  # The rule is the prefix and not the extension, and issue #1175's
+  # table is what decides that: "DOES_NOT_EXIST.txt",
+  # "sub/DOES_NOT_EXIST.md", "DOES_NOT_EXIST" and "../DOES_NOT_EXIST.md"
+  # each reach myst's fallback, and each is missed by the union of both
+  # greps a repository ran. An ".md"-scoped rule would leave all four
+  # writable; a prefix refuses all four where they are written, which
+  # answers that issue by prevention rather than by the extra patterns
+  # its Options section contemplates.
+  #
+  # Measured here as well, by building this repository's documentation
+  # with an unresolvable link written each way: "./page.md",
+  # "./page.md#anchor", "./page.txt", "./sub/page.md" and an
+  # extensionless "./page" each render "#./" and the destination, so the
+  # one grep sees every one; the same destinations without the "./"
+  # render the destination alone, which no single pattern reaches
+  # without also matching the autodoc anchors these pages carry --
+  # href="#btclib.ecc.dsa.sign" and href="#module-btclib.b32".
+  #
+  # "../" is the row worth naming on its own, because it is the one
+  # shape with nothing downstream behind it. conf.py's transform
+  # declines a target that normalizes above the repository root --
+  # nothing above the root is a document this build can answer for --
+  # so "../page.md" reaches myst's fallback by design rather than by a
+  # gap in the transform, and renders href="#../page.md", which the grep
+  # in docs.yml does not match and should not be widened to. Refusing it
+  # here is the only place that shape can be caught at all, which is why
+  # it is refused rather than allowed as an ordinary relative path.
+  #
+  # pygrep, and the same hook in every repository of this organization
+  # (btclib-org/.github#20): there is no shared hook repository to put
+  # it in, and `pinned-rev` above is that arrangement already. The
+  # pattern asks for a whole `[text](destination)` whose "[" is not
+  # preceded by a backtick, which is what lets prose quote the refused
+  # shape in a code span; grep output of the form `FILE.md:21:](x.md)`
+  # carries no "[" and is not matched either.
+  #
+  # A reference definition is a link too, and the second branch is for
+  # it: "[label]: page.md" renders the same fallback as the inline form
+  # -- measured on the built html -- and carries no "(", so the first
+  # branch cannot see it. That branch is anchored at the start of the
+  # line, which is what keeps it off a *use* site: "[label][ref]: the"
+  # is prose in a sibling repository's changelog, and an unanchored
+  # pattern reported it. At most three leading spaces, four making the
+  # line an indented code block rather than a definition.
+  #
+  # What pygrep cannot see is a fenced block, being line based -- an
+  # example of the refused shape inside one fails this hook, and the
+  # code span is the way round it
+  - repo: local
+    hooks:
+      - id: local-link-prefix
+        name: a local markdown link destination begins with ./
+        language: pygrep
+        entry: '(?<!`)(?:\[[^]]*\]\(|^ {0,3}\[[^]]+\]:\s*)(?!\./|#|[A-Za-z][A-Za-z0-9+.-]*:)[^)\s]'
+        types: [markdown]
   # what ruff-format is for Python, on the structured files ruff does not
   # read: yaml, and the jsonc that carries a comment. Before yamllint below,
   # so the linter judges the formatted file and not the one that was typed.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -320,13 +320,28 @@ repos:
   # here is the only place that shape can be caught at all, which is why
   # it is refused rather than allowed as an ordinary relative path.
   #
+  # The first branch steps over a nested image, and it has to: a badge is
+  # "[![alt](src)](href)", and link text written "[^]]*" stops at the "]"
+  # that closes the alt text -- so a scan anchored on it checks the image
+  # src and never reaches the badge's own destination. That was this
+  # hook's first shape, and it left every badge href unchecked; the link
+  # text is now "(?:[^]]|\]\([^)]*\))*", a character that is not "]" or a
+  # whole "](...)" group, which steps over the image and, by
+  # backtracking, still checks the src on the way. Measured: a badge href
+  # renders exactly what a plain href renders, so every row of the table
+  # above can be written as a badge destination and only the "./" one is
+  # caught downstream.
+  #
   # pygrep, and the same hook in every repository of this organization
   # (btclib-org/.github#20): there is no shared hook repository to put
   # it in, and `pinned-rev` above is that arrangement already. The
-  # pattern asks for a whole `[text](destination)` whose "[" is not
-  # preceded by a backtick, which is what lets prose quote the refused
-  # shape in a code span; grep output of the form `FILE.md:21:](x.md)`
-  # carries no "[" and is not matched either.
+  # pattern asks for a whole `[text](destination)`, so grep output of the
+  # form `FILE.md:21:](x.md)` carries no "[" and is not matched. The
+  # lookbehind refuses a "[" preceded by a backtick, which is what lets
+  # prose quote the refused shape in a code span -- and one preceded by
+  # "!" or "[" as well, so that a *quoted* badge is escaped whole rather
+  # than re-entered at the image inside it. The leading "!?" is what
+  # keeps a standalone image's own src checked despite that.
   #
   # A reference definition is a link too, and the second branch is for
   # it: "[label]: page.md" renders the same fallback as the inline form
@@ -345,7 +360,14 @@ repos:
       - id: local-link-prefix
         name: a local markdown link destination begins with ./
         language: pygrep
-        entry: '(?<!`)(?:\[[^]]*\]\(|^ {0,3}\[[^]]+\]:\s*)(?!\./|#|[A-Za-z][A-Za-z0-9+.-]*:)[^)\s]'
+        # one line, and no literal space in it -- "\x20" is the space the
+        # reference branch allows -- so yamllint reads the value as a
+        # single unbreakable word and its 100-column rule exempts it. A
+        # block scalar rather than a quoted one for the same reason a
+        # folded scalar was rejected: folding joins lines with a space,
+        # which would land inside the regex
+        entry: |-
+          (?<![`!\[])(?:!?\[(?:[^]]|\]\([^)]*\))*\]\(|^\x20{0,3}\[[^]]+\]:\s*)(?!\./|#|[A-Za-z][A-Za-z0-9+.-]*:)[^)\s]
         types: [markdown]
   # what ruff-format is for Python, on the structured files ruff does not
   # read: yaml, and the jsonc that carries a comment. Before yamllint below,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -568,6 +568,24 @@ documented at release-notes length in the first place, and are still in
   grep catches the rendered `#./X.md`; `X.md`, `X.txt`, `sub/X.md`, `X`
   and `../X.md` are each refused, so none can be written at all.
 
+  **That claim was checked against every position a destination can
+  occupy, and the check found a hole before it found the answer.** A
+  badge is `[![alt](src)](href)`, and a link text written `[^]]*` stops
+  at the `]` that closes the alt text — so the first version of this
+  pattern checked the image `src` and never the badge's own href, and
+  measured on the built html a badge href renders exactly what a plain
+  href renders. Every row of the table above was therefore still
+  writable as a badge destination, past the hook and past both greps.
+  Link text is now `(?:[^]]|\]\([^)]*\))*`, a character that is not
+  `]` or a whole `](…)` group, which steps over the image and reaches
+  what is behind it while still checking the `src` by backtracking. The
+  six rows were then re-derived across five positions — plain link,
+  badge href, image src, badge src and reference definition — and only
+  `./X.md` is accepted in any of them. This repository carries badge
+  links in `README.md` and `CONTRIBUTING.md`, none of them violating
+  the rule; the siblings' counts differ and the hook is what says so
+  for each.
+
   `../` is the row worth naming on its own, because it is the only one
   with nothing downstream behind it: `RootFileLinks` *declines* to
   resolve a target normalizing above the repository root, nothing above

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -536,6 +536,61 @@ documented at release-notes length in the first place, and are still in
   `bitcoin-core-rpc` each had one further instance, in their own
   `test.yml`, fixed in a pull request of their own
   (`btclib-org/btclib#1148` is the issue both reference).
+- **A `local-link-prefix` hook refuses a local markdown link destination
+  that does not begin with `./`, and `docs.yml`'s unresolved-link check
+  is one grep again** (btclib-org/.github#20). What that grep can match
+  is decided by how the link was written, myst rendering the destination
+  of a link `docs/source/conf.py`'s `RootFileLinks` transform cannot
+  resolve verbatim: `./SECURITY.md` breaking gives
+  `href="#./SECURITY.md"`, a bare `SECURITY.md` breaking gives
+  `href="#SECURITY.md"`. The links here were already written the first
+  way, and nothing said they had to be — the hook is what says so, and
+  with it the second grep, added for the bare shape a sibling repository
+  was writing, has nothing left it can catch.
+
+  That second grep was no superset of the first even so: a character
+  class of name characters stops at the `#` of an anchor, so
+  `href="#README.md#build"` is a shape both patterns pass over. Which is
+  the argument for moving the rule upstream rather than writing a third
+  pattern — a check on the rendered page has to anticipate every way a
+  link can be written, and a rule on the source permits one.
+
+  The rule is the prefix and not the extension, and issue #1175's table
+  is what decides that: `DOES_NOT_EXIST.txt`, `sub/DOES_NOT_EXIST.md`,
+  `DOES_NOT_EXIST` and `../DOES_NOT_EXIST.md` each reach MyST's
+  fallback, and each is missed by the union of both greps a repository
+  ran — so an `.md`-scoped rule would leave all four writable. A prefix
+  refuses all four where they are written, which answers that issue by
+  prevention rather than by the extra patterns its Options section
+  contemplates: a grep finds a broken link after somebody writes it, a
+  hook stops it being written. Its six rows, against what lands here —
+  `./X.md` is allowed and, if the target does not exist, the surviving
+  grep catches the rendered `#./X.md`; `X.md`, `X.txt`, `sub/X.md`, `X`
+  and `../X.md` are each refused, so none can be written at all.
+
+  `../` is the row worth naming on its own, because it is the only one
+  with nothing downstream behind it: `RootFileLinks` *declines* to
+  resolve a target normalizing above the repository root, nothing above
+  the root being a document this build can answer for, so that shape
+  reaches the fallback by design and renders `href="#../X.md"` — which
+  the surviving grep does not match and should not be widened to reach.
+  The hook is the only place it can be caught.
+
+  Measured here too, by building this documentation with an
+  unresolvable link written each way: `./page.md`, `./page.md#anchor`,
+  `./page.txt`, `./sub/page.md` and an extensionless `./page` each
+  render `#./` followed by the destination, so the one grep sees every
+  one; the same destinations without the `./` render the destination
+  alone, which nothing catches without also matching the autodoc
+  anchors these pages carry. A link reference definition,
+  `[label]: page.md`, renders that same fallback and carries no `(`, so
+  the pattern has a second branch for it, anchored at the start of the
+  line — a reference *use* followed by a colon is ordinary prose, and
+  an unanchored pattern reported one in `btclib-benchmarks`'s
+  changelog. `RELEASING.md`'s link to `release.yml` was the one
+  destination in this repository's markdown that did not begin `./`,
+  and now does. `uv run --locked --only-group lint pre-commit run
+  local-link-prefix --all-files` re-derives the whole of it.
 
 - **`generate_sbom.py` writes one component per dependency, where it
   wrote one per `Requires-Dist` line** (issue #1194). A component's

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing btclib
 
 Releases are published by GitHub Actions
-([release.yml](.github/workflows/release.yml)), not from a developer
+([release.yml](./.github/workflows/release.yml)), not from a developer
 machine. Pushing a `v<version>` tag runs the full test matrix, builds
 and checks the distribution files, publishes them to PyPI, and creates
 the GitHub release. There is no PyPI token anywhere: both indices are


### PR DESCRIPTION
A local destination written without a `./` prefix is not a style question in
these repositories: it is the shape that breaks silently. MyST's fallback
renders whatever string the link carried, so an unresolvable target becomes an
`href="#<target>"` anchor rather than a warning `-W` can fail on, and the
greps in `docs.yml` see only two of the shapes that fallback can take.

The rule is now enforced where the link is written. `local-link-prefix` is a
pygrep hook over markdown that refuses a link destination which is neither
`./`-prefixed, an anchor, nor a scheme — covering both the inline form and a
link reference definition, whose bare destination renders the identical
fallback and which the first draft of the pattern could not see.

**The prefix, not the extension.** `btclib-org/btclib#1175` measured six
shapes reaching that fallback, and the union of both greps catches two of
them: a bare `.txt`, a nested path with no leading `./`, an extensionless
name and a `../` climb are all invisible downstream. An `.md`-scoped rule
would leave every one of them writable.

**`../` in particular has no downstream check at all.** `conf.py`'s
`RootFileLinks` transform declines, by design, to resolve a target that
normalizes above the repository root — nothing above the root is a document
that build can answer for — so that shape reaches the fallback deliberately
and neither grep can see it. The source is the only place it can be caught.

The `href="#[A-Za-z0-9_.-]*\.md"` grep goes with it: what it answers is now
unwritable, and it never covered `X.md#fragment`, which is the shape one of
these repositories actually carried.

Stated rather than solved: pygrep is line based and cannot see a fenced block,
so a bare link inside one is reported. An inline code span is the escape
hatch, which is already the house style for quoting markup.

Gates: `pre-commit`, `sphinx-build -E -W --keep-going`, the surviving link
step run verbatim, and the suite at its coverage gate, each exit 0.

Part of `btclib-org/.github#20`, which no single branch here satisfies.

Closes #1175: every shape in that issue's table is refused at source, and the
seventh — a link reference definition with a bare destination — was found
while checking that claim rather than assumed away.

## Summary by Sourcery

Enforce a consistent `./` prefix for local Markdown link destinations at source and streamline the documentation build check around that convention.

New Features:
- Add a pre-commit markdown hook that requires local link destinations to use a `./` prefix while allowing anchors and schemes.

Bug Fixes:
- Prevent unresolved local links, including reference definitions, badges, extensionless paths, nested paths, and parent-directory traversals, from bypassing source checks.

Enhancements:
- Simplify the built-document unresolved-link check to match the single permitted local-link spelling.
- Update the releasing documentation to comply with the enforced link format.

CI:
- Update the documentation workflow to rely on the source-level link rule and retain a focused rendered-artifact check.

Documentation:
- Document the new link-destination convention and its coverage in the changelog.