### PR TITLE
Four workflow comments say what this tree says

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,7 +10,8 @@ name: claude-review
 # comment, which is an opinion for the author to weigh -- REPOSITORY.md's
 # rule is that `main`'s required contexts are named outside the repository,
 # and a review that gates a merge would make a model's judgement a branch
-# rule. The four required checks stay what they are.
+# rule. The required checks stay what they are, and which ones those
+# are is REPOSITORY.md's to record and the endpoint's to answer.
 #
 # It is one more job on every pull request, which is not free: GitHub Free
 # gives this organization twenty concurrent jobs and REPOSITORY.md measures

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,9 +38,10 @@ on:
     # Fridays, 04:29 UTC. Not on the hour: GitHub queues scheduled
     # workflows across every repository that asked for the same minute,
     # and the run can be dropped outright when the queue is long.
-    # After the four weekday sentinels -- links Monday, published
-    # Tuesday, latest Wednesday, Dependabot Thursday -- and before the
-    # mutation session that has the weekend, so each of the week's
+    # After the weekday sentinels that come before it -- links Monday,
+    # codeql Tuesday, latest and macos Wednesday, Dependabot Thursday --
+    # and before the windows run on Saturday and the mutation session
+    # that has the rest of the weekend, so each of the week's
     # unattended questions is answered on a day of its own and a failure
     # notification names the workflow by the day it arrived.
     # Cron runs from the default branch only, so this file asks nothing

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,9 +1,9 @@
 ---
 name: macos
 
-# the platform the merge gate does not wait for. test.yml runs four
-# operating systems on every pull request and this one runs the two macOS
-# images, weekly and before a release, because macOS is where the wait comes
+# the platform the merge gate does not wait for. test.yml runs the two
+# ubuntu images on every pull request and this one runs the two macOS
+# ones, weekly and before a release, because macOS is where the wait comes
 # from. Measured on one pull request run of the full six: 45 jobs, 93
 # minutes of work and 399 minutes of queueing, the macOS cells waiting 29.4
 # and 23.2 minutes on average for a runner -- one of them 42.2 -- against

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -8,11 +8,11 @@ name: published
 # guarantees the checks below resolve to what was installed from the
 # index and not to a source tree.
 #
-# `import btclib` runs __init__.py alone, and 25 files under
-# btclib/*/_data/ -- the twelve BIP39 wordlists among them -- are opened
-# by path at the first call that needs one, not imported, so a wheel
-# missing one of them installs cleanly, imports cleanly, and only fails
-# there. dist's smoke test and release.yml's share that blind spot;
+# `import btclib` runs __init__.py alone, and the data files under
+# btclib/ -- `git ls-files | grep '^btclib/.*_data/'` is which, the BIP39
+# wordlists among them -- are opened by path at the first call that needs
+# one, not imported, so a wheel missing one of them installs cleanly,
+# imports cleanly, and only fails there. dist's smoke test and release.yml's share that blind spot;
 # this workflow's second check is the one that does not have it.
 #
 # Version-independent on purpose, checking a BIP39 vector and a BIP340

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,42 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **Four workflow comments say what this tree says**
+  (btclib-org/.github#22). That issue's sweep had been run over
+  `bitcoin-core-rpc` and never here; these are what the mechanically
+  checkable half of it found -- the claims a command can settle, which
+  is where all three of its findings came from.
+
+  `macos.yml` opened with "test.yml runs four operating systems on every
+  pull request". It runs two, `ubuntu-latest` and `ubuntu-24.04-arm`;
+  four is what `macos.yml` and `windows.yml` carry between them, which
+  `test.yml`'s own matrix comment says correctly twelve lines from the
+  matrix. Two files describing the same split, one of them wrong.
+
+  `integration.yml` listed the weekday sentinels as "links Monday,
+  published Tuesday, latest Wednesday". `published.yml` runs monthly on
+  the 1st and is no weekday sentinel at all; Tuesday is `codeql`, which
+  `codeql.yml`'s own header gets right and is the list this one now
+  carries.
+
+  `published.yml` said "25 files under `btclib/*/_data/`". The count is
+  right and the path is not: that glob answers 19, the other six living
+  in `btclib/_data/` one level up. It now names the command that finds
+  them and no number.
+
+  `claude-review.yml`'s "The four required checks stay what they are" is
+  true here and is a count nothing re-derives -- the same sentence is in
+  the same file in four repositories and is wrong in two of them, which
+  is why it goes rather than gets confirmed.
+
+  Nothing else the sweep could settle mechanically was wrong: every
+  workflow named in a comment exists, every cron matches the day its
+  comment claims, the two minute-uniqueness claims hold, and the
+  trigger claims match each `on:` block. The prose half of the sweep --
+  reading every comment end to end, which is how a stale claim that
+  reads like a true one is found -- is not done here and is what keeps
+  that issue open.
+
 - **`.yamllint.yaml` turns the default rule set back on**
   (btclib-org/.github#68). The file listed `line-length` and
   `document-start` under `rules:` and extended nothing, and yamllint


### PR DESCRIPTION
btclib-org/.github#22's sweep had been run over `bitcoin-core-rpc` and
never here. These are what its **mechanically checkable half** found —
the claims a command can settle, which is where all three of that
repository's findings came from.

**`macos.yml:4`** — "test.yml runs four operating systems on every pull
request".

```shell
sed -n '/^        os:/,/^        [a-z]/p' .github/workflows/test.yml
#   - ubuntu-latest
#   - ubuntu-24.04-arm
```

It runs **two**. Four is what `macos.yml` and `windows.yml` carry between
them — which `test.yml`'s own matrix comment says correctly, twelve lines
from the matrix. Two files describing one split, one of them wrong.

**`integration.yml:41`** — "the four weekday sentinels — links Monday,
**published Tuesday**, latest Wednesday, Dependabot Thursday".

`published.yml`'s cron is `31 4 1 * *`: monthly, on the 1st, and no
weekday sentinel at all. Tuesday is `codeql` (`23 4 * * 2`), which
`codeql.yml`'s own header gets right — and that is the list this comment
now carries.

**`published.yml:12`** — "25 files under `btclib/*/_data/`".

```shell
git ls-files 'btclib/*/_data/*' | wc -l              # 19
git ls-files | grep -c '^btclib/.*_data/'            # 25
```

The count is right and the path is not: six of them live in
`btclib/_data/`, one level up from that glob. It now names the command
and no number.

**`claude-review.yml:13`** — "The four required checks stay what they
are". True here, and a count nothing re-derives; the same sentence is in
the same file in four repositories and is wrong in two of them
(`btclib-secp256k1` and `btclib-benchmarks` require three). Removed
rather than confirmed, and the sibling repositories have their own pull
requests for it.

**What the sweep could settle and found clean**: every workflow named in
a comment exists; every cron matches the day its comment claims; both
minute-uniqueness claims hold (`53`, `07`); `hwi-integration.yml` and
`integration.yml` share Friday 04:29 and say so; every trigger claim
matches its `on:` block.

**What is not done here**, and keeps #22 open: the prose half — reading
every comment end to end, which is the only way a stale claim that reads
exactly like a true one is found. That issue's own method section says
so, and this pull request does not pretend to be it.

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run
after the rebase onto current `main`. The suite, the lint job, the
coverage ratchet and the documentation build run beside this review on
this same sha. `Claude review` will be red: this edits
`claude-review.yml`, which the action refuses to run under
(btclib-org/.github#58).

## Summary by Sourcery

Correct stale workflow comments and document the mechanically verified CI configuration audit.

Bug Fixes:
- Correct inaccurate workflow comments about pull-request operating systems, scheduled workflow sentinels, and repository data-file locations.
- Remove an unverifiable claim about the number of required checks.
- Document the corrected workflow-comment findings in the changelog.

Enhancements:
- Clarify workflow comments so they describe the current repository configuration and defer dynamic required-check information to authoritative sources.

Documentation:
- Add changelog coverage for the mechanically verified workflow-comment corrections and the remaining scope of the audit.