### PR TITLE
COPYRIGHT, AUTHORS.md and CODE_OF_CONDUCT.md are the same file everywhere

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,5 +1,5 @@
 # Authors
 
-To see the list of btclib authors for copyright purposes, see the revision
-history in source control:
+To see the list of btclib authors for copyright purposes, see the
+revision history in source control:
 <https://github.com/btclib-org/btclib/graphs/contributors>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@
 -->
 
 Every change of a release, in full: what changed, why, and what it cost.
-[RELEASE_NOTES.md](./RELEASE_NOTES.md) has the release notes, which say
-what a user has to act on; this file is the record behind them, and is
-where a claim in those notes can be checked.
+The release notes, which say what a user has to *act* on, are in
+[RELEASE_NOTES.md](./RELEASE_NOTES.md); this file is the record behind
+them.
 
 Only v2026.8.7 and what follows it are here. The releases before it were
 documented at release-notes length in the first place, and are still in

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,10 @@
 # Code of Conduct
 
-Everyone interacting in the btclib project's codebases, issue trackers,
-chat rooms, and mailing lists is expected to follow the
-[PSF Code of Conduct](https://www.python.org/psf/conduct/).
+Everyone interacting in a btclib-org project — its codebase, its issue
+tracker, its pull requests and its discussions — is expected to follow
+the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
+
+The copy in [btclib-org/.github](https://github.com/btclib-org/.github)
+is what GitHub shows for a repository of the organization carrying none
+of its own. A repository that does carry one carries this same file, so
+that no repository of the organization advertises a second policy.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,10 @@
   }
 -->
 
-Notable changes to the codebase are documented here.
+What a user has to *act* on, and nothing else: a breaking change, a
+migration, a default that moved under them. Everything a reader would
+merely notice is in [CHANGELOG.md](./CHANGELOG.md), which is the record
+behind this file.
 
 Release names follow *[calendar versioning](https://calver.org/)*:
 full year, short month, short day (YYYY-M-D)


### PR DESCRIPTION
## What this changes

Section 14 calls `COPYRIGHT`, `AUTHORS.md` and `CODE_OF_CONDUCT.md` the
same file in every repository. The organization's alignment suite says
they are not:

```text
COPYRIGHT           bitcoin-core-rpc | btclib, btclib-benchmarks, btclib-node | btclib-secp256k1
AUTHORS.md          bitcoin-core-rpc | btclib, btclib-benchmarks | btclib-secp256k1
CODE_OF_CONDUCT.md  .github | bitcoin-core-rpc, btclib, btclib-benchmarks, btclib-secp256k1
```

This tree already carries the copy the others are being brought to for
the first two, so what changes here is the code of conduct alone.

**Why `.github`'s text and not this one's.** Section 14's own reason for
the file is that GitHub falls back to `btclib-org/.github`'s copy for a
repository carrying none, so a repository that does carry one must carry
the *same* one or the organization advertises two policies. This tree's
text scopes itself to "the btclib project's codebases, issue trackers,
chat rooms, and mailing lists"; the shared one scopes itself to a
btclib-org project and says which copy is the fallback, which is true
read from any repository including `.github` itself.

**`CHANGELOG.md` and `RELEASE_NOTES.md` take a shared opening**, so a
reader arriving in an unfamiliar tree does not have to work out which of
the two files they want. Their bodies are untouched, and so is what this
tree's opening said beyond the shared sentence — that only v2026.8.7 and
later are here, and that release names are calendar versions. Those are
this repository's facts; the sentence saying what the file *is* was the
one being said seven different ways.

## How it was verified

```shell
uv run --locked --only-group lint pre-commit run --all-files   # exit 0
```

The two preambles were rewritten by replacing the first paragraph and
keeping every paragraph after it, rather than by rewriting the head —
the first attempt dropped both of this tree's own paragraphs, which is
what the diff not showing them is now evidence against. `COPYRIGHT` and
`AUTHORS.md` are byte-identical to the copies going into the other
repositories.

## Checks

- [x] the lint gate is clean
- [ ] the suite is not run: no module changes
- [ ] no `CHANGELOG.md` entry — the change *is* the changelog's own
      opening, and an entry saying so would be the only line in the file
      about the file
- [x] every commit carries a verified signature

## Anything the reviewer should know

One pull request per repository, seven projects plus `btclib-org/.github`,
all carrying the same three canonical files. `btclib-node`, `portanode`
and `bbt` are gaining rather than replacing them.

`bbt` is a fork of `fametrano/bbt`, and the alignment suite's
`repositories` fixture filters `fork == false` — so whatever files it
gains, the suite will not compare them. That is a separate decision and
is being raised separately.

## Summary by Sourcery

Align the repository’s canonical policy and release-document introductions with the organization-wide shared files.

Enhancements:
- Align the code of conduct with the organization-wide policy and clarify the relationship between repository-local and shared copies.
- Standardize the opening explanations of the changelog and release notes while preserving repository-specific release information.

Documentation:
- Align AUTHORS.md formatting with the canonical organization copy.