### PR TITLE
ssa takes an x-only key and not an extended one (issue #1188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1113,6 +1113,62 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **`ecc.ssa` stops taking an extended key**, and `BIP340PubKey`
+  narrows from `Integer | Octets | BIP32Key | Point | PreparedPoint` to
+  `int | Octets | Point | PreparedPoint` (issue #1188). An extended key
+  is bip32's object, and turning one into a public key is bip32's call
+  to make; `ssa` is the module #1188 names as reaching it *around* the
+  converters rather than through them, by importing `BIP32Key` itself.
+
+  Dropping the union alone would have changed nothing. The spellings did
+  not arrive through that annotation: they arrived through
+  `to_pub_key.point_from_pub_key`, whose own union names `BIP32KeyData`,
+  so an annotation without `BIP32Key` in front of a body that still
+  called it would have said one thing and done another. What withdraws
+  them is `ssa` parsing the spellings itself, with `curves`, and that is
+  also what leaves the module free of `to_pub_key` on its public-key
+  side.
+
+  The dispatch that replaces it is a branch per type where there was a
+  `contextlib.suppress` around a guess — the module's own comment called
+  it one, "this being a guess at the spelling". Refusals improve as a
+  consequence, each of them a case the guess used to swallow.
+
+  A `Point` off the curve, and the point at infinity, were
+  `BTClibTypeError` "not a BIP340 public key" and are now
+  `BTClibValueError` naming the point. That is a class change as well as
+  a message: a point that is not on the curve is a wrong value and not a
+  wrong type, and it read as the second only because the suppress caught
+  the accurate refusal and let the function fall through to its own.
+
+  Thirty-three or sixty-five octets that are no point were "invalid
+  size: 33 bytes instead of 32" — the size complaint of the x-only path
+  they fell through to — and are now what `point_from_octets` says of
+  them, a prefix or a curve.
+
+  Octets of any other size were "invalid size: N bytes instead of 32"
+  and now name all three sizes this function accepts. Delegating that
+  complaint would name the two `point_from_octets` knows and so call
+  BIP340's own encoding wrong.
+
+  A tuple that is malformed or out of range moves with them. Where it is
+  the shape or the y that is wrong, the refusal is now `curve_group`'s --
+  "point must be a tuple[int, int]", or the negative-integer complaint;
+  a bad x is still this module's own "not a valid public key", the
+  on-curve test reaching it first. The class changes in every case, the
+  wording in some.
+
+  One thing widens. A `bytearray` or `memoryview` reached
+  `point_from_octets` at the SEC sizes and was refused at the x-only
+  one, whose fallback asked for `(str, bytes)`; the branch per size
+  takes them at all three. They are the buffers `bytes_from_octets`
+  accepts beside `Octets`, and `to_pub_key` names the same asymmetry
+  between what a union declares and what the run time takes.
+
+  Nothing in this package passed an extended key to `ssa`: its callers
+  pass x-only octets or points. The only exercise of the spelling was a
+  test that built an xpub and then replaced its key field with a point.
+
 - **`fingerprint` moves from `to_pub_key` to `bip32`**, and takes a
   `BIP32Key` where it took anything a key can be spelled as (issue
   #1188). The four octets are bip32's own idea — nothing outside its

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,55 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **`ecc.ssa` no longer accepts a BIP32 extended key as a BIP340 public
+  key** (issue #1188). `BIP340PubKey` was
+
+  ```python
+  BIP340PubKey = Integer | Octets | BIP32Key | Point | PreparedPoint
+  ```
+
+  — with `BIP32Key` in it as far back as `v2023.7.12` — and is now
+
+  ```python
+  BIP340PubKey = int | Octets | Point | PreparedPoint
+  ```
+
+  Act on it if you pass a **public** extended key — an xpub as text, the
+  same text as ASCII bytes, or a public `BIP32KeyData` — to
+  `ssa.verify`, `ssa.verify_`, `ssa.assert_as_valid`,
+  `ssa.assert_as_valid_`, `ssa.point_from_bip340pub_key` or the
+  batch-verification entry points. That is the whole of the withdrawal:
+  an xprv and a private `BIP32KeyData` were refused before this change
+  too, the first as octets it could not parse and the second by name.
+
+  Convert it first. From a `BIP32KeyData` the public key is `.key`, and
+  from either text spelling it is `BIP32KeyData.b58decode(xpub).key`:
+  33 compressed SEC octets, which these still take. One check does not
+  survive the conversion: an xpub handed to a non-secp256k1 `ec` was
+  refused, its version bytes matched against the curve — as text the
+  complaint that surfaced was about octets, as a `BIP32KeyData` it was
+  about the type. The 33 octets carry no version, so nothing compares
+  them to the curve; what is left is the lift, which on a curve of the
+  same size answers for about half of them and refuses the rest. On
+  `secp256k1`, which is BIP340's curve, the answer is the same as
+  before.
+
+  Everything else is unchanged, and one thing is wider: an `int`, the
+  p-size octets BIP340 defines, 33 or 65 SEC octets, their hex, a
+  `Point` and a `PreparedPoint` all still work, and a `bytearray` or
+  `memoryview` now works at the p-size too, where before it worked only
+  at the SEC sizes.
+
+  Refusals move as well, and the one to act on is a class change. What
+  the old dispatch could not tell apart it reported as a type error,
+  and each of those is a value error now: a `Point` off the curve, the
+  point at infinity, a tuple that is malformed or out of range, a
+  buffer of no key size, and a buffer of a key size that is no point.
+  Code catching `BTClibTypeError` alone around any of them has to
+  widen to `BTClibValueError` or to `BTClibException` — which is the
+  rule rather than the list, the list being what was measured.
+  CHANGELOG.md has the wording changes, which need no action.
+
 - **`fingerprint` is `btclib.bip32`'s, and takes a BIP32 key** (issue
   #1188). It was
 

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -52,7 +52,6 @@ ECDSA.
 
 from __future__ import annotations
 
-import contextlib
 import secrets
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -61,9 +60,8 @@ from types import TracebackType
 from typing import overload
 
 from btclib._libsecp256k1 import ssa as libsecp256k1_ssa
-from btclib.alias import BinaryData, HashF, Integer, JacPoint, Octets, Point
-from btclib.bip32 import BIP32Key
-from btclib.curves import Curve, PreparedPoint, secp256k1
+from btclib.alias import BinaryData, HashF, JacPoint, Octets, Point
+from btclib.curves import Curve, PreparedPoint, point_from_octets, secp256k1
 from btclib.curves.curve import (
     _assert_valid_ec,
     _is_x_coordinate_var,
@@ -80,7 +78,6 @@ from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueEr
 from btclib.hashes import _assert_valid_hf, reduce_to_hlen, tagged_hash
 from btclib.number_theory import mod_inv_var
 from btclib.to_prv_key import PrvKey, int_from_prv_key
-from btclib.to_pub_key import point_from_pub_key
 from btclib.utils import (
     assert_no_trailing,
     assert_type,
@@ -231,11 +228,13 @@ class Sig:
         return cls(r, s, ec, check_validity=check_validity)
 
 
-# hex-string or bytes representation of an int
-# 33 or 65 bytes or hex-string
-# BIP32Key as dict or String
-# tuple Point
-BIP340PubKey = Integer | Octets | BIP32Key | Point | PreparedPoint
+# an x-only key is an x, and these are the ways of writing one down:
+# the integer itself; p-size octets or their hex, which is BIP340's own
+# encoding of it; the 33 or 65 octets of a SEC point, whose x it is; and
+# the point, prepared or not. An extended key is not among them -- it is
+# bip32's object, and turning one into a key is bip32's call to make
+# (issue #1188)
+BIP340PubKey = int | Octets | Point | PreparedPoint
 
 
 def _x_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve) -> int:
@@ -252,20 +251,49 @@ def _x_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve) -> int:
     anything: it is validated as far as its spelling goes, and whoever
     lifts or parses it is what refuses the rest. Private for that reason.
     """
-    # BIP340 key as integer
+    # BIP340 key as integer. A bool is one to `isinstance` and is
+    # answered as the number it subclasses, as the key converters do and
+    # as `utils.is_integer` exists to stop elsewhere -- `var_int` and a
+    # satoshi amount refuse one. Which of the two rules the key path
+    # should follow is issue #1206, and is not settled in passing
     if isinstance(x_Q, int):
         return x_Q
 
-    # (tuple) Point, (dict or str) BIP32Key, or 33/65 bytes
-    # both classes, this being a guess at the spelling: a type no public
-    # key has may still be a BIP340 one -- an int is, and is a private
-    # key to `to_pub_key` -- so the refusal that names BIP340 is the one
-    # at the end
-    with contextlib.suppress(BTClibTypeError, BTClibValueError):
-        return point_from_pub_key(x_Q, ec)[0]
-    # BIP340 key as bytes or hex-string
-    if isinstance(x_Q, (str, bytes)):
-        return int.from_bytes(bytes_from_octets(x_Q, ec.p_size), "big", signed=False)
+    if isinstance(x_Q, PreparedPoint):
+        x_Q = x_Q.point
+    if isinstance(x_Q, tuple):
+        # the same check `to_pub_key.point_from_pub_key` made for a point
+        # before this function stopped going through it: on the curve,
+        # and a y that is not zero -- `alias` marks infinity that way,
+        # no affine point of a prime-order group having y = 0
+        if ec.is_on_curve(x_Q) and x_Q[1] != 0:
+            return x_Q[0]
+        raise BTClibValueError(f"not a valid public key: {x_Q}")
+
+    if isinstance(x_Q, (str, bytes, bytearray, memoryview)):
+        # the buffers beside `Octets`, which is `bytes | str`: they are
+        # what `bytes_from_octets` takes and returns as they came, and
+        # what `to_pub_key` names at run time beside the static union.
+        # Accepted at all three sizes here, where the dispatch this
+        # replaces took them at the SEC two and refused them at the
+        # x-only one, its fallback having asked for `(str, bytes)`
+        #
+        # the two octet spellings are told apart by length and not by
+        # trying one and catching the other: p-size is BIP340's x-only
+        # encoding, and the SEC sizes are a point whose x this wants.
+        # `point_from_octets` is the parse and the proof for the second,
+        # where the first is unproved here on purpose -- what an x-only
+        # key is unlifted is an x, and the docstring above says who
+        # proves it
+        # the sizes go to `bytes_from_octets` rather than to
+        # `point_from_octets`, which knows the SEC two: the x-only one is
+        # this function's to accept, so a caller refused by the parse
+        # below would be told that BIP340's own encoding is a wrong size
+        sizes = (ec.p_size, ec.p_size + 1, 2 * ec.p_size + 1)
+        octets = bytes_from_octets(x_Q, sizes)
+        if len(octets) == ec.p_size:
+            return int.from_bytes(octets, "big", signed=False)
+        return point_from_octets(octets, ec)[0]
 
     raise BTClibTypeError("not a BIP340 public key")
 
@@ -275,9 +303,10 @@ def point_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve = secp256k1) -> Point:
 
     It supports:
 
-    - BIP32 extended keys (bytes, string, or BIP32KeyData)
-    - SEC Octets (bytes or hex-string, with 02, 03, or 04 prefix)
+    - an int, the x-coordinate itself
     - BIP340 Octets (bytes or hex-string, p-size Point x-coordinate)
+    - SEC Octets (bytes or hex-string, with 02, 03, or 04 prefix)
+    - a PreparedPoint, read as the point it holds
     - native tuple
     """
     _assert_valid_ec(ec)

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -74,10 +74,13 @@ def test_signature() -> None:
     with pytest.raises(BTClibRuntimeError, match=err_msg):
         ssa.assert_as_valid(msg, x_Q_fake, sig)
 
-    err_msg = "not a BIP340 public key"
-    with pytest.raises(BTClibTypeError, match=err_msg):
+    # a value and not a type: the point at infinity is a `Point`, and
+    # what is wrong with it is which point it is. It read as a type error
+    # until the spelling dispatch stopped guessing (issue #1188)
+    err_msg = "not a valid public key"
+    with pytest.raises(BTClibValueError, match=err_msg):
         ssa.assert_as_valid(msg, INF, sig)
-    with pytest.raises(BTClibTypeError, match=err_msg):
+    with pytest.raises(BTClibValueError, match=err_msg):
         ssa.point_from_bip340pub_key(INF)
 
     sig_invalid = ssa.Sig(sig.ec.p, sig.s, check_validity=False)
@@ -291,17 +294,89 @@ def test_point_from_bip340pub_key() -> None:
         ssa.point_from_bip340pub_key(bytes_from_point(Q, compressed=False).hex()) == Q
     )
 
+
+def test_an_extended_key_is_no_longer_a_bip340_key() -> None:
+    """The three spellings of a public xpub, refused (issue #1188).
+
+    An extended key is bip32's object, and turning one into a public key
+    is bip32's call to make; `ssa` reaching it was `to_pub_key`'s doing,
+    through a `point_from_pub_key` whose own union names `BIP32KeyData`.
+    Dropping that import is what withdraws all three at once, and the
+    annotation would otherwise say so while the code went on accepting
+    them.
+
+    The key field is replaced with a point of the curve, so what refuses
+    these is their being extended keys and not their contents. Only the
+    public half is here because only the public half ever arrived: an
+    xprv was refused as octets that would not parse, and a private
+    `BIP32KeyData` by name, both before this change.
+    """
+    q, _ = ssa.gen_keys()
+    Q = mult(q)
     xpub_data = BIP32KeyData.b58decode(
         "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy"
     )
     xpub_data = replace_unchecked(xpub_data, key=bytes_from_point(Q))
-    # BIP32KeyData
-    assert ssa.point_from_bip340pub_key(xpub_data) == Q
-    # BIP32Key encoded str
     xpub = xpub_data.b58encode()
-    assert ssa.point_from_bip340pub_key(xpub) == Q
-    # BIP32Key str
-    assert ssa.point_from_bip340pub_key(xpub.encode("ascii")) == Q
+
+    with pytest.raises(BTClibTypeError, match="not a BIP340 public key"):
+        ssa.point_from_bip340pub_key(xpub_data)
+    # the two text spellings are refused as the octets they are not, and
+    # not by the same complaint: a `str` is read as hex and the Base58
+    # alphabet is not hex, where the same characters as `bytes` are
+    # already octets and are refused for their length. Both are what
+    # dropping the union leaves -- a string reaching here is octets or
+    # it is nothing
+    with pytest.raises(BTClibValueError, match="invalid hex string"):
+        ssa.point_from_bip340pub_key(xpub)
+    err_msg = r"invalid size: 111 bytes instead of \(32, 33, 65\)"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        ssa.point_from_bip340pub_key(xpub.encode("ascii"))
+
+
+def test_a_buffer_is_octets_at_every_size_this_takes() -> None:
+    """A bytearray and a memoryview, at all three sizes (issue #1188).
+
+    They are what `bytes_from_octets` accepts beside `Octets` and returns
+    as they came, and what `to_pub_key` names at run time beside the
+    static union -- the asymmetry `alias` states and this module
+    inherits.
+
+    All three sizes because two of them worked and one did not: the
+    dispatch this replaces reached `point_from_octets` for a SEC key,
+    which takes any buffer, and fell through to an x-only branch that
+    asked for `(str, bytes)` and so refused the same value one size
+    down. Nothing decided that; it was where the fallback sat.
+    """
+    q, x_Q = ssa.gen_keys()
+    Q = mult(q)
+    spellings = (
+        x_Q.to_bytes(32, "big"),
+        bytes_from_point(Q),
+        bytes_from_point(Q, compressed=False),
+    )
+
+    for octets in spellings:
+        # `Any`, because `Octets` is `bytes | str` and these are neither:
+        # the annotation is narrower than what every consumer of it
+        # takes, which is the asymmetry issue #1238 asks about
+        buffers: tuple[Any, ...] = (bytearray(octets), memoryview(octets))
+        for buffer in buffers:
+            assert ssa.point_from_bip340pub_key(buffer) == Q
+
+
+def test_octets_of_no_key_size_name_every_size_there_is() -> None:
+    """Three sizes are accepted here, so three are named (issue #1188).
+
+    `point_from_octets` knows two of them, the SEC pair, and this module
+    adds the x-only one on top -- so a refusal delegated to it would
+    tell a caller that 32 octets are wrong when they are the spelling
+    BIP340 itself defines.
+    """
+    for size in (0, 31, 34, 64):
+        err_msg = f"invalid size: {size} bytes instead of \\(32, 33, 65\\)"
+        with pytest.raises(BTClibValueError, match=err_msg):
+            ssa.point_from_bip340pub_key(b"\x11" * size)
 
 
 def test_low_cardinality() -> None:


### PR DESCRIPTION
The checkbox [ISS #1188](https://github.com/btclib-org/btclib/issues/1188)
says the converters' removal does not reach: `ssa` declares its own union
and imports `BIP32Key` itself, so abandoning `to_prv_key` and
`to_pub_key` is necessary and not sufficient for a curve-generic `ecc`.

```python
BIP340PubKey = Integer | Octets | BIP32Key | Point | PreparedPoint   # was
BIP340PubKey = int | Octets | Point | PreparedPoint                  # is
```

`Integer` goes with `BIP32Key` because `Integer` is `bytes | str | int`
and `Octets` is `bytes | str`, so the union named the octets twice.

## Narrowing the annotation alone would have changed nothing

The extended-key spellings did not arrive through this union. They
arrived through `to_pub_key.point_from_pub_key`, whose own union names
`BIP32KeyData` — so an annotation without `BIP32Key` in front of a body
that still called it would have said one thing and done another, which
is the defect this sequence exists to remove rather than to relocate.

What withdraws them is `ssa` parsing the spellings itself with `curves`,
and that is also what leaves the module free of `to_pub_key` on its
public-key side. The dispatch that replaces it is a branch per type
where there was a `contextlib.suppress` around a guess — the module's
own comment called it one, "this being a guess at the spelling".

## What moves, measured

Old against new over 141 cases — 47 spellings × three curves, two of
them of `secp256k1`'s size and one smaller — run against a snapshot of
`origin/main`:

- **Withdrawn**: the three spellings of a public xpub (text, ASCII
  bytes, `BIP32KeyData`). An xprv and a private `BIP32KeyData` were
  refused before this change too.
- **Widened**: a `bytearray` or `memoryview` at the x-only size. The old
  dispatch took buffers at the SEC sizes, through `point_from_octets`,
  and refused them one size down, where its fallback asked for
  `(str, bytes)`. Nothing decided that; it was where the fallback sat.
- **Refusals improve**, each a case the guess used to swallow: an
  off-curve `Point` and the point at infinity were `BTClibTypeError`
  where the accurate `BTClibValueError` had been raised and caught;
  SEC octets that are no point were told "invalid size: 33 bytes instead
  of 32", the complaint of the x-only path they fell through to.
- Nothing else moves.

Octets of no key size are refused by `bytes_from_octets`, handed all
three sizes this function takes rather than the SEC two
`point_from_octets` knows — a caller told `(33, 65)` would be told that
BIP340's own encoding is a wrong size.

## Two design questions this surfaced, filed rather than answered here

- [ISS #1238](https://github.com/btclib-org/btclib/issues/1238):
  `Octets` is `bytes | str` and every consumer of it takes a `bytearray`
  and a `memoryview` too. The buffers are accepted here for consistency
  with the tree, not for compatibility; that the annotation does not say
  so is real, bigger than `ssa`, and the recommendation is to widen the
  alias and let mypy check the buffer paths it currently cannot see.
- [ISS #1206](https://github.com/btclib-org/btclib/issues/1206): a bool
  is still answered as the number it subclasses, as the key converters
  do — not as everywhere else, `utils.is_integer` existing to stop one
  reaching a var_int or a satoshi amount. Refusing it in `ssa` alone
  would put it at odds with `int_from_prv_key`, so the rule belongs to
  the whole key path at once.

## What was run

On this sha, after the rebase:

- `uv run pytest` — exit 0, coverage 100.00%
- `uv run pre-commit run --all-files` — exit 0
- the documented sphinx `-W --keep-going` build — exit 0

Three local review rounds, each verifying claims by executing them. They
caught a buffer withdrawal I had not noticed and three false sentences,
including a claim that the converted SEC octets are "accepted by any
curve of the same size" — measured, a same-size curve accepts about half
and refuses the rest, because what the conversion loses is the curve
check and what is left is the lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hde6RUtTpqFBkPziUqzZkX

## Summary by Sourcery

Make `ecc.ssa` parse only supported BIP340 public-key forms directly instead of accepting extended keys through the generic public-key converter.

Bug Fixes:
- Stop `ecc.ssa` from accepting BIP32 extended public keys as BIP340 public keys.
- Report invalid BIP340 public-key values with value errors and accurate size or point-validation messages.

Enhancements:
- Narrow the BIP340 public-key API to integers, octets, points, and prepared points while preserving SEC and x-only key support.
- Accept bytearray and memoryview inputs at all supported key sizes.

Documentation:
- Document the breaking change, migration guidance, supported key forms, and updated error behavior in the changelog and release notes.

Tests:
- Add coverage for rejecting extended keys, accepting buffers across all supported sizes, and reporting unsupported octet lengths.