### PR TITLE
The Esplora module names the second deployment its argument rests on (issue #1130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -887,6 +887,31 @@ documented at release-notes length in the first place, and are still in
 
 ### Documentation and the website
 
+- **The Esplora module names the second deployment its own argument
+  rests on** (issue #1130). Its docstring says the backend is an api and
+  not a product, and gave "several operators run it" as the evidence --
+  naming none of them, in a file whose one concrete deployment is
+  `BLOCKSTREAM_INFO`, the very endpoint the paragraph says it is not
+  tied to. The claim carrying the design decision was the one thing a
+  reader could not check.
+
+  `mempool.space` is named instead, and it was checked before it was
+  written, which the issue asked for and is the whole of what makes the
+  sentence worth more than the one it replaces. All three endpoints this
+  module calls answer there, in the encoding it needs:
+
+  | endpoint | status | content type |
+  | --- | --- | --- |
+  | `/blocks/tip/height` | 200 | `text/plain` |
+  | `/blocks/tip/hash` | 200 | `text/plain` |
+  | `/tx/<txid>/hex` | 200 | `text/plain` |
+
+  It is not offered as a second constant, for the reason
+  `BLOCKSTREAM_INFO` is offered as a value to pass rather than a
+  default: which stranger sees every address a user looks up is not
+  btclib's decision to take. So the name is evidence for the sentence
+  above it and not a recommendation, and the docstring says so.
+
 - **`RELEASING.md`'s reason for attaching no bill of materials to a
   sibling's release holds for both of its wheels** (issue #1189). The
   paragraph described the vendored libsecp256k1 as "statically-linked",

--- a/btclib/fetch/esplora.py
+++ b/btclib/fetch/esplora.py
@@ -5,12 +5,15 @@
 """The block-explorer fallback, for a caller with no node.
 
 Esplora's HTTP api, because it is an api and not a product: Blockstream
-publishes the server as open source, several operators run it, and anyone
-can run their own -- so a client written against it is not written
-against one company's endpoint. `BLOCKSTREAM_INFO` below is the reference
-deployment and is offered as a *value to pass*, never as a default: the
-one decision btclib will not take on a user's behalf is which stranger
-gets to see every address they look up.
+publishes the server as open source, mempool.space serves the same three
+endpoints this module calls, and anyone can run their own -- so a client
+written against it is not written against one company's endpoint.
+`BLOCKSTREAM_INFO` below is the reference deployment and is offered as a
+*value to pass*, never as a default: the one decision btclib will not
+take on a user's behalf is which stranger gets to see every address they
+look up. mempool.space is not offered as a second constant for the same
+reason, and naming it here is the evidence for the sentence above rather
+than a recommendation.
 
 What the fallback promises is the same three answers behind the same
 interface. What it does not promise is that they are true. A node
@@ -27,7 +30,10 @@ trade the fallback exists to offer, and `SECURITY.md` states it.
 Three endpoints, each answering in plain text rather than json:
 `/tx/<txid>/hex`, `/blocks/tip/height` and `/blocks/tip/hash`. The json
 renderings beside them carry the same values with more to disagree about
--- and `/hex` is what makes the id check above possible at all.
+-- and `/hex` is what makes the id check above possible at all. That
+those three are what a second deployment has to serve is why they are
+the thing to check before naming one: a host answering json where this
+expects text is not compatible in the way that matters.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
`btclib/fetch/esplora.py`'s module docstring makes the design argument:

> Esplora's HTTP api, because it is an api and not a product: Blockstream
> publishes the server as open source, **several operators run it**, and
> anyone can run their own

It names none of them, and the file's one concrete deployment is
`BLOCKSTREAM_INFO` — the very endpoint the paragraph says the client is
not tied to. The claim carrying the design decision was the one thing a
reader could not check.

**`mempool.space`, checked before it was written**, which is the whole of
what makes the new sentence worth more than the old one. All three
endpoints this module calls answer there in the encoding it needs:

| endpoint | status | content type |
| --- | --- | --- |
| `/blocks/tip/height` | 200 | `text/plain` |
| `/blocks/tip/hash` | 200 | `text/plain` |
| `/tx/<txid>/hex` | 200 | `text/plain` |

```shell
curl -s -o /dev/null -w '%{http_code} %{content_type}\n' \
  https://mempool.space/api/blocks/tip/height
# 200 text/plain
```

`/hex` is the one that matters most: it is what makes `tx_from_raw`'s id
check possible at all, so a deployment serving json where this expects
text would not be compatible in the way that decides the argument. It
serves text.

**It is not offered as a second constant**, for the same reason
`BLOCKSTREAM_INFO` is offered as a *value to pass* rather than a default:
which stranger sees every address a user looks up is not btclib's
decision to take. So the name is evidence for the sentence above it, not
a recommendation, and the docstring says so in as many words.

The endpoint paragraph lower down gains the reason those three are the
thing to check before naming any deployment.

Closes #1130

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run
after the rebase onto current `main`. The suite, the lint job, the
coverage ratchet and the documentation build run beside this review on
this same sha.

## Summary by Sourcery

Document Esplora's deployment-agnostic design with a verified mempool.space example and clarify the endpoint compatibility requirement.

Enhancements:
- Clarify the Esplora module documentation by naming mempool.space as a compatible second deployment and explaining that it is cited as evidence rather than recommended as a default.
- Document that compatibility depends on the three plain-text endpoints used by the module, including transaction hex retrieval.

Documentation:
- Update the changelog with the rationale and compatibility checks supporting the additional deployment reference.