### PR TITLE
The reason for attaching no bill of materials holds for both wheels (issue #1189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -801,6 +801,27 @@ documented at release-notes length in the first place, and are still in
 
 ### Documentation and the website
 
+- **`RELEASING.md`'s reason for attaching no bill of materials to a
+  sibling's release holds for both of its wheels** (issue #1189). The
+  paragraph described the vendored libsecp256k1 as "statically-linked",
+  which is true of the static wheels alone: `btclib-secp256k1` also
+  ships a dynamic, ABI-mode build that `dlopen`s a shared object beside
+  the extension, and that build is not statically linked to anything.
+
+  The conclusion was right for both and the mechanism was right for one,
+  which is the worse of the two ways to be wrong here: a reader who
+  takes the stated mechanism at face value concludes the gap is an
+  artefact of static linking and that the dynamic build escapes it. It
+  does not. What `Requires-Dist` cannot say is the *pinned commit*,
+  however the object code reaches the wheel -- so the paragraph says
+  that, and names both builds.
+
+  `btclib-secp256k1`'s own `RELEASING.md` was corrected first, in that
+  repository's #307, and this was the copy left behind.
+  `bitcoin-core-rpc#173`'s blockquote is deliberately not touched: it
+  quotes what this file said at the time, and becomes an accurate record
+  of a corrected claim rather than a fifth copy of the error.
+
 - **CONTRIBUTING.md sends a contributor to the organization standard**
   (btclib-org/.github#52). `README.md` in `btclib-org/.github` states
   the toolchain, the lint gate, the workflow set and the branch rules

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -477,10 +477,17 @@ to `latest`'s own result.
    already asserts that against the installed package on every run; a
    bill of materials there would be an empty `components` list restating
    a fact CI checks more directly. btclib-secp256k1's interesting
-   dependency is the vendored, statically-linked libsecp256k1 C library
-   pinned in its `secp256k1` submodule, which this generator cannot
-   describe — it reads `Requires-Dist`, and the submodule is not a
-   Python dependency. A bill of materials built the way this one is
+   dependency is the vendored libsecp256k1 C library at the commit its
+   `secp256k1` submodule pins, which this generator cannot describe — it
+   reads `Requires-Dist`, and the submodule is not a Python dependency.
+   That holds for both wheel kinds it ships and not only the static one:
+   a static build links the library into the extension, a dynamic
+   (ABI-mode) build ships it as a shared object beside the extension
+   instead, and `Requires-Dist` says nothing about the pin either way.
+   Naming the linkage would invite the opposite conclusion, that the
+   dynamic build escapes the gap — where what is missing is the pinned
+   commit however the object code arrives.
+   A bill of materials built the way this one is
    would name `cffi` and say nothing about the pin a verifier of that
    package would most want described, which is worse than omitting the
    document. Issue #1159 has the evaluation. What would change it is


### PR DESCRIPTION
`RELEASING.md`'s paragraph explaining why the sibling repositories carry
no CycloneDX SBOM described the vendored libsecp256k1 as

> the vendored, **statically-linked** libsecp256k1 C library

**True of the static wheels only.** `btclib-secp256k1` also ships a
dynamic, ABI-mode build: `_load_lib` returns `module.lib` where the
extension has the library linked in, and otherwise `ffi.dlopen`s a shared
object shipped *beside* the extension. That build is not statically
linked to anything.

**The conclusion was right for both and the mechanism was right for
one**, which is the worse of the two ways to be wrong here. The paragraph
exists to say that a metadata-derived SBOM is blind to the one component
a verifier of that package would most want described — and that is true
whichever wheel is in front of you, because `Requires-Dist` cannot name a
submodule pin however the object code is delivered. But a reader who
takes the stated mechanism at face value concludes the gap is an artefact
of static linking, and therefore that the dynamic build would not have
it. **It would.** So the error did not weaken the conclusion; it invited
the reader to discard it for the wrong reason.

The fix is not a hedge. The paragraph now states the gap in the terms
that hold for both — what is missing is the *pinned commit*, however the
object code arrives — and names both builds so the reader cannot
reconstruct the wrong inference.

`btclib-secp256k1`'s own `RELEASING.md` was corrected first, in that
repository's #307; this was the copy left behind.
`bitcoin-core-rpc#173`'s review-response blockquote is deliberately **not**
touched: it quotes what this file said at the time, and becomes an
accurate record of a corrected claim rather than a fifth copy of the
error.

Closes #1189

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run
after the rebase onto current `main`. The suite, the lint job, the
coverage ratchet and the documentation build run beside this review on
this same sha.

## Summary by Sourcery

Clarify that the missing vendored dependency pin affects both wheel builds, regardless of how the native library is delivered.

Bug Fixes:
- Correct the release documentation to explain that metadata-derived SBOMs omit the pinned vendored libsecp256k1 commit for both static and dynamic wheels.

Documentation:
- Clarify the SBOM rationale in RELEASING.md and record the documentation correction in the changelog.