### PR TITLE
check_output_pubkey takes a memoryview control block (issue #1220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1260,6 +1260,33 @@ documented at release-notes length in the first place, and are still in
   reports a refused internal key on the delegated arm. The suite catches
   it, which is why the fix is one line and the finding is about ordering
   rather than about the code.
+- **`check_output_pubkey` takes a memoryview control block, as every
+  other entry point measured takes one** (issue #1220). It raised a bare
+  `TypeError` from the merkle fold, on both arms: `bytes_from_octets`
+  returns every buffer as it came -- deliberately, `utils` says why, an
+  `assert_valid` being a read that must not rewrite the field it reads
+  -- so `control[33 + 32 * j : 65 + 32 * j]` stayed a memoryview and
+  would not order against the `bytes` digest it is compared with. A
+  `bytearray` was unaffected, ordering against `bytes` where a
+  memoryview does not; the asymmetry is Python's and not this library's.
+
+  A memoryview is a spelling this library accepts on purpose --
+  `to_pub_key._PUB_KEY_TYPES` names it beside `bytes` and `bytearray` --
+  and nothing else measured leaks a non-`BTClibException` for one, so
+  this was one function out of step rather than a spelling nobody
+  promised.
+
+  `control` is coerced once where it is normalized, rather than at the
+  fold: nothing is stored here, it being a local, so the copy costs one
+  allocation of at most `33 + 32 * MAX_TREE_DEPTH` octets and buys every
+  line under it not having to know which spelling arrived. `q` and
+  `script` need no copy -- one is read as an integer, the other hashed
+  -- and are left as they came, which a test over all three spellings of
+  all three parameters holds.
+
+  The census in `tests/bool_parameter_test.py` could not have found it:
+  the wrong spelling is accepted at the door and refused halfway, which
+  is the shape a type census does not see.
 
 - **`check_output_pubkey`'s two arms agree on the sentence, which its
   own comment already promised** (issue #1218). That comment says the

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -530,7 +530,18 @@ def check_output_pubkey(q: Octets, script: Octets, control: Octets) -> bool:
     """
     q = bytes_from_octets(q)
     script = bytes_from_octets(script)
-    control = bytes_from_octets(control)
+    # `bytes(...)` because the merkle fold below orders two slices of this
+    # against a `bytes` digest, and a memoryview does not order against
+    # `bytes` where a bytearray does -- the asymmetry is Python's, and it
+    # reaches here because `bytes_from_octets` returns every buffer as it
+    # came, deliberately: `utils` states why, an `assert_valid` being a
+    # read that must not rewrite the field it reads. Nothing is stored
+    # here, `control` being a local, so the copy costs one allocation of
+    # at most 33 + 32 * MAX_TREE_DEPTH octets and buys every line under it
+    # not having to know which spelling arrived. `q` and `script` need no
+    # such copy -- one is read as an integer and the other is hashed --
+    # and are left as they came (issue 1220)
+    control = bytes(bytes_from_octets(control))
     if len(control) > 33 + 32 * MAX_TREE_DEPTH:
         raise BTClibValueError("control block too long")
     m = (len(control) - 33) // 32

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -503,15 +503,15 @@ def test_check_output_pubkey_takes_every_buffer_the_door_accepts(
     this: the wrong spelling is accepted at the door and refused
     halfway (issue 1220).
     """
-    tree: list[Any] = [[(0xC0, ["OP_2"])], [(0xC0, ["OP_3"])]]
+    tree: TaprootScriptTree = [[(0xC0, ["OP_2"])], [(0xC0, ["OP_3"])]]
     q, _ = output_pubkey(0xC0FFEE, tree)
     witness = input_script_sig(0xC0FFEE, tree, 0)
     script, control = serialize(witness[0]), witness[1]
 
-    assert check_output_pubkey(q, spelling(script), spelling(control))
+    assert check_output_pubkey(spelling(q), spelling(script), spelling(control))
     with monkeypatch.context() as no_bindings:
         no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
-        assert check_output_pubkey(q, spelling(script), spelling(control))
+        assert check_output_pubkey(spelling(q), spelling(script), spelling(control))
 
 
 def test_invalid_control_block() -> None:

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -12,13 +12,14 @@ Core rather than anything a BIP publishes.
 tests/_data/README.md pins the revision of each.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import pytest
 
 from btclib import b32
 from btclib._libsecp256k1 import xonly as libsecp256k1_xonly
-from btclib.alias import ScriptList
+from btclib.alias import Octets, ScriptList
 from btclib.curves import bytes_from_point, curve, curve_group, mult, secp256k1
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.number_theory import mod_sqrt_var
@@ -484,6 +485,33 @@ def test_the_tweak_names_no_half_of_a_sec_it_cannot_blame(
         no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
         with pytest.raises(BTClibValueError, match="point not on curve"):
             output_pubkey(sec)
+
+
+@pytest.mark.parametrize("spelling", [bytes, bytearray, memoryview])
+def test_check_output_pubkey_takes_every_buffer_the_door_accepts(
+    spelling: Callable[[bytes], Octets], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every spelling `bytes_from_octets` takes reaches the same answer.
+
+    A memoryview used to raise a bare `TypeError` from the merkle fold,
+    on both arms: `bytes_from_octets` returns every buffer as it came,
+    so a slice of the control block stayed a memoryview and would not
+    order against the `bytes` digest it is compared with. A bytearray
+    was unaffected, ordering against `bytes` where a memoryview does
+    not, which is Python's asymmetry rather than this library's --
+    and it is why the census in `bool_parameter_test.py` could not see
+    this: the wrong spelling is accepted at the door and refused
+    halfway (issue 1220).
+    """
+    tree: list[Any] = [[(0xC0, ["OP_2"])], [(0xC0, ["OP_3"])]]
+    q, _ = output_pubkey(0xC0FFEE, tree)
+    witness = input_script_sig(0xC0FFEE, tree, 0)
+    script, control = serialize(witness[0]), witness[1]
+
+    assert check_output_pubkey(q, spelling(script), spelling(control))
+    with monkeypatch.context() as no_bindings:
+        no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
+        assert check_output_pubkey(q, spelling(script), spelling(control))
 
 
 def test_invalid_control_block() -> None:


### PR DESCRIPTION
A `memoryview` control block raised a bare `TypeError` from the merkle
fold, **on both arms**:

```
bindings  bytes       -> True
bindings  bytearray   -> True
bindings  memoryview  TypeError: '<' not supported between instances of 'bytes' and 'memoryview'
python    (identical)
```

`bytes_from_octets` returns every buffer as it came — deliberately;
`utils` states why, an `assert_valid` being a read that must not rewrite
the field it reads, and `tests/bip32/bip32_test.py` pins it for
`BIP32KeyData.chain_code`. So `control[33 + 32 * j : 65 + 32 * j]` stayed
a memoryview and would not order against the `bytes` digest it is
compared with. A `bytearray` was unaffected, ordering against `bytes`
where a memoryview does not — **Python's asymmetry, not this library's**.

**Not a spelling nobody promised**: `to_pub_key._PUB_KEY_TYPES` names
`memoryview` beside `bytes` and `bytearray`, and #1220's sweep found no
other entry point leaking a non-`BTClibException` for one. This was one
function out of step with the tree.

**Of the two fixes #1220 names, this is the boundary one.** `control` is
coerced once where it is already normalized rather than `bytes(...)` at
the fold, and the reason is that the rule `bytes_from_octets` follows is
about *storing*: nothing is stored here, `control` being a local. The
copy costs one allocation of at most `33 + 32 * MAX_TREE_DEPTH` octets
and buys every line under it not having to know which spelling arrived.

`q` and `script` need no copy — one is read as an integer, the other
hashed — and are left as they came. Measured, and the new test is
parametrized over all three spellings with all three parameters passed
that way, on both arms.

**Why the census could not have found it**, which is #1220's third box
and the general form: `tests/bool_parameter_test.py` asks what a
parameter *accepts at the door*. Here the wrong spelling is accepted at
the door and refused halfway.

Closes #1220

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run
after the rebase onto current `main` — which now carries #1231's restored
import, so this branch's tree is the one CI tested. The suite, the lint
job, the coverage ratchet and the documentation build run beside this
review on this same sha.

## Summary by Sourcery

Make `check_output_pubkey` consistently accept every supported buffer type for control blocks.

Bug Fixes:
- Fix `check_output_pubkey` so memoryview inputs for the control block produce the same result as bytes and bytearray inputs instead of leaking a TypeError during validation.

Tests:
- Add coverage for bytes, bytearray, and memoryview inputs across both validation paths and all `check_output_pubkey` parameters.