### PR TITLE
check_output_pubkey's two arms agree on the sentence (issue #1218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1125,6 +1125,25 @@ documented at release-notes length in the first place, and are still in
 
 ### Malformed input and the exception contract
 
+- **`check_output_pubkey`'s two arms agree on the sentence, which its
+  own comment already promised** (issue #1218). That comment says the
+  two "must agree on what they raise as well as on what they answer",
+  and they agreed on the class and the bool alone: for a control block
+  whose internal key is no point, the bindings arm answered "invalid
+  internal public key: invalid public key" and the Python one "invalid
+  x-coordinate: 5". A promise kept in one half is worse than one not
+  made.
+
+  Issue #1216 settled the neighbouring question for `_tweaked_pubkey`:
+  the sentence agrees where the call knows what was refused, and only
+  the class agrees where it does not. This call knows.
+  `tweak_add_check` is handed the internal key's x alone, with no `sec`
+  carrying a y beside it, and a `q` that is no x-coordinate is answered
+  `False` by both arms rather than raised on -- measured, not reasoned
+  -- so the only refusal it can produce is about that x. The wording is
+  now the lift's, range check included, and the test holds both arms to
+  all three shapes that sentence has.
+
 - **taproot's tweak translates the bindings' refusal, as every other arm
   in the tree does** (issue #1214). `_tweaked_pubkey`'s delegated arm
   hands `libsecp256k1_xonly.tweak_add` octets nothing has proved are a

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -571,8 +571,20 @@ def check_output_pubkey(q: Octets, script: Octets, control: Octets) -> bool:
             # through a plain ValueError and the Python path below
             # through the BTClibValueError of _y_even_var. The engine
             # catches the library's own error, so the two must agree on
-            # what they raise as well as on what they answer
-            raise BTClibValueError(f"invalid internal public key: {e}") from e
+            # what they raise as well as on what they answer -- and this
+            # call knows which half was refused, unlike _tweaked_pubkey's
+            # arm given a sec: tweak_add_check is handed the internal
+            # key's x alone, and a q that is no x-coordinate is answered
+            # False by both arms rather than raised on. So the wording is
+            # the lift's below, range check included, and the two arms
+            # answer the same sentence for the same control block
+            err_msg = (
+                "invalid x-coordinate: "
+                if p < secp256k1.p
+                else "x-coordinate not in 0..p-1: "
+            )
+            err_msg += f"{hex_string(p)}" if p > HEX_THRESHOLD else f"{p}"
+            raise BTClibValueError(err_msg) from e
 
     # _y_even_var, i.e. secp256k1.y_even_var with the lift delegated: this is
     # the path a q of any other length takes, secp256k1 included, so the

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -317,22 +317,33 @@ def test_check_output_pubkey_of_a_key_that_is_not_32_bytes() -> None:
 def test_check_output_pubkey_of_an_internal_key_that_is_not_a_point(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Both paths refuse an internal key with no y, and refuse it alike.
+    """Both paths refuse an internal key with no y, in the same words.
 
-    x = 5 is not the x-coordinate of a secp256k1 point: 5**3 + 7 is not
-    a quadratic residue. libsecp256k1 rejects it while parsing and
-    ec.y_even_var while lifting it, and the two errors have to be the same
-    kind, the script engine catching the library's own.
+    libsecp256k1 rejects it while parsing and `ec.y_even_var` while
+    lifting it, and the two have to agree on what they raise as well as
+    on what they answer, the script engine catching the library's own.
+    This call can make them agree on the sentence too, unlike
+    `_tweaked_pubkey` given a `sec`: `tweak_add_check` is handed the
+    internal key's x alone, so a refusal is about that x and nothing
+    else (issue 1218).
+
+    Three shapes, as the tweak's own test has: 5 is no x-coordinate and
+    is written as a decimal, p - 1 is no x-coordinate and is written as
+    hex, and p is not a field element at all, which `y_even_var` says in
+    words of its own.
     """
-    control = b"\xc0" + (5).to_bytes(32, "big")
-    err_msg = "invalid"
-
-    with pytest.raises(BTClibValueError, match=err_msg):
-        check_output_pubkey(b"\x00" * 32, b"\x51", control)
-    with monkeypatch.context() as no_bindings:
-        no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
+    for x, err_msg in (
+        (5, "invalid x-coordinate: 5"),
+        (secp256k1.p - 1, "invalid x-coordinate: FFFFFFFF"),
+        (secp256k1.p, r"x-coordinate not in 0\.\.p-1: FFFFFFFF"),
+    ):
+        control = b"\xc0" + x.to_bytes(32, "big")
         with pytest.raises(BTClibValueError, match=err_msg):
             check_output_pubkey(b"\x00" * 32, b"\x51", control)
+        with monkeypatch.context() as no_bindings:
+            no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
+            with pytest.raises(BTClibValueError, match=err_msg):
+                check_output_pubkey(b"\x00" * 32, b"\x51", control)
 
 
 def test_the_tweak_refuses_an_internal_key_that_is_no_point_alike(


### PR DESCRIPTION
The comment above that arm says the two arms

> must agree on what they raise **as well as on what they answer**

They agreed on the class and the bool alone:

| arm | `control = b"\xc0" + (5).to_bytes(32, "big")` |
| --- | --- |
| bindings | `invalid internal public key: invalid public key` |
| Python | `invalid x-coordinate: 5` |

A promise kept in one half is worse than one not made — which is why
this is the comment's defect and not the caller's problem, `except
BTClibValueError` catching both either way.

**#1216 settled the neighbouring question** for `_tweaked_pubkey`: the
sentence agrees where the call knows what was refused, and only the
class agrees where it does not. **This call knows.** `tweak_add_check`
is handed the internal key's x alone — no `sec` carrying a y beside it —
and a `q` that is no x-coordinate is answered `False` by both arms rather
than raised on:

```
bindings  bad internal key p   BTClibValueError: invalid x-coordinate: 5
bindings  bad output key q     -> False
python    bad internal key p   BTClibValueError: invalid x-coordinate: 5
python    bad output key q     -> False
```

Measured, not reasoned: that second row is what makes naming the x
correct here and wrong on `_tweaked_pubkey`'s `sec` path.

So the wording is the lift's, range check included, and the test that
already held the two arms to the same *class* now holds them to the same
*sentence* over all three shapes it has — `5` as a decimal, `p - 1` as
hex, `p` out of range — which is the shape #1216's own test uses.

Closes #1218

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0 and
`pytest tests/script/` 2399 passed, run after the rebase onto current
`main`. The suite, the lint job, the coverage ratchet and the
documentation build run beside this review on this same sha.

## Summary by Sourcery

Align `check_output_pubkey` error messages across implementations and verify their consistency for malformed internal keys.

Bug Fixes:
- Make `check_output_pubkey` report the same detailed invalid-coordinate error across its bindings and Python execution paths.

Enhancements:
- Extend taproot validation coverage to ensure consistent error messages for invalid, hexadecimal, and out-of-range internal key coordinates.

Tests:
- Update the internal-key validation test to compare both execution paths across three malformed coordinate values.