### PR TITLE
The measurement is what it measures, and not what cites it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,22 @@ documented at release-notes length in the first place, and are still in
   produced it, and the `PUT` that moves this repository by hand the next
   time the organization default moves. Documentation only: nothing was
   set, and the read-back is the same object before and after.
+- **`REPOSITORY.md` drops a false claim about what cites its concurrency
+  measurement**. The passage closed with "it is what the workflows citing
+  this file cite", and most of what cites this file cites something else:
+  the required-contexts rule, the order settings are exchanged in, the
+  permissions shape, a paths filter, a rename recipe, the required-checks
+  table, the Read the Docs section, the Pages setting. `grep -rn
+  REPOSITORY.md .github/workflows` is what a reader would have checked the
+  clause against, and the clause loses. The sentence before it already
+  scopes the measurement to the gate and the weekly sweeps, which is a
+  claim about this file rather than about a citation set nobody
+  enumerated, so the paragraph ends there.
+- **Two paragraphs wrap through, rather than at the seam an edit landed
+  on.** `CONTRIBUTING.md`'s `integration` paragraph had `tests/README.md`
+  alone on a line of its own; `REPOSITORY.md`'s CodeQL paragraph had "pull
+  request here". Each came of reflowing part of a paragraph and stopping
+  where the edit stopped.
 
 ### Packaging, linting and CI
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -736,17 +736,16 @@ exits non-zero for one, which is the only thing the workflow is red about.
 Its docstring says why it reads the session file rather than `cosmic-ray
 dump`, which cannot read one of these sessions at all.
 
-The `integration` workflow, which gates and is the exception here: it
-runs on every pull request, on every push to `main` and before a release,
-and `Regtest against Bitcoin Core` is required on `main`. It runs weekly
-too, and that workflow's own header says what the weekly run asks that
-the others do not: it pins one Core release, so the tree is not the
-question a schedule puts to it -- whether bitcoincore.org still serves
-that release is. It asks the one question the rest of CI cannot, whether
-Bitcoin Core accepts what btclib built. It downloads a pinned Core
-release, verifies its published sha256, and runs the tests
-`tests/README.md`
-documents with the binary named rather than found on PATH:
+The `integration` workflow, which gates and is the exception here: it runs
+on every pull request, on every push to `main` and before a release, and
+`Regtest against Bitcoin Core` is required on `main`. It runs weekly too,
+and that workflow's own header says what the weekly run asks that the
+others do not: it pins one Core release, so the tree is not the question a
+schedule puts to it -- whether bitcoincore.org still serves that release
+is. It asks the one question the rest of CI cannot, whether Bitcoin Core
+accepts what btclib built. It downloads a pinned Core release, verifies
+its published sha256, and runs the tests `tests/README.md` documents with
+the binary named rather than found on PATH:
 
 ```shell
 BTCLIB_INTEGRATION=1 BTCLIB_BITCOIND=/path/to/bitcoind \

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -82,8 +82,7 @@ GitHub Free gives an organization twenty concurrent jobs (as of
 for thirty-nine, this repository sat at nineteen or twenty running jobs
 for 1375 of 2100 seconds — so a pull request's wall clock was the wait
 for a slot and not the work. That is the measurement the gate and the
-weekly sweeps are arranged around, and it is what the workflows citing
-this file cite.
+weekly sweeps are arranged around.
 
 `codeql: every job passed` is not among the required checks, and that is
 the one place a check was traded for the wait it cost. `codeql.yml` now
@@ -234,10 +233,9 @@ gh api -X PATCH repos/btclib-org/btclib/code-quality/setup \
 
 What decided it is the concurrency ceiling and not the queries. GitHub
 Free gives an organization twenty concurrent jobs (as of 2026-08-21), a
-pull request here
-asks for twenty-one on purpose, and `Analyze (python)` and `Analyze
-(ruby)` were two more on every pull request and every push to `main` —
-`Code Quality: PR #N` in the run list, 80 seconds and 32.
+pull request here asks for twenty-one on purpose, and `Analyze (python)`
+and `Analyze (ruby)` were two more on every pull request and every push
+to `main` — `Code Quality: PR #N` in the run list, 80 seconds and 32.
 
 What they produced in exchange cannot be read from here at all. There is
 no `code-quality/alerts` and no `code-quality/analyses`, both 404, and a


### PR DESCRIPTION
The concurrency passage in REPOSITORY.md closed by claiming it is "what
the workflows citing this file cite". Most of what cites this file cites
something else -- the required-contexts rule, the order settings are
exchanged in, the permissions shape, a paths filter, a rename recipe, the
required-checks table, the Read the Docs section, the Pages setting --
and `grep -rn REPOSITORY.md .github/workflows` says so. The sentence
before it already scopes the measurement to the gate and the weekly
sweeps, which is a claim about this file and not about a citation set
nobody enumerated, so the paragraph ends there.

Two paragraphs are rewrapped through rather than at the seam an edit
landed on: the `integration` one in CONTRIBUTING.md, which had
`tests/README.md` alone on a line of its own, and the CodeQL one in
REPOSITORY.md, which had "pull request here". Each came of reflowing part
of a paragraph and stopping where the edit stopped.
Follow-up to #1251, which had merged by the time its review found these.
btclib-org/btclib#1256 is the other half of the same rule, left out of
this branch on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao774JtUq6tF3SnK359Krm

## Summary by Sourcery

Correct documentation claims and formatting around CI concurrency measurements.

Bug Fixes:
- Correct inaccurate documentation about what references the concurrency measurement in REPOSITORY.md.

Enhancements:
- Reflow documentation paragraphs in CONTRIBUTING.md and REPOSITORY.md for consistent formatting.
- Record the documentation corrections in the changelog.

Documentation:
- Clarify the scope of the concurrency measurement and improve paragraph wrapping in the repository and contribution documentation.