### PR TITLE
A Dependabot pull request can be reviewed (issue btclib-org/.github#77)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -118,6 +118,18 @@ jobs:
         uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # dependabot opens a pull request here every Thursday, and the
+          # action refuses a run a bot initiated unless that bot is named:
+          # "Workflow initiated by non-human actor". Without this those are
+          # the one class of pull request that can never carry the ack of
+          # record, which REVIEWING.md says comes from this workflow.
+          # Named rather than `*`, which this input's own description warns
+          # against on a public repository: with it an external App could
+          # invoke this action carrying a prompt it wrote.
+          # The mention job below takes no such input, deliberately -- what
+          # triggers it is somebody writing @claude, and a bot doing that
+          # is not a thing this repository has asked for
+          allowed_bots: "dependabot[bot]"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,27 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **A Dependabot pull request can be reviewed**
+  (btclib-org/.github#77). `claude-review.yml`'s review job fails on one,
+  twice over. The credential is the first half and is fixed off the tree:
+  a `pull_request` run whose actor is `dependabot[bot]` reads from
+  GitHub's Dependabot secret store rather than from Actions secrets, and
+  that store was empty, so the guard fired exactly as designed. The
+  second half is this: the action refuses a run a bot initiated unless
+  the bot is named — "Workflow initiated by non-human actor".
+
+  `allowed_bots: "dependabot[bot]"`, named rather than `*`: the input's
+  own description warns that on a public repository `*` lets an external
+  App invoke the action carrying a prompt it wrote. The mention job takes
+  no such input, what triggers it being somebody writing `@claude`.
+
+  Without it a Dependabot pull request is the one class that can never
+  carry the ack of record `REVIEWING.md` requires — the class whose whole
+  value is landing promptly, `latest.yml` having reported on the same
+  upgrade the day before. Measured on btclib-org/bitcoin-core-rpc#207,
+  the first Dependabot pull request opened after the credential guard
+  landed.
+
 - **The Slack badge is gone from README.md and CONTRIBUTING.md**, and
   with it the "come find us on Slack" bullet that opened the second. A
   badge reports state, which is the criterion the badge block's own


### PR DESCRIPTION
`claude-review.yml`'s review job failed on #207, the first Dependabot
pull request opened since the credential guard landed, and it failed
**twice for two different reasons**. btclib-org/.github#77 has the first;
this is the second.

## First: the credential was in the wrong store

A `pull_request` run whose actor is `dependabot[bot]` reads from GitHub's
**Dependabot** secret store, not from Actions secrets. That store was
empty, so `CLAUDE_CODE_OAUTH_TOKEN` resolved to the empty string and the
guard fired:

```
##[error]CLAUDE_CODE_OAUTH_TOKEN is empty. It is an organization secret
of btclib-org, visible to all repositories; without it this workflow
reviews nothing.
```

Exactly as designed — before that guard landed on 2026-08-20 this was a
silent green, the action finding the token empty, reviewing nothing and
reporting success. Fixed on the dashboard, not here:

```shell
$ gh api orgs/btclib-org/dependabot/secrets --jq '.secrets[] | "\(.name)\t\(.visibility)"'
CLAUDE_CODE_OAUTH_TOKEN	all
```

## Second: the action refuses a bot

With the credential arriving, the rerun got one step further and stopped
at the action itself:

```
##[error]Action failed with error: Workflow initiated by non-human actor:
dependabot (type: Bot). Add bot to allowed_bots list or use '*' to allow
all bots.
```

That is this pull request. `allowed_bots: "dependabot[bot]"`.

**Named rather than `*`**, and the input's own description is the
argument:

> Comma-separated list of allowed bot usernames, or '*' to allow all
> bots. Empty string (default) allows no bots. **WARNING: On public repos
> with '\*', external Apps may be able to invoke this action with prompts
> they control.**

This repository is public. `*` would mean any App GitHub lets comment
here can start a run carrying a prompt it wrote, against a job holding
the organization's credential. Naming the one bot that opens pull
requests here costs nothing and buys none of that.

The `mention` job takes no such input, deliberately. What triggers it is
somebody writing `@claude`; a bot doing that is not something this
repository has asked for, and the two jobs having different answers here
is the point rather than an inconsistency.

## Why it matters beyond one red check

`REVIEWING.md` and the landing convention say the ack of record comes
from `claude-review.yml` and never from a self-ack. Without this, a
Dependabot pull request is the **one class that can never obtain it** —
and it is the class whose whole value is landing promptly, `latest.yml`
having already reported on the same upgrade the day before.

## This pull request's own review is red, by construction

It edits `claude-review.yml`, and the action refuses to run when that
file differs from the copy on the default branch. So the job reports
"no review happened" until this is on `main`. That is
btclib-org/.github#58, recorded rather than worked around, and the
workflow's own comment already says it: *"on the pull request that adds
or edits this file, this job is red until the change is on `main`. It
gates nothing, and a red check that says 'no review happened' is the
honest shape of that."*

Sibling pull requests do the same in the three other repositories that
configure Dependabot. `.github` and `btclib-node` configure none, so
neither needs it.

## Summary by Sourcery

Enable Claude reviews for Dependabot pull requests while restricting bot access to the named Dependabot actor.

New Features:
- Allow the Claude review workflow to review Dependabot pull requests by explicitly permitting the Dependabot bot.

Bug Fixes:
- Restore the required review acknowledgement for Dependabot pull requests while avoiding unrestricted bot-triggered workflow access.

CI:
- Configure the Claude review action to allow only `dependabot[bot]` as a workflow-initiating bot.

Chores:
- Document the Dependabot review workflow fix in the changelog.