### PR TITLE
The convention-test sentinel is read when it wraps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **The convention-test sentinel is read when it wraps**
+  (btclib-org/.github#32). `conventions_test.py` matched the
+  "Not tested here: ..." line with `re.MULTILINE` alone, so it read a
+  declaration that fits one line and no other. This repository's fits —
+  "none", all eight being tested — which is why nothing here noticed.
+  btclib-secp256k1 names six conventions there, the line wraps at eighty
+  columns, and the test reported that the sentinel was **missing**: the
+  one failure message that sends a reader looking for the wrong thing.
+
+  `re.DOTALL` beside it, and the consequence written where the pattern
+  is: no name in that list may carry a full stop of its own, the
+  non-greedy match stopping at the first one that ends a line.
+
 - **Which of section 7's conventions this suite tests is declared, and a
   test says the declaration is true** (btclib-org/.github#32).
   `tests/README.md` gains a table naming each of the eight conventions

--- a/tests/conventions_test.py
+++ b/tests/conventions_test.py
@@ -55,11 +55,15 @@ _CONVENTIONS = (
 )
 
 _HEADING = "## Convention tests"
-# the sentinel for the other half of the declaration. "none" is a legal
-# answer and the one this repository gives; a repository testing fewer
-# than eight names the rest here, and the two halves are checked against
+# the sentinel for the other half of the declaration. DOTALL as well as
+# MULTILINE because eighty columns wrap the list of names across lines
+# and the non-greedy match then stops at the first full stop that ends
+# one -- which is why no name in that list may carry a full stop of its
+# own. "none" is a legal answer and the one this repository gives, and it
+# fits a line; the six btclib-secp256k1 names do not, which is where the
+# single-line form was found wanting. The two halves are checked against
 # each other below rather than each against nothing
-_NOT_TESTED = re.compile(r"^Not tested here: (.+?)\.$", re.MULTILINE)
+_NOT_TESTED = re.compile(r"^Not tested here: (.+?)\.$", re.MULTILINE | re.DOTALL)
 # a table row, and the separator row is what the second group's leading
 # backtick excludes: `| --- | --- |` has no backtick to match
 _ROW = re.compile(


### PR DESCRIPTION
A follow-up to #1241, found by porting its test to the next repository.

`conventions_test.py` matched the declaration's second half —

```
Not tested here: none.
```

— with `re.MULTILINE` alone, so it read a sentinel that fits one line and
no other. This repository's fits: `none`, all eight conventions being
tested here, which is why nothing here noticed.

`btclib-secp256k1` names six conventions on that line
(btclib-org/btclib-secp256k1#333). At eighty columns it wraps, and the
test reported **the sentinel missing** rather than anything about the
declaration — the one failure message that sends a reader looking for the
wrong thing entirely.

`re.DOTALL` beside `re.MULTILINE`, with the consequence written where the
pattern is rather than left to be discovered: the non-greedy match now
stops at the first full stop that ends a line, so no name in that list
may carry a full stop of its own.

## Why it lands here and not only there

The fix belongs in the repository whose file has the defect, and this is
that repository — #1241 landed the pattern here first and
btclib-org/btclib-secp256k1#333 ported it. Leaving this one alone would
make the two copies differ in the direction that reads as deliberate,
and the latent failure would wait here for the day this suite stops
testing all eight, which is the day the line wraps.

## What I ran

The declaration was rewritten to name six absences, the way
`btclib-secp256k1`'s does, and the suite was run against it:

- before the fix, on `main`: the sentinel is reported missing.
- after: `test_the_two_halves_account_for_every_convention` fails saying
  which conventions are claimed by both halves, which is the real defect
  of that made-up declaration.

Then reverted, and `32 passed`.

## Summary by Sourcery

Ensure convention tests correctly read sentinel declarations that wrap across multiple lines.

Bug Fixes:
- Fix convention declaration parsing so wrapped sentinel lines are recognized correctly.

Enhancements:
- Document the parsing constraint that convention names cannot contain periods because the sentinel ends at the first line-ending period.

Documentation:
- Add a changelog entry describing the wrapped-sentinel parsing fix.