### PR TITLE
A markdown line does not end inside a word

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -369,6 +369,16 @@ repos:
         entry: |-
           (?<![`!\[])(?:!?\[(?:[^]]|\]\([^)]*\))*\]\(|^\x20{0,3}\[[^]]+\]:\s*)(?!\./|#|[A-Za-z][A-Za-z0-9+.-]*:)[^)\s]
         types: [markdown]
+      # a word wrapped at its own hyphen, which markdown renders with a
+      # space inside it. Section 4 of the organization standard is the
+      # rule: why a line ending inside a word is the shape to refuse,
+      # what the pattern cannot see, and what the measurement was before
+      # it was proposed
+      - id: no-hyphen-at-end-of-line
+        name: a word is not wrapped at its own hyphen
+        language: pygrep
+        entry: "[A-Za-z0-9]-$"
+        types: [markdown]
   # what ruff-format is for Python, on the structured files ruff does not
   # read: yaml, and the jsonc that carries a comment. Before yamllint below,
   # so the linter judges the formatted file and not the one that was typed.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -369,11 +369,11 @@ repos:
         entry: |-
           (?<![`!\[])(?:!?\[(?:[^]]|\]\([^)]*\))*\]\(|^\x20{0,3}\[[^]]+\]:\s*)(?!\./|#|[A-Za-z][A-Za-z0-9+.-]*:)[^)\s]
         types: [markdown]
-      # a word wrapped at its own hyphen, which markdown renders with a
-      # space inside it. Section 4 of the organization standard is the
-      # rule: why a line ending inside a word is the shape to refuse,
-      # what the pattern cannot see, and what the measurement was before
-      # it was proposed
+      # a line that ends inside a word, at that word's own hyphen.
+      # Section 4 of the organization standard is the rule: what such a
+      # line renders as, why nothing else here catches it, what this
+      # pattern cannot see, and what the measurement was before it was
+      # proposed
       - id: no-hyphen-at-end-of-line
         name: a word is not wrapped at its own hyphen
         language: pygrep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,25 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **A markdown line does not end inside a word**
+  (btclib-org/.github#71). Markdown joins two source lines with a space,
+  so a word wrapped at its own hyphen renders with the hyphen and then a
+  space inside it -- "read-any-" and "number-of-times" on consecutive
+  lines come out as "read-any- number-of-times". The source looks
+  correct, which is why reading a diff does not find one, and nothing
+  here read the output: markdownlint has no rule for it, the width rules
+  read a line rather than what two lines become, and `sphinx-build -W`
+  is not asked whether a token means anything.
+
+  A `pygrep` hook, for the reason `local-link-prefix` beside it is one:
+  nothing off the shelf does it and the pattern is one line. The rule
+  and what the hook cannot see -- a code span whose content breaks at a
+  `/` or a `.` renders the same way and has no hyphen to match -- are in
+  section 4 of the organization standard, which the comment points at
+  rather than restates. This tree was already clean under it, so the
+  hook costs nothing today and exists to keep the next one from being
+  written.
+
 - **`check-wheel-contents` names the package tree** (issue #1200).
   `package = ["btclib"]`, where it ran unconfigured. Without it the tool
   reads the wheel's own `RECORD` and asks nothing about the tree the


### PR DESCRIPTION
Markdown joins two source lines with a space, so a word wrapped at its
own hyphen renders with the hyphen **and then a space** inside it:

```markdown
a keypair's read-any-
number-of-times constness
```

renders `read-any- number-of-times`. **The source looks correct**, which
is why reading a diff does not find one.

Nothing here read the output: markdownlint has no rule for it, the width
rules read a line rather than what two lines become, and `sphinx-build
-W` is not asked whether a token means anything. A `pygrep` hook now
does, for the reason `local-link-prefix` beside it is one — nothing off
the shelf does it and the pattern is one line:

```yaml
      - id: no-hyphen-at-end-of-line
        name: a word is not wrapped at its own hyphen
        language: pygrep
        entry: "[A-Za-z0-9]-$"
        types: [markdown]
```

The rule, and **what the hook cannot see** — a code span whose content
breaks at a `/` or a `.` renders with the same intruding space and has no
hyphen to match — are in section 4 of the organization standard, which
the comment points at rather than restates.

**This tree was already clean under it**, so the hook costs nothing today
and exists to keep the next one from being written. `git grep -n -E
'[A-Za-z0-9]-$' -- '*.md'` is what says so; the instances that produced
the rule were three in `btclib-secp256k1`, fixed in that repository's
#318 and found by scanning rendered `<code>` spans in built html rather
than by reading markdown.

Part of btclib-org/.github#71. The standard's own copy is
btclib-org/.github#73. No parenthetical in the title: this closes no
issue in this repository.

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0,
including the new hook over this repository's own markdown, run after the
rebase onto current `main`.

## Summary by Sourcery

Prevent Markdown words from being split at their own hyphens by adding a repository-wide pre-commit validation rule.

New Features:
- Add a pre-commit check that prevents Markdown lines from ending at a word's hyphen.

Documentation:
- Document the new Markdown wrapping check and its limitations in the changelog.