### PR TITLE
Key latest.yml's cache on the runner image, and record the token-permissions status

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -263,13 +263,38 @@ jobs:
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
-      # keyed on the config file, as in lint.yml: the hook environments
-      # are the slow part and the upgrade above does not touch them
+      # ImageOS is set by the runner image, not by this workflow, so the
+      # env context holds nothing for it and a shell is where it is read.
+      # lint.yml's step of this name carries the rest of that reasoning,
+      # ImageVersion included
+      - name: Identify the runner image
+        id: image
+        run: echo "os=${ImageOS:-unknown}" >> "$GITHUB_OUTPUT"
+      # the hook environments are the slow part and the upgrade below does
+      # not touch them, which is why they are cached here at all.
+      # The key carries the runner image and the interpreter as well as the
+      # config hash because what is cached is virtualenvs: on the config
+      # hash alone an ubuntu-latest rotation is not a graceful miss but a
+      # hit, handing the job environments built on the previous image. This
+      # is the job that can least afford one -- it runs to report what a
+      # new release of a dependency breaks, so a failure the cache caused
+      # is read as the thing this workflow was watching for and chased in
+      # the tree instead.
+      # That is the key lint.yml uses, deliberately rather than by
+      # coincidence, and
+      #   git grep -n 'pre-commit-\${{' -- .github/workflows/
+      # is what re-reads the two together: they are meant to agree
       - name: Cache the pre-commit hook environments
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: >-
+            pre-commit-${{ runner.os }}-${{ steps.image.outputs.os }}-${{
+            hashFiles('.pre-commit-config.yaml', '.python-version') }}
+          # a prefix that still names the image, so a partial restore
+          # cannot cross an image boundary either
+          restore-keys: |
+            pre-commit-${{ runner.os }}-${{ steps.image.outputs.os }}-
       - name: Upgrade every dependency to its latest release
         run: uv lock --upgrade
       # --all-files, so pre-commit does not stash the rewritten uv.lock:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,8 +153,43 @@ documented at release-notes length in the first place, and are still in
   It leaves the entry above where it was. The gates exercise what the
   tree already held, so what a diff decides with has been run by nothing
   whether they ran or not, and a review runs that either way.
+- **`REPOSITORY.md` records the default workflow-token permission, the
+  call that reads it back, and that this repository is untested against
+  the organization default** (btclib-org/.github#23). The value is
+  `read`, with `can_approve_pull_request_reviews` false — and it was
+  already `read` before the organization default moved there on
+  21 August 2026, so this repository was never among the ones that could
+  be seen following that move, and an override set before that day reads
+  back exactly like an inheritance. No endpoint distinguishes the two and
+  none clears an override; that is the organization standard's argument
+  and the new subsection links to it rather than repeating it. What the
+  subsection adds is this repository's own answer, the command that
+  produced it, and the `PUT` that moves this repository by hand the next
+  time the organization default moves. Documentation only: nothing was
+  set, and the read-back is the same object before and after.
 
 ### Packaging, linting and CI
+
+- **`latest.yml`'s pre-commit cache is keyed on the runner image and the
+  interpreter rather than on the config hash alone**
+  (btclib-org/.github#25). What that cache holds is virtualenvs, so the
+  config hash alone survives an `ubuntu-latest` rotation and restores
+  environments built on the previous image — not a graceful miss but a
+  hit, surfacing as whichever hook touches the broken environment first.
+  `lint-latest` is the job with the most to lose from that: it runs to
+  report what a new release of a dependency breaks, so a failure the
+  cache caused arrives looking exactly like the one the workflow exists
+  to find, and is chased in the tree. The `Identify the runner image`
+  step reading `ImageOS` from a shell, the key over `runner.os`, that
+  output and `hashFiles` of `.pre-commit-config.yaml` and
+  `.python-version`, and `restore-keys` still naming the image so a
+  partial restore cannot cross an image boundary, are all `lint.yml`'s,
+  which has carried them since before this was noticed. The comment
+  above the bare key claimed it was keyed "as in `lint.yml`", which was
+  false where it stood and offered that file as the justification; what
+  replaces it is this job's own reason for the key, with
+  `git grep -n 'pre-commit-\${{' -- .github/workflows/` beside it as the
+  command that re-reads both keys together.
 
 - **`test.yml`'s and `lint.yml`'s concurrency groups take a
   `concurrency-suffix` input, and `release.yml` passes `-release` at both

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -473,6 +473,41 @@ git grep -n "permissions:$" -- .github/workflows/*.yml
 re-derives the current list, whenever it's wanted, rather than a count
 here going stale the next time a job's own needs change.
 
+### Whether that default is pinned here is untested
+
+```shell
+gh api repos/btclib-org/btclib/actions/permissions/workflow
+# {"default_workflow_permissions":"read",
+#  "can_approve_pull_request_reviews":false}
+```
+
+`read`, and a false `can_approve_pull_request_reviews` beside it. What
+the call cannot say is whether either value is this repository's own or
+the organization's, no endpoint reporting an override and none clearing
+one: [the standard's tokens
+section](https://github.com/btclib-org/.github/blob/main/README.md#tokens-publishing-scanning)
+is where that is argued, and the answer this file adds is which of the
+two states this repository is in.
+
+It is **untested**, and that is what the date makes it: this repository
+already held `read` when the organization default moved there on
+21 August 2026, so it was not among the ones that could be *seen*
+following the move, and an override set before that day reads back
+exactly like an inheritance does. Nobody has recorded setting one here,
+which is weaker than knowing there is none — `bitcoin-core-rpc` is the
+repository where one was found, by that survey, and its `REPOSITORY.md`
+records it as pinned.
+
+So whoever moves the organization default reads this repository back
+afterwards rather than assuming it followed, and moves it by hand where
+it did not:
+
+```shell
+gh api -X PUT repos/btclib-org/btclib/actions/permissions/workflow \
+  -f default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=false
+```
+
 ## Publishing
 
 **Publishing waits for an approval**: the `pypi` and `testpypi`


### PR DESCRIPTION
**`latest.yml`'s pre-commit cache was keyed on the config hash alone**,
under a comment claiming the key was `lint.yml`'s — which it was not.
What the cache holds is hook virtualenvs: compiled artifacts and
interpreter-linked binaries. On the config hash alone an `ubuntu-latest`
rotation is not a graceful miss but a **hit**, handing the job
environments built on the previous image, and surfacing as whichever
hook touches one first.

`lint-latest` is the job least able to absorb that. Its only product is a
signal about the outside world — *a new release of something broke this
tree* — so a cache-induced failure there is indistinguishable from the
finding the workflow exists to produce, and gets chased in the tree
rather than in the cache, on a schedule nobody is watching. Trimming the
comment to match the bare key would have made the file honest and left
that failure mode in place; the key changes instead, to `lint.yml`'s:
`Identify the runner image` reading `ImageOS` from a shell, a key over
`runner.os` + that output + `hashFiles` of `.pre-commit-config.yaml` and
`.python-version`, and `restore-keys` whose prefix still carries the
image so a partial restore cannot cross an image boundary. The cost is
one cold rebuild per rotation, which `lint.yml` already pays.

The comment no longer *justifies* the key by pointing at the sibling —
this job's own reason stands on its own — and carries the command that
re-reads both keys together, since nothing automated compares them:
`git grep -n 'pre-commit-\${{' -- .github/workflows/`.

**The workflow-token default is recorded as untested, not as inherited.**
No endpoint distinguishes an override from an inheritance, `PUT` takes
only `read`/`write`, and the org audit log answers 404 on this plan. Each
repository already held `read` before the organization default moved
there on 21 August 2026, so none could have been *observed* following the
move. `REPOSITORY.md` records the measured object — `read`, with
`can_approve_pull_request_reviews` false, the field that decides whether
a run can approve a pull request and so whether the one rule requiring
somebody other than the author has a way around it — the command that
produced it, and the by-hand `PUT` for the next time the default moves.

---

Neither `btclib-org/.github#23` nor `#25` is closed by this: each spans repositories that land separately, so no single commit answers either in full.

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run after the rebase onto current `main`. The suite and the documentation build run beside this review on this same sha — `REVIEWING.md` is what that reliance takes.

## Summary by Sourcery

Make the latest dependency workflow resilient to runner image changes and document the repository's workflow-token permission status.

Bug Fixes:
- Prevent stale pre-commit environments from being restored across runner image rotations by including the image and Python interpreter in the cache key and restore prefix.

Enhancements:
- Document the repository's measured workflow-token permission state, its untested relationship to the organization default, and the commands for verifying or updating it.

CI:
- Align latest.yml pre-commit caching with runner-specific invalidation to avoid cache-induced failures in the dependency freshness check.

Documentation:
- Record the workflow-token permission status, verification command, and manual update procedure in REPOSITORY.md and the changelog.