### PR TITLE
The interpreters this package claims are the ones it runs on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,25 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **The interpreters this package claims are the ones it runs on**
+  (btclib-org/.github#83). `requires-python`, the per-version
+  `Programming Language :: Python ::` classifiers and `test.yml`'s own
+  matrix are one fact written three times, and nothing compared them.
+  `tests/interpreters_test.py` does: the floor is the lowest classifier,
+  the classified set and the matrix's CPython set are each other, and the
+  PyPy classifier is present exactly when a PyPy interpreter runs.
+
+  The drift it catches misleads somebody who is not reading this
+  repository — PyPI shows a classifier to whoever is choosing the
+  package, so a version left behind when a floor moves is an interpreter
+  advertised and never touched.
+
+  It does not encode the calendar. The organization standard's rule is
+  that a library covers every Python still in support, which moves twice
+  around each October; python.org keeps that schedule, and a date written
+  here would be one more thing to move. The claim held is the weaker and
+  checkable one: whatever the three say, they say the same thing.
+
 - **The declaration section is read to its own end, not to the file's**
   (btclib-org/.github#32). `conventions_test.py`'s `_section()` sliced
   from `## Convention tests` to the end of `tests/README.md`, on the

--- a/tests/interpreters_test.py
+++ b/tests/interpreters_test.py
@@ -1,0 +1,123 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The interpreters this package claims are the ones it runs on.
+
+One fact, declared three times: `requires-python` is the floor,
+`Programming Language :: Python :: X.Y` is what PyPI shows whoever is
+choosing the package, and `test.yml`'s own list is what actually runs.
+Nothing compared them, and the three drift in the direction that is
+hardest to notice -- a classifier left behind when a floor moves is a
+package advertising an interpreter its suite never touches, and the
+person it misleads is not reading this repository.
+
+The organization standard's rule is that a library covers every Python
+that is not out of support, so all three move together twice around each
+October: one version leaves support as another is released. This module
+does not know that calendar and does not try to -- python.org keeps it,
+and a test that hard-coded a date would be one more thing to move. What
+it holds is the weaker and checkable claim: whatever the three say, they
+say the same thing.
+
+Read with a regex rather than parsed. `tomllib` arrives in 3.11 and the
+floor here is 3.10, which is the reason `test_copyright.py` reads
+pyproject.toml the same way; the workflow is yaml and no group here
+carries a parser for it.
+"""
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).parents[1]
+_PYPROJECT = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+_TEST_WORKFLOW = (_ROOT / ".github/workflows/test.yml").read_text(encoding="utf-8")
+
+# "3.10" out of `requires-python = ">=3.10"`, the floor and nothing else:
+# an upper bound is not declared here and would be a different claim
+_FLOOR = re.compile(r'^requires-python = ">=(?P<version>3\.\d+)"', re.MULTILINE)
+# the per-version classifiers, not `:: 3` or `:: 3 :: Only`, which say
+# something about the major version rather than about an interpreter
+_CLASSIFIER = re.compile(
+    r'^    "Programming Language :: Python :: (?P<version>3\.\d+)",$', re.MULTILINE
+)
+_PYPY_CLASSIFIER = "Programming Language :: Python :: Implementation :: PyPy"
+# the matrix list `test.yml` builds its suite cells from
+_PYTHONS = re.compile(
+    r"^        python:\n(?P<block>(?:^          - \"\S+\"\n)+)", re.MULTILINE
+)
+
+
+def _versions(pattern: re.Pattern[str], text: str) -> tuple[str, ...]:
+    """Return every `version` group `pattern` finds, in order."""
+    return tuple(m["version"] for m in pattern.finditer(text))
+
+
+def _matrix() -> tuple[str, ...]:
+    """Return the interpreters `test.yml`'s suite matrices name."""
+    found: set[str] = set()
+    for match in _PYTHONS.finditer(_TEST_WORKFLOW):
+        found.update(
+            line.strip().removeprefix('- "').removesuffix('"')
+            for line in match["block"].splitlines()
+        )
+    return tuple(sorted(found))
+
+
+_CLASSIFIED = _versions(_CLASSIFIER, _PYPROJECT)
+_MATRIX = _matrix()
+# the free-threaded build and PyPy are the same interpreter version as
+# far as a classifier is concerned: "3.14t" is CPython 3.14, and
+# "pypy-3.11" is what the PyPy classifier covers rather than a version
+# of its own
+_CPYTHON = tuple(sorted({v.rstrip("t") for v in _MATRIX if not v.startswith("pypy")}))
+
+
+def test_the_three_declarations_were_read() -> None:
+    """Each pattern found something, so the checks below quantify over it.
+
+    A key renamed, a classifier reindented, the workflow's block moved:
+    each would leave one of these empty and every comparison below
+    trivially true.
+    """
+    assert _FLOOR.search(_PYPROJECT), "pyproject.toml declares no requires-python"
+    assert _CLASSIFIED, "pyproject.toml declares no per-version Python classifier"
+    assert _MATRIX, "test.yml declares no PYTHONS block"
+
+
+def test_the_floor_is_the_lowest_classifier() -> None:
+    """`requires-python` and the classifiers name the same oldest Python."""
+    floor = _FLOOR.search(_PYPROJECT)
+    assert floor, "pyproject.toml declares no requires-python"
+    lowest = min(_CLASSIFIED, key=lambda v: tuple(int(p) for p in v.split(".")))
+    assert floor["version"] == lowest, (
+        f"requires-python is >={floor['version']} and the lowest classifier"
+        f" is {lowest}: one of the two was moved and the other was not"
+    )
+
+
+def test_every_classified_interpreter_is_in_the_matrix() -> None:
+    """A version PyPI advertises is a version the suite runs."""
+    unrun = [v for v in _CLASSIFIED if v not in _CPYTHON]
+    assert not unrun, (
+        f"classified and not in test.yml's matrix: {', '.join(unrun)}."
+        " PyPI shows a classifier to whoever is choosing this package"
+    )
+
+
+def test_every_matrix_interpreter_is_classified() -> None:
+    """A version the suite runs is a version PyPI advertises."""
+    unclassified = [v for v in _CPYTHON if v not in _CLASSIFIED]
+    assert not unclassified, (
+        f"in test.yml's matrix and not classified: {', '.join(unclassified)}"
+    )
+
+
+def test_pypy_is_classified_exactly_when_it_is_run() -> None:
+    """The PyPy classifier is a claim about the matrix, not a decoration."""
+    classified = _PYPY_CLASSIFIER in _PYPROJECT
+    run = any(v.startswith("pypy") for v in _MATRIX)
+    assert classified == run, (
+        f"the PyPy classifier is {'present' if classified else 'absent'} and"
+        f" the matrix {'runs' if run else 'does not run'} a PyPy interpreter"
+    )


### PR DESCRIPTION
btclib-org/.github#83's third box, ported from
btclib-org/btclib-secp256k1#335 to the second and third of the three
libraries.

## One fact, three declarations, nothing comparing them

- `requires-python = ">=3.10"` — the floor
- `Programming Language :: Python :: 3.10` … `:: 3.14` — what PyPI shows
  whoever is choosing this package
- `test.yml`'s `python:` matrix — what actually runs

The drift this catches misleads somebody who is not reading this
repository: a classifier left behind when a floor moves is an interpreter
advertised on the index and never touched by the suite.

## The four claims that are checkable

1. the floor is the lowest per-version classifier;
2. every classified interpreter is in the matrix;
3. every matrix interpreter is classified;
4. the PyPy classifier is present exactly when a PyPy row runs.

`3.14t` folds to `3.14` and `pypy3.11` to the PyPy classifier — the
free-threaded build is CPython 3.14 as far as a classifier is concerned,
and PyPy's own version is not one of these.

Each made false and watched to fail:

| what was broken | what failed |
| --- | --- |
| a `:: 3.15` classifier added | `test_every_classified_interpreter_is_in_the_matrix` |
| `requires-python` raised to `>=3.11` alone | `test_the_floor_is_the_lowest_classifier` |
| the PyPy classifier deleted | `test_pypy_is_classified_exactly_when_it_is_run` |

The second needs `--frozen` rather than `--locked` to run at all: raising
`requires-python` invalidates `uv.lock`, so `uv run --locked` refuses
before pytest starts. Recorded because the first attempt at it looked
like a mutation the test missed, and was a mutation the runner never
reached.

## What it does not encode

The calendar. The standard's rule is that a library covers every Python
still in support, which moves twice around each October — one version
out, one released. python.org keeps that schedule; a date written here
would be one more thing to move. The claim held is the weaker and
checkable one: **whatever the three say, they say the same thing.**

## Not a copy

The pattern is this repository's own. `btclib-secp256k1` spells its
matrix as a block scalar named `PYTHONS`, read twice by one job; here it
is a list under `python:`, and the parser reads that. What is shared is
the four claims, not the file — which is the same distinction section 7
draws about convention tests.

## Summary by Sourcery

Keep the package’s advertised Python interpreters aligned with the versions exercised by its test suite.

Enhancements:
- Add convention tests that keep the declared Python support floor, PyPI classifiers, and CI interpreter matrix synchronized, including PyPy coverage.

Documentation:
- Document the interpreter-declaration consistency checks and clarify that they validate agreement without encoding Python’s support calendar.

Tests:
- Add tests verifying the Python floor matches the lowest classifier, classified and tested CPython versions match in both directions, and PyPy classification matches CI coverage.