### PR TITLE
interpreters_test.py cites the file this repository has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,23 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **`interpreters_test.py` cites the file this repository has**. Its
+  docstring named `test_copyright.py` as the module that reads
+  `pyproject.toml` by regex for the same `tomllib`-arrives-in-3.11
+  reason. That is the name in `btclib-secp256k1`, where the module was
+  written; here every test file is suffixed rather than prefixed and the
+  file is `copyright_test.py`. The substance was right — that module does
+  give that reason, at its own line 16 — and a reader following the
+  citation landed nowhere.
+
+  Found by the review of the same port into `bitcoin-core-rpc`
+  (btclib-org/bitcoin-core-rpc#210), where the repair is different again:
+  that tree has no copyright test at all, and the file that does read
+  `pyproject.toml` by regex reads it for an unrelated reason, so the
+  citation goes rather than moves. Section 15's rule, met three times in
+  one afternoon: check the claim against this tree, not against the
+  sibling the file came from.
+
 - **The interpreters this package claims are the ones it runs on**
   (btclib-org/.github#83). `requires-python`, the per-version
   `Programming Language :: Python ::` classifiers and `test.yml`'s own

--- a/tests/interpreters_test.py
+++ b/tests/interpreters_test.py
@@ -21,7 +21,7 @@ it holds is the weaker and checkable claim: whatever the three say, they
 say the same thing.
 
 Read with a regex rather than parsed. `tomllib` arrives in 3.11 and the
-floor here is 3.10, which is the reason `test_copyright.py` reads
+floor here is 3.10, which is the reason `copyright_test.py` reads
 pyproject.toml the same way; the workflow is yaml and no group here
 carries a parser for it.
 """


### PR DESCRIPTION
A one-line follow-up to btclib-org/btclib#1246, found by the review of
the same port into a third repository.

The module's docstring named `test_copyright.py` as the file that reads
`pyproject.toml` by regex for the same reason — `tomllib` arrives in 3.11
and the floor is 3.10. That is the name in `btclib-secp256k1`, where the
module was written. Here every test file is suffixed rather than
prefixed, and the file is `copyright_test.py`.

The substance was right: that module does give exactly that reason, at
its own line 16 —

> Regex rather than `tomllib` for the one line wanted out of
> pyproject.toml

— so what was wrong was the name, and a reader following the citation
landed nowhere.

## Why it is worth a pull request of its own

Because the same sentence needs a **different** repair in the third tree,
and that is the part worth recording. btclib-org/bitcoin-core-rpc#210's
review found it there first: that repository has no copyright test at
all, and `conftest_test.py`, which does read `pyproject.toml` with a
regex, reads it for an unrelated reason — *"nothing about a run reports
its own addopts"*. So there the citation goes rather than moves, and the
`tomllib` reason stands on its own.

Section 15's own rule, met three times in one afternoon: check the claim
against this tree, not against the sibling the file came from. I wrote
that step this morning and then ported a file without applying it.

## What I ran

`5 passed`, and `copyright_test.py` exists where the citation now points.

## Summary by Sourcery

Correct the test documentation citation so it points to the repository’s actual copyright test module.

Bug Fixes:
- Correct the interpreters test docstring to cite the repository’s existing `copyright_test.py` module.

Documentation:
- Document the corrected test-file citation in the changelog.