### PR TITLE
Pin the guard the delegated tweak reads, and drop a false universal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1160,9 +1160,12 @@ documented at release-notes length in the first place, and are still in
   That sentence is `point_from_octets`', because `point_from_octets` is
   the lift now, and it wraps both of `curve_group.y_var`'s complaints —
   an x that is no coordinate and an x that is no field element — in one.
-  So taproot's x-only path stops naming the range, and says instead what
-  every other caller of `point_from_octets` in this library says; the
-  hex the message quotes still tells p from p - 1.
+  So taproot's x-only path stops naming the range and says what its own
+  lift says — which is not what every caller of that lift says:
+  `to_pub_key.point_from_pub_key` replaces the sentence with "not a
+  public key", and going through that replacement is what this module
+  has stopped doing. The hex the message quotes still tells p from
+  p - 1.
 
 - **`btclib.key` holds the canonical form of a key**, `PubKeyData` and
   `PrvKeyData`, so that a key parsed once can be carried rather than

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -442,10 +442,15 @@ def test_the_tweak_refuses_an_internal_key_that_is_no_point_alike(
     carried: the three cases below are 5, p - 1 and p, and the hex the
     sentence quotes still tells them apart.
     """
+    # the whole sentence on the last two, and not a prefix of it: they
+    # differ in their final hex group alone, so a pattern stopping short
+    # of it matches either message -- which is the discrimination this
+    # docstring claims, and the one a truncation silently drops
+    head = "FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE"
     for x, err_msg in (
         (5, "invalid x-coordinate: '05'"),
-        (secp256k1.p - 1, "invalid x-coordinate: 'FFFFFFFF"),
-        (secp256k1.p, "invalid x-coordinate: 'FFFFFFFF"),
+        (secp256k1.p - 1, f"invalid x-coordinate: '{head} FFFFFC2E'"),
+        (secp256k1.p, f"invalid x-coordinate: '{head} FFFFFC2F'"),
     ):
         x_only = x.to_bytes(32, "big")
         with pytest.raises(BTClibValueError, match=err_msg):
@@ -460,31 +465,49 @@ def test_the_tweak_refuses_an_internal_key_that_is_no_point_alike(
 def test_the_tweak_names_no_half_of_a_sec_it_cannot_blame(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A sec whose y is not its x's is refused without naming the x.
+    """A sec whose fault is not its x is refused without naming one.
 
-    Marked: the first half of it is the delegated arm's own message, so
-    with no bindings installed there is no such arm to reach and nothing
-    to compare the one below against.
+    Marked: the first assertion of each pair is the delegated arm's own
+    message, so with no bindings installed there is no such arm to reach
+    and nothing to compare the second against.
 
     `_sec_from_key` leaves the octets unproven for the reason the arm
-    itself does, so `04 || x || y` with a good x and a y that is not its
-    own reaches `tweak_add` and is refused there. The x is the half that
-    is right, and a message naming it would be false -- which is what
-    keeps the two arms to agreeing on the class here rather than on the
-    sentence: without the bindings the key never reaches the tweak at
-    all, the lift `PubKeyData.point` performs refusing it a step earlier
-    and in the curve's own words.
+    itself does, and `bytes_from_octets(pub_key, (33, 65))` is the whole
+    of what it checks, so what reaches `tweak_add` can be wrong in more
+    than one place. The arm names the x only where the x is the only
+    place left, which these three are not:
+
+    - `04 || x || y`, a good x and a y that is not its own. The x is the
+      half that is right, and naming it would be false.
+    - `05 || x`, a SEC length and no SEC prefix, which is the fault of
+      neither coordinate.
+    - `02 || x || y`, a compressed prefix at the uncompressed length,
+      where the two disagree and neither is wrong on its own.
+
+    The last two are here because they are the two halves of what the
+    arm reads to decide -- a length and a prefix -- and without them
+    dropping either half would leave this suite green while the arm
+    named a valid x.
+
+    The two arms agree on the class here rather than on the sentence.
+    With no bindings the refusal is the lift `PubKeyData.point` performs,
+    in the curve's own words: the tweak is computed either way, and what
+    never happens is the addition it was computed for.
     """
     Q = mult(7)
-    y_not_x_s = (Q[1] + 1) % secp256k1.p
-    sec = b"\x04" + Q[0].to_bytes(32, "big") + y_not_x_s.to_bytes(32, "big")
-
-    with pytest.raises(BTClibValueError, match="invalid internal public key"):
-        output_pubkey(sec)
-    with monkeypatch.context() as no_bindings:
-        no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
-        with pytest.raises(BTClibValueError, match="point not on curve"):
+    x = Q[0].to_bytes(32, "big")
+    y_not_x_s = ((Q[1] + 1) % secp256k1.p).to_bytes(32, "big")
+    for sec, python_msg in (
+        (b"\x04" + x + y_not_x_s, "point not on curve"),
+        (b"\x05" + x, "not a point: prefix 0x05"),
+        (b"\x02" + x + Q[1].to_bytes(32, "big"), "invalid size for compressed point"),
+    ):
+        with pytest.raises(BTClibValueError, match="invalid internal public key"):
             output_pubkey(sec)
+        with monkeypatch.context() as no_bindings:
+            no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
+            with pytest.raises(BTClibValueError, match=python_msg):
+                output_pubkey(sec)
 
 
 @pytest.mark.parametrize("spelling", [bytes, bytearray, memoryview])


### PR DESCRIPTION
Three findings from a review round that arrived after
[#1219](https://github.com/btclib-org/btclib/pull/1219) had already been
merged. None is a defect in what that pull request does: two are tests
asserting less than their docstrings claim, and one is a sentence that
is false. No library change — `tests/script/taproot_test.py` and
`CHANGELOG.md` only.

## The guard the delegated tweak reads was unpinned, both halves of it

`_tweaked_pubkey`'s delegated arm names the x in its refusal only for a
compressed key, whose prefix names its y and whose x is therefore all
`tweak_add` can be objecting to. That reading is
`pub_key.is_compressed and pub_key.sec[0] in (0x02, 0x03)` — a length
and a prefix — and the suite could see neither half. Mutating the line
and running the whole suite against the **old** test file:

```
if not pub_key.is_compressed:            29464 passed, 11 skipped
if pub_key.sec[0] not in (0x02, 0x03):   29464 passed, 11 skipped
```

Both mutants are wrong, and both then name a *valid* x as the fault:

```
33 octets, prefix 05 -> invalid x-coordinate: '79BE667E … 16F81798'
65 octets, prefix 02 -> invalid x-coordinate: '79BE667E … 16F81798'
```

The two endpoints were pinned and nothing between them, and the 100%
ratchet cannot see the gap — `A and B` in one `if` is one branch to
coverage.py. `test_the_tweak_names_no_half_of_a_sec_it_cannot_blame`
gains the two cases that kill them, one each, and says in its docstring
why those two.

## A docstring claimed a discrimination its assertion had dropped

`test_the_tweak_refuses_an_internal_key_that_is_no_point_alike` says
collapsing three sentences into one loses nothing because "the hex the
sentence quotes still tells them apart" — and then asserted a pattern
stopping before that hex. `p` and `p - 1` differ in their final group
alone, so each message matched the other's row. Now the whole sentence
on both, the shared head factored into a local so the difference is what
a reader sees.

## A false universal

> says instead what every other caller of `point_from_octets` in this
> library says

Measured across every call site of it in the tree, five replace or
swallow the lift's sentence and eight pass it through. The one that
matters most is in the same paragraph:

```
point_from_octets                     invalid x-coordinate: '05…'
to_pub_key.point_from_pub_key         not a public key
to_pub_key.point_from_key             not a public key
to_pub_key.pub_keyinfo_from_pub_key   invalid x-coordinate: '05…'
```

`to_pub_key` replaces the sentence, and going through that replacement
is precisely what the entry says taproot has stopped doing. The claim is
now the narrower true one, and names the caller that differs.

## What was run

On this sha, after the rebase onto a `main` that
[#1230](https://github.com/btclib-org/btclib/pull/1230) has unbroken:

- `uv run pytest` — exit 0, coverage 100.00%
- `uv run pre-commit run --all-files` — exit 0
- the documented sphinx `-W --keep-going` build — exit 0

and the mutation runs above, in a copy of the tree rather than in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hde6RUtTpqFBkPziUqzZkX

## Summary by Sourcery

Tighten taproot error-message tests and correct the changelog’s description of the underlying error behavior.

Enhancements:
- Strengthen taproot tests to verify delegated tweak errors identify only the invalid portion of malformed keys and distinguish closely related invalid coordinates.

Documentation:
- Correct the changelog description of taproot error handling to accurately distinguish its message from other public-key parsing callers.

Tests:
- Expand taproot validation tests to cover malformed SEC lengths and prefixes, and assert complete error-message discrimination for adjacent invalid coordinates.