### PR TITLE
Why one dependency is required and the other an extra (issue #1131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,25 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **Why `bitcoin-core-rpc` is required and the bindings are an extra is
+  written where a reader meets it** (issue #1131). Issue #1126 decided
+  it and closed on the decision; neither `pyproject.toml`'s comment
+  block nor `CONTRIBUTING.md`'s dependency paragraph carried the
+  reasoning, both arguing the absence of a version *ceiling* at length
+  and saying nothing about the asymmetry above it. A contributor could
+  ask #1126's question again from the files alone, which is what a
+  decision made and not recorded looks like.
+
+  The reasoning rather than the conclusion, which is already visible in
+  the file: an optional dependency whose absence changes a *speed* is a
+  different object from one whose absence removes a *capability*, and
+  only the first is what an extra is for. The bindings are the first --
+  btclib answers without them, on a pure-Python arm made supported,
+  CI-covered and documented by issues #990, #991 and #992 -- and nothing
+  stands behind "ask a node". A `fetch` extra was weighed and refused on
+  that: it would leave `btclib.fetch` importable and unable to answer,
+  which is the shape an extra exists to avoid.
+
 - **A markdown line does not end inside a word**
   (btclib-org/.github#71). Markdown joins two source lines with a space,
   so a word wrapped at its own hyphen renders with the hyphen and then a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,15 +179,14 @@ documented at release-notes length in the first place, and are still in
   ask #1126's question again from the files alone, which is what a
   decision made and not recorded looks like.
 
-  The reasoning rather than the conclusion, which is already visible in
-  the file: an optional dependency whose absence changes a *speed* is a
-  different object from one whose absence removes a *capability*, and
-  only the first is what an extra is for. The bindings are the first --
-  btclib answers without them, on a pure-Python arm made supported,
-  CI-covered and documented by issues #990, #991 and #992 -- and nothing
-  stands behind "ask a node". A `fetch` extra was weighed and refused on
-  that: it would leave `btclib.fetch` importable and unable to answer,
-  which is the shape an extra exists to avoid.
+  The reasoning goes in `CONTRIBUTING.md`, beside the ceiling argument
+  that paragraph already makes, and `pyproject.toml` points at it rather
+  than saying it a second time -- what the decision turns on is the
+  difference between an optional dependency whose absence changes a
+  *speed* and one whose absence removes a *capability*, and that
+  argument is a paragraph rather than a line. What goes in the comment
+  is only that the alternative was weighed and refused, and where to
+  read why.
 
 - **A markdown line does not end inside a word**
   (btclib-org/.github#71). Markdown joins two source lines with a space,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,17 @@ would make a published artifact refuse a version it in fact works with; a
 `<1` ceiling constrains nothing, pre-1.0 semver putting the breaking
 changes in the minor.
 
+**One is required and the other is an extra, and that was weighed rather
+than inherited.** Making `bitcoin-core-rpc` a `fetch` extra was
+considered and refused: an optional dependency whose absence changes a
+*speed* is a different object from one whose absence removes a
+*capability*, and only the first is what an extra is for. The bindings
+are the first — btclib answers without them, on a pure-Python arm that
+is supported, covered by CI and documented — and nothing stands behind
+"ask a node". A caller either has a client or does not have the feature,
+so a `fetch` extra would leave `btclib.fetch` importable and unable to
+answer, which is the shape an extra exists to avoid.
+
 **Both floors name a release PyPI serves**, so `pyproject.toml` carries
 no `[tool.uv.sources]` table and uv resolves the bindings from the index
 like anything else: `uv.lock` pins a version and its wheels, every job

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,16 +24,10 @@ license = "MIT"
 license-files = ["LICENSE", "COPYRIGHT", "AUTHORS.md"]
 authors = [{ name = "The btclib developers", email = "devs@btclib.org" }]
 requires-python = ">=3.10"
-# Required, where the bindings below are an extra, and the asymmetry is a
-# decision rather than an accident of history: making this a `fetch` extra
-# was weighed and refused (issue #1126). An optional dependency whose
-# absence changes a speed is a different object from one whose absence
-# removes a capability, and only the first is what an extra is for. The
-# bindings are the first -- btclib answers without them, on a pure-Python
-# arm that is supported, CI-covered and documented -- and nothing stands
-# behind "ask a node": a caller either has a client or does not have the
-# feature, and an extra would turn `btclib.fetch` into a module that
-# imports and then cannot answer.
+# Required, where the bindings below are an extra, and that asymmetry was
+# weighed rather than inherited: a `fetch` extra was considered and
+# refused (issue #1126). CONTRIBUTING.md's dependency paragraph carries
+# the reasoning, beside the ceiling argument it already makes.
 dependencies = [
     "bitcoin-core-rpc>=2026.8.13",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,16 @@ license = "MIT"
 license-files = ["LICENSE", "COPYRIGHT", "AUTHORS.md"]
 authors = [{ name = "The btclib developers", email = "devs@btclib.org" }]
 requires-python = ">=3.10"
+# Required, where the bindings below are an extra, and the asymmetry is a
+# decision rather than an accident of history: making this a `fetch` extra
+# was weighed and refused (issue #1126). An optional dependency whose
+# absence changes a speed is a different object from one whose absence
+# removes a capability, and only the first is what an extra is for. The
+# bindings are the first -- btclib answers without them, on a pure-Python
+# arm that is supported, CI-covered and documented -- and nothing stands
+# behind "ask a node": a caller either has a client or does not have the
+# feature, and an extra would turn `btclib.fetch` into a module that
+# imports and then cannot answer.
 dependencies = [
     "bitcoin-core-rpc>=2026.8.13",
 ]


### PR DESCRIPTION
#1126 decided that `bitcoin-core-rpc` stays a required dependency while
`btclib_secp256k1` stays the `secp256k1` extra, and closed on the
decision. **Neither place a reader meets the asymmetry carried the
reasoning**: `pyproject.toml`'s comment block and `CONTRIBUTING.md`'s
dependency paragraph both argue the absence of a version *ceiling*, at
length and well, and are silent on why one is required and the other is
an extra.

So a contributor could ask #1126's question again from the files alone —
which is what a decision that was made and not recorded looks like, and
what this pull request owes rather than adds.

**The reasoning, not the conclusion.** That `bitcoin-core-rpc` is
required is already visible in the file; what is not is that a `fetch`
extra was weighed and refused, and on what:

> An optional dependency whose absence changes a **speed** is a
> different object from one whose absence removes a **capability**, and
> only the first is what an extra is for.

The bindings are the first — btclib answers without them, on a
pure-Python arm that #990, #991 and #992 made supported, CI-covered and
documented. Nothing stands behind "ask a node": a caller either has a
client or does not have the feature, so a `fetch` extra would leave
`btclib.fetch` importable and unable to answer, which is the shape an
extra exists to avoid.

Both files are prose whose whole style is the reasoning with its negative
results kept, so the refused alternative is what goes in, not a one-line
assertion of the outcome.

Closes #1131

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run
after the rebase onto current `main`. The suite, the lint job, the
coverage ratchet and the documentation build run beside this review on
this same sha.

## Summary by Sourcery

Document why the Bitcoin Core RPC client is required while secp256k1 bindings remain optional.

Enhancements:
- Document the rationale for keeping `bitcoin-core-rpc` required while retaining `btclib_secp256k1` as an optional extra, including the rejected `fetch` extra alternative.

Documentation:
- Record the dependency decision and its capability-versus-performance rationale in contributor guidance and link to it from the project configuration.

Chores:
- Add the dependency rationale to the changelog.