### PR TITLE
deserialize_tx stops declaring a value that meant nothing (issue #1190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -864,6 +864,33 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **`deserialize_tx` stops declaring an `include_witness` value that
+  meant nothing** (issue #1190). The signature was `bool | None`, and
+  the comment above the guard said `None` was "either encoding". It was
+  not: the round trip is guarded by `not include_witness`, and `not
+  None` is `not False`, so `None` took the strict arm that refuses a
+  witness serialization -- exactly what `False` does. `True`, the
+  default, is the value that accepts either. Three declared values, two
+  behaviours, and the documented mapping named the wrong one.
+
+  Nothing in this tree passed `None`, which is why nothing was
+  observably wrong and why it was worth removing rather than
+  documenting: a parameter whose contract is stated only in a comment,
+  whose wrong case is unreachable, is a trap primed for the first caller
+  who reads the comment and believes it. It had propagated once already
+  -- a test repeated the claim in its own docstring and could not have
+  caught the discrepancy, having fed non-witness octets to both arms.
+
+  `None` is now a `BTClibTypeError` like any other non-bool, and the
+  `is not None` guard around `assert_type` is gone with it. The
+  alternative was to keep `None` as a synonym for `False` and say why a
+  third spelling exists, and there is no why: it was declared by an
+  annotation and read by nothing. The test that pinned the old behaviour
+  -- written so that answering this issue would be a red test rather
+  than a silent change -- now pins the new one, and
+  `tests/bool_parameter_test.py` drops the `optional=True` that read
+  `None` off the annotation.
+
 - **`KeyWallet.add` multiplies once where it multiplied twice**, being
   the first module to take `btclib.key` up (issue #1188). It computed the
   public key with `pub_keyinfo_from_key` and then handed the *private*

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,19 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **`psbt.psbt_utils.deserialize_tx` no longer accepts `None` for
+  `include_witness`** (issue #1190). The annotation declared `bool |
+  None` and a comment called `None` "either encoding"; the code took the
+  same strict arm for `None` as for `False`, `not None` being `not
+  False`. A third spelling of the second behaviour, and the only one
+  whose documented meaning was never implemented. Passing `None` now
+  raises `BTClibTypeError` as any other non-bool does.
+
+  Act on it only if you call this function with `None`, which no caller
+  in this package did: pass `False`, which is what `None` was doing.
+  `True` is unchanged and is still the default, and is the value that
+  accepts either encoding.
+
 - **`NETWORKS["regtest"].genesis_block` was byte-reversed and is now
   Bitcoin Core's value** (issue #1203):
 

--- a/btclib/psbt/psbt_utils.py
+++ b/btclib/psbt/psbt_utils.py
@@ -818,7 +818,7 @@ def deserialize_tx(
     k: bytes,
     v: bytes,
     type_: str,
-    include_witness: bool | None = True,
+    include_witness: bool = True,
     *,
     unsigned_template: bool = False,
 ) -> Tx:
@@ -837,10 +837,15 @@ def deserialize_tx(
     the encoding this could not write back, where a validating parse
     answers "Missing outputs", which is true of it but not the fault.
     """
-    # None is a declared value for include_witness -- "either encoding" --
-    # and every other non-bool decides which one is accepted
-    if include_witness is not None:
-        assert_type(include_witness, bool, "include_witness")
+    # two values and two behaviours, and the flag is read as a truth
+    # below: `not include_witness` is false for True alone, so True is
+    # the one that accepts either encoding and False is the one that
+    # demands the round trip. None used to be declared here as well,
+    # documented as "either encoding" and doing what False does, since
+    # `not None` is `not False` -- a third spelling of the second
+    # behaviour, unreachable from any caller in this tree and a trap for
+    # the first one to read the comment (issue 1190)
+    assert_type(include_witness, bool, "include_witness")
     assert_type(unsigned_template, bool, "unsigned_template")
     if len(k) != 1:
         err_msg = f"invalid {type_} key length: {len(k)}"

--- a/tests/bool_parameter_test.py
+++ b/tests/bool_parameter_test.py
@@ -515,7 +515,6 @@ _KINDS = (
         deserialize_tx,
         {"k": b"\x00", "v": _TX_BYTES, "type_": "field"},
         valid=False,
-        optional=True,
     ),
     _Case(
         "btclib.psbt.psbt_utils.deserialize_tx",

--- a/tests/psbt/psbt_utils_test.py
+++ b/tests/psbt/psbt_utils_test.py
@@ -9,7 +9,7 @@ from io import BytesIO
 import pytest
 
 from btclib.bip32 import BIP32KeyOrigin
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.psbt.psbt_utils import (
     deserialize_map,
     deserialize_tx,
@@ -103,29 +103,20 @@ def test_deserialize_map_unterminated() -> None:
 
 
 def test_deserialize_tx_reads_include_witness_for_its_truth() -> None:
-    """`None` waives the type check, and then refuses what `False` refuses.
+    """`True` accepts either encoding, `False` demands the round trip.
 
-    Two separate readings of the one parameter, and only the first treats
-    `None` as its own value: `assert_type` is guarded by `is not None`,
-    so `None` is the one non-bool this signature takes, and that guard is
-    the branch nothing else reaches -- every psbt field calling this names
-    a bool. The round trip below it is guarded by `not include_witness`
-    instead, which is a truth: false for `True` alone, so `True` is the
-    value that accepts either encoding, and `False` and `None` both take
-    the strict arm that refuses a witness serialization.
+    Two values and two behaviours, which is what issue #1190 settled:
+    the flag is read as a truth, `not include_witness` being false for
+    `True` alone, so `True` is the one that does not ask for the round
+    trip and `False` is the one that refuses a witness serialization.
+    `None` used to be declared here too, documented as "either encoding"
+    and doing what `False` does, and is now a `BTClibTypeError` like any
+    other non-bool.
 
     Asserted rather than described, and asserted on octets that tell the
     two encodings apart: a legacy serialization is accepted by every
     value of the flag, so a test that fed only one could not have seen
     which arm ran.
-
-    Whether that is the contract this parameter was meant to have is
-    btclib-org/btclib#1190, which asks for a decision and not a patch --
-    the comment on `deserialize_tx` reads the two guards as one and says
-    `None` means "either", which is the opposite of what the second does.
-    This pins the behaviour as it stands, so that whichever way the issue
-    is answered, the answer changing is a red test rather than a silent
-    change of what a psbt is refused for.
     """
     tx = Tx(
         1,
@@ -144,13 +135,11 @@ def test_deserialize_tx_reads_include_witness_for_its_truth() -> None:
     assert deserialize_tx(b"\x00", witness, "tx", True) == tx
     assert deserialize_tx(b"\x00", legacy, "tx", True) == stripped
 
-    # False and None: the same arm, and neither is a third answer
-    err_msg = "wrong tx serialization format"
-    for flag in (False, None):
-        assert deserialize_tx(b"\x00", legacy, "tx", flag) == stripped
-        with pytest.raises(BTClibValueError, match=err_msg):
-            deserialize_tx(b"\x00", witness, "tx", flag)
+    # False: the round trip is the check, and the witness form fails it
+    assert deserialize_tx(b"\x00", legacy, "tx", False) == stripped
+    with pytest.raises(BTClibValueError, match="wrong tx serialization format"):
+        deserialize_tx(b"\x00", witness, "tx", False)
 
-    # what `None` does waive is the type check, and not the length one
-    with pytest.raises(BTClibValueError, match="invalid tx key length: 2"):
-        deserialize_tx(b"\x00\x00", legacy, "tx", None)
+    # None is no longer a third spelling of False; it is a wrong type
+    with pytest.raises(BTClibTypeError):
+        deserialize_tx(b"\x00", legacy, "tx", None)  # type: ignore[arg-type]


### PR DESCRIPTION
`psbt_utils.deserialize_tx`'s `include_witness` was `bool | None`, and
the comment above the guard said `None` was **"either encoding"**. It was
not:

```python
if (
    not include_witness
    and tx.serialize(include_witness=False, check_validity=False) != v
):
```

`not None` is `not False`, so `None` took the strict arm that refuses a
witness serialization — exactly what `False` does. `True`, the default,
is the value that accepts either.

| value | documented | actual |
| --- | --- | --- |
| `False` | strict, non-witness | strict, non-witness |
| `None` | **either encoding** | **strict, non-witness** |
| `True` | — | either encoding |

Three declared values, two behaviours, and the documented mapping named
the wrong one.

**Nothing in this tree passed `None`**, which is why nothing was
observably wrong — and why removing it beats documenting it. A parameter
whose contract is stated only in a comment, and whose wrong case is
unreachable, is a trap primed for the first caller who reads the comment
and believes it. It had already propagated once: a test repeated the
claim in its own docstring and could not have caught the discrepancy,
having fed non-witness octets to both arms.

**Of the three fixes #1190 lists, this is the third**, and the second is
why the first is wrong: keeping `None` as a synonym for `False` requires
saying why a third spelling of one behaviour exists, and there is no why
— it was declared by an annotation and read by nothing. Making `None`
mean "either" would give `True` a second spelling instead, which is the
same defect facing the other way.

`None` is now a `BTClibTypeError` like any other non-bool, and the
`is not None` guard around `assert_type` is gone with it.

The test that pinned the old behaviour — written for #1179 *so that*
answering this issue would be a red test rather than a silent change —
now pins the new one, and `tests/bool_parameter_test.py` drops the
`optional=True` that read `None` off the annotation.

`RELEASE_NOTES.md` carries it as a breaking change: the public signature
narrows, even though no caller in this package took the value away.

Closes #1190

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0 and
`pytest` 29459 passed, run after the rebase onto current `main`. The
suite, the lint job, the coverage ratchet and the documentation build run
beside this review on this same sha.

## Summary by Sourcery

Remove the unused `None` option from `deserialize_tx` so invalid callers receive a type error and witness-encoding behaviour is unambiguous.

Bug Fixes:
- Reject `None` as an invalid `include_witness` value in `deserialize_tx` instead of silently treating it like `False`.

Enhancements:
- Narrow the `deserialize_tx` public signature to accept only boolean witness-encoding flags and clarify the two supported behaviours.

Documentation:
- Document the breaking API change in the changelog and release notes.

Tests:
- Update parameter validation and transaction deserialization tests to enforce the narrowed boolean contract.