### PR TITLE
taproot.py gets back the import a merge dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1247,6 +1247,20 @@ documented at release-notes length in the first place, and are still in
 
 ### Malformed input and the exception contract
 
+- **`taproot.py` gets back the import a merge dropped.**
+  `check_output_pubkey`'s translation reads `HEX_THRESHOLD`, added with
+  it in #1228; #1219 rewrote `_tweaked_pubkey`'s arm in the same file
+  and removed the only other use, and therefore the import. Both landed
+  green, and neither branch's tree ever held the combination: #1228 was
+  BEHIND when it was merged, and a squash of a behind branch produces a
+  tree no gate has run on -- `git tree == what CI tested` holds for each
+  branch and not for their merge.
+
+  It parsed, so nothing refused it: a `NameError` at the one line that
+  reports a refused internal key on the delegated arm. The suite catches
+  it, which is why the fix is one line and the finding is about ordering
+  rather than about the code.
+
 - **`check_output_pubkey`'s two arms agree on the sentence, which its
   own comment already promised** (issue #1218). That comment says the
   two "must agree on what they raise as well as on what they answer",

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -28,6 +28,7 @@ from btclib.alias import (
 )
 from btclib.curves import bytes_from_prv_key_int, mult, secp256k1
 from btclib.curves.curve import _libsecp256k1_serves, _y_even_var
+from btclib.curves.curve_group import HEX_THRESHOLD
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import tagged_hash
 from btclib.key import PubKeyData


### PR DESCRIPTION
**`main` raises `NameError` on one path today.**
`btclib/script/taproot.py:577`:

```python
            err_msg += f"{hex_string(p)}" if p > HEX_THRESHOLD else f"{p}"
```

and `HEX_THRESHOLD` is imported nowhere in the file.

**How it got there, which is the part worth writing down.** `HEX_THRESHOLD`
arrived with `check_output_pubkey`'s translation in #1228. #1219 rewrote
`_tweaked_pubkey`'s arm in the same file and removed the only *other* use
— and, correctly for its own tree, the import with it.

Both landed green. **Neither branch's tree ever held the combination**:
#1228 was `BEHIND` when I merged it, and a squash of a behind branch
produces a tree no gate has run on. That is the whole defect: `git tree
== what CI tested` holds for each branch and not for their merge.

It **parses**, so nothing refused it. The failure is a `NameError` at the
one line that reports a refused internal key on the delegated arm, and
the suite catches it — which is why the fix is one line and the finding
is about ordering rather than about the code.

```
pytest: 29464 passed, 11 skipped
pre-commit run --all-files: exit 0
```

and, on this tree, the two arms answer alike again over all three shapes
#1228's test holds them to:

```
bindings  x=5      invalid x-coordinate: 5
bindings  x=p-1    invalid x-coordinate: FFFFFFFF …
bindings  x=p      x-coordinate not in 0..p-1: FFFFFFFF …
python    (identical)
```

**My mistake, and the rule it costs.** I merged a `BEHIND` pull request
because `enforce_admins: false` lets me, and because the alternative —
rebasing — voids the ack. That trade is fine for a branch nothing else
is touching. It is not fine for a branch whose file another branch is
rewriting, and #1219 was rewriting exactly this one. **Rebase before
landing when another branch has touched the same file, and pay for the
fresh review.**

No parenthetical in the title: this closes no issue.

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0 and the
full suite green, run after the rebase onto current `main`.

## Summary by Sourcery

Restore the Taproot threshold constant import and document the merge-order issue that caused the delegated-key error path to fail.

Bug Fixes:
- Restore the missing `HEX_THRESHOLD` import so `check_output_pubkey` reports invalid internal keys without raising `NameError`.

Documentation:
- Document the merge-order failure that caused the missing import and the resulting malformed-input regression.