### PR TITLE
documented's wait says why its budget is under the job's timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -603,6 +603,21 @@ jobs:
   # the one signal the existing curl call already carries for free: the
   # last HTTP status or transport failure it saw, which the final message
   # now names instead of "is not served yet"
+  #
+  # The loop's own budget stays below the job's timeout-minutes, and the
+  # gap is the whole point: an attempt costs its curl --max-time plus the
+  # sleep, so the loop's worst case is the attempt count times that sum,
+  # and where that reaches timeout-minutes the runner kills the job before
+  # the `::error::` line -- the one line the job exists to print -- ever
+  # runs. A red run would then say only that it exceeded its maximum
+  # execution time, which is a fact about this workflow and not about the
+  # documentation. Re-derive the margin from the values the script sets
+  # rather than from this sentence. An ordinary failure never comes near
+  # it, read the docs answering a 404 in well under a second while a build
+  # has not started; what the margin buys is the slow or unreachable case,
+  # which is the case a reader most needs the pointer for. The last
+  # attempt does not sleep before giving up, which would buy nothing.
+  # This is issue btclib-org/.github#18
   documented:
     name: Check read the docs built the tag
     needs: version-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,24 @@ documented at release-notes length in the first place, and are still in
   page and the script are compared in both directions by
   `tests/verify_dist_contents_test.py`, so the prose is not free to
   drift from what the tree does.
+- **`documented`'s wait says why its budget is under the job's timeout**
+  (btclib-org/.github#18). The behaviour was already right here -- the
+  loop's worst case is 20 attempts of a 10-second `curl --max-time` plus
+  19 sleeps of 30, which is 770 seconds against a `timeout-minutes: 20`
+  of 1200, and the last attempt does not sleep before giving up. What
+  was missing is the reason, which is the half that keeps it right: the
+  gap is what lets the `::error::` line run at all. Where the loop's
+  budget reaches the timeout the runner kills the job first, and a red
+  run then says only that it exceeded its maximum execution time --
+  a fact about this workflow and not about the documentation, in
+  exactly the case a reader most needs the pointer to the builds page.
+
+  An ordinary failure never comes near it: Read the Docs answers a 404
+  in well under a second while a build has not started. The comment says
+  to re-derive the margin from the values the script sets rather than
+  from the sentence, which is what stops the next change to `attempts`
+  or `interval` from closing the gap silently. `bitcoin-core-rpc` has
+  carried the same paragraph since its own #198.
 
 - **Four workflow comments say what this tree says**
   (btclib-org/.github#22). That issue's sweep had been run over


### PR DESCRIPTION
btclib-org/.github#18 is about `release.yml`'s `documented` job spending
its whole `timeout-minutes` inside the polling loop and being killed
before the `::error::` line — the one line the job exists to print.

**The behaviour here is already right**, which is worth stating with the
arithmetic rather than asserting:

```
attempts=20, interval=30, curl --max-time 10
worst case: 20 × 10 + 19 × 30 = 770 s
timeout-minutes: 20            = 1200 s
margin:                          430 s
```

and the last attempt does not sleep before giving up.

**What was missing is the reason**, which is the half that keeps it
right. The gap is what lets the error line run at all: where the loop's
budget reaches the timeout the runner kills the job first, and a red run
then says only that it exceeded its maximum execution time — a fact about
this workflow and not about the documentation, in exactly the case a
reader most needs the pointer to the builds page. An ordinary failure
never comes near it, Read the Docs answering a 404 in well under a second
while a build has not started.

The comment says to **re-derive the margin from the values the script
sets** rather than from the sentence, which is what stops the next change
to `attempts` or `interval` from closing the gap silently.

`bitcoin-core-rpc` has carried the same paragraph since its own #198;
this is the copy that was behind. `btclib-secp256k1`'s box on #18 waits
on that repository's #295, which is blocked on its Read the Docs side.

Comment only — no behaviour changes, and none was needed.

Part of btclib-org/.github#18; no parenthetical in the title, since this
closes no issue in this repository.

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run
after the rebase onto current `main`. The suite, the lint job, the
coverage ratchet and the documentation build run beside this review on
this same sha.

## Summary by Sourcery

Clarify the `documented` job's polling timeout margin without changing its behavior.

Enhancements:
- Document why the `documented` workflow reserves timeout margin so its final error message can run before the runner terminates the job.
- Record the timeout-budget rationale and worst-case polling arithmetic in the changelog.