### PR TITLE
The spelling aliases name every buffer their consumers take (issue #1238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1382,6 +1382,82 @@ documented at release-notes length in the first place, and are still in
   what the module decides: each command spelled as Core's `NetMsgType`
   spells it, a misspelling round-tripping as well as the real thing,
   and a fee rate outside the money range surviving the round trip.
+- **The spelling aliases name every buffer their consumers take**:
+  `Octets` and `String` are `bytes | str | bytearray | memoryview` now,
+  `Integer` is `Octets | int`, and `PrvKey`, `PubKey`, `Key` and
+  `Command` are spelled from those rather than from `bytes | str`
+  (issue #1238). Nothing is added at run time: the check tuples were
+  already the wider list — `to_prv_key._PRV_KEY_TYPES` and
+  `to_pub_key._PUB_KEY_TYPES` name the buffers outright, and
+  `utils.bytes_from_octets` documents why it returns one as it came —
+  so it was the annotations that were narrower than the contract, and
+  a caller who wrote a buffer down needed a `type: ignore` to say what
+  the library already did.
+
+  What that cost was not only noise. mypy could not see the buffer
+  paths, so the places that would break on one were found a caller at a
+  time, which is how issue #1220 was found. Widening the aliases asks
+  the question of the whole tree at once, and these are what it
+  answered:
+
+    - `wallet.__contains__` and `address_info`: `_address_str` promises a
+    `str` and returned what it was handed, so a bytearray reached the
+    dict of handed-out addresses and raised `TypeError: cannot use
+    'bytearray' as a dict key`, and a memoryview never got there —
+    `AttributeError` on the `strip` it does not have
+    - `script_pub_key._script_from`: `invalid script_pub_key type:
+    bytearray`, which is what `Descriptor.index_of` and
+    `RangedWallet.position_of` ask through
+    - `PsbtView`: the buffer was taken for the stream it is not, and died
+    on `AttributeError: 'bytearray' object has no attribute 'seekable'`
+    - `bip322.assert_as_valid`: a legacy BMS signature held as a bytearray
+    took the BIP322 branch instead, where it is not a BIP322 signature,
+    and verified False
+    - `bip32.BIP32KeyData.b58decode`: `invalid base58 string type:
+    bytearray`
+    - `bms.sign`: an address as `bytes` was decoded and not stripped,
+    where one as text was, so `f"  {addr}  ".encode()` did not name the
+    address it holds and the recovery flag came back as
+    `BTClibValueError: mismatch between private key and address` — a
+    complaint about the key, for blanks. Both spellings read through
+    `str_from_string` now, which is the library's one answer for a
+    `String`, and which also puts a non-ascii address inside
+    `BTClibValueError: non-ascii character in address` where the
+    hand-rolled `decode` let Python's own `UnicodeDecodeError` out
+    - `base58._b58decode` and `script._serialize_bytes_command` took every
+    buffer already — the first says so in a comment — and their
+    signatures said `bytes`
+    - `taproot.serialize`: the arm that writes the push after an
+    OP_SUCCESS asked `isinstance(script[0], bytes)`, so it refused a
+    bytearray with "OP_SUCCESS must be followed by a single bytes
+    command" — about a command that is a single bytes command
+    - `fetch.tx_from_raw`: the guard in front of the parse asked the same
+    narrow question, so a backend's answer held in a buffer was refused
+    as `FetchError: transaction <id>: not a serialization, but a
+    bytearray`
+
+  The `isinstance` ones are all the same mistake: `isinstance(x,
+  bytes)` and `isinstance(x, (str, bytes))` were asking "is this the
+  packed form" by naming the types that were the packed form when the
+  line was written. mypy does not flag a narrowing, so those were read
+  for rather than reported — `bip322`'s is now `not isinstance(sig,
+  Sig)`, which is the question it was actually asking.
+
+  `bytes_from_octets` is the one place the widening leaves an untrue
+  annotation: it promises `bytes` and returns the buffer it was given,
+  which is deliberate and documented, and which only the widened
+  `Octets` makes visible. Both returns carry a `type: ignore` naming
+  issue #1255 rather than a silence. Making the signature true is its
+  own change, across the tree rather than in one file, and an
+  `@overload` does not pay for itself — the callers that matter hand it
+  a value already typed `Octets`, so the whole union comes back out and
+  the downstream errors stand. Issue #1255 has the command that
+  measures both.
+
+  `DerPath` is deliberately not widened: it holds `Sequence[int]` beside
+  `bytes`, and a buffer satisfies both, so the same octets already mean
+  two different paths depending on the spelling. That is issue #1258,
+  and it wants a decision rather than a wider union.
 
 - **`ecc` takes a scalar and not a WIF**: `curves.scalar_from_prv_key`
   is the conversion, and the `ecc` modules that resolved a private key

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -231,6 +231,35 @@ full year, short month, short day (YYYY-M-D)
   answer rather than an error, and one that had compensated by reversing
   the octets itself has to stop doing so. CHANGELOG.md has why.
 
+### Worth knowing, though nothing raises
+
+- **A `bytearray` and a `memoryview` are octets, and now the signatures
+  say so** (issue #1238). `Octets` and `String` name all four spellings,
+  and `Integer`, `PrvKey`, `PubKey`, `Key` and `Command` are built from
+  them. Every one of those buffers was already accepted at run time —
+  the type checks inside the library listed them — so no call that
+  worked stops working, and nothing new is refused.
+
+  Act on it only if you type-check your own code against btclib: a
+  `# type: ignore[arg-type]` you wrote to pass a buffer is now unused,
+  and mypy reports an unused ignore as an error under
+  `warn_unused_ignores`. Delete those and the annotation says what the
+  library does.
+
+  Several places did not in fact take a buffer, and now do. The two worth
+  reading are the ones that answered rather than raising: a legacy BMS
+  signature held as a bytearray was checked as a BIP322 signature, which
+  it is not, and came back False; and an address handed to `bms.sign` as
+  `bytes` was not stripped of surrounding blanks where the same address
+  as text was, so it signed under a different address than the caller
+  named and said `mismatch between private key and address`.
+
+  One exception class moves with that second fix: a non-ascii address as
+  `bytes` raised Python's `UnicodeDecodeError` and now raises
+  `BTClibValueError: non-ascii character in address`, so an `except
+  UnicodeDecodeError` around `bms.sign` stops catching it.
+  CHANGELOG.md lists them.
+
 ## v2026.8.21
 
 ### Breaking changes

--- a/btclib/alias.py
+++ b/btclib/alias.py
@@ -4,8 +4,8 @@
 
 """The type aliases of the public API, and the input conventions they name.
 
-Octets and String below are both `bytes | str`, so mypy cannot tell
-one from the other: passing a text string where a hex-string is expected
+Octets and String below are the same union, so mypy cannot tell one
+from the other: passing a text string where a hex-string is expected
 is a type error this file names but no checker can catch. The distinction
 is enforced at run time instead, by the converter each function calls on
 its way in -- bytes_from_octets for Octets, str_from_string for String --
@@ -73,7 +73,15 @@ __all__ = [
 # dsa.Sig (DER serialization of ECDSA signature),
 # ssa.Sig (BIP340 serialization of Schnorr signature)
 # etc.
-Octets = bytes | str
+#
+# Every buffer, and not `bytes` alone: each is accepted at run time by
+# every consumer of an `Octets`, `utils.bytes_from_octets` being the one
+# coercion they share and `to_pub_key._PUB_KEY_TYPES` naming the same
+# list from the other side. Narrower here than in the code, this cost a
+# caller who wrote a buffer down a `type: ignore` -- and cost more than
+# that, mypy not being able to see the buffer paths, so a place that
+# breaks on one was found a caller at a time (issue #1238)
+Octets = bytes | str | bytearray | memoryview
 
 # bytes or text string (not hex-string)
 #
@@ -95,7 +103,11 @@ Octets = bytes | str
 #
 # In those cases often there is no need to encode() to bytes
 # as b58decode/b32decode/etc. will take care of that
-String = bytes | str
+#
+# The buffers for the reason `Octets` has them: `utils.str_from_string`
+# reads every one of them, and `base58.decode` did before either
+# annotation said so
+String = bytes | str | bytearray | memoryview
 
 # binary data, usually to be consumed as byte stream,
 # but possibly provided as Octets too
@@ -108,7 +120,7 @@ BinaryData = BytesIO | Octets
 # resolve by convention here -- a decimal representation is what int itself
 # is for, and int("1234") costs the caller nothing -- so the ambiguity is
 # resolved the way every other str in this file resolves it
-Integer = bytes | str | int
+Integer = Octets | int
 
 # What kind of chain a network is: the real one, or one of the test ones.
 #
@@ -448,7 +460,15 @@ JacPoint = tuple[int, int, int]
 # which sends Q to its two coordinates followed by 1, or by 0 at infinity
 INFJ = 7, 0, 0
 
-Command = int | str | bytes
+# spelled out rather than written `int | Octets`, though the spellings
+# are the same list: a `str` here is an opcode name or hex data and an
+# `Octets` str is hex and nothing else, so the two aliases would be one
+# name for two roles. The buffers are here because a push of a
+# bytearray is a push of what it holds: `script.serialize` wrote one
+# already, and `taproot.serialize` had to be taught to -- its
+# OP_SUCCESS arm asked `isinstance(script[0], bytes)` and refused the
+# other two
+Command = int | str | bytes | bytearray | memoryview
 ScriptList = list[Command]
 
 # A BIP341 taproot script tree: a leaf is a one-element list holding a

--- a/btclib/base58.py
+++ b/btclib/base58.py
@@ -153,7 +153,7 @@ def _b58decode_to_int(v: bytes) -> int:
     return i
 
 
-def _b58decode(v: bytes) -> bytes:
+def _b58decode(v: bytes | bytearray | memoryview) -> bytes:
     # bytes for the buffers that are a String and are not bytes: a
     # memoryview has neither translate nor lstrip, and a bytearray
     # answers both in its own type. Free on the path that matters:

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -377,14 +377,21 @@ class BIP32KeyData:
 
         The type is asked here rather than left to `base58.decode`, which
         does ask it: the cache in front of that call keys on the argument,
-        so an unhashable one -- a list, a bytearray, the mutable buffers
-        `String` does not cover -- left as a TypeError about hashing
-        instead of the refusal decoding would have given.
+        so anything unhashable -- a list, or a mutable buffer -- would
+        leave a complaint about hashing instead of the refusal decoding
+        would have given.
         """
-        assert_type(address, (str, bytes), "base58 string")
+        assert_type(address, (str, bytes, bytearray, memoryview), "base58 string")
 
         if isinstance(address, str):
             address = address.strip()
+        elif not isinstance(address, bytes):
+            # copied for the cache and not for the decoding, which takes
+            # a buffer as it comes: a bytearray is unhashable, and a
+            # memoryview of one raises `ValueError: cannot hash writable
+            # memoryview object` -- two different complaints, neither
+            # about the address, where the copy answers both
+            address = bytes(address)
 
         xkey_bin = _cached_base58_decode(address)
         return cls.parse(xkey_bin, check_validity=check_validity)

--- a/btclib/bip322.py
+++ b/btclib/bip322.py
@@ -497,7 +497,11 @@ def assert_as_valid(
 
     script_pub_key = ScriptPubKey.from_address(addr).script
 
-    if legacy and isinstance(sig, (str, bytes)) and _is_bms(sig):
+    # `not a Sig` rather than a list of the String spellings: the
+    # question here is whether the signature is still text to be read,
+    # and a list of spellings answers it wrongly the moment `String`
+    # gains one -- a bytearray took the BIP322 branch in silence
+    if legacy and not isinstance(sig, Sig) and _is_bms(sig):
         if type_and_payload(script_pub_key)[0] != "p2pkh":
             err_msg = "a legacy signature is for a p2pkh address alone"
             raise BTClibValueError(err_msg)
@@ -625,7 +629,7 @@ def _is_bms(sig: String) -> bool:
     octets long -- the shortest is a lone BIP340 signature, which its
     count and push length make 66.
     """
-    text = sig.decode("ascii") if isinstance(sig, bytes) else sig
+    text = str_from_string(sig, "base64 signature")
     try:
         return len(base64.b64decode(text.strip(), validate=True)) == _BMS_SIZE
     except ValueError:

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -298,10 +298,8 @@ def sign(msg: Octets, prv_key: PrvKey, addr: String | None = None) -> Sig:
     # own serialization without a point in between (issue #127)
     pub_key = bytes_from_prv_key_int(q, compressed=compressed)
 
-    if isinstance(addr, str):
-        addr = addr.strip()
-    elif isinstance(addr, bytes):
-        addr = addr.decode("ascii")
+    if addr is not None:
+        addr = str_from_string(addr, "address").strip()
 
     # finally, calculate the recovery flag
     if addr is None or addr == p2pkh(pub_key, network, compressed):

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -283,10 +283,9 @@ def _x_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve) -> int:
         raise BTClibValueError(f"not a valid public key: {x_Q}")
 
     if isinstance(x_Q, (str, bytes, bytearray, memoryview)):
-        # the buffers beside `Octets`, which is `bytes | str`: they are
-        # what `bytes_from_octets` takes and returns as they came, and
-        # what `to_pub_key` names at run time beside the static union.
-        # Accepted at all three sizes here, where the dispatch this
+        # every spelling `Octets` names, which is what
+        # `bytes_from_octets` takes and returns as it came. Accepted at
+        # all three sizes here, where the dispatch this
         # replaces took them at the SEC two and refused them at the
         # x-only one, its fallback having asked for `(str, bytes)`
         #

--- a/btclib/fetch/fetcher.py
+++ b/btclib/fetch/fetcher.py
@@ -230,7 +230,7 @@ def tx_from_raw(raw: Octets, tx_id: str, network: str) -> Tx:
     all show up here, as the wrong id rather than as a wrong amount
     somewhere later.
     """
-    if not isinstance(raw, (bytes, str)):
+    if not isinstance(raw, (bytes, str, bytearray, memoryview)):
         # `Tx.parse` reads a stream and lets anything that is not Octets
         # through untouched, so a json number where the hex belongs
         # surfaces as AttributeError on `.read` -- a traceback into the

--- a/btclib/p2p/address.py
+++ b/btclib/p2p/address.py
@@ -135,7 +135,7 @@ def _ipv6_from_ip_address(ip: IPAddress) -> IPv6Address:
     `CNetAddr::SerializeV1Array` writes for one.
 
     Text is read as an address and never as hex, which is where this
-    departs from every other `bytes | str` field of this library:
+    departs from every other `Octets` field of this library:
     `bytes_from_octets` would take "10.0.0.1" for a hex string and refuse
     it, and would take a sixteen-character dotted quad -- there is none --
     for octets. Sixteen octets are the one bytes-shaped input, being what

--- a/btclib/psbt/psbt_view.py
+++ b/btclib/psbt/psbt_view.py
@@ -218,8 +218,14 @@ class PsbtView:
     sp_dleq_proofs: dict[bytes, bytes]
 
     def __init__(self, data: BinaryIO | Octets) -> None:
+        # `bytes` where `BytesIO` would take the buffer itself: it copies
+        # either way — what it does not do is flatten a non-contiguous
+        # memoryview, which `Octets` admits and which it refuses with
+        # `BufferError: underlying buffer is not C-contiguous`
         stream: BinaryIO = (
-            BytesIO(bytes_from_octets(data)) if isinstance(data, (bytes, str)) else data
+            BytesIO(bytes(bytes_from_octets(data)))
+            if isinstance(data, (bytes, str, bytearray, memoryview))
+            else data
         )
         if not stream.seekable():
             err_msg = "a psbt view needs a seekable stream: it reads a map "
@@ -302,7 +308,7 @@ class PsbtView:
             offsets.append(_skip_map(stream))
         self._offsets = offsets
 
-        if isinstance(data, (bytes, str)):
+        if isinstance(data, (bytes, str, bytearray, memoryview)):
             # octets are one whole psbt and a stream is the caller's:
             # btclib/utils.py states the rule both halves read. The cast is
             # this branch's own premise -- octets are what the stream above

--- a/btclib/script/script.py
+++ b/btclib/script/script.py
@@ -378,7 +378,7 @@ def _serialize_str_command(command: str) -> bytes:
     return _serialize_bytes_command(data)
 
 
-def _serialize_bytes_command(command: bytes) -> bytes:
+def _serialize_bytes_command(command: bytes | bytearray | memoryview) -> bytes:
     """Convert to canonical push: OP_PUSHDATA (if needed) | length | command.
 
     According to standardness rules (BIP62) the minimum possible
@@ -414,7 +414,7 @@ def _serialize_bytes_command(command: bytes) -> bytes:
     #123). The last branch is Core's own bound, `CScript::operator<<`
     having nothing wider than a four-byte length either.
     """
-    out: list[bytes] = []
+    out: list[bytes | bytearray | memoryview] = []
     length = len(command)
     if length < 76:  # 1-byte-length
         out.append(length.to_bytes(1, byteorder="little", signed=False))
@@ -430,7 +430,7 @@ def _serialize_bytes_command(command: bytes) -> bytes:
     return b"".join(out)
 
 
-def _pushdata(i: int, length: int, out: list[bytes]) -> None:
+def _pushdata(i: int, length: int, out: list[bytes | bytearray | memoryview]) -> None:
     out.extend(
         (
             BYTE_FROM_OP_CODE_NAME[f"OP_PUSHDATA{i}"],

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -836,8 +836,11 @@ def _script_from(script_pub_key: Octets | ScriptPubKey) -> bytes:
     """
     if isinstance(script_pub_key, ScriptPubKey):
         return script_pub_key.script
-    if isinstance(script_pub_key, bytes):
-        return script_pub_key
+    if isinstance(script_pub_key, (bytes, bytearray, memoryview)):
+        # copied, where `bytes_from_octets` deliberately does not copy:
+        # this function exists to produce the thing a caller compares and
+        # keys a dict by, and a bytearray is unhashable
+        return bytes(script_pub_key)
     # unreachable to mypy, the annotation having no fourth case, and the
     # whole point to a caller who is not running it: `Octets` is honoured
     # inside btclib and nowhere else

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -100,7 +100,9 @@ def serialize(script: ScriptList) -> bytes:
         elif isinstance(command, str):
             r.append(_serialize_str_command(command))
             if "OP_SUCCESS" in command:
-                if len(script) != 1 or not isinstance(script[0], bytes):
+                if len(script) != 1 or not isinstance(
+                    script[0], (bytes, bytearray, memoryview)
+                ):
                     raise BTClibValueError(
                         "OP_SUCCESS must be followed by a single bytes command"
                     )

--- a/btclib/to_prv_key.py
+++ b/btclib/to_prv_key.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from btclib.alias import String
+from btclib.alias import Octets, String
 from btclib.base58 import decode as b58decode
 from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, _key_data_from_bip32_key
 from btclib.curves import Curve, secp256k1
@@ -39,7 +39,7 @@ __all__ = [
 #
 # BIP32key and WIF also provide extra info about
 # network and (un)compressed-pub_key-derivation
-PrvKey = int | bytes | str | BIP32KeyData
+PrvKey = int | Octets | BIP32KeyData
 
 # the union at run time, with the buffers bytes_from_octets accepts beside
 # bytes. `to_pub_key._PUB_KEY_TYPES` is the same list plus a Point and

--- a/btclib/to_pub_key.py
+++ b/btclib/to_pub_key.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import contextlib
 
-from btclib.alias import Point
+from btclib.alias import Octets, Point
 from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, _key_data_from_bip32_key
 from btclib.curves import (
     Curve,
@@ -44,11 +44,11 @@ __all__ = [
 
 # public key inputs:
 # elliptic curve point as Union[Octets, BIP32Key, Point, PreparedPoint]
-PubKey = bytes | str | BIP32KeyData | Point | PreparedPoint
+PubKey = Octets | BIP32KeyData | Point | PreparedPoint
 
 # public or private key input,
 # usable wherever a PubKey is logically expected
-Key = int | bytes | str | BIP32KeyData | Point | PreparedPoint
+Key = int | Octets | BIP32KeyData | Point | PreparedPoint
 
 # the two unions at run time, with the buffers bytes_from_octets accepts
 # beside bytes. An int is in one and not the other on purpose: in this

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -115,7 +115,11 @@ def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> byte
         raise BTClibTypeError(err_msg)
 
     if out_size is None:
-        return octets
+        # the annotation says `bytes` and this hands back the buffer it
+        # was given, which the widened `Octets` is what makes visible:
+        # disclosed rather than silenced, because making the signature
+        # true is a change across the tree and its own (issue #1255)
+        return octets  # type: ignore[return-value]
 
     # one size or an iterable of them, and nothing else: `tuple()` on
     # whatever is left would refuse a float with a bare TypeError about
@@ -135,7 +139,7 @@ def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> byte
             raise BTClibTypeError(err_msg)
 
     if len(octets) in sizes:
-        return octets
+        return octets  # type: ignore[return-value]
 
     err_msg = f"invalid size: {len(octets)} bytes instead of {out_size}"
     raise BTClibValueError(err_msg)
@@ -144,8 +148,8 @@ def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> byte
 def str_from_string(s: String, what: str) -> str:
     """Return the text of a String, whether it came as text or as ascii bytes.
 
-    What `bytes_from_octets` is to the other `bytes | str` alias, in the
-    direction the addresses go: an address, a WIF and an xkey are ascii,
+    What `bytes_from_octets` is to `Octets`, in the direction the
+    addresses go: an address, a WIF and an xkey are ascii,
     so a byte outside it is an invalid character like any other and gets
     the same answer -- a UnicodeDecodeError let out would fly past every
     caller written to catch a BTClibValueError.

--- a/btclib/wallet/wallet.py
+++ b/btclib/wallet/wallet.py
@@ -66,6 +66,7 @@ from btclib.alias import Octets, String
 from btclib.exceptions import BTClibValueError
 from btclib.network import NETWORKS
 from btclib.script.script_pub_key import ScriptPubKey, _validated_script_from
+from btclib.utils import str_from_string
 
 __all__ = [
     "AddressInfo",
@@ -88,8 +89,7 @@ def _address_str(address: String) -> str:
     one the wallet handed out. Base58 is not case insensitive -- `1Lq`
     and `1lq` are different payloads -- so it is left exactly as it came.
     """
-    addr = address.decode("ascii") if isinstance(address, bytes) else address
-    addr = addr.strip()
+    addr = str_from_string(address, "address").strip()
     return addr.lower() if b32.is_segwit_prefixed(addr) else addr
 
 

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -124,15 +124,18 @@ things that are bytes:
 
 The four aliases:
 
-``Octets = bytes | str``
+``Octets = bytes | str | bytearray | memoryview``
     Bytes, or their hex spelling. Blanks inside the hex string are
     allowed, so ``"02 cc71eb30..."`` is fine. Use
-    ``btclib.utils.bytes_from_octets`` to normalize one yourself.
+    ``btclib.utils.bytes_from_octets`` to normalize one yourself. The
+    mutable buffers are here because every consumer takes one: a
+    ``memoryview`` sliced out of a larger field is octets like any
+    other, and is not copied on its way in.
 
-``String = bytes | str``
-    The same two types, read the other way round: here a ``str`` is
-    *text*, and this is what addresses, WIFs and extended keys are. The
-    alias a function names tells you which reading applies.
+``String = bytes | str | bytearray | memoryview``
+    The same types, read the other way round: here a ``str`` is *text*,
+    and this is what addresses, WIFs and extended keys are. The alias a
+    function names tells you which reading applies.
 
 ``PrvKey``
     An ``int``, an ``Octets`` scalar, a WIF, a BIP32 ``xprv``, or a

--- a/tests/alias_test.py
+++ b/tests/alias_test.py
@@ -21,7 +21,7 @@ from typing import Any, get_args, get_type_hints
 
 import pytest
 
-from btclib.alias import HashDigestF, HashF, HashObject
+from btclib.alias import HashDigestF, HashF, HashObject, Octets
 from btclib.hashes import hash256, merkle_root, reduce_to_hlen, tagged_hash
 
 
@@ -100,7 +100,9 @@ def test_the_aliases_are_distinct() -> None:
     assert returns is HashObject
 
     # a one-shot digest: Octets in, bytes out. The arities alone make the
-    # two unassignable to each other, which is what a checker acts on
+    # two unassignable to each other, which is what a checker acts on.
+    # Against `Octets` itself and not against what it expands to: the
+    # spellings it names are its own to change
     parameters, returns = get_args(HashDigestF)
-    assert parameters == [bytes | str]
+    assert parameters == [Octets]
     assert returns is bytes

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -93,6 +93,25 @@ def test_exceptions() -> None:
     assert rootxprv_from_seed("00" * 64)
 
 
+def test_an_xkey_decodes_however_its_text_is_held() -> None:
+    """`b58decode` takes a String, and a String is text or any buffer.
+
+    They used to be refused outright, with "invalid base58 string type:
+    bytearray", by a check written against the narrower `String` -- and
+    written there rather than left to `base58.decode` for a reason the
+    widening does not remove: the `lru_cache` in front of the decoding
+    keys on the argument, a bytearray cannot key one at all, and a
+    memoryview of one raises `ValueError: cannot hash writable
+    memoryview object`. Copied for the cache before the lookup, so each
+    spelling decodes to what the text decodes to (issue #1238).
+    """
+    xkey = "xprv9s21ZrQH143K2ZP8tyNiUtgoezZosUkw9hhir2JFzDhcUWKz8qFYk3cxdgSFoCMzt8E2Ubi1nXw71TLhwgCfzqFHfM5Snv4zboSebePRmLS"
+    expected = BIP32KeyData.b58decode(xkey)
+    octets = xkey.encode("ascii")
+    for spelling in (octets, bytearray(octets), memoryview(octets)):
+        assert BIP32KeyData.b58decode(spelling) == expected
+
+
 def test_bip32keydata_is_still_a_dataclass() -> None:
     """Frozen trades the hand-written __init__ for object.__setattr__.
 

--- a/tests/bip322_test.py
+++ b/tests/bip322_test.py
@@ -343,6 +343,17 @@ def test_legacy_signature_is_accepted_for_p2pkh_alone() -> None:
     # reaches assert_as_valid's default unless called directly
     bip322.assert_as_valid(msg, p2pkh(WIF), legacy)
 
+    # and the variant does not depend on how the signature is held.
+    # Which branch runs was decided by `isinstance(sig, (str, bytes))`,
+    # a list of spellings where the question is whether the signature is
+    # still text to be read: a bytearray answered that list falsely and
+    # went down the BIP322 branch, where it is not a BIP322 signature at
+    # all (issue #1238)
+    octets = legacy.encode("ascii")
+    for spelling in (octets, bytearray(octets), memoryview(octets)):
+        assert bip322.verify(msg, p2pkh(WIF), spelling)
+        assert not bip322.verify(msg, p2wpkh(WIF), spelling)
+
 
 def test_a_simple_signature_is_not_65_octets() -> None:
     """The size that tells a BMS signature from a witness stack.

--- a/tests/curves/sec_point_test.py
+++ b/tests/curves/sec_point_test.py
@@ -337,7 +337,7 @@ def test_a_scalar_is_an_int_or_its_octets_and_nothing_else() -> None:
     q = 0xC0FFEE
     octets = q.to_bytes(32, "big")
     for spelling in (q, octets, octets.hex(), bytearray(octets), memoryview(octets)):
-        assert scalar_from_prv_key(spelling) == q  # type: ignore[arg-type]
+        assert scalar_from_prv_key(spelling) == q
 
     # a WIF and an xprv reach here as text, and text is hex or nothing
     for text in (wif_from_prv_key(q), rootxprv_from_seed("5e" * 32)):

--- a/tests/ecc/bms_test.py
+++ b/tests/ecc/bms_test.py
@@ -303,6 +303,39 @@ def test_every_recovery_flag_is_ruled_on_by_range_alone() -> None:
                 check(rf)
 
 
+def test_the_address_is_read_the_same_however_it_is_held() -> None:
+    """`sign` takes a String address, and a String is text or any buffer.
+
+    Two spellings of one address used to sign under different flags:
+    text was stripped of blanks and `bytes` was only decoded, so a
+    padded `bytes` address named an address the key does not have and
+    the call came back `mismatch between private key and address` -- a
+    complaint about the key, for blanks around the address. The buffers
+    did not decode at all. All of them read through `str_from_string`
+    now, which strips nothing and is followed by the strip that does
+    (issue #1238).
+    """
+    msg = b"however it is held"
+    wif = "Kx45GeUBSMPReYQwgXiKhG9FzNXrnCeutJp4yjTd5kKxCitadm3C"
+    address = b58.p2pkh(wif)
+    expected = bms.sign(msg, wif, address)
+
+    padded = f"  {address}  "
+    for spelling in (
+        address.encode("ascii"),
+        padded,
+        padded.encode("ascii"),
+        bytearray(address.encode("ascii")),
+        memoryview(address.encode("ascii")),
+    ):
+        assert bms.sign(msg, wif, spelling).rf == expected.rf
+
+    # and a byte outside ascii is this library's complaint about the
+    # address, where the hand-rolled decode let Python's own out
+    with pytest.raises(BTClibValueError, match="non-ascii character in address"):
+        bms.sign(msg, wif, address.encode("ascii") + b"\xc3")
+
+
 def test_one_prv_key_multiple_addresses() -> None:
     """Verify the BIP137 flag binds a signature to its address type."""
     msg = b"Paolo is afraid of ephemeral random numbers"

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -357,11 +357,7 @@ def test_a_buffer_is_octets_at_every_size_this_takes() -> None:
     )
 
     for octets in spellings:
-        # `Any`, because `Octets` is `bytes | str` and these are neither:
-        # the annotation is narrower than what every consumer of it
-        # takes, which is the asymmetry issue #1238 asks about
-        buffers: tuple[Any, ...] = (bytearray(octets), memoryview(octets))
-        for buffer in buffers:
+        for buffer in (bytearray(octets), memoryview(octets)):
             assert ssa.point_from_bip340pub_key(buffer) == Q
 
 

--- a/tests/fetch/fetcher_test.py
+++ b/tests/fetch/fetcher_test.py
@@ -141,10 +141,19 @@ def test_the_label_is_what_an_address_is_rendered_from() -> None:
 
 
 def test_tx_from_raw_returns_the_transaction_asked_for() -> None:
-    """Parse the raw hex into the transaction with the requested id."""
-    tx = tx_from_raw(RAW, TX_ID, "mainnet")
-    assert tx.id.hex() == TX_ID
-    assert len(tx.vout) == 2
+    """Parse the raw serialization into the transaction with that id.
+
+    However the caller holds it: the guard in front of the parse used to
+    ask `isinstance(raw, (bytes, str))`, which is the packed form named
+    by the types that were the packed form when the line was written, so
+    a backend's answer kept in a buffer was refused as "not a
+    serialization, but a bytearray" (issue #1238).
+    """
+    octets = bytes.fromhex(RAW)
+    for spelling in (RAW, octets, bytearray(octets), memoryview(octets)):
+        tx = tx_from_raw(spelling, TX_ID, "mainnet")
+        assert tx.id.hex() == TX_ID
+        assert len(tx.vout) == 2
 
 
 def test_tx_from_raw_catches_the_answer_to_another_question() -> None:

--- a/tests/key_test.py
+++ b/tests/key_test.py
@@ -12,10 +12,9 @@ spellings of one key are deliberately unequal, and that a private key
 never reaches a repr.
 """
 
-from typing import Any
-
 import pytest
 
+from btclib.alias import Octets
 from btclib.curves import bytes_from_point, mult, secp256k1
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.key import PrvKeyData, PubKeyData
@@ -45,7 +44,7 @@ def test_pub_key_data() -> None:
     [SEC_COMPRESSED, bytearray(SEC_COMPRESSED), memoryview(SEC_COMPRESSED)],
     ids=["bytes", "bytearray", "memoryview"],
 )
-def test_the_sec_field_is_bytes_however_the_octets_were_spelled(sec: Any) -> None:
+def test_the_sec_field_is_bytes_however_the_octets_were_spelled(sec: Octets) -> None:
     """A buffer is octets here, because the field is declared `bytes`.
 
     `bytes_from_octets` returns a bytearray and a memoryview as they
@@ -59,10 +58,6 @@ def test_the_sec_field_is_bytes_however_the_octets_were_spelled(sec: Any) -> Non
     concatenate is no use to the callers this type exists for --
     `script.taproot` joins a merkle root to the x it reads off `sec`
     before hashing the pair under a tag.
-
-    `Any` and not `Octets`, which is `bytes | str`: the buffers are a
-    run-time spelling the static alias does not name, and
-    `utils.bytes_from_octets` is where that asymmetry is stated.
     """
     key = PubKeyData(sec)
 

--- a/tests/psbt/psbt_view_test.py
+++ b/tests/psbt/psbt_view_test.py
@@ -238,15 +238,31 @@ def test_a_stream_may_carry_more_than_the_psbt() -> None:
 
 
 def test_octets_are_one_whole_psbt() -> None:
-    """What follows the last map in octets is refused, hex string included."""
+    """What follows the last map in octets is refused, however they are held.
+
+    Every spelling `Octets` names, because the octets used to have to be
+    `bytes` or a hex `str` to be octets at all. A psbt handed over as a
+    bytearray or a memoryview -- a slice of a larger buffer being
+    exactly what a caller reaches for here -- was taken for the stream
+    it is not, and died on `AttributeError: 'bytearray' object has no
+    attribute 'seekable'`. The trailing-octets check behind it asked the
+    same narrow question a second time, so it would have been skipped
+    too (issue #1238).
+    """
     raw = _named("PSBT with one P2PKH input. Outputs are empty")
     assert PsbtView(raw).input_count == 1
+    assert PsbtView(bytearray(raw)).input_count == 1
+    assert PsbtView(memoryview(raw)).input_count == 1
 
     for trailing in (b"\x00", b"junk"):
-        with pytest.raises(BTClibValueError, match="bytes after the psbt"):
-            PsbtView(raw + trailing)
-        with pytest.raises(BTClibValueError, match="bytes after the psbt"):
-            PsbtView((raw + trailing).hex())
+        for spelling in (
+            raw + trailing,
+            (raw + trailing).hex(),
+            bytearray(raw + trailing),
+            memoryview(raw + trailing),
+        ):
+            with pytest.raises(BTClibValueError, match="bytes after the psbt"):
+                PsbtView(spelling)
 
 
 def test_no_prefix_of_a_psbt_is_a_view() -> None:

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -43,6 +43,7 @@ from btclib.script.taproot import (
     serialize,
     tree_helper,
 )
+from btclib.to_pub_key import Key
 from btclib.tx import TxOut
 from tests import load, needs_bindings, vector_id
 from tests.curves.curve_test import low_card_curves, no_bindings_anywhere
@@ -139,11 +140,7 @@ def test_one_internal_key_however_it_is_spelled(
     prv_key = 0xC0FFEE
     point = mult(prv_key)
     sec = bytes_from_point(point, compressed=True)
-    # `Any` and not `Key`: a bytearray and a memoryview are spellings the
-    # static union does not name and `_KEY_TYPES` accepts, which is the
-    # asymmetry `to_pub_key` states -- the buffers `bytes_from_octets`
-    # takes beside bytes, and passes through as they came
-    spellings: tuple[Any, ...] = (
+    spellings: tuple[Key, ...] = (
         point,
         sec,
         bytes_from_point(point, compressed=False),
@@ -650,8 +647,7 @@ def test_the_two_output_keys_are_one_tweak() -> None:
     # `memoryview + bytes` is not an operation at all. The internal key of
     # `output_pubkey` becomes bytes one layer lower, in `PubKeyData`, so
     # this entry point needs its own assertion rather than that one's
-    buffer: Any = memoryview(x_only)  # `Octets` is `bytes | str`, as above
-    assert output_pubkey_from_merkle_root(buffer, merkle_root) == (
+    assert output_pubkey_from_merkle_root(memoryview(x_only), merkle_root) == (
         output_pubkey(internal_pubkey, script_tree)
     )
 
@@ -742,6 +738,24 @@ def test_invalid_serialization() -> None:
         serialize(["OP_SUCCESS80", 1])
     with pytest.raises(BTClibValueError, match="OP_SUCCESS must be followed"):
         serialize(["OP_SUCCESS80", "00"])
+
+
+def test_op_success_is_followed_by_bytes_however_they_are_held() -> None:
+    """The refusal is about the command's kind, not about how it is held.
+
+    `Command` names every buffer, so the push after an OP_SUCCESS is one
+    whether it arrives as bytes or as a slice of a larger field, and all
+    three write the same script. Asked because the check that guards
+    this branch reads `isinstance(script[0], ...)` and a list of types
+    is what stops being the answer when the alias gains a spelling: a
+    bytearray drew "OP_SUCCESS must be followed by a single bytes
+    command" about a command that is a single bytes command
+    (issue #1238).
+    """
+    push = b"\x01\x02\x03"
+    expected = serialize(["OP_SUCCESS80", push])
+    for spelling in (bytearray(push), memoryview(push)):
+        assert serialize(["OP_SUCCESS80", spelling]) == expected
 
 
 def test_parse_unknown_op_code() -> None:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -266,12 +266,12 @@ def test_octets_are_bytes_or_the_hex_string_of_bytes_and_nothing_else() -> None:
     """
     assert bytes_from_octets(b"\x00\x01") == b"\x00\x01"
     assert bytes_from_octets("0001") == b"\x00\x01"
-    # every buffer, though `Octets` names only the two spellings a caller
-    # writes: what reaches this is whatever a field was built from
-    assert bytes_from_octets(bytearray(b"\x00\x01")) == b"\x00\x01"  # type: ignore[arg-type]
-    assert bytes_from_octets(memoryview(b"\x00\x01")) == b"\x00\x01"  # type: ignore[arg-type]
+    # every buffer `Octets` names, and what reaches this is whatever a
+    # field was built from rather than only what a caller writes
+    assert bytes_from_octets(bytearray(b"\x00\x01")) == b"\x00\x01"
+    assert bytes_from_octets(memoryview(b"\x00\x01")) == b"\x00\x01"
     # unchanged, and not merely equal
-    buffer: object = bytes_from_octets(bytearray(b"\x00"))  # type: ignore[arg-type]
+    buffer: object = bytes_from_octets(bytearray(b"\x00"))
     assert isinstance(buffer, bytearray)
 
     for not_octets in (tuple(range(33)), [1, 2], None, 1.5):

--- a/tests/wallet/wallet_test.py
+++ b/tests/wallet/wallet_test.py
@@ -129,11 +129,19 @@ def test_next_address_is_one_past_the_top_of_a_branch(
 def test_position_of_takes_every_spelling_of_an_output(
     build: Callable[[], RangedWallet],
 ) -> None:
-    """The output as a ScriptPubKey, as bytes, as hex, or as its address.
+    """The output named any way it can be named.
 
-    One question -- "is this output mine" -- and the answer is the whole
+    As a ScriptPubKey, as octets however held, or as its address. One
+    question -- "is this output mine" -- and the answer is the whole
     script compared at each position, which is why the address is read
     for the script it encodes rather than matched as text.
+
+    The buffers are here because the answer used to depend on how the
+    caller held the octets, which is the one thing it must not depend on:
+    a script as a bytearray or a memoryview was refused outright, with
+    "invalid script_pub_key type", where the same octets as bytes
+    answered (issue #1238). An address is a `str` here and not octets --
+    its own bytes are read as a script, which is what they are.
     """
     wallet = build()
     script_pub_key = wallet.script_pub_key(1, 3)
@@ -142,6 +150,8 @@ def test_position_of_takes_every_spelling_of_an_output(
         script_pub_key.script,
         script_pub_key.script.hex(),
         script_pub_key.address,
+        bytearray(script_pub_key.script),
+        memoryview(script_pub_key.script),
     ):
         assert wallet.position_of(named, 4) == (1, 3)
 
@@ -235,10 +245,27 @@ def test_only_a_key_wallet_records_one_derivation_path() -> None:
 
 
 def test_an_address_of_a_bech32_spelling_is_found_however_it_is_written() -> None:
-    """Which is `Wallet.__contains__` and the lookup under it."""
+    """Which is `Wallet.__contains__` and the lookup under it.
+
+    Held however a caller holds it, `String` naming the buffers too.
+    Neither used to reach the lookup at all: `_address_str` promises a
+    `str` and returned what it was given, so a bytearray arrived at the
+    dict of handed-out addresses and raised `TypeError: cannot use
+    'bytearray' as a dict key`, and a memoryview did not get that far --
+    a bare `AttributeError` on the `strip` it does not have. Two Python
+    errors for a supported spelling, neither of them this library's
+    (issue #1238).
+    """
     wallet = script_wallet()
     address = wallet.address(0, 0)
-    for spelling in (address.upper(), f"  {address}  ", address.encode("ascii")):
+    octets = address.encode("ascii")
+    for spelling in (
+        address.upper(),
+        f"  {address}  ",
+        octets,
+        bytearray(octets),
+        memoryview(octets),
+    ):
         assert spelling in wallet
         assert wallet.address_info(spelling).address == address
 


### PR DESCRIPTION
Closes #1238.

`Octets` and `String` were `bytes | str`, and every consumer of either
took a bytearray and a memoryview as well. The run-time checks said so
outright — `to_prv_key._PRV_KEY_TYPES` and `to_pub_key._PUB_KEY_TYPES`
list the buffers, and `utils.bytes_from_octets` documents why it hands
one back as it came — so it was the annotations that were narrower than
the contract, and a caller who wrote a buffer down needed a
`# type: ignore` to say what the library already did.

Both are the four spellings now. `Integer` is `Octets | int`, and
`PrvKey`, `PubKey`, `Key` and `Command` are spelled from those rather
than from `bytes | str`. `Command` is written out rather than reusing
`Octets`, its `str` being an opcode name where an `Octets` str is hex:
one name for two roles is what this issue is about.

What the narrow annotation cost was not only noise. mypy could not see
the buffer paths, so a place that breaks on one was found a caller at a
time — issue #1220 being how. Asking the whole tree at once found
these, each measured against origin/main rather than read:

- `wallet.__contains__` and `address_info`: `_address_str` promises a
  `str` and returned what it was handed, so a bytearray reached the dict
  of handed-out addresses and raised `TypeError: cannot use 'bytearray'
  as a dict key`, and a memoryview never got there — `AttributeError`
  on the `strip` it does not have
- `script_pub_key._script_from`: `invalid script_pub_key type:
  bytearray`, which `Descriptor.index_of` and `RangedWallet.position_of`
  both ask through
- `PsbtView`: the buffer was taken for the stream it is not, and died on
  `AttributeError: 'bytearray' object has no attribute 'seekable'`
- `bip322.assert_as_valid`: a legacy BMS signature held as a bytearray
  was checked as a BIP322 signature, which it is not, and verified False
- `bip32.BIP32KeyData.b58decode`: `invalid base58 string type: bytearray`
- `bms.sign`: an address as `bytes` was decoded and not stripped where
  one as text was, so a padded one signed under an address the key does
  not have and said `mismatch between private key and address`
- `base58._b58decode` and `script._serialize_bytes_command` took every
  buffer already — the first says so in a comment — and their
  signatures said `bytes`
- `taproot.serialize`: the arm that writes the push after an OP_SUCCESS
  asked `isinstance(script[0], bytes)`, so a bytearray drew "OP_SUCCESS
  must be followed by a single bytes command" — about a command that is
  a single bytes command
- `fetch.tx_from_raw`: the guard in front of the parse asked the same
  narrow question, so a backend's answer held in a buffer drew
  `FetchError: transaction <id>: not a serialization, but a bytearray`

The `isinstance` ones are all the same mistake: `isinstance(x, bytes)`
and `isinstance(x, (str, bytes))` asked "is this the packed form" by
naming the types that were the packed form when the line was written.
mypy does not flag a narrowing, so those had to be read for rather than
reported. `bip322`'s is `not isinstance(sig, Sig)` now, which is the
question it was actually asking, and does not move again when `String`
gains a spelling.

`bytes_from_octets` is the one place left with an untrue annotation: it
promises `bytes` and returns the buffer, deliberately, and only the
widened `Octets` makes mypy say so. Both returns carry a
`type: ignore[return-value]` naming issue #1255 rather than a silence.
Making it true is a change across the tree rather than in one file, and
an `@overload` does not pay for itself: the callers that matter hand it
a value already typed `Octets`, so the whole union comes back out and
the downstream errors stand. Issue #1255 carries the command that
measures both, rather than a number that moves with every fix.

`DerPath` is deliberately not widened. It holds `Sequence[int]` beside
`bytes` and a buffer satisfies both, so the same octets already mean two
different paths depending on how they are held — and the wrong one is a
different key. That is issue #1258, and it wants a decision rather than
a wider union.

## Summary by Sourcery

Widen the public input aliases to accurately describe and robustly support all buffer types already accepted by the library.

Bug Fixes:
- Handle bytearray and memoryview inputs consistently across wallet, script, PSBT, BIP32, BIP322, BMS, taproot, and transaction-fetching paths.
- Normalize string-like address inputs consistently and report non-ASCII addresses with the library's standard error.

Enhancements:
- Widen public input aliases to include bytes, str, bytearray, and memoryview, and derive key and integer aliases from the shared definitions.
- Align runtime type checks and conversions with the widened input contract while preserving existing behavior for supported inputs.

Documentation:
- Document the expanded input aliases, compatibility impact, and updated exception behavior in the changelog and release notes.

Tests:
- Add coverage for buffer spellings across key, address, signature, transaction, PSBT, script, and wallet APIs.