### PR TITLE
A bool is not an integer, and so not a private key (issue #1206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1660,6 +1660,83 @@ documented at release-notes length in the first place, and are still in
 
 ### Malformed input and the exception contract
 
+- **A bool is not a private key, and not an integer anywhere `Integer`
+  is taken** (issue #1206). `utils.is_integer` has stated the rule since
+  issue #326 — "A boolean is not another spelling of a number" — and the
+  fields that answer an integer quantity apply it, `var_int` and a
+  satoshi amount among them.
+  `int_from_integer` did not, so every `Integer` parameter in the
+  library answered `True` as the number one.
+
+  The key path is where it bit. `b58.wif_from_prv_key(True)` returned a
+  WIF of the key 1; `b58.p2pkh(True)` and `b32.p2wpkh(True)` returned
+  its addresses; and `dsa.sign(msg, True)` **signed under the Python
+  arithmetic and raised under the bindings** — one call, two answers,
+  decided by whether `btclib_secp256k1` is installed, and the bindings'
+  refusal a bare `TypeError` rather than anything this library declares.
+
+  The refusal goes in `int_from_integer` and nowhere else among the
+  `Integer` callers, that being the one coercion every one of them runs
+  through: `mult`, the
+  `Curve` and `CurveGroup` constructors, `bytes_from_prv_key_int` and
+  `hex_string` inherit it without naming it. `to_prv_key` and
+  `to_pub_key`'s type gates refuse a bool beside the types their unions
+  never named, since the int branch there does not reach the coercion,
+  and `curves.scalar_from_prv_key` reads its int through
+  `int_from_integer` rather than repeating the rule.
+
+  So the refusal has three wordings, decided by which check a value
+  reaches first, and one class throughout. `"non-integer: True"` comes
+  from the coercion — `mult`, `dsa.sign`, `scalar_from_prv_key`; `"not a
+  private key"` from `to_prv_key`'s gate — `wif_from_prv_key`,
+  `bms.sign`; and `"not a private or public key"` from `to_pub_key`'s —
+  `p2pkh`, `p2wpkh`. Those three are the change's own and not a census of
+  what a bool can draw: `pub_keyinfo_from_pub_key`, `PrvKeyData`,
+  `number_theory.mod_inv` and `bip32.derive` each refused one in a
+  sentence of their own before this and still do, and `PubKeyData` in
+  `bytes_from_octets`', the sentence every `Octets` parameter of the
+  library shares — which is why the notes tell a caller to match on the class
+  and not on the text. `tests/integer_policy_test.py` pins the three,
+  and that table is also the only test `to_pub_key`'s line can have —
+  drop it and a bool is still refused, one frame down and told it is not
+  a private key.
+
+  `ssa`'s x-only key is the same rule on the public side, and was the
+  last int spelling of a key outside it: `point_from_bip340pub_key(True)`
+  returned the point at x = 1 — carrying the bool itself as the
+  coordinate — so `ssa.verify(msg, True, sig)` answered False about a
+  value `dsa.verify` refused as a type. Not an arm disagreement, that
+  one: 1 is an x-coordinate of secp256k1, so both arms lifted the bool
+  and both answered about it — two schemes disagreeing, where the
+  private side had one scheme answering two ways. A `Point` is the arm
+  this does not reach, `is_on_curve` reading a bool as the number beside
+  it, and is issue #1249.
+
+  It reads its int through `int_from_integer` now and says
+  `"non-integer: True"`. Every entry point taking a `BIP340PubKey` moves
+  with it, `_x_from_bip340pub_key` being what they share — and the two
+  bools did not start from the same place. `True` reached the lift as
+  x = 1, so `point_from_bip340pub_key` returned that point,
+  `assert_as_valid`, `assert_as_valid_`, `assert_batch_as_valid` and
+  `assert_batch_as_valid_` raised a `BTClibRuntimeError` naming a failed
+  verification, and `verify`, `verify_`, `batch_verify` and
+  `batch_verify_` returned False. `False` the lift refused, so those
+  same four `assert_` spellings raised a `BTClibValueError` about the
+  coordinate — and the four `verify` spellings, which swallow exactly
+  that, returned False for it just as they had for `True`. All nine
+  raise a `BTClibTypeError` now, which is neither of the two: that is
+  issue #814's rule rather than an exception to it, those excepts taking
+  `ValueError` and `BTClibRuntimeError` precisely so a caller's own
+  mistake is refused instead of answered.
+
+  An `IntEnum` is untouched. `is_integer` is `isinstance` and not
+  `type(value) is int` precisely so a deliberate integer subclass stays
+  an integer — the distinction issue #273 asked about for the sighash
+  types, and answered with a `Literal` rather than an enum.
+
+  Nothing in the package passed a bool, and no test did: the change
+  costs the suite nothing and closes the arm disagreement.
+
 - **`taproot.py` gets back the import a merge dropped.**
   `check_output_pubkey`'s translation reads `HEX_THRESHOLD`, added with
   it in #1228; #1219 rewrote `_tweaked_pubkey`'s arm in the same file

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,34 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **A bool is no longer accepted as an integer** (issue #1206), which
+  matters most where it was accepted as a *key*:
+
+  ```python
+  b58.wif_from_prv_key(True)   # was a WIF of the key 1
+  ```
+
+  Act on it if you pass `True` or `False` where an integer is expected —
+  a key, a multiplier, a curve parameter, anything typed `Integer`. The
+  class is always `BTClibTypeError`; the message depends on which check
+  the value reaches first, so match on the class and not on the text.
+  A key is the case to watch: `wif_from_prv_key(True)` says "not a
+  private key" and `p2pkh(True)` "not a private or public key", where
+  `mult(True)` and `dsa.sign(msg, True)` say "non-integer: True".
+
+  A BIP340 x-only key is where that lands hardest, `ssa` having answered
+  about a bool rather than refusing one — `True` as the key at x = 1,
+  `False` as a complaint about the coordinate that the `verify`
+  spellings swallow. All nine entry points raise a `BTClibTypeError`
+  now: `point_from_bip340pub_key` where it returned that point, the four
+  `verify` spellings where they returned False, and the four `assert_`
+  spellings where they raised a `BTClibRuntimeError` for `True` and a
+  `BTClibValueError` for `False`. An `except` written for either stops
+  catching this.
+
+  An `IntEnum` is unaffected and stays an integer. CHANGELOG.md has why
+  a bool was reaching a key at all, and what the two arms did with it.
+
 - **`ecc` no longer takes a WIF or an extended key as a private key**
   (issue #1188). The entry points that took a private key however it was
   spelled — every one in `dsa`, `ssa`, `musig2`, `dleq`, `ecies`,

--- a/btclib/curves/sec_point.py
+++ b/btclib/curves/sec_point.py
@@ -63,7 +63,12 @@ def scalar_from_prv_key(prv_key: Integer, ec: Curve = secp256k1) -> int:
     _assert_valid_ec(ec)
 
     if isinstance(prv_key, int):
-        q = prv_key
+        # through `int_from_integer` for an int this already has: it is
+        # where the bool rule lives, so a `True` is refused here in the
+        # words every other `Integer` parameter refuses it in, and a real
+        # int comes back untouched. The hex spellings it also takes never
+        # reach it -- the isinstance above is what keeps "0xc0ffee" out
+        q = int_from_integer(prv_key)
     else:
         # `n_size` and not a guess: 32 for secp256k1, where a point is 33
         # or 65, so the size alone separates a scalar from one. That is

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -90,6 +90,7 @@ from btclib.utils import (
     bytesio_from_binarydata,
     hex_string,
     int_from_bits,
+    int_from_integer,
 )
 
 __all__ = [
@@ -256,13 +257,19 @@ def _x_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve) -> int:
     anything: it is validated as far as its spelling goes, and whoever
     lifts or parses it is what refuses the rest. Private for that reason.
     """
-    # BIP340 key as integer. A bool is one to `isinstance` and is
-    # answered as the number it subclasses, as the key converters do and
-    # as `utils.is_integer` exists to stop elsewhere -- `var_int` and a
-    # satoshi amount refuse one. Which of the two rules the key path
-    # should follow is issue #1206, and is not settled in passing
+    # BIP340 key as integer, read through the library's one integer
+    # coercion rather than taken as it comes: an x is a number, and a
+    # bool is not one anywhere a number is (issue #326). This was the
+    # last int spelling of a key outside that rule -- the tuple arm below
+    # is not covered by it, `is_on_curve` reading a bool as the number
+    # beside it, which is issue #1249. `isinstance(True, int)` made
+    # `True` the key at x = 1, an x-coordinate of secp256k1, so both
+    # arms lifted it and both answered about it where `dsa.verify`
+    # refused the same value as a type: two schemes disagreeing and not
+    # two arms, where the private side of issue #1206 had one scheme
+    # answering two ways.
     if isinstance(x_Q, int):
-        return x_Q
+        return int_from_integer(x_Q)
 
     if isinstance(x_Q, PreparedPoint):
         x_Q = x_Q.point

--- a/btclib/to_prv_key.py
+++ b/btclib/to_prv_key.py
@@ -59,10 +59,21 @@ def _assert_prv_key_type(prv_key: PrvKey) -> None:
     BIP32 xkey (...); not octets (...)", three formats tried against a
     value no format could have held.
 
+    A bool is refused here rather than answered as the number one.
+    `utils.is_integer` is where that rule is stated -- issue #326 gave it
+    to the fields of this library whose contract is an integer quantity,
+    and `int_from_integer` carries it for every `Integer` parameter. A
+    `PrvKey` is not one of those: the int branch below takes the value as
+    it comes rather than coercing it, so this line and not
+    `int_from_integer` is what refuses a bool spelled as a `PrvKey`
+    (issue #1206). What made it worth a refusal there makes it worth one
+    here and more so: `true` decodes from json to `True`, and a key of
+    one is a key an attacker knows.
+
     Never echo the input, every message in this module being about
     candidate key material.
     """
-    if not isinstance(prv_key, _PRV_KEY_TYPES):
+    if isinstance(prv_key, bool) or not isinstance(prv_key, _PRV_KEY_TYPES):
         raise BTClibTypeError("not a private key")
 
 

--- a/btclib/to_pub_key.py
+++ b/btclib/to_pub_key.py
@@ -107,8 +107,17 @@ def _assert_key_type(key: Key) -> None:
 
     `_assert_pub_key_type`'s wider twin, for the converters that take
     either: an int is a private key, and the two lists differ by it.
+
+    A bool is named here for the sentence and not for the refusal: with
+    the line dropped it still does not become a key, `to_prv_key`'s own
+    gate refusing it one frame down. What it draws there is "not a
+    private key", which is half the union -- where a float, a None and
+    anything else of no key type are refused here and told so. So this
+    line is what makes a bool answer like the rest of them, and
+    `tests/integer_policy_test.py` pins it by its wording, there being
+    no outcome to pin (issue #1206).
     """
-    if not isinstance(key, _KEY_TYPES):
+    if isinstance(key, bool) or not isinstance(key, _KEY_TYPES):
         raise BTClibTypeError("not a private or public key")
 
 

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -413,6 +413,10 @@ def int_from_bits(octets: Octets, nlen: int) -> int:
 def int_from_integer(i: Integer) -> int:
     r"""Return an int from many possible integer representations.
 
+    A bool is not one of them, `is_integer` being where this library
+    says so: every `Integer` parameter runs through here, so the refusal
+    is stated once and inherited (issue #1206).
+
     Allowed integer representations are:
 
     * 3735928559
@@ -433,6 +437,13 @@ def int_from_integer(i: Integer) -> int:
     (e.g. "0b11011110101011011011111011101111").
     """
     if isinstance(i, int):
+        # `is_integer` and not the `isinstance` above: a bool is an int
+        # to Python and is not a number to this library, which is the
+        # rule issue #326 gave every integer field and issue #1206 found
+        # the key path without. Here rather than at each caller, this
+        # being the one coercion every `Integer` parameter runs through
+        if not is_integer(i):
+            raise BTClibTypeError(f"non-integer: {i}")
         return i
 
     if isinstance(i, str):

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -24,6 +24,8 @@ import pytest
 from btclib import base58, bech32, var_int
 from btclib.alias import TaprootScriptTree
 from btclib.amount import valid_sats_amount
+from btclib.b32 import p2wpkh
+from btclib.b58 import p2pkh, wif_from_prv_key
 from btclib.bip32 import BIP32KeyData
 from btclib.bip32.bip32 import rootxprv_from_seed, xpub_from_xprv
 from btclib.bip32.der_path import (
@@ -37,6 +39,12 @@ from btclib.block.block import bip34_commitment
 from btclib.block.block_context import BlockContext
 from btclib.block.mining import mine
 from btclib.block.proof_of_work import hash_rate, retarget_first_height
+from btclib.curves import mult, scalar_from_prv_key, secp256k1
+from btclib.ecc.bms import sign as bms_sign
+from btclib.ecc.dsa import sign as dsa_sign
+from btclib.ecc.ssa import point_from_bip340pub_key
+from btclib.ecc.ssa import sign as ssa_sign
+from btclib.ecc.ssa import verify as ssa_verify
 from btclib.exceptions import BTClibTypeError
 from btclib.fee import FeeRate, fee_from_vsize
 from btclib.hashes import merkle_root_from_branch, sha256
@@ -45,12 +53,22 @@ from btclib.mnemonic.entropy import bin_str_entropy_from_wordlist_indexes
 from btclib.number_theory import mod_inv, mod_inv_batch_var, mod_inv_var
 from btclib.psbt.psbt import PSBT_V2, Psbt
 from btclib.script import input_script_sig, sig_hash
+from btclib.to_prv_key import int_from_prv_key
+from btclib.to_pub_key import point_from_key
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
-from btclib.utils import bytes_from_octets, encode_num, is_integer
+from btclib.utils import (
+    bytes_from_octets,
+    encode_num,
+    hex_string,
+    int_from_integer,
+    is_integer,
+)
 from btclib.wallet.script_wallet import KeyGroup
 
 _TX_ID = "01" * 32
 _RATE = FeeRate(sats_per_kvbyte=1000)
+# the key is 1, so the x-only public key it verifies under is `secp256k1.G[0]`
+_SSA_SIG = ssa_sign(b"msg", 1)
 _NOW = datetime(2026, 8, 4, tzinfo=timezone.utc)
 # a one-leaf tree and the prevout of the one input `_tx` builds: what the
 # two index parameters below have to be handed something valid to index
@@ -169,6 +187,33 @@ _CASES: list[tuple[str, Callable[[Any], object]]] = [
     ("hash rate difficulty", lambda v: hash_rate(v, 600.0)),
     ("hash rate timespan", lambda v: hash_rate(1.0, v)),
     ("hash rate block count", lambda v: hash_rate(1.0, 600.0, v)),
+    # the key path, which this census did not reach until issue #1206.
+    # Two lines of the library stand behind all of it: `int_from_integer`,
+    # and `to_prv_key`'s type gate for the int branch that does not reach
+    # the coercion. Neither is alone everywhere -- `bms.sign` is behind
+    # both, and `point_from_key`, `p2pkh` and `p2wpkh` meet `to_pub_key`'s
+    # gate before either -- so dropping one line lets a bool back through
+    # only where nothing else stands behind it, and these cases are here
+    # for the reach of the policy and not as a test apiece. `to_pub_key`'s
+    # gate is a third line and not a third refusal: drop it and
+    # `to_prv_key`'s answers those three one frame down, which is why the
+    # wordings below are what pin it
+    ("integer coercion", int_from_integer),
+    ("hex string", hex_string),
+    ("curve multiplier", mult),
+    ("curve scalar", scalar_from_prv_key),
+    ("private key converter", int_from_prv_key),
+    ("public key converter", point_from_key),
+    ("WIF private key", wif_from_prv_key),
+    ("base58 address key", p2pkh),
+    ("bech32 address key", p2wpkh),
+    ("message signing key", lambda v: bms_sign(b"msg", v)),
+    ("BIP340 x-only key", point_from_bip340pub_key),
+    # not the converter twice: `verify` answers False where it cannot
+    # verify, so what this pins is that the refusal is not one of those
+    # answers -- `BTClibTypeError` is a `TypeError` and the except there
+    # takes `ValueError`, which is issue #814's rule
+    ("BIP340 verification key", lambda v: ssa_verify(b"msg", v, _SSA_SIG)),
 ]
 
 _IDS = [case[0] for case in _CASES]
@@ -188,6 +233,52 @@ def test_a_bool_is_not_an_integer_field(
     """
     with pytest.raises(BTClibTypeError):
         call(value)
+
+
+# the sentence each of these gives back, CHANGELOG.md and
+# RELEASE_NOTES.md naming which entry points give which. Whichever
+# control reaches the value first writes it, so
+# an entry point moves between these families by gaining or losing a
+# check above it and never by choosing a wording -- which is why the
+# notes tell a caller to match on the class. Three families, and no
+# census of what a bool can draw: these are the sentences this change
+# writes, `_CASES` above is the wider list and pins the class rather
+# than the text, and a refusal older than this one belongs to whatever
+# raises it and not to the key surface -- `PrvKeyData`'s is its own and
+# `key_test.py` has it, where `PubKeyData` gives back
+# `bytes_from_octets`', the sentence every `Octets` parameter shares
+_WORDINGS = [
+    ("integer coercion", int_from_integer, "non-integer: True"),
+    ("hex string", hex_string, "non-integer: True"),
+    ("curve multiplier", mult, "non-integer: True"),
+    ("curve scalar", scalar_from_prv_key, "non-integer: True"),
+    ("dsa signing key", lambda v: dsa_sign(b"msg", v), "non-integer: True"),
+    ("private key converter", int_from_prv_key, "not a private key"),
+    ("WIF private key", wif_from_prv_key, "not a private key"),
+    ("message signing key", lambda v: bms_sign(b"msg", v), "not a private key"),
+    ("public key converter", point_from_key, "not a private or public key"),
+    ("base58 address key", p2pkh, "not a private or public key"),
+    ("bech32 address key", p2wpkh, "not a private or public key"),
+    ("BIP340 x-only key", point_from_bip340pub_key, "non-integer: True"),
+]
+
+
+@pytest.mark.parametrize(
+    "call, message",
+    [(case[1], case[2]) for case in _WORDINGS],
+    ids=[case[0] for case in _WORDINGS],
+)
+def test_which_check_refuses_the_bool_decides_the_sentence(
+    call: Callable[[Any], object], message: str
+) -> None:
+    """The wordings the release notes promise, held to what is raised.
+
+    `to_pub_key._assert_key_type`'s bool line has nothing else to be
+    tested by: dropping it leaves every one of these a refusal, and
+    moves the three it answers for onto "not a private key".
+    """
+    with pytest.raises(BTClibTypeError, match=message):
+        call(True)
 
 
 def test_the_integers_a_bool_refusal_must_not_take_with_it() -> None:
@@ -213,6 +304,18 @@ def test_the_integers_a_bool_refusal_must_not_take_with_it() -> None:
     assert indexes_from_der_path([1, 2]) == [1, 2]
     assert bytes_from_der_path(1).hex() == "01000000"
     assert str_from_der_path([1]) == "m/1"
+    assert int_from_integer(1) == 1
+    assert hex_string(1) == "01"
+    assert mult(1) == secp256k1.G
+    assert scalar_from_prv_key(1) == 1
+    assert int_from_prv_key(1) == 1
+    assert point_from_key(1) == secp256k1.G
+    assert wif_from_prv_key(1).startswith("Kw")
+    assert p2pkh(1).startswith("1")
+    assert p2wpkh(1).startswith("bc1")
+    assert bms_sign(b"msg", 1).dsa_sig.r
+    assert point_from_bip340pub_key(secp256k1.G[0]) == secp256k1.G
+    assert ssa_verify(b"msg", secp256k1.G[0], _SSA_SIG)
     assert str_from_index_int(1) == "1"
     assert bytes_from_octets(b"x", 1) == b"x"
     assert bytes_from_octets(b"xx", [1, 2]) == b"xx"


### PR DESCRIPTION
Closes #1206.

`utils.is_integer` has stated the rule since #326 — "A boolean is not
another spelling of a number" — and the fields that answer an integer
quantity apply it. `int_from_integer` did not, so every `Integer`
parameter in the library answered `True` as the number one.

The key path is where that bit, and it bit twice:

```python
b58.wif_from_prv_key(True)   # a WIF of the key 1
dsa.sign(msg, True)          # python arm: a signature
                             # bindings arm: a bare TypeError
```

One call, two answers, decided by whether `btclib_secp256k1` is
installed. The bindings had the policy right and btclib did not.

The refusal goes in `int_from_integer`, the one coercion every `Integer`
parameter runs through, so `mult`, `double_mult_var`, `multi_mult_var`,
the `Curve` and `CurveGroup` constructors, `bytes_from_prv_key_int` and
`hex_string` inherit it without naming it — putting it on the key path
alone was the first attempt and would have left all of those taking a
bool. `to_prv_key` and `to_pub_key`'s type gates say it themselves,
their int branches being what does not reach the coercion.

`ssa`'s x-only key was the last int spelling of a key outside the rule,
and its own comment deferred the question here. All nine entry points
taking a `BIP340PubKey` move with it; CHANGELOG.md has which of them
raise where they returned False and which change exception class, for
`True` and for `False` separately, since the two did not start from the
same place.

A `Point` of bools is the arm none of this reaches — `is_on_curve` reads
a bool as the number beside it, so `p2pkh((True, y))` still builds the
address of the point at x = 1, which is nobody's key. That is #1249, and
it is what #1206's fourth checkbox asked for.

Nothing in the package passed a bool and no test did, so the change
costs the suite nothing.

## Summary by Sourcery

Enforce the library policy that booleans are not integers or cryptographic keys across all relevant APIs.

Bug Fixes:
- Reject booleans wherever integer or key inputs are accepted, preventing them from being interpreted as the value one or as the x-coordinate one.
- Make BIP340 x-only key handling consistently raise BTClibTypeError for boolean inputs across point conversion, verification, and assertion APIs.
- Align private-key scalar conversion with the library-wide integer validation policy and eliminate Python-versus-bindings behavior differences.

Documentation:
- Document the boolean-input breaking change, affected key paths, exception behavior, and IntEnum compatibility in the changelog and release notes.

Tests:
- Expand integer-policy coverage across integer coercion, elliptic-curve, key conversion, address, signing, and BIP340 verification entry points.