### PR TITLE
taproot's tweak translates the bindings' refusal (issue #1214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -988,6 +988,7 @@ documented at release-notes length in the first place, and are still in
   this class of mistake: a reversed hash is thirty-two well-formed bytes
   carrying a plausible run of zeros, and only the value tells it from
   the real one.
+
 ### Malformed input and the exception contract
 
 - **taproot's tweak translates the bindings' refusal, as every other arm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1004,13 +1004,23 @@ documented at release-notes length in the first place, and are still in
   states the rule the rest of the tree follows: the discrimination is
   the bindings', but the hierarchy has to be btclib's.
 
-  The arm now raises `BTClibValueError` with the wording the arm beside
-  it uses — `y_even_var`'s "invalid x-coordinate", and its
-  "x-coordinate not in 0..p-1" for an x that is no field element, the
-  bindings' parse refusing both the same way and this making the
-  distinction their message does not. So the two arms agree on the
-  sentence and not only on the class, which a test holds them to over
-  the three shapes that sentence has.
+  The arm now raises `BTClibValueError`, and says as much about what was
+  refused as the call it was refused by can know. Given the x-only key
+  and no `sec`, there is nothing else for `tweak_add` to object to, so
+  the wording is `y_even_var`'s — "invalid x-coordinate", and its
+  "x-coordinate not in 0..p-1" for an x that is no field element, a
+  distinction the bindings' parse does not make and this makes for it —
+  and the two arms answer the same sentence for the same input. Given a
+  `sec`, they cannot: `_sec_from_key` leaves those octets unproven for
+  the same reason this arm does, so `04 || x || y` with a good x and a y
+  that is not its own reaches the tweak and is refused there, and naming
+  the x would be naming the half that is right. That case takes
+  `check_output_pubkey`'s existing words for a refusal it cannot
+  decompose either, "invalid internal public key", and the two arms are
+  held to the class alone — the Python one refusing that key a step
+  earlier, in `point_from_key`, and never reaching the tweak. A test
+  holds both: three shapes of the shared sentence, and the sec whose x
+  is not to blame.
 
   This was issue #1008's defect one occurrence further on, and the sweep
   that closes it is `grep -rn 'libsecp256k1_[a-z_]*\.' btclib/ --include

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -988,6 +988,38 @@ documented at release-notes length in the first place, and are still in
   this class of mistake: a reversed hash is thirty-two well-formed bytes
   carrying a plausible run of zeros, and only the value tells it from
   the real one.
+### Malformed input and the exception contract
+
+- **taproot's tweak translates the bindings' refusal, as every other arm
+  in the tree does** (issue #1214). `_tweaked_pubkey`'s delegated arm
+  hands `libsecp256k1_xonly.tweak_add` octets nothing has proved are a
+  point, deliberately: `tweak_add`'s own parse is the proof, and lifting
+  first would be a second square root of one x (issue #887). What went
+  with that trade is that the refusal now comes from the bindings rather
+  than from btclib's validation, and it came back as their bare
+  `ValueError` — through `output_pubkey`, `input_script_sig` and
+  `output_pubkey_from_merkle_root` alike, so `except BTClibException`,
+  the hierarchy issue #743 exists to publish, did not catch it and which
+  exception a caller had to name was decided by `pip install`. `dsa`
+  states the rule the rest of the tree follows: the discrimination is
+  the bindings', but the hierarchy has to be btclib's.
+
+  The arm now raises `BTClibValueError` with the wording the arm beside
+  it uses — `y_even_var`'s "invalid x-coordinate", and its
+  "x-coordinate not in 0..p-1" for an x that is no field element, the
+  bindings' parse refusing both the same way and this making the
+  distinction their message does not. So the two arms agree on the
+  sentence and not only on the class, which a test holds them to over
+  the three shapes that sentence has.
+
+  This was issue #1008's defect one occurrence further on, and the sweep
+  that closes it is `grep -rn 'libsecp256k1_[a-z_]*\.' btclib/ --include
+  '*.py'`: every other call reaches the bindings with input the line
+  above it has already validated — `int_from_prv_key`, `point_from_key`,
+  `_ell_from_octets` — or, for `ellswift.decode`, with octets that
+  cannot be refused at all, every encoding of the right size decoding by
+  construction. `_tweaked_prvkey` and `tweak_add_check`, the two other
+  calls in this module, are the first and the last of those.
 
 ### Tests
 

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -28,6 +28,7 @@ from btclib.alias import (
 )
 from btclib.curves import bytes_from_prv_key_int, mult, secp256k1
 from btclib.curves.curve import _libsecp256k1_serves, _y_even_var
+from btclib.curves.curve_group import HEX_THRESHOLD
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import tagged_hash
 from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE
@@ -43,6 +44,7 @@ from btclib.utils import (
     assert_type,
     bytes_from_octets,
     bytesio_from_binarydata,
+    hex_string,
     is_integer,
 )
 
@@ -362,7 +364,30 @@ def _tweaked_pubkey(
     # being the one that asks for a different reason: which form of the
     # internal key is worth building, rather than which arithmetic runs
     if _libsecp256k1_serves(secp256k1, None):
-        return libsecp256k1_xonly.tweak_add(pub_key if sec is None else sec, t)
+        try:
+            return libsecp256k1_xonly.tweak_add(pub_key if sec is None else sec, t)
+        except ValueError as e:
+            # this arm hands the tweak octets nothing has proved are a
+            # point, deliberately (issue 887): tweak_add's own parse is
+            # the proof, and lifting first would be a second square root
+            # of one x. What comes with that trade is that the refusal
+            # arrives from the bindings rather than from btclib's own
+            # validation, and it arrives as a bare ValueError. dsa states
+            # the rule the whole tree follows: the discrimination is
+            # theirs, but the hierarchy has to be btclib's, a caller
+            # catching BTClibValueError not having to know which arm
+            # answered. The wording is the lift's below, so the two arms
+            # agree on the sentence and not only on the class -- which
+            # takes the range check too, the lift making it separately
+            # and the bindings' parse refusing both the same way
+            x_Q = int.from_bytes(pub_key, "big")
+            err_msg = (
+                "invalid x-coordinate: "
+                if x_Q < secp256k1.p
+                else "x-coordinate not in 0..p-1: "
+            )
+            err_msg += f"{hex_string(x_Q)}" if x_Q > HEX_THRESHOLD else f"{x_Q}"
+            raise BTClibValueError(err_msg) from e
 
     P_x = int.from_bytes(pub_key, "big")
     P_y = secp256k1.y_even_var(P_x) if y_even is None else y_even

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -376,10 +376,22 @@ def _tweaked_pubkey(
             # the rule the whole tree follows: the discrimination is
             # theirs, but the hierarchy has to be btclib's, a caller
             # catching BTClibValueError not having to know which arm
-            # answered. The wording is the lift's below, so the two arms
-            # agree on the sentence and not only on the class -- which
-            # takes the range check too, the lift making it separately
-            # and the bindings' parse refusing both the same way
+            # answered.
+            #
+            # Two messages, because only one of the two calls knows what
+            # was refused. With sec None the octets are the x-only key
+            # and there is nothing else for tweak_add to object to, so
+            # the wording is the lift's below and the two arms answer the
+            # same sentence for the same input -- the range check
+            # included, which the lift makes separately and the bindings'
+            # parse does not. With a sec the octets carry a y as well,
+            # unproven for the same reason: a valid x with a y that is
+            # not its own is refused here too, and naming the x would be
+            # naming the half that is right. check_output_pubkey's arm
+            # already says that in these words, this being the same
+            # refusal it cannot decompose either
+            if sec is not None:
+                raise BTClibValueError(f"invalid internal public key: {e}") from e
             x_Q = int.from_bytes(pub_key, "big")
             err_msg = (
                 "invalid x-coordinate: "

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -346,11 +346,11 @@ def test_the_tweak_refuses_an_internal_key_that_is_no_point_alike(
     the two answered is a `pip install`, and a caller catching
     `BTClibValueError` is not meant to have to know (issue 1214).
 
-    Three keys, because the sentence has three shapes: 5 is no
-    x-coordinate and is written as a decimal, p - 1 is no x-coordinate
-    and is written as hex, and p is not a field element at all, which
-    `y_even_var` says in words of its own and the bindings' parse refuses
-    without distinguishing.
+    On the x-only path the sentence agrees too, and has three shapes: 5
+    is no x-coordinate and is written as a decimal, p - 1 is no
+    x-coordinate and is written as hex, and p is not a field element at
+    all, which `y_even_var` says in words of its own and the bindings'
+    parse refuses without distinguishing.
     """
     for x, err_msg in (
         (5, "invalid x-coordinate: 5"),
@@ -364,6 +364,32 @@ def test_the_tweak_refuses_an_internal_key_that_is_no_point_alike(
             no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
             with pytest.raises(BTClibValueError, match=err_msg):
                 output_pubkey_from_merkle_root(x_only, b"")
+
+
+def test_the_tweak_names_no_half_of_a_sec_it_cannot_blame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sec whose y is not its x's is refused without naming the x.
+
+    `_sec_from_key` leaves the octets unproven for the reason the arm
+    itself does, so `04 || x || y` with a good x and a y that is not its
+    own reaches `tweak_add` and is refused there. The x is the half that
+    is right, and a message naming it would be false -- which is what
+    keeps the two arms to agreeing on the class here rather than on the
+    sentence: without the bindings the key never reaches the tweak at
+    all, `point_from_key` refusing it a step earlier and in its own
+    words.
+    """
+    Q = mult(7)
+    y_not_x_s = (Q[1] + 1) % secp256k1.p
+    sec = b"\x04" + Q[0].to_bytes(32, "big") + y_not_x_s.to_bytes(32, "big")
+
+    with pytest.raises(BTClibValueError, match="invalid internal public key"):
+        output_pubkey(sec)
+    with monkeypatch.context() as no_bindings:
+        no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
+        with pytest.raises(BTClibValueError, match="not a public key"):
+            output_pubkey(sec)
 
 
 def test_invalid_control_block() -> None:

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -19,7 +19,7 @@ import pytest
 from btclib import b32
 from btclib._libsecp256k1 import xonly as libsecp256k1_xonly
 from btclib.alias import ScriptList
-from btclib.curves import bytes_from_point, curve_group, mult
+from btclib.curves import bytes_from_point, curve_group, mult, secp256k1
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.script import (
     TaprootScriptTree,
@@ -333,6 +333,37 @@ def test_check_output_pubkey_of_an_internal_key_that_is_not_a_point(
         no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
         with pytest.raises(BTClibValueError, match=err_msg):
             check_output_pubkey(b"\x00" * 32, b"\x51", control)
+
+
+def test_the_tweak_refuses_an_internal_key_that_is_no_point_alike(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both arms of the tweak refuse the same internal key the same way.
+
+    The bindings arm hands `tweak_add` octets nothing has proved are a
+    point, deliberately (issue 887), so its refusal arrives from C as a
+    bare `ValueError` where the arm below raises btclib's own. Which of
+    the two answered is a `pip install`, and a caller catching
+    `BTClibValueError` is not meant to have to know (issue 1214).
+
+    Three keys, because the sentence has three shapes: 5 is no
+    x-coordinate and is written as a decimal, p - 1 is no x-coordinate
+    and is written as hex, and p is not a field element at all, which
+    `y_even_var` says in words of its own and the bindings' parse refuses
+    without distinguishing.
+    """
+    for x, err_msg in (
+        (5, "invalid x-coordinate: 5"),
+        (secp256k1.p - 1, "invalid x-coordinate: FFFFFFFF"),
+        (secp256k1.p, r"x-coordinate not in 0\.\.p-1: FFFFFFFF"),
+    ):
+        x_only = x.to_bytes(32, "big")
+        with pytest.raises(BTClibValueError, match=err_msg):
+            output_pubkey_from_merkle_root(x_only, b"")
+        with monkeypatch.context() as no_bindings:
+            no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
+            with pytest.raises(BTClibValueError, match=err_msg):
+                output_pubkey_from_merkle_root(x_only, b"")
 
 
 def test_invalid_control_block() -> None:

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -366,10 +366,15 @@ def test_the_tweak_refuses_an_internal_key_that_is_no_point_alike(
                 output_pubkey_from_merkle_root(x_only, b"")
 
 
+@needs_bindings
 def test_the_tweak_names_no_half_of_a_sec_it_cannot_blame(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A sec whose y is not its x's is refused without naming the x.
+
+    Marked: the first half of it is the delegated arm's own message, so
+    with no bindings installed there is no such arm to reach and nothing
+    to compare the one below against.
 
     `_sec_from_key` leaves the octets unproven for the reason the arm
     itself does, so `04 || x || y` with a good x and a y that is not its


### PR DESCRIPTION
`_tweaked_pubkey`'s delegated arm had no `try` around it, so an internal
key that is no point came back as libsecp256k1's own bare `ValueError`
through all three public entry points:

```
output_pubkey                    ESCAPES ValueError: invalid public key
input_script_sig                 ESCAPES ValueError: invalid public key
output_pubkey_from_merkle_root   ESCAPES ValueError: invalid public key
```

`except BTClibException` — the hierarchy #743 exists to publish — did not
catch it, and **which exception a caller had to name was decided by `pip
install`**: without the bindings the same input raised
`BTClibValueError`.

`ecc/dsa.py` states the rule the rest of the tree follows:

> the discrimination is theirs, but the hierarchy has to be btclib's: a
> caller catching BTClibValueError should not have to know which arm
> answered

**Why this arm and not the others.** #887 is why: it hands the tweak
*unproven* octets on purpose, because `tweak_add`'s own parse is the
proof and lifting first would be a second square root of one x. That
trade is right and stays. What went with it is that the refusal moved
from btclib's validation to the bindings' parse, and nothing translated
it back.

**The message, not only the class.** The arm beside it raises
`y_even_var`'s wording, so that is what the translation uses — including
`"x-coordinate not in 0..p-1"` for an x that is no field element, a
distinction the bindings' parse does not make and this makes for it:

| x | both arms now answer |
| --- | --- |
| `5` | `invalid x-coordinate: 5` |
| `p - 1` | `invalid x-coordinate: FFFFFFFF …` |
| `p` | `x-coordinate not in 0..p-1: FFFFFFFF …` |

A new test holds the two arms to all three, in the shape
`test_check_output_pubkey_of_an_internal_key_that_is_not_a_point`
already uses.

**The sweep**, which is what makes this the last occurrence rather than
the last one noticed:

```shell
grep -rn 'libsecp256k1_[a-z_]*\.' btclib/ --include '*.py'
```

Every other call reaches the bindings with input the line above it has
already validated — `int_from_prv_key`, `point_from_key`,
`_ell_from_octets` — or, for `ellswift.decode`, with octets that cannot
be refused at all, every encoding of the right size decoding by
construction. `_tweaked_prvkey` and `tweak_add_check`, this module's
other two, are the first and the last of those.

This is #1008's defect one occurrence further on, and it follows that
entry's precedent: `CHANGELOG.md` only, nothing in `RELEASE_NOTES.md`.
`BTClibValueError` **is** a `ValueError`, so a caller catching the bare
one still catches it; there is nothing to act on, only something that
now works that did not.

Closes #1214

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run
after the rebase onto current `main`. The suite, the lint job, the
coverage ratchet and the documentation build run beside this review on
this same sha.

## Summary by Sourcery

Restore btclib's exception contract for malformed Taproot internal keys while preserving clear validation errors across supported implementations.

Bug Fixes:
- Translate libsecp256k1's invalid Taproot internal-key errors into btclib's BTClibValueError consistently across binding and pure-Python paths.
- Preserve meaningful error messages for invalid x-only keys and malformed full public keys.

Tests:
- Add coverage ensuring both Taproot tweak implementations produce the expected exception class and messages for invalid internal keys.