### PR TITLE
test_the_flag_still_switches_the_check_off's docstring stops counting the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -933,6 +933,24 @@ documented at release-notes length in the first place, and are still in
   adoption is per module, and each step of it removes one of the round
   trips above.
 
+### Tests
+
+- **`test_the_flag_still_switches_the_check_off`'s docstring stops
+  counting the registry** (issue #1212). It said "the nine in
+  `NETWORKS`", where `NETWORKS` holds five — a number nothing in the
+  suite reads, sitting a hundred lines below `test_numbers_of_networks`,
+  whose `assert len(NETWORKS) == 5` is checked on every run and was
+  right the whole time. The sentence needs no number to say what it
+  means: the point is that *every* network built above it was built
+  checked, so the `check_validity=False` path below is the only one of
+  the two `if check_validity:` lines left unexercised. "Every one in
+  `NETWORKS`" says exactly that and cannot drift when a network is
+  added, which is what CONTRIBUTING.md's "measure, don't assert" asks
+  for — the count it forbids is the one written where nothing runs it.
+  `test_numbers_of_networks`'s own docstring keeps its "five": the
+  assertion that verifies it is the next line, so the run fails in the
+  same breath the sentence goes wrong. Introduced by 2f887453 (#1179).
+
 ## v2026.8.21
 
 ### Repository

--- a/tests/network_test.py
+++ b/tests/network_test.py
@@ -415,7 +415,7 @@ def test_a_field_no_network_has_is_refused_rather_than_scanned_for() -> None:
 def test_the_flag_still_switches_the_check_off() -> None:
     """Verify check_validity=False builds a network and writes its dict.
 
-    Every network above is built checked -- the nine in `NETWORKS` and
+    Every network above is built checked -- every one in `NETWORKS` and
     the ones the refusals raise on -- so both `if check_validity:` lines
     ran one way only. A genesis block of the wrong length is the
     invalidity to carry: `to_dict` writes it as hex whatever its width,


### PR DESCRIPTION
`tests/network_test.py`'s docstring said:

> Every network above is built checked -- **the nine in `NETWORKS`** and
> the ones the refusals raise on -- so both `if check_validity:` lines
> ran one way only.

`NETWORKS` holds **five**. `test_numbers_of_networks`, a hundred lines
above in the same file, asserts exactly that and has been right the whole
time; the sentence drifted because nothing reads it.

**The sentence needs no number.** What it is establishing is that
*every* network built above it was built checked, so the
`check_validity=False` path below is the only one of the two
`if check_validity:` lines left unexercised. "Every one in `NETWORKS`"
says that, and cannot go stale when a network is added — which is the
property the count lacked and the reason CONTRIBUTING.md's *measure,
don't assert* exists.

**`test_numbers_of_networks` keeps its own "five"** and is deliberately
not touched: the assertion that verifies it is the next line down, so a
run fails in the same breath the sentence goes wrong. The count the rule
forbids is the one written where nothing runs it.

Introduced by `2f887453` (#1179).

Closes #1212

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run
after the rebase onto current `main`. The suite, the lint job and the
documentation build run beside this review on this same sha.

## Summary by Sourcery

Remove the stale network count from the test documentation so it remains accurate as the registry changes.

Enhancements:
- Make the network test docstring describe all networks in `NETWORKS` without relying on a stale hard-coded count.

Chores:
- Document the test docstring correction in the changelog.