### PR TITLE
Say what each .readthedocs.yaml is true of, and stop copying what it is not

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,9 +9,22 @@
 # The build has to install btclib itself, not sphinx alone: every autodoc
 # directive in docs/source imports its module, a failed import is a
 # sphinx warning rather than an error, and a "requirements:
-# docs/requirements.txt" install therefore publishes 15 bare module
-# titles with no API beneath them, silently. The same build with btclib
-# importable emits 89 signatures, measured on this tree.
+# docs/requirements.txt" install therefore publishes a bare module title
+# in place of each of them, silently. Which pages go empty that way is
+# `grep -rl automodule docs/source`'s answer, and the same build with
+# btclib importable renders their signatures instead: the command rather
+# than the figures it returns, CONTRIBUTING.md's "Measure, don't assert"
+# asking for the command beside a number and nothing here re-deriving
+# the ones this comment used to state.
+#
+# What this file cannot say is *which* versions run it. `latest`,
+# `stable` and each release tag are versions on read the docs' side, and
+# an automation rule is what activates a new tag there -- so a release
+# that keeps a permanent URL of its own and one that does not differ in
+# a setting, not in this file. REPOSITORY.md's "Read the Docs" section
+# records those settings with the commands that read them back, and
+# btclib-org/.github#26 is where the publishing repositories are
+# compared on them.
 
 # Required
 version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -746,6 +746,30 @@ documented at release-notes length in the first place, and are still in
   correction: the reasoning about a redundant definition survives,
   and only the number that could go stale again is gone.
 
+- **`.readthedocs.yaml`'s comment states no counts either, and says what
+  the file does not decide** (btclib-org/.github#26). The paragraph on
+  installing btclib so that autodoc can import it carried a figure for
+  the module titles a sphinx-only install leaves bare and another for the
+  signatures the same build renders with btclib importable — measured
+  once, on a tree that has moved, and re-derived by nothing, which is the
+  shape the entry above was written for and which `CLAUDE.md` summarizes
+  as "nothing states a count now". `grep -rl automodule docs/source`
+  stands where the figures were, CONTRIBUTING.md's "Measure, don't
+  assert" asking for the command beside a number; the reasoning is
+  otherwise unchanged.
+
+  A paragraph is added for what this file cannot say at all: *which*
+  versions run it. `latest`, `stable` and each release tag are versions
+  on read the docs' side, and an automation rule is what activates a new
+  tag there — so a release that keeps a permanent URL of its own and one
+  that does not differ in a setting rather than in the tree.
+  `REPOSITORY.md`'s "Read the Docs" section already records those
+  settings with the commands that read them back, and the file now points
+  at it instead of leaving a reader to find out that the question is
+  elsewhere. This repository has the rule and its newest tag is built;
+  what the siblings answer is btclib-org/.github#26's subject, and each
+  of their copies of this file now says so where it is read.
+
 ### The public API and the module layout
 
 - **`btclib.key` holds the canonical form of a key**, `PubKeyData` and


### PR DESCRIPTION
`btclib-org/.github#26` asks whether Read the Docs is wired the same way
in the three publishing repositories. The question underneath it is
whether it *should* be: **a difference that follows from what a
repository publishes is not drift; one nobody chose is.** Each difference
was judged on that, and most were left alone.

Left alone, because they follow from the repository:
`btclib-secp256k1`'s `submodules:` block, which every `automodule` there
needs to compile; plural against singular in the autodoc paragraph, which
follows from what each publishes; and the shared mechanism — `version`,
`build.os`, the interpreter, `pip install uv`, `uv sync --locked`,
`sphinx-build -W --keep-going` — identical in all four for the same
reason in each.

**The file that was most identical was the most wrong.**
`btclib-benchmarks/.readthedocs.yaml` was byte-for-byte identical to
`btclib`'s — `diff -u` empty — which is how a repository that publishes
no API came to declare an autodoc build of a package it does not install,
and to carry a Jekyll `include *.yml` clause with no `_config.yml` and no
`MANIFEST.in` to record it. Its command is now the one `docs.yml` really
runs: `--only-group docs`, not the sibling form. Measured — the sibling
form exits 1 building secp256k1 on 3.14, because the comparands *are*
this project's dependencies and coincurve publishes no cp314 wheel. A
divergence that follows from what the repository publishes.

Fixed as drift: the Jekyll clause copied into repositories that have
neither file; the uv-not-pinned reasoning missing from
`btclib-secp256k1` alone for no reason; and the fact that **no file said
which versions run it**, now recorded in each with a pointer to where the
answer lives.

`btclib`'s stated counts — "15 bare module titles", "89 signatures" — are
gone. Its own `CONTRIBUTING.md` forbids them, its `CLAUDE.md` claims
nothing states a count, and re-derivation shows the numbers were stale.
The command replaces them.

**The brief's premise about the never-built tag was wrong, and the issue
is stale with it.** `versions/stable/` reports `ref: v0.8.0.4`,
`type: tag`, `built: true`, with repeated successful builds from tag
commits. So `.readthedocs.yaml` *is* exercised against a release tag's
tree and succeeds. What has never existed is a version **named** for a
release: every tag-type version other than `stable` is inactive, so
`/en/<version>/` 404s where both siblings serve it. The missing thing is
the permanent per-release URL, not an untested build — written that way
because the weaker reading sends the next reader hunting in the tree.

`btclib-org/.github#26` **stays open**: every box it carries is an action
on `app.readthedocs.org`, and none is reachable from a tree.

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0 after the
rebase onto current `main`. The suite and the documentation build run
beside this review on this same sha.

## Summary by Sourcery

Clarify the scope and maintenance guidance for the Read the Docs configuration without encoding stale build measurements or externally managed version details.

Enhancements:
- Clarify the Read the Docs configuration comments to describe repository-specific behavior, avoid stale generated counts, and distinguish tree configuration from externally managed version settings.

Documentation:
- Document where Read the Docs version activation and URL behavior are managed and point contributors to the repository documentation and tracking issue.

Chores:
- Record the documentation-configuration clarification in the changelog.