### PR TITLE
The gate runs one image and one interpreter, and the sweeps run on the grid

### DIFF
--- a/.github/scripts/check_python_arm_authority.py
+++ b/.github/scripts/check_python_arm_authority.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Re-derive tests/python_arm_authority_test.py's `_AUTHORITY`, monthly.
+"""Re-derive tests/python_arm_authority_test.py's `_AUTHORITY`, weekly.
 
 That file's docstring documents the measurement by hand: per third-party
 test module, in an environment with no bindings installed,

--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Re-check every vendored-vector pin against upstream, monthly.
+"""Re-check every vendored-vector pin against upstream, weekly.
 
 tests/_data/README.md pins each vendored file to a commit and a git blob
 SHA-1, with a documented manual procedure to re-check one -- last done
@@ -142,9 +142,9 @@ def _latest_commit(repo: str, path: str) -> tuple[str, str] | None:
     path has been renamed or deleted: the sharpest drift there is, a pin
     naming a file that is not there any more. This used to unpack one
     commit out of an empty list and raise `ValueError` instead, so the
-    monthly run went red and `report` was never reached -- no issue
-    opened, on the one kind of drift nobody would otherwise notice, which
-    is what this workflow exists for.
+    run went red and `report` was never reached -- no issue opened, on
+    the one kind of drift nobody would otherwise notice, which is what
+    this workflow exists for.
     """
     result = subprocess.run(  # noqa: S603
         [

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -77,21 +77,14 @@ on:
     # against
     branches: [main]
   schedule:
-    # Tuesdays, 04:23 UTC. Not on the hour: GitHub queues scheduled
-    # workflows across every repository that asked for the same minute,
-    # and the run can be dropped outright when the queue is long.
-    # Tuesday is a day nothing else here asks for -- links Monday, latest
-    # and macos Wednesday, Dependabot Thursday, integration Friday, windows
-    # Saturday and the mutation session Sunday -- so a failure notification
-    # still names the workflow by the day it arrived; and it is the day
-    # btclib-secp256k1 and bitcoin-core-rpc analyse on, so "did CodeQL
-    # go red anywhere" has one morning to read rather than three. Weekly, as
-    # default setup was: what a scheduled analysis catches is a query
-    # CodeQL added since the last commit, which arrives with the bundle
-    # rather than with a branch.
+    # Weekly, as default setup was: what a scheduled analysis catches is
+    # a query CodeQL added since the last commit, which arrives with the
+    # bundle rather than with a branch.
+    # The time is section 10's grid in btclib-org/.github and not this
+    # file's to restate.
     # Cron runs from the default branch only, so this asks nothing until
     # it reaches main; elsewhere the dispatch below is the way in
-    - cron: "23 4 * * 2"
+    - cron: "4 4 * * 2"
   # the escape hatch, and with no pull_request trigger above it is the only
   # way to analyse a branch before it is merged: worth reaching for on one
   # that touches a workflow, which is what the actions queries read
@@ -162,7 +155,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the suite job in test.yml
+          # see the checkout of the coverage job in test.yml
           persist-credentials: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the suite job in test.yml
+          # see the checkout of the coverage job in test.yml
           persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/hwi-integration.yml
+++ b/.github/workflows/hwi-integration.yml
@@ -28,9 +28,13 @@ name: hwi-integration
 
 on:
   schedule:
-    # the same slot integration.yml answers Friday's other half in --
-    # Fridays, 04:29 UTC, not on the hour for the reason given there
-    - cron: "29 4 * * 5"
+    # Friday, the hour after ubuntu.yml: an emulator is a service to keep
+    # working, and a week is as often as anybody acts on the answer.
+    # The time is section 10's grid in btclib-org/.github and not this
+    # file's to restate.
+    # Only the default branch schedules workflows, so on any other branch
+    # this is reachable through the dispatch below alone
+    - cron: "4 5 * * 5"
   push:
     branches: [main]
   workflow_call:
@@ -107,7 +111,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the suite job in test.yml
+          # see the checkout of the coverage job in test.yml
           persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,23 +32,31 @@ name: integration
 # all produces no check on one, skipped or otherwise. What checks the HWI
 # command line on every commit stays tests/hwi_test.py, whose stand-in
 # device is a subprocess answering HWI's own json.
+#
+# A schedule too, like every other unattended question here, and it is
+# not about the tree: the job below is a required check on every pull
+# request and on the commit a merge creates, so a weekly run asks the
+# same node the same question about a tree nothing has touched. What it
+# asks that nothing else does is whether bitcoincore.org still serves the
+# tarball pinned below. A pruned release or a moved path is external rot
+# of exactly the kind published.yml is weekly for -- both fetch a pinned
+# third-party artifact and verify a hash -- and unscheduled it would
+# first appear during a quiet stretch as a red required check on the
+# branch of whoever opened the next pull request, about something that
+# branch did not do. Sweeping several Core majors would be a different
+# question again, and is what bitcoin-core-rpc has
+# (btclib-org/bitcoin-core-rpc#211)
 
 on:
   schedule:
-    # Fridays, 04:29 UTC. Not on the hour: GitHub queues scheduled
-    # workflows across every repository that asked for the same minute,
-    # and the run can be dropped outright when the queue is long.
-    # After the weekday sentinels that come before it -- links Monday,
-    # codeql Tuesday, latest and macos Wednesday, Dependabot Thursday --
-    # and before the windows run on Saturday and the mutation session
-    # that has the rest of the weekend, so each of the week's
-    # unattended questions is answered on a day of its own and a failure
-    # notification names the workflow by the day it arrived.
-    # Cron runs from the default branch only, so this file asks nothing
-    # until it reaches the default branch -- elsewhere it is reachable
-    # through the
-    # dispatch button below and nowhere else
-    - cron: "29 4 * * 5"
+    # Sunday, the hour after mutation.yml: what this run watches is the
+    # download rather than the tree, so it wants the emptiest day rather
+    # than a particular one, and Sunday holds one other job.
+    # The time is section 10's grid in btclib-org/.github and not this
+    # file's to restate.
+    # Only the default branch schedules workflows, so on any other branch
+    # this is reachable through the dispatch below alone
+    - cron: "4 5 * * 0"
   # the same trigger set as the other gates: main so that the commit a
   # merge creates is asked the question too -- and so that a cache is
   # written where every pull request can read it -- the pull request so
@@ -59,8 +67,8 @@ on:
   push:
     branches: [main]
   workflow_call:
-  # the escape hatch, and the way to ask a node about a Core version the
-  # matrix does not carry
+  # the escape hatch, and the way to ask a node about a Core version
+  # other than the one pinned below
   workflow_dispatch:
   # so a change to the tests this runs, or to this file, is checked by the
   # thing it configures -- links.yml does the same for its ignore list.
@@ -145,7 +153,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the suite job in test.yml
+          # see the checkout of the coverage job in test.yml
           persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -197,9 +205,9 @@ jobs:
               sys.exit(1)
           print(f"{len(ran)} regtest tests ran against the node")
           PY
-      # always(), because a failure is what somebody reads on Friday and
-      # the report is what says whether the node refused the transaction
-      # or the test never reached it
+      # always(), because a failure is what somebody opens this job for
+      # and the report is what says whether the node refused the
+      # transaction or the test never reached it
       - name: Upload the report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -208,5 +216,6 @@ jobs:
           path: integration.xml
           if-no-files-found: error
           # long enough to compare a run with the one before it, short
-          # enough that a weekly job does not accumulate a year of xml
+          # enough that a required check does not accumulate a year of
+          # xml
           retention-days: 90

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -50,17 +50,16 @@ name: latest
 
 on:
   schedule:
-    # weekly, on a minute that is not the hour: everything scheduled on
-    # the hour is queued together, and a run that waits is a run whose
-    # failure is noticed later. Wednesday, the day after codeql.yml's
-    # Tuesday, and the same morning macos.yml runs, half an hour after
-    # it -- that pairing is macos.yml's own comment. Thursday is left
-    # for Dependabot, opening the day after this has already reported.
-    # published.yml is on no weekday at all: its subject is an artifact
-    # already released and therefore fixed, so it asks monthly.
+    # Wednesday, the day before Dependabot's, which is the whole point of
+    # the placement: this reports on the upgrade before the pull request
+    # carrying it opens. published.yml follows an hour later, the pair
+    # asking what moved underneath -- the dependencies here, and what the
+    # index serves there.
+    # The time is section 10's grid in btclib-org/.github and not this
+    # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "43 4 * * 3"
+    - cron: "4 4 * * 3"
   workflow_dispatch:
 
 # least privilege for the GITHUB_TOKEN: everything running in a job
@@ -105,7 +104,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the suite job in test.yml
+          # see the checkout of the coverage job in test.yml
           persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -18,16 +18,14 @@ name: links
 
 on:
   schedule:
-    # Mondays, 04:17 UTC. Not on the hour: GitHub queues scheduled
-    # workflows across every repository that asked for the same minute, and
-    # the run can be dropped outright when the queue is long.
-    # First among the weekday sentinels: whether an external page still
-    # resolves is the least volatile of the questions this week asks --
-    # latest.yml (Wednesday) and Dependabot (Thursday) each ask something
-    # that changes more often than the last. published.yml asks the
-    # quietest of them all and asks it monthly, its subject being an
-    # artifact already released and therefore fixed
-    - cron: "17 4 * * 1"
+    # Monday, with vendored-vectors.yml an hour later: both ask whether
+    # what this tree points at is still where it says, one over the
+    # internet and one over a pinned blob.
+    # The time is section 10's grid in btclib-org/.github and not this
+    # file's to restate.
+    # Only the default branch schedules workflows, so on any other branch
+    # this is reachable through the dispatch below alone
+    - cron: "4 4 * * 1"
   # the escape hatch, and the way to check a branch before merging a
   # documentation change that adds links
   workflow_dispatch:
@@ -104,7 +102,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the suite job in test.yml
+          # see the checkout of the coverage job in test.yml
           persist-credentials: false
       - name: Check the links
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the suite job in test.yml
+          # see the checkout of the coverage job in test.yml
           persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,16 +1,18 @@
 ---
 name: macos
 
-# the platform the merge gate does not wait for. test.yml runs the two
-# ubuntu images on every pull request and this one runs the two macOS
-# ones, weekly and before a release, because macOS is where the wait comes
-# from. Measured on one pull request run of the full six: 45 jobs, 93
-# minutes of work and 399 minutes of queueing, the macOS cells waiting 29.4
-# and 23.2 minutes on average for a runner -- one of them 42.2 -- against
-# 0.5 to 1.6 for ubuntu and windows. The command that re-derives it, for
-# whoever doubts the split later:
+# the macOS third of the platform sweep, and ubuntu.yml's header is the
+# argument for all three: what one cell gates, what a sentinel then owes,
+# and what a matrix buys on a library whose bindings are compiled.
 #
-#     id=$(gh run list --workflow=test.yml --limit 1 \
+# macOS is where the queueing is worst, which is the measurement that
+# keeps these cells off the gate. One pull request run of a six-image
+# gate: 45 jobs, 93 minutes of work and 399 minutes of queueing, the
+# macOS cells waiting 29.4 and 23.2 minutes on average for a runner --
+# one of them 42.2 -- against 0.5 to 1.6 for ubuntu and windows. What a
+# run of this workflow costs is the same query, asked of this workflow:
+#
+#     id=$(gh run list --workflow=macos.yml --limit 1 \
 #         --json databaseId --jq '.[0].databaseId')
 #     gh api "repos/$GITHUB_REPOSITORY/actions/runs/$id/jobs?per_page=100"
 #
@@ -23,23 +25,25 @@ name: macos
 #
 # A workflow of its own rather than a row in latest.yml, and that is the
 # whole design: this one holds the dependencies at the lock and moves the
-# platform, latest.yml moves the dependencies over the platforms it samples,
-# and the two are scheduled on the same morning half an hour apart. A red
-# macOS cell in latest.yml with this workflow green is an upgrade; red in
-# both is macOS. One variable each, and the pair reads as a difference.
+# platform, latest.yml moves the dependencies over the platforms it
+# samples. A red macOS cell in latest.yml with this workflow green is an
+# upgrade; red in both is macOS. One variable each, and the pair reads as
+# a difference.
 #
 # It gates no commit and no merge -- a macOS regression sits on main for at
 # most a week -- but release.yml calls it, so one cannot be published
 
 on:
   schedule:
-    # Wednesday, the morning latest.yml also runs, and thirty minutes before
-    # it: the two answer halves of the same question and are worth reading
-    # together. A minute that is not the hour, as every schedule here, so
-    # the run does not queue behind everything else cron starts.
+    # Saturday, with windows.yml an hour later: the two platforms whose
+    # runners are the slowest to come, on the day the grid gives to
+    # platforms. Red in both is the tree; red in one is that platform,
+    # which is the whole of what running them apart buys.
+    # The time is section 10's grid in btclib-org/.github and not this
+    # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "13 4 * * 3"
+    - cron: "4 4 * * 6"
   # lets release.yml gate a publication on this platform too, which is what
   # keeps a weekly sentinel from being the only thing that ever asks
   workflow_call:
@@ -71,16 +75,15 @@ jobs:
       # whole answer, and stopping at the first one hides the rest
       fail-fast: false
       matrix:
-        # the two images test.yml no longer carries. Both, and not the
-        # newest alone: one is Apple silicon and the other Intel, and what
-        # differs between them is the architecture the interpreter and the
-        # bindings wheel target
+        # both, and not the newest alone: one is Apple silicon and the
+        # other Intel, and what differs between them is the architecture
+        # the interpreter and the bindings wheel target
         os:
           - macos-26-intel
           - macos-latest
-        # the interpreter set test.yml runs, unchanged: this workflow moves
-        # the platform and nothing else, so a difference between the two is
-        # attributable to the platform
+        # the interpreter set ubuntu.yml names, unchanged: this workflow
+        # moves the platform and nothing else, so a difference against it
+        # is attributable to the platform
         python:
           - "3.10"
           - "3.11"
@@ -94,20 +97,19 @@ jobs:
     # happens before a job starts and is not counted here
     timeout-minutes: 30
     steps:
-      # the three steps of test.yml's suite job, and each `with:` there
-      # carries the reason for itself
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # see the checkout of the coverage job in test.yml
           persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           python-version: ${{ matrix.python }}
-      # --no-cov for the reason test.yml's suite job gives beside its own
-      # step: this matrix carries the same PyPy cells behind the same
-      # timeout, and the coverage job there is the one place the number is
+      # --no-cov for the reason ubuntu.yml gives beside its own step:
+      # this matrix carries the same PyPy cells behind the same timeout,
+      # and test.yml's coverage job is the one place the number is
       # measured and gated
       - name: Run pytest
         run: uv run --locked --no-default-groups --group test pytest --no-cov

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -30,20 +30,17 @@ on:
   # every commit, and `cosmic-ray baseline` below fails the run before any
   # mutant if the test command has gone stale
   schedule:
-    # Sundays, 03:41 UTC, so a session measured in hours has the weekend
-    # to itself. Not on the hour: GitHub queues scheduled workflows across
-    # every repository that asked for the same minute, and the run can be
-    # dropped outright when the queue is long.
-    # The weekday sentinels run Monday through Thursday in the order the
-    # questions build on each other (links, codeql, latest, then
-    # Dependabot's pull request), and this one asks something on a
-    # different axis entirely -- the suite's own quality, not a
-    # dependency's -- which is what leaves it the weekend on its own.
+    # Sunday, an hour before integration.yml and nothing else: a session
+    # measured in hours gets the emptiest day the grid has. It also asks
+    # something on a different axis from every other sentinel here -- the
+    # suite's own quality, not a dependency's or a platform's.
+    # The time is section 10's grid in btclib-org/.github and not this
+    # file's to restate.
     # Cron runs from the default branch only, so this file gates nothing
     # until it reaches the default branch -- elsewhere it is reachable
     # through the
     # dispatch button below and nowhere else
-    - cron: "41 3 * * 0"
+    - cron: "4 4 * * 0"
   # the escape hatch, and the way to spend a whole afternoon on the engine
   # session that the weekly budget only samples
   workflow_dispatch:
@@ -307,7 +304,7 @@ jobs:
         if: env.SELECTED == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the suite job in test.yml
+          # see the checkout of the coverage job in test.yml
           persist-credentials: false
       - name: Setup uv
         if: env.SELECTED == 'true'

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -20,12 +20,11 @@ name: published
 # one whose values are fixed forever, so neither needs an edit after a
 # release the way a version-pinned assertion would.
 #
-# A schedule this quiet is also the one GitHub itself might stop
-# firing: it suspends a workflow's cron trigger after sixty days
-# without repository activity, and says so only by email. That is
-# exactly the interval this sentinel exists to cover, so a silence
-# from it is worth a look at the Actions tab before it is read as
-# green.
+# A schedule is also something GitHub itself stops firing: it suspends a
+# workflow's cron trigger after sixty days without repository activity,
+# and says so only by email. Sixty quiet days is exactly the stretch this
+# sentinel exists to cover, so a silence from it is worth a look at the
+# Actions tab before it is read as green.
 #
 # What this is not: a sentinel for whether the newest btclib_secp256k1
 # breaks this tree. That question -- issue #397 -- belongs to latest.yml's
@@ -52,24 +51,26 @@ name: published
 
 on:
   schedule:
-    # The first of the month, at a minute that is not the hour: everything
-    # scheduled on the hour queues together, and a run that waits is a run
-    # whose failure is noticed later. Monthly and not weekly because the
-    # subject does not change: an already-released artifact is fixed, and
-    # what can move under it -- a new interpreter, an index serving a file
-    # that does not match its own hash -- moves on nobody's week. The one
-    # moment the answer can change is a release, and that is a call from
-    # release.yml rather than a day on the calendar.
+    # Wednesday, the hour after latest.yml, and the pair is why this is
+    # weekly: latest.yml upgrades every dependency and runs the suite,
+    # this asks what the index actually serves, and read together they
+    # separate a break this tree caused from one that arrived. What it
+    # watches is external rot -- a new interpreter, an index serving a
+    # file that does not match its own hash -- which a week samples as
+    # well as anything longer, and after a release the trigger below
+    # answers immediately regardless.
+    # The time is section 10's grid in btclib-org/.github and not this
+    # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "31 4 1 * *"
+    - cron: "4 5 * * 3"
   # after a release, which is the one moment this workflow's answer can
   # change: a call does not forget, where RELEASING.md's step is a verdict
   # to read. Called by release.yml rather than triggered by
   # workflow_run, which zizmor rates a dangerous trigger and rightly -- it
   # runs the default branch's copy with the token of a push nobody reviewed
   # -- where a call runs inside the release that gated it. The caller passes
-  # the tag, and only the caller does: the monthly run and a dispatch have
+  # the tag, and only the caller does: the weekly run and a dispatch have
   # no particular version in mind, which is the point of them
   workflow_call:
     inputs:

--- a/.github/workflows/python-arm-authority.yml
+++ b/.github/workflows/python-arm-authority.yml
@@ -9,7 +9,7 @@ name: python arm authority
 # and not seconds: every module `_THIRD_PARTY_VECTORS` names, each under
 # coverage, each in an environment with no bindings installed. Issue
 # #1003 is this workflow --
-# a pull request should not pay what a schedule can pay once a month.
+# a pull request should not pay what a schedule can pay once a week.
 #
 # This reimplements the no-bindings environment test.yml's own
 # `no-bindings` job builds, rather than depending on issue #1002's
@@ -57,15 +57,13 @@ on:
   push:
     branches: [main]
   schedule:
-    # the 15th of the month, 04:07 UTC. Not the 1st, which
-    # `vendored-vectors` and `published` already share, and not on the
-    # hour: GitHub queues same-minute scheduled workflows across every
-    # repository that asked for it, and a long queue can drop the run
-    # outright. Minute 07 is not shared with any other cron in this
-    # repository, which `grep -h 'cron:' .github/workflows/*.yml` is
-    # what re-derives -- a list written out here is complete only until
-    # the next workflow gains a schedule
-    - cron: "07 4 15 * *"
+    # Tuesday, the hour after codeql.yml: both are censuses of the tree
+    # rather than questions about a dependency, and neither gates.
+    # The time is section 10's grid in btclib-org/.github and not this
+    # file's to restate.
+    # Only the default branch schedules workflows, so on any other branch
+    # this is reachable through the dispatch below alone
+    - cron: "4 5 * * 2"
   workflow_dispatch:
   pull_request:
     # ready_for_review, so a pull request marked ready gets the run the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the suite job in test.yml
+          # see the checkout of the coverage job in test.yml
           persist-credentials: false
           # the whole history, where every other checkout in these
           # workflows takes the default single commit: the ancestry check
@@ -291,10 +291,16 @@ jobs:
     name: Run the docs workflow
     uses: ./.github/workflows/docs.yml
 
-  # and the two platforms the merge gate does not wait for: each runs
-  # weekly, so a regression there could otherwise sit on main until the
-  # morning after the tag. Cheap in work and the slowest calls here in wall
-  # clock, which a release is the one place worth paying for
+  # and the three platform sweeps, which between them are every image
+  # and every interpreter this package claims: the gate runs one cell of
+  # ubuntu.yml's matrix and each of these runs its own whole, weekly, so
+  # a regression outside that cell could otherwise sit on main until the
+  # morning after the tag. Cheap in work and the slowest calls here in
+  # wall clock, which a release is the one place worth paying for
+  ubuntu:
+    name: Run the ubuntu workflow
+    uses: ./.github/workflows/ubuntu.yml
+
   macos:
     name: Run the macos workflow
     uses: ./.github/workflows/macos.yml
@@ -317,7 +323,7 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI
-    needs: [test, lint, docs, macos, windows, integration]
+    needs: [test, lint, docs, ubuntu, macos, windows, integration]
     if: github.event_name == 'workflow_dispatch' && github.repository == 'btclib-org/btclib'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -341,7 +347,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [test, lint, docs, macos, windows, integration]
+    needs: [test, lint, docs, ubuntu, macos, windows, integration]
     if: github.event_name == 'push' && github.repository == 'btclib-org/btclib'
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,16 @@
 ---
 name: test
 
+# the merge gate, and it is one cell of what a sweep runs: ubuntu-latest
+# on the interpreter .python-version pins, which is the `coverage` job
+# below. The platform matrices are ubuntu.yml, macos.yml and windows.yml,
+# weekly and before a release, and ubuntu.yml's header is where the trade
+# is argued -- what a review stops waiting for, and how long a regression
+# outside this cell can sit on main.
+# What stays here beside `coverage` is what is one cell anyway: the
+# no-bindings configuration, the union of the two, and the packaging
+# checks. lint.yml and docs.yml are the same shape in their own files
+
 on:
   push:
     # main only: a push to a branch that has an open pull request would
@@ -18,7 +28,7 @@ on:
     branches: [main]
     # GitHub Pages serves btclib.org from main's root, so a
     # website-only commit lands here and would otherwise run the whole
-    # matrix.
+    # gate.
     # None of these files is imported by the library or read by a test --
     # README.md is the homepage, not a doctest source; CONTRIBUTING.md is
     # checked by markdownlint, which is the lint workflow's business.
@@ -100,7 +110,7 @@ on:
           for the unconstrained smoke test, applied to caching instead.
         type: boolean
         default: false
-  # the escape hatch: the matrix on demand for a branch whose pull
+  # the escape hatch: the gate on demand for a branch whose pull
   # request is not open yet
   workflow_dispatch:
 
@@ -141,10 +151,10 @@ concurrency:
 jobs:
   # the cheapest job in the workflow, and the one that decides whether the
   # rest of it runs at all: a pull request that edits only prose changes
-  # nothing the five jobs below build or test, and running the whole
-  # matrix to prove it was the cost. Each of `suite`, `coverage`,
-  # `no-bindings` and `dist` takes this job as a `needs` and reads its
-  # output in its own `if`; `coverage-union` does too, rather than
+  # nothing the jobs below build or test, and running the whole gate to
+  # prove it is what this saves. Each of `coverage`, `no-bindings` and
+  # `dist` takes this job as a `needs` and reads its output in its own
+  # `if`; `coverage-union` does too, rather than
   # relying on `coverage` and `no-bindings` skipping under it, because a
   # job's own `if` here replaces the implicit "needs succeeded" check
   # rather than adding to it, and its two `needs` would otherwise be
@@ -174,7 +184,7 @@ jobs:
   #   undefined in an expression unless the job is named in its own
   #   `needs`
   changes:
-    name: Decide whether the matrix has anything to check
+    name: Decide whether the jobs below have anything to check
     if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -213,80 +223,50 @@ jobs:
           prose='^(AUTHORS|CLAUDE|CODE_OF_CONDUCT|CONTRIBUTING|RELEASING|REPOSITORY|REVIEWING|SECURITY)\.md$|^\.github/[^/]*\.md$'
           if [ ! -s files.txt ] || grep -qvE "$prose" files.txt; then
             echo "code=true" >> "$GITHUB_OUTPUT"
-            echo "something the matrix reads changed: everything runs"
+            echo "something the jobs below read changed: everything runs"
           else
             echo "code=false" >> "$GITHUB_OUTPUT"
-            echo "prose only: the matrix has nothing to check"
+            echo "prose only: the jobs below have nothing to check"
           fi
 
-  # what the matrix buys: every (os, architecture, interpreter) triple
-  # selects a different published wheel of btclib_secp256k1, each with
-  # its own compiled libsecp256k1 inside, and the pure Python code meets a
-  # distinct hashlib and OpenSSL
-  suite:
-    name: Run the suite on ${{ matrix.python }}, ${{ matrix.os }}
-    # a draft pull request is work in progress: every push to one spends
-    # the whole matrix on a tree its author is not asking anyone to
-    # review yet. The gate below carries the same condition, so a draft
-    # skips uniformly and the gate does not read that skip as a job that
-    # should have run.
-    # A closed pull request spends none either: the trigger above takes
+  # the one cell a merge waits for, and the one place coverage is
+  # measured: ubuntu-latest on the interpreter below, which is what the
+  # header calls the gate. ubuntu.yml, macos.yml and windows.yml each run
+  # this cell again inside their own matrix, on purpose -- a sweep that
+  # subtracted it would be a matrix with a hole in it, and whoever asked
+  # what ran would have to re-derive the hole from this file.
+  # Measured here and not on any of those cells: the code base has
+  # no platform- or version-conditional branch (no sys.platform, no
+  # sys.version_info) and no conditional skip, so every one of them walks
+  # the very same lines. The one fallback, btclib.__version__ when no
+  # metadata is installed, is not conditional on the job: they all install
+  # the package, and a test reaches the other branch by making the lookup
+  # raise, which is why it needs no "pragma: no cover" either. Per-job
+  # measurement would buy only the instrumentation overhead, one
+  # coveralls.io upload per job, and the parallel/--finish handshake to
+  # stitch the uploads back together.
+  # The number is a gate rather than a report: fail_under, in
+  # tool.coverage.report, fails this job on a regression. It needs no
+  # secret and no third party, and it applies to every run, where a
+  # coveralls.io upload happens only on a pull request.
+  # A suite that passes is what this job reports before it reads a
+  # number, which is why the gate needs no plain run of the suite beside
+  # it on the same pair
+  coverage:
+    name: Measure coverage, gated at 100%
+    # a draft pull request is work in progress: every push to one would
+    # spend the gate on a tree its author is not asking anyone to review
+    # yet. Every job here carries this same condition, the aggregate
+    # below included, so a draft skips uniformly rather than leaving that
+    # gate reading the skip as a job that should have run.
+    # A closed pull request spends nothing either: the trigger above takes
     # the closed event only to supersede a run this ref's group is still
-    # holding, and every job here carries the same skip for the reason
-    # the draft one already does
+    # holding
     if: >-
       ${{ !github.event.pull_request.draft
           && github.event.action != 'closed'
           && needs.changes.outputs.code == 'true' }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # two, and macos.yml and windows.yml carry the other four, each with
-        # its measurement in its own header: what a platform row costs a
-        # pull request is the wait for a runner, and what it buys is a
-        # standard library under code this library writes no
-        # platform-conditional branch in. The two cheapest and fastest rows
-        # stay, because something has to run the suite before a merge; the
-        # rest answer weekly and before a release
-        os:
-          - ubuntu-latest
-          - ubuntu-24.04-arm
-        # 3.14t is the free-threaded interpreter, and it is in the matrix
-        # for what it installs as much as for what it runs: the bindings
-        # ship a py3-none dynamic wheel for it, and nothing else here
-        # exercises a build without the GIL. python-build-standalone has a
-        # freethreaded build for every platform this repository runs, the
-        # two here and the four of macos.yml and windows.yml, so it needs no
-        # exclusion of its own.
-        # no pypy3.10, and PyPy is still tested: hypothesis ships
-        # compiled wheels from 6.160 on and publishes none for pypy3.10, so
-        # uv falls back to its sdist, whose maturin build needs a PyO3 that
-        # requires PyPy 3.11 or newer. Pinning hypothesis below 6.160
-        # behind an implementation marker buys a suite generating its
-        # inputs with a version nobody else runs, on the older of the two
-        # PyPy releases; pypy3.11 covers the implementation
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-          - "3.14"
-          - "3.14t"
-          - "pypy3.11"
-        # the one cell the coverage job below already is: same runner image,
-        # same interpreter, the same suite, and the only difference is the
-        # instrumentation. Running both asks one question twice and holds two
-        # of the twenty concurrent jobs GitHub Free gives an organization,
-        # which is what a pull request's wall clock is made of here. Nothing
-        # else in the matrix is excluded: that job is pinned to this pair,
-        # for the reason its own comment gives, so this is the only overlap
-        # there can be
-        exclude:
-          - os: ubuntu-latest
-            python: "3.14"
-    # far above what a run of the suite needs: what it bounds is a hung
-    # job holding a runner for six hours
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: changes
     steps:
@@ -301,63 +281,18 @@ jobs:
           # the workspace would carry it out of the job. No job in any of
           # these workflows performs an authenticated git operation -- the
           # release is created by gh, from GH_TOKEN in its environment --
-          # so nothing needs it to stay
+          # so nothing needs it to stay.
+          # This is the checkout the other workflows here cite: the one
+          # on the gate, which runs on every pull request.
+          # claude-review.yml still names the job this one replaced,
+          # because a pull request editing that file is refused a review
+          # by it -- btclib-org/.github#91
           persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # the cache holds the wheels uv.lock resolves, this matrix
-          # fetching the same ones on every run of every commit
-          enable-cache: true
-          python-version: ${{ matrix.python }}
-      # --no-cov, against the --cov that pyproject.toml's addopts carries:
-      # what this matrix asks is whether every (os, architecture,
-      # interpreter) triple passes, and the job below is where coverage is
-      # measured and gated. Instrumenting these cells measures the same
-      # lines over again -- that job's comment is why they are the same
-      # lines -- and on the PyPy cells it costs enough wall clock to reach
-      # the timeout above with every test passed, coverage.py collecting
-      # there through a trace hook the JIT cannot compile through. It also
-      # keeps `fail_under` where pyproject.toml's comment argues it
-      # belongs, on the one interpreter the statement count was checked
-      # against, rather than enforced on every cell of the matrix
-      - name: Run pytest
-        run: uv run --locked --no-default-groups --group test pytest --no-cov
-
-  # coverage is measured once, not once per matrix job: the code base has
-  # no platform- or version-conditional branch (no sys.platform, no
-  # sys.version_info) and no conditional skip, so every job walks the very
-  # same lines. The one fallback, btclib.__version__ when no metadata is
-  # installed, is not conditional on the job: every one of them installs
-  # the package, and a test reaches the other branch by making the lookup
-  # raise, which is why it needs no "pragma: no cover" either. Per-job
-  # measurement would buy only the instrumentation overhead, one
-  # coveralls.io upload per job, and the parallel/--finish handshake to
-  # stitch the uploads back together.
-  # The number is a gate rather than a report: fail_under, in
-  # tool.coverage.report, fails this job on a regression. It needs no
-  # secret and no third party, and it applies to every run, where a
-  # coveralls.io upload happens only on a pull request.
-  # It is also the (3.14, ubuntu-latest) cell of the matrix above, which is
-  # why that pair is excluded there: a suite that passes is what this job
-  # reports before it reads a number, so the pair needs no job of its own
-  coverage:
-    name: Measure coverage, gated at 100%
-    if: >-
-      ${{ !github.event.pull_request.draft
-          && github.event.action != 'closed'
-          && needs.changes.outputs.code == 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs: changes
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-        with:
+          # the cache holds the wheels uv.lock resolves, which every run
+          # of every commit otherwise fetches again
           enable-cache: true
           # 3.14, i.e. what .python-version pins and what a bare `uv run`
           # gives a maintainer locally: the number this job gates on is a
@@ -425,7 +360,8 @@ jobs:
   # test marked `needs_bindings` too broadly, or a Python arm no test
   # here reaches, now shows up as a line neither run covers rather than
   # as nothing. What it costs is this job's wall clock, now instrumented
-  # like the `coverage` job's rather than the `suite` matrix's
+  # like the `coverage` job's, which is the same instrumentation and
+  # the same reason
   # The tests that hold both implementations and compare them are marked
   # `bindings` and skip themselves; everything else runs, which is what
   # makes this a suite and not a smoke test
@@ -498,7 +434,7 @@ jobs:
   # covers rather than as nothing.
   # What it costs: a third job, an artifact round trip in each direction,
   # and coverage.py's own combine step, which is the same trade the
-  # `coverage` job already made against the `suite` matrix, applied once
+  # `coverage` job already makes for the number it gates, applied once
   # more
   coverage-union:
     name: Combine coverage from both runs, gated at 100% too
@@ -619,7 +555,7 @@ jobs:
         run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
       # empty on every trigger but a release rehearsal: `inputs` is unset
       # outside a workflow_call, so a direct run of this workflow -- the
-      # matrix a pull request or a push to main gets -- skips this and
+      # gate a pull request or a push to main gets -- skips this and
       # ships the version the tree declares, same as a real release does.
       # TestPyPI refuses a version it has already seen, which is what the
       # suffix is for; release.yml's `version-check` job computes it once
@@ -844,15 +780,14 @@ jobs:
 
   # the single check main's branch protection requires from this
   # workflow, and it exists because that rule names its checks as literal
-  # strings, stored outside the repository. The matrix above produces one
-  # per (runner label, interpreter) pair -- `gh api` on a run's jobs counts
-  # them, and the count moves whenever the matrix does: naming those
-  # directly means every matrix edit has to be mirrored in a setting no
-  # pull request can
-  # review, and a name that stops being produced -- macos-latest moving
-  # on, 3.10 aging out in its turn -- becomes a required check that never
-  # reports, which blocks every merge until someone remembers where the
-  # rule lives.
+  # strings, stored outside the repository. A job's name is what such a
+  # rule matches, and a name that stops being produced -- a job renamed,
+  # a job moved out to a sentinel the way the platform matrix lives in
+  # ubuntu.yml, macos.yml and windows.yml -- becomes a required check
+  # that never reports, which blocks every merge until
+  # someone remembers where the rule lives. Naming the jobs below
+  # directly would mean every edit here has to be mirrored in a setting
+  # no pull request can review.
   # This job depends on the others instead, so the rule names one thing
   # that never changes and adding a job here is enough to gate on it
   test-passed:
@@ -864,7 +799,7 @@ jobs:
     # day either grows a second one, this pattern and a change to the rule
     # are what that costs
     name: "test: every job passed"
-    needs: [changes, suite, coverage, no-bindings, coverage-union, dist]
+    needs: [changes, coverage, no-bindings, coverage-union, dist]
     # !cancelled(), not always(): a run superseded by the concurrency
     # group above -- the next push landing on this ref, or a re-run
     # cancelled from the UI -- cancels every job still in flight, and
@@ -893,9 +828,10 @@ jobs:
     steps:
       # unconditional -- no `if:` of its own -- and deciding in the
       # shell rather than in a boolean `contains(needs.*.result, ...)`
-      # expression: issue #1001 saw four `suite` cells die in "Set up
-      # job" on an action download's HTTP 429, the run's own conclusion
-      # was `failure`, and yet `needs.suite.result` was not `'failure'`
+      # expression: issue #1001 saw four matrix cells die in "Set up job"
+      # on an action download's HTTP 429, the run's own conclusion was
+      # `failure`, and
+      # yet that job's `needs.<job>.result` was not `'failure'`
       # when the old expression checked it -- so that `if:`-gated step
       # was skipped, and a skipped step leaves the job green by
       # construction, the same shape the job-level condition used to
@@ -905,7 +841,7 @@ jobs:
       # is what makes a job added to `needs` above covered without
       # touching this loop, the same as the expression it replaces.
       # `skipped` is an allowed result now, not just `success`: `changes`
-      # makes `suite`, `coverage`, `no-bindings`, `dist` and
+      # makes `coverage`, `no-bindings`, `dist` and
       # `coverage-union` conditional on its own output, so a prose-only
       # pull request means every one of them reports `skipped` on
       # purpose. `changes` itself is not conditional, and a job that

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,9 +13,8 @@ name: ubuntu
 # buys is every pull request. GitHub Free gives an organization twenty
 # concurrent jobs, shared across every repository in it, and a gate wider
 # than one cell spends a review's wall clock waiting for a slot rather
-# than running the suite; REPOSITORY.md measures that ceiling against
-# what a commit here asks for, windows.yml has the runner seconds and
-# macos.yml the queueing.
+# than running the suite; REPOSITORY.md has that measurement,
+# windows.yml the runner seconds and macos.yml the queueing.
 #
 # What a matrix buys here is not the pure Python, which is the same
 # everywhere: every (os, architecture, interpreter) triple selects a

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,139 @@
+---
+name: ubuntu
+
+# every ubuntu cell the merge gate does not spend, and the one it does.
+# The gate is a single cell -- ubuntu-latest on the interpreter
+# .python-version pins, which is test.yml's `coverage` job -- and this
+# workflow is the rest of that matrix: both architectures, every
+# interpreter, once a week and before a release.
+#
+# What the gate gives up is the point of the arrangement rather than a
+# cost it hides. The gate does not refuse a regression on 3.10, on arm or
+# on PyPy: one sits on main until this runs, at most six days. What that
+# buys is every pull request. GitHub Free gives an organization twenty
+# concurrent jobs, shared across every repository in it, and a gate wider
+# than one cell spends a review's wall clock waiting for a slot rather
+# than running the suite; REPOSITORY.md measures that ceiling against
+# what a commit here asks for, windows.yml has the runner seconds and
+# macos.yml the queueing.
+#
+# What a matrix buys here is not the pure Python, which is the same
+# everywhere: every (os, architecture, interpreter) triple selects a
+# different published wheel of btclib_secp256k1, each with its own
+# compiled libsecp256k1 inside, and that code meets a distinct hashlib
+# and a distinct OpenSSL under it. macos.yml and windows.yml make the
+# same argument for their own images, and each says what its cells add.
+#
+# Both images, and not the newest alone: what differs between them is the
+# architecture the interpreter and the bindings wheel target, and
+# ubuntu-24.04-arm is the cheapest place this package is asked about
+# aarch64 at all.
+#
+# It gates no commit and no merge -- a regression outside the gate's cell
+# sits on main for at most a week -- but release.yml calls it, so one
+# cannot be published over an interpreter this never answered for
+
+on:
+  schedule:
+    # Friday, with hwi-integration.yml an hour later: a platform sentinel
+    # is two images times every interpreter, and three of them in one
+    # morning is the queue this arrangement exists to avoid, so the three
+    # take separate mornings. What shares this one is two emulator jobs.
+    # The time is section 10's grid in btclib-org/.github and not this
+    # file's to restate.
+    # Only the default branch schedules workflows, so on any other branch
+    # this is reachable through the dispatch below alone
+    - cron: "4 4 * * 5"
+  # lets release.yml gate a publication on these cells too, which is what
+  # keeps a weekly sentinel from being the only thing that ever asks
+  workflow_call:
+  # the escape hatch: the matrix on demand, for a branch that touches
+  # anything an interpreter version or an architecture reaches
+  workflow_dispatch:
+
+# least privilege for the GITHUB_TOKEN: everything running in a job
+# (actions, dependencies) can read the token, so it must not be able to
+# write to the repository
+permissions:
+  contents: read
+
+# cancel superseded runs: the subject here is the commit, which a newer one
+# supersedes. Named literally rather than with github.workflow, which in a
+# called workflow is the caller's name -- release.yml calls this one
+# alongside test.yml, and with that expression the two would share a group
+# and cancel each other
+concurrency:
+  group: ubuntu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  suite-ubuntu:
+    name: Run the suite on ${{ matrix.python }}, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # every cell to the end: which interpreter fails on which image is
+      # the whole answer, and stopping at the first one hides the rest
+      fail-fast: false
+      matrix:
+        # both images, the one the gate runs included: the cell
+        # test.yml's `coverage` job spends is here rather than excluded,
+        # because a matrix with the gate's cell cut out of it is one
+        # nobody can read the shape of, and whoever asked what ran would
+        # have to re-derive the hole from another file
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+        # 3.14t is the free-threaded interpreter, and it is in the matrix
+        # for what it installs as much as for what it runs: the bindings
+        # ship a py3-none dynamic wheel for it, and nothing else here
+        # exercises a build without the GIL. python-build-standalone has a
+        # freethreaded build for every platform this repository runs, the
+        # two here and the four of macos.yml and windows.yml, so it needs
+        # no exclusion of its own.
+        # no pypy3.10, and PyPy is still tested: hypothesis ships
+        # compiled wheels from 6.160 on and publishes none for pypy3.10,
+        # so uv falls back to its sdist, whose maturin build needs a PyO3
+        # that requires PyPy 3.11 or newer. Pinning hypothesis below 6.160
+        # behind an implementation marker buys a suite generating its
+        # inputs with a version nobody else runs, on the older of the two
+        # PyPy releases; pypy3.11 covers the implementation.
+        # macos.yml and windows.yml name this same list, which
+        # tests/interpreters_test.py is what holds to one another and to
+        # pyproject.toml's classifiers
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "3.14t"
+          - "pypy3.11"
+    # far above what a run of the suite needs, and it bounds a hung job
+    # rather than a slow one: the queueing this workflow exists to move
+    # happens before a job starts and is not counted here
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # see the checkout of the coverage job in test.yml
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python }}
+      # --no-cov, against the --cov that pyproject.toml's addopts carries:
+      # what this matrix asks is whether every (os, architecture,
+      # interpreter) triple passes, and test.yml's coverage job is where
+      # the number is measured and gated. Instrumenting these cells
+      # measures the same lines over again -- that job's comment is why
+      # they are the same lines -- and on the PyPy cells it costs enough
+      # wall clock to reach the timeout above with every test passed,
+      # coverage.py collecting there through a trace hook the JIT cannot
+      # compile through. It also keeps `fail_under` where pyproject.toml's
+      # comment argues it belongs, on the one interpreter the statement
+      # count was checked against, rather than enforced on every cell.
+      # macos.yml and windows.yml pass the flag citing this step
+      - name: Run pytest
+        run: uv run --locked --no-default-groups --group test pytest --no-cov

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -4,7 +4,7 @@ name: vendored vectors
 # tests/_data/README.md pins every vendored test vector to a commit and a
 # git blob SHA-1, with a documented manual procedure to re-check one --
 # last done by hand on specific dates the file itself records. This runs
-# that procedure once a month instead, over every pin the script can
+# that procedure once a week instead, over every pin the script can
 # check, and opens or updates an issue on drift rather than fixing
 # anything: refreshing a vector file is a decision the script does not
 # get to make.
@@ -14,20 +14,20 @@ name: vendored vectors
 # read, an automatic issue being the usual next step it deliberately
 # does not take. This one does take it, on purpose: a link is noticed
 # the next time somebody follows it, where a vendored vector is trusted
-# without anybody looking at it again, and that is exactly what a
-# monthly issue is for
+# without anybody looking at it again, and an issue is what carries that
+# past the one email a failed run sends
 
 on:
   schedule:
-    # the 1st of the month, 04:53 UTC. Not on the hour, for the reason
-    # links.yml's own cron comment gives -- GitHub queues same-minute
-    # scheduled workflows across every repository that asked for it, and
-    # a long queue can drop the run outright. Minute 53 is not shared
-    # with any other cron in this repository, which
-    # `grep -h 'cron:' .github/workflows/*.yml` is what re-derives: a
-    # list written out here was complete when it was written and six
-    # crons short a fortnight later
-    - cron: "53 4 1 * *"
+    # Monday, the hour after links.yml: that one asks whether a page this
+    # tree points at still resolves, this one whether a file it pinned is
+    # still the file, and the two are the same question over different
+    # distances.
+    # The time is section 10's grid in btclib-org/.github and not this
+    # file's to restate.
+    # Only the default branch schedules workflows, so on any other branch
+    # this is reachable through the dispatch below alone
+    - cron: "4 5 * * 1"
   workflow_dispatch:
   pull_request:
     # ready_for_review, so a pull request marked ready gets the run the
@@ -43,7 +43,7 @@ on:
     # rather than plain github.ref for exactly this event: a merged pull
     # request's closed event sets github.ref to the base branch, not the
     # merge ref, which used to land it in main's own group -- racing the
-    # monthly schedule run for cancellation (PR 1023's bug) instead of
+    # scheduled run for cancellation (PR 1023's bug) instead of
     # the PR's own group as intended
     types: [opened, reopened, synchronize, ready_for_review, closed]
     paths:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # see the checkout of the suite job in test.yml
+          # see the checkout of the coverage job in test.yml
           persist-credentials: false
       # 3.3.4 is what Pages runs, from the same versions.json the Gemfile
       # names: a build that passes here on a ruby Pages does not have says

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,26 +1,27 @@
 ---
 name: windows
 
-# the second platform the merge gate does not wait for, and it is here for
-# the reason macos.yml is, measured on this repository rather than assumed.
-# GitHub Free gives an organization twenty concurrent jobs, and a commit used
-# to ask for thirty-nine: measured over a working afternoon, the repository
-# sat at nineteen or twenty running jobs for 1375 of 2100 seconds, so a pull
-# request's wall clock was set by waiting for a slot and not by the suite.
-# The fourteen Windows cells were 2357 of the 3556 seconds of matrix work per
-# commit -- windows-11-arm alone 1250, the slowest row and the one with the
-# longest queue -- and they also carry the largest fixed cost per cell, some
-# 50 to 75 seconds of checkout, uv and wheel build against 17 on ubuntu.
-# Moving them here took a commit from 66 runner-minutes to 25. To re-derive:
+# the Windows third of the platform sweep, and it is here for the reason
+# ubuntu.yml's header gives for all three, measured on this repository
+# rather than assumed. REPOSITORY.md holds the concurrency ceiling and
+# what a wider gate cost against it; what is measured here is Windows's
+# share. The fourteen cells below are 2357 of the 3556 seconds of matrix
+# work a full platform sweep spends -- windows-11-arm alone 1250, the
+# slowest row and the one with the longest queue -- and they also carry
+# the largest fixed cost per cell, some 50 to 75 seconds of checkout, uv
+# and wheel build against 17 on ubuntu. Holding them off the gate is what
+# makes a commit cost 25 runner-minutes rather than 66. What a run of
+# this workflow costs is the same query, asked of this workflow:
 #
-#     id=$(gh run list --workflow=test.yml --limit 1 \
+#     id=$(gh run list --workflow=windows.yml --limit 1 \
 #         --json databaseId --jq '.[0].databaseId')
 #     gh api "repos/$GITHUB_REPOSITORY/actions/runs/$id/jobs?per_page=100"
 #
-# What these cells buy is what macos.yml's comment says of its own: there is
-# no platform-conditional branch in this library -- no sys.platform and no
-# sys.version_info anywhere, which is the property the coverage job of
-# test.yml records from the other side -- so every cell walks the same lines.
+# What these cells buy is what macos.yml's comment says of its own: there
+# is no platform-conditional branch in this library -- no sys.platform and
+# no sys.version_info anywhere, which is the property the coverage job of
+# test.yml records from the other side -- so every cell walks the same
+# lines.
 # What runs here is the standard library under them, the published
 # btclib_secp256k1 wheel for each interpreter, and the one path separator
 # and line ending this library never sees otherwise.
@@ -32,27 +33,23 @@ name: windows
 # than for the host, so either one links.
 #
 # A workflow of its own rather than a row in macos.yml, which is the same
-# design that file argues for itself: one variable each, so a red cell names
-# a platform. On its own morning too, and that is this workflow's whole
-# point -- macos.yml and latest.yml already share Wednesday, and fourteen
-# more jobs against twenty slots would rebuild on that morning the queue
+# design that file argues for itself: one variable each, so a red cell
+# names a platform. On its own hour too, an hour after macos.yml: fourteen
+# more jobs against twenty slots would rebuild in one morning the queue
 # this file exists to take out of a pull request.
 #
-# It gates no commit and no merge -- a Windows regression sits on main for at
-# most a week -- but release.yml calls it, so one cannot be published
+# It gates no commit and no merge -- a Windows regression sits on main for
+# at most a week -- but release.yml calls it, so one cannot be published
 
 on:
   schedule:
-    # Saturday, the one day nothing else here asks for -- the mutation
-    # session Sunday, links Monday, codeql Tuesday, latest and macos
-    # Wednesday, Dependabot Thursday, integration Friday -- so a failure
-    # notification still names the workflow by the day it arrived, which is
-    # the convention codeql.yml states at its own cron. A minute that is not
-    # the hour, as every schedule here, so the run does not queue behind
-    # everything else cron starts; 19 is unused by the others.
+    # Saturday, the hour after macos.yml: see that file for why the two
+    # platforms share a day and not an hour.
+    # The time is section 10's grid in btclib-org/.github and not this
+    # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "19 4 * * 6"
+    - cron: "4 5 * * 6"
   # lets release.yml gate a publication on this platform too, which is what
   # keeps a weekly sentinel from being the only thing that ever asks
   workflow_call:
@@ -84,15 +81,14 @@ jobs:
       # whole answer, and stopping at the first one hides the rest
       fail-fast: false
       matrix:
-        # the two images test.yml no longer carries. Both, and not the
-        # newest alone: what differs between them is the architecture the
-        # interpreter and the bindings wheel target
+        # both, and not the newest alone: what differs between them is
+        # the architecture the interpreter and the bindings wheel target
         os:
           - windows-latest
           - windows-11-arm
-        # the interpreter set test.yml runs, unchanged: this workflow moves
-        # the platform and nothing else, so a difference between the two is
-        # attributable to the platform
+        # the interpreter set ubuntu.yml names, unchanged: this workflow
+        # moves the platform and nothing else, so a difference against it
+        # is attributable to the platform
         python:
           - "3.10"
           - "3.11"
@@ -106,20 +102,19 @@ jobs:
     # happens before a job starts and is not counted here
     timeout-minutes: 30
     steps:
-      # the three steps of test.yml's suite job, and each `with:` there
-      # carries the reason for itself
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # see the checkout of the coverage job in test.yml
           persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           python-version: ${{ matrix.python }}
-      # --no-cov for the reason test.yml's suite job gives beside its own
-      # step: this matrix carries the same PyPy cells behind the same
-      # timeout, and the coverage job there is the one place the number is
+      # --no-cov for the reason ubuntu.yml gives beside its own step:
+      # this matrix carries the same PyPy cells behind the same timeout,
+      # and test.yml's coverage job is the one place the number is
       # measured and gated
       #
       # every cell here runs on windows-latest or windows-11-arm, where the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,7 +325,8 @@ documented at release-notes length in the first place, and are still in
   grid. `published`, `vendored-vectors` and `python-arm-authority` were
   monthly and are weekly with the rest.
 
-  `integration.yml` gains a cron with them and keeps every other trigger.
+  `integration.yml`'s own cron moves onto the grid beside them, and it
+  keeps every other trigger.
   Its job is a required check on every pull request and on the commit a
   merge creates, so the weekly run asks nothing new about the tree; what
   it asks is whether bitcoincore.org still serves the tarball pinned in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,67 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **One cell gates a merge, three weekly sweeps run the matrices whole,
+  and every schedule sits on the organization's grid**
+  (btclib-org/.github#85). `test.yml`'s `suite` job is gone: what a pull
+  request waits for is `ubuntu-latest` on the interpreter
+  `.python-version` pins — the `coverage` job that was already one cell
+  of that matrix — plus `no-bindings`, `coverage-union` and `dist`, and
+  the one-job `lint`, `docs` and `integration` workflows beside them.
+
+  Why: GitHub Free gives the organization twenty concurrent jobs, shared
+  across every repository in it, and a commit here asked for thirty-nine
+  of them, so a review's wall clock was the wait for a slot rather than
+  the suite. Thirteen cells per pull request become none.
+
+  What it costs, said here rather than discovered later: a regression on
+  `3.10`, on arm or on PyPy is no longer refused before a merge. It sits
+  on `main` until the sentinel for it runs, at most six days — the trade
+  `macos.yml` and `windows.yml` were already making for their platforms,
+  applied to the rest.
+
+  `ubuntu.yml` is new and holds what left: `ubuntu-latest` and
+  `ubuntu-24.04-arm` by every interpreter this package claims, the cell
+  the gate runs included. A sweep that subtracted that cell would be a
+  matrix with a hole in it, and whoever asked what ran would have to
+  re-derive the hole from another file. `release.yml` calls it beside
+  `macos.yml` and `windows.yml`, so nothing is published over an
+  interpreter no sweep answered for. The reasoning the deleted job
+  carried moved with the cells rather than going with them — what a
+  matrix buys on a package whose bindings are compiled, why `3.14t` is
+  in the list, why `pypy3.10` is not — and the canonical checkout
+  comment is now the `coverage` job's.
+
+  Every schedule reads `4 <hour> * * <weekday>`: the day belongs to the
+  workflow, the hour separates a day's second run, and minute `:04`
+  belongs to this repository, so no two repositories in the organization
+  ask GitHub for the same slot. `grep -h 'cron:' .github/workflows/*.yml`
+  reads them back; the calendar itself is section 10 of
+  `btclib-org/.github`, and no file here carries a second copy of it.
+  `CONTRIBUTING.md`'s cadence table names no day at all, and a workflow's
+  own comment names its day only to say what it sits beside and why —
+  which is this repository's reason for its slot, not the organization's
+  grid. `published`, `vendored-vectors` and `python-arm-authority` were
+  monthly and are weekly with the rest.
+
+  `integration.yml` gains a cron with them and keeps every other trigger.
+  Its job is a required check on every pull request and on the commit a
+  merge creates, so the weekly run asks nothing new about the tree; what
+  it asks is whether bitcoincore.org still serves the tarball pinned in
+  the file. That is external rot of exactly the kind `published.yml` is
+  weekly for — both fetch a pinned third-party artifact and verify a hash
+  — and unscheduled it would first appear, after a quiet stretch, as a
+  red required check on the branch of whoever opened the next pull
+  request. A sweep over several Core majors would be a different question
+  again, which is what `bitcoin-core-rpc` has
+  (btclib-org/bitcoin-core-rpc#211).
+
+  `tests/interpreters_test.py` reads the sweeps rather than `test.yml`,
+  the interpreter list having moved, and holds the three of them to one
+  another besides: three copies of a list is three chances for one to be
+  left behind, and a platform quietly running a narrower set than
+  another reads, from the outside, as that platform passing.
+
 - **The Python-arm census runs on the merge commit, and names
   `script/taproot_test.py`** (issue #1003). `main` was red on
   `Re-derive the Python-arm authority table` and nothing said so: the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -291,49 +291,68 @@ read by every checkout of this repository.
 
 | workflow | when | what it varies |
 | --- | --- | --- |
-| `test` | pull request, push | 2 platforms × 7 interpreters |
+| `test` | pull request, push | — |
 | `lint`, `docs` | pull request, push | — |
-| `integration` | pull request, push | a node, two device emulators |
+| `integration` | pull request, push, weekly | a node |
 | `website` | pull request, push, on website files | — |
 | `claude-review` | pull request, and `@claude` in a comment | — |
-| `codeql` | push to main, Tuesday | 2 languages |
-| `windows` | Saturday, a release | 2 Windows images × 7 interpreters |
-| `macos` | Wednesday, a release | 2 macOS images × 7 interpreters |
-| `latest` | Wednesday | platforms sampled, deps upgraded |
+| `codeql` | push to main, and weekly | 2 languages |
+| `ubuntu` | weekly, a release | 2 ubuntu images × 7 interpreters |
+| `macos` | weekly, a release | 2 macOS images × 7 interpreters |
+| `windows` | weekly, a release | 2 Windows images × 7 interpreters |
+| `latest` | weekly | platforms sampled, deps upgraded |
+| `hwi-integration` | weekly, push to main | two device emulators |
 | `links`, `mutation` | weekly | — |
-| `vendored-vectors` | monthly | upstream's vectors |
-| `published` | monthly, a release | what PyPI serves |
-| `python-arm-authority` | monthly | the arm-to-vector-module table |
-| `release` | a tag | calls test, lint, docs, macos, windows, published |
+| `vendored-vectors` | weekly | upstream's vectors |
+| `published` | weekly, a release | what PyPI serves |
+| `python-arm-authority` | weekly, push to main | the arm-authority table |
+| `release` | a tag | the workflows `release.yml` names in a `uses:` |
+
+That last cell is a pointer rather than a list on purpose: which
+workflows a release calls is read out of the file, where a list here goes
+stale the next time one is added or dropped.
+
+```shell
+grep -n 'uses: \./\.github/workflows/' .github/workflows/release.yml
+```
 
 The `test`, `lint`/`docs`, `integration` and `website` rows are what a
 merge waits for, and between them they report the required checks: `lint`
-and `docs` share a row and report one each.
+and `docs` share a row and report one each. They run one image on one
+interpreter: `ubuntu-latest`, and the version `.python-version` names.
+Which day each of the rest runs is section 10 of the organization
+standard, in `btclib-org/.github`, and not this file's to restate — one
+calendar covering six repositories is one thing to remember, and six
+copies of it are six things to keep true.
 
-What the other rows have in common is that a pull request does not wait for
-them, and the reason is one number: the ceiling GitHub Free puts on an
-organization's concurrent jobs. REPOSITORY.md measures it and what it cost,
-and the consequence is this table's: at that ceiling a pull request's wall
-clock is the wait for a slot rather than the suite, so a platform row earns
-its place before a review only if it is cheap to wait for. macOS queued 29.4
-and 23.2 minutes on average against 0.5 to 1.6 elsewhere, and the fourteen
-Windows cells were 2357 of the 3556 seconds of matrix work per commit, the
-slowest rows and the longest queues. Both answer weekly and before a
-release instead, which is a regression sitting on `main` for at most a week
-against every review paying for it. `codeql` is there for the same
-arithmetic, with `zizmor` in `lint` still reading these workflows on every
-pull request.
+Why so little gates is one number: the ceiling GitHub Free puts on an
+organization's concurrent jobs, twenty shared across every repository in
+it. REPOSITORY.md measures what a wider gate cost against that ceiling,
+and the consequence is this table's: at that ceiling a pull request's
+wall clock is the wait for a slot rather than the suite. `macos.yml` and
+`windows.yml` each carry the measurement for their own cells, the
+queueing and the runner seconds. `codeql` is off the gate for the same
+arithmetic, with `zizmor` in `lint` still reading these workflows on
+every pull request.
 
-`macos` and `latest` share a morning half an hour apart, which is what makes
-the pair readable: red in both is the platform, red in `latest` alone is the
-upgrade. `windows` takes a morning of its own, Saturday being the day
-nothing else here asks for — fourteen jobs beside those two would rebuild on
-Wednesday the queue this arrangement exists to remove. Every workflow in the
+The trade, stated here rather than discovered later: the gate does not
+refuse a regression on `3.10`, on arm, on PyPy or on a platform. It sits
+on `main` until the sentinel for it runs, at most six days.
+
+**What a sentinel varies, it varies whole.** `ubuntu` runs the images and
+the interpreters the gate leaves alone *and* the cell it spends. A matrix
+with the gate's cell cut out of it is one nobody can read the shape of,
+and whoever asked what ran would have to re-derive the hole from
+`test.yml`.
+
+`ubuntu`, `macos` and `windows` hold the dependencies at the lock and move
+the platform; `latest` moves both. Red in one of the three with `latest`
+green is that platform; red in both is the upgrade. Every workflow in the
 table also takes `workflow_dispatch`, the gates included: a branch whose
 pull request is not open yet has no other way to ask, and for `codeql` and
-the two platform workflows it is the only way to ask about a branch at all.
-`claude-review` is the exception, and takes none: both its jobs read the
-pull request or the comment that triggered them, so a manual dispatch
+the three platform workflows it is the only way to ask about a branch at
+all. `claude-review` is the exception, and takes none: both its jobs read
+the pull request or the comment that triggered them, so a manual dispatch
 would start a run with nothing to read.
 
 ### Reproducing what CI runs
@@ -353,9 +372,10 @@ uv run --locked --only-group lint \
 `Build the documentation` is a workflow of its own, `docs.yml`, and its
 command is the one below under "The documentation".
 
-One cell of the `suite` matrix of `test.yml`. The interpreter is chosen with
-`--python`, which accepts any of the ones the matrix lists, `3.14t` and
-`pypy3.11` included, and downloads it if the machine has none:
+One cell of the matrix `ubuntu.yml`, `macos.yml` and `windows.yml` each
+carry. The interpreter is chosen with `--python`, which accepts any of the
+ones those workflows list, `3.14t` and `pypy3.11` included, and downloads
+it if the machine has none:
 
 ```shell
 uv run --locked --no-default-groups --group test --python 3.10 pytest --no-cov
@@ -370,15 +390,16 @@ touching `.venv`. The command is what CI runs, verbatim, and CI has no
 `--no-cov` is the matrix asking about the platform and not about the
 number: it undoes the `--cov` addopts carries, so what a cell reports is
 whether that (os, architecture, interpreter) triple passes. The job below
-is where coverage is measured, and `macos.yml` and `windows.yml` pass the
-flag for the same reason. `latest.yml` does not: it runs no PyPy cell and
-has no coverage job of its own, so the ratchet meeting an upgraded
-coverage.py is one of the things that workflow exists to find out.
+is where coverage is measured, which is the reason `ubuntu.yml` gives and
+the other two cite. `latest.yml` does not pass the flag: it runs no PyPy
+cell and has no coverage job of its own, so the ratchet meeting an
+upgraded coverage.py is one of the things that workflow exists to find
+out.
 
-One pair is missing from that matrix, `(3.14, ubuntu-latest)`, and the
-coverage job below is it: same image, same interpreter, same suite, and the
-only difference is the instrumentation. Reproducing that cell is therefore
-the coverage command rather than this one.
+The `(3.14, ubuntu-latest)` cell of those matrices is the gate, and the
+job below is it: same image, same interpreter, same suite, and the only
+difference is the instrumentation. Reproducing that cell is therefore the
+coverage command rather than this one.
 
 The `coverage` job, gated by `fail_under` in pyproject.toml:
 
@@ -583,7 +604,7 @@ uv run --locked --no-default-groups --group test python -c \
 uv run --locked --no-default-groups --group test pytest
 ```
 
-The `published` workflow, monthly, on demand and as part of a release,
+The `published` workflow, weekly, on demand and as part of a release,
 has two jobs, entitled to different answers about what the index
 serves.
 
@@ -716,8 +737,11 @@ Its docstring says why it reads the session file rather than `cosmic-ray
 dump`, which cannot read one of these sessions at all.
 
 The `integration` workflow, which gates and is the exception here: it
-runs on every pull request, weekly besides, and `Regtest against Bitcoin
-Core` is required on `main`. It asks the one question the rest of CI
+runs on every pull request, on every push to `main` and before a release,
+and `Regtest against Bitcoin Core` is required on `main`. It has no
+schedule of its own, and that workflow's own header says why: it pins one
+Core release, so a weekly run would ask the gate's question again about a
+tree nothing had touched. It asks the one question the rest of CI
 cannot, whether Bitcoin Core accepts what btclib built. It downloads a
 pinned Core release,
 verifies its published sha256, and runs the tests `tests/README.md`
@@ -898,7 +922,7 @@ Three consequences worth knowing before editing any of them:
   `paths` filter, and a required check that produces no run blocks a merge.
 
 Because Pages serves from `main`, a website-only commit there also
-triggers the full test matrix; `test.yml`'s `push` trigger carries a
+triggers the whole gate; `test.yml`'s `push` trigger carries a
 `paths-ignore` for these files so that it does not. The `pull_request`
 trigger deliberately does not: those checks are required on `main`, and a
 required check that produces no run blocks the merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -738,13 +738,14 @@ dump`, which cannot read one of these sessions at all.
 
 The `integration` workflow, which gates and is the exception here: it
 runs on every pull request, on every push to `main` and before a release,
-and `Regtest against Bitcoin Core` is required on `main`. It has no
-schedule of its own, and that workflow's own header says why: it pins one
-Core release, so a weekly run would ask the gate's question again about a
-tree nothing had touched. It asks the one question the rest of CI
-cannot, whether Bitcoin Core accepts what btclib built. It downloads a
-pinned Core release,
-verifies its published sha256, and runs the tests `tests/README.md`
+and `Regtest against Bitcoin Core` is required on `main`. It runs weekly
+too, and that workflow's own header says what the weekly run asks that
+the others do not: it pins one Core release, so the tree is not the
+question a schedule puts to it -- whether bitcoincore.org still serves
+that release is. It asks the one question the rest of CI cannot, whether
+Bitcoin Core accepts what btclib built. It downloads a pinned Core
+release, verifies its published sha256, and runs the tests
+`tests/README.md`
 documents with the binary named rather than found on PATH:
 
 ```shell

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,17 +11,17 @@ configured to trust the workflow itself
 The same workflow, started by hand instead of by a tag, is a full
 rehearsal against TestPyPI. A rehearsal is never tagged.
 
-**A workflow GitHub has not registered cannot be dispatched, and it
-registers one only once its file has reached the default branch.** That
-makes `release.yml`, `latest.yml`, `published.yml`, `macos.yml` and
-`windows.yml` — `schedule` and `workflow_dispatch` only, so nothing else
-ever triggers them — answer `gh: Not Found (HTTP 404)` until the release
-pull request is merged. It bites once, on the first release after any of
-them is written, and it inverts the order below: the TestPyPI rehearsal
-and the `latest` run that this file asks for *before* the merge can only
-happen after it, still before the tag. It also means such a workflow
-reaches `main` having never run, which is how `published.yml` shipped a
-`windows-11-arm` cell that failed at setup.
+**A workflow GitHub has not registered cannot be dispatched, and it registers
+one only once its file has reached the default branch.** That makes
+`release.yml`, `latest.yml`, `published.yml`, `ubuntu.yml`, `macos.yml` and
+`windows.yml` — `schedule` and `workflow_dispatch` only, so nothing else ever
+triggers them — answer `gh: Not Found (HTTP 404)` until the release pull
+request is merged. It bites once, on the first release after any of them is
+written, and it inverts the order below: the TestPyPI rehearsal and the
+`latest` run that this file asks for *before* the merge can only happen after
+it, still before the tag. It also means such a workflow reaches `main` having
+never run, which is how `published.yml` shipped a `windows-11-arm` cell that
+failed at setup.
 
 ## Which version string is which
 
@@ -140,7 +140,7 @@ unconstrained — and publishes the very files those checks passed to
 ## Release to PyPI
 
 `latest` is worth dispatching before the tag rather than waiting for its
-Wednesday cron, because what it answers is cheaper to know before a version
+weekly cron, because what it answers is cheaper to know before a version
 is consumed than after. It gates nothing, so it will not stop you:
 reading it is the point. Its `suite-bindings-latest` job is the one worth
 reading closely: it asks about the newest btclib_secp256k1 release
@@ -504,7 +504,7 @@ to `latest`'s own result.
    vector against the `_data/` files a wheel missing one would still
    install and import cleanly, and a BIP340 vector besides — both fixed
    forever, so neither needs an edit after a release the way a
-   version-pinned assertion would. From then on it runs monthly on its
+   version-pinned assertion would. From then on it runs weekly on its
    own, and a failure means the outside world moved, not this repository —
    a new interpreter release, PyPI serving a file that does not match its
    own hash — which is why it is a workflow of its own rather than a job

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -77,16 +77,20 @@ answers the one claim the recorded vectors cannot make. `integration.yml`
 therefore carries no `paths` filter: a required check that never runs blocks
 a merge, where a skipped one satisfies it.
 
-`codeql: every job passed` is not among them, and that is the one place a
-check was traded for the wait it cost. GitHub Free gives an organization
-twenty concurrent jobs (as of 2026-08-21); a commit here asked for
-thirty-nine, and measured
-over a working afternoon the repository sat at nineteen or twenty running
-jobs for 1375 of 2100 seconds — so a pull request's wall clock was the wait
-for a slot and not the work. `codeql.yml` now runs on `main` and on its
-schedule, the analysis landing on the merge commit rather than ahead of it,
-and it still produces that aggregate: the name is available, so requiring it
-again is a patch to the rule and nothing in the tree.
+GitHub Free gives an organization twenty concurrent jobs (as of
+2026-08-21). Measured over a working afternoon while a commit here asked
+for thirty-nine, this repository sat at nineteen or twenty running jobs
+for 1375 of 2100 seconds — so a pull request's wall clock was the wait
+for a slot and not the work. That is the measurement the gate and the
+weekly sweeps are arranged around, and it is what the workflows citing
+this file cite.
+
+`codeql: every job passed` is not among the required checks, and that is
+the one place a check was traded for the wait it cost. `codeql.yml` now
+runs on `main` and on its schedule, the analysis landing on the merge
+commit rather than ahead of it, and it still produces that aggregate:
+the name is available, so requiring it again is a patch to the rule and
+nothing in the tree.
 
 What still reads a branch before it merges is the workflow half of the same
 question: `zizmor` is a pre-commit hook, so `lint.yml` audits these very

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -14,18 +14,19 @@ recovered by reading the tree.
 **Never name matrix contexts in the branch rule.** The rule lives outside
 the repository, so a context that stops being produced blocks every merge
 with nothing in the tree to explain why. `test: every job passed` is an
-aggregate job at the end of `test.yml` that `needs` the matrix; a new job in
-`test.yml` belongs in that job's `needs`, or it gates nothing. Its name
-carries the workflow because a context is keyed by name alone: two
-workflows with a job named the same thing produce one ambiguous check.
+aggregate job at the end of `test.yml` that `needs` every other job in
+it; a new job in `test.yml` belongs in that job's `needs`, or it gates
+nothing. Its name carries the workflow because a context is keyed by name
+alone: two workflows with a job named the same thing produce one
+ambiguous check.
 
 That aggregate skips, rather than fails, when the run itself was
 cancelled by the concurrency group superseding it -- a skip satisfies a
 required check, the same as this very job's own draft/closed condition
-already relies on. A `changes` job gates `suite`, `coverage`,
-`no-bindings`, `dist` and `coverage-union` on whether a pull request
-touched anything the matrix reads, so `skipped` from any one of those
-five is legitimate too, on purpose, whenever the diff is prose alone
+already relies on. A `changes` job gates `coverage`, `no-bindings`,
+`dist` and `coverage-union` on whether a pull request touched anything
+those jobs read, so `skipped` from any one of them is legitimate too, on
+purpose, whenever the diff is prose alone
 (issue #1044) -- not only the whole-run-cancelled case. The aggregate
 fails hard on anything else a dependency reports, `success` or
 `skipped` and nothing besides, checked by name in a shell loop that
@@ -40,15 +41,16 @@ repos/btclib-org/btclib/branches/main/protection --jq
 
 | Check | Produced by |
 | --- | --- |
-| `test: every job passed` | `test.yml`, aggregate over the matrix |
+| `test: every job passed` | `test.yml`, aggregate over its own jobs |
 | `Lint and type-check` | `lint.yml`, its only job |
 | `Build the documentation` | `docs.yml`, its only job |
 | `Regtest against Bitcoin Core` | `integration.yml`, its regtest job |
 
-A workflow needs an aggregate when every one of its jobs has to gate: the
-matrix of `test.yml` is the one, and a context naming one cell of it would
-leave the rest outside the rule. Where a single job is what gates, that job
-*is* the context, which is why most of the checks above are job names.
+A workflow needs an aggregate when every one of its jobs has to gate:
+`test.yml` is the one with several, and a context naming any one of them
+would leave the rest outside the rule. Where a single job is what gates,
+that job *is* the context, which is why most of the checks above are job
+names.
 `integration.yml` holds only the regtest job: the HWI jobs — `HWI against a
 Trezor emulator` and `HWI against a Ledger emulator` — live in
 `hwi-integration.yml`, a workflow with no `pull_request` trigger at all, so
@@ -70,7 +72,7 @@ rule is waiting for.
 
 `Regtest against Bitcoin Core` is the newest of the four, and it is here
 because its cost was measured rather than assumed: 36 seconds of work for a
-disposable regtest node, which is less than the matrix it runs beside. It
+disposable regtest node, which is less than the gate it runs beside. It
 answers the one claim the recorded vectors cannot make. `integration.yml`
 therefore carries no `paths` filter: a required check that never runs blocks
 a merge, where a skipped one satisfies it.
@@ -390,7 +392,7 @@ request: once the parent lands, the
 child's base is an object no longer on `main` — a button recreates
 rather than moves, GitHub's documentation saying rebase-and-merge
 "always updates the committer information and creates new commit SHAs"
-— so the child is rebased and pays a fresh run of the matrix. That is
+— so the child is rebased and pays a fresh run of the gate. That is
 the price of having no way to write to `main` by hand, and it is the
 one worth paying: the afternoon this rule was written, a `git merge` run
 in the wrong working tree advanced `main` locally, and only the absence

--- a/btclib/hwi.py
+++ b/btclib/hwi.py
@@ -89,7 +89,7 @@ Staying aligned with a project this does not import is two things, and
 neither is a copy of it. `tests/hwi_test.py` writes out the surface used
 -- the commands, the flags, the answer keys, the error codes -- and
 `tests/_data/README.md` pins `hwilib/_cli.py` and `hwilib/errors.py` to
-the revisions it was read from, so the monthly upstream re-check reports
+the revisions it was read from, so the weekly upstream re-check reports
 a command line that moved. What that already caught: `signtx` answers
 `signed` beside the psbt, which `sign_psbt` now holds the two strings to.
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,20 +292,23 @@ testpaths = ["tests"]
 # -n auto pays here, and the number is worth writing down because a local
 # run says the opposite: on ten cores this suite is 18 seconds either way,
 # six alternating pairs splitting three to three, so a laptop cannot decide
-# this. CI can, and does. One dispatch of test.yml per configuration, the
-# `Run pytest` step compared cell by cell over the 28 of them plus coverage:
+# this. CI can, and does. One dispatch per configuration of each platform
+# sweep, the `Run pytest` step compared cell by cell across the three of
+# them and the coverage job:
 # the pool wins in every single cell, 189s against 87s at the median, 2.2x,
-# and 106 minutes of suite time against 46 across a whole run -- an hour of
-# compute per run. The ratio rises where the runner is slowest: about 2.9x
-# on both arm images against 1.9x on the x86 ones, which is the shape of a
+# which over a full sweep is better than an hour of compute. The ratio
+# rises where the runner is slowest: about 2.9x on the arm images against
+# 1.9x on the x86 ones, which is the shape of a
 # fixed startup cost amortised over more work. bitcoin-core-rpc measured the
 # same question and removed the flag, its 298 socket-free tests finishing
 # before ten workers start; the criterion the two share is in checksig's
 # docs/test-parallelism.md, and it is the length of a cell rather than the
 # count of its tests. To re-derive:
 #
-#     gh workflow run test.yml --ref <a branch with the flag removed>
-#     gh workflow run test.yml --ref main
+#     for w in ubuntu macos windows; do
+#         gh workflow run $w.yml --ref <a branch with the flag removed>
+#         gh workflow run $w.yml --ref main
+#     done
 #     gh api repos/$GITHUB_REPOSITORY/actions/runs/<id>/jobs?per_page=100
 #
 # --dist worksteal rather than xdist's default `load`, because the cost
@@ -799,8 +802,8 @@ select = [
 # the locale's: UTF-8 wherever this suite is usually read, cp1252 on
 # Windows, where a typographic quote in a docstring is a byte that maps
 # to nothing and the module holding it fails to load rather than fails a
-# test. windows.yml answers on Saturday and before a release, so nothing
-# else asks in between.
+# test. windows.yml answers weekly and before a release, so nothing else
+# asks in between.
 # Zero findings when it was selected, which makes it a ratchet and not a
 # cleanup. .pre-commit-config.yaml carries the other half, `text=True`
 # being the same locale-dependent decode one layer out
@@ -885,7 +888,7 @@ ignore = [
 # case it is not about
 ".github/scripts/mutation_counts.py" = ["T201"]
 # and the vendored-vector checker: BEHIND, SKIPPED and the all-clear line
-# are what a monthly run's log says happened, the issue it opens or
+# are what a weekly run's log says happened, the issue it opens or
 # closes being the same report a second way
 ".github/scripts/check_vendored_vectors.py" = ["T201"]
 # and the device wait, whose whole output is one line for the log of the
@@ -894,7 +897,7 @@ ignore = [
 ".github/scripts/wait_for_hwi_device.py" = ["T201"]
 # and the Python-arm authority re-derivation: which module it is
 # measuring, one line per disagreement found, and the all-clear or count
-# at the end are what a monthly run's log says happened
+# at the end are what a weekly run's log says happened
 ".github/scripts/check_python_arm_authority.py" = ["T201"]
 # the D rules are not here: a public test function, fixture or method
 # states what it verifies -- the property, the vector, the failure

--- a/tests/README.md
+++ b/tests/README.md
@@ -100,13 +100,13 @@ every commit rather than a defect.
 
 Both halves run unattended, in three jobs across two workflows, and each
 job fails if its tests skipped rather than ran. The regtest one is
-`integration.yml`'s, and downloads a pinned Core release on every pull
-request and weekly. The other two are this module against an emulator,
-one vendor each, in `hwi-integration.yml` — a workflow with no
-`pull_request` trigger at all, so a firmware release or an emulator that
-stopped starting headless never shows up as a check on a review that has
-nothing to do with it. They run weekly, on a push to `main`, and on
-demand:
+`integration.yml`'s, and downloads a pinned Core release weekly, on every
+pull request and on every push to `main`. The other two are this module
+against an emulator, one vendor each, in `hwi-integration.yml` — a
+workflow with no `pull_request` trigger at all, so a firmware release or
+an emulator that stopped starting headless never shows up as a check on a
+review that has nothing to do with it. They run weekly, on a push to
+`main`, and on demand:
 
 ```shell
 gh workflow run hwi-integration.yml --ref <branch>

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -209,7 +209,7 @@ and under upstream's own names: `key_sort_vectors.json`,
 path per pin, rather than to one placeholder path shared by all eight:
 a placeholder is not a path GitHub's own "commits touching a path" API
 can be asked about, which is what kept every one of the eight out of
-the monthly check. It also papered over a real difference between
+the weekly check. It also papered over a real difference between
 them: six were untouched since the commit that added all eight,
 `87394eaeb436d02e0a68b38a1e94bc526d50056e` (2023-03-27, "Add BIP327:
 MuSig2 for BIP340-compatible Multi-Signatures"); `sign_verify_vectors.json`
@@ -349,7 +349,7 @@ unlike BIP327 above, there is no exception a shared pin would have
 papered over here. Each is pinned below in its own entry, one real path
 per pin, rather than to one placeholder path standing in for both: a
 placeholder is not a path GitHub's own "commits touching a path" API can
-be asked about, which is what kept the pair out of the monthly check.
+be asked about, which is what kept the pair out of the weekly check.
 
 ### `tests/ecc/_data/ellswift_decode_test_vectors.csv`
 
@@ -540,7 +540,7 @@ and again on 2026-08-06 — both times still test vectors 1 to 5 and no
 sixth, every extended key in it one of ours, 48 matching the key
 pattern: our 34 valid plus 14 of the 16 invalid, the other 2 being the
 zero-prefix keys of test vector 5, which serialize outside it — the pin
-above is now that tip, so the monthly automated check can carry it.
+above is now that tip, so the weekly automated check can carry it.
 
 ### `tests/bip32/_data/bip32_invalid_keys.json`
 
@@ -560,7 +560,7 @@ pinned commit and on master today.
 btclib is the upstream here, not the consumer: commit ee2e0598, "added
 invalid extended keys vectors", is Ferdinando Ametrano's, and is what
 first put these 16 keys into the BIP. The pin above is the tip of the
-same path rather than that commit, so the monthly automated check can
+same path rather than that commit, so the weekly automated check can
 carry it too; the second column of the file is btclib's own regardless —
 it holds btclib error messages, which the BIP does not and should not
 carry, and which change when the messages change. Refreshing from
@@ -769,7 +769,7 @@ commit added both and one has touched them since — `3ab70c98`
 `d77863fb` (2026-05-06, "BIP-0322: update test vectors"), which is the
 tip of both paths — and each is pinned below in its own entry all the
 same, a shared placeholder path being what kept eight BIP327 files out of
-the monthly check.
+the weekly check.
 
 Between them they are what `tests/bip322_test.py` runs: three
 transaction hashes, eight *simple* signatures, ten *full*, three
@@ -1153,7 +1153,7 @@ tool -- and what re-derives the file is reading those calls again.
 
 Not vendored as the file itself because there is no data file upstream:
 the vectors are arguments to a C++ function. The blob above is that source
-file, so the monthly re-check still reports a case added to it.
+file, so the weekly re-check still reports a case added to it.
 
 Four of the calls are not here, being loops rather than literals: the
 `multi_a()` of twenty-one keys, the three `and_b()` chains that pass the
@@ -1188,7 +1188,7 @@ of the four Core expands from the private form alone, and the two
 Not vendored as a file because there is no file: the values are literals
 in C++ source, so a copy of it would be a copy of a test program. What
 this pin buys instead is the upstream re-check: a case added to that
-function moves the commit, and the monthly run says so.
+function moves the commit, and the weekly run says so.
 
 The subset is deliberate and is what a refresh would revisit: Core's file
 also holds `CheckUnparsable` cases, which this module has as `UNPARSABLE`
@@ -1207,7 +1207,7 @@ commands and flags a caller sends, and the numbers it gets back.
 
 Which makes these pins do something the others do not. A vector file is
 refreshed or it is not; an interface that moves is code here that stops
-working against the next release somebody installs — so the monthly
+working against the next release somebody installs — so the weekly
 re-check is the alignment, and `tests/hwi_test.py` carries the
 transcription it is checked against.
 

--- a/tests/check_python_arm_authority_test.py
+++ b/tests/check_python_arm_authority_test.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Tests for `compare()`, the diff logic of the monthly Python-arm sentinel.
+"""Tests for `compare()`, the diff logic of the weekly Python-arm sentinel.
 
 `measure()` is what actually runs the suite under coverage, module by
 module -- exactly what this repository collects no coverage from, the

--- a/tests/check_vendored_vectors_test.py
+++ b/tests/check_vendored_vectors_test.py
@@ -252,9 +252,9 @@ def test_latest_commit_is_none_when_upstream_has_no_commit_for_the_path(
     `repos/{repo}/commits?path=` answers `[]` with a 200 when upstream
     has no commit touching that path -- it was renamed, moved or deleted.
     Unpacking one commit out of that raised `ValueError`, which took
-    `find_drift` down with it and left `report` unreached: a red monthly
-    run and no issue, on the one drift a vendored file nobody re-reads
-    would otherwise hide.
+    `find_drift` down with it and left `report` unreached: a red run and
+    no issue, on the one drift a vendored file nobody re-reads would
+    otherwise hide.
     """
     fake_gh.commits["btclib-org/btclib", "tests/gone.json"] = None
     assert checker._latest_commit("btclib-org/btclib", "tests/gone.json") is None

--- a/tests/descriptors/descriptors_test.py
+++ b/tests/descriptors/descriptors_test.py
@@ -17,7 +17,7 @@ Not vendored as files, those and BIP387's and BIP390's alike: the values
 are read out of C++ source and mediawiki prose rather than copied from a
 data file, so what this module cites is the path and the case, and
 `tests/_data/README.md` carries the revision each is pinned to -- which
-is also what the monthly upstream re-check reads.
+is also what the weekly upstream re-check reads.
 
 Four of those descriptors have no public spelling to check, and Core's
 own flags say why: HARDENED and DERIVE_HARDENED mark a derivation that

--- a/tests/hwi_test.py
+++ b/tests/hwi_test.py
@@ -25,7 +25,7 @@ run over it here.
 The tables below that transcription is written out in are the other half
 of staying aligned with a project btclib does not import: they say what
 btclib sends and reads, and `tests/_data/README.md` pins the two upstream
-paths they were read from, so the monthly re-check reports a command line
+paths they were read from, so the weekly re-check reports a command line
 that moved. The module cites, the README carries the revision -- the same
 split every vendored vector here has.
 """
@@ -116,7 +116,7 @@ else:
 
 # The surface btclib depends on, transcribed from HWI's `_cli.py` and
 # `errors.py`; `tests/_data/README.md` carries the revision each is
-# pinned to, so the monthly upstream re-check reports a path that moved.
+# pinned to, so the weekly upstream re-check reports a path that moved.
 #
 # Written out rather than derived from `btclib.hwi`: a table that read
 # the adapter would agree with it by construction and say nothing. This

--- a/tests/interpreters_test.py
+++ b/tests/interpreters_test.py
@@ -6,8 +6,8 @@
 
 One fact, declared three times: `requires-python` is the floor,
 `Programming Language :: Python :: X.Y` is what PyPI shows whoever is
-choosing the package, and `test.yml`'s own list is what actually runs.
-Nothing compared them, and the three drift in the direction that is
+choosing the package, and the platform sweeps' own list is what actually
+runs. Nothing compared them, and the three drift in the direction that is
 hardest to notice -- a classifier left behind when a floor moves is a
 package advertising an interpreter its suite never touches, and the
 person it misleads is not reading this repository.
@@ -22,8 +22,8 @@ say the same thing.
 
 Read with a regex rather than parsed. `tomllib` arrives in 3.11 and the
 floor here is 3.10, which is the reason `copyright_test.py` reads
-pyproject.toml the same way; the workflow is yaml and no group here
-carries a parser for it.
+pyproject.toml the same way; the workflows are yaml and no group here
+carries a parser for that either.
 """
 
 import re
@@ -31,7 +31,7 @@ from pathlib import Path
 
 _ROOT = Path(__file__).parents[1]
 _PYPROJECT = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-_TEST_WORKFLOW = (_ROOT / ".github/workflows/test.yml").read_text(encoding="utf-8")
+_WORKFLOWS = sorted((_ROOT / ".github/workflows").glob("*.yml"))
 
 # "3.10" out of `requires-python = ">=3.10"`, the floor and nothing else:
 # an upper bound is not declared here and would be a different claim
@@ -42,10 +42,19 @@ _CLASSIFIER = re.compile(
     r'^    "Programming Language :: Python :: (?P<version>3\.\d+)",$', re.MULTILINE
 )
 _PYPY_CLASSIFIER = "Programming Language :: Python :: Implementation :: PyPy"
-# the matrix list `test.yml` builds its suite cells from
+# the matrix list a suite workflow builds its cells from. The gate runs
+# one interpreter, so the list lives in the weekly platform sweeps now --
+# in each of them, which is why they are read together below rather than
+# one of them being named here as the one that counts
 _PYTHONS = re.compile(
     r"^        python:\n(?P<block>(?:^          - \"\S+\"\n)+)", re.MULTILINE
 )
+# the platform sweeps, named rather than counted: the pattern above reads
+# a block sequence, so one sweep rewritten as a flow sequence -- which is
+# how latest.yml writes its own, and why that file is skipped here -- would
+# drop out of the comparison below in silence, leaving the remaining two
+# to agree with each other and the test green
+_SWEEPS = ("macos.yml", "ubuntu.yml", "windows.yml")
 
 
 def _versions(pattern: re.Pattern[str], text: str) -> tuple[str, ...]:
@@ -53,14 +62,27 @@ def _versions(pattern: re.Pattern[str], text: str) -> tuple[str, ...]:
     return tuple(m["version"] for m in pattern.finditer(text))
 
 
+def _declared() -> dict[str, tuple[str, ...]]:
+    """Return each workflow's interpreter list, those that declare one."""
+    found: dict[str, tuple[str, ...]] = {}
+    for workflow in _WORKFLOWS:
+        listed: set[str] = set()
+        text = workflow.read_text(encoding="utf-8")
+        for match in _PYTHONS.finditer(text):
+            listed.update(
+                line.strip().removeprefix('- "').removesuffix('"')
+                for line in match["block"].splitlines()
+            )
+        if listed:
+            found[workflow.name] = tuple(sorted(listed))
+    return found
+
+
 def _matrix() -> tuple[str, ...]:
-    """Return the interpreters `test.yml`'s suite matrices name."""
+    """Return the interpreters the platform sweeps name."""
     found: set[str] = set()
-    for match in _PYTHONS.finditer(_TEST_WORKFLOW):
-        found.update(
-            line.strip().removeprefix('- "').removesuffix('"')
-            for line in match["block"].splitlines()
-        )
+    for listed in _declared().values():
+        found.update(listed)
     return tuple(sorted(found))
 
 
@@ -82,7 +104,7 @@ def test_the_three_declarations_were_read() -> None:
     """
     assert _FLOOR.search(_PYPROJECT), "pyproject.toml declares no requires-python"
     assert _CLASSIFIED, "pyproject.toml declares no per-version Python classifier"
-    assert _MATRIX, "test.yml declares no PYTHONS block"
+    assert _MATRIX, "no workflow declares a python matrix block"
 
 
 def test_the_floor_is_the_lowest_classifier() -> None:
@@ -100,7 +122,7 @@ def test_every_classified_interpreter_is_in_the_matrix() -> None:
     """A version PyPI advertises is a version the suite runs."""
     unrun = [v for v in _CLASSIFIED if v not in _CPYTHON]
     assert not unrun, (
-        f"classified and not in test.yml's matrix: {', '.join(unrun)}."
+        f"classified and no workflow runs it: {', '.join(unrun)}."
         " PyPI shows a classifier to whoever is choosing this package"
     )
 
@@ -109,7 +131,7 @@ def test_every_matrix_interpreter_is_classified() -> None:
     """A version the suite runs is a version PyPI advertises."""
     unclassified = [v for v in _CPYTHON if v not in _CLASSIFIED]
     assert not unclassified, (
-        f"in test.yml's matrix and not classified: {', '.join(unclassified)}"
+        f"run by a workflow and not classified: {', '.join(unclassified)}"
     )
 
 
@@ -120,4 +142,27 @@ def test_pypy_is_classified_exactly_when_it_is_run() -> None:
     assert classified == run, (
         f"the PyPy classifier is {'present' if classified else 'absent'} and"
         f" the matrix {'runs' if run else 'does not run'} a PyPy interpreter"
+    )
+
+
+def test_every_sweep_runs_the_same_interpreters() -> None:
+    """One interpreter set, however many platforms sweep it.
+
+    The gate runs one, so the list is declared once per platform sweep
+    and nowhere else. Three copies of a list is three chances for one of
+    them to be left behind, and a platform quietly running a narrower set
+    than another reads, from the outside, as that platform passing.
+
+    Every sweep has to be read for that to mean anything, which is the
+    first assertion: agreement among however many were found is a claim
+    that gets weaker the fewer there are, and vacuous at one.
+    """
+    declared = _declared()
+    assert tuple(sorted(declared)) == _SWEEPS, (
+        f"the platform sweeps are {', '.join(_SWEEPS)} and the interpreter"
+        f" block was read from {', '.join(sorted(declared)) or 'none of them'}"
+    )
+    lists = set(declared.values())
+    assert len(lists) <= 1, (
+        f"the workflows do not name the same interpreters: {declared}"
     )

--- a/tests/python_arm_authority_test.py
+++ b/tests/python_arm_authority_test.py
@@ -42,7 +42,7 @@ belongs: every module `_THIRD_PARTY_VECTORS` names, under coverage, in
 an environment with no bindings, is minutes rather than seconds, and
 nothing here asks a contributor's branch to pay for it.
 
-That re-derivation runs monthly instead, is
+That re-derivation runs weekly instead, is
 `.github/workflows/python-arm-authority.yml`, calling
 `.github/scripts/check_python_arm_authority.py` -- issue #1003's answer.
 It repeats the measurement above, module by module, and fails loudly on


### PR DESCRIPTION
The merge gate becomes one image and one interpreter. Everything
exhaustive moves to a weekly sentinel on the organization grid, at
btclib's minute `:04`.

`test.yml`'s `suite` job — two images by seven interpreters, minus the
cell `coverage` already is — is deleted, along with the `exclude:` that
carved out that cell. What remains on a pull request: `changes`,
`coverage`, `no-bindings`, `coverage-union`, `dist`, `test-passed`.

`ubuntu.yml` takes those cells, run **whole** including the one the gate
spends, so a red column reads as a column rather than as a question about
which cells were skipped. `release.yml` calls it beside `macos.yml` and
`windows.yml`, and both publish jobs take it as a `needs`.

Twelve crons at `:04` and `:05`, each on the row section 10 gives.

## What this gives up

A regression on 3.10, on arm or on PyPy is not refused before a merge; it
sits on `main` until that sentinel runs. That is the trade the platform
sentinels were already making for macOS and Windows, applied to the rest.

Two things narrow it. mypy is pinned to `python_version = "3.10"` and
ruff infers the same floor, so the narrowed gate still statically checks
the oldest interpreter on every pull request. And `cibuildwheel` runs the
suite against each wheel as it builds it.

## `integration.yml` keeps its cron

The obvious reading is that it should lose it: one pinned Core release,
one `regtest` job, no matrix, already a required check on every pull
request and every push to `main`. A weekly run repeats the gate over a
tree nothing touched.

That is true of the *tree* and silent about the *download*. The job asks
two questions with one run — does Core accept what this branch built,
which the gate already asks, and does bitcoincore.org still serve the
tarball this file pins, which nothing else asks at all. The second is
external rot of exactly the shape `published.yml` is weekly for; both
fetch a pinned third-party artifact and verify a hash.

Unscheduled, a prune or a moved path surfaces during a quiet stretch as a
red **required** check on the branch of whoever opens the next pull
request, about something that branch did not do. The asymmetry is argued
in the file rather than left silent.

## The calendar is section 10's

No file here carries a second copy of it. `CONTRIBUTING.md`'s table names
no day, and a workflow's schedule comment names its own day only to say
what it sits beside and why — that `links` and `vendored-vectors` ask the
same question over different distances, that a three-hour mutation
session wants the emptiest day, that `latest` must report before
Dependabot opens. Section 10 holds slots; it does not hold btclib's
reasons for wanting them.

## The test that keeps the three lists one fact

`tests/interpreters_test.py` read `test.yml`'s `PYTHONS:` blocks, which
this deletes. It now names the three sentinels and asserts it read all
three before comparing — a bare count would still pass if one sweep
silently dropped out while an unrelated fourth file grew a matching
block, which is exactly what rewriting one list to `latest.yml`'s flow
form does.

`published`, `vendored-vectors` and `python-arm-authority` become weekly,
and every place in the tree that called those runs monthly now says
weekly — including `btclib/hwi.py`'s docstring and five test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao774JtUq6tF3SnK359Krm

## Summary by Sourcery

Make pull requests run one Ubuntu gate while moving complete platform and interpreter coverage to weekly organization-grid sweeps and release validation.

New Features:
- Add a weekly Ubuntu platform sweep covering both images and all supported interpreters, including the merge-gate cell.

Bug Fixes:
- Keep interpreter declarations synchronized across the Ubuntu, macOS, and Windows sweeps and improve detection when an upstream vendored path disappears.

Enhancements:
- Reduce pull-request testing to a single Ubuntu coverage gate while moving exhaustive platform and interpreter validation to whole weekly sweeps.
- Run the complete Ubuntu, macOS, and Windows sweeps during releases before publishing artifacts.
- Move scheduled workflows onto the organization-wide calendar and increase published-artifact, vendored-vector, and Python-arm authority checks to weekly cadence.
- Retain and document the weekly integration check as protection against external Bitcoin Core artifact rot.

CI:
- Restructure required CI checks around the single test gate and aggregate pass job, removing the former pull-request test matrix.
- Update workflow dependencies, schedules, and checkout references to reflect the new gate and sentinel layout.

Documentation:
- Update contributor, release, repository, testing, and changelog documentation for the gate/sweep model and centralized scheduling.

Tests:
- Update interpreter consistency tests to validate all three platform sweep workflows rather than the removed test matrix.

Chores:
- Refresh monthly-to-weekly references across scripts, tests, and documentation.