### PR TITLE
Declare which of section 7's conventions this suite tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,35 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **Which of section 7's conventions this suite tests is declared, and a
+  test says the declaration is true** (btclib-org/.github#32).
+  `tests/README.md` gains a table naming each of the eight conventions
+  the organization standard lists and the module here that tests it,
+  followed by a line naming the ones it does not — "Not tested here:
+  none", this repository implementing all eight.
+
+  A declaration rather than a `grep` over `tests/`, because a grep cannot
+  answer the question. Section 7 closes by saying a repository needs the
+  conventions its own prose states rather than all of them, which is
+  right and which makes an *absent* convention test read exactly like a
+  convention the repository does not have. And the suites of the
+  organization name the same idea three ways: a module per bullet here, a
+  `test_` prefix in btclib-secp256k1, and in bitcoin-core-rpc several of
+  these checks folded into the one file that is about its single module.
+
+  `tests/conventions_test.py` is what keeps the declaration from being
+  prose — section 7's own rule, that a convention worth stating is worth
+  a test, applied to section 7 itself. Four assertions, each failing on a
+  way the declaration actually rots: a convention invented here rather
+  than taken from the standard, a module renamed or deleted with its row
+  left behind, a module emptied of its tests, and a bullet that stops
+  being accounted for by either half. Each was checked by making the
+  declaration wrong in that way and watching the suite go red.
+
+  What it does not check is whether a module tests the convention it is
+  named against; nothing short of reading it can, and the docstring says
+  so rather than leaving the reader to assume otherwise.
+
 - **A Dependabot pull request can be reviewed**
   (btclib-org/.github#77). `claude-review.yml`'s review job fails on one,
   twice over. The credential is the first half and is fixed off the tree:

--- a/tests/README.md
+++ b/tests/README.md
@@ -251,3 +251,45 @@ What to know before reading one:
   self time buries it: something called a handful of times can be
   expensive in each of them and rank nowhere. Read `ncalls` beside
   `tottime`, or divide one by the other.
+
+## Convention tests
+
+Section 7 of the [organization standard][std] lists eight conventions a
+suite can turn into a red test, and says a repository needs the ones its
+own prose states rather than all of them. That escape clause is right and
+it costs something: an absent convention test reads exactly like a
+convention this repository does not have, and a `grep` over `tests/`
+cannot tell the two apart — the suites of the organization name the same
+idea three different ways, and one of them folds several checks into the
+file that is about its single module.
+
+So which of the eight this repository tests is **declared here**, and
+`conventions_test.py` asserts the declaration is true: every convention
+named below is one of section 7's, every module named exists and holds at
+least one test, and the two halves together account for all eight. One
+row per module, so a convention answered by more than one file is named
+once per file rather than in a row too wide for eighty columns.
+
+| convention | tested in |
+| --- | --- |
+| the public surface | `all_test.py` |
+| the copyright header | `copyright_test.py` |
+| the documentation | `docs_test.py` |
+| the import graph | `imports_test.py` |
+| the changelog | `release_notes_test.py` |
+| the build system | `build_system_test.py` |
+| the calling convention | `keyword_only_test.py` |
+| the calling convention | `name_contract_test.py` |
+| the calling convention | `private_defaults_test.py` |
+| input validation | `input_validation_test.py` |
+
+Not tested here: none.
+
+The calling convention takes three modules because it is three rules —
+a keyword-only parameter stays keyword-only, a private signature carries
+no default, and a public name promises what the call answers — and
+section 7 states it as one bullet. What must not be aligned across the
+organization is where these live or what they are called; only which
+conventions are tested, and that each tree says which.
+
+[std]: https://github.com/btclib-org/.github/blob/main/README.md

--- a/tests/conventions_test.py
+++ b/tests/conventions_test.py
@@ -1,0 +1,175 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The convention-test declaration in tests/README.md is true.
+
+Section 7 of the organization standard lists eight conventions a suite
+can turn into a red test, and closes with the clause that makes the list
+usable: a repository needs the ones its own prose states rather than all
+of them. That clause is right, and its price is that an *absent*
+convention test is indistinguishable from a convention this repository
+does not have. Nothing anywhere recorded which of the two it was.
+
+A filename cannot answer it either. The suites of the organization name
+the same idea three ways -- a module per bullet here, a `test_` prefix in
+btclib-secp256k1, and in bitcoin-core-rpc several of these checks folded
+into the one file that is about its single module, which is the honest
+shape for a package that is one module. So the audit reads a declaration
+rather than a directory, and this module is what keeps the declaration
+from being prose: section 7's own rule, that a convention worth stating
+is worth a test, applied to section 7 itself.
+
+What it does not check is whether a named module tests the convention it
+is named against. Nothing short of reading it can, and the four
+assertions below are the ones that fail on the ways a declaration
+actually rots: a convention invented here rather than taken from section
+7, a module renamed or deleted with the row left behind, a module emptied
+of its tests, and a bullet that quietly stops being accounted for by
+either half.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+_TESTS = Path(__file__).parent
+_README = _TESTS / "README.md"
+
+# section 7's eight, in its order and its words: the lead of each bullet,
+# which is what the first column of the table repeats. This tuple is the
+# standard's rather than this repository's, so a bullet added there is a
+# failure here until both this and the table have caught up -- which is
+# the point of naming them rather than accepting whatever the table says.
+_CONVENTIONS = (
+    "the public surface",
+    "the copyright header",
+    "the documentation",
+    "the import graph",
+    "the changelog",
+    "the build system",
+    "the calling convention",
+    "input validation",
+)
+
+_HEADING = "## Convention tests"
+# the sentinel for the other half of the declaration. "none" is a legal
+# answer and the one this repository gives; a repository testing fewer
+# than eight names the rest here, and the two halves are checked against
+# each other below rather than each against nothing
+_NOT_TESTED = re.compile(r"^Not tested here: (.+?)\.$", re.MULTILINE)
+# a table row, and the separator row is what the second group's leading
+# backtick excludes: `| --- | --- |` has no backtick to match
+_ROW = re.compile(
+    r"^\| (?P<convention>[^|]+?) \| `(?P<module>[^`]+)` \|$", re.MULTILINE
+)
+
+
+def _section() -> str:
+    """Return the declaration section, heading to end of file.
+
+    Read rather than the whole file: a `##` heading elsewhere in
+    tests/README.md must not contribute rows, and the section is the last
+    one, so its end is the end of the file.
+    """
+    text = _README.read_text(encoding="utf-8")
+    assert text.count(_HEADING) == 1, f"{_README.name} has no one {_HEADING}"
+    return text[text.index(_HEADING) :]
+
+
+_SECTION = _section()
+_ROWS = tuple((m["convention"], m["module"]) for m in _ROW.finditer(_SECTION))
+
+
+def test_the_table_is_not_empty() -> None:
+    """A declaration that parsed to nothing is the failure that hides.
+
+    Every assertion below quantifies over the rows, so a table this
+    module's regex stopped matching -- a column added, the backticks
+    dropped, the heading retitled -- would satisfy all of them silently.
+    """
+    assert _ROWS, f"{_README.name}'s {_HEADING} section parsed to no rows"
+
+
+@pytest.mark.parametrize("convention, module", _ROWS, ids=lambda v: v)
+def test_every_convention_named_is_one_of_section_sevens(
+    convention: str, module: str
+) -> None:
+    """A convention invented here is not a convention the standard has."""
+    assert convention in _CONVENTIONS, (
+        f"{module} is declared against {convention!r}, which is not one of"
+        f" section 7's: {', '.join(_CONVENTIONS)}"
+    )
+
+
+@pytest.mark.parametrize("convention, module", _ROWS, ids=lambda v: v)
+def test_every_module_named_exists(convention: str, module: str) -> None:
+    """A row outliving the file it names is the ordinary way this rots."""
+    assert (_TESTS / module).is_file(), (
+        f"{_README.name} declares {convention!r} tested in {module},"
+        " which is not a file in this directory"
+    )
+
+
+@pytest.mark.parametrize("convention, module", _ROWS, ids=lambda v: v)
+def test_every_module_named_holds_a_test(convention: str, module: str) -> None:
+    """A file emptied of its tests still satisfies the check above.
+
+    The source is parsed rather than the suite queried: an import would
+    make this module's result depend on every other module's import
+    side effects, and pytest's own collection is not available to a test
+    it has already collected.
+    """
+    # no guard for a missing file: the test above is what reports that,
+    # and a guard here would be a branch nothing can reach while it passes
+    path = _TESTS / module
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    found = any(
+        isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+        and node.name.startswith("test_")
+        for node in ast.walk(tree)
+    )
+    assert found, (
+        f"{module} is declared to test {convention!r} and defines no"
+        " function whose name begins with test_"
+    )
+
+
+def test_the_two_halves_account_for_every_convention() -> None:
+    """The table and the "Not tested here" line partition section 7's eight.
+
+    This is the assertion the declaration exists for. Either half alone
+    is satisfiable by saying less: a table naming three conventions is
+    true about those three and silent about the other five, and silence
+    is exactly what section 7's escape clause makes unreadable. Together
+    they have to name each of the eight once.
+    """
+    match = _NOT_TESTED.search(_SECTION)
+    assert match, (
+        f'{_README.name} has no "Not tested here: ...." line;'
+        " the declaration is half of one"
+    )
+    listed = match[1].strip()
+    absent = () if listed == "none" else tuple(s.strip() for s in listed.split(";"))
+    tested = {convention for convention, _ in _ROWS}
+
+    overlap = tested.intersection(absent)
+    assert not overlap, (
+        f"{', '.join(sorted(overlap))} is both declared tested and listed as not tested"
+    )
+
+    unknown = [name for name in absent if name not in _CONVENTIONS]
+    assert not unknown, (
+        f"{', '.join(unknown)} is listed as not tested and is not one of"
+        f" section 7's: {', '.join(_CONVENTIONS)}"
+    )
+
+    unaccounted = [
+        name for name in _CONVENTIONS if name not in tested and name not in absent
+    ]
+    assert not unaccounted, (
+        f"{', '.join(unaccounted)} is neither declared tested nor listed as"
+        " not tested; section 7's eight are what the two halves must cover"
+    )


### PR DESCRIPTION
btclib-org/.github#32's first repository, and the reference the other
three follow.

## Why a declaration and not a grep

Section 7 calls the convention tests "the distinguishing feature of the
suite", and section 15 has no command that answers for them — the one
section the standard calls distinguishing is the one where alignment was
remembered rather than measured.

A `grep` over `tests/` cannot fix that, for two reasons that compound:

- **Section 7's escape clause.** "A new repository does not need all of
  these. It needs the ones its own conventions state in prose." That is
  right, and it makes an *absent* convention test indistinguishable from
  a convention this repository does not have. Nothing recorded which of
  the two it was.
- **The suites name the same idea three ways.** A module per bullet here;
  a `test_` prefix in `btclib-secp256k1`; and in `bitcoin-core-rpc`
  several of these checks folded into `standalone_test.py`, the one file
  that is about its single module — the honest shape for a package that
  *is* one module, and a shape no filename convention can be read off.

## The declaration

`tests/README.md` gains a `## Convention tests` section: one row per
module, and a line naming what is not tested here.

| convention | tested in |
| --- | --- |
| the public surface | `all_test.py` |
| the copyright header | `copyright_test.py` |
| the documentation | `docs_test.py` |
| the import graph | `imports_test.py` |
| the changelog | `release_notes_test.py` |
| the build system | `build_system_test.py` |
| the calling convention | `keyword_only_test.py` |
| the calling convention | `name_contract_test.py` |
| the calling convention | `private_defaults_test.py` |
| input validation | `input_validation_test.py` |

`Not tested here: none.` — this repository implements all eight.

One row per module rather than a comma-separated cell, because the
calling convention takes three modules and that row is 104 columns.
Section 9 holds markdown to 80, tables included.

## The test, and what it is worth

`tests/conventions_test.py` is what keeps the declaration from being
prose: section 7's own rule — a convention worth stating is worth a test
— applied to section 7 itself. Four assertions, each aimed at a way the
declaration actually rots, and **each verified by making the declaration
wrong in that way and watching the suite go red**:

| what was broken | what failed |
| --- | --- |
| `docs_test.py` renamed in the table | `test_every_module_named_exists` |
| the build-system row deleted | `test_the_two_halves_account_for_every_convention` |
| "the import graph" renamed to "the import ordering" | the same |
| "the changelog" claimed by both halves | the same |

The fifth, `test_the_table_is_not_empty`, is the one that has no
interesting failure and is the most necessary: every other assertion
quantifies over the parsed rows, so a table this module's regex stopped
matching — a column added, the backticks dropped, the heading retitled —
would satisfy all of them in silence.

**What it does not check** is whether a named module tests the convention
it is named against. Nothing short of reading it can, and the module's
docstring says so rather than leaving a reader to assume otherwise.

## What I ran

```
29502 passed, 11 skipped in 41.56s
tests/conventions_test.py     42     0      0      0  100.00%
```

The whole suite, with coverage, on this tree. The new module is 42
statements at 100% with no `pragma`, and the four mutations above were
each run and reverted.

Section 7 already requires this (`btclib-org/.github#72` landed it); what
was missing was a repository doing it. The `.github` half — the section
15 command that reads these declarations across the organization and
prints the matrix — is #32's second box and is not this pull request.

## Summary by Sourcery

Declare and validate the repository’s coverage of the organization’s section 7 testing conventions.

Enhancements:
- Declare which organization-standard conventions are covered by the test suite and identify the modules responsible for each convention.
- Add automated validation ensuring the convention declaration is complete, uses recognized conventions, and references existing test modules.

Documentation:
- Document the repository’s convention-test coverage and explicitly state that all eight standard conventions are tested.

Tests:
- Add tests that detect stale, incomplete, invalid, or empty convention-test declarations.