### PR TITLE
The Python-arm census reads the merge commit (issue #1003)

### DIFF
--- a/.github/workflows/python-arm-authority.yml
+++ b/.github/workflows/python-arm-authority.yml
@@ -41,6 +41,21 @@ name: python arm authority
 # make for a comparable reason.
 
 on:
+  # a merge creates a commit no pull request measured, and this census is
+  # the one gate here with nothing on that commit: issue #1219 removed an
+  # arm and the entry that named `script/taproot_test.py` with it, both
+  # correctly, and the same change made that module reach
+  # `bytes_from_prv_key_int` instead. Its own run was green two hours
+  # before it landed, on a tree that stopped being the tree, and main
+  # carried the disagreement until the next pull request to touch a path
+  # below happened to run this.
+  # No `paths` filter here, where the pull_request trigger has one: the
+  # surface a run reads is every module `_THIRD_PARTY_VECTORS` names plus
+  # every arm's own module -- most of the package and most of the suite --
+  # so a filter that named it honestly would be "every merge", spelled at
+  # length and wrong the next time a module moves
+  push:
+    branches: [main]
   schedule:
     # the 15th of the month, 04:07 UTC. Not the 1st, which
     # `vendored-vectors` and `published` already share, and not on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,37 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **The Python-arm census runs on the merge commit, and names
+  `script/taproot_test.py`** (issue #1003). `main` was red on
+  `Re-derive the Python-arm authority table` and nothing said so: the
+  workflow had no `push` trigger, so no run ever measured a merge
+  commit, and the disagreement was waiting for the 15th.
+
+  What drifted, and it took two correct changes to do it. #1219 removed
+  the `script.taproot._output_pubkey_and_internal_key` arm — the guard
+  it named is gone, the `cached_property` replacing it being the point
+  of that change — and removed the `_AUTHORITY` entry naming it, which
+  was the only entry that mentioned `script/taproot_test.py`. The same
+  change made that module reach `curves.sec_point.bytes_from_prv_key_int`
+  instead, and nothing added it there. #1219's own census run was green
+  two hours before it landed, on a tree that had stopped being the tree
+  by the time it did.
+
+  The entry now names it, re-derived rather than reasoned about: a fresh
+  no-bindings measurement of every module `_THIRD_PARTY_VECTORS` names
+  agrees with the table again.
+
+  And the workflow triggers on a push to `main`, which is the trigger
+  every other gate here carries for the reason `lint.yml` writes down —
+  a merge creates a commit that is not the one the pull request tested.
+  No `paths` filter on it, where the `pull_request` trigger has one:
+  what a run reads is every module `_THIRD_PARTY_VECTORS` names plus
+  every arm's own module, which is most of the package and most of the
+  suite, so a filter naming that honestly would be "every merge" spelled
+  at length — and neither `btclib/script/taproot.py` nor
+  `tests/script/taproot_test.py` is in the filter that exists, which is
+  exactly how this one got through.
+
 - **Why `bitcoin-core-rpc` is required and the bindings are an extra is
   written where a reader meets it** (issue #1131). Issue #1126 decided
   it and closed on the decision; neither `pyproject.toml`'s comment

--- a/tests/python_arm_authority_test.py
+++ b/tests/python_arm_authority_test.py
@@ -248,6 +248,7 @@ _AUTHORITY: dict[str, tuple[str, ...]] = {
         "ecc/musig2_test.py",
         "script/sig_hash_legacy_test.py",
         "script/sig_hash_taproot_test.py",
+        "script/taproot_test.py",
         "script_engine/script_test.py",
     ),
     "ecc.bms.assert_as_valid": ("bip322_test.py", "ecc/bms_test.py"),


### PR DESCRIPTION
**`main` is red on `Re-derive the Python-arm authority table` right now,
and nothing said so.** Reproduced on a clean checkout of `origin/main`,
not on a branch:

```
UNDERSTATED: curves.sec_point.bytes_from_prv_key_int is reached by
['script/taproot_test.py'], not named in its entry
1 disagreement(s) with a fresh measurement.
```

## How, and why neither review caught it

Two changes, each correct on its own.

`#1219` removed the `script.taproot._output_pubkey_and_internal_key`
arm — deleting that guard is what the change exists for, the
`cached_property` being its replacement — and removed the `_AUTHORITY`
entry that named it. That entry was the only one mentioning
`script/taproot_test.py`. The same change made that module reach
`curves.sec_point.bytes_from_prv_key_int` instead, and nothing added it
there.

`#1219`'s own census run was green at **02:14**. It landed at **04:25**.
Nothing measured the tree the merge produced, because this workflow has
no `push` trigger, and the disagreement sat on `main` until a pull
request happened to touch one of the three paths its filter names — which
is what btclib-org/.github#22's sweep did an hour ago, by editing a
comment in this very file.

## What this changes

**The entry names it**, re-derived rather than reasoned about. A fresh
no-bindings measurement over every module `_THIRD_PARTY_VECTORS` names
now agrees with the whole table:

```
$ uv run --locked --no-default-groups --group harness \
    python .github/scripts/check_python_arm_authority.py
Every _AUTHORITY entry matches a fresh no-bindings measurement.
```

**The workflow triggers on a push to `main`.** That is the trigger every
other gate here carries, for the reason `lint.yml` writes down at the
same key: *a merge creates a commit that is not the one the pull request
tested.* This census was the one without it.

**No `paths` filter on that trigger**, where `pull_request` has one, and
the asymmetry is the finding rather than an oversight. What a run reads
is every module `_THIRD_PARTY_VECTORS` names plus every arm's own
module — most of the package and most of the suite — so a filter naming
that honestly would be "every merge" spelled at length, and wrong the
next time a module moves. The filter that exists names this workflow,
its script and its test module, and **neither `btclib/script/taproot.py`
nor `tests/script/taproot_test.py` is among them**, which is precisely
how this got through.

Cost: one ~3-minute job per push to `main`. It gates nothing — the check
is not in `main`'s required set — so a red here is a report, not a block.

## What was considered and not done

Widening the `pull_request` filter to `btclib/**` and `tests/**` covers
the same drift and is nearly "every pull request" written out, against a
job the file's own header describes as minutes rather than seconds —
which is the reason issue #1003 put it on a schedule in the first place.
Measuring the merge commit costs one run instead of one per push to a
branch.

Issue #1003

## Summary by Sourcery

Ensure the Python-arm authority census validates merge commits and accurately tracks Taproot test coverage.

Bug Fixes:
- Correct the Python-arm authority table by adding the missing `script/taproot_test.py` entry.

Enhancements:
- Run the Python-arm census on pushes to `main` without a path filter so merge commits are validated.

CI:
- Add push-to-`main` coverage to the Python-arm authority workflow.

Documentation:
- Document the Python-arm census drift fix and merge-commit validation in the changelog.

Tests:
- Update the Python-arm authority test fixture to include `script/taproot_test.py`.