### PR TITLE
Correct regtest's genesis block, which was stored byte-reversed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -814,6 +814,32 @@ documented at release-notes length in the first place, and are still in
   adoption is per module, and each step of it removes one of the round
   trips above.
 
+- **`NETWORKS["regtest"].genesis_block` was stored byte-reversed**
+  (issue #1203). It held `06226e46…f188910f`, which is Bitcoin Core's
+  `0f9188f1…466e2206` with its octets in the opposite order; the other
+  networks were right. The library already disagreed with itself about
+  it: given Core's regtest genesis parameters, `BlockHeader.hash`
+  derives the value Core publishes, so what `_data/regtest.json` shipped
+  was the reverse of what this library computes.
+
+  Nothing inside btclib reads the field — `network_from_key_value`'s
+  docstring says no encoding here reads the genesis block — so
+  addresses, WIF and the bip32 versions were never affected, and no
+  other stored value moves. What is affected is a caller seeding a chain
+  from it: the value is well-formed, thirty-two bytes, and looks like a
+  plausible low-difficulty hash, so it is a silent wrong answer rather
+  than an error, and a node seeded with it accepts no regtest chain at
+  all. A caller that compensated for the reversal has to stop.
+
+  The test that should have caught it pinned the genesis of some
+  networks and not others, and regtest was one it did not pin. It now
+  covers every network in `NETWORKS` and asserts its expectation table
+  has an entry for each, so a network added without its genesis block
+  fails rather than passing unchecked. No structural check can catch
+  this class of mistake: a reversed hash is thirty-two well-formed bytes
+  carrying a plausible run of zeros, and only the value tells it from
+  the real one.
+
 ## v2026.8.21
 
 ### Repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -958,6 +958,7 @@ documented at release-notes length in the first place, and are still in
   this class of mistake: a reversed hash is thirty-two well-formed bytes
   carrying a plausible run of zeros, and only the value tells it from
   the real one.
+
 ### Tests
 
 - **`test_the_flag_still_switches_the_check_off`'s docstring stops

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,18 @@ full year, short month, short day (YYYY-M-D)
 
 ## v2026.9 (work in progress, not released yet)
 
+### Breaking changes
+
+- **`NETWORKS["regtest"].genesis_block` was byte-reversed and is now
+  Bitcoin Core's value**, `0f9188f13cb7b2c71f2a335e3a4fc328bf5beb43601
+  2afca590b1a11466e2206`, where it read `06226e46…f188910f` (issue
+  #1203). Nothing inside btclib reads the field, so addresses, WIF and
+  the bip32 versions are unaffected and no other network's value moves.
+  A caller that read it — seeding a regtest chain, or comparing against
+  `getblockhash 0` — got a silent wrong answer, not an error, and one
+  that had compensated by reversing the octets itself has to stop doing
+  so. CHANGELOG.md has why.
+
 ## v2026.8.21
 
 ### Breaking changes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,14 +21,19 @@ full year, short month, short day (YYYY-M-D)
 ### Breaking changes
 
 - **`NETWORKS["regtest"].genesis_block` was byte-reversed and is now
-  Bitcoin Core's value**, `0f9188f13cb7b2c71f2a335e3a4fc328bf5beb43601
-  2afca590b1a11466e2206`, where it read `06226e46…f188910f` (issue
-  #1203). Nothing inside btclib reads the field, so addresses, WIF and
-  the bip32 versions are unaffected and no other network's value moves.
-  A caller that read it — seeding a regtest chain, or comparing against
-  `getblockhash 0` — got a silent wrong answer, not an error, and one
-  that had compensated by reversing the octets itself has to stop doing
-  so. CHANGELOG.md has why.
+  Bitcoin Core's value** (issue #1203):
+
+  ```text
+  0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
+  ```
+
+  where it read the same octets in the opposite order,
+  `06226e46…f188910f`. Nothing inside btclib reads the field, so
+  addresses, WIF and the bip32 versions are unaffected, and no other
+  network's value moves. A caller that read it — seeding a regtest
+  chain, or comparing against `getblockhash 0` — got a silent wrong
+  answer rather than an error, and one that had compensated by reversing
+  the octets itself has to stop doing so. CHANGELOG.md has why.
 
 ## v2026.8.21
 

--- a/btclib/_data/regtest.json
+++ b/btclib/_data/regtest.json
@@ -1,7 +1,7 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
-    "genesis_block": "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f",
+    "genesis_block": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
     "wif": "ef",
     "p2pkh": "6f",
     "p2sh": "c4",

--- a/tests/_generated_files/regtest.json
+++ b/tests/_generated_files/regtest.json
@@ -1,7 +1,7 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
-    "genesis_block": "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f",
+    "genesis_block": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
     "wif": "ef",
     "p2pkh": "6f",
     "p2sh": "c4",

--- a/tests/network_test.py
+++ b/tests/network_test.py
@@ -182,15 +182,40 @@ def test_the_test_networks_differ_from_testnet_in_the_genesis_block() -> None:
 
     assert NETWORKS["signet"].hrp == "tb"
     assert NETWORKS["testnet4"].hrp == "tb"
-    assert NETWORKS["testnet4"].genesis_block.hex() == (
-        "00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043"
-    )
-    assert NETWORKS["signet"].genesis_block.hex() == (
-        "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6"
-    )
     # every network is a distinct chain, and the genesis block says so
     genesis = {net.genesis_block for net in NETWORKS.values()}
     assert len(genesis) == len(NETWORKS)
+
+
+# Bitcoin Core's `getblockhash 0` on each chain, which is the authority
+# for this field: a genesis block is a constant nothing here computes,
+# so a wrong one is wrong quietly. Mainnet's is checked once more, in
+# tests/block/block_test.py, against the vendored block 1 whose
+# previous_block_hash it is; every other network's is checked only here.
+# Every network is named, without exception -- naming only some is how
+# regtest came to hold its hash byte-reversed with the suite green
+# (issue #1203), and the assertion below fails if a network is added
+# here without its genesis.
+_GENESIS_BLOCKS: dict[NetworkName, str] = {
+    "mainnet": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+    "testnet": "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
+    "testnet4": "00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043",
+    "signet": "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
+    "regtest": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
+}
+
+
+def test_genesis_block_of_every_network() -> None:
+    """Pin the genesis block of every network, leaving none unpinned.
+
+    Covering the whole table, rather than the networks a reader happens
+    to name, is the point: a byte-reversed hash is still thirty-two
+    well-formed bytes carrying a plausible run of zeros, so no other
+    check in this file can tell it from the real one. Only the value can.
+    """
+    assert set(_GENESIS_BLOCKS) == set(NETWORKS)
+    for name, expected in _GENESIS_BLOCKS.items():
+        assert NETWORKS[name].genesis_block.hex() == expected, name
 
 
 # the prefix fields, i.e. every field a reverse lookup is asked about:


### PR DESCRIPTION
`NETWORKS["regtest"].genesis_block` held
`06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f`,
which is Bitcoin Core's
`0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206`
with its octets in the opposite order. The other networks were right.

## The library already disagreed with itself

The strongest evidence is not Core's published value but btclib's own
arithmetic. Given Core's regtest genesis parameters, `BlockHeader.hash`
derives what Core publishes:

```python
BlockHeader(
    version=1,
    previous_block_hash="00" * 32,
    merkle_root="4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
    time=datetime.fromtimestamp(1296688602, UTC),
    bits=b"\x20\x7f\xff\xff",
    nonce=2,
).hash.hex()
# 0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
```

So `_data/regtest.json` shipped the reverse of what this library
computes.

## Impact

Nothing inside btclib reads the field — `network_from_key_value`'s
docstring says no encoding here reads the genesis block — so addresses,
WIF and the bip32 versions were never affected, and no other stored
value moves.

What is affected is a caller seeding a chain from it. The value is
well-formed, thirty-two bytes, and looks like a plausible
low-difficulty hash, so it is a silent wrong answer rather than an
error: a node seeded with it accepts no regtest chain at all. A caller
that compensated by reversing the octets itself has to stop — which is
why this is in `RELEASE_NOTES.md` and not only in `CHANGELOG.md`.

## Why the suite was green

The test that should have caught it pinned the genesis of some networks
and not others, and regtest was one it did not pin. It now covers every
network in `NETWORKS` and asserts its expectation table has an entry for
each, so a network added without its genesis block fails rather than
passing unchecked.

No *structural* check can catch this class of mistake: a reversed hash
is thirty-two well-formed bytes carrying a plausible run of zeros.
Deriving it from the header does catch it, as above, and
`tests/block/block_test.py` catches it for mainnet alone — the vendored
block 1 carries the genesis hash as its `previous_block_hash`. Every
other network's value is checked only by the new test.

## What I ran

- `uv run pytest` — the whole suite passes.
- `uv run pre-commit run --all-files` — every hook passes, tree clean
  afterwards.
- Both after rebasing onto current `main`, so they describe what would
  land.
- I confirmed the new test catches the bug by putting the reversed value
  back and watching `test_genesis_block_of_every_network` fail on
  `regtest` — while the test it replaces still passed, which is how the
  bug got in.

A review of this branch independently re-derived **every** network's
genesis from Core's `chainparams.cpp` — rebuilding each coinbase, its
merkle root and its header — rather than trusting Core's published
hashes, and confirmed the whole table now agrees. No other network's
entry is wrong.

Closes #1203

## Summary by Sourcery

Correct regtest chain initialization by replacing its byte-reversed genesis hash with Bitcoin Core's canonical value and strengthening coverage for all network genesis blocks.

Bug Fixes:
- Correct the regtest genesis block to match Bitcoin Core's canonical hash instead of its byte-reversed value.

Enhancements:
- Pin the genesis block for every configured network and ensure newly added networks cannot bypass genesis verification.

Documentation:
- Document the regtest genesis hash correction and its compatibility impact in the changelog and release notes.

Tests:
- Expand network tests to validate the expected genesis block for every network.