### PR TITLE
Multiply once where KeyWallet.add multiplied twice (issue #1188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -748,6 +748,41 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **`KeyWallet.add` multiplies once where it multiplied twice**, being
+  the first module to take `btclib.key` up (issue #1188). It computed the
+  public key with `pub_keyinfo_from_key` and then handed the *private*
+  one to the address builder, which computed it again: two scalar
+  multiplications on one secret, and on the `pip install btclib` that
+  brings no bindings, twice through the arithmetic `SECURITY.md`
+  publishes as not constant-time.
+
+  `_key_data` replaces `_wif_if_private` and answers a `PrvKeyData` or a
+  `PubKeyData` rather than a WIF or the empty string, so the question
+  "can this wallet sign for this address" is the type of what came back
+  instead of a second walk over the spellings, and the address is built
+  from the SEC octets `PrvKeyData.pub` memoized. The spellings stop at
+  that one function, which is the shape the rest of the adoption takes.
+
+  `tests/wallet/key_wallet_test.py` counts the multiplications, so the
+  saving is a gate rather than a claim. It counts them where they
+  happen — the bindings call and `mult`, inside the module that defines
+  `bytes_from_prv_key_int` — because every caller of that function binds
+  it with a from-import, so a count taken at one caller's name misses
+  the address builder deriving through another's, which is the whole of
+  what this change removes.
+
+  Two things a caller can see change with it. `add(True)` raises
+  `BTClibTypeError` where it used to answer the address of the scalar 1:
+  `to_prv_key` admits a `bool` and `PrvKeyData` refuses one, and the
+  refusal is a `TypeError`, so it escapes an `except BTClibValueError`.
+  A malformed or wrong-network key now leaves with the diagnosis of the
+  parser that refused it — `NotAPrvKeyError` accumulating what each of
+  the three parsers said where none of them recognised the format, and
+  `InvalidPrvKeyError` naming the WIF prefix or the xkey version where
+  one of them did — rather than one `BTClibValueError` saying "not a
+  private or public key for mainnet" for every one of them; all three
+  are `BTClibValueError` subclasses, so only the message differs there.
+
 - **`btclib.key` holds the canonical form of a key**, `PubKeyData` and
   `PrvKeyData`, so that a key parsed once can be carried rather than
   spelled back for the next call to parse again (issue #1188). Every
@@ -755,9 +790,7 @@ documented at release-notes length in the first place, and are still in
   the canonical form was what came *out* of a conversion and never what
   went *in*. `bip32.derive_`, `to_pub_key._sec_from_pub_key` and
   `taproot._output_pubkey_and_internal_key` each work around the round
-  trip that leaves — issues 886, 887 and 896 — and `KeyWallet.add` pays
-  it twice over, deriving a public key and then handing the private one
-  to an address builder that derives it again. This is the cut those
+  trip that leaves — issues 886, 887 and 896. This is the cut those
   patch locally.
 
   The SEC octets are the field and the point is a `cached_property`

--- a/btclib/key.py
+++ b/btclib/key.py
@@ -9,12 +9,10 @@ hex string of them, a point, an xpub -- and a private key has as many.
 Every converter in this library takes all of them and answers a tuple, so
 the canonical form is what comes *out* of a conversion and never what
 goes *in*: a caller that has one has to spell it back for the next call,
-which parses it again. That round trip is what
-`bip32.derive_`, `to_pub_key._sec_from_pub_key` and
+which parses it again. That round trip is what `bip32.derive_`,
+`to_pub_key._sec_from_pub_key` and
 `taproot._output_pubkey_and_internal_key` each work around locally --
-issues 886, 887 and 896 -- and that `KeyWallet.add` pays twice over,
-deriving a public key and then handing the private one to an address
-builder that derives it again.
+issues 886, 887 and 896.
 
 `PubKeyData` and `PrvKeyData` are that cut: the spellings stay at the
 boundary, the parse happens once, and what travels afterwards is an

--- a/btclib/wallet/key_wallet.py
+++ b/btclib/wallet/key_wallet.py
@@ -42,7 +42,6 @@ https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
 
 from __future__ import annotations
 
-import contextlib
 from collections.abc import Iterable
 
 from btclib import b58
@@ -64,10 +63,11 @@ from btclib.bip44 import _ADDRESS_FROM_SCRIPT_TYPE, _script_type_from_purpose
 from btclib.curves import PreparedPoint
 from btclib.ecc import bms
 from btclib.exceptions import BTClibValueError
+from btclib.key import PrvKeyData, PubKeyData
 from btclib.network import network_from_xkeyversion
 from btclib.script.script_pub_key import ScriptPubKey
 from btclib.to_prv_key import prv_keyinfo_from_prv_key
-from btclib.to_pub_key import Key, pub_keyinfo_from_key, pub_keyinfo_from_pub_key
+from btclib.to_pub_key import Key, pub_keyinfo_from_pub_key
 from btclib.wallet.wallet import AddressInfo, RangedWallet, Wallet
 
 __all__ = [
@@ -103,16 +103,20 @@ def _checked_script_type(script_type: str) -> BIP44ScriptType:
     return script_type
 
 
-def _wif_if_private(key: Key, network: str) -> str:
-    """Return the WIF of a private key, or "" for a public one.
+def _key_data(key: Key, network: str) -> PrvKeyData | PubKeyData:
+    """Return the canonical form of a key, and which half it is.
 
-    Two of the spellings `to_pub_key.Key` admits say which they are by
-    their type, and are taken first because the ambiguous test below
-    cannot be asked of them: an int is a scalar, so it is a private key,
-    and a point is a pair of coordinates, so it is a public one -- a
-    `PreparedPoint` with it, that being a point and a caller's word about
-    how often it will be multiplied, which says nothing about who can
-    sign.
+    The spellings `to_pub_key.Key` admits stop here: what leaves is one
+    of the two `btclib.key` types, parsed once, and which of them it is
+    is the answer to "can this wallet sign", which `add` therefore reads
+    off a type instead of walking the spellings for it.
+
+    Two of them say which half they are by their type, and are taken
+    first because the ambiguous test below cannot be asked of them: an
+    int is a scalar, so it is a private key, and a point is a pair of
+    coordinates, so it is a public one -- a `PreparedPoint` with it, that
+    being a point and a caller's word about how often it will be
+    multiplied, which says nothing about who can sign.
 
     The rest -- octets, a WIF or an extended key -- are told apart in the
     order `to_pub_key.pub_keyinfo_from_key` tells them apart, public
@@ -120,19 +124,27 @@ def _wif_if_private(key: Key, network: str) -> str:
     that address and unable to sign for it, while anything that is not
     one has to be a private key, and the error raised for a malformed one
     is the diagnosis the caller needs rather than a silent demotion to
-    watch-only.
+    watch-only. Only the converter's refusal is caught, and not
+    `PubKeyData`'s own: what the type refused would otherwise fall
+    through to the private branch and come back as "not a private key",
+    its own diagnosis lost. Nothing reaches that today, and the narrow
+    `try` is so that nothing can rather than that nothing does.
+
+    Both types re-check what the converter that fed them has already
+    guaranteed, which looks redundant and is not: `to_prv_key` admits a
+    `bool` and `PrvKeyData` refuses one, so without this second check
+    `add(True)` is the scalar 1 and an address handed back for it.
     """
     if isinstance(key, int):
-        return b58.wif_from_prv_key(key, network)
+        return PrvKeyData(*prv_keyinfo_from_prv_key(key, network))
     if isinstance(key, (tuple, PreparedPoint)):
-        return ""
+        return PubKeyData(*pub_keyinfo_from_pub_key(key, network))
 
-    with contextlib.suppress(BTClibValueError):
-        pub_keyinfo_from_pub_key(key, network)
-        return ""
-
-    q, net, compressed = prv_keyinfo_from_prv_key(key, network)
-    return b58.wif_from_prv_key(q, net, compressed)
+    try:
+        pub_key_info = pub_keyinfo_from_pub_key(key, network)
+    except BTClibValueError:
+        return PrvKeyData(*prv_keyinfo_from_prv_key(key, network))
+    return PubKeyData(*pub_key_info)
 
 
 class KeyWallet(Wallet):
@@ -184,18 +196,25 @@ class KeyWallet(Wallet):
         checked = _checked_script_type(
             self.script_type if script_type is None else script_type
         )
-        pub_key, _ = pub_keyinfo_from_key(key, self.network)
+        # parsed once, and the type of what comes back is what says
+        # whether this wallet can sign: `data.pub` derives at most once
+        # and memoizes, so the address builder below is handed those
+        # octets rather than a key it would derive them from again
+        # (issue #1188)
+        data = _key_data(key, self.network)
+        pub = data.pub if isinstance(data, PrvKeyData) else data
         # segwit has no uncompressed form, so the three segwit encodings
         # would silently answer an uncompressed key with the address of
         # its compressed twin -- an address bms cannot then sign for,
         # because the recovery flag it would need says compressed
-        if checked != "p2pkh" and len(pub_key) != 33:
+        if checked != "p2pkh" and not pub.is_compressed:
             err_msg = f"uncompressed key cannot be {checked}:"
             err_msg += " segwit has no uncompressed form"
             raise BTClibValueError(err_msg)
 
-        address = _ADDRESS_FROM_SCRIPT_TYPE[checked](key, self.network)
-        if wif := _wif_if_private(key, self.network):
+        address = _ADDRESS_FROM_SCRIPT_TYPE[checked](pub.sec, self.network)
+        if isinstance(data, PrvKeyData):
+            wif = b58.wif_from_prv_key(data.q, data.network, data.compressed)
             self._prv_keys[address] = wif
         return self._record(AddressInfo(address, checked, ""))
 

--- a/tests/wallet/key_wallet_test.py
+++ b/tests/wallet/key_wallet_test.py
@@ -6,15 +6,18 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from btclib import b58
 from btclib.alias import BIP44ScriptType
 from btclib.bip32 import bip32
+from btclib.curves import curve, sec_point
 from btclib.ecc import bms
 from btclib.exceptions import BTClibValueError
 from btclib.wallet import AddressInfo, BIP32KeyWallet, KeyWallet
-from tests import replace_unchecked
+from tests import needs_bindings, replace_unchecked
 
 # the "abandon abandon ... about" seed, whose master key BIP84 and BIP86
 # both publish as their rootpriv and whose addresses SLIP132, BIP49,
@@ -469,3 +472,54 @@ def test_the_output_is_the_script_the_address_pays() -> None:
         assert script_pub_key.address == wallet.address(1, 3)
         assert script_pub_key.network == "mainnet"
         assert wallet.position_of(script_pub_key, 4) == (1, 3)
+
+
+@pytest.mark.parametrize(
+    "bindings",
+    [
+        pytest.param(True, marks=needs_bindings, id="bindings"),
+        pytest.param(False, id="python"),
+    ],
+)
+def test_add_derives_the_public_key_once(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A private key handed to a wallet is multiplied once, not twice.
+
+    `add` computes the public key through `PrvKeyData.pub`, which
+    memoizes, and builds the address out of the SEC octets that answered
+    rather than out of the key that would derive them again -- one scalar
+    multiplication on the secret where there were two (issue #1188).
+
+    What makes that a gate rather than a claim is *where* this counts.
+    Every caller of `bytes_from_prv_key_int` binds it with a from-import,
+    so patching one caller's name leaves the others multiplying
+    uncounted -- which is exactly what the address builder does, through
+    `to_pub_key`'s own binding. Counted here instead are the two calls
+    that name is a wrapper around, in the module that defines it, so
+    every derivation reaching that function is counted whichever caller
+    spelled it -- and both of the ones at issue here do reach it.
+
+    One of those two calls answers per install, which is why both arms
+    run: the bindings for the one that has them, `mult` for the one that
+    does not.
+    """
+    if not bindings:
+        monkeypatch.setattr(curve, "_libsecp256k1_available", False)
+
+    calls = 0
+    for name in ("libsecp256k1_pubkey_from_prvkey", "mult"):
+        original = getattr(sec_point, name)
+
+        def counting(*args: object, _original: Any = original, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            return _original(*args, **kwargs)
+
+        monkeypatch.setattr(sec_point, name, counting)
+
+    wallet = KeyWallet()
+    wallet.add(_WIF_COMPRESSED)
+
+    assert calls == 1
+    assert not wallet.is_watch_only


### PR DESCRIPTION
Step 1 of [ISS #1188](https://github.com/btclib-org/btclib/issues/1188)'s
sequence, and the first module to take `btclib.key` up.

## What it removes

`add` computed the public key with `pub_keyinfo_from_key` and then handed
the *private* one to the address builder, which computed it again: two
scalar multiplications on one secret, and on the `pip install btclib`
that brings no bindings, twice through the arithmetic `SECURITY.md`
publishes as not constant-time. It then walked the spellings a third
time, in `_wif_if_private`, to ask whether the wallet could sign.

`_key_data` replaces `_wif_if_private` and answers a `PrvKeyData` or a
`PubKeyData` rather than a WIF or the empty string. "Can this wallet sign
for this address" becomes the type of what came back, the segwit check
reads `pub.is_compressed` rather than a length, and the address is built
from the SEC octets `PrvKeyData.pub` memoized. **The spellings stop at
that one function**, which is the shape the rest of the adoption takes.

## The test is a gate, and where it counts is the point

Counting `bytes_from_prv_key_int` at one caller's name does not work:
every caller binds it with a from-import, and the derivation this removes
is the address builder's, through `to_pub_key`'s own binding. A count
taken there passes on the reintroduced regression.

So the count is taken on the two calls that name wraps, inside the module
that defines it, and the test runs on both arms — one of the two answers
per install:

```
bindings  {'libsecp256k1_pubkey_from_prvkey': 1}
python    {'mult': 1}
```

Reintroducing the second derivation fails it at `assert 2 == 1`, on both.

## Two things a caller can see

- `add(True)` raises `BTClibTypeError` where it used to answer
  `bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4` — the address of the
  scalar 1. `to_prv_key` admits a `bool` and `PrvKeyData` refuses one.
  The converter is the wrong layer for the fix to stop there, so that gap
  is [ISS #1206](https://github.com/btclib-org/btclib/issues/1206): eight
  public entry points still take `True` for a private key, and `dsa.sign`
  raises on the install with the bindings while signing with the scalar 1
  on the install without.
- a malformed or wrong-network key leaves with the refusing parser's
  diagnosis rather than one `BTClibValueError` for all of them.

Both are in CHANGELOG.md.

## Checked

Three gates on this sha, after the rebase onto `origin/main`:
`uv run pytest` — 29456 passed, coverage 100.00%;
`uv run pre-commit run --all-files` — exit 0;
the documented `sphinx-build -W --keep-going` — exit 0.

Behaviour against `origin/main` was swept spelling by spelling — WIF
compressed and uncompressed, xprv, xpub, tprv, SEC as bytes and hex, a
scalar, a point, a `PreparedPoint`, malformed and cross-network — across
all four script types: every valid case answers the same address and the
same WIF, and the only differences are the two documented above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hde6RUtTpqFBkPziUqzZkX

## Summary by Sourcery

Make `KeyWallet.add` parse keys once and reuse canonical public-key data when creating addresses.

Bug Fixes:
- Prevent `KeyWallet.add` from performing duplicate public-key derivations for private keys.
- Preserve parser-specific diagnostics for malformed or wrong-network keys and reject boolean private-key inputs.

Enhancements:
- Use canonical private and public key data throughout wallet address creation, including memoized public-key material and type-based signing detection.
- Validate segwit compatibility using the parsed key’s compression state.

Documentation:
- Document the single-multiplication behavior and the observable key-validation changes in the changelog.

Tests:
- Add coverage that verifies private-key addition performs exactly one public-key derivation with and without secp256k1 bindings.