### PR TITLE
Carry taproot's internal key as a PubKeyData (issue #1188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1014,15 +1014,103 @@ documented at release-notes length in the first place, and are still in
   private or public key for mainnet" for every one of them; all three
   are `BTClibValueError` subclasses, so only the message differs there.
 
+- **`script.taproot` carries its internal key as a `PubKeyData`**, which
+  is what let the dispatch in front of it go (issue #1188). That guard
+  read as one of the module's `_libsecp256k1_serves` and was not asking
+  what the others ask: not which arithmetic runs, but *how much of the
+  key is worth building*. The bindings arm
+  wanted unproven octets, a second lift being issue 887; the Python arm
+  wanted the point, a second lift being issue 896. A `cached_property`
+  answers both without either arm saying which it is, so the arm that
+  reads `point` pays for it and the arm that never asks never does.
+
+  `_tweaked_pubkey` takes one object where it took three parameters —
+  the x-only octets, the even y for the arm that had it, the full SEC key
+  for the arm that had that — each a partial view of one key, and the
+  last two `None` where the caller held it in another form.
+
+  Nothing is faster: the modular square roots per output key are the same
+  numbers they were, 1 for a compressed internal key and 0 for an
+  uncompressed one, and `output_pubkey` on the bindings-free arm measures
+  234 against 232 microseconds. What changes is that the count is now
+  asserted: `tests/script/taproot_test.py` gained
+  `test_the_python_output_key_lifts_the_internal_x_once`, which counts
+  `mod_sqrt_var` for both SEC forms and for both readers of
+  `_output_pubkey_and_internal_key`, where before it was a comment.
+
+  The messages that refuse a bad internal key move, on the
+  bindings-free arm. Where the key is octets or a `Point`, one rule
+  covers them: the refusal belongs to the call that parses it rather
+  than to `to_pub_key`, so it names what is wrong with the key where
+  "not a public key" said only that something was. `point_from_octets`
+  answers for octets — an unrecognised prefix, an x that is no
+  coordinate, a y out of range, a pair off the curve — and
+  `bytes_from_point` for a `Point` argument, where a point off the curve
+  and the point at infinity now draw the curve's own complaint instead
+  of "not a valid public key".
+
+  Two refusals go the other way, and both arrive at "not a private or
+  public key": a key of no recognised form, which that arm called "not a
+  public key"; and an extended key whose own key field is no point,
+  which bip32 named and echoed, and which `_sec_from_key` swallows — its
+  `contextlib.suppress` covers the reading as a public key, so the
+  private fallback's message is what surfaces. Both are what the
+  bindings arm already said, which is the direction all of this moves
+  in. None of it reaches that arm, whose messages are what they were.
+
+  `output_pubkey_from_merkle_root` moves for a second reason:
+  `point_from_octets` collapses `curve_group.y_var`'s two complaints
+  into one, so an x at or above p is refused as "invalid x-coordinate"
+  where the range used to be named, and every x is quoted hex where a
+  small one was decimal.
+
+  Which of these echo the key they refuse moves both ways, and neither
+  way by design: an off-curve `Point` stops being echoed, octets start,
+  and each follows from which call refuses rather than from a decision
+  about the message.
+
+  A `memoryview` internal key now reaches the tweak everywhere, and
+  what refused it is Python's own asymmetry: `bytes + memoryview` is a
+  concatenation and `memoryview + bytes` is not, while `_tap_tweak`
+  joins the merkle root to the x it is handed. On `output_pubkey` and
+  `input_script_sig` the bindings arm refused one, taking these octets
+  unproven where the other lifted them to a point and serialized bytes
+  back; `PubKeyData` coercing its own field is what answers those, and
+  is what keeps this change from carrying the refusal over to the arm
+  that worked. `output_pubkey_from_merkle_root` refused one on both
+  arms, and there the `02` this entry point prefixes is the answer,
+  `bytes` being the left operand after it. The `TypeError` that came
+  back was neither a `BTClibValueError` nor documented; a `bytearray`
+  was never affected, being a concatenation Python takes from either
+  side.
+
+  The translation the entry below adds for issue #1214 moves with the
+  signature, and keeps its promise under a new lift. It discriminated on
+  whether the caller had handed over a full SEC key, which stood in for
+  the question it meant to ask; a `PubKeyData` asks that question
+  outright — whether the octets are a compressed key, whose y its prefix
+  names and whose x is therefore all `tweak_add` can be objecting to.
+  What changes for a caller is that the bindings arm names the x for
+  such a key where it said "invalid internal public key", which is what
+  the arm beside it says and what `output_pubkey_from_merkle_root` said
+  already.
+
+  That sentence is `point_from_octets`', because `point_from_octets` is
+  the lift now, and it wraps both of `curve_group.y_var`'s complaints —
+  an x that is no coordinate and an x that is no field element — in one.
+  So taproot's x-only path stops naming the range, and says instead what
+  every other caller of `point_from_octets` in this library says; the
+  hex the message quotes still tells p from p - 1.
+
 - **`btclib.key` holds the canonical form of a key**, `PubKeyData` and
   `PrvKeyData`, so that a key parsed once can be carried rather than
   spelled back for the next call to parse again (issue #1188). Every
   converter in the library takes each spelling and answers a tuple, so
   the canonical form was what came *out* of a conversion and never what
-  went *in*. `bip32.derive_`, `to_pub_key._sec_from_pub_key` and
-  `taproot._output_pubkey_and_internal_key` each work around the round
-  trip that leaves — issues 886, 887 and 896. This is the cut those
-  patch locally.
+  went *in*. `bip32.derive_` and `to_pub_key._sec_from_pub_key` work
+  around the round trip that leaves — issues 886 and 887 — and
+  `taproot._output_pubkey_and_internal_key` did, issue 896, until the
+  entry above. This is the cut those patch locally.
 
   The SEC octets are the field and the point is a `cached_property`
   because the two conversions do not cost the same. Measured on
@@ -1071,12 +1159,21 @@ documented at release-notes length in the first place, and are still in
   `PrvKeyData.pub` is lazy for the same reason and buys most, a scalar
   multiplication being the dearest conversion of the three.
 
+  `sec` is coerced to `bytes` in the constructor, where
+  `bytes_from_octets` on its own would not: that returns a `bytearray`
+  and a `memoryview` as they came, deliberately, being what
+  `assert_valid` reads with and a read having to leave its field alone.
+  A constructor builds instead, and both promises above rest on the
+  field being what it is declared — a key spelled as a `bytearray` would
+  be unhashable, where equality and hashing read the declared fields,
+  and one spelled as a `memoryview` would carry octets that do not
+  concatenate.
+
   The module docstring carries the rest of the reasoning rather than this
   entry repeating it: why one type per half and not a `PubKeySecData`
   beside a `PubKeyPointData`, why frozen as `BIP32KeyData` is, and why
-  not `slots=True`. Nothing in the library consumes these yet: the
-  adoption is per module, and each step of it removes one of the round
-  trips above.
+  not `slots=True`. The adoption is per module, and each step of it
+  removes one of the round trips above.
 
 - **`NETWORKS["regtest"].genesis_block` was stored byte-reversed**
   (issue #1203). It held `06226e46…f188910f`, which is Bitcoin Core's

--- a/btclib/key.py
+++ b/btclib/key.py
@@ -9,10 +9,10 @@ hex string of them, a point, an xpub -- and a private key has as many.
 Every converter in this library takes all of them and answers a tuple, so
 the canonical form is what comes *out* of a conversion and never what
 goes *in*: a caller that has one has to spell it back for the next call,
-which parses it again. That round trip is what `bip32.derive_`,
-`to_pub_key._sec_from_pub_key` and
-`taproot._output_pubkey_and_internal_key` each work around locally --
-issues 886, 887 and 896.
+which parses it again. That round trip is what `bip32.derive_` and
+`to_pub_key._sec_from_pub_key` work around locally -- issues 886 and
+887. Issue 896 is the same round trip where `script.taproot` reads an
+internal key, and there it is this module that answers it.
 
 `PubKeyData` and `PrvKeyData` are that cut: the spellings stay at the
 boundary, the parse happens once, and what travels afterwards is an
@@ -106,10 +106,11 @@ def _normalized(network: Any) -> Any:
     network at all -- and whether it is a string -- stays
     `assert_valid`'s question.
 
-    `sec` is asymmetric here, and the asymmetry is inherited rather than
-    chosen: `bytes_from_octets` refuses a wrong type whatever
-    `check_validity` says, and it belongs to `utils` rather than to this
-    module.
+    `sec` is asymmetric here, and only the refusal is inherited:
+    `bytes_from_octets` refuses a wrong type whatever `check_validity`
+    says, and it belongs to `utils` rather than to this module. The
+    coercion beside it is this module's own, and the constructor says
+    what it is for.
     """
     return network.strip().lower() if isinstance(network, str) else network
 
@@ -134,7 +135,19 @@ class PubKeyData:
         *,
         check_validity: bool = True,
     ) -> None:
-        object.__setattr__(self, "sec", bytes_from_octets(sec))
+        # `bytes()` around it: `bytes_from_octets` returns a bytearray or
+        # a memoryview as it came, deliberately, and `utils` says why --
+        # `assert_valid` is a read and must not rewrite the field it
+        # reads. Here the field is built rather than read, and it is
+        # declared `bytes`: without the coercion a key made from a
+        # bytearray is unhashable, where the docstring above promises that
+        # equality and hashing read the declared fields, and one made from
+        # a memoryview carries octets no concatenation accepts --
+        # `script.taproot` joins a merkle root to the x it reads off
+        # `sec` before hashing the pair under a tag.
+        # `bytes(b)` on bytes is `b` itself, so the spelling every caller
+        # of this library uses copies nothing
+        object.__setattr__(self, "sec", bytes(bytes_from_octets(sec)))
         object.__setattr__(self, "network", _normalized(network))
 
         if check_validity:

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -28,9 +28,9 @@ from btclib.alias import (
 )
 from btclib.curves import bytes_from_prv_key_int, mult, secp256k1
 from btclib.curves.curve import _libsecp256k1_serves, _y_even_var
-from btclib.curves.curve_group import HEX_THRESHOLD
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import tagged_hash
+from btclib.key import PubKeyData
 from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE
 from btclib.script.op_codes_tapscript import (
     OP_CODE_NAMES,
@@ -39,7 +39,7 @@ from btclib.script.op_codes_tapscript import (
 )
 from btclib.script.script import _serialize_bytes_command, _serialize_int_command
 from btclib.to_prv_key import PrvKey, int_from_prv_key
-from btclib.to_pub_key import Key, _sec_from_key, point_from_key
+from btclib.to_pub_key import Key, _sec_from_key
 from btclib.utils import (
     assert_type,
     bytes_from_octets,
@@ -256,55 +256,44 @@ def _output_pubkey_and_internal_key(
     of an internal key: a form accepted for the output key and refused for
     the control block that proves it would be refused one call after being
     accepted, and one reader cannot drift from another.
+
+    The key travels as a `PubKeyData`, so that neither arm has to say how
+    much of it is worth building (issue #1188): the octets are the field
+    and `point` is a `cached_property`. The bindings arm wants the octets
+    unproven, the tweak's own parse being the proof and a second lift
+    issue 887; the Python arm wants the point it would otherwise lift
+    twice, which is issue 896. The arm that reads the point pays for it
+    and the arm that does not never asks.
     """
     if not internal_pubkey and not script_tree:
         raise BTClibValueError("missing data")
     if internal_pubkey:
-        # a fourth reading of the dispatch, and the only one in this module
-        # that is not about which arithmetic runs: what differs between the
-        # two arms is *how much of the key is worth building*.
+        # `_sec_from_key` and not `pub_keyinfo_from_key`: unproven octets
+        # are what both arms want, and `PubKeyData` proves them in `point`
+        # or not at all. It accepts the 33-byte and the 65-byte form, and
+        # `[1:33]` is the x-coordinate of either.
         #
-        # `_tweaked_pubkey` lifts the x-only key to a point on the Python
-        # path, and validating a key is how a point is built, so the same
-        # modular square root of the same x was taken twice -- 74 us of the
-        # 311 an output key cost there (issue 896). The bindings arm builds
-        # no point of btclib's own and proves nothing either: the tweak
-        # below parses these octets, and that parse is the proof, so a key
-        # that is no point is refused there instead of here (issue 887).
-        # `point_from_key` is 6.58 us against `_sec_from_key`'s 3.74, which
-        # is a sixth of a 17.3 us output key added to the path every
-        # install takes.
-        #
-        # So each arm reads what it uses, and both read the same spellings:
-        # `_sec_from_key` accepts the 33-byte and the 65-byte form as
-        # `point_from_key` does, and `[1:33]` is the x-coordinate of either
-        if _libsecp256k1_serves(secp256k1, None):
-            sec = _sec_from_key(internal_pubkey)
-            pub_key = sec[1:33]
-            y_even: int | None = None
-        else:
-            # which of the two roots the key names is its prefix's business
-            # and not BIP341's, whose lift wants the even one: an 03 key
-            # validates to the odd-y point, and the even y is then a
-            # subtraction from the root already taken rather than a second
-            # root
-            x_P, y_P = point_from_key(internal_pubkey)
-            pub_key = x_P.to_bytes(32, "big")
-            y_even = y_P if y_P % 2 == 0 else secp256k1.p - y_P
-            sec = None
+        # check_validity=False, and not because what arrives is known
+        # good: `assert_valid` reads a length and a prefix, and
+        # `_sec_from_key` answers any prefix at those two lengths -- the
+        # hybrid 06 and 07 among them -- so some of what reaches here it
+        # would refuse. It is skipped because it is half a proof bought
+        # early: whatever these octets are handed to parses them, which is
+        # `_sec_from_key`'s own reason for not proving them, and it names
+        # what is wrong with the key where a prefix check names the prefix
+        key_data = PubKeyData(_sec_from_key(internal_pubkey), check_validity=False)
     else:
         h_str = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
-        pub_key = bytes.fromhex(h_str)
         # BIP341's unspendable point is published as an x-only key and
-        # nothing else, so there the 32 octets are all there is
-        y_even = None
-        sec = None
+        # nothing else, so the prefix is this module's to supply -- 02,
+        # BIP341's lift being the even one
+        key_data = PubKeyData(b"\x02" + bytes.fromhex(h_str), check_validity=False)
     if script_tree:
         _, h = tree_helper(script_tree)
     else:
         h = b""
-    q, parity_bit = _tweaked_pubkey(pub_key, h, y_even, sec)
-    return q, parity_bit, pub_key
+    q, parity_bit = _tweaked_pubkey(key_data, h)
+    return q, parity_bit, key_data.sec[1:33]
 
 
 def output_pubkey(
@@ -323,29 +312,20 @@ def output_pubkey(
     return q, parity_bit
 
 
-def _tweaked_pubkey(
-    pub_key: bytes, h: bytes, y_even: int | None, sec: bytes | None
-) -> tuple[bytes, int]:
+def _tweaked_pubkey(pub_key: PubKeyData, h: bytes) -> tuple[bytes, int]:
     """Return the x-only key an internal key tweaked by h, and its parity.
 
     The half of BIP341's output key that does not care where h came
     from: a tree the caller built, or the merkle root a psbt carries.
 
-    The last two arguments are what the caller already holds of the
-    internal key, one per arm, and None where it holds neither -- a caller
-    with x-only octets and nothing else, which is what a merkle root
-    arrives with.
-
-    y_even is the even y-coordinate of pub_key, which `output_pubkey` has
-    on the Python path: validating the key is a modular square root of
-    this very x, and taking a second one is the redundancy of issue 896.
-    sec is the full public key of the bindings path, uncompressed where
-    the caller had a point to serialize: `xonly.tweak_add` reads the y it
-    is given there, where the 32 x-only octets are a square root to lift
-    -- 4.11 us against 5.92, and the same key either way, `02 || x`,
-    `03 || x` and `04 || x || y` all naming it.
+    One `PubKeyData` for both arms, each reading off it the field it
+    uses (issue #1188). `sec` is what `xonly.tweak_add` prefers whole,
+    `04 || x || y` carrying the y it would otherwise lift -- 4.11 us
+    against 5.92 -- and `02 || x`, `03 || x` and `04 || x || y` all name
+    the same x-only key to it. `point` is the square root, taken once
+    however many readers ask, which is issue 896.
     """
-    t = _tap_tweak(pub_key, h)
+    t = _tap_tweak(pub_key.sec[1:33], h)
 
     # secp256k1_xonly_pubkey_tweak_add is this very operation, parity
     # included, and it answers the pair this function returns. 12.0 us
@@ -355,17 +335,17 @@ def _tweaked_pubkey(
     # while libsecp256k1 needs no such lift, having the y coordinate as
     # it goes.
     #
-    # The predicate is a constant now that the curve is, and the four
-    # guards in this module keep it rather than saying so: it is the
-    # seam the suite closes -- curve._libsecp256k1_available set to
-    # False -- to reach the Python arithmetic below, which is the
-    # reference implementation the bindings are checked against and not
-    # a path any caller takes. Stated here for all four, `output_pubkey`'s
-    # being the one that asks for a different reason: which form of the
-    # internal key is worth building, rather than which arithmetic runs
+    # The predicate is a constant now that the curve is, and the guards
+    # in this module keep it rather than saying so: it is the seam the
+    # suite closes -- curve._libsecp256k1_available set to False -- to
+    # reach the Python arithmetic below, which is the reference
+    # implementation the bindings are checked against and not a path any
+    # caller takes. Stated here for every one of them: whatever else a
+    # guard goes on to read, its `_libsecp256k1_serves` half asks the
+    # one question, which arithmetic runs
     if _libsecp256k1_serves(secp256k1, None):
         try:
-            return libsecp256k1_xonly.tweak_add(pub_key if sec is None else sec, t)
+            return libsecp256k1_xonly.tweak_add(pub_key.sec, t)
         except ValueError as e:
             # this arm hands the tweak octets nothing has proved are a
             # point, deliberately (issue 887): tweak_add's own parse is
@@ -378,31 +358,35 @@ def _tweaked_pubkey(
             # catching BTClibValueError not having to know which arm
             # answered.
             #
-            # Two messages, because only one of the two calls knows what
-            # was refused. With sec None the octets are the x-only key
-            # and there is nothing else for tweak_add to object to, so
-            # the wording is the lift's below and the two arms answer the
-            # same sentence for the same input -- the range check
-            # included, which the lift makes separately and the bindings'
-            # parse does not. With a sec the octets carry a y as well,
-            # unproven for the same reason: a valid x with a y that is
-            # not its own is refused here too, and naming the x would be
-            # naming the half that is right. check_output_pubkey's arm
-            # already says that in these words, this being the same
-            # refusal it cannot decompose either
-            if sec is not None:
+            # Two messages, and what decides between them is what the
+            # octets are rather than which caller handed them over. A
+            # compressed key names its y by its prefix, so its x is all
+            # that is left for tweak_add to object to, and the wording is
+            # the lift's below, so that the two arms say one sentence for
+            # one input: `point_from_octets` is that lift, and it answers
+            # both of `curve_group.y_var`'s complaints -- an x out of
+            # range and an x that is no coordinate -- in the one sentence
+            # this reproduces.
+            #
+            # Anything else carries more than an x. An uncompressed key's
+            # y is unproven for the same reason as its x, and a valid x
+            # with a y that is not its own is refused here too, where
+            # naming the x would name the half that is right; and
+            # `_sec_from_key` answers any prefix at either length, a
+            # prefix being the fault of neither coordinate.
+            # `check_output_pubkey`'s arm already says that in these
+            # words, its refusal being one it cannot decompose either
+            if not (pub_key.is_compressed and pub_key.sec[0] in (0x02, 0x03)):
                 raise BTClibValueError(f"invalid internal public key: {e}") from e
-            x_Q = int.from_bytes(pub_key, "big")
-            err_msg = (
-                "invalid x-coordinate: "
-                if x_Q < secp256k1.p
-                else "x-coordinate not in 0..p-1: "
-            )
-            err_msg += f"{hex_string(x_Q)}" if x_Q > HEX_THRESHOLD else f"{x_Q}"
-            raise BTClibValueError(err_msg) from e
+            x_Q = int.from_bytes(pub_key.sec[1:33], "big")
+            raise BTClibValueError(f"invalid x-coordinate: '{hex_string(x_Q)}'") from e
 
-    P_x = int.from_bytes(pub_key, "big")
-    P_y = secp256k1.y_even_var(P_x) if y_even is None else y_even
+    # which of the two roots the key names is its prefix's business and
+    # not BIP341's, whose lift wants the even one: an 03 key is the odd-y
+    # point, and the even y is then a subtraction from the root already
+    # taken rather than a second root
+    P_x, y_P = pub_key.point
+    P_y = y_P if y_P % 2 == 0 else secp256k1.p - y_P
     Q = secp256k1.add_var((P_x, P_y), mult(t))
     return Q[0].to_bytes(32, "big"), Q[1] % 2
 
@@ -425,9 +409,16 @@ def output_pubkey_from_merkle_root(
     reached them in.
     """
     internal_pubkey = bytes_from_octets(internal_pubkey, 32)
-    # y_even=None: x-only octets are all this caller has, so the lift is
-    # `_tweaked_pubkey`'s to make
-    return _tweaked_pubkey(internal_pubkey, bytes_from_octets(merkle_root), None, None)
+    # 02 and not 03: x-only octets are all this caller has, and BIP341's
+    # lift is the even one, so the prefix says what the key means rather
+    # than adding anything to it
+    return _tweaked_pubkey(
+        # `assert_valid` reads a length and a prefix, and this call
+        # settles both itself: the size is checked on the way in and the
+        # prefix is the one supplied on the line below
+        PubKeyData(b"\x02" + internal_pubkey, check_validity=False),
+        bytes_from_octets(merkle_root),
+    )
 
 
 def output_prvkey(

--- a/tests/key_test.py
+++ b/tests/key_test.py
@@ -12,6 +12,8 @@ spellings of one key are deliberately unequal, and that a private key
 never reaches a repr.
 """
 
+from typing import Any
+
 import pytest
 
 from btclib.curves import bytes_from_point, mult, secp256k1
@@ -36,6 +38,37 @@ def test_pub_key_data() -> None:
 
     # a hex string is octets, as it is everywhere else in the library
     assert PubKeyData(SEC_COMPRESSED.hex()) == PubKeyData(SEC_COMPRESSED)
+
+
+@pytest.mark.parametrize(
+    "sec",
+    [SEC_COMPRESSED, bytearray(SEC_COMPRESSED), memoryview(SEC_COMPRESSED)],
+    ids=["bytes", "bytearray", "memoryview"],
+)
+def test_the_sec_field_is_bytes_however_the_octets_were_spelled(sec: Any) -> None:
+    """A buffer is octets here, because the field is declared `bytes`.
+
+    `bytes_from_octets` returns a bytearray and a memoryview as they
+    came, deliberately: it is what `assert_valid` reads with, and a read
+    must not rewrite what it reads. A constructor builds instead, and two
+    of this module's promises rest on its field being what it says.
+
+    Equality and hashing read the declared fields, which a bytearray
+    would take away: it is unhashable, so a key spelled that way could
+    not be a dict key or enter a set. And a key whose octets do not
+    concatenate is no use to the callers this type exists for --
+    `script.taproot` joins a merkle root to the x it reads off `sec`
+    before hashing the pair under a tag.
+
+    `Any` and not `Octets`, which is `bytes | str`: the buffers are a
+    run-time spelling the static alias does not name, and
+    `utils.bytes_from_octets` is where that asymmetry is stated.
+    """
+    key = PubKeyData(sec)
+
+    assert isinstance(key.sec, bytes)
+    assert key == PubKeyData(SEC_COMPRESSED)
+    assert hash(key) == hash(PubKeyData(SEC_COMPRESSED))
 
 
 def test_pub_key_data_point_is_computed_once() -> None:

--- a/tests/python_arm_authority_test.py
+++ b/tests/python_arm_authority_test.py
@@ -307,12 +307,6 @@ _AUTHORITY: dict[str, tuple[str, ...]] = {
         "script_engine/script_test.py",
         "script_engine/transactions_test.py",
     ),
-    "script.taproot._output_pubkey_and_internal_key": (
-        "bip322_test.py",
-        "script/sig_hash_taproot_test.py",
-        "script/taproot_test.py",
-        "script_engine/script_test.py",
-    ),
     "script.taproot._tweaked_prvkey": (
         "bip322_test.py",
         "script/sig_hash_taproot_test.py",

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -19,8 +19,9 @@ import pytest
 from btclib import b32
 from btclib._libsecp256k1 import xonly as libsecp256k1_xonly
 from btclib.alias import ScriptList
-from btclib.curves import bytes_from_point, curve_group, mult, secp256k1
+from btclib.curves import bytes_from_point, curve, curve_group, mult, secp256k1
 from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.number_theory import mod_sqrt_var
 from btclib.script import (
     TaprootScriptTree,
     Witness,
@@ -128,13 +129,25 @@ def test_one_internal_key_however_it_is_spelled(
     same spellings by sharing one reader rather than by agreeing. Both
     arithmetics, because the arms read the key differently: the bindings one
     wants the octets alone and the Python one the point.
+
+    The buffers are here because the key reaches the tweak as octets to be
+    concatenated, and a memoryview is not one: `bytes_from_octets` returns
+    every buffer as it came, so what makes them octets is `PubKeyData`
+    coercing its own field, and nothing else on this path would.
     """
     prv_key = 0xC0FFEE
     point = mult(prv_key)
-    spellings = (
+    sec = bytes_from_point(point, compressed=True)
+    # `Any` and not `Key`: a bytearray and a memoryview are spellings the
+    # static union does not name and `_KEY_TYPES` accepts, which is the
+    # asymmetry `to_pub_key` states -- the buffers `bytes_from_octets`
+    # takes beside bytes, and passes through as they came
+    spellings: tuple[Any, ...] = (
         point,
-        bytes_from_point(point, compressed=True),
+        sec,
         bytes_from_point(point, compressed=False),
+        bytearray(sec),
+        memoryview(sec),
     )
 
     for script_tree in SCRIPT_TREES:
@@ -184,6 +197,70 @@ def test_the_python_tweak_is_the_bindings_tweak(
 
 
 @pytest.mark.parametrize(
+    "compressed, roots",
+    [(True, 1), (False, 0)],
+    ids=["compressed", "uncompressed"],
+)
+def test_the_python_output_key_lifts_the_internal_x_once(
+    compressed: bool, roots: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One reading of the internal key is one square root, not two.
+
+    Two things want the internal key's point: proving the octets are one,
+    and adding tG to it. Taken separately those are two modular square
+    roots of the same x -- issue 896, which is 74 of the 311 us an output
+    key cost on this arm. `PubKeyData` is what makes them one: `point` is
+    a `cached_property`, so the lift is the proof and the proof is the
+    lift (issue #1188).
+
+    Counting `mod_sqrt_var` rather than forbidding it, which is what
+    `test_the_python_prvkey_tweak_lifts_nothing` does below: here the
+    right answer is not zero, and a test that only refused a second root
+    would pass on a function that took none and answered nothing.
+
+    Both SEC forms, because they are the two sides of what is being
+    asserted: 65 octets carry the y and must lift nothing at all, and 33
+    are exactly the x a second reader would have lifted again.
+
+    `input_script_sig` beside `output_pubkey` because they are the two
+    readers of `_output_pubkey_and_internal_key`, and reading it twice is
+    the shape the count would otherwise hide.
+
+    The dispatch goes off at `curve._libsecp256k1_available` and not at
+    this module's own guard, which is what the test below patches: the
+    lift is `point_from_octets`', and that call delegates on its own, so
+    silencing taproot alone leaves the square root being taken in C where
+    `mod_sqrt_var` never sees it. A count needs every arm Python; a test
+    asserting zero, as that one does, does not.
+    """
+    pub_key = bytes_from_point(mult(0xC0FFEE), compressed=compressed)
+    roots_taken = 0
+
+    # `number_theory` and not the `curve_group` binding being patched: the
+    # two are one function, and reading it off the module that exports it
+    # is what strict mypy allows -- an attribute an `__all__` does not
+    # name cannot be read, only set
+    def counting(a: int, p_: int) -> int:
+        nonlocal roots_taken
+        roots_taken += 1
+        return mod_sqrt_var(a, p_)
+
+    for tree in SCRIPT_TREES:
+        with monkeypatch.context() as no_bindings:
+            no_bindings.setattr(curve, "_libsecp256k1_available", False)
+            no_bindings.setattr(curve_group, "mod_sqrt_var", counting)
+
+            roots_taken = 0
+            output_pubkey(pub_key, tree)
+            assert roots_taken == roots
+
+            if tree is not None:
+                roots_taken = 0
+                input_script_sig(pub_key, tree, 0)
+                assert roots_taken == roots
+
+
+@pytest.mark.parametrize(
     "prv_key, parity", [(0xC0FFEE, 1), (3, 0)], ids=["odd y", "even y"]
 )
 def test_the_python_prvkey_tweak_lifts_nothing(
@@ -224,16 +301,14 @@ def test_the_python_prvkey_tweak_lifts_nothing(
 
 @needs_bindings
 def test_the_python_arm_reaches_no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Three of the four guards this module keeps must be Python throughout.
+    """Both tweaks this module gates must be Python throughout.
 
     A mixed arm is the one shape that is never right: with libsecp256k1 in
     reach `libsecp256k1_xonly.tweak_add` and `.prvkey_tweak_add` are the
     better calls, and out of reach there is nothing to mix.
-    `_output_pubkey_and_internal_key`'s choice of which form of the
-    internal key to build, `_tweaked_pubkey`'s tweak and
-    `_tweaked_prvkey`'s are that shape, gated on `secp256k1` and nothing
-    else, and `output_pubkey` together with `output_prvkey` reach all
-    three between them.
+    `_tweaked_pubkey`'s tweak and `_tweaked_prvkey`'s are that shape,
+    gated on `secp256k1` and nothing else, and `output_pubkey` together
+    with `output_prvkey` reach both between them.
 
     `check_output_pubkey`'s guard is not: it adds `len(q) == 32` to the
     same predicate, so with the bindings in reach and a q of another
@@ -346,16 +421,19 @@ def test_the_tweak_refuses_an_internal_key_that_is_no_point_alike(
     the two answered is a `pip install`, and a caller catching
     `BTClibValueError` is not meant to have to know (issue 1214).
 
-    On the x-only path the sentence agrees too, and has three shapes: 5
-    is no x-coordinate and is written as a decimal, p - 1 is no
-    x-coordinate and is written as hex, and p is not a field element at
-    all, which `y_even_var` says in words of its own and the bindings'
-    parse refuses without distinguishing.
+    On the x-only path the sentence agrees too, and it is one sentence
+    rather than three: the lift is `point_from_octets`, which wraps both
+    of `curve_group.y_var`'s complaints -- an x that is no coordinate and
+    an x that is no field element -- in a single "invalid x-coordinate",
+    and this arm reproduces what the lift says rather than what the
+    lift's own caller would have said. Nothing is lost that the message
+    carried: the three cases below are 5, p - 1 and p, and the hex the
+    sentence quotes still tells them apart.
     """
     for x, err_msg in (
-        (5, "invalid x-coordinate: 5"),
-        (secp256k1.p - 1, "invalid x-coordinate: FFFFFFFF"),
-        (secp256k1.p, r"x-coordinate not in 0\.\.p-1: FFFFFFFF"),
+        (5, "invalid x-coordinate: '05'"),
+        (secp256k1.p - 1, "invalid x-coordinate: 'FFFFFFFF"),
+        (secp256k1.p, "invalid x-coordinate: 'FFFFFFFF"),
     ):
         x_only = x.to_bytes(32, "big")
         with pytest.raises(BTClibValueError, match=err_msg):
@@ -382,8 +460,8 @@ def test_the_tweak_names_no_half_of_a_sec_it_cannot_blame(
     is right, and a message naming it would be false -- which is what
     keeps the two arms to agreeing on the class here rather than on the
     sentence: without the bindings the key never reaches the tweak at
-    all, `point_from_key` refusing it a step earlier and in its own
-    words.
+    all, the lift `PubKeyData.point` performs refusing it a step earlier
+    and in the curve's own words.
     """
     Q = mult(7)
     y_not_x_s = (Q[1] + 1) % secp256k1.p
@@ -393,7 +471,7 @@ def test_the_tweak_names_no_half_of_a_sec_it_cannot_blame(
         output_pubkey(sec)
     with monkeypatch.context() as no_bindings:
         no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
-        with pytest.raises(BTClibValueError, match="not a public key"):
+        with pytest.raises(BTClibValueError, match="point not on curve"):
             output_pubkey(sec)
 
 
@@ -501,6 +579,17 @@ def test_the_two_output_keys_are_one_tweak() -> None:
     script_tree: TaprootScriptTree = [[(0xC0, ["OP_2"])], [(0xC0, ["OP_3"])]]
     merkle_root = tree_helper(script_tree)[1]
     assert output_pubkey_from_merkle_root(x_only, merkle_root) == (
+        output_pubkey(internal_pubkey, script_tree)
+    )
+
+    # a memoryview x, which `bytes_from_octets` passes through as it came:
+    # what makes it octets here is the `02` this function prefixes, `bytes`
+    # on the left of a concatenation taking any buffer on the right where
+    # `memoryview + bytes` is not an operation at all. The internal key of
+    # `output_pubkey` becomes bytes one layer lower, in `PubKeyData`, so
+    # this entry point needs its own assertion rather than that one's
+    buffer: Any = memoryview(x_only)  # `Octets` is `bytes | str`, as above
+    assert output_pubkey_from_merkle_root(buffer, merkle_root) == (
         output_pubkey(internal_pubkey, script_tree)
     )
 


### PR DESCRIPTION
Step 2 of issue #1188's sequence: `script.taproot` carries its internal
key as a `PubKeyData`, and what that removes is a dispatch rather than an
operation. The commit message carries the reasoning; this is what a
reviewer may want stated separately.

## What it removes, and why that guard was the odd one out

`_output_pubkey_and_internal_key` had a `_libsecp256k1_serves` guard in
front of it that was not asking what the module's other guards ask.
Theirs is which arithmetic runs; this one asked *how much of the key is
worth building* — the bindings arm wanting unproven octets, because
`xonly.tweak_add`'s own parse is the proof and lifting first would be the
second square root of one x (issue 887), and the Python arm wanting the
point it would otherwise lift twice (issue 896).

A `cached_property` is both of those at once, so neither arm has to say
which it is. `_tweaked_pubkey` accordingly takes one object where it took
three key parameters, the last two `None` at whichever call site held the
key in the other form.

## Nothing is faster, and the count is now asserted

The first benchmark of this suggested a win. It was noise: counting
`mod_sqrt_var` end to end gives 1 square root for a compressed internal
key and 0 for an uncompressed one, before and after, and `output_pubkey`
on the bindings-free arm measures 234 µs against 232.

What changes is that the count is no longer a comment.
`test_the_python_output_key_lifts_the_internal_x_once` counts for both
SEC forms and for both readers of `_output_pubkey_and_internal_key`, and
restoring issue 896's shape fails it at `2 == 1` and `1 == 0`.

## The behaviour that does change

Error messages, on the bindings-free arm only — the bindings arm's are
byte-identical over the batteries below. CHANGELOG.md states the rule and
its two exceptions as measured rather than enumerating cases, an earlier
draft's enumeration having twice read as complete when it was not.

`PubKeyData` also coerces `sec` to `bytes`, which it did not, and the
field is declared `bytes`. Without that a key spelled as a `bytearray`
was **unhashable**, where the module promises equality and hashing read
the declared fields, and one spelled as a `memoryview` carried octets
that do not concatenate — `bytes + memoryview` is a concatenation in
Python and `memoryview + bytes` is not. That last one was reaching users
as a bare `TypeError` out of taproot, outside the exception contract:
already on the bindings arm of `output_pubkey` and `input_script_sig`,
and on **both** arms of `output_pubkey_from_merkle_root`.

## What was run

Locally on this sha, after the rebase:

- `uv run pytest` — exit 0, 29462 passed, coverage 100.00%
- `uv run pre-commit run --all-files` — exit 0
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` — exit 0

Beyond the gates, four local review rounds, each verifying claims by
executing them: `git show origin/main:btclib/script/taproot.py` loaded
beside the branch's and both called over the internal-key spellings ×
tree shapes × entry points × both arms. Every blocking finding across all
four rounds was a false sentence in a comment, docstring, CHANGELOG entry
or commit message; none was a defect in the code.

## Interaction with #1216

**#1216 and this PR conflict semantically**, both touching
`btclib/script/taproot.py`, `tests/script/taproot_test.py` and
CHANGELOG.md. #1216 adds its translation inside the old
`_tweaked_pubkey` body and branches on `sec is None`; this PR collapses
that signature to `(pub_key: PubKeyData, h: bytes)`. Whichever lands
second needs a rebase, not a rewrite.

Rebasing #1216 onto this shape should make it *simpler*: `sec is None`
currently conflates "the caller had a y" with "the caller passed x-only
octets", where under a `PubKeyData` the question is `len(sec) == 65` and
`sec[1:33]` is the x either way. #1216's two-message design survives
intact. Its new comment also repeats the "four guards" and "which form of
the internal key is worth building" prose that this PR deletes, that
sentence having become false once the guard is gone.

Issue #1214 is neither caused nor fixed here; the bindings arm still lets
`tweak_add`'s own `ValueError` out unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hde6RUtTpqFBkPziUqzZkX

## Summary by Sourcery

Represent taproot internal keys with `PubKeyData` to remove redundant key conversion while preserving cross-arm behavior and validation contracts.

Bug Fixes:
- Normalize `PubKeyData.sec` to immutable bytes so buffer-based keys remain hashable and usable throughout taproot operations.
- Align bindings-free taproot validation errors with the library's established public-key and coordinate error messages, including merkle-root entry points.

Enhancements:
- Carry taproot internal public keys as `PubKeyData`, consolidating key representations and eliminating redundant parsing and point lifting.
- Cache internal-key point conversion so Python taproot operations lift compressed keys only once while preserving existing performance and bindings behavior.

Documentation:
- Document the taproot key representation, validation behavior, performance characteristics, and buffer coercion changes in the changelog.

Tests:
- Add coverage for immutable key-field normalization, buffer-based internal keys, and single-lift behavior across taproot entry points and SEC encodings.