### PR TITLE
Carry a key parsed once instead of spelling it back to be parsed again (issue #1188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -585,6 +585,40 @@ documented at release-notes length in the first place, and are still in
   which is what makes the fix a subtraction rather than a
   correction: the reasoning about a redundant definition survives,
   and only the number that could go stale again is gone.
+### The public API and the module layout
+
+- **`btclib.key` holds the canonical form of a key**, `PubKeyData` and
+  `PrvKeyData`, so that a key parsed once can be carried rather than
+  spelled back for the next call to parse again (issue #1188). Every
+  converter in the library takes each spelling and answers a tuple, so
+  the canonical form was what came *out* of a conversion and never what
+  went *in*; three places already work around the round trip that leaves
+  — `bip32.derive_`, `to_pub_key._sec_from_pub_key` and
+  `taproot._output_pubkey_and_internal_key`, issues 886, 887 and 896 —
+  and this is the cut those three patch locally.
+
+  The SEC octets are the field and the point is a `cached_property`
+  because the two conversions do not cost the same: serializing a point
+  is a concatenation, where parsing a compressed one is a square root in
+  the field and costs several times as much, so the cheap direction is
+  paid on the way in and the expensive one on first use and kept. That
+  lazy lift is also the *proof*: the constructor reads a length and a
+  prefix, and whether they frame a point of the curve is what `point`
+  answers — which is the trade `_sec_from_pub_key` already states, made
+  explicit and paid once instead of at every caller.
+  `PrvKeyData.pub` is lazy for the same reason and buys most, a scalar
+  multiplication being the dearest conversion of the three.
+
+  One type per half rather than a `PubKeySecData` beside a
+  `PubKeyPointData`: two would hand the caller a choice that is a cache
+  decision and not a meaning, any function taking either would take a
+  union again, and one key in the two types could not compare equal
+  without performing the conversion the split was meant to avoid. Frozen,
+  as `BIP32KeyData` is and for its reason; not `slots=True`, because
+  `cached_property` stores into an instance `__dict__` that a slotted
+  dataclass has none of. Nothing in the library consumes these yet: the
+  adoption is per module, and each step of it removes one of the round
+  trips above.
 
 ## v2026.8.21
 

--- a/btclib/__init__.py
+++ b/btclib/__init__.py
@@ -97,6 +97,7 @@ __all__ = [
     "hashes",
     "hwi",
     "kdf",
+    "key",
     "mnemonic",
     "network",
     "number_theory",

--- a/btclib/key.py
+++ b/btclib/key.py
@@ -1,0 +1,233 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The canonical form of a bitcoin key, parsed once and carried.
+
+**What this is for.** A public key has several spellings -- SEC octets, a
+hex string of them, a point, an xpub -- and a private key has as many.
+Every converter in this library takes all of them and answers a tuple, so
+the canonical form is what comes *out* of a conversion and never what
+goes *in*: a caller that has one has to spell it back for the next call,
+which parses it again. That round trip is what
+`bip32.derive_`, `to_pub_key._sec_from_pub_key` and
+`taproot._output_pubkey_and_internal_key` each work around locally --
+issues 886, 887 and 896, three patches over one cut.
+
+`PubKeyData` and `PrvKeyData` are that cut: the spellings stay at the
+boundary, the parse happens once, and what travels afterwards is an
+object that knows which half it is.
+
+**Why the SEC octets are the field and the point is derived.** The two
+conversions do not cost the same. Serializing a point is a byte
+concatenation; parsing a compressed one is a square root in the field.
+Measured on secp256k1 over twenty thousand rounds of one key, a
+compressed point costs 3.35 us to parse against the 0.99 of writing it
+-- 3.4x -- where an uncompressed one costs 1.33 against 1.04, both
+coordinates being there to read rather than lifted. Deriving a public
+key from a private one is dearer than either, at 8.00 us.
+
+So the cheap direction is paid on the way in, the expensive one on first
+use and kept, and `PrvKeyData.pub` is where laziness buys most.
+
+That is not only a cache. **`point` is also the proof**: a length and a
+prefix are what the constructor checks, and whether those octets are a
+point of the curve is the question `point` answers. It is the contract
+`to_pub_key._sec_from_pub_key` already states -- "the guarantee is the
+caller's to complete" -- made explicit and paid once, rather than left to
+each caller and paid again at every one.
+
+**Why one type and not two.** A `PubKeySecData` beside a `PubKeyPointData`
+would hand the caller a choice that is a cache decision rather than a
+meaning, which is the burden this module exists to remove; any function
+taking either would take a union again; and the same key in the two types
+could not compare equal without performing the very conversion the split
+was meant to avoid.
+
+**Why frozen, and why not `slots=True`.** Frozen for the reason
+`BIP32KeyData` is (issue 727): a public function handed one may trust it
+instead of revalidating, and a mutable field would let
+`check_validity=False` stay unchecked forever. Not slotted, because
+`functools.cached_property` stores into the instance `__dict__` and a
+slotted dataclass has none -- it raises `TypeError: No '__dict__'
+attribute`. Equality and hashing read the declared fields alone, so what
+a lazy property has computed never changes either, and two objects for
+one key compare equal whichever of them has been asked for a point.
+
+The compressed and uncompressed spellings of one key are **not** equal
+here, and that is right rather than an oversight: they hash to different
+addresses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cached_property
+
+from btclib.alias import Octets, Point
+from btclib.curves import Curve, bytes_from_prv_key_int, point_from_octets
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.network import network_from_name
+from btclib.utils import assert_type, bytes_from_octets, is_integer
+
+__all__ = [
+    "PrvKeyData",
+    "PubKeyData",
+]
+
+# the two SEC forms, and the prefix each one takes. 0x04 is the
+# uncompressed marker; 0x02 and 0x03 name the parity of y. A hybrid key --
+# 0x06 or 0x07, both coordinates *and* a parity byte -- is SEC1 and is not
+# bitcoin: Core has never relayed one, and `curves.sec_point` refuses it,
+# so this refuses it too rather than parse what the layer below will not
+_COMPRESSED_PREFIXES = (2, 3)
+_UNCOMPRESSED_PREFIX = 4
+
+
+@dataclass(frozen=True)
+class PubKeyData:
+    """A public key as its SEC octets, on a named network.
+
+    The octets are the field because serializing a point is cheap and
+    parsing one is not; `point` is the lift, paid on first use and kept.
+    The module docstring carries the measurement and the reasoning.
+    """
+
+    sec: bytes
+    network: str
+
+    def __init__(
+        self,
+        sec: Octets,
+        network: str = "mainnet",
+        *,
+        check_validity: bool = True,
+    ) -> None:
+        object.__setattr__(self, "sec", bytes_from_octets(sec))
+        object.__setattr__(self, "network", network)
+
+        if check_validity:
+            self.assert_valid()
+
+    @property
+    def is_compressed(self) -> bool:
+        """Answer whether the key is in the compressed SEC form.
+
+        `is_` and not `compressed`, which is what `PrvKeyData` calls the
+        same idea: there it is a field, a kind the caller states and a
+        WIF carries, and here it is a question about octets already in
+        hand. CONTRIBUTING.md's vocabulary is what makes the two names
+        differ, and the difference is the point.
+        """
+        return len(self.sec) == self.curve.p_size + 1
+
+    @property
+    def curve(self) -> Curve:
+        """Return the curve of the network the key is on."""
+        return network_from_name(self.network).curve
+
+    @cached_property
+    def point(self) -> Point:
+        """Return the curve point the octets encode, lifting it once.
+
+        The lift is the proof: `assert_valid` reads a length and a
+        prefix, and whether what they frame is a point of the curve is
+        what this answers. A key nobody asks this of has never been
+        proved one -- deliberately, that being the trade
+        `to_pub_key._sec_from_pub_key` already makes for the callers
+        that hand the octets straight to a call which parses them
+        anyway.
+        """
+        return point_from_octets(self.sec, self.curve)
+
+    def assert_valid(self) -> None:
+        """Refuse octets no SEC public key has, and an unknown network.
+
+        A length and a prefix, and not a point: see `point`, which is
+        where the curve is asked. That `sec` is bytes at all is not
+        asked here: `bytes_from_octets` is what the constructor runs it
+        through, whatever `check_validity` says, so a second check would
+        re-ask a question already answered one layer down.
+        """
+        assert_type(self.network, str, "network")
+        # refuses a name no network has, which is what this is called for
+        ec = network_from_name(self.network).curve
+        prefix = self.sec[0] if self.sec else None
+        if len(self.sec) == ec.p_size + 1:
+            if prefix not in _COMPRESSED_PREFIXES:
+                raise BTClibValueError(f"invalid compressed SEC prefix: {prefix}")
+        elif len(self.sec) == 2 * ec.p_size + 1:
+            if prefix != _UNCOMPRESSED_PREFIX:
+                raise BTClibValueError(f"invalid uncompressed SEC prefix: {prefix}")
+        else:
+            # never echo the octets: a caller that reached here with
+            # private material spelled them as a public key by mistake,
+            # and the size is the whole of what is wrong
+            raise BTClibValueError(f"invalid SEC key size: {len(self.sec)}")
+
+
+@dataclass(frozen=True)
+class PrvKeyData:
+    """A private key as its scalar, on a named network, compressed or not.
+
+    `compressed` is not decoration: it is what a WIF carries and what
+    decides the SEC form of `pub`, so without it the public key this
+    derives would not be one key but two.
+
+    `pub` is the derivation, and it is the most expensive conversion in
+    this module -- a scalar multiplication, some two and a half times
+    what lifting a compressed point costs -- so it is where laziness
+    pays most.
+    """
+
+    q: int
+    network: str
+    compressed: bool
+
+    def __init__(
+        self,
+        q: int,
+        network: str = "mainnet",
+        compressed: bool = True,
+        *,
+        check_validity: bool = True,
+    ) -> None:
+        object.__setattr__(self, "q", q)
+        object.__setattr__(self, "network", network)
+        object.__setattr__(self, "compressed", compressed)
+
+        if check_validity:
+            self.assert_valid()
+
+    def __repr__(self) -> str:
+        # never echo private key material, as BIP32KeyData's repr does not
+        masked = f"{type(self).__name__}(q=..., network={self.network!r}"
+        return f"{masked}, compressed={self.compressed!r})"
+
+    @property
+    def curve(self) -> Curve:
+        """Return the curve of the network the key is on."""
+        return network_from_name(self.network).curve
+
+    @cached_property
+    def pub(self) -> PubKeyData:
+        """Return the public key this one derives, multiplying once."""
+        sec = bytes_from_prv_key_int(self.q, self.curve, self.compressed)
+        return PubKeyData(sec, self.network)
+
+    def assert_valid(self) -> None:
+        """Refuse a scalar outside 1..n-1, and an unknown network."""
+        assert_type(self.network, str, "network")
+        # `is_integer` and not `assert_type(self.q, int, "q")`: a bool is
+        # an int to `isinstance`, and here the two mean different things
+        # -- `compressed` is a kind and `q` is a number -- so True
+        # reaching the scalar is a caller's mistake and not the key one.
+        # That policy is one decision for the whole library, which
+        # `utils.is_integer` states and `integer_policy_test.py` keeps
+        if not is_integer(self.q):
+            raise BTClibTypeError("not a private key scalar")
+        assert_type(self.compressed, bool, "compressed")
+        ec = network_from_name(self.network).curve
+        if not 0 < self.q < ec.n:
+            # never echo the scalar: it is the secret itself
+            raise BTClibValueError("private key not in 1..n-1")

--- a/docs/source/btclib.rst
+++ b/docs/source/btclib.rst
@@ -128,6 +128,13 @@ btclib.hashes module
    :members:
    :show-inheritance:
 
+btclib.key module
+-----------------
+
+.. automodule:: btclib.key
+   :members:
+   :show-inheritance:
+
 btclib.hwi module
 -----------------
 

--- a/tests/bool_parameter_test.py
+++ b/tests/bool_parameter_test.py
@@ -130,6 +130,7 @@ from btclib.ecc import bms, dsa, musig2, ssa
 from btclib.exceptions import BTClibTypeError
 from btclib.fetch.bitcoin_core import BitcoinCoreFetcher
 from btclib.hwi import HwiSigner, enumerate_devices
+from btclib.key import PrvKeyData
 from btclib.mnemonic import bip39, slip39
 from btclib.mnemonic.entropy import (
     bin_str_entropy_from_random,
@@ -287,6 +288,12 @@ _KINDS = (
         "compressed",
         bytes_from_prv_key_int,
         {"prv_key_int": _PRV_KEY},
+    ),
+    _Case(
+        "btclib.key.PrvKeyData.__init__",
+        "compressed",
+        PrvKeyData,
+        {"q": _PRV_KEY},
     ),
     _Case(
         "btclib.to_prv_key.prv_keyinfo_from_prv_key",

--- a/tests/key_test.py
+++ b/tests/key_test.py
@@ -1,0 +1,144 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for `btclib.key`, the canonical form of a key.
+
+What is worth asserting beyond the conversions themselves is the shape
+the module chose and the reasons it chose it for: that the lazy
+properties are computed once, that equality reads the declared fields and
+so does not change when a lazy one has been asked for, that the two SEC
+spellings of one key are deliberately unequal, and that a private key
+never reaches a repr.
+"""
+
+import pytest
+
+from btclib.curves import bytes_from_point, mult, secp256k1
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.key import PrvKeyData, PubKeyData
+
+Q_INT = 0xC28FCA386C7A227600B2FE50B7CAE11EC86D3BF1FBE471BE89827E19D72AA1D
+Q_POINT = mult(Q_INT, secp256k1.G, secp256k1)
+SEC_COMPRESSED = bytes_from_point(Q_POINT, secp256k1, True)
+SEC_UNCOMPRESSED = bytes_from_point(Q_POINT, secp256k1, False)
+
+
+def test_pub_key_data() -> None:
+    """A public key parses from either SEC form, and lifts to its point."""
+    for sec, compressed in ((SEC_COMPRESSED, True), (SEC_UNCOMPRESSED, False)):
+        key = PubKeyData(sec)
+        assert key.sec == sec
+        assert key.network == "mainnet"
+        assert key.is_compressed is compressed
+        assert key.curve == secp256k1
+        assert key.point == Q_POINT
+
+    # a hex string is octets, as it is everywhere else in the library
+    assert PubKeyData(SEC_COMPRESSED.hex()) == PubKeyData(SEC_COMPRESSED)
+
+
+def test_pub_key_data_point_is_computed_once() -> None:
+    """The lift is memoized: the same tuple comes back, not an equal one."""
+    key = PubKeyData(SEC_COMPRESSED)
+    assert key.point is key.point
+
+
+def test_pub_key_data_equality_ignores_what_was_asked_for() -> None:
+    """Equality and hashing read the declared fields: a lift changes neither."""
+    lifted, untouched = PubKeyData(SEC_COMPRESSED), PubKeyData(SEC_COMPRESSED)
+    assert lifted.point == Q_POINT
+    assert lifted == untouched
+    assert hash(lifted) == hash(untouched)
+    assert len({lifted, untouched}) == 1
+
+
+def test_pub_key_data_sec_forms_are_not_equal() -> None:
+    """The two spellings of one key are different keys: different addresses."""
+    assert PubKeyData(SEC_COMPRESSED) != PubKeyData(SEC_UNCOMPRESSED)
+
+
+def test_pub_key_data_deferred_validity() -> None:
+    """`check_validity=False` builds what the constructor would refuse."""
+    key = PubKeyData(b"\x02", check_validity=False)
+    with pytest.raises(BTClibValueError, match="invalid SEC key size"):
+        key.assert_valid()
+
+
+@pytest.mark.parametrize(
+    "sec, err_msg",
+    [
+        (b"", "invalid SEC key size"),
+        (b"\x02" + b"\x11" * 31, "invalid SEC key size"),
+        (b"\x05" + b"\x11" * 32, "invalid compressed SEC prefix"),
+        (b"\x02" + b"\x11" * 64, "invalid uncompressed SEC prefix"),
+    ],
+)
+def test_invalid_pub_key_data(sec: bytes, err_msg: str) -> None:
+    """Octets no SEC public key has are refused, and never echoed."""
+    with pytest.raises(BTClibValueError, match=err_msg):
+        PubKeyData(sec)
+
+
+def test_pub_key_data_type_and_network() -> None:
+    """A type no key has, and a name no network has, are both refused."""
+    with pytest.raises(BTClibTypeError, match="invalid octets type"):
+        PubKeyData(1)  # type: ignore[arg-type]
+    with pytest.raises(BTClibTypeError, match="invalid network type"):
+        PubKeyData(SEC_COMPRESSED, 1)  # type: ignore[arg-type]
+    with pytest.raises(BTClibValueError):
+        PubKeyData(SEC_COMPRESSED, "no-such-network")
+
+
+def test_prv_key_data() -> None:
+    """A private key derives its public one, in the SEC form it says."""
+    for compressed, sec in ((True, SEC_COMPRESSED), (False, SEC_UNCOMPRESSED)):
+        key = PrvKeyData(Q_INT, "mainnet", compressed)
+        assert key.q == Q_INT
+        assert key.network == "mainnet"
+        assert key.compressed is compressed
+        assert key.curve == secp256k1
+        assert key.pub == PubKeyData(sec)
+
+
+def test_prv_key_data_pub_is_derived_once() -> None:
+    """The multiplication is memoized, being the dearest conversion here."""
+    key = PrvKeyData(Q_INT)
+    assert key.pub is key.pub
+
+
+def test_prv_key_data_repr_masks_the_secret() -> None:
+    """A private key never reaches a repr, as `BIP32KeyData`'s does not."""
+    text = repr(PrvKeyData(Q_INT))
+    assert f"{Q_INT:x}" not in text
+    assert str(Q_INT) not in text
+    assert "q=..." in text
+    assert "mainnet" in text
+
+
+def test_prv_key_data_deferred_validity() -> None:
+    """`check_validity=False` builds what the constructor would refuse."""
+    key = PrvKeyData(0, check_validity=False)
+    with pytest.raises(BTClibValueError, match="not in 1..n-1"):
+        key.assert_valid()
+
+
+@pytest.mark.parametrize("q", [0, secp256k1.n, -1])
+def test_invalid_prv_key_data(q: int) -> None:
+    """A scalar outside 1..n-1 is refused, and never echoed."""
+    with pytest.raises(BTClibValueError, match="not in 1..n-1"):
+        PrvKeyData(q)
+
+
+def test_prv_key_data_types() -> None:
+    """A bool is a kind and not a number, and neither is a string a scalar."""
+    with pytest.raises(BTClibTypeError, match="not a private key scalar"):
+        PrvKeyData(True)
+    with pytest.raises(BTClibTypeError, match="not a private key scalar"):
+        PrvKeyData("cafe")  # type: ignore[arg-type]
+    with pytest.raises(BTClibTypeError, match="invalid network type"):
+        PrvKeyData(Q_INT, 1)  # type: ignore[arg-type]
+    with pytest.raises(BTClibTypeError, match="invalid compressed type"):
+        PrvKeyData(Q_INT, "mainnet", 1)  # type: ignore[arg-type]
+    with pytest.raises(BTClibValueError):
+        PrvKeyData(Q_INT, "no-such-network")

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -210,6 +210,8 @@ KEYWORD_ONLY: dict[str, list[str]] = {
         "max_output",
         "emulators",
     ],
+    "btclib.key:PrvKeyData.__init__": ["check_validity"],
+    "btclib.key:PubKeyData.__init__": ["check_validity"],
     "btclib.network:Network.__init__": ["check_validity"],
     "btclib.network:Network.from_dict": ["check_validity"],
     "btclib.network:Network.to_dict": ["check_validity"],


### PR DESCRIPTION
Closes part of #1188 — the first of the six steps that issue lists, and
the only additive one: nothing in the library consumes these yet, so
nothing changes for a caller.

## What this is

Every converter here takes each spelling of a key and answers a tuple, so
the canonical form is what comes *out* of a conversion and never what
goes *in*. A caller holding one has to spell it back for the next call,
which parses it again — and three places already work around that round
trip locally:

- `bip32.derive_`, issue 886 — "the Base58Check text would be decoded
  straight back by `pub_keyinfo_from_key` on this same line", 53.56 us
  against 36.69;
- `to_pub_key._sec_from_pub_key`, issue 887 — the proof omitted because
  "the two together lift one x twice";
- `taproot._output_pubkey_and_internal_key`, issue 896 — "the same square
  root of the same x".

And `KeyWallet.add` pays it twice over: it computes
`pub_keyinfo_from_key(key, …)` and then hands **`key`** to the address
builder, which derives it again.

`btclib.key` is the cut those four patch: `PubKeyData` and `PrvKeyData`,
built at the boundary and carried afterwards.

## The two design decisions, and what decided them

**The SEC octets are the declared field; the point is a
`cached_property`.** Measured on secp256k1 over twenty thousand rounds of
one key:

| conversion | cost |
| --- | --- |
| point → sec, compressed | 0.99 us |
| point → sec, uncompressed | 1.04 us |
| **sec → point, compressed** | **3.35 us** — the square root |
| sec → point, uncompressed | 1.33 us |
| **prv → pub** | **8.00 us** |

The cheap direction is paid on the way in and the dear one on first use
and kept, so nothing is ever computed that no caller asked for. The lazy
lift is also the **proof**: the constructor reads a length and a prefix,
and whether they frame a point of the curve is what `point` answers —
which is the trade `_sec_from_pub_key` already states, paid once instead
of at every caller.

**One type per half**, not a `PubKeySecData` beside a `PubKeyPointData`:
two would hand the caller a choice that is a cache decision and not a
meaning; any function taking either would take a union again; and one key
in the two types could not compare equal without performing the very
conversion the split was meant to avoid.

Frozen as `BIP32KeyData` is and for its reason (issue 727), and **not**
`slots=True` — `cached_property` stores into an instance `__dict__` that
a slotted dataclass has none of. Equality and hashing read the declared
fields alone, so a lift changes neither, and the compressed and
uncompressed spellings of one key are deliberately unequal: they hash to
different addresses.

## Gates

`uv run pytest` green at 100.00% coverage, `uv run pre-commit run
--all-files` clean, and the `sphinx-build -W --keep-going` job builds —
that last one caught a fenced code block in the module docstring, which
docutils does not read as markdown.

The four library-wide convention tests did their job and are updated
here: the root's module list, the keyword-only census, the bool-parameter
census (`compressed` is a kind, as it is at the four sites beside it),
and the name contract — which is why `PubKeyData.is_compressed` is a
question and `PrvKeyData.compressed` is a field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hde6RUtTpqFBkPziUqzZkX

## Summary by Sourcery

Introduce canonical key data objects so parsed keys can be carried between operations without repeated conversion.

New Features:
- Add canonical `PubKeyData` and `PrvKeyData` types for carrying parsed public and private keys across library operations.

Enhancements:
- Expose the new key module and support lazy, memoized public-key and curve-point derivation while preserving key identity and validation semantics.

Documentation:
- Document the canonical key representations, their validation and caching behavior, and the module in the changelog and API documentation.

Tests:
- Add comprehensive tests for key parsing, validation, equality, hashing, lazy derivation, type handling, and secret-safe representations.