### PR TITLE
The declaration section is read to its own end, not to the file's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **The declaration section is read to its own end, not to the file's**
+  (btclib-org/.github#32). `conventions_test.py`'s `_section()` sliced
+  from `## Convention tests` to the end of `tests/README.md`, on the
+  stated ground that it is the last heading there. It is, and a section
+  added after it would have been read as part of it — its table rows
+  parsed as declarations, in silence.
+
+  The slice now ends at the next `##`. This is the same fragility
+  btclib-org/btclib-secp256k1#333 had to remove from a sibling parser in
+  that repository in order to add a section at all, which is where it was
+  noticed: the fix went in there and the pattern it came from was left
+  here.
+
 - **The convention-test sentinel is read when it wraps**
   (btclib-org/.github#32). `conventions_test.py` matched the
   "Not tested here: ..." line with `re.MULTILINE` alone, so it read a

--- a/tests/conventions_test.py
+++ b/tests/conventions_test.py
@@ -72,15 +72,17 @@ _ROW = re.compile(
 
 
 def _section() -> str:
-    """Return the declaration section, heading to end of file.
+    """Return the declaration section, heading to the next one or the end.
 
     Read rather than the whole file: a `##` heading elsewhere in
-    tests/README.md must not contribute rows, and the section is the last
-    one, so its end is the end of the file.
+    tests/README.md must not contribute rows. The slice ends at the next
+    `## ` rather than at the end of the file, so that a section added
+    after this one is not read as part of it.
     """
     text = _README.read_text(encoding="utf-8")
     assert text.count(_HEADING) == 1, f"{_README.name} has no one {_HEADING}"
-    return text[text.index(_HEADING) :]
+    section = text[text.index(_HEADING) + len(_HEADING) :]
+    return _HEADING + section.split("\n## ", 1)[0]
 
 
 _SECTION = _section()


### PR DESCRIPTION
`conventions_test.py`'s `_section()` sliced from `## Convention tests` to
the **end of the file**, and said so:

> Read rather than the whole file: a `##` heading elsewhere in
> tests/README.md must not contribute rows, and the section is the last
> one, so its end is the end of the file.

It is the last one. A section added after it would have had its table
rows parsed as declarations — in silence, because every assertion in that
module quantifies over the rows it parsed.

The slice ends at the next `##` instead.

## Where it was noticed, and why it lands here second

btclib-org/btclib-secp256k1#333 adds a `## Convention tests` section to a
`tests/README.md` that already had a parser assuming its own section ran
to the end of the file — `test_vendored_data.py`'s `_summary()`. Adding
the section is what would have made that assumption false, so that pull
request had to fix it before it could add anything.

Its review then pointed at the identical shape one file over, in the
module this pull request's own diff had just ported there. So: the fix
went in where it was blocking, and the pattern it came from was left
here. That is what this is.

## What I ran

A section was appended to `tests/README.md` carrying one bogus row —

```markdown
## A later section

| the changelog | `docs_test.py` |
```

— and the suite run against it. `32 passed`: the row is outside the
slice and contributes nothing. Before the change it would have been read
as a declaration, put "the changelog" in both halves of the section, and
failed `test_the_two_halves_account_for_every_convention` — which is the
right failure for a made-up row and the wrong one for a section that has
nothing to do with conventions.

Then reverted, and `32 passed` again.

## Summary by Sourcery

Stop convention tests from parsing declarations beyond their own README section.

Bug Fixes:
- Limit convention declaration parsing to the Convention tests section instead of consuming rows from later sections in tests/README.md.

Tests:
- Verify that rows in sections following Convention tests are excluded from declaration validation.