### PR TITLE
check-wheel-contents names the package tree (issue #1200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,37 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **`check-wheel-contents` names the package tree** (issue #1200).
+  `package = ["btclib"]`, where it ran unconfigured. Without it the tool
+  reads the wheel's own `RECORD` and asks nothing about the tree the
+  wheel was supposed to carry; with it, the wheel's `btclib/` is diffed
+  against this checkout's, file for file and in both directions -- W101
+  for what the wheel is missing, W102 for what it has and the tree does
+  not. Measured on a wheel with `btclib/py.typed` removed and `RECORD`
+  edited to match, which installs and imports cleanly: unconfigured,
+  `OK`; configured, `W101: Wheel library is missing files in package
+  tree: btclib/py.typed`.
+
+  It was left unconfigured on purpose, and the recorded reason was
+  redundancy rather than inapplicability: `check-manifest` gates this
+  tree against the sdist and `verify_dist_contents.py` gates the sdist
+  against the wheel, so chained they imply checkout == sdist == wheel.
+  The organization standard no longer accepts that trade
+  (btclib-org/.github#51): some other check implying the same diff does
+  not stand in for the flag where the flag applies, the implication
+  being the same assertion bought with code to maintain -- and here the
+  two links sit in different workflows, a pre-commit hook under the lint
+  gate and `test.yml`'s `dist` job, so the chain holds only while both
+  run.
+
+  No `ignore` list: nothing here ships outside `btclib/`, so W003 and
+  W009 cannot fire, and a list naming codes that cannot trigger asserts
+  a fact instead of preventing one.
+  `docs/source/package-content-policy.md`'s section moves with it -- the
+  page and the script are compared in both directions by
+  `tests/verify_dist_contents_test.py`, so the prose is not free to
+  drift from what the tree does.
+
 - **Four workflow comments say what this tree says**
   (btclib-org/.github#22). That issue's sweep had been run over
   `bitcoin-core-rpc` and never here; these are what the mechanically

--- a/docs/source/package-content-policy.md
+++ b/docs/source/package-content-policy.md
@@ -123,36 +123,41 @@ from it, so `btclib/` is the same set of files in both; a difference
 either way is a file that reaches a user installing from source and not
 one installing the wheel, or the reverse.
 
-## check-wheel-contents needs no configuration here
+## check-wheel-contents names the package tree
 
-`check-wheel-contents` runs unconfigured, in the one job
+`check-wheel-contents` runs with `package = ["btclib"]`, in the one job
 `verify_dist_contents.py` runs in — `test.yml`'s `dist` job, on every pull
 request and, through `release.yml`'s `test` call, on the files a release
-publishes — and btclib-org/btclib#1160 is where that was decided rather than
-merely left alone. `btclib-secp256k1` configures `[tool.check-wheel-contents]`
-— `ignore = ["W003", "W009"]`, for the shared library its dynamic wheel ships
-beside the package — because its wheel is not one package tree: a legitimate
-top-level member outside `btclib_secp256k1/` is exactly what those two checks
-exist to flag.
-Nothing here ships outside `btclib/`, so neither check would ever fire,
-and an `ignore` list naming codes that can never trigger would be a line
-asserting a fact instead of preventing one.
+publishes.
 
-The stronger question is whether `check-wheel-contents --package btclib`
-would catch something this script does not: a full diff of the wheel's
-`btclib/` against this checkout's own, the same completeness
-`bitcoin-core-rpc` gained by configuring `package = ["bitcoin_core_rpc"]`
-in that repository's own pull request (btclib-org/bitcoin-core-rpc#178),
-for a project with no second check standing behind it. This project
-already has two: `check-manifest`, a pre-commit hook gated by the lint
-workflow, diffs the sdist against this same tree, and the completeness
-check above — `uv build` builds the sdist and then the wheel from it, so
-`btclib/` is the same set of files in both, and a difference either way
-is reported — diffs the wheel against the sdist. Chained, checkout tree
-== sdist == wheel, which is what `--package` would assert directly and
-in one hop; configuring it here would be a third way of asking a question
-two already answer, watching the same failure from a different angle
-rather than closing a gap neither covers.
+What that flag buys is the one question the tool does not ask without it.
+Unconfigured, it reads the wheel's own `RECORD` and says nothing about the
+tree the wheel was supposed to carry; with the package named it diffs the
+wheel's `btclib/` against this checkout's, file for file and in both
+directions — W101 for what the wheel is missing, W102 for what it has and
+the tree does not. Measured on a wheel with `btclib/py.typed` removed and
+`RECORD` edited to match, which installs and imports cleanly:
+unconfigured, `OK`; configured, `W101: Wheel library is missing files in
+package tree: btclib/py.typed`.
+
+It ran unconfigured until btclib-org/btclib#1200, and the reason recorded
+in btclib-org/btclib#1160 was redundancy rather than inapplicability:
+`check-manifest`, a pre-commit hook gated by the lint workflow, diffs this
+tree against the sdist, and the completeness check above diffs the sdist
+against the wheel, so chained they imply checkout == sdist == wheel. The
+organization standard's section 12 no longer accepts that trade
+(btclib-org/.github#51): *some other check implying the same diff does not
+stand in for the flag where the flag applies*, because the implication is
+the same assertion bought with code to maintain, and it moves what the
+`dist` job knows about the artifact into a chain that holds only while
+every link runs — and the two links here sit in different workflows.
+
+No `ignore` list. Nothing here ships outside `btclib/`, so neither W003
+nor W009 can fire, and a list naming codes that cannot trigger would be a
+line asserting a fact instead of preventing one. `btclib-secp256k1`
+configures `ignore = ["W003", "W009"]` because its dynamic wheel ships a
+shared library beside the package on purpose, which is exactly what those
+two checks exist to flag.
 
 ## The rules nothing here enforces
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,31 @@ required-version = ">=0.11.31"
 include = ["btclib*"]
 namespaces = true
 
+[tool.check-wheel-contents]
+# the wheel's `btclib/` diffed against this checkout's, file for file and
+# in both directions (W101 missing, W102 extra). With no `package` given
+# check-wheel-contents reads the wheel's own RECORD and asks nothing
+# about the tree the wheel was supposed to carry, so a `py.typed` or a
+# `_data/*.json` dropped by a packaging change builds, installs and
+# imports cleanly and is reported clean.
+#
+# It was left unconfigured here on purpose until now, and the reason was
+# redundancy rather than inapplicability: `check-manifest` below gates
+# this tree against the sdist and `verify_dist_contents.py` gates the
+# sdist against the wheel, so chained they imply tree == sdist == wheel.
+# The organization standard's section 12 no longer accepts that trade
+# (btclib-org/.github#51, issue #1200): some other check implying the
+# same diff does not stand in for the flag where the flag applies,
+# because the implication is the same assertion bought with code to
+# maintain, and the two hops here sit in different workflows -- a
+# pre-commit hook under the lint gate, and `test.yml`'s `dist` job -- so
+# the chain holds only while both run.
+#
+# No `ignore`: nothing ships outside `btclib/`, so neither W003 nor W009
+# can fire, unlike btclib-secp256k1, whose dynamic wheel carries a shared
+# object beside the package on purpose.
+package = ["btclib"]
+
 [tool.check-manifest]
 # the website, not the package. btclib.org is served from this repository's
 # root, so the Jekyll sources sit beside the library: they are tracked, they


### PR DESCRIPTION
`check-wheel-contents` ran unconfigured. It now carries
`package = ["btclib"]`.

**What the flag buys**, measured rather than argued. A wheel with
`btclib/py.typed` removed and `RECORD` edited to match — a wheel that
builds, installs and imports cleanly:

```shell
# unconfigured
$ uvx check-wheel-contents btclib-2026.9-py3-none-any.whl
btclib-2026.9-py3-none-any.whl: OK

# with package = ["btclib"]
$ uvx check-wheel-contents btclib-2026.9-py3-none-any.whl
btclib-2026.9-py3-none-any.whl: W101: Wheel library is missing files in package tree:
  btclib/py.typed
```

Without the package named, the tool reads the wheel's own `RECORD` and
asks nothing about the tree the wheel was supposed to carry. With it, the
wheel's `btclib/` is diffed against this checkout's, file for file, in
both directions — W101 missing, W102 extra.

**Why it was unconfigured, and why that stopped being enough.** #1160
recorded the decision, and the reason was *redundancy*, not
inapplicability: `check-manifest` diffs this tree against the sdist and
`verify_dist_contents.py` diffs the sdist against the wheel, so chained
they imply `checkout == sdist == wheel`. btclib-org/.github#51 amended
§12 to reject exactly that trade —

> Some other check implying the same diff does not stand in for the flag
> where the flag applies: that is the same assertion bought with code to
> maintain, and it moves what the `dist` job knows about the artifact into
> a chain that holds only while every link runs.

— and here the two links sit in **different workflows**: `check-manifest`
is a pre-commit hook under the lint gate, the payload diff is in
`test.yml`'s `dist` job.

Nothing about this distribution makes the flag inapplicable:
`setuptools.build_meta`, one package tree, `py.typed`, an include-list
`MANIFEST.in` — the same shape as `bitcoin-core-rpc`, which configures it.

**No `ignore` list.** Nothing here ships outside `btclib/`, so W003 and
W009 cannot fire, and a list naming codes that cannot trigger asserts a
fact instead of preventing one. `btclib-secp256k1` needs
`ignore = ["W003", "W009"]` because its dynamic wheel carries a shared
library beside the package on purpose.

`docs/source/package-content-policy.md`'s section moves with it, heading
included. The page and the script are compared in both directions by
`tests/verify_dist_contents_test.py` (38 passed), so the prose is not free
to drift from what the tree does.

Closes #1200

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run
after the rebase onto current `main`. The suite, the lint job, the
coverage ratchet and the documentation build run beside this review on
this same sha.

## Summary by Sourcery

Configure wheel validation to verify that the published `btclib` package contains exactly the files in the source package tree.

New Features:
- Configure `check-wheel-contents` to compare the wheel’s `btclib` package tree against the source tree and detect missing or extra files.

Enhancements:
- Align the package-content policy documentation with the new wheel validation configuration and its rationale.

Documentation:
- Update the changelog and package-content policy to document direct package-tree validation and the absence of ignored checks.