### PR TITLE
CONTRIBUTING.md sends a contributor to the organization standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -738,8 +738,12 @@ documented at release-notes length in the first place, and are still in
   the toolchain, the lint gate, the workflow set and the branch rules
   once for this repository and its siblings, and it claims to be linked
   from each repository's CONTRIBUTING.md. Nothing here named it: the
-  only mentions of that repository in this tree were CHANGELOG.md and
-  RELEASING.md citing issue numbers filed there, so a contributor
+  mentions of that repository in this tree were every one of them an
+  issue-number citation — in a workflow comment, a hook comment, the
+  changelog and the release guide — and not one of them a pointer to
+  the standard. `git grep -n 'btclib-org/\.github'` is what re-derives
+  them, a list here going stale the next time one is cited. So a
+  contributor
   following CONTRIBUTING.md to REPOSITORY.md to CLAUDE.md was never
   told a document above them existed — and a rule stated only there was
   one they could not find, a divergence they introduce one nothing in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -733,6 +733,26 @@ documented at release-notes length in the first place, and are still in
 
 ### Documentation and the website
 
+- **CONTRIBUTING.md sends a contributor to the organization standard**
+  (btclib-org/.github#52). `README.md` in `btclib-org/.github` states
+  the toolchain, the lint gate, the workflow set and the branch rules
+  once for this repository and its siblings, and it claims to be linked
+  from each repository's CONTRIBUTING.md. Nothing here named it: the
+  only mentions of that repository in this tree were CHANGELOG.md and
+  RELEASING.md citing issue numbers filed there, so a contributor
+  following CONTRIBUTING.md to REPOSITORY.md to CLAUDE.md was never
+  told a document above them existed — and a rule stated only there was
+  one they could not find, a divergence they introduce one nothing in
+  this tree warned them about. The pointer is in the opening list,
+  where the file already says what to read first, rather than in
+  REPOSITORY.md or CLAUDE.md: the audit and the normalizing checklist
+  are performed *holding* the standard, so the reader who arrives
+  without it is the contributor, and CONTRIBUTING.md is the file that
+  reader is already in. It is also the one of the three that the
+  documentation build renders, `docs/source/contributing_link.md`
+  including it, which is why the destination is the absolute github.com
+  url a sibling repository is linked with elsewhere here and not a
+  relative path — a relative one resolves against btclib.org.
 - **`docs/source/conf.py`'s `RootFileLinks` comment no longer states a
   count of the root markdown files a build-time copy would duplicate**
   (issue #1195). The paragraph rejecting that alternative said the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -737,13 +737,14 @@ documented at release-notes length in the first place, and are still in
   (btclib-org/.github#52). `README.md` in `btclib-org/.github` states
   the toolchain, the lint gate, the workflow set and the branch rules
   once for this repository and its siblings, and it claims to be linked
-  from each repository's CONTRIBUTING.md. Nothing here named it: the
-  mentions of that repository in this tree were every one of them an
-  issue-number citation — in a workflow comment, a hook comment, the
-  changelog and the release guide — and not one of them a pointer to
-  the standard. `git grep -n 'btclib-org/\.github'` is what re-derives
-  them, a list here going stale the next time one is cited. So a
-  contributor
+  from each repository's CONTRIBUTING.md. Nothing here named it. Every
+  mention of that repository in this tree either pointed at an issue
+  filed there or deep-linked
+  one subsection of it to justify one setting, reached only by
+  somebody already reading the paragraph that carries it; not one of
+  them told a reader the document exists.
+  `git grep -n 'btclib-org/\.github'` is what re-derives them, a list
+  here going stale the next time one is written. So a contributor
   following CONTRIBUTING.md to REPOSITORY.md to CLAUDE.md was never
   told a document above them existed — and a rule stated only there was
   one they could not find, a divergence they introduce one nothing in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -739,16 +739,15 @@ documented at release-notes length in the first place, and are still in
   once for this repository and its siblings, and it claims to be linked
   from each repository's CONTRIBUTING.md. Nothing here named it. Every
   mention of that repository in this tree either pointed at an issue
-  filed there or deep-linked
-  one subsection of it to justify one setting, reached only by
-  somebody already reading the paragraph that carries it; not one of
-  them told a reader the document exists.
+  filed there or deep-linked one subsection of it to justify one
+  setting, reached only by somebody already reading the paragraph that
+  carries it; not one of them told a reader the document exists.
   `git grep -n 'btclib-org/\.github'` is what re-derives them, a list
   here going stale the next time one is written. So a contributor
   following CONTRIBUTING.md to REPOSITORY.md to CLAUDE.md was never
-  told a document above them existed — and a rule stated only there was
-  one they could not find, a divergence they introduce one nothing in
-  this tree warned them about. The pointer is in the opening list,
+  told a document above them existed — a rule stated only there was one
+  they could not find, and a divergence they introduce is one nothing
+  in this tree warned them about. The pointer is in the opening list,
   where the file already says what to read first, rather than in
   REPOSITORY.md or CLAUDE.md: the audit and the normalizing checklist
   are performed *holding* the standard, so the reader who arrives

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,14 @@ If you haven't already:
   [pull request](https://github.com/btclib-org/btclib/pulls) to propose
   it: both are read, and both leave a record the next reader of this
   file can find.
+- read the
+  [btclib-org repository standard](https://github.com/btclib-org/.github/blob/main/README.md),
+  where the toolchain, the lint gate, the workflow set and the branch
+  rules are stated once for this repository and its siblings, each with
+  the alternative it was decided against. It binds this repository, so a
+  change departing from it is a divergence — and one filed as an issue
+  in that repository rather than here, a difference between two
+  repositories belonging to neither of them.
 
 In this guide you will get an overview of the contribution workflow from
 opening an issue, creating a PR, reviewing, and merging the PR.


### PR DESCRIPTION
The organization standard — `README.md` in `btclib-org/.github` — states
the toolchain, the lint gate, the tool tables behind it, the workflow set
and the branch rules once for this repository and its siblings, each rule
with the alternative it was decided against. **Nothing in this tree named
it.** The only mentions of that repository were `CHANGELOG.md` and
`RELEASING.md` citing issue numbers filed there, so a contributor
following `CONTRIBUTING.md` → `REPOSITORY.md` → `CLAUDE.md` was never
told a document above them existed. A rule stated only there was a rule
they could not find, and a divergence they introduce is one nothing here
warned them about.

**The pointer goes in `CONTRIBUTING.md`, and nowhere else.** The
standard's three readers are not equally in need of it: §15's audit and
§16's checklists are performed *holding* the standard — that is what
makes their commands runnable — so the only reader who reaches a
btclib-org tree without it is the contributor, and `CONTRIBUTING.md` is
the file that reader is already in.

Three things settled it rather than left it a preference:

- The standard already claims exactly this — "linked from each
  repository's `CONTRIBUTING.md`, rather than a copy per repository" — so
  a pointer in `REPOSITORY.md` or `CLAUDE.md` would have left that
  sentence false.
- `CONTRIBUTING.md` is the only one of the three the documentation build
  renders: `docs/source/contributing_link.md` `{include}`s it and `index`
  lists it, while `REPOSITORY.md` and `CLAUDE.md` are in no toctree.
- Each repository's own *one fact in one place* rule argues against five
  pointers where one carries it.

The destination is an absolute `https://github.com/…` url, the shape
every cross-repository link here already takes: a `./`-relative one
resolves against btclib.org or the Read the Docs site and reaches
nothing. `local-link-prefix`'s lookahead exempts a scheme, so the hook is
unaffected, and the rendered `href` was checked in the built html.

`btclib-org/.github#52` **stays open**: btclib-node is inside its
measurement and outside this work.

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run
after the rebase onto current `main`. The suite and the documentation
build run beside this review on this same sha.

## Summary by Sourcery

Direct contributors to the shared organization standard before they begin repository work.

New Features:
- Link contributors from CONTRIBUTING.md to the shared btclib organization repository standard.

Documentation:
- Document the organization-wide toolchain, lint, workflow, and branch rules as required contributor guidance.
- Record the documentation change in the changelog.