### PR TITLE
Restore the HEX_THRESHOLD import two green pull requests removed between them

### DIFF
--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -28,6 +28,7 @@ from btclib.alias import (
 )
 from btclib.curves import bytes_from_prv_key_int, mult, secp256k1
 from btclib.curves.curve import _libsecp256k1_serves, _y_even_var
+from btclib.curves.curve_group import HEX_THRESHOLD
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import tagged_hash
 from btclib.key import PubKeyData


### PR DESCRIPTION
**`main` is red.** `check_output_pubkey` raises `NameError: name
'HEX_THRESHOLD' is not defined`, and six tests fail on it:

```
tests/script_engine/transactions_test.py::test_invalid_taproot[102-spendpath-bitflippubkey]
tests/script_engine/transactions_test.py::test_invalid_taproot[1948-spendpath-bitflippubkey]
tests/script_engine/transactions_test.py::test_invalid_taproot[2243-output-invalid-x]
tests/fuzz_test.py::test_witness_consumer_honors_the_exception_contract[engine.verify_transaction]
tests/fuzz_test.py::test_witness_consumer_honors_the_exception_contract[engine.verify_input]
tests/script/taproot_test.py::test_check_output_pubkey_of_an_internal_key_that_is_not_a_point
```

`mypy` says it too, in one line: `btclib/script/taproot.py:577: error:
Name "HEX_THRESHOLD" is not defined [name-defined]`. Two of the six are
the tests whose whole subject is that a witness consumer honours the
exception contract, which is exactly what a `NameError` in place of a
`BTClibValueError` breaks.

## How two green pull requests did this

Neither is wrong.
[#1219](https://github.com/btclib-org/btclib/pull/1219) removed the
`HEX_THRESHOLD` import because its rewrite of `_tweaked_pubkey` left
nothing using it.
[#1228](https://github.com/btclib-org/btclib/pull/1228) added a use of
it in `check_output_pubkey`. They touch different lines of one file, so
git saw no conflict; #1228 was written and checked against a base
without #1219 in it, and merged after it.

## The fix, and what it deliberately is not

One line: the import. The suite goes from six failures to none and
coverage back to 100.00%, with nothing else touched.

**No CHANGELOG entry.** The broken state never left this release, so an
entry would tell a reader about a defect and a repair that between them
come to nothing; what the two entries already there say about
`check_output_pubkey` and `_tweaked_pubkey` stays true either way.

**No behaviour change.** `check_output_pubkey`'s message for an x at or
above p is what #1228 intended it to be; it simply could not be
constructed.

## What let it land, which is not this PR's to fix

The branch was not required to be up to date with `main` before merging,
so #1228's green checks answered for a tree that no longer existed by
the time it merged. Worth deciding separately, in `REPOSITORY.md`'s
terms — the cost of requiring it is a rebase per merge, and the cost of
not requiring it is this.

## What was run

- `uv run pytest` — exit 0, coverage 100.00% (six failures before)
- `uv run pre-commit run --all-files` — exit 0 (mypy failed before)
- the documented sphinx `-W --keep-going` build — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hde6RUtTpqFBkPziUqzZkX

## Summary by Sourcery

Bug Fixes:
- Restore the missing `HEX_THRESHOLD` import so Taproot output-key validation raises the intended error instead of `NameError`.