### PR TITLE
borromean.sign takes a scalar, and checks its range (issue #1243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1798,6 +1798,51 @@ documented at release-notes length in the first place, and are still in
 
   Nothing in the package passed a bool, and no test did: the change
   costs the suite nothing and closes the arm disagreement.
+- **`borromean.sign` refuses a scalar outside 1..n-1, and reads one
+  however it is spelled** (issue #1243). `sign_keys[i]` reached step 2's
+  `(k + sign_keys[i] * e[i][j_star]) % ec.n` exactly as the caller wrote
+  it, so three values outside 1..n-1 signed that `dsa.sign` and every
+  other signer in `ecc` refuse: 0, `n`, and `q + n`.
+
+  `q + n` is the one that mattered. That line's own modulo made it the
+  key `q`, silently, so `sign` with `q` and `sign` with `q + n` both
+  return a signature that verifies under the same ring, and a caller who
+  had added `n` to a key was never told. 0 and `n` were the quieter
+  half: they returned a `BorromeanSig` that does not verify under the
+  ring it was signed against, where every other signer says the key is
+  out of range instead of handing one back.
+
+  ```python
+  borromean.sign(msg, [1], [0], [q + secp256k1.n], pubk_rings)  # signed
+  dsa.sign(msg, q + secp256k1.n)   # BTClibValueError: private key not in 1..n-1
+  ```
+
+  Both sequences now read through `curves.scalar_from_prv_key`, which is
+  the range check, before step 1 spends a scalar multiplication. `ks` is
+  the same kind of value and moves with `sign_keys`: a nonce of 0 or of
+  `n` used to draw "no bytes representation for infinity point", which
+  blames the point step 1 built rather than the value that was passed.
+  `sign_key_idx` does not move — it indexes a ring, and an index is not
+  a scalar written in hex.
+
+  The spelling follows from the same call. `ks` and `sign_keys` are
+  `Sequence[Integer]` where they were `Sequence[int]`, so a key held as
+  its `n_size` octets or as hex is passed here as it is passed to `mult`
+  and to `dsa.sign`. That mattered beyond the annotation: the
+  unconverted spellings did not raise this library's own error but
+  Python's, all of them out of the one line that builds the real
+  s-value. A key gets `OverflowError: cannot fit 'int' into an
+  index-sized integer`, `sign_keys[i] * e[i][j_star]` repeating the str
+  or the bytes rather than multiplying it; a nonce gets a `TypeError`
+  from adding an int to that, one sentence per spelling — `can only
+  concatenate str (not "int") to str` for hex, `can't concat int to
+  bytes` for octets. None of the three is a `BTClibValueError` or a
+  `BTClibTypeError`, so all escaped the contract the way issue #1220's
+  `TypeError` did.
+
+  The refusal does not name the ring, where `_assert_sign_key_idx_in_range`
+  does: a ring's size is a fact the caller has to be told, and a key of
+  0 is one they can see in the sequence they passed.
 
 - **`taproot.py` gets back the import a merge dropped.**
   `check_output_pubkey`'s translation reads `HEX_THRESHOLD`, added with

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -47,6 +47,29 @@ full year, short month, short day (YYYY-M-D)
 
   An `IntEnum` is unaffected and stays an integer. CHANGELOG.md has why
   a bool was reaching a key at all, and what the two arms did with it.
+- **`borromean.sign` refuses a private key or a nonce outside 1..n-1**
+  (issue #1243). Neither sequence was read as a scalar, so a key of 0,
+  of `n` or of `q + n` signed, where every other signer in `ecc`
+  refuses all three. `q + n` is the one to look for in your own code:
+  step 2's own `% ec.n` reduced it to `q`, so it produced a signature
+  that verifies, and it now raises `BTClibValueError: private key not
+  in 1..n-1`. A nonce of `k + n` was reduced by the same line and is
+  refused by the same check.
+
+  ```python
+  borromean.sign(msg, ks, idx, [q + secp256k1.n], rings)  # signed
+  borromean.sign(msg, ks, idx, [q % secp256k1.n], rings)  # reduce first
+  ```
+
+  Act on it if you build a key or a nonce by addition and rely on the
+  reduction. An `int` key already in 1..n-1 signs exactly as it did.
+
+  Widened in the same call: `ks` and `sign_keys` are
+  `Sequence[Integer]` where they were `Sequence[int]`, so a scalar held
+  as its `n_size` octets or as hex is taken here as `mult` and
+  `dsa.sign` take it. Those spellings used to leave Python's own
+  `OverflowError` and `TypeError`. `sign_key_idx` is still
+  `Sequence[int]`: it indexes a ring.
 
 - **`ecc` no longer takes a WIF or an extended key as a private key**
   (issue #1188). The entry points that took a private key however it was
@@ -55,8 +78,9 @@ full year, short month, short day (YYYY-M-D)
   `anti_exfil_signer_commit` and `anti_exfil_sign` among them — took a
   WIF, an xprv, an
   `int` or octets. They now take an `int`, its `n_size` octets, or their
-  hex. `borromean` is not among them and never was: it asks for a
-  sequence of `int` outright.
+  hex. `borromean` is not among them and never was: it asked for a
+  sequence of `int` outright, and issue #1243's bullet above is what
+  gave it the same three spellings — never the WIF.
 
   ```python
   dsa.sign(msg, wif)                                  # was

--- a/btclib/ecc/borromean.py
+++ b/btclib/ecc/borromean.py
@@ -63,8 +63,15 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from hashlib import sha256
 
-from btclib.alias import BinaryData, HashF, Octets, Point
-from btclib.curves import Curve, bytes_from_point, double_mult_var, mult, secp256k1
+from btclib.alias import BinaryData, HashF, Integer, Octets, Point
+from btclib.curves import (
+    Curve,
+    bytes_from_point,
+    double_mult_var,
+    mult,
+    scalar_from_prv_key,
+    secp256k1,
+)
 from btclib.curves.curve import _assert_valid_ec
 from btclib.exceptions import BorromeanRingError, BTClibRuntimeError, BTClibValueError
 from btclib.utils import (
@@ -369,9 +376,9 @@ def _assert_sign_key_idx_in_range(
 
 def sign(
     msg: Octets,
-    ks: Sequence[int],
+    ks: Sequence[Integer],
     sign_key_idx: Sequence[int],
-    sign_keys: Sequence[int],
+    sign_keys: Sequence[Integer],
     pubk_rings: Sequence[PubkeyRing],
     ec: Curve = secp256k1,
     hf: HashF = sha256,
@@ -385,6 +392,12 @@ def sign(
     key in each ring, `sign_keys` the real private key of each ring --
     `sign_keys[i]` signs at `pubk_rings[i][sign_key_idx[i]]` -- and
     `pubk_rings` the full public rings, real key included.
+
+    `ks` and `sign_keys` are scalars, spelled as `Integer` the way `dsa`
+    and `ssa` spell one, and each is read through
+    `curves.scalar_from_prv_key`: in 1..n-1, or refused (issue #1243).
+    `sign_key_idx` is not one of them and stays `int` -- it indexes a
+    ring, and an index is not a scalar written in hex.
     `sign_key_idx[i]` must be a valid index into `pubk_rings[i]`, refused
     with `BTClibValueError` naming the ring, the index and the ring's
     size otherwise -- a ring with no keys has none, whatever the index
@@ -418,10 +431,11 @@ def sign(
     # 3" and no parameter of this function; strict=True stays, as the
     # assertion that this check and those loops cannot drift apart.
     # sign_keys is part of this check for the same reason as the other
-    # three: step 2 indexes it per ring (`sign_keys[i]`), so a shorter
-    # sequence there is the same shape exposure _assert_matches_pubk_rings
-    # refuses on the verification side, one ring's worth of tuple away
-    # from a bare IndexError instead of this message
+    # three: step 2 indexes it per ring, through the `q_ints` built from
+    # it one entry at a time, so a shorter sequence there is the same
+    # shape exposure _assert_matches_pubk_rings refuses on the
+    # verification side, one ring's worth of tuple away from a bare
+    # IndexError instead of this message
     if not len(pubk_rings) == len(sign_key_idx) == len(ks) == len(sign_keys):
         err_msg = f"{len(pubk_rings)} rings, {len(sign_key_idx)} signing indexes, "
         err_msg += f"{len(ks)} nonces and {len(sign_keys)} signing keys"
@@ -435,9 +449,26 @@ def sign(
     # verification side
     _assert_sign_key_idx_in_range(pubk_rings, sign_key_idx)
 
+    # both sequences are scalars and neither was read as one. Step 2 took
+    # `sign_keys[i]` as it came, so a key of 0, of n, or of q + n signed
+    # where every other signer in `ecc` refuses all three -- q + n
+    # silently the same key as q, the reduction being that line's own
+    # `% ec.n` -- and the octets and hex spellings `Integer` names left
+    # Python's `OverflowError` for a key and its `TypeError` for a nonce,
+    # neither of them anything this library declares (issue #1243).
+    # Read before step 1 rather than in the loop that consumes each, so
+    # a scalar a later ring's would have refused costs no scalar
+    # multiplication first.
+    #
+    # The ring is not named here, where `_assert_sign_key_idx_in_range`
+    # names it: a ring's size is a fact the caller has to be told, and a
+    # key of 0 is one they can see in the sequence they passed.
+    k_ints = [scalar_from_prv_key(k, ec) for k in ks]
+    q_ints = [scalar_from_prv_key(q, ec) for q in sign_keys]
+
     # step 1
     for i, (pubk_ring, j_star, k) in enumerate(
-        zip(pubk_rings, sign_key_idx, ks, strict=True)
+        zip(pubk_rings, sign_key_idx, k_ints, strict=True)
     ):
         keys_size = len(pubk_ring)
         start_idx = (j_star + 1) % keys_size
@@ -465,7 +496,7 @@ def sign(
     e0 = hasher.digest()
     # step 2
     # strict=True: see step 1
-    for i, (j_star, k) in enumerate(zip(sign_key_idx, ks, strict=True)):
+    for i, (j_star, k) in enumerate(zip(sign_key_idx, k_ints, strict=True)):
         e[i][0] = int_from_bits(_hash(m, e0, i, 0, hf), ec.nlen) % ec.n
         # zero e again: the same accident documented above
         if not 0 < e[i][0] < ec.n:
@@ -488,13 +519,13 @@ def sign(
                 raise BorromeanRingError(err_msg, i, j)  # pragma: no cover
         # reduced mod n, like every forged value above: unreduced, this
         # is about twice the bit length of the others -- k and
-        # sign_keys[i] * e[i][j_star] are each near n, so their sum is
+        # q_ints[i] * e[i][j_star] are each near n, so their sum is
         # about 512 bits where a forged s stays at 256 -- and the real
         # signer's ring position is then the longest s in the ring, with
         # no computation needed to read it off a published signature.
         # Every consumer already reduces mod n (`mult`, `double_mult_var`),
         # so this changes no signature, only what it discloses.
-        s[i][j_star] = (k + sign_keys[i] * e[i][j_star]) % ec.n
+        s[i][j_star] = (k + q_ints[i] * e[i][j_star]) % ec.n
     return BorromeanSig(e0, s, ec)
 
 

--- a/tests/ecc/borromean_test.py
+++ b/tests/ecc/borromean_test.py
@@ -548,6 +548,68 @@ def test_sign_key_idx_out_of_range_is_refused() -> None:
         borromean.sign(b"msg", [1], [-1], [1], [[q1, q2]])
 
 
+def test_a_scalar_outside_1_to_n_minus_1_is_refused() -> None:
+    """The range check every other signer in `ecc` has, and this had not.
+
+    `sign_keys[i]` reached step 2's `(k + sign_keys[i] * e[i][j_star]) %
+    ec.n` as it came, so three values outside 1..n-1 signed that
+    `dsa.sign` refuses: 0, `n`, and `q + n`. The last is the one that
+    mattered -- that line's own modulo made it silently the key `q`, so
+    two different inputs produced signatures that both verify under one
+    ring, and a caller who had added `n` to a key was never told
+    (issue #1243).
+
+    Zero and `n` were the quieter half: they produced a `BorromeanSig`
+    that verifies under nothing, where every other signer says so
+    instead of handing one back. `ks` is the same scalar and gets the
+    same reading -- a nonce of 0 or of `n` drew "no bytes representation
+    for infinity point", blaming the point step 1 built rather than the
+    value the caller passed.
+    """
+    ec = secp256k1
+    q = 3
+    pubk_rings = [[mult(1, ec.G, ec), mult(q, ec.G, ec)]]
+    err_msg = "private key not in 1..n-1"
+
+    for bad in (0, ec.n, q + ec.n):
+        with pytest.raises(BTClibValueError, match=err_msg):
+            borromean.sign(b"msg", [1], [1], [bad], pubk_rings)
+        with pytest.raises(BTClibValueError, match=err_msg):
+            borromean.sign(b"msg", [bad], [1], [q], pubk_rings)
+
+    # the key itself still signs, and the ring still verifies: what the
+    # check refuses is the three values, not the shape of the call
+    sig = borromean.sign(b"msg", [1], [1], [q], pubk_rings)
+    assert borromean.verify(b"msg", sig, pubk_rings)
+
+
+def test_a_key_and_a_nonce_are_spelled_the_way_ecc_spells_a_scalar() -> None:
+    """`Integer`, which is what `mult` and `dsa.sign` take.
+
+    `Sequence[int]` was this signer's alone, so a caller holding a key as
+    octets or hex converted for it and for nothing else -- and the
+    conversion they skipped did not raise btclib's own error but
+    Python's, all of them out of the one line that builds the real
+    s-value: an `OverflowError` where the key repeats a str or a bytes
+    instead of multiplying, the challenge being far too large a repeat
+    count to fit the index-sized integer CPython wants, and a
+    `TypeError` where the nonce adds an int to one -- a different
+    sentence per spelling. None of the three is a `BTClibValueError` or
+    a `BTClibTypeError`, so all escaped the contract (issue #1243).
+    """
+    ec = secp256k1
+    q = 3
+    pubk_rings = [[mult(1, ec.G, ec), mult(q, ec.G, ec)]]
+
+    for key in (q, f"{q:064x}", q.to_bytes(ec.n_size, "big")):
+        sig = borromean.sign(b"msg", [1], [1], [key], pubk_rings)
+        assert borromean.verify(b"msg", sig, pubk_rings)
+
+    for nonce in (1, f"{1:064x}", (1).to_bytes(ec.n_size, "big")):
+        sig = borromean.sign(b"msg", [nonce], [1], [q], pubk_rings)
+        assert borromean.verify(b"msg", sig, pubk_rings)
+
+
 # each maps an s-value to a key `_guess_signer` maximizes over the ring: a
 # published signature must not let any of them recover which position was
 # the real signer. "bit_length" and "value" are the two the unreduced real


### PR DESCRIPTION
Closes #1243.

`borromean.sign` took its two scalar sequences as they came. `sign_keys[i]`
reached step 2's `(k + sign_keys[i] * e[i][j_star]) % ec.n` unexamined, so
three values outside 1..n-1 signed that `dsa.sign` and every other signer in
`ecc` refuse: 0, `n`, and `q + n`.

`q + n` is the one that mattered. That line's own modulo made it the key `q`,
so signing with `q` and signing with `q + n` both return a signature that
verifies under the same ring, and a caller who had added `n` to a key was
never told which key they had used. 0 and `n` were the quieter half: they
returned a `BorromeanSig` that does not verify under the ring it was signed
against, where every other signer says the key is out of range rather than
handing one back.

Both sequences now read through `curves.scalar_from_prv_key`, which is where
that range lives. The read sits before step 1 rather than in the loop that
consumes each, so a scalar a later ring's would have refused costs no scalar
multiplication first.

The spelling follows from the same call, and is not only an annotation. `ks`
and `sign_keys` are `Sequence[Integer]` where they were `Sequence[int]`, so a
scalar held as its `n_size` octets or as hex reaches this signer the way it
reaches `mult` and `dsa.sign`. Before, those spellings left Python's own
errors rather than this library's — an `OverflowError` for a key, a
`TypeError` for a nonce, all out of the one line that builds the real s-value,
and none of them a `BTClibValueError` or a `BTClibTypeError`.

`sign_key_idx` does not move: it indexes a ring, and an index is not a scalar
written in hex.

### What this does not add

`sign` still does not check that `sign_keys[i]` is the key at
`pubk_rings[i][sign_key_idx[i]]`. Any in-range key that is not the ring's
produces a signature that does not verify, exactly as before. The range is a
contract about the scalar, not a proof about the ring.

### Breaking

A bool key is withdrawn: routing through `Integer` is what subjects it to
#1206's refusal, which RELEASE_NOTES.md states once for anything typed that
way. Everything else that worked keeps working — an `int` key in 1..n-1 signs
exactly as it did, and an `IntEnum` is unaffected. Measured against
`origin/main` rather than inferred.

### Gates

Run locally on this sha, all three:

- `uv run pytest` — exit 0, 29552 passed, `TOTAL 100.00%`
- `uv run pre-commit run --all-files` — exit 0
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hde6RUtTpqFBkPziUqzZkX

## Summary by Sourcery

Validate Borromean signing scalars consistently and support the standard scalar input representations.

Bug Fixes:
- Make `borromean.sign` reject private keys and nonces outside the valid 1..n-1 range instead of silently reducing or producing invalid signatures.
- Accept scalar keys and nonces in the same integer, hexadecimal, and byte representations supported by other ECC signing APIs.

Enhancements:
- Align `borromean.sign` scalar inputs and validation behavior with the rest of the ECC APIs while preserving ring-index handling.

Documentation:
- Document the new scalar range validation and accepted input representations in the changelog and release notes.

Tests:
- Add coverage for rejecting invalid scalar values and accepting integer, hexadecimal, and byte scalar representations.