### PR TITLE
ecc takes a scalar and not a WIF (issue #1188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1225,6 +1225,84 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **`ecc` takes a scalar and not a WIF**: `curves.scalar_from_prv_key`
+  is the conversion, and the `ecc` modules that resolved a private key
+  through `to_prv_key` resolve it through `curves` now (issue #1188).
+  The name says the role and not the Python type, which is the
+  distinction the narrowing is about — and it keeps the new function
+  from colliding with the wide `to_prv_key.int_from_prv_key`, which
+  `tests/curve_parameter_test.py` drives beside it.
+
+  No new alias comes with it. The parameter is an `Integer`, and what
+  the function takes is narrower than what that names: `int_from_integer`
+  reads a "0x" prefix and a short hex string, where a key is `n_size`
+  octets or nothing. What rules those out is reading them with
+  `bytes_from_octets` and the size handed to it, not the annotation,
+  which could not — the two being the same union of types. So a `PrvKey` of
+  `curves`' own would have been that union under a second name, where
+  `mult`'s `m_int` shows that the role belongs in the parameter. Issue
+  #1238 is where the aliases are being asked what they promise.
+
+  ```python
+  to_prv_key.int_from_prv_key(prv_key: PrvKey)   # WIF, xprv, int, octets
+  curves.scalar_from_prv_key(prv_key: Integer)   # int, octets, hex
+  ```
+
+  A private key at this layer is a scalar: the integer, its `n_size`
+  octets, or their hex, and the buffers `bytes_from_octets` takes beside
+  them. A WIF and an extended key are `b58`'s and `bip32`'s objects, and
+  turning one into a scalar is a call a caller makes rather than a
+  spelling the curve layer guesses at. `scalar_from_prv_key` lives beside
+  `bytes_from_prv_key_int` for its reason: whether a scalar is in
+  1..n-1 is a fact about the curve, and nothing above it knows more
+  about that than `curves` does.
+
+  `ecc.bms` keeps `to_prv_key`, and keeps a different function — it
+  wants the `(int, network, compressed)` record, message signing being
+  bitcoin by definition, and of the `ecc` modules that used
+  `to_prv_key` it is the one that stays.
+
+  Three spellings go, on every entry point of those nine modules that
+  takes a private key: a WIF, an xprv as text, and an xprv as
+  `BIP32KeyData`. The first two are refused as the octets they are not —
+  a string reaching this layer is hex or it is nothing — and the third
+  by its type. What is left keeps its answers: an out-of-range int and
+  right-sized out-of-range octets raise the same "private key not in
+  1..n-1" they did.
+
+  Refusals change class as well as wording, and the classes are what a
+  caller has to read. `NotAPrvKeyError`, which named the formats tried
+  and why each declined, is not raised by these modules any more: octets
+  of the wrong size are `bytes_from_octets`' "invalid size", a string
+  that is no hex is its "invalid hex string", and a type no key has is
+  "invalid octets type" rather than "not a private key". `bms` raises it
+  exactly as before, so an `except NotAPrvKeyError` is load-bearing
+  there and dead around `dsa.sign`.
+
+  An extended *public* key spelled as a `BIP32KeyData` is the one shape
+  that crosses families: it was an `InvalidPrvKeyError`, which is a
+  `BTClibValueError`, and is a `BTClibTypeError` now, the `BIP32KeyData`
+  branch being gone and `bytes_from_octets` refusing it on the type. The
+  private one is not a message change at all — it was accepted, and is
+  the third of the three spellings withdrawn above.
+
+  `except BTClibValueError` does not cover everything these modules
+  raise, and did not before either: `_assert_prv_key_type` already
+  answered a `float` or a `None` with a `BTClibTypeError`. What changes
+  is which inputs land there, not that some do. `except BTClibException`
+  was the only complete catch and still is.
+
+  `psbt.musig2` is where the boundary shows. It keeps taking the wide
+  `PrvKey` — a psbt signer holding a WIF is not doing anything wrong —
+  and converts once, explicitly, before calling `ecc.musig2`. That
+  explicit call is what the union was hiding.
+
+  The two conversions coexist until issue #1188's last step deletes the
+  wide one, and they coexist under different names:
+  `tests/curve_parameter_test.py` drives `curves.scalar_from_prv_key`
+  and `to_prv_key.int_from_prv_key` side by side, each under its own,
+  which is what the rename bought.
+
 - **`ecc.ssa` stops taking an extended key**, and `BIP340PubKey`
   narrows from `Integer | Octets | BIP32Key | Point | PreparedPoint` to
   `int | Octets | Point | PreparedPoint` (issue #1188). An extended key

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,50 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **`ecc` no longer takes a WIF or an extended key as a private key**
+  (issue #1188). The entry points that took a private key however it was
+  spelled — every one in `dsa`, `ssa`, `musig2`, `dleq`, `ecies`,
+  `ellswift` and the three nonce modules, `gen_keys`, `Signer`,
+  `anti_exfil_signer_commit` and `anti_exfil_sign` among them — took a
+  WIF, an xprv, an
+  `int` or octets. They now take an `int`, its `n_size` octets, or their
+  hex. `borromean` is not among them and never was: it asks for a
+  sequence of `int` outright.
+
+  ```python
+  dsa.sign(msg, wif)                                  # was
+  dsa.sign(msg, prv_keyinfo_from_prv_key(wif)[0])     # is
+  ```
+
+  `prv_keyinfo_from_prv_key` is the converter that decodes every
+  spelling, and it answers the network and the compression flag beside
+  the scalar; take the first of the three. The point is that the
+  conversion is now a call you write, where it used to be a try-and-see
+  inside the signer.
+
+  Act on it if you hand one of those nine anything but a scalar.
+  **`ecc.bms` is not among them**: message signing is bitcoin, so it
+  still takes a WIF, an xprv and everything else it took, and everything
+  below is about the nine and not about it.
+
+  Refusals change with the input. `NotAPrvKeyError` is no longer raised
+  by the nine — wrong-size octets, a non-hex string and a bad-checksum
+  WIF are `bytes_from_octets`' own complaints now — and `bms` raises it
+  exactly as before, so an `except NotAPrvKeyError` around `bms.sign`
+  stays load-bearing while one around `dsa.sign` stops catching.
+
+  One shape changes exception *family*: an extended **public** key
+  spelled as a `BIP32KeyData` was an `InvalidPrvKeyError`, which is a
+  `BTClibValueError`, and is now a `BTClibTypeError`. The private one
+  does not appear here because it was accepted before and is withdrawn,
+  not re-messaged.
+
+  `except BTClibValueError` does not cover everything these nine raise —
+  but it never did, a wrong type having always been a `BTClibTypeError`.
+  If that is your catch, widen it to `BTClibException`; the advice is
+  the same as it always was, and this change makes more inputs reach
+  it.
+
 - **`ecc.ssa` no longer accepts a BIP32 extended key as a BIP340 public
   key** (issue #1188). `BIP340PubKey` was
 

--- a/btclib/curves/__init__.py
+++ b/btclib/curves/__init__.py
@@ -80,10 +80,19 @@ argument and every path, and reaching past them is reaching past that. The
 test suite takes each variant from the module that defines it, which is
 what a private name is still good for.
 
-The codec has a third function, bytes_from_prv_key_int: the composition of
-a multiplication and an encoding that every private-to-public conversion
-is, answered for secp256k1 out of the bindings' own serialization, without
-materializing the point (issue #127).
+Beside the two point conversions the codec carries bytes_from_prv_key_int,
+the composition of a multiplication and an encoding that every
+private-to-public conversion is, answered for secp256k1 out of the
+bindings' own serialization, without materializing the point (issue #127);
+and scalar_from_prv_key, which reads a private key the other way, as the
+scalar in 1..n-1 that it is. What a private key may be spelled as at this
+layer is the integer, its n_size octets, or their hex. That is narrower
+than everything Integer takes -- int_from_integer reads a "0x" prefix
+and a short hex string, which a key of a fixed size must not be -- and
+the annotation is Integer because the two are the same union of types
+and a second name for it would say nothing mypy could check. A WIF and
+an extended key are not among the spellings at all, belonging to b58 and
+bip32, above here (issue #1188).
 """
 
 from btclib.curves.curve import (
@@ -103,6 +112,7 @@ from btclib.curves.sec_point import (
     bytes_from_point,
     bytes_from_prv_key_int,
     point_from_octets,
+    scalar_from_prv_key,
 )
 
 __all__ = [
@@ -119,6 +129,7 @@ __all__ = [
     "mult",
     "multi_mult_var",
     "point_from_octets",
+    "scalar_from_prv_key",
     "secp256k1",
     "set_libsecp256k1_serving",
 ]

--- a/btclib/curves/sec_point.py
+++ b/btclib/curves/sec_point.py
@@ -28,7 +28,57 @@ __all__ = [
     "bytes_from_point",
     "bytes_from_prv_key_int",
     "point_from_octets",
+    "scalar_from_prv_key",
 ]
+
+
+def scalar_from_prv_key(prv_key: Integer, ec: Curve = secp256k1) -> int:
+    """Return a verified-as-valid private key integer.
+
+    Here rather than in a converter, and beside `bytes_from_prv_key_int`
+    for its reason: a scalar in 1..n-1 is a fact about the curve and
+    nothing above it knows more about it than this file does.
+
+    `Integer` and not a `PrvKey` of this module's own, which would be
+    that same union of types under a second name and so nothing mypy
+    could check; the parameter carries the role the way `mult`'s `m_int`
+    does. The spellings this takes are narrower than the ones `Integer`
+    names -- `int_from_integer` reads "0xc0ffee" and a short hex string,
+    where a key is `n_size` octets or nothing. What rules those out is
+    reading them with `bytes_from_octets` and the size handed to it,
+    rather than with `int_from_integer`; the annotation could not, the
+    two unions being one. A WIF and an extended key are not among the
+    spellings -- they are `b58`'s and `bip32`'s objects, and turning one
+    into a scalar is a call a caller makes rather than a spelling this
+    layer guesses at (issue #1188).
+
+    The range is checked in Python for every curve. `keys.prvkey_verify`
+    is libsecp256k1's answer to the same question and is not called for
+    want of anything to gain: a comparison on a value that is already a
+    Python int, with no constant-time argument to pay for the call with,
+    since whether a key is in range is precisely what the caller is being
+    told. `to_prv_key.int_from_prv_key` carries the measurement behind
+    that, and carries it until issue #1188's last step removes it.
+    """
+    _assert_valid_ec(ec)
+
+    if isinstance(prv_key, int):
+        q = prv_key
+    else:
+        # `n_size` and not a guess: 32 for secp256k1, where a point is 33
+        # or 65, so the size alone separates a scalar from one. That is
+        # not true of every curve in the catalogue -- secp160k1,
+        # secp160r1, secp160r2 and secp224k1 have an `n_size` equal to
+        # their compressed point size -- and there a point is refused by
+        # the range check below instead, its 02 or 03 prefix putting the
+        # integer past n. The refusal is the same; only which line makes
+        # it differs
+        q = int.from_bytes(bytes_from_octets(prv_key, ec.n_size), "big")
+
+    if not 0 < q < ec.n:
+        raise BTClibValueError("private key not in 1..n-1")
+
+    return q
 
 
 def bytes_from_point(Q: Point, ec: Curve = secp256k1, compressed: bool = True) -> bytes:

--- a/btclib/ecc/bip340_nonce.py
+++ b/btclib/ecc/bip340_nonce.py
@@ -34,10 +34,9 @@ from __future__ import annotations
 import secrets
 from hashlib import sha256
 
-from btclib.alias import HashF, Octets
-from btclib.curves import Curve, mult, secp256k1
+from btclib.alias import HashF, Integer, Octets
+from btclib.curves import Curve, mult, scalar_from_prv_key, secp256k1
 from btclib.hashes import tagged_hash
-from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.utils import bytes_from_octets, int_from_bits
 
 __all__ = [
@@ -87,7 +86,7 @@ def _bip340_nonce_(msg: bytes, q: int, Q: int, aux: bytes, ec: Curve, hf: HashF)
 
 def bip340_nonce_(
     msg: Octets,
-    prv_key: PrvKey,
+    prv_key: Integer,
     aux: Octets | None = None,
     ec: Curve = secp256k1,
     hf: HashF = sha256,
@@ -101,7 +100,7 @@ def bip340_nonce_(
     hf_len = hf().digest_size
     msg = bytes_from_octets(msg)
 
-    q = int_from_prv_key(prv_key, ec)
+    q = scalar_from_prv_key(prv_key, ec)
 
     x_Q, y_Q = mult(q, ec=ec)
     if y_Q % 2:

--- a/btclib/ecc/commit_nonce.py
+++ b/btclib/ecc/commit_nonce.py
@@ -63,12 +63,17 @@ from __future__ import annotations
 from hashlib import sha256
 
 from btclib._libsecp256k1 import keys as libsecp256k1_keys
-from btclib.alias import HashF, Octets, Point
-from btclib.curves import Curve, bytes_from_point, mult, secp256k1
+from btclib.alias import HashF, Integer, Octets, Point
+from btclib.curves import (
+    Curve,
+    bytes_from_point,
+    mult,
+    scalar_from_prv_key,
+    secp256k1,
+)
 from btclib.curves.curve import _libsecp256k1_serves, _tweak_add_var
 from btclib.exceptions import BTClibRuntimeError
 from btclib.hashes import tagged_hash
-from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.utils import bytes_from_octets, int_from_bits
 
 __all__ = [
@@ -118,7 +123,7 @@ def _tweak(
 
 def commit_nonce_(
     commit_hash: Octets,
-    nonce: PrvKey,
+    nonce: Integer,
     tag: bytes,
     ec: Curve = secp256k1,
     hf: HashF = sha256,
@@ -129,7 +134,7 @@ def commit_nonce_(
     tweak hashes, so a verifier given the committed value can recompute
     the tweak and reach the point the signature carries.
     """
-    nonce = int_from_prv_key(nonce, ec)
+    nonce = scalar_from_prv_key(nonce, ec)
     receipt = mult(nonce, ec.G, ec)
     tweak = _tweak(commit_hash, receipt, tag, ec, hf)
 

--- a/btclib/ecc/dleq.py
+++ b/btclib/ecc/dleq.py
@@ -43,11 +43,16 @@ from __future__ import annotations
 
 import secrets
 
-from btclib.alias import Octets, Point
-from btclib.curves import bytes_from_point, double_mult_var, mult, secp256k1
+from btclib.alias import Integer, Octets, Point
+from btclib.curves import (
+    bytes_from_point,
+    double_mult_var,
+    mult,
+    scalar_from_prv_key,
+    secp256k1,
+)
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.hashes import tagged_hash
-from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.to_pub_key import PubKey, point_from_pub_key
 from btclib.utils import bytes_from_octets
 
@@ -107,7 +112,7 @@ def _bytes_xor(a: bytes, b: bytes) -> bytes:
 
 
 def generate_proof(
-    a: PrvKey,
+    a: Integer,
     B: PubKey,
     aux: Octets | None = None,
     G: PubKey = secp256k1.G,
@@ -125,7 +130,7 @@ def generate_proof(
     public key, which are BIP374's two "fail" conditions before any
     arithmetic happens.
     """
-    a_int = int_from_prv_key(a)
+    a_int = scalar_from_prv_key(a)
     B_point = point_from_pub_key(B)
     G_point = point_from_pub_key(G)
     m = _msg_bytes(msg)

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -45,8 +45,14 @@ from btclib import var_bytes
 from btclib._libsecp256k1 import dsa as libsecp256k1_dsa
 from btclib._libsecp256k1 import ffi as libsecp256k1_ffi
 from btclib._libsecp256k1 import recovery as libsecp256k1_recovery
-from btclib.alias import BinaryData, HashF, JacPoint, Octets, Point
-from btclib.curves import Curve, PreparedPoint, mult, secp256k1
+from btclib.alias import BinaryData, HashF, Integer, JacPoint, Octets, Point
+from btclib.curves import (
+    Curve,
+    PreparedPoint,
+    mult,
+    scalar_from_prv_key,
+    secp256k1,
+)
 from btclib.curves.curve import (
     _assert_valid_ec,
     _is_x_coordinate_var,
@@ -59,7 +65,6 @@ from btclib.ecc.rfc6979_nonce import _rfc6979_nonce_, challenge_
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
 from btclib.hashes import _assert_valid_hf, reduce_to_hlen
 from btclib.number_theory import mod_inv, mod_inv_var
-from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.to_pub_key import (
     PubKey,
     _sec_from_pub_key,
@@ -412,10 +417,12 @@ def _sig_from_compact(compact: bytes, ec: Curve) -> Sig:
     return Sig(r, s, ec, check_validity=False)
 
 
-def gen_keys(prv_key: PrvKey | None = None, ec: Curve = secp256k1) -> tuple[int, Point]:
+def gen_keys(
+    prv_key: Integer | None = None, ec: Curve = secp256k1
+) -> tuple[int, Point]:
     """Return a private/public (int, Point) key-pair."""
     # here rather than in the branch below that reads n off the curve: a
-    # key that was given reaches int_from_prv_key's own check, and one
+    # key that was given reaches scalar_from_prv_key's own check, and one
     # that is drawn reaches nothing else
     _assert_valid_ec(ec)
 
@@ -423,7 +430,7 @@ def gen_keys(prv_key: PrvKey | None = None, ec: Curve = secp256k1) -> tuple[int,
         # q in the range [1, ec.n-1]
         q = 1 + secrets.randbelow(ec.n - 1)
     else:
-        q = int_from_prv_key(prv_key, ec)
+        q = scalar_from_prv_key(prv_key, ec)
 
     # mult, not the _mult under it: the scalar is the private key and the
     # point is the generator, which is the one multiplication libsecp256k1
@@ -772,8 +779,8 @@ def _libsecp256k1_sign_(
 @overload
 def sign_(
     msg_hash: Octets,
-    prv_key: PrvKey,
-    nonce: PrvKey | None = ...,
+    prv_key: Integer,
+    nonce: Integer | None = ...,
     lower_s: bool = ...,
     ec: Curve = ...,
     hf: HashF = ...,
@@ -788,8 +795,8 @@ def sign_(
 @overload
 def sign_(
     msg_hash: Octets,
-    prv_key: PrvKey,
-    nonce: PrvKey | None = ...,
+    prv_key: Integer,
+    nonce: Integer | None = ...,
     lower_s: bool = ...,
     ec: Curve = ...,
     hf: HashF = ...,
@@ -803,8 +810,8 @@ def sign_(
 
 def sign_(
     msg_hash: Octets,
-    prv_key: PrvKey,
-    nonce: PrvKey | None = None,
+    prv_key: Integer,
+    nonce: Integer | None = None,
     lower_s: bool = True,
     ec: Curve = secp256k1,
     hf: HashF = sha256,
@@ -890,7 +897,7 @@ def sign_(
 
     # the secret key q: an integer in the range 1..n-1.
     # SEC 1 v.2 section 3.2.1
-    q = int_from_prv_key(prv_key, ec)
+    q = scalar_from_prv_key(prv_key, ec)
 
     # the committed value has to reach the nonce derivation, or the
     # untweaked nonce is a function of the message and the key alone and
@@ -964,7 +971,7 @@ def sign_(
         # nonce: an integer in the range 1..n-1.
         if nonce is not None:
             # second part delegated to helper function
-            return _checked(_sign_(c, q, int_from_prv_key(nonce, ec), lower_s, ec))
+            return _checked(_sign_(c, q, scalar_from_prv_key(nonce, ec), lower_s, ec))
         # the check is of the signature the loop keeps and not of every
         # attempt, which is Core's order in `CKey::Sign` and the bindings'
         # own: a discarded attempt that was faulted costs an attempt
@@ -999,8 +1006,8 @@ def sign_(
 @overload
 def sign(
     msg: Octets,
-    prv_key: PrvKey,
-    nonce: PrvKey | None = ...,
+    prv_key: Integer,
+    nonce: Integer | None = ...,
     lower_s: bool = ...,
     ec: Curve = ...,
     hf: HashF = ...,
@@ -1015,8 +1022,8 @@ def sign(
 @overload
 def sign(
     msg: Octets,
-    prv_key: PrvKey,
-    nonce: PrvKey | None = ...,
+    prv_key: Integer,
+    nonce: Integer | None = ...,
     lower_s: bool = ...,
     ec: Curve = ...,
     hf: HashF = ...,
@@ -1030,8 +1037,8 @@ def sign(
 
 def sign(
     msg: Octets,
-    prv_key: PrvKey,
-    nonce: PrvKey | None = None,
+    prv_key: Integer,
+    nonce: Integer | None = None,
     lower_s: bool = True,
     ec: Curve = secp256k1,
     hf: HashF = sha256,
@@ -1101,8 +1108,8 @@ def sign(
 
 def sign_recoverable_(
     msg_hash: Octets,
-    prv_key: PrvKey,
-    nonce: PrvKey | None = None,
+    prv_key: Integer,
+    nonce: Integer | None = None,
     lower_s: bool = True,
     ec: Curve = secp256k1,
     hf: HashF = sha256,
@@ -1136,7 +1143,7 @@ def sign_recoverable_(
 
     # the secret key q: an integer in the range 1..n-1.
     # SEC 1 v.2 section 3.2.1
-    q = int_from_prv_key(prv_key, ec)
+    q = scalar_from_prv_key(prv_key, ec)
 
     # as in sign_: a nonce of the caller's is the nonce, where what the
     # bindings take is extra entropy for the RFC6979 nonce they derive
@@ -1172,15 +1179,15 @@ def sign_recoverable_(
     if nonce is None:
         nonce = _rfc6979_nonce_(c, q, ec, hf, None)  # 1
     else:
-        nonce = int_from_prv_key(nonce, ec)
+        nonce = scalar_from_prv_key(nonce, ec)
     # second part delegated to helper function
     return _sign_recoverable_(c, q, nonce, lower_s, ec)
 
 
 def sign_recoverable(
     msg: Octets,
-    prv_key: PrvKey,
-    nonce: PrvKey | None = None,
+    prv_key: Integer,
+    nonce: Integer | None = None,
     lower_s: bool = True,
     ec: Curve = secp256k1,
     hf: HashF = sha256,
@@ -1303,13 +1310,13 @@ class Signer:
     """
 
     def __init__(
-        self, prv_key: PrvKey, ec: Curve = secp256k1, hf: HashF = sha256
+        self, prv_key: Integer, ec: Curve = secp256k1, hf: HashF = sha256
     ) -> None:
         _assert_valid_hf(hf)
         # the scalar, whatever spelling the key arrived in, and the
         # validation with it -- this is a public constructor and the
         # refusal belongs at it rather than at the first signature
-        self._q = int_from_prv_key(prv_key, ec)
+        self._q = scalar_from_prv_key(prv_key, ec)
         self._ec = ec
         self._hf = hf
         self._hf_len = hf().digest_size
@@ -1789,7 +1796,7 @@ def anti_exfil_host_commit(rho: Octets, hf: HashF = sha256) -> bytes:
 
 def anti_exfil_signer_commit(
     msg_hash: Octets,
-    prv_key: PrvKey,
+    prv_key: Integer,
     host_commitment: Octets,
     ec: Curve = secp256k1,
     hf: HashF = sha256,
@@ -1807,14 +1814,14 @@ def anti_exfil_signer_commit(
     with.
     """
     c = challenge_(msg_hash, ec, hf)
-    q = int_from_prv_key(prv_key, ec)
+    q = scalar_from_prv_key(prv_key, ec)
     entropy = bytes_from_octets(host_commitment, hf().digest_size)
     return mult(_rfc6979_nonce_(c, q, ec, hf, entropy), ec.G, ec)
 
 
 def anti_exfil_sign(
     msg_hash: Octets,
-    prv_key: PrvKey,
+    prv_key: Integer,
     rho: Octets,
     lower_s: bool = True,
     ec: Curve = secp256k1,

--- a/btclib/ecc/ecies.py
+++ b/btclib/ecc/ecies.py
@@ -76,11 +76,10 @@ import secrets
 from dataclasses import dataclass
 from hashlib import sha256, sha512
 
-from btclib.alias import CipherF, Octets, String
-from btclib.curves import bytes_from_point, mult, secp256k1
+from btclib.alias import CipherF, Integer, Octets, String
+from btclib.curves import bytes_from_point, mult, scalar_from_prv_key, secp256k1
 from btclib.curves.sec_point import _mult_sec_var
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
-from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.to_pub_key import PubKey, point_from_pub_key, pub_keyinfo_from_pub_key
 from btclib.utils import assert_type, bytes_from_octets, str_from_string
 
@@ -108,7 +107,7 @@ _MAC_SIZE = 32
 _BLOCK_SIZE = 16
 
 
-def derive_keys(prv_key: PrvKey, pub_key: PubKey) -> tuple[bytes, bytes, bytes]:
+def derive_keys(prv_key: Integer, pub_key: PubKey) -> tuple[bytes, bytes, bytes]:
     """Return the (iv, key_e, key_m) triple BIE1 derives from an ECDH exchange.
 
     The shared point is serialized compressed and hashed with sha512; the
@@ -124,10 +123,10 @@ def derive_keys(prv_key: PrvKey, pub_key: PubKey) -> tuple[bytes, bytes, bytes]:
 
     No infinity check on the shared point, unlike
     :func:`btclib.ecc.dh.diffie_hellman`, which takes a bare int: the
-    scalars that could produce one are exactly those `int_from_prv_key`
+    scalars that could produce one are exactly those `scalar_from_prv_key`
     rejects, and both inputs here go through a validating conversion.
     """
-    q = int_from_prv_key(prv_key)
+    q = scalar_from_prv_key(prv_key)
     # the public key stays octets: no coordinate of it is read here, and
     # `_mult_sec_var` is the multiplication without the point in between
     sec = pub_keyinfo_from_pub_key(pub_key)[0]
@@ -350,7 +349,7 @@ def encrypt(
     pub_key: PubKey,
     encrypt_f: CipherF,
     *,
-    eph_prv_key: PrvKey | None = None,
+    eph_prv_key: Integer | None = None,
     magic: bytes = MAGIC,
 ) -> str:
     """Encrypt a message to a public key, returning the BIE1 base64 armor.
@@ -370,7 +369,7 @@ def encrypt(
     if eph_prv_key is None:
         # in the range [1, n-1], as everywhere else a key is generated here
         eph_prv_key = 1 + secrets.randbelow(secp256k1.n - 1)
-    q = int_from_prv_key(eph_prv_key)
+    q = scalar_from_prv_key(eph_prv_key)
 
     iv, key_e, key_m = derive_keys(q, pub_key)
     ciphertext = encrypt_f(key_e, iv, msg)
@@ -392,7 +391,7 @@ def encrypt(
 
 def decrypt(
     armor: String,
-    prv_key: PrvKey,
+    prv_key: Integer,
     decrypt_f: CipherF,
     *,
     magic: bytes = MAGIC,

--- a/btclib/ecc/ellswift.py
+++ b/btclib/ecc/ellswift.py
@@ -55,8 +55,14 @@ from __future__ import annotations
 import secrets
 
 from btclib._libsecp256k1 import ellswift as libsecp256k1_ellswift
-from btclib.alias import Octets, Point
-from btclib.curves import Curve, bytes_from_point, mult, secp256k1
+from btclib.alias import Integer, Octets, Point
+from btclib.curves import (
+    Curve,
+    bytes_from_point,
+    mult,
+    scalar_from_prv_key,
+    secp256k1,
+)
 from btclib.curves.curve import (
     _assert_valid_ec,
     _is_x_coordinate_var,
@@ -67,7 +73,6 @@ from btclib.curves.curve import (
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.hashes import tagged_hash
 from btclib.number_theory import mod_inv_var, mod_sqrt_var
-from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.to_pub_key import PubKey, point_from_pub_key
 from btclib.utils import bytes_from_octets
 
@@ -273,7 +278,7 @@ def _ell_from_octets(ell: Octets, ec: Curve) -> bytes:
     return ell
 
 
-def create_var(prv_key: PrvKey, ec: Curve = secp256k1) -> bytes:
+def create_var(prv_key: Integer, ec: Curve = secp256k1) -> bytes:
     """Return an ElligatorSwift encoding of the private key's public key.
 
     The private key is its own entropy for the encoding, which is what
@@ -281,9 +286,9 @@ def create_var(prv_key: PrvKey, ec: Curve = secp256k1) -> bytes:
     encoding the public key: a caller cannot supply randomness that is a
     function of the key, because it supplies none.
     """
-    q = int_from_prv_key(prv_key, ec)
+    q = scalar_from_prv_key(prv_key, ec)
 
-    # the bindings hold the private key to the same 1..n-1 int_from_prv_key
+    # the bindings hold the private key to the same 1..n-1 scalar_from_prv_key
     # does, so what reaches them is a key they take
     if _libsecp256k1_serves(ec, None):
         return libsecp256k1_ellswift.create(q)
@@ -333,7 +338,7 @@ def decode_var(ell: Octets, ec: Curve = secp256k1) -> Point:
 def xdh(
     ell_a: Octets,
     ell_b: Octets,
-    prv_key: PrvKey,
+    prv_key: Integer,
     party: int,
     ec: Curve = secp256k1,
 ) -> bytes:
@@ -351,7 +356,7 @@ def xdh(
     if party not in {0, 1}:
         err_msg = f"invalid party: {party}, not 0 (A) or 1 (B)"
         raise BTClibValueError(err_msg)
-    q = int_from_prv_key(prv_key, ec)
+    q = scalar_from_prv_key(prv_key, ec)
 
     if _libsecp256k1_serves(ec, None):
         return libsecp256k1_ellswift.xdh(ell_a, ell_b, q, party)

--- a/btclib/ecc/musig2.py
+++ b/btclib/ecc/musig2.py
@@ -117,8 +117,8 @@ from hashlib import sha256
 from typing import TYPE_CHECKING
 
 from btclib._libsecp256k1 import musig as libsecp256k1_musig
-from btclib.alias import INF, Octets, Point
-from btclib.curves import mult, multi_mult_var, secp256k1
+from btclib.alias import INF, Integer, Octets, Point
+from btclib.curves import mult, multi_mult_var, scalar_from_prv_key, secp256k1
 from btclib.curves.curve import _libsecp256k1_serves, _sum_var, _tweak_add_var
 from btclib.curves.sec_point import (
     bytes_from_point,
@@ -132,7 +132,6 @@ from btclib.exceptions import (
     InvalidContributionError,
 )
 from btclib.hashes import tagged_hash
-from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.utils import assert_type, bytes_from_octets
 
 __all__ = [
@@ -274,9 +273,9 @@ def _flags(is_xonly: Sequence[bool]) -> tuple[bool, ...]:
     return tuple(_flag(flag) for flag in is_xonly)
 
 
-def individual_pub_key(prv_key: PrvKey) -> bytes:
+def individual_pub_key(prv_key: Integer) -> bytes:
     """Return the plain (33-byte, compressed) public key of a signer."""
-    return bytes_from_prv_key_int(int_from_prv_key(prv_key, secp256k1), secp256k1)
+    return bytes_from_prv_key_int(scalar_from_prv_key(prv_key, secp256k1), secp256k1)
 
 
 def key_sort(pub_keys: Sequence[Octets]) -> list[bytes]:
@@ -449,7 +448,7 @@ def _nonce_hash(
 
 def nonce_gen_(
     rand_: Octets,
-    prv_key: PrvKey | None,
+    prv_key: Integer | None,
     pub_key: Octets,
     agg_x_only_pub_key: Octets | None = None,
     msg: Octets | None = None,
@@ -485,7 +484,7 @@ def nonce_gen_(
         # the key is masked by xor with the hashed randomness, rather
         # than hashed together with it, as BIP340 does: the fewer
         # operations touch the secret, the less there is to measure
-        q = int_from_prv_key(prv_key, secp256k1)
+        q = scalar_from_prv_key(prv_key, secp256k1)
         rand = _bytes_xor(q.to_bytes(_SCALAR_SIZE, "big"), tagged_hash(_AUX_TAG, rand_))
     pk = bytes_from_octets(pub_key, _PK_SIZE)
     agg_pk = (
@@ -516,7 +515,7 @@ def nonce_gen_(
 
 
 def nonce_gen(
-    prv_key: PrvKey | None,
+    prv_key: Integer | None,
     pub_key: Octets,
     agg_x_only_pub_key: Octets | None = None,
     msg: Octets | None = None,
@@ -770,7 +769,7 @@ def _session_key_agg_coeff(session_ctx: SessionContext, pub_key: bytes) -> int:
     return _key_agg_coeff_(values.L, values.second, pub_key)
 
 
-def sign(sec_nonce: bytearray, prv_key: PrvKey, session_ctx: SessionContext) -> bytes:
+def sign(sec_nonce: bytearray, prv_key: Integer, session_ctx: SessionContext) -> bytes:
     """Return the 32-byte partial signature of one signer.
 
     The secnonce is consumed: its first 64 bytes are zeroed the moment
@@ -801,7 +800,7 @@ def sign(sec_nonce: bytearray, prv_key: PrvKey, session_ctx: SessionContext) -> 
     if values.R[1] % 2:
         k_1_, k_2_ = secp256k1.n - k_1_, secp256k1.n - k_2_
 
-    d_ = int_from_prv_key(prv_key, secp256k1)
+    d_ = scalar_from_prv_key(prv_key, secp256k1)
     pk = individual_pub_key(d_)
     if pk != bytes(sec_nonce[2 * _SCALAR_SIZE :]):
         raise BTClibValueError("Public key does not match nonce_gen argument")
@@ -832,7 +831,7 @@ def _det_nonce_hash(
 
 
 def deterministic_sign(
-    prv_key: PrvKey,
+    prv_key: Integer,
     agg_other_nonce: Octets,
     pub_keys: Sequence[Octets],
     tweaks: Sequence[Octets],
@@ -852,7 +851,7 @@ def deterministic_sign(
     key is what a deterministic scheme must not do -- pass `rand` when
     there is any doubt.
     """
-    q = int_from_prv_key(prv_key, secp256k1)
+    q = scalar_from_prv_key(prv_key, secp256k1)
     sk = q.to_bytes(_SCALAR_SIZE, "big")
     if rand is not None:
         sk = _bytes_xor(sk, tagged_hash(_AUX_TAG, bytes_from_octets(rand)))
@@ -1122,7 +1121,7 @@ def partial_sig_agg_adaptor(
     return PreSignature(x_R, s)
 
 
-def adapt(pre_sig: PreSignature, t: PrvKey, session_ctx: SessionContext) -> ssa.Sig:
+def adapt(pre_sig: PreSignature, t: Integer, session_ctx: SessionContext) -> ssa.Sig:
     """Complete a pre-signature into a signature, given the secret adaptor.
 
     `session_ctx` is the session `pre_sig` was built from -- the same
@@ -1142,7 +1141,7 @@ def adapt(pre_sig: PreSignature, t: PrvKey, session_ctx: SessionContext) -> ssa.
     against the aggregate key it already has.
     """
     values = session_values(session_ctx)
-    t_ = int_from_prv_key(t, secp256k1)
+    t_ = scalar_from_prv_key(t, secp256k1)
     if values.R[1] % 2:
         t_ = secp256k1.n - t_
     s = (pre_sig.s + t_) % secp256k1.n

--- a/btclib/ecc/rfc6979_nonce.py
+++ b/btclib/ecc/rfc6979_nonce.py
@@ -28,10 +28,9 @@ import hashlib
 import hmac
 from hashlib import sha256
 
-from btclib.alias import HashF, Octets
-from btclib.curves import Curve, secp256k1
+from btclib.alias import HashF, Integer, Octets
+from btclib.curves import Curve, scalar_from_prv_key, secp256k1
 from btclib.curves.curve import _assert_valid_ec
-from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.utils import bytes_from_octets, int_from_bits
 
 __all__ = [
@@ -117,7 +116,7 @@ def _rfc6979_nonce_(
 
 def rfc6979_nonce_(
     msg_hash: Octets,
-    prv_key: PrvKey,
+    prv_key: Integer,
     ec: Curve = secp256k1,
     hf: HashF = sha256,
     extra_entropy: Octets | None = None,
@@ -135,7 +134,7 @@ def rfc6979_nonce_(
     function underneath it gives the same 32 octets.
     """
     c = challenge_(msg_hash, ec, hf)
-    q = int_from_prv_key(prv_key, ec)
+    q = scalar_from_prv_key(prv_key, ec)
     extra = None if extra_entropy is None else bytes_from_octets(extra_entropy)
 
     return _rfc6979_nonce_(c, q, ec, hf, extra)

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -60,8 +60,14 @@ from types import TracebackType
 from typing import overload
 
 from btclib._libsecp256k1 import ssa as libsecp256k1_ssa
-from btclib.alias import BinaryData, HashF, JacPoint, Octets, Point
-from btclib.curves import Curve, PreparedPoint, point_from_octets, secp256k1
+from btclib.alias import BinaryData, HashF, Integer, JacPoint, Octets, Point
+from btclib.curves import (
+    Curve,
+    PreparedPoint,
+    point_from_octets,
+    scalar_from_prv_key,
+    secp256k1,
+)
 from btclib.curves.curve import (
     _assert_valid_ec,
     _is_x_coordinate_var,
@@ -77,7 +83,6 @@ from btclib.ecc.commit_nonce import commit_entropy_, commit_nonce_, commit_point
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
 from btclib.hashes import _assert_valid_hf, reduce_to_hlen, tagged_hash
 from btclib.number_theory import mod_inv_var
-from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.utils import (
     assert_no_trailing,
     assert_type,
@@ -320,7 +325,7 @@ def point_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve = secp256k1) -> Point:
     return x, _y_even_var(x, ec)
 
 
-def gen_keys(prv_key: PrvKey | None = None, ec: Curve = secp256k1) -> tuple[int, int]:
+def gen_keys(prv_key: Integer | None = None, ec: Curve = secp256k1) -> tuple[int, int]:
     """Return a BIP340 private/public (int, int) key-pair."""
     # as in dsa.gen_keys, and for its reason
     _assert_valid_ec(ec)
@@ -328,7 +333,7 @@ def gen_keys(prv_key: PrvKey | None = None, ec: Curve = secp256k1) -> tuple[int,
     if prv_key is None:
         q = 1 + secrets.randbelow(ec.n - 1)
     else:
-        q = int_from_prv_key(prv_key, ec)
+        q = scalar_from_prv_key(prv_key, ec)
 
     x_Q, y_Q = mult(q, ec=ec)
     if y_Q % 2:
@@ -394,7 +399,7 @@ def _sign_(c: int, q: int, nonce: int, r: int, ec: Curve) -> Sig:
 @overload
 def sign_(
     msg: Octets,
-    prv_key: PrvKey,
+    prv_key: Integer,
     aux: Octets | None = ...,
     ec: Curve = ...,
     hf: HashF = ...,
@@ -407,7 +412,7 @@ def sign_(
 @overload
 def sign_(
     msg: Octets,
-    prv_key: PrvKey,
+    prv_key: Integer,
     aux: Octets | None = ...,
     ec: Curve = ...,
     hf: HashF = ...,
@@ -419,7 +424,7 @@ def sign_(
 
 def sign_(
     msg: Octets,
-    prv_key: PrvKey,
+    prv_key: Integer,
     aux: Octets | None = None,
     ec: Curve = secp256k1,
     hf: HashF = sha256,
@@ -499,9 +504,9 @@ def sign_(
     # A commitment stays with the Python path: it tweaks the nonce, and
     # the nonce is the bindings' own to derive
     if _libsecp256k1_serves(ec, hf) and commit_hash is None:
-        # the bindings take a scalar, not the many representations of a
-        # private key btclib accepts
-        q = int_from_prv_key(prv_key, ec)
+        # the bindings take a scalar, and so does this module now: what
+        # the call still buys is the range check and the octets
+        q = scalar_from_prv_key(prv_key, ec)
         # the caller's `verify`, crossing with the rest: the bindings
         # perform the check and there is nothing for this arm to add,
         # BIP340's step being a bare verification under a point the
@@ -596,7 +601,7 @@ def sign_(
 @overload
 def sign(
     msg: Octets,
-    prv_key: PrvKey,
+    prv_key: Integer,
     aux: Octets | None = ...,
     ec: Curve = ...,
     hf: HashF = ...,
@@ -609,7 +614,7 @@ def sign(
 @overload
 def sign(
     msg: Octets,
-    prv_key: PrvKey,
+    prv_key: Integer,
     aux: Octets | None = ...,
     ec: Curve = ...,
     hf: HashF = ...,
@@ -621,7 +626,7 @@ def sign(
 
 def sign(
     msg: Octets,
-    prv_key: PrvKey,
+    prv_key: Integer,
     aux: Octets | None = None,
     ec: Curve = secp256k1,
     hf: HashF = sha256,
@@ -716,13 +721,13 @@ class Signer:
     """
 
     def __init__(
-        self, prv_key: PrvKey, ec: Curve = secp256k1, hf: HashF = sha256
+        self, prv_key: Integer, ec: Curve = secp256k1, hf: HashF = sha256
     ) -> None:
         _assert_valid_hf(hf)
         # the scalar, whatever spelling the key arrived in, and the
         # validation with it -- this is a public constructor and the
         # refusal belongs at it rather than at the first signature
-        self._q = int_from_prv_key(prv_key, ec)
+        self._q = scalar_from_prv_key(prv_key, ec)
         self._ec = ec
         self._hf = hf
         self._hf_len = hf().digest_size

--- a/btclib/psbt/musig2.py
+++ b/btclib/psbt/musig2.py
@@ -81,7 +81,7 @@ from btclib.psbt.psbt_utils import (
     assert_valid_musig2_pub_key,
 )
 from btclib.script import type_and_payload
-from btclib.to_prv_key import PrvKey
+from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.utils import assert_type, bytes_from_octets
 
 __all__ = [
@@ -386,14 +386,18 @@ def nonce_gen(
     aggregate_pub_key = bytes_from_octets(aggregate_pub_key, MUSIG2_PUB_KEY_SIZE)
     leaf_hash = bytes_from_octets(leaf_hash)
     parts = _session_parts(psbt, vin_i, aggregate_pub_key, leaf_hash)
-    pub_key = musig2.individual_pub_key(prv_key)
+    # the scalar here rather than the spelling below: `ecc.musig2` takes
+    # an int and the octets of one, and a WIF or an xprv is this layer's
+    # to decode -- an explicit call where a union guessed (issue #1188)
+    q = int_from_prv_key(prv_key)
+    pub_key = musig2.individual_pub_key(q)
     if pub_key not in parts.participants:
         err_msg = f"{pub_key.hex()} is not a participant of aggregate key "
         err_msg += aggregate_pub_key.hex()
         raise BTClibValueError(err_msg)
 
     sec_nonce, pub_nonce = musig2.nonce_gen(
-        prv_key, pub_key, parts.tweaked_pub_key[1:], parts.msg, extra_in
+        q, pub_key, parts.tweaked_pub_key[1:], parts.msg, extra_in
     )
     key_data = _key_data(pub_key, parts.tweaked_pub_key, leaf_hash)
     psbt.inputs[vin_i].musig2_pub_nonces[key_data] = pub_nonce
@@ -423,7 +427,9 @@ def partial_sign(
     aggregate_pub_key = bytes_from_octets(aggregate_pub_key, MUSIG2_PUB_KEY_SIZE)
     leaf_hash = bytes_from_octets(leaf_hash)
     psbt_in = psbt.inputs[vin_i]
-    pub_key = musig2.individual_pub_key(prv_key)
+    # as in `nonce_gen` above, and for its reason
+    q = int_from_prv_key(prv_key)
+    pub_key = musig2.individual_pub_key(q)
     tweaked_pub_key = _session_parts(
         psbt, vin_i, aggregate_pub_key, leaf_hash
     ).tweaked_pub_key
@@ -435,7 +441,7 @@ def partial_sign(
         raise BTClibValueError(err_msg)
 
     session = session_context(psbt, vin_i, aggregate_pub_key, leaf_hash=leaf_hash)
-    psig = musig2.sign(sec_nonce, prv_key, session.context)
+    psig = musig2.sign(sec_nonce, q, session.context)
     if not musig2.partial_sig_verify_(psig, pub_nonce, pub_key, session.context):
         # unreachable short of a defect in either this module or `sign`:
         # the context is the one the signature was just made against.

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -142,6 +142,14 @@ The four aliases:
     carries neither and everything downstream has to assume mainnet and
     compressed.
 
+    **This is the bitcoin layer's type, not** ``ecc``\ **'s.** The
+    signature schemes take a scalar — an ``int``, its ``n_size`` octets,
+    or their hex — because a WIF and an extended key are ``b58``'s and
+    ``bip32``'s objects, and converting one is a call you make. So
+    ``b58.p2pkh(wif)`` works and ``dsa.sign(msg, wif)`` does not; pass
+    ``prv_keyinfo_from_prv_key(wif)[0]``. ``ecc.bms`` is the exception,
+    message signing being bitcoin: it still takes the lot.
+
 ``Key``
     A public key in any of its spellings — SEC bytes compressed or not,
     an ``(x, y)`` tuple, an ``xpub`` — and also anything that is a

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -378,6 +378,7 @@ def test_ec_exports_the_curve_api_not_the_benchmark() -> None:
         "mult",
         "multi_mult_var",
         "point_from_octets",
+        "scalar_from_prv_key",
         "secp256k1",
         "set_libsecp256k1_serving",
     ]

--- a/tests/curve_parameter_test.py
+++ b/tests/curve_parameter_test.py
@@ -94,6 +94,7 @@ from btclib.curves.sec_point import (
     bytes_from_point,
     bytes_from_prv_key_int,
     point_from_octets,
+    scalar_from_prv_key,
 )
 from btclib.ecc import borromean, dsa, ellswift, pedersen, ssa
 from btclib.ecc.bip340_nonce import bip340_nonce_
@@ -209,6 +210,11 @@ _CASES = (
         "btclib.curves.sec_point.bytes_from_prv_key_int",
         bytes_from_prv_key_int,
         {"prv_key_int": _PRV_KEY},
+    ),
+    _Case(
+        "btclib.curves.sec_point.scalar_from_prv_key",
+        scalar_from_prv_key,
+        {"prv_key": _PRV_KEY},
     ),
     _Case(
         "btclib.curves.sec_point.point_from_octets",

--- a/tests/curves/sec_point_test.py
+++ b/tests/curves/sec_point_test.py
@@ -7,6 +7,8 @@
 import pytest
 
 from btclib.alias import INF
+from btclib.b58 import wif_from_prv_key
+from btclib.bip32 import BIP32KeyData, rootxprv_from_seed
 from btclib.curves import (
     Curve,
     bytes_from_point,
@@ -17,10 +19,12 @@ from btclib.curves import (
     curve,
     mult,
     point_from_octets,
+    scalar_from_prv_key,
+    secp256k1,
 )
 from btclib.curves.curve import CURVES
 from btclib.curves.sec_point import _mult_sec_var, _sec_from_octets
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from tests import needs_bindings
 
 # test curves: very low cardinality
@@ -313,3 +317,35 @@ def test_mult_sec_var(bindings: bool, monkeypatch: pytest.MonkeyPatch) -> None:
     x_Q = 0xEEFDEA4CDB677750A420FEE807EACF21EB9898AE79B9768766E4FAA04A2D4A34
     with pytest.raises(BTClibValueError, match="invalid x-coordinate: "):
         _mult_sec_var(b"\x02" + x_Q.to_bytes(ec.p_size, "big"), 2, ec)
+
+
+def test_a_scalar_is_an_int_or_its_octets_and_nothing_else() -> None:
+    """What a private key may be spelled as at this layer (issue #1188).
+
+    The integer, its `n_size` octets, their hex, and the buffers
+    `bytes_from_octets` takes beside them. A WIF and an extended key are
+    not among them: they are `b58`'s and `bip32`'s objects, and this file
+    knows about a curve and not about bitcoin, so it could not decode one
+    without importing a layer above itself.
+
+    On secp256k1 the size alone separates a scalar from a point --
+    `n_size` is 32 where a point is 33 or 65. That is a coincidence and
+    not a rule: `sec_point` names the catalogued curves whose `n_size`
+    is their compressed size, and there a point is refused by the range
+    check instead.
+    """
+    q = 0xC0FFEE
+    octets = q.to_bytes(32, "big")
+    for spelling in (q, octets, octets.hex(), bytearray(octets), memoryview(octets)):
+        assert scalar_from_prv_key(spelling) == q  # type: ignore[arg-type]
+
+    # a WIF and an xprv reach here as text, and text is hex or nothing
+    for text in (wif_from_prv_key(q), rootxprv_from_seed("5e" * 32)):
+        with pytest.raises(BTClibValueError, match="invalid hex string"):
+            scalar_from_prv_key(text)
+    with pytest.raises(BTClibTypeError, match="invalid octets type: BIP32KeyData"):
+        scalar_from_prv_key(BIP32KeyData.b58decode(rootxprv_from_seed("5e" * 32)))  # type: ignore[arg-type]
+
+    for out_of_range in (0, secp256k1.n):
+        with pytest.raises(BTClibValueError, match="private key not in 1..n-1"):
+            scalar_from_prv_key(out_of_range)


### PR DESCRIPTION
The uniform half of the row `ssa` was the exception to. Nine `ecc`
modules resolved a private key through `to_prv_key`, all with the same
import and the same call; they resolve it through `curves` now, and
`ecc` takes a scalar where it took a WIF.

```python
to_prv_key.int_from_prv_key(prv_key: PrvKey)   # WIF, xprv, int, octets
curves.scalar_from_prv_key(prv_key: Integer)   # int, octets, hex
```

`scalar_from_prv_key` goes beside `bytes_from_prv_key_int` for its
reason: whether a scalar is in 1..n-1 is a fact about the curve, and
nothing above `curves` knows more about it than `curves` does.

**`ecc.bms` keeps `to_prv_key`**, and keeps a different function — it
wants the `(int, network, compressed)` record, message signing being
bitcoin by definition. Of the `ecc` modules that used `to_prv_key` it is
the one that stays.

## No new alias, and why the name is `scalar_`

`Integer` is the parameter. A `PrvKey` of `curves`' own would have been
that same union of types under a second name and so nothing mypy could
check — which is what
[ISS #1238](https://github.com/btclib-org/btclib/issues/1238) is about,
and which this branch briefly did before the measurement said not to.
`mult`'s `m_int` is the tree's answer: the role goes in the parameter
name.

`scalar_from_prv_key` and not `int_from_prv_key`, because `int` names
the Python type where `scalar` names the role — and because it keeps the
new function off the wide converter's name.
`tests/curve_parameter_test.py` drives both, side by side, each under
its own; they shared one for exactly as long as it took to measure that
they should not.

## What moves, measured

Old against new over every entry point these modules expose:

- **Three spellings go**: a WIF, an xprv as text, an xprv as
  `BIP32KeyData`.
- **Three refusals change wording**, two of them class with it.
  `NotAPrvKeyError` is not raised by these nine any more — `bms` raises
  it exactly as before, so an `except NotAPrvKeyError` is load-bearing
  there and dead around `dsa.sign`.
- **One shape crosses exception families**: an extended *public* key as
  a `BIP32KeyData`, from `InvalidPrvKeyError` to `BTClibTypeError`. The
  private one was accepted and is withdrawn, not re-messaged.
- `except BTClibValueError` does not cover everything these modules
  raise — and did not before either, `_assert_prv_key_type` having
  always answered a wrong type with a `BTClibTypeError`.
- **What is left keeps its answers**: an out-of-range int and
  right-sized out-of-range octets raise the same "private key not in
  1..n-1" they did.

## Where the layer boundary shows

`psbt.musig2` keeps the wide `PrvKey` — a psbt signer holding a WIF is
not doing anything wrong — and converts once, explicitly, before calling
`ecc.musig2`. That explicit call is what the union was hiding, and mypy
is what found it.

## What was run

- `uv run pytest` — exit 0, coverage 100.00%
- `uv run pre-commit run --all-files` — exit 0
- the documented sphinx `-W --keep-going` build — exit 0

Two censuses had to be told, which is what they are for:
`tests/all_test.py` pins `btclib.curves.__all__` name by name, and
`tests/curve_parameter_test.py` requires every function taking an `ec`
to be driven over the curve table.

Six local review rounds, each verifying claims by executing them. Every
blocking finding across all six was a false sentence in prose; none was
a defect in the code. Among them: a claim that the octet size tells a
scalar from a point, which four catalogued curves falsify; a migration
note that described a pre-existing fact as a change; and, twice, a
sentence corrected in one file and left standing in another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hde6RUtTpqFBkPziUqzZkX

## Summary by Sourcery

Make ECC private-key APIs operate on curve-validated scalars while leaving Bitcoin-specific key decoding at higher layers.

New Features:
- Add the curve-aware `scalar_from_prv_key` conversion API for validating scalar private keys.

Enhancements:
- Narrow nine ECC private-key interfaces to accept scalar integers, octets, or hex instead of WIF and extended-key representations.
- Preserve Bitcoin-specific private-key decoding in `ecc.bms` and add explicit conversion at the PSBT MuSig2 boundary.
- Clarify and standardize the resulting input validation and exception behavior across affected ECC modules.

Documentation:
- Document the breaking private-key input changes and migration guidance in the changelog and release notes.

Tests:
- Expand curve API coverage and validate accepted scalar representations, rejected key formats, and range checks.