### PR TITLE
A review runs what a diff decides with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,33 @@ documented at release-notes length in the first place, and are still in
   is open. Both siblings gain the same trigger in their own
   `RELEASING.md`.
 
+- **`REVIEWING.md` asks a review to run what a diff decides with.** A
+  regex, a grep, a pattern in a hook, a script or a query decides an
+  outcome by matching or computing, and a review of one executes it
+  rather than reading it — against the shapes the diff's own prose
+  claims to cover, and against the shapes the tree actually holds. A
+  claim the prose makes about the tree takes the same treatment, "every
+  link here is already `./`-prefixed" being one `git grep`'s worth of
+  evidence and the reason a change is offered as safe.
+
+  What earned the rule is the `local-link-prefix` pygrep hook proposed
+  across the organization with a byte-identical pattern, here as pull
+  request #1199. Its leading clause `\[[^]]*\]\(` cannot cross the `]`
+  that closes an image's alt text, so on the badge shape
+  `[![alt](./src)](./href)` it examines the image source and never the
+  destination the link itself carries — which is the destination that
+  hook's own comment cites as its motivating case, left free to lose
+  its `./` unreported. Running the clause against a real README line is
+  what found it, on btclib-org/bitcoin-core-rpc#192; the reviews that
+  reasoned about the pattern instead reported it correct.
+
+  The section says what it is not, `claude-review.yml`'s prompt telling
+  a review here not to re-run the gates: those run what the rest of the
+  tree already exercises, where a pattern a diff adds has been run
+  against nothing until a review runs it. The prompt is unchanged — it
+  names `REVIEWING.md` rather than restating it, so the standard moves
+  without the workflow being edited.
+
 ### Packaging, linting and CI
 
 - **`test.yml`'s and `lint.yml`'s concurrency groups take a

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -68,7 +68,8 @@ In priority order, stopping at what this diff can be wrong about:
   A diff carrying an unrelated fix cannot be acked for either question.
 - **Is it correct?** Reason about the code as it will run, not as it
   reads. Where a claim can be checked, check it rather than believing
-  it.
+  it — and where what the diff adds is what does the deciding, checking
+  it means running it, below.
 - **Does it break a rule this repository states?** Not a rule the
   reviewer would have written — one the repository's own documents
   state, cited by the line that states it. This is the class of finding
@@ -194,6 +195,49 @@ Two properties decide when not to:
 A suggestion carries the severity of the finding it belongs to. Offering
 one does not make a blocking finding a nit, and accepting one is what
 closes the thread.
+
+## What a diff decides with is run, not read
+
+A diff that adds a regex, a grep, a pattern in a hook, a script or a
+query adds something that decides an outcome by matching or computing.
+**Run it.** Reading it again is not a second check: the author read it
+and believed it, and a reviewer who only reads reproduces that reading
+rather than testing it. Running it is what makes the verdict something
+the author's own reading did not already decide.
+
+The cases to run are not the reviewer's to invent:
+
+- **The shapes the diff's own prose claims to cover** — the example in
+  the hook's comment, in the `CHANGELOG.md` entry, in the pull request
+  body. A motivating case the pattern does not in fact handle is the
+  finding, and the diff named that case itself.
+- **The shapes the tree actually holds.** `git grep` for the construct
+  the pattern is about and run it against those lines, rather than
+  against an example composed to be matched.
+
+A claim the prose makes *about the tree* takes the same treatment.
+"Every link here is already `./`-prefixed", "nothing calls this any
+more": each is one command's worth of evidence, and each is the reason
+the change is offered as safe. Settle it. Where it is false, the finding
+is not the code but the reason given for it.
+
+What this is not:
+
+- **A run of the gates.** They run what the rest of the tree already
+  exercises; what this diff adds has been run against nothing, and the
+  review is the first thing to run it. A review told to leave the gates
+  to the workflows running beside it on the same sha is told about the
+  gates, and this is not one of them.
+- **A test suite written inside a review.** It is a handful of one-line
+  runs, and their output is the "how it is known" that a finding carries
+  anyway.
+- **A hand trace wearing a run's authority.** Where what is at hand
+  cannot run the thing — a script or a query wanting an interpreter,
+  where a pattern against the tree needs only a grep and is the usual
+  case — say so in the summary, in those words: it was not run. A trace
+  is the author's reading performed a second time, which is what running
+  it is meant to replace; it can carry a finding, and it cannot carry an
+  ack.
 
 ## The gates are the evidence
 


### PR DESCRIPTION
One pull request was opened in five repositories with a byte-identical
addition: a pygrep hook whose regex decides whether a link destination is
acceptable. Five reviews of the same pattern gave one `CHANGES REQUESTED`, two
`ACK`, and two no verdict at all. The one that requested changes found a real
defect — the pattern could not cross the bracket closing an image's alt text,
so on a badge link it examined the image and never the link's own destination
— and it found it by running the pattern against the licence badge the hook's
own comment cites as its motivating case.

The other reviews traced it by hand. Their own words: "traced the regex … by
hand", "what I checked by hand rather than believed". A hand trace reproduces
the reading the author already performed and believed, which is why two of
them acked a pattern with a measured blocking defect in it.

So: **what a diff decides with is run, not read.** The cases to run are not
the reviewer's to invent — the shapes the diff's own prose claims to cover,
and the shapes the tree actually holds. A motivating case the pattern does not
handle is the finding, and the diff named that case itself. A claim the prose
makes about the tree takes the same treatment: "every link here is already
`./`-prefixed" is one `git grep`'s worth of evidence and is the reason the
change is offered as safe.

Three boundaries, because a rule about running invites two wrong readings and
a third failure that already happened here:

- **Not a run of the gates.** Those run beside the review on the same sha, or
  are the author's to run before pushing. What the diff adds has been run
  against nothing until a review runs it.
- **Not a test suite written inside a review.** A handful of one-line runs,
  whose output is the "how it is known" a finding carries anyway.
- **Not a hand trace wearing a run's authority.** Where what is at hand cannot
  run the thing, the summary says so in those words. A re-review in this
  campaign did exactly that — "`re` wasn't reachable from this sandbox, so
  this is a manual trace" — and was right to; the one that acked on a trace
  without saying so was not.

The hunk is byte-identical in the four `REVIEWING.md` files, which is the
measured answer rather than the lazy one: those files diverge only in their
title and in the section on what a review of that particular tree checks, and
every candidate placement is identical across all four. Writing four
placements would have manufactured divergence.

The section carries no markdown links, deliberately: `btclib-benchmarks`
includes its root files without a link-rewriting transform, so a relative link
between two of them fails `sphinx-build -W` there and would have passed in the
other three.

Gates: `pre-commit run --all-files` and `sphinx-build -E -W --keep-going`, each
exit 0, run after the rebase rather than before it.

## Summary by Sourcery

Require reviews to run the decision-making logic introduced by a diff against its stated examples and the repository’s actual content.

New Features:
- Require reviews to execute newly added decision-making patterns, scripts, queries, and hooks against documented examples and relevant repository content.
- Document how to distinguish executable review checks from CI gates, ad hoc review test suites, and manual tracing.

Enhancements:
- Strengthen review guidance to favor evidence from running checks and validating claims about the repository rather than relying on code inspection alone.
- Add a documented example showing how execution exposed an incorrect link-prefix pattern and clarify when reviewers must disclose that a check was only traced manually.

Documentation:
- Update the changelog and REVIEWING.md with the new review practice and its rationale.