### PR TITLE
Shared .yamllint.yaml and .taplo.toml stop carrying one tree's claims

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -4,20 +4,24 @@
 # which for a pre-commit hook is the repository root, so the hook needs no
 # flag.
 #
+# This file is the same in every repository of the organization,
+# deliberately, so nothing written here may be true of one tree only. Which
+# toml files a repository actually has is that repository's own
+# .pre-commit-config.yaml to name, beside the hook that runs this.
+#
 # What is *not* set matters as much: reorder_keys stays at its default of
 # false, the order of a table here being an argument rather than an accident
-# -- [project] reads top to bottom, and the ruff rule sets are grouped by
-# what they cover rather than sorted.
+# -- a table meant to be read top to bottom, or grouped by what its keys
+# cover rather than by how they are spelled, says something that sorting
+# would throw away.
 [formatting]
-# four spaces, which is what pyproject.toml already uses and what
-# ruff-format writes in the Python beside it. The mutation configurations
-# under .github/mutation are the files this moves: they were written with
-# two, and one indent for every toml in the tree is the point of having a
-# formatter at all
+# four spaces, and not taplo's own default of two: one indent for every toml
+# in the organization is the point of having a formatter at all, and four is
+# what a pyproject.toml's arrays are already written with wherever there is
+# one, ruff-format writing the same four in the Python beside them
 indent_string = "    "
 # an array that is exploded stays exploded: one entry per line is what makes
-# adding a module to a mutation session, or a rule set to ruff, a one-line
-# diff, and the default would collapse a short array onto one line and
-# expand it again when it outgrows the width -- churn driven by a column
-# count
+# adding an entry a one-line diff, and the default would collapse a short
+# array onto one line and expand it again when it outgrows the width -- churn
+# driven by a column count
 array_auto_collapse = false

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,46 +1,54 @@
 ---
 # yamllint's configuration, in a file of its own because the reasoning
-# below needs more room than a hook argument has -- the same split as
-# codespell and typos, which are configured in pyproject.toml rather than
-# in .pre-commit-config.yaml. yamllint finds this file by name in the
-# directory it runs from, which for a pre-commit hook is the repository
-# root, so the hook needs no -c.
+# below needs more room than a hook argument has, and because a
+# repository with no pyproject.toml has nowhere else to keep it. yamllint
+# finds this file by name in the directory it runs from, which for a
+# pre-commit hook is the repository root, so the hook needs no -c.
 #
-# Two rules of the twelve in the default set are enabled: the width of a
-# line, which ruff measures for Python and markdownlint for markdown and
-# nothing measured here, and the marker that opens a document. The other
-# two that fire report a convention rather than a defect, so each stays
-# off, with the count written down so that nobody has to run the survey
-# again:
-#   - comments, 33 findings, every one of them "too few spaces before
-#     comment" on a "uses: action@sha # v1.2.3" pin. One space is what
-#     dependabot writes when it bumps one, so the rule would report the
-#     bot's own output on every update
-#   - truthy, 6 findings, all of them the "on:" that opens a workflow,
-#     which yaml 1.1 reads as the boolean true. One per workflow, by
-#     construction
+# This file is the same in every repository of the organization,
+# deliberately, so nothing written here may be true of one tree only.
+# What the default set reports is therefore a question for the command
+# below, asked in the tree that wants the answer, rather than a number
+# recorded here and carried into repositories nobody re-measured it in.
+#
+# Enabled: the width of a line, which nothing else here measures for
+# yaml, and the marker that opens a document. The rest of the default set
+# is off, reporting a convention rather than a defect:
+#   - comments wants two spaces before a trailing comment where one is
+#     written. Dependabot writes one when it bumps a
+#     "uses: action@sha # v1.2.3" pin, so the rule would report the bot's
+#     own output on every update
+#   - truthy reports the "on:" that opens a workflow: yaml 1.1 reads that
+#     key as the boolean true, so what the rule objects to is the
+#     spelling GitHub Actions requires, one per workflow by construction
+# What the default set says about this tree today:
+#
+#   git ls-files '*.yml' '*.yaml' | xargs uvx yamllint -f parsable \
+#     -d '{extends: default, rules: {line-length: {max: 100}}}'
 rules:
   line-length:
-    # 100, where markdown and the Python docstrings are held to 80, and
-    # the difference is the pinning convention. An action pinned to a
-    # 40-character commit SHA with its tag in a trailing comment lands
-    # between 77 and 92 columns on the length of its name alone, and 31
-    # of the 35 in this tree are at or past 80: a limit of 80 reports 27
-    # lines, 18 of them such a pin, and buys its 80 with 18 "yamllint
-    # disable-line" comments. A width rule does not get to break a
-    # security one. 100 clears today's longest pin, at 92, by enough
-    # room for an action with a longer name, so a dependabot pull
-    # request cannot go red for having no defect in it; what the rule
-    # still catches is prose, the two shell lines in release.yml at 111
-    # and 117 columns
+    # 100, where markdown is held to 80 and any Python beside it to the
+    # same, and the difference is the pinning convention. An action
+    # pinned to a 40-character commit SHA with its tag in a trailing
+    # comment has spent most of an 80-column line before the name of the
+    # action is written, so a limit of 80 reports the pins and buys its
+    # 80 with a "yamllint disable-line" on each. A width rule does not
+    # get to break a security one. 100 clears today's longest pin with
+    # room for an action whose name is longer, so a dependabot pull
+    # request cannot go red for having no defect in it; what the rule is
+    # left guarding is prose, the one thing here that can be rewrapped.
+    # What 80 would cost, in the tree that is asking:
+    #
+    #   git ls-files '*.yml' '*.yaml' | xargs uvx yamllint -f parsable \
+    #     -d '{rules: {line-length: {max: 80}}}'
     max: 100
     # allow-non-breakable-words stays at its default, true: a line that
     # is one long token has nowhere to break, which is the exemption
     # MD013 already makes for a bare URL
-  # the "---" every one of the 15 yaml files here opens with, which is
-  # yamllint's default and one line each. What it buys is that the files
-  # answer the question the same way instead of each beginning however
-  # its author left it, and that the default set carries one exemption
-  # fewer to justify. On line 1, above the header comment rather than
-  # below it, so there is no second place to look for it
+  # the "---" every yaml file here opens with, which is yamllint's
+  # default and one line each. What it buys is that the files answer the
+  # question the same way instead of each beginning however its author
+  # left it, and that the default set carries one exemption fewer to
+  # justify. On line 1, above the header comment rather than below it, so
+  # there is no second place to look for it
   document-start: enable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -847,6 +847,43 @@ documented at release-notes length in the first place, and are still in
   adoption is per module, and each step of it removes one of the round
   trips above.
 
+- **`.yamllint.yaml` and `.taplo.toml` say what is true of every
+  repository that carries them, and re-derive the rest**
+  (btclib-org/.github#40). Both files are copied byte-for-byte across
+  the organization, and both carried reasoning taken from this tree and
+  read as settled fact everywhere else. `.yamllint.yaml`'s comment
+  recorded a survey — how many findings each disabled rule produced,
+  what share of the action pins sat at or past 80 columns, what a limit
+  of 80 would report and how much of that was pins, the width of the
+  longest pin, how many yaml files the tree held, and two over-length
+  shell lines in `release.yml` — explicitly "so nobody has to run the
+  survey again". Re-measured with the pinned yamllint, not one of those
+  figures still holds here, the tree they were taken from: the rule that
+  fires on a `uses:` pin also fires on a hand-written trailing comment
+  in `codeql.yml`, a third rule of the default set fires that the
+  comment does not mention, nothing in the tree exceeds the configured
+  width any more so the two `release.yml` lines are gone, and the
+  default set is not the size the comment gives it. The survey is
+  replaced by the commands that answer for whichever tree is asking,
+  beside the reasons that do not vary between repositories: dependabot
+  writes one space before a pin's trailing tag, `on:` is the boolean
+  true in yaml 1.1, and a 40-character SHA with its tag has spent most
+  of an 80-column line before the action is named.
+
+  `.taplo.toml`'s indent comment named the mutation configurations under
+  `.github/mutation` as the files the four-space setting moves, and
+  said what they had been written with before it. That is this
+  repository's tree — `btclib-benchmarks` and `btclib-org/.github` share
+  the file and have never had mutation testing — and it is history in a
+  comment besides, which `CONTRIBUTING.md` puts in `CHANGELOG.md`
+  instead. It is not the reason for the setting either: four rather than
+  taplo's own default of two, so that one indent covers every toml,
+  survives without it, and which toml files a repository actually has is
+  already named in that repository's own `.pre-commit-config.yaml`,
+  beside the hook that runs taplo. The `[project]`-and-ruff example under
+  `reorder_keys` goes the same way, `btclib-org/.github` having no
+  `pyproject.toml` at all.
+
 ## v2026.8.21
 
 ### Repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -731,6 +731,44 @@ documented at release-notes length in the first place, and are still in
   hand, a vendored schema and a validator being what a test of it would
   cost.
 
+- **`.yamllint.yaml` and `.taplo.toml` say what is true of every
+  repository that carries them, and re-derive the rest**
+  (btclib-org/.github#40). Both files are copied byte-for-byte across
+  the organization, and both carried reasoning taken from this tree and
+  read as settled fact everywhere else. `.yamllint.yaml`'s comment
+  recorded a survey — how many findings each disabled rule produced,
+  what share of the action pins sat at or past 80 columns, what a limit
+  of 80 would report and how much of that was pins, the width of the
+  longest pin, how many yaml files the tree held, and two over-length
+  shell lines in `release.yml` — explicitly "so nobody has to run the
+  survey again". Re-measured with the pinned yamllint, not one of those
+  figures still holds here, the tree they were taken from: the rule that
+  fires on a `uses:` pin also fires on a hand-written trailing comment
+  in `codeql.yml`, a third rule of the default set fires that the
+  comment does not mention, nothing in the tree exceeds the configured
+  width any more so the two `release.yml` lines are gone, and the
+  default set is not the size the comment gives it. The survey is
+  replaced by the commands that answer for whichever tree is asking,
+  beside the reasons that do not vary between repositories: dependabot
+  writes one space before a pin's trailing tag, `on:` is the boolean
+  true in yaml 1.1, and a 40-character SHA with its tag has spent most
+  of an 80-column line before the action is named.
+
+  `.taplo.toml`'s indent comment named the mutation configurations under
+  `.github/mutation` as the files the four-space setting moves, and
+  said what they had been written with before it. That is this
+  repository's tree — `btclib-benchmarks` and `btclib-org/.github` share
+  the file and have never had mutation testing — and it is history in a
+  comment besides, which `CONTRIBUTING.md` puts in `CHANGELOG.md`
+  instead. It is not the reason for the setting either: four rather than
+  taplo's own default of two, so that one indent covers every toml,
+  survives without it, and which toml files a repository actually has is
+  that repository's own `.pre-commit-config.yaml` to name, beside the
+  hook that runs taplo — which this one does, naming `pyproject.toml`
+  and the mutation sessions there. The `[project]`-and-ruff example under
+  `reorder_keys` goes the same way, `btclib-org/.github` having no
+  `pyproject.toml` at all.
+
 ### Documentation and the website
 
 - **`docs/source/conf.py`'s `RootFileLinks` comment no longer states a
@@ -846,43 +884,6 @@ documented at release-notes length in the first place, and are still in
   not `slots=True`. Nothing in the library consumes these yet: the
   adoption is per module, and each step of it removes one of the round
   trips above.
-
-- **`.yamllint.yaml` and `.taplo.toml` say what is true of every
-  repository that carries them, and re-derive the rest**
-  (btclib-org/.github#40). Both files are copied byte-for-byte across
-  the organization, and both carried reasoning taken from this tree and
-  read as settled fact everywhere else. `.yamllint.yaml`'s comment
-  recorded a survey — how many findings each disabled rule produced,
-  what share of the action pins sat at or past 80 columns, what a limit
-  of 80 would report and how much of that was pins, the width of the
-  longest pin, how many yaml files the tree held, and two over-length
-  shell lines in `release.yml` — explicitly "so nobody has to run the
-  survey again". Re-measured with the pinned yamllint, not one of those
-  figures still holds here, the tree they were taken from: the rule that
-  fires on a `uses:` pin also fires on a hand-written trailing comment
-  in `codeql.yml`, a third rule of the default set fires that the
-  comment does not mention, nothing in the tree exceeds the configured
-  width any more so the two `release.yml` lines are gone, and the
-  default set is not the size the comment gives it. The survey is
-  replaced by the commands that answer for whichever tree is asking,
-  beside the reasons that do not vary between repositories: dependabot
-  writes one space before a pin's trailing tag, `on:` is the boolean
-  true in yaml 1.1, and a 40-character SHA with its tag has spent most
-  of an 80-column line before the action is named.
-
-  `.taplo.toml`'s indent comment named the mutation configurations under
-  `.github/mutation` as the files the four-space setting moves, and
-  said what they had been written with before it. That is this
-  repository's tree — `btclib-benchmarks` and `btclib-org/.github` share
-  the file and have never had mutation testing — and it is history in a
-  comment besides, which `CONTRIBUTING.md` puts in `CHANGELOG.md`
-  instead. It is not the reason for the setting either: four rather than
-  taplo's own default of two, so that one indent covers every toml,
-  survives without it, and which toml files a repository actually has is
-  already named in that repository's own `.pre-commit-config.yaml`,
-  beside the hook that runs taplo. The `[project]`-and-ruff example under
-  `reorder_keys` goes the same way, `btclib-org/.github` having no
-  `pyproject.toml` at all.
 
 ## v2026.8.21
 


### PR DESCRIPTION
`.yamllint.yaml` and `.taplo.toml` are copied verbatim across
repositories, and carried claims true of exactly one tree — or of none.

**A shared file cannot carry a repository-specific reason.** Each claim
became a statement true of every repository, moved to the repository it
is about, or went with the reason for going stated.

The survey written into `.yamllint.yaml` so "nobody has to run it again"
was re-measured with the pinned yamllint 1.38.0, in the tree it was taken
from: not one of its numbers still holds, and there were more of them
than the issue counted. A third rule fires that the file says does not.
"Every one of them on a `uses:` pin" is false — two are hand-written
trailing comments. What replaces the survey is the reason plus the
command that re-derives it in whichever tree is asking, which is the
shape the standard asks for and the shape a copied file can honestly
carry.

`.taplo.toml` claimed the mutation configurations "were written with two"
spaces — false in two of the three trees that carry it, history in a
comment where `CONTRIBUTING.md` sends history, and not the reason for the
setting. It needed no move: each repository's own
`.pre-commit-config.yaml` already names its own toml files beside the
taplo hook.

**Which fixes survive a future copy and which do not**, stated on the
branch: the wording survives, because nothing in it is about one tree,
and the embedded commands survive, because they measure the tree they run
in. The discipline does not — nothing fails when a copy drifts. That is
`#39`, and this does not try to solve it.

`btclib-org/.github#40` is closed by none of these: each answers only its
own repository's share.

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0 after the
rebase onto current `main`. The suite and the documentation build run
beside this review on this same sha.

## Summary by Sourcery

Make the shared YAML and TOML linting configurations portable across repositories by removing stale repository-specific claims and preserving reusable rationale.

Enhancements:
- Make the shared yamllint and Taplo configurations repository-agnostic by removing tree-specific claims and documenting only organization-wide rationale.
- Replace stale yamllint survey results with commands that remeasure findings in the repository where the configuration is used.
- Move the historical and repository-specific configuration context into the changelog.

Documentation:
- Document the rationale for shared formatting and YAML linting rules, including how to reproduce repository-specific measurements.