### PR TITLE
.yamllint.yaml turns the default rule set back on

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -21,6 +21,14 @@ name: mutation
 # commands, not a second copy of them in yaml.
 
 on:
+  # No pull_request trigger, unlike links.yml, which does run itself when
+  # its own configuration changes. The difference is the clock: a link
+  # sweep is a couple of hundred requests, a mutation session is hours, so
+  # a trigger on .github/mutation/*.toml would hang an hours-long job off a
+  # pull request it is not allowed to gate. What that trigger would have
+  # caught is caught cheaply elsewhere -- check-toml parses these files on
+  # every commit, and `cosmic-ray baseline` below fails the run before any
+  # mutant if the test command has gone stale
   schedule:
     # Sundays, 03:41 UTC, so a session measured in hours has the weekend
     # to itself. Not on the hour: GitHub queues scheduled workflows across
@@ -70,14 +78,6 @@ on:
           - psbt
           - script
           - boundaries
-  # No pull_request trigger, unlike links.yml, which does run itself when
-  # its own configuration changes. The difference is the clock: a link
-  # sweep is a couple of hundred requests, a mutation session is hours, so
-  # a trigger on .github/mutation/*.toml would hang an hours-long job off a
-  # pull request it is not allowed to gate. What that trigger would have
-  # caught is caught cheaply elsewhere -- check-toml parses these files on
-  # every commit, and `cosmic-ray baseline` below fails the run before any
-  # mutant if the test command has gone stale
 
 # least privilege for the GITHUB_TOKEN: everything running in a job can
 # read it, and nothing here writes. In particular no issues: write --

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -415,10 +415,12 @@ repos:
   # docstrings to the same, and the workflows were a place prose could
   # grow without a limit -- 117 columns at the worst. Toml was the other,
   # and the hook below is what closed it.
+  # Width is the half of this a sibling gate could in principle have
+  # covered; a key written twice, a block indented under nothing, a value
+  # that is octal by accident are read by nothing else at all.
   # Configured in .yamllint.yaml rather than in args here, as codespell
-  # and typos are configured in pyproject.toml: the two rules enabled and
-  # the two left off need a paragraph each, and the width is not 80 for a
-  # reason that has to be written down.
+  # and typos are configured in pyproject.toml: the default set, the two
+  # rules left off, and a width that is not 80 need a paragraph each.
   # No args, and the hook declares none either, so there is nothing here
   # to drop by omission -- unlike zizmor below
   - repo: https://github.com/adrienverge/yamllint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -425,7 +425,7 @@ repos:
     rev: v1.38.0
     hooks:
       - id: yamllint
-        name: yamllint (line width and document start)
+        name: yamllint (the default rule set, less two)
   # the width of a toml comment, which was the last prose here held to
   # nothing. pyproject.toml carries more reasoning than any single file
   # the rules above cover, and one of its comments had reached 118

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -11,21 +11,31 @@
 # below, asked in the tree that wants the answer, rather than a number
 # recorded here and carried into repositories nobody re-measured it in.
 #
-# Enabled: the width of a line, which nothing else here measures for
-# yaml, and the marker that opens a document. The rest of the default set
-# is off, reporting a convention rather than a defect:
-#   - comments wants two spaces before a trailing comment where one is
-#     written. Dependabot writes one when it bumps a
-#     "uses: action@sha # v1.2.3" pin, so the rule would report the bot's
-#     own output on every update
-#   - truthy reports the "on:" that opens a workflow: yaml 1.1 reads that
-#     key as the boolean true, so what the rule objects to is the
-#     spelling GitHub Actions requires, one per workflow by construction
-# What the default set says about this tree today:
+# The default set, minus two rules and with one width changed. extends is
+# what carries the rest: yamllint enables no rule a configuration does
+# not name, so a file that lists rules and extends nothing runs those
+# rules alone -- indentation, trailing whitespace, duplicate keys and the
+# rest silently off, with a lint gate that still passes because a check
+# nobody runs cannot fail. The two exceptions are named under rules
+# below, where a reader can see them, rather than left to be inferred
+# from what is missing.
+#
+# What the whole default set says about this tree today, the two
+# exceptions included, is a question for the tree that is asking:
 #
 #   git ls-files '*.yml' '*.yaml' | xargs uvx yamllint -f parsable \
 #     -d '{extends: default, rules: {line-length: {max: 100}}}'
+extends: default
+
 rules:
+  # two spaces before a trailing comment where one is written. Dependabot
+  # writes one when it bumps a "uses: action@sha # v1.2.3" pin, so the
+  # rule reports the bot's own output on every update
+  comments: disable
+  # the "on:" that opens a workflow: yaml 1.1 reads that key as the
+  # boolean true, so what the rule objects to is the spelling GitHub
+  # Actions requires, one per workflow by construction
+  truthy: disable
   line-length:
     # 100, where markdown is held to 80 and any Python beside it to the
     # same, and the difference is the pinning convention. An action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,33 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **`.yamllint.yaml` turns the default rule set back on**
+  (btclib-org/.github#68). The file listed `line-length` and
+  `document-start` under `rules:` and extended nothing, and yamllint
+  enables no rule a configuration does not name -- so those two were the
+  only rules that had ever run here. Indentation, trailing whitespace,
+  duplicate keys, colon spacing and the rest of the default set were
+  off, while the file's own comment named `comments` and `truthy` as the
+  exceptions and read as though the rest were on.
+
+  Three things kept it out of sight, and each generalizes past this
+  file: the comment said otherwise; the gate stayed green, because
+  removing a check cannot make a conformant tree fail; and the file is
+  shared byte-for-byte across the organization, so the defect travelled
+  by being copied rather than by being written twice. `extends: default`
+  is back, the two exceptions are named under `rules:` as explicit
+  `disable`s with their reasons beside them, and the hook's own name
+  follows -- "yamllint (line width and document start)" was an accurate
+  description of what the hook did, which is the point.
+
+  One finding in the whole tree, and it is the shape the rule exists for:
+  `mutation.yml`'s note about having no `pull_request` trigger sat at the
+  end of the `on:` block, indented two spaces under a list indented ten,
+  above a `permissions:` at zero -- a comment attached to nothing. It now
+  opens the block it is about, where the key under it carries the same
+  indentation, which is also where a reader looking for what triggers
+  that workflow reads first.
+
 - **`latest.yml`'s pre-commit cache is keyed on the runner image and the
   interpreter rather than on the config hash alone**
   (btclib-org/.github#25). What that cache holds is virtualenvs, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,13 +189,16 @@ documented at release-notes length in the first place, and are still in
   follows -- "yamllint (line width and document start)" was an accurate
   description of what the hook did, which is the point.
 
-  One finding in the whole tree, and it is the shape the rule exists for:
-  `mutation.yml`'s note about having no `pull_request` trigger sat at the
-  end of the `on:` block, indented two spaces under a list indented ten,
-  above a `permissions:` at zero -- a comment attached to nothing. It now
-  opens the block it is about, where the key under it carries the same
-  indentation, which is also where a reader looking for what triggers
-  that workflow reads first.
+  What the restored set had to say about this tree is the shape the rule
+  exists for: `mutation.yml`'s note about having no `pull_request`
+  trigger sat at the end of the `on:` block, indented two spaces under a
+  list indented ten, above a `permissions:` at zero -- a comment attached
+  to nothing. It now opens the block it is about, where the key under it
+  carries the same indentation, which is also where a reader looking for
+  what triggers that workflow reads first. What it has to say tomorrow is
+  `git ls-files '*.yml' '*.yaml' | xargs uvx yamllint`, in the tree that
+  is asking, which is the answer this entry declines to write down as a
+  number.
 
 - **`latest.yml`'s pre-commit cache is keyed on the runner image and the
   interpreter rather than on the config hash alone**


### PR DESCRIPTION
`.yamllint.yaml` listed `line-length` and `document-start` under `rules:`
and **extended nothing**. yamllint enables no rule a configuration does
not name, so those two are the only rules that have ever run here:

```shell
printf -- '---\nfoo:   bar   \nfoo: baz\n' > t.yaml
uvx yamllint -f parsable t.yaml     # before: nothing
uvx yamllint -f parsable t.yaml     # after:
# t.yaml:2:7:  [error] too many spaces after colon (colons)
# t.yaml:2:11: [error] trailing spaces (trailing-spaces)
# t.yaml:3:1:  [error] duplication of key "foo" in mapping (key-duplicates)
```

The whole default set — indentation, trailing whitespace, duplicate keys,
colon spacing, empty values, octal values, anchors — was off, while the
file's own comment named `comments` and `truthy` as *the* exceptions and
read as though the rest were on.

**Three things kept it out of sight**, and each generalizes past this
file:

- the comment said otherwise, so two rules read as the exception list
  where it was the whole list of what was meant;
- the gate stayed green, because removing a check cannot make a
  conformant tree fail — a pass that is the absence of a measurement;
- the file is shared byte-for-byte across the organization, so the defect
  travelled by being copied rather than by being written twice.

`extends: default` is back, `comments` and `truthy` are explicit
`disable`s with their reasons beside them, and the hook's name follows:
**"yamllint (line width and document start)"** described exactly what the
hook did, which is the point.

**One finding in the whole tree, and it is the shape the rule exists
for.** `.github/workflows/mutation.yml`'s note about having no
`pull_request` trigger sat at the *end* of the `on:` block — indented two
spaces, under a list indented ten, above a `permissions:` at zero. A
comment attached to nothing:

```yaml
          - script
          - boundaries
  # No pull_request trigger, unlike links.yml, …

# least privilege for the GITHUB_TOKEN: …
```

It now opens the block it is about, where the key under it carries the
same indentation — and where a reader asking what triggers that workflow
looks first. `comments-indentation` is `warning`-level and the hook is
not `--strict`, so this never failed anything; it was simply never seen.

```shell
git ls-files '*.yml' '*.yaml' | xargs uvx yamllint -f parsable
# (nothing, after)
```

Part of btclib-org/.github#68, which has the measurement for all four
repositories. `btclib-org/btclib-secp256k1#326` is where the corrected
file is written; this adopts it unchanged. No parenthetical in the title:
this closes no issue in this repository, and section 11 of the standard
says a pull request that closes nothing carries none.

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run
after the rebase onto current `main`. The suite, the lint job, the
coverage ratchet and the documentation build run beside this review on
this same sha.

## Summary by Sourcery

Re-enable comprehensive YAML linting and align the mutation workflow documentation with the configuration it describes.

Bug Fixes:
- Restore yamllint's default rule set while explicitly disabling only the `comments` and `truthy` rules required by the repository's workflow and dependency-update conventions.
- Correct the misplaced mutation workflow comment so it is attached to the `on:` block it documents.

Enhancements:
- Rename the yamllint pre-commit hook to reflect that it enforces the default rule set with two exceptions.

Documentation:
- Document the restored YAML lint coverage and its rationale in the changelog.