### PR TITLE
Read every workflow comment end to end, and call integration.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,15 +21,23 @@ name: codeql
 #   #  "query_suite":"default","threat_model":"remote",
 #   #  "schedule":"weekly","runner_type":"standard"}
 #
-# Ruby is not in that list and not in the matrix below, which is worth a
-# word because default-setup runs here have carried an `Analyze (ruby)`
-# job: GitHub Pages serves btclib.org from main's root, so a Gemfile sits
-# beside the library and autodetection sees it. It analyses nothing -- of
-# the analyses this repository has ever received, every one is python or
-# actions, and none is ruby:
+# Ruby was not in that list and is not in the matrix below, which is
+# worth a word because default-setup runs here did carry an
+# `Analyze (ruby)` job: GitHub Pages serves btclib.org from main's root,
+# so a Gemfile sits beside the library and autodetection saw it. It
+# analysed nothing, and the evidence is the results rather than the
+# absence of the job -- 263 ruby analyses ran here, the last on
+# 2026-07-30, and every one of them found zero:
 #
-#   gh api "repos/btclib-org/btclib/code-scanning/analyses?per_page=100" \
-#     --jq '[.[] | .category] | group_by(.) | map({cat: .[0], n: length})'
+#   gh api --paginate \
+#     "repos/btclib-org/btclib/code-scanning/analyses?per_page=100" \
+#     --jq '.[] | select(.category == "/language:ruby") | .results_count' \
+#     | sort | uniq -c        # 263 0
+#
+# --paginate is the point of that line and not a detail. Without it the
+# endpoint answers the newest hundred, which since the switch are all
+# python and actions, so the command this comment used to carry
+# confirmed "none is ruby" by never reaching one.
 #
 # `threat_model: remote` is CodeQL's own default, so nothing here sets it;
 # it would take a `config:` block naming `threat-models` to depart from.
@@ -165,10 +173,16 @@ jobs:
           # rather than left to the default because it is the input that
           # would have to change first if a compiled language ever joined
           # the matrix, and because it is what default setup used here:
-          # every analysis this repository has received carries
-          # `"build-mode":"none"` in its environment --
-          #   gh api repos/btclib-org/btclib/code-scanning/analyses \
-          #     --jq '.[0].environment'
+          # every analysis default setup produced carries
+          # `"build-mode":"none"` in its environment, and not one this
+          # workflow has produced does. What an analysis records there
+          # changed when the analysis moved into the tree, so the newest
+          # answers `{"language":"python"}` and says nothing either way
+          # about the input below --
+          #   gh api --paginate \
+          #     "repos/btclib-org/btclib/code-scanning/analyses?per_page=100" \
+          #     --jq '.[] | .environment | test("build-mode")' \
+          #     | sort | uniq -c        # 1046 false, 2896 true
           build-mode: none
           # no `queries`, no `packs` and no `config`, which is not an
           # omission: `query_suite: "default"` is precisely the state in

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,9 +51,11 @@ on:
     - cron: "29 4 * * 5"
   # the same trigger set as the other gates: main so that the commit a
   # merge creates is asked the question too -- and so that a cache is
-  # written where every pull request can read it -- the pull request so that
-  # the merge result is, and workflow_call so release.yml can reuse the
-  # answer
+  # written where every pull request can read it -- the pull request so
+  # that the merge result is, and workflow_call because release.yml calls
+  # this workflow, as it calls test.yml, lint.yml and docs.yml: a
+  # rehearsal is dispatched from a branch, where the required check this
+  # job's name is on main has asked nothing
   push:
     branches: [main]
   workflow_call:

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -33,9 +33,9 @@ name: latest
 # pull request -- that pull request runs the whole matrix, so ruff and the
 # other pinned hooks already have their sentinel. mypy is the exception
 # and the reason the lint job below is here at all: its hook is local and
-# shells out to uv, so it is the lock that pins it. Not sphinx: lint.yml's
-# second job already builds the docs, with --locked, on every pull
-# request, so a broken build surfaces there, not here. What it builds
+# shells out to uv, so it is the lock that pins it. Not sphinx: docs.yml
+# already builds the docs, with --locked, on every pull request, so a
+# broken build surfaces there, not here. What it builds
 # against is the same lock this workflow exists to get ahead of, so a
 # sphinx break in the newest releases is the one gap this file leaves
 # open too, same as everywhere else in it.
@@ -52,10 +52,12 @@ on:
   schedule:
     # weekly, on a minute that is not the hour: everything scheduled on
     # the hour is queued together, and a run that waits is a run whose
-    # failure is noticed later. Wednesday, the day after published.yml's
-    # Tuesday: a fixed, already-released artifact is checked first, this
-    # the more volatile question. Thursday is left for Dependabot,
-    # opening the day after this has already reported.
+    # failure is noticed later. Wednesday, the day after codeql.yml's
+    # Tuesday, and the same morning macos.yml runs, half an hour after
+    # it -- that pairing is macos.yml's own comment. Thursday is left
+    # for Dependabot, opening the day after this has already reported.
+    # published.yml is on no weekday at all: its subject is an artifact
+    # already released and therefore fixed, so it asks monthly.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
     - cron: "43 4 * * 3"

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -89,10 +89,8 @@ jobs:
     name: Check the documentation links
     # a draft pull request is work in progress and spends no runner
     # here either: a draft is work its author is not asking anyone to
-    # a draft from one release to the next, and its runs are what
-    # read yet. The same condition lint.yml and
-    # test.yml carry, and ready_for_review is a trigger type above for
-    # the same reason.
+    # read yet. The same condition lint.yml and test.yml carry, and
+    # ready_for_review is a trigger type above for the same reason.
     # A closed pull request spends none either -- the trigger above takes
     # the closed event only to supersede a run this ref's group is still
     # holding
@@ -116,7 +114,12 @@ jobs:
           # reference rather than a link a reader clicks. What is checked
           # is what a user is invited to follow -- the README, which is
           # also the btclib.org homepage and the PyPI long description,
-          # the other root markdown files, and the documentation sources.
+          # the other root markdown files, the documentation sources, and
+          # the markdown kept under tests/, next to what it documents
+          # rather than at the root: README.md is how the suite is run and
+          # profiled, _data/README.md pins every vendored vector to a
+          # commit, and both are prose for a reader rather than a citation
+          # in a comment.
           # --no-progress because the log is not a terminal; the retries,
           # the timeout and the cache are what keep a slow or throttling
           # host from being reported as a dead one.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,7 +96,6 @@ jobs:
     # yet. A run on the merge result still happens the moment the pull
     # request is marked ready, which is why ready_for_review is a
     # trigger type above.
-    # The exception is by base branch, and it is the release pull
     # A closed pull request spends no runner either, for the reason the
     # trigger above gives: closed is taken only to supersede a run this
     # ref's group is still holding

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -35,7 +35,7 @@ on:
     # every repository that asked for the same minute, and the run can be
     # dropped outright when the queue is long.
     # The weekday sentinels run Monday through Thursday in the order the
-    # questions build on each other (links, published, latest, then
+    # questions build on each other (links, codeql, latest, then
     # Dependabot's pull request), and this one asks something on a
     # different axis entirely -- the suite's own quality, not a
     # dependency's -- which is what leaves it the weekend on its own.

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -12,8 +12,9 @@ name: published
 # btclib/ -- `git ls-files | grep '^btclib/.*_data/'` is which, the BIP39
 # wordlists among them -- are opened by path at the first call that needs
 # one, not imported, so a wheel missing one of them installs cleanly,
-# imports cleanly, and only fails there. dist's smoke test and release.yml's share that blind spot;
-# this workflow's second check is the one that does not have it.
+# imports cleanly, and only fails there. test.yml's dist job shares that
+# blind spot with its own smoke test; this workflow's second check is the
+# one that does not have it.
 #
 # Version-independent on purpose, checking a BIP39 vector and a BIP340
 # one whose values are fixed forever, so neither needs an edit after a
@@ -237,11 +238,11 @@ jobs:
           else
             uv pip install --verbose --only-binary btclib btclib
           fi
-      # the ecc surface, as dist and release.yml assert it: a signature
+      # the ecc surface, as test.yml's dist job asserts it: a signature
       # round trip is the one thing an import cannot get wrong by itself,
       # and a bindings release that installs and answers incorrectly is
       # what this catches.
-      # Those two assert one thing more, that the bindings are serving
+      # That one asserts something more, that the bindings are serving
       # (issue #1117), and this deliberately does not: the install above
       # names btclib and no extra, so the bindings are not asked for and
       # nothing here is entitled to them. That is the supported
@@ -297,7 +298,8 @@ jobs:
         # two are not equally likely to hide one. Measured against
         # https://pypi.org/pypi/btclib-secp256k1/json for the newest
         # release, 0.8.0.4: every platform below has a wheel for every
-        # supported interpreter, cp310 through cp315(t), so trying a
+        # supported interpreter, cp310 through cp315t, win_arm64's floor
+        # of cp311 excepted -- which is the paragraph below -- so trying a
         # second interpreter on a platform that already has one answers
         # the same "does a wheel exist and import here" question again.
         # A missing wheel is where the two publishing pipelines actually

--- a/.github/workflows/python-arm-authority.yml
+++ b/.github/workflows/python-arm-authority.yml
@@ -62,7 +62,9 @@ on:
     # hour: GitHub queues same-minute scheduled workflows across every
     # repository that asked for it, and a long queue can drop the run
     # outright. Minute 07 is not shared with any other cron in this
-    # repository (13, 17, 19, 23, 29, 31, 41, 43, 53)
+    # repository, which `grep -h 'cron:' .github/workflows/*.yml` is
+    # what re-derives -- a list written out here is complete only until
+    # the next workflow gains a schedule
     - cron: "07 4 15 * *"
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,9 +303,21 @@ jobs:
     name: Run the windows workflow
     uses: ./.github/workflows/windows.yml
 
+  # and the one required check on main this workflow was not asking for.
+  # `Regtest against Bitcoin Core` gates every merge, which is why it was
+  # left out and why leaving it out was wrong: a rehearsal is dispatched
+  # from a branch, and a tag is pushed at a commit whose merge that check
+  # answered for -- but the calls to test.yml, lint.yml and docs.yml are
+  # every one of them a required check too, made again here for exactly
+  # that reason. integration.yml declared `workflow_call` for this from
+  # the day it became a gate; nothing had ever called it
+  integration:
+    name: Run the integration workflow
+    uses: ./.github/workflows/integration.yml
+
   publish-testpypi:
     name: Publish to TestPyPI
-    needs: [test, lint, docs, macos, windows]
+    needs: [test, lint, docs, macos, windows, integration]
     if: github.event_name == 'workflow_dispatch' && github.repository == 'btclib-org/btclib'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -329,7 +341,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [test, lint, docs, macos, windows]
+    needs: [test, lint, docs, macos, windows, integration]
     if: github.event_name == 'push' && github.repository == 'btclib-org/btclib'
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -23,7 +23,10 @@ on:
     # links.yml's own cron comment gives -- GitHub queues same-minute
     # scheduled workflows across every repository that asked for it, and
     # a long queue can drop the run outright. Minute 53 is not shared
-    # with any other cron in this repository (17, 31, 41, 43)
+    # with any other cron in this repository, which
+    # `grep -h 'cron:' .github/workflows/*.yml` is what re-derives: a
+    # list written out here was complete when it was written and six
+    # crons short a fortnight later
     - cron: "53 4 1 * *"
   workflow_dispatch:
   pull_request:
@@ -67,10 +70,8 @@ jobs:
     name: Check vendored vectors against upstream
     # a draft pull request is work in progress and spends no runner
     # here either: a draft is work its author is not asking anyone to
-    # a draft from one release to the next, and its runs are what
-    # read yet. The same condition lint.yml and
-    # test.yml carry, and ready_for_review is a trigger type above for
-    # the same reason.
+    # read yet. The same condition lint.yml and test.yml carry, and
+    # ready_for_review is a trigger type above for the same reason.
     # A closed pull request spends none either -- the trigger above takes
     # the closed event only to supersede a run this ref's group is still
     # holding

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -125,8 +125,10 @@ jobs:
           ruby-version: "3.3.4"
           bundler-cache: true
       # PAGES_REPO_NWO is what jekyll-github-metadata resolves
-      # `site.github` from, and _layouts/default.html reads four of its
-      # fields. Unauthenticated, so the fields it cannot reach without a
+      # `site.github` from, and _layouts/default.html reads seven of its
+      # fields -- `grep -o 'site\.github\.[a-z_]*' _layouts/default.html
+      # | sort -u` is which, rather than a count to keep in step.
+      # Unauthenticated, so the fields it cannot reach without a
       # token are empty rather than wrong -- the claim this job makes is
       # that the site builds and its own links are well formed, not that
       # the metadata GitHub injects on its side is present here
@@ -141,12 +143,14 @@ jobs:
       # the sources; this is the same claim made about the artifact.
       #
       # An attribute of a real tag, not the string anywhere on the page:
-      # CHANGELOG.md, RELEASE_NOTES.md, SECURITY.md and AUTHORS.md all recount
-      # that defect and quote the broken tag, and a rendered page carries
-      # that prose with the `<` escaped as `&lt;` -- so requiring an
-      # unescaped `<tag ... src="` is what separates the page that has the
-      # bug from the page that describes it. Measured: the first run of
-      # this workflow failed on six such lines and no real URL
+      # CHANGELOG.md recounts that defect and quotes the broken tag, and
+      # CONTRIBUTING.md quotes the `%20` beside it. Both are published --
+      # _config.yml's exclude list is what decides that -- and a rendered
+      # page carries that prose with the `<` escaped as `&lt;`, so
+      # requiring an unescaped `<tag ... src="` is what separates the page
+      # that has the bug from the page that describes it. Measured: the
+      # first run of this workflow failed on six such lines and no real
+      # URL
       - name: The built pages carry no encoded-space URL
         run: |
           if grep -rEn '<[a-zA-Z]+[^>]+(src|href)="[^"]*%20' \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,74 @@ documented at release-notes length in the first place, and are still in
   at length — and neither `btclib/script/taproot.py` nor
   `tests/script/taproot_test.py` is in the filter that exists, which is
   exactly how this one got through.
+- **A release now waits for Bitcoin Core, and eleven workflow comments
+  say what this tree says** (btclib-org/.github#22). Every comment in
+  all seventeen workflow files was read end to end against the tree,
+  which is the half of that issue's method a mechanical pass cannot
+  run: the four claims `#1222` fixed were each found by comparing a
+  number or a name, and not one of the eleven below could have been.
+
+  The one that is not prose: `integration.yml` has declared
+  `workflow_call` since it became a gate, with a comment saying
+  "release.yml can reuse the answer", and `release.yml` has never
+  called it — in any commit. So a tag published without Core ever
+  having been asked whether it accepts what btclib built, while the
+  three *other* required checks on `main` are each called again from
+  `release.yml` for the reason that file gives: a rehearsal is
+  dispatched from a branch, where the branch rule has asked nothing.
+  `release.yml` now calls it and both publish jobs need it.
+
+  The ten comments, and what each was:
+
+    - `lint.yml`, `links.yml` and `vendored-vectors.yml` each kept a line of
+      the release-pull-request exemption that `237c86d4` removed. In
+      `lint.yml` it is the orphaned first line of four, describing a
+      `github.base_ref == 'master'` arm the `if:` has not carried since; in
+      the other two it is the *middle* line of the same comment, left in place
+      while the lines above and below it were rewritten, so the sentence reads
+      "a draft is work its author is not asking anyone to / a draft from one
+      release to the next, and its runs are what / read yet".
+    - `codeql.yml` said "of the analyses this repository has ever received,
+      every one is python or actions, and none is ruby", under a command that
+      reads the newest hundred and no more. 263 ruby analyses ran here, the
+      last on 2026-07-30 — so the command as written *confirmed* the claim by
+      never reaching one. The conclusion is right and now carries the evidence
+      that shows it: every one of the 263 has `results_count` 0.
+    - `codeql.yml` also said "every analysis this repository has received
+      carries `"build-mode":"none"` in its environment", with `--jq
+      '.[0].environment'` beside it. That answers `{"language":"python"}`:
+      what an analysis records there changed when the analysis moved into this
+      file, and 1046 of 3942 carry no such key.
+    - `website.yml` said `_layouts/default.html` reads four `site.github`
+      fields. It reads seven, and read seven the day the sentence was written.
+    - `website.yml` also named `CHANGELOG.md`, `RELEASE_NOTES.md`,
+      `SECURITY.md` and `AUTHORS.md` as the published files quoting the `%20`
+      tag the step below greps for. Only `CHANGELOG.md` ever did;
+      `CONTRIBUTING.md`, which does and is published, was not named.
+    - `latest.yml` and `mutation.yml` both put `published.yml` on Tuesday. It
+      is `31 4 1 * *` — monthly, on the first. Tuesday is `codeql`. This is
+      the claim `#1222` corrected in `integration.yml` and these two copies of
+      it survived.
+    - `latest.yml` sent a reader to "lint.yml's second job" for the
+      documentation build. That job left for `docs.yml` in `237c86d4`;
+      `lint.yml` has one job.
+    - `published.yml` credited a smoke test to `release.yml`, twice. `#1180`
+      moved the build into `test.yml`'s `dist` job the day before, and
+      `release.yml` no longer contains the word.
+    - `published.yml`'s first paragraph also carried a 99-column line where
+      every other comment line in all seventeen files fits 80 — an
+      un-rewrapped remainder of `#1222`'s own fix, which is what made it
+      findable at all.
+    - `published.yml` said every platform in its matrix has a wheel for every
+      supported interpreter, and excepted `win_arm64` below cp311 ten lines
+      further down. The exception is the true half.
+
+  Two enumerations were correct and are now commands.
+  `vendored-vectors.yml` listed the other crons' minutes as
+  "(17, 31, 41, 43)"; that was the complete set on 2026-08-06 and is
+  six short today. `python-arm-authority.yml`'s copy of the same list
+  is right, having been written later, and carries the same fragility —
+  both now name `grep -h 'cron:' .github/workflows/*.yml` instead.
 
 - **Why `bitcoin-core-rpc` is required and the bindings are an extra is
   written where a reader meets it** (issue #1131). Issue #1126 decided


### PR DESCRIPTION
The prose half of btclib-org/.github#22, in this repository: 2,968
comment lines across all seventeen workflow files, read end to end
against the tree rather than grepped. **Eleven claims were wrong**, and
not one of them is a shape the mechanical pass (#1222) could have
reached — that pass compared numbers and names a command re-derives,
and every claim below reads exactly like a true one.

## The one that is not a comment

`integration.yml` has declared `workflow_call:` since it became a gate,
under a comment saying **"so release.yml can reuse the answer"**.
`release.yml` has never called it. `git log -S 'workflows/integration.yml'`
on `release.yml` returns nothing, in any commit.

So a tag is published without Bitcoin Core having been asked whether it
accepts what btclib built — while `test.yml`, `lint.yml` and `docs.yml`,
the three *other* required checks on `main`, are each called again from
`release.yml`, for the reason that file gives at each: a rehearsal is
dispatched from a branch, where the branch rule has asked nothing.
`integration` was the fourth required check and the only one left out.

`release.yml` now calls it, and both publish jobs need it. 36 seconds of
work and one bitcoind download, once per release.

## The ten comments

| where | the claim | what is true |
| --- | --- | --- |
| `lint.yml:99` | "The exception is by base branch, and it is the release pull" | a sentence cut mid-clause: the orphaned first line of a four-line comment `237c86d4` removed with the `github.base_ref == 'master'` arm it described |
| `links.yml:92`, `vendored-vectors.yml:70` | "…is not asking anyone to / **a draft from one release to the next, and its runs are what** / read yet" | the *middle* line of that same removed comment, left standing while the lines above and below it were rewritten around it |
| `codeql.yml:27` | "of the analyses this repository has ever received … none is ruby" | **263 ruby analyses ran here**, the last on 2026-07-30. The cited command asks `per_page=100` and does not paginate, so it reads the newest hundred — all python and actions — and **confirms the false claim by never reaching one** |
| `codeql.yml:169` | "every analysis this repository has received carries `\"build-mode\":\"none\"`", with `--jq '.[0].environment'` | that answers `{\"language\":\"python\"}`. What an analysis records there changed the moment the analysis moved into this file; 1046 of 3942 carry no such key |
| `website.yml:128` | `_layouts/default.html` "reads **four** of its fields" | seven — and seven at the commit that wrote the sentence |
| `website.yml:144` | `CHANGELOG.md`, `RELEASE_NOTES.md`, `SECURITY.md`, `AUTHORS.md` "all recount that defect and quote the broken tag" | only `CHANGELOG.md` ever did. `CONTRIBUTING.md` does, and is published, and is not named — wrong in both directions |
| `latest.yml:55`, `mutation.yml:38` | "published.yml's **Tuesday**" / "links, **published**, latest, then Dependabot" | `published.yml` is `31 4 1 * *`: monthly, on the first, no weekday at all. Tuesday is `codeql` |
| `latest.yml:36` | "**lint.yml's second job** already builds the docs" | `237c86d4` moved it to `docs.yml`; `lint.yml` has one job |
| `published.yml:15,240` | "dist's smoke test **and release.yml's**" (twice) | #1180 moved the build into `test.yml`'s `dist` job the day before this was read; `release.yml` does not contain the word |
| `published.yml:299` | "every platform below has a wheel for every supported interpreter, cp310 through cp315(t)" | contradicted ten lines below by the same block, correctly: `btclib_secp256k1` 0.8.0.4 publishes 72 wheels and none is `win_arm64` cp310 |

## What each one says about the method

Three are worth calling out because they are about how a sweep finds
things rather than about these files.

**`codeql.yml`'s ruby claim is the trap #22's own method comment names,
in its sharpest form.** Running the command as written does not fail to
support the claim — it *supports* it. Only `--paginate` disproves it.
The conclusion ("it analyses nothing") is right, and the command that
actually shows it is now there: all 263 have `results_count` 0.

**`published.yml`'s 99-column line is mine, twelve hours old.** #1222
rewrapped that paragraph and left one line at 99 columns where every
other comment line in all seventeen files fits 80. That anomalous width
is what made the paragraph get read again, which is how the two stale
`release.yml` references were found — a width is the one thing about a
comment a reader notices without reading it.

**`latest.yml` and `mutation.yml` are #176's shape, one repository
over**: a pass that corrected three instances of a defect and missed a
fourth. #1222 fixed exactly this sentence in `integration.yml`.

## Two enumerations that were right

`vendored-vectors.yml` gave the other crons' minutes as `(17, 31, 41,
43)`. That was the **complete** set on 2026-08-06 and is six short
today. `python-arm-authority.yml` carries the same list, complete,
having been written after them — and with the same fragility. Both now
name `grep -h 'cron:' .github/workflows/*.yml`, the idiom
btclib-secp256k1's own `codeql.yml` already uses, instead of a list the
next schedule invalidates.

## What was checked and passed

`docs.yml`, `test.yml`, `release.yml`, `hwi-integration.yml`,
`claude-review.yml`, `macos.yml`, `windows.yml` and `integration.yml`'s
prose carry nothing this sweep could disagree with. Every command any
of them tells a reader to run was run: the readthedocs and CONTRIBUTING
copies of the sphinx command match; `pages` answers `build_type:
legacy`; versions.json still says ruby 3.3.4, github-pages 232, jekyll
3.10.0; the 21 mutation tomls referenced all exist and none is unused;
`hwi_device_test.py` holds the three tests its guard demands; `20 * 10 +
19 * 30 = 770` against a 1200s ceiling is the 36% margin `release.yml`
claims; and `main`'s four required checks are what REPOSITORY.md's table
says.

Closes nothing: btclib-org/.github#22's `btclib` box, and the
btclib-secp256k1 half is next.

btclib-org/.github#22

## Summary by Sourcery

Make release publication depend on Bitcoin Core integration validation and bring workflow documentation into agreement with the repository.

Bug Fixes:
- Require Bitcoin Core integration checks to pass before either TestPyPI or PyPI publication.

Enhancements:
- Correct stale workflow comments and replace fragile hard-coded repository facts with commands or evidence that can be revalidated.
- Clarify workflow schedules, documentation ownership, published-file coverage, CodeQL history, and package wheel support across the workflow prose.

Documentation:
- Document the comprehensive review and correction of workflow comments in the changelog.