### PR TITLE
Correct what the review of btclib.key found after it landed (issue #1188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -685,6 +685,7 @@ documented at release-notes length in the first place, and are still in
   which is what makes the fix a subtraction rather than a
   correction: the reasoning about a redundant definition survives,
   and only the number that could go stale again is gone.
+
 ### The public API and the module layout
 
 - **`btclib.key` holds the canonical form of a key**, `PubKeyData` and
@@ -692,31 +693,64 @@ documented at release-notes length in the first place, and are still in
   spelled back for the next call to parse again (issue #1188). Every
   converter in the library takes each spelling and answers a tuple, so
   the canonical form was what came *out* of a conversion and never what
-  went *in*; three places already work around the round trip that leaves
-  — `bip32.derive_`, `to_pub_key._sec_from_pub_key` and
-  `taproot._output_pubkey_and_internal_key`, issues 886, 887 and 896 —
-  and this is the cut those three patch locally.
+  went *in*. `bip32.derive_`, `to_pub_key._sec_from_pub_key` and
+  `taproot._output_pubkey_and_internal_key` each work around the round
+  trip that leaves — issues 886, 887 and 896 — and `KeyWallet.add` pays
+  it twice over, deriving a public key and then handing the private one
+  to an address builder that derives it again. This is the cut those
+  patch locally.
 
   The SEC octets are the field and the point is a `cached_property`
-  because the two conversions do not cost the same: serializing a point
-  is a concatenation, where parsing a compressed one is a square root in
-  the field and costs several times as much, so the cheap direction is
-  paid on the way in and the expensive one on first use and kept. That
-  lazy lift is also the *proof*: the constructor reads a length and a
-  prefix, and whether they frame a point of the curve is what `point`
-  answers — which is the trade `_sec_from_pub_key` already states, made
-  explicit and paid once instead of at every caller.
+  because the two conversions do not cost the same. Measured on
+  secp256k1 with the bindings serving, `timeit` over twenty thousand
+  rounds of one key:
+
+  | conversion | us |
+  | --- | --- |
+  | point to sec, compressed | 0.99 |
+  | point to sec, uncompressed | 1.04 |
+  | sec to point, compressed | 3.35 |
+  | sec to point, uncompressed | 1.33 |
+  | prv to pub | 8.00 |
+
+  ```shell
+  uv run python -c "
+  import timeit
+  from btclib.curves import bytes_from_point, bytes_from_prv_key_int, mult
+  from btclib.curves import secp256k1 as ec
+  from btclib.curves.sec_point import point_from_octets
+  q = 0xc28fca386c7a227600b2fe50b7cae11ec86d3bf1fbe471be89827e19d72aa1d
+  Q = mult(q, ec.G, ec)
+  sec_c, sec_u = bytes_from_point(Q, ec, True), bytes_from_point(Q, ec, False)
+  n = 20000
+  for stmt in ('bytes_from_point(Q, ec, True)',
+               'bytes_from_point(Q, ec, False)',
+               'point_from_octets(sec_c, ec)',
+               'point_from_octets(sec_u, ec)',
+               'bytes_from_prv_key_int(q, ec, True)'):
+      print(stmt, timeit.timeit(stmt, globals=globals(), number=n) / n * 1e6)
+  "
+  ```
+
+  Those are this machine's, and they sit beside rather than replace the
+  figures `curves.sec_point.point_from_octets` and
+  `to_pub_key._sec_from_pub_key` record, taken on other hardware. Those
+  two time lifts alone, and agree with the table on the one thing they
+  measure, a compressed lift being the dearer of the two; the three-tier
+  ordering the design rests on — a write cheaper than a lift, a lift than
+  a derivation — is this table's, which is why the command is beside it.
+  So the cheap direction is paid on the way in and the dear one on first
+  use and kept. That lazy lift is also the *proof*: the constructor reads
+  a length and a prefix, and whether they frame a point of the curve is
+  what `point` answers — which is the trade `_sec_from_pub_key` already
+  states, made explicit and paid once instead of at every caller.
   `PrvKeyData.pub` is lazy for the same reason and buys most, a scalar
   multiplication being the dearest conversion of the three.
 
-  One type per half rather than a `PubKeySecData` beside a
-  `PubKeyPointData`: two would hand the caller a choice that is a cache
-  decision and not a meaning, any function taking either would take a
-  union again, and one key in the two types could not compare equal
-  without performing the conversion the split was meant to avoid. Frozen,
-  as `BIP32KeyData` is and for its reason; not `slots=True`, because
-  `cached_property` stores into an instance `__dict__` that a slotted
-  dataclass has none of. Nothing in the library consumes these yet: the
+  The module docstring carries the rest of the reasoning rather than this
+  entry repeating it: why one type per half and not a `PubKeySecData`
+  beside a `PubKeyPointData`, why frozen as `BIP32KeyData` is, and why
+  not `slots=True`. Nothing in the library consumes these yet: the
   adoption is per module, and each step of it removes one of the round
   trips above.
 

--- a/btclib/key.py
+++ b/btclib/key.py
@@ -12,7 +12,9 @@ goes *in*: a caller that has one has to spell it back for the next call,
 which parses it again. That round trip is what
 `bip32.derive_`, `to_pub_key._sec_from_pub_key` and
 `taproot._output_pubkey_and_internal_key` each work around locally --
-issues 886, 887 and 896, three patches over one cut.
+issues 886, 887 and 896 -- and that `KeyWallet.add` pays twice over,
+deriving a public key and then handing the private one to an address
+builder that derives it again.
 
 `PubKeyData` and `PrvKeyData` are that cut: the spellings stay at the
 boundary, the parse happens once, and what travels afterwards is an
@@ -20,15 +22,16 @@ object that knows which half it is.
 
 **Why the SEC octets are the field and the point is derived.** The two
 conversions do not cost the same. Serializing a point is a byte
-concatenation; parsing a compressed one is a square root in the field.
-Measured on secp256k1 over twenty thousand rounds of one key, a
-compressed point costs 3.35 us to parse against the 0.99 of writing it
--- 3.4x -- where an uncompressed one costs 1.33 against 1.04, both
-coordinates being there to read rather than lifted. Deriving a public
-key from a private one is dearer than either, at 8.00 us.
+concatenation; parsing a compressed one is a modular square root, whose
+cost `curves.sec_point.point_from_octets` records beside the two arms
+that pay it. A write is cheaper than a lift and a lift than a
+derivation. The first of those two gaps is widest exactly where it
+matters, at the compressed form that bitcoin uses.
 
-So the cheap direction is paid on the way in, the expensive one on first
-use and kept, and `PrvKeyData.pub` is where laziness buys most.
+So the cheap direction is paid on the way in, the dear one on first use
+and kept, and `PrvKeyData.pub` is where laziness buys most. The CHANGELOG
+entry for this module carries the measurements and the command that took
+them: one fact in one place, and this is not the place.
 
 That is not only a cache. **`point` is also the proof**: a length and a
 prefix are what the constructor checks, and whether those octets are a
@@ -63,6 +66,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import cached_property
+from typing import Any
 
 from btclib.alias import Octets, Point
 from btclib.curves import Curve, bytes_from_prv_key_int, point_from_octets
@@ -78,19 +82,48 @@ __all__ = [
 # the two SEC forms, and the prefix each one takes. 0x04 is the
 # uncompressed marker; 0x02 and 0x03 name the parity of y. A hybrid key --
 # 0x06 or 0x07, both coordinates *and* a parity byte -- is SEC1 and is not
-# bitcoin: Core has never relayed one, and `curves.sec_point` refuses it,
-# so this refuses it too rather than parse what the layer below will not
-_COMPRESSED_PREFIXES = (2, 3)
-_UNCOMPRESSED_PREFIX = 4
+# among them: `sec_point.point_from_octets` does parse one when its
+# `hybrid` argument asks for it, the script engine being the caller that
+# has to accept what was mined, and it defaults to `hybrid=False` because
+# nothing in bitcoin produces one. This type takes that default, so a
+# hybrid key is refused here rather than carried as a canonical form
+_COMPRESSED_PREFIXES = (0x02, 0x03)
+_UNCOMPRESSED_PREFIX = 0x04
 
 
-@dataclass(frozen=True)
+def _normalized(network: Any) -> Any:
+    """Return a network name in the one spelling two of them share.
+
+    `network_from_name` accepts " MainNet " for "mainnet" -- the
+    tolerance issue #216 decided to keep, and `network`'s
+    `_validated_network_name` is where that rule is stated. Without the
+    same coercion here the two spellings build objects that are not equal
+    and do not hash alike, and the claim above that equality reads the
+    declared fields would be true of the fields and false of the key.
+
+    A normalization and not a check, which is why it refuses nothing:
+    `check_validity=False` means the validity checks do not run, so that
+    a test can build the invalid object it means to exercise, and a
+    coercion that raised would take that away. Whether the name is a
+    network at all -- and whether it is a string -- stays
+    `assert_valid`'s question.
+
+    `sec` is asymmetric here, and the asymmetry is inherited rather than
+    chosen: `bytes_from_octets` refuses a wrong type whatever
+    `check_validity` says, and it belongs to `utils` rather than to this
+    module.
+    """
+    return network.strip().lower() if isinstance(network, str) else network
+
+
+@dataclass(frozen=True, init=False)
 class PubKeyData:
     """A public key as its SEC octets, on a named network.
 
     The octets are the field because serializing a point is cheap and
     parsing one is not; `point` is the lift, paid on first use and kept.
-    The module docstring carries the measurement and the reasoning.
+    The module docstring carries the reasoning and the CHANGELOG entry
+    the measurements.
     """
 
     sec: bytes
@@ -104,7 +137,7 @@ class PubKeyData:
         check_validity: bool = True,
     ) -> None:
         object.__setattr__(self, "sec", bytes_from_octets(sec))
-        object.__setattr__(self, "network", network)
+        object.__setattr__(self, "network", _normalized(network))
 
         if check_validity:
             self.assert_valid()
@@ -144,21 +177,24 @@ class PubKeyData:
         """Refuse octets no SEC public key has, and an unknown network.
 
         A length and a prefix, and not a point: see `point`, which is
-        where the curve is asked. That `sec` is bytes at all is not
-        asked here: `bytes_from_octets` is what the constructor runs it
-        through, whatever `check_validity` says, so a second check would
-        re-ask a question already answered one layer down.
+        where the curve is asked. That `sec` is bytes at all is not asked
+        here, `bytes_from_octets` having refused anything else in the
+        constructor whatever `check_validity` said; `network` is asked,
+        `_normalized` being a coercion that refuses nothing.
         """
         assert_type(self.network, str, "network")
         # refuses a name no network has, which is what this is called for
         ec = network_from_name(self.network).curve
-        prefix = self.sec[0] if self.sec else None
         if len(self.sec) == ec.p_size + 1:
-            if prefix not in _COMPRESSED_PREFIXES:
-                raise BTClibValueError(f"invalid compressed SEC prefix: {prefix}")
+            if self.sec[0] not in _COMPRESSED_PREFIXES:
+                raise BTClibValueError(
+                    f"invalid compressed SEC prefix: {self.sec[0]:#04x}"
+                )
         elif len(self.sec) == 2 * ec.p_size + 1:
-            if prefix != _UNCOMPRESSED_PREFIX:
-                raise BTClibValueError(f"invalid uncompressed SEC prefix: {prefix}")
+            if self.sec[0] != _UNCOMPRESSED_PREFIX:
+                raise BTClibValueError(
+                    f"invalid uncompressed SEC prefix: {self.sec[0]:#04x}"
+                )
         else:
             # never echo the octets: a caller that reached here with
             # private material spelled them as a public key by mistake,
@@ -166,7 +202,7 @@ class PubKeyData:
             raise BTClibValueError(f"invalid SEC key size: {len(self.sec)}")
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class PrvKeyData:
     """A private key as its scalar, on a named network, compressed or not.
 
@@ -175,9 +211,8 @@ class PrvKeyData:
     derives would not be one key but two.
 
     `pub` is the derivation, and it is the most expensive conversion in
-    this module -- a scalar multiplication, some two and a half times
-    what lifting a compressed point costs -- so it is where laziness
-    pays most.
+    this module -- a scalar multiplication, dearer than lifting a
+    compressed point -- so it is where laziness pays most.
     """
 
     q: int
@@ -193,7 +228,7 @@ class PrvKeyData:
         check_validity: bool = True,
     ) -> None:
         object.__setattr__(self, "q", q)
-        object.__setattr__(self, "network", network)
+        object.__setattr__(self, "network", _normalized(network))
         object.__setattr__(self, "compressed", compressed)
 
         if check_validity:
@@ -211,9 +246,21 @@ class PrvKeyData:
 
     @cached_property
     def pub(self) -> PubKeyData:
-        """Return the public key this one derives, multiplying once."""
+        """Return the public key this one derives, multiplying once.
+
+        `check_validity=False`, and it is the one call in this module
+        entitled to it. What makes the skip safe is not that
+        `assert_valid` ran -- on an object built with
+        `check_validity=False` it never did -- but that the two lines
+        above ask everything it would: `self.curve` resolves the network
+        name through `network_from_name`, which refuses one no network
+        has, and `bytes_from_prv_key_int` asserts `compressed` is a bool
+        and answers the SEC form by construction. Asking again is what
+        CONTRIBUTING.md's "checking them a second time buys nothing"
+        names, and it would be this module's own argument run backwards.
+        """
         sec = bytes_from_prv_key_int(self.q, self.curve, self.compressed)
-        return PubKeyData(sec, self.network)
+        return PubKeyData(sec, self.network, check_validity=False)
 
     def assert_valid(self) -> None:
         """Refuse a scalar outside 1..n-1, and an unknown network."""

--- a/docs/source/btclib.rst
+++ b/docs/source/btclib.rst
@@ -128,13 +128,6 @@ btclib.hashes module
    :members:
    :show-inheritance:
 
-btclib.key module
------------------
-
-.. automodule:: btclib.key
-   :members:
-   :show-inheritance:
-
 btclib.hwi module
 -----------------
 
@@ -146,6 +139,13 @@ btclib.kdf module
 -----------------
 
 .. automodule:: btclib.kdf
+   :members:
+   :show-inheritance:
+
+btclib.key module
+-----------------
+
+.. automodule:: btclib.key
    :members:
    :show-inheritance:
 

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -40,6 +40,7 @@ from btclib.block.proof_of_work import hash_rate, retarget_first_height
 from btclib.exceptions import BTClibTypeError
 from btclib.fee import FeeRate, fee_from_vsize
 from btclib.hashes import merkle_root_from_branch, sha256
+from btclib.key import PrvKeyData
 from btclib.mnemonic.entropy import bin_str_entropy_from_wordlist_indexes
 from btclib.number_theory import mod_inv, mod_inv_batch_var, mod_inv_var
 from btclib.psbt.psbt import PSBT_V2, Psbt
@@ -120,6 +121,7 @@ _CASES: list[tuple[str, Callable[[Any], object]]] = [
     ("header nonce", lambda v: _header(nonce=v)),
     ("block height", lambda v: BlockContext(v, _NOW)),
     ("bip34 height", lambda v: BlockContext(1, _NOW, v)),
+    ("private key scalar", PrvKeyData),
     (
         "bip32 depth",
         lambda v: BIP32KeyData(

--- a/tests/key_test.py
+++ b/tests/key_test.py
@@ -58,6 +58,54 @@ def test_pub_key_data_sec_forms_are_not_equal() -> None:
     assert PubKeyData(SEC_COMPRESSED) != PubKeyData(SEC_UNCOMPRESSED)
 
 
+def test_the_lift_is_the_proof() -> None:
+    """Octets of the right shape that are no point are refused by `point`.
+
+    The whole of what makes this design lazy rather than eager: the
+    constructor reads a length and a prefix, and the curve is asked only
+    when somebody wants the point. A key nobody asks has never been
+    proved one, which is deliberate and is what this asserts.
+    """
+    not_a_point = PubKeyData(b"\x02" + b"\x11" * 32)
+    assert not_a_point.is_compressed
+    with pytest.raises(BTClibValueError, match="invalid x-coordinate"):
+        _ = not_a_point.point
+
+
+def test_hybrid_sec_prefixes_are_refused() -> None:
+    """0x06 and 0x07 carry both coordinates, and are not a canonical form.
+
+    `sec_point.point_from_octets` parses one when asked; this type takes
+    that function's default and does not ask, so a hybrid key never
+    becomes a `PubKeyData`.
+    """
+    for prefix in (b"\x06", b"\x07"):
+        with pytest.raises(BTClibValueError, match="invalid uncompressed SEC prefix"):
+            PubKeyData(prefix + SEC_UNCOMPRESSED[1:])
+
+
+def test_a_network_name_is_normalized_on_the_way_in() -> None:
+    """Two spellings of one network are one key, not two.
+
+    `network_from_name` accepts " MainNet ", so without the coercion the
+    two would be unequal and hash apart -- and a dict or a set would hold
+    the same key twice.
+    """
+    plain, spelled = PubKeyData(SEC_COMPRESSED), PubKeyData(SEC_COMPRESSED, " MainNet ")
+    assert plain == spelled
+    assert hash(plain) == hash(spelled)
+    assert len({plain, spelled}) == 1
+    assert spelled.network == "mainnet"
+    assert PrvKeyData(Q_INT, " MainNet ") == PrvKeyData(Q_INT)
+
+
+def test_the_network_travels_to_the_derived_key() -> None:
+    """What the type exists to carry: a derived key is on its parent's chain."""
+    key = PrvKeyData(Q_INT, "testnet")
+    assert key.pub.network == "testnet"
+    assert key.pub.sec == SEC_COMPRESSED
+
+
 def test_pub_key_data_deferred_validity() -> None:
     """`check_validity=False` builds what the constructor would refuse."""
     key = PubKeyData(b"\x02", check_validity=False)


### PR DESCRIPTION
Follow-up to #1201, which landed the version of `btclib.key` written
*before* its review. Four review rounds ran against it and their findings
were held on a local branch; the pull request was open and green in the
meantime, so the pre-review commit is the one that merged. This carries
the findings across. No new design, no new API: every line here answers a
finding.

## What is wrong on `main` today

| finding | evidence |
| --- | --- |
| **The equality contract the module documents is false.** `network` is a declared field, so it is what `__eq__`/`__hash__` compare — by the caller's spelling, and `network_from_name` accepts `" MainNet "` for `"mainnet"` (issue #216). A `set` or `dict` holds the same key on the same chain twice. | `PubKeyData(sec, " MainNet ") == PubKeyData(sec, "mainnet")` → `False`, and the hashes differ, under a docstring that says "two objects for one key compare equal" |
| **A comment states the opposite of what the layer below does**: "`curves.sec_point` refuses it, so this refuses it too rather than parse what the layer below will not" | `sec_point.point_from_octets` *parses* `0x06`/`0x07` when its `hybrid` argument asks — the script engine is the caller that has to accept what was mined. What refuses one here is the `hybrid=False` default |
| **`PrvKeyData.pub` re-validates what it just produced** — this module's own argument run backwards | `bytes_from_prv_key_int` answers the SEC form by construction and asserts `compressed` is a bool; `self.curve` resolves the network name and refuses one no network has |
| **The module's headline claim has no test.** "`point` is also the proof" is what makes the design lazy rather than eager | nothing exercised octets of the right length and prefix that are no point of the curve |
| `PrvKeyData.q` is absent from `integer_policy_test.py`'s census, where every other integer field that refuses a bool is registered | that census is hand-kept, so no gate says so |
| the docs stanza is out of alphabetical order; the prefix constants and messages read in decimal where `sec_point` writes hex | — |

## What this changes

`_normalized` coerces the network name on the way in, as `sec` is coerced
on the way in. **It refuses nothing, deliberately**: `check_validity=False`
means the validity checks do not run, so that a test can build the invalid
object it means to exercise, and a coercion that raised would take that
away. `sec` is asymmetric there and the asymmetry is inherited rather than
chosen — `bytes_from_octets` refuses a wrong type whatever the flag says,
and it belongs to `utils`.

Four tests join the file: the proof above, the hybrid refusal the
constants' comment asserts, the normalization, and that a derived key is
on its parent's chain.

The CHANGELOG entry gains the measurements and the command that
reproduces them. CONTRIBUTING.md puts the matrix in the entry and the
reason in the docstring, and this had it the other way round — with a
command that measured two of five rows and printed total seconds where the
column said microseconds. The figures `curves.sec_point.point_from_octets`
and `to_pub_key._sec_from_pub_key` already record are named for what they
are: lifts alone, taken on other hardware, agreeing with the table on the
one thing they measure.

## Gates

`uv run pytest` green at 100.00% coverage, `uv run pre-commit run
--all-files` clean, `sphinx-build -W --keep-going` builds — all three run
after the rebase, which is the other lesson from #1201.

## The process lesson

The review-before-push rule works only while the pull request is not yet
open: an open, green branch is mergeable at any moment, and it won the
race against the review. Open the pull request *after* the local review,
not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hde6RUtTpqFBkPziUqzZkX

## Summary by Sourcery

Correct reviewed key-data validation, equality, and documentation issues while preserving the existing API and lazy key representation.

Bug Fixes:
- Normalize network names when constructing key data so equivalent spellings compare and hash as the same key.
- Avoid redundant validation when deriving public key data from a private key.
- Reject non-canonical hybrid SEC prefixes and report SEC prefixes consistently in hexadecimal.
- Add coverage for deferred point validation, network normalization, hybrid-key rejection, derived-key network propagation, and private-key integer policy enforcement.

Enhancements:
- Clarify key validation, lazy point derivation, and SEC format behavior in module documentation.
- Reorganize documentation and record key-conversion performance measurements with a reproducible benchmark.

Documentation:
- Update the changelog, contribution guidance, and API documentation ordering to reflect key validation behavior and performance measurements.

Tests:
- Expand key tests and integer-policy coverage for reviewed validation and equality contracts.