### PR TITLE
The py-arm authority census is py_ in every path it lives at

### DIFF
--- a/.github/scripts/check_py_arm_authority.py
+++ b/.github/scripts/check_py_arm_authority.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Re-derive tests/python_arm_authority_test.py's `_AUTHORITY`, weekly.
+"""Re-derive tests/py_arm_authority_test.py's `_AUTHORITY`, weekly.
 
 That file's docstring documents the measurement by hand: per third-party
 test module, in an environment with no bindings installed,
@@ -28,13 +28,13 @@ directions plus the one `_WITHOUT_AN_AUTHORITY` exists to notice:
 - something now reaches an arm in `_WITHOUT_AN_AUTHORITY` -- NEW
   AUTHORITY, the good news that set exists to pick up.
 
-Reuses `tests/python_arm_authority_test.py`'s own `_arm_locations` for
+Reuses `tests/py_arm_authority_test.py`'s own `_arm_locations` for
 where each arm's body lives rather than re-walking the AST: one parser,
 one definition of "arm", read by the shape tests, the content tests and
 this script alike.
 
     uv sync --no-default-groups --group harness
-    python .github/scripts/check_python_arm_authority.py
+    python .github/scripts/check_py_arm_authority.py
 
 Not a gate: `.github/workflows/py-arm-authority.yml` runs this on a
 schedule, with no branch rule attached, for the reason `vendored-vectors`
@@ -53,7 +53,7 @@ from pathlib import Path
 _ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(_ROOT))
 
-from tests.python_arm_authority_test import (  # noqa: E402
+from tests.py_arm_authority_test import (  # noqa: E402
     _AUTHORITY,
     _THIRD_PARTY_VECTORS,
     _WITHOUT_AN_AUTHORITY,
@@ -65,7 +65,7 @@ def _run_coverage(module: str, report_path: Path) -> dict[str, set[int]]:
     """Run tests/<module> under coverage and return its executed lines by file.
 
     The exact command the docstrings of this file and
-    tests/python_arm_authority_test.py both give, `--cov-report` pointed
+    tests/py_arm_authority_test.py both give, `--cov-report` pointed
     at a file of its own so each module's run leaves the others untouched.
     `check=True`: a test module failing outright is not a disagreement
     this script is built to phrase, and is worth a loud traceback rather

--- a/.github/workflows/py-arm-authority.yml
+++ b/.github/workflows/py-arm-authority.yml
@@ -1,7 +1,7 @@
 ---
 name: py arm authority
 
-# tests/python_arm_authority_test.py's `_AUTHORITY` says, per Python arm,
+# tests/py_arm_authority_test.py's `_AUTHORITY` says, per Python arm,
 # which third-party-vector-driven test module reaches it -- issue #993's
 # answer, landed by #1000. Its own tests check the table's shape
 # against the source and against itself, and none of them re-runs the
@@ -20,7 +20,7 @@ name: py arm authority
 # names as the reason it "depends on #1002, or at least on the same
 # plumbing".
 #
-# `.github/scripts/check_python_arm_authority.py` does the comparing: it
+# `.github/scripts/check_py_arm_authority.py` does the comparing: it
 # imports `_AUTHORITY` straight from the test module rather than parsing
 # a second copy of it, runs each `_THIRD_PARTY_VECTORS` module under
 # coverage on its own, and diffs what it measures against
@@ -84,8 +84,8 @@ on:
     types: [opened, reopened, synchronize, ready_for_review, closed]
     paths:
       - .github/workflows/py-arm-authority.yml
-      - .github/scripts/check_python_arm_authority.py
-      - tests/python_arm_authority_test.py
+      - .github/scripts/check_py_arm_authority.py
+      - tests/py_arm_authority_test.py
 
 permissions:
   contents: read
@@ -102,7 +102,7 @@ concurrency:
 
 jobs:
   authority:
-    name: Re-derive the Python-arm authority table
+    name: Re-derive the py-arm authority table
     # a draft pull request is work in progress and spends no runner
     # here either: a draft is work its author is not asking anyone to
     # review yet, and its runs are what the required checks already
@@ -142,4 +142,4 @@ jobs:
       - name: Re-derive the authority table against a fresh measurement
         run: >
           uv run --locked --no-default-groups --group harness
-          python .github/scripts/check_python_arm_authority.py
+          python .github/scripts/check_py_arm_authority.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,48 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **The py-arm authority census is `py_` in every path it lives at.**
+  `py-arm-authority.yml` ran `.github/scripts/check_python_arm_authority.py`
+  over `tests/python_arm_authority_test.py`, with
+  `tests/check_python_arm_authority_test.py` beside them: one feature
+  spelled `py` in the workflow that schedules it and `python` in
+  everything that workflow runs. The workflow disagreed with itself too,
+  its `name:` key reading `py arm authority` and its job
+  `Re-derive the Python-arm authority table`. The files are
+  `check_py_arm_authority.py`, `py_arm_authority_test.py` and
+  `check_py_arm_authority_test.py`, and what names them follows: the
+  script's import of the test module, the job's display name, the
+  `per-file-ignores` key and the sdist exclusion in `pyproject.toml`,
+  the citation in `tests/silent_payments_test.py`, and the census's own
+  `_py_arms()` and `test_every_py_arm_is_in_the_inventory`.
+
+  A rename of a file a `paths:` filter names is the part that fails
+  quietly: `py-arm-authority.yml`'s `pull_request` trigger lists the
+  script and the test module, and a pattern matching a path that no
+  longer exists stops firing without saying so. The filter moves with
+  them.
+
+  Renaming the job is free here only because that job is not a required
+  check -- the checks a merge waits for are held outside the repository,
+  and renaming one of those is what REPOSITORY.md records as the one
+  change that cannot be made in a pull request. Read the list back
+  rather than trust this sentence:
+
+  ```shell
+  gh api repos/btclib-org/btclib/branches/main/protection \
+    --jq '.required_status_checks.checks'
+  ```
+
+  What the library calls the arm is untouched, and that is a decision
+  rather than an omission: `btclib/curves/curve.py`, `SECURITY.md` and
+  `CONTRIBUTING.md` say Python arm, `tests/bip32/bip32_test.py` and its
+  siblings name tests `test_the_python_arm_...`, and `py-arm-authority`
+  is the name of the census, not a second name for the arm.
+
+  The entries below keep the spelling each file carried when they were
+  written, which is what a record of a release is for; this entry is
+  where the old spelling and the new one meet.
+
 - **`.yamllint.yaml` is the organization's copy, and `document-start`
   gates instead of reporting.** Section 14 of the standard in
   `btclib-org/.github` names the file as the same one in every

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,7 @@ source-exclude = [
     # path that is not there -- a fixture error rather than a test.
     # Anchored, because a name this specific matching at some other
     # depth would be an accident rather than a decision
-    "/tests/check_python_arm_authority_test.py",
+    "/tests/check_py_arm_authority_test.py",
     "/tests/check_vendored_vectors_test.py",
     "/tests/generate_sbom_test.py",
     "/tests/mutation_counts_test.py",
@@ -956,10 +956,10 @@ ignore = [
 # job that started an emulator: what it saw and how long it took, or the
 # ::error:: annotation naming what it saw instead
 ".github/scripts/wait_for_hwi_device.py" = ["T201"]
-# and the Python-arm authority re-derivation: which module it is
+# and the py-arm authority re-derivation: which module it is
 # measuring, one line per disagreement found, and the all-clear or count
 # at the end are what a weekly run's log says happened
-".github/scripts/check_python_arm_authority.py" = ["T201"]
+".github/scripts/check_py_arm_authority.py" = ["T201"]
 # the D rules are not here: a public test function, fixture or method
 # states what it verifies -- the property, the vector, the failure
 # mode -- under the same docstring gate as the library's public

--- a/tests/check_py_arm_authority_test.py
+++ b/tests/check_py_arm_authority_test.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Tests for `compare()`, the diff logic of the weekly Python-arm sentinel.
+"""Tests for `compare()`, the diff logic of the weekly py-arm sentinel.
 
 `measure()` is what actually runs the suite under coverage, module by
 module -- exactly what this repository collects no coverage from, the
@@ -12,7 +12,7 @@ the first place. `compare()` takes none of that: a
 AUTHORITY diff against `_AUTHORITY` and `_WITHOUT_AN_AUTHORITY` out, no
 subprocess or coverage run needed to exercise it. `_AUTHORITY` and
 `_WITHOUT_AN_AUTHORITY` are monkeypatched to small synthetic tables here
-rather than read from `tests/python_arm_authority_test.py`, so a change
+rather than read from `tests/py_arm_authority_test.py`, so a change
 to the real table cannot make this test pass or fail by accident.
 
 Loaded by path, the same reason and the same shape as
@@ -29,18 +29,18 @@ from types import ModuleType
 import pytest
 
 _SCRIPT = (
-    Path(__file__).parents[1] / ".github" / "scripts" / "check_python_arm_authority.py"
+    Path(__file__).parents[1] / ".github" / "scripts" / "check_py_arm_authority.py"
 )
 
 
 @pytest.fixture
 def checker(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     """Return the script, imported by path, registered before it runs."""
-    spec = importlib.util.spec_from_file_location("check_python_arm_authority", _SCRIPT)
+    spec = importlib.util.spec_from_file_location("check_py_arm_authority", _SCRIPT)
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    monkeypatch.setitem(sys.modules, "check_python_arm_authority", module)
+    monkeypatch.setitem(sys.modules, "check_py_arm_authority", module)
     spec.loader.exec_module(module)
     return module
 

--- a/tests/py_arm_authority_test.py
+++ b/tests/py_arm_authority_test.py
@@ -44,7 +44,7 @@ nothing here asks a contributor's branch to pay for it.
 
 That re-derivation runs weekly instead, is
 `.github/workflows/py-arm-authority.yml`, calling
-`.github/scripts/check_python_arm_authority.py` -- issue #1003's answer.
+`.github/scripts/check_py_arm_authority.py` -- issue #1003's answer.
 It repeats the measurement above, module by module, and fails loudly on
 any of three disagreements: an entry claims a module that no longer
 reaches the arm (stale, the harmful direction), a module reaches an arm
@@ -369,9 +369,9 @@ def _arm_locations() -> dict[str, tuple[Path, int, int]]:
     `node.end_lineno`, the `def` line itself excluded on purpose, since it
     runs at import regardless of whether the function is ever called and
     would otherwise report every arm of every imported module as reached.
-    `.github/scripts/check_python_arm_authority.py` is what reads this
+    `.github/scripts/check_py_arm_authority.py` is what reads this
     range against a coverage run's `executed_lines` to re-derive
-    `_AUTHORITY`; `_python_arms()` below reads only the keys.
+    `_AUTHORITY`; `_py_arms()` below reads only the keys.
     """
     found: dict[str, tuple[Path, int, int]] = {}
     for path in sorted(_LIBRARY.rglob("*.py")):
@@ -393,7 +393,7 @@ def _arm_locations() -> dict[str, tuple[Path, int, int]]:
     return found
 
 
-def _python_arms() -> set[str]:
+def _py_arms() -> set[str]:
     """Return every function of btclib that holds a dispatch to the bindings.
 
     The keys of `_arm_locations()`, which is where the counting rule --
@@ -402,7 +402,7 @@ def _python_arms() -> set[str]:
     return set(_arm_locations())
 
 
-def test_every_python_arm_is_in_the_inventory() -> None:
+def test_every_py_arm_is_in_the_inventory() -> None:
     """An arm added without an entry fails here, which is the point.
 
     The inventory is worth nothing if it can go quietly out of date: a
@@ -412,7 +412,7 @@ def test_every_python_arm_is_in_the_inventory() -> None:
     of the day it was written.
     """
     listed = set(_AUTHORITY)
-    found = _python_arms()
+    found = _py_arms()
     assert listed == found, (
         f"not in the inventory: {sorted(found - listed)};"
         f" gone from the library: {sorted(listed - found)}"

--- a/tests/silent_payments_test.py
+++ b/tests/silent_payments_test.py
@@ -220,7 +220,7 @@ def test_receiving_vectors(index: int, test: dict[str, Any]) -> None:
     # answer is what it has to match, on whichever arm this environment
     # runs -- delegated where the bindings serve, `scan_outputs` itself
     # otherwise, which is what makes this the vector this arm's own
-    # entry in `tests/python_arm_authority_test.py` cites
+    # entry in `tests/py_arm_authority_test.py` cites
     pub_keys_with_scripts = [
         (pub_key, v["prevout"]["scriptPubKey"]["hex"])
         for v in given["vin"]


### PR DESCRIPTION
A rename left one feature spelled two ways: the workflow was
`py-arm-authority.yml` while the script and the tests it drives kept
`python_arm_`. The three files take the workflow's spelling.

The stem does not move, and the reason is measurable: section 10 of the
organization's standard carries a row for it, and
`tests/grid_test.py` there reads that table against every `cron:` in
both directions, so a renamed stem fails it twice over.

```shell
git show origin/main:README.md   # in btclib-org/.github
# 947:| `py-arm-authority` | Tuesday | 05 |
```

## What was measured rather than read

- The `paths:` filters of every workflow, matched as GitHub globs
  against all six names, old and new: only `py-arm-authority.yml`'s own
  `pull_request` filter selects any of these files, and it moved with
  them. A rename that fell outside a filter would stop triggering its
  own workflow in silence.
- The renamed script's import line, executed rather than inspected.

## Not closed by this branch

btclib-org/btclib#1270 stays open. It is about the two spellings
coexisting across identifiers; this settles the census half, and leaves
the suite half, where the rest of that issue's citations point.

## Declined in local review, with the measure

The workflow's `name:` key stays `py arm authority` rather than
becoming its stem verbatim. `CHANGELOG.md` records that spelling as a
deliberate choice made when the workflow was renamed, and `name:` is
the spelling the other files are moving *towards* — changing it is a
decision about that line, not about this diff.

## Summary by Sourcery

Align all authority census paths and references on the py-arm naming convention without changing the census scope or workflow identity.

Enhancements:
- Standardize the py-arm authority census naming across its scripts, tests, workflow references, configuration, and related citations.

CI:
- Update the authority workflow and its path filters to use the standardized py-arm filenames and terminology.

Documentation:
- Document the authority census rename and preserve the existing workflow display name and arm terminology.

Tests:
- Rename the authority inventory and checker tests and update their internal references.