### PR TITLE
.gitattributes is the organization's file, with this tree's rule under the marker

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,10 +10,14 @@
 # the same existing entry edited on two branches merges in silence rather
 # than being flagged. That is why neither states how many entries it has —
 # a count is exactly such an edit, and union would have kept both numbers.
-# Section 9 of README.md in btclib-org/.github is where this rule is
-# recorded, this repository having no section of its own to record it in.
+# Section 9 of the organization standard, btclib-org/.github's README.md,
+# is where this rule is recorded.
 CHANGELOG.md merge=union
 RELEASE_NOTES.md merge=union
+
+## This repository in particular
+# Everything above is the same file in every repository of the organization;
+# everything below is this one's, and the comparison stops at this heading.
 
 # Electrum's Portuguese word-list is Monero's, and the blank lines of the
 # licence header it opens with end in a space upstream. Our copy being byte

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,22 @@ documented at release-notes length in the first place, and are still in
   questions the organization asks of every tree, and are asked in
   `## What every review here also checks` rather than twice.
 
+- **`.gitattributes` is the organization's file, and this tree's rule
+  is under `## This repository in particular`.** Section 14 of the
+  standard in `btclib-org/.github` names the file as the same in every
+  repository up to that heading, which git reads as a comment and
+  `tests/verbatim_test.py` there reads as where the comparison stops
+  (btclib-org/.github#102). The shared half is now byte for byte that
+  copy: what this one said beyond it was the closing sentence of the
+  comment, that the rule is recorded in the organization's README.md
+  because this tree has no section of its own for it, which every other
+  copy could say and none needs to. The `-whitespace` line for the
+  vendored Portuguese word-list moves under the heading, with its
+  comment: a rule for one repository's path above it would be a copy for
+  every other to drift from. `git check-attr` still answers `union` for
+  `CHANGELOG.md` and `RELEASE_NOTES.md` and `unset` for the word-list's
+  `whitespace`.
+
 - **`LICENSE` and `.claude/commands/review.md` are the organization's
   copies of themselves.** Section 14 of the standard in
   `btclib-org/.github` names both as the same file in every repository,


### PR DESCRIPTION
Under btclib-org/.github#34's regime: local gates the gate (pre-commit 0, and the suite where the tree has one), one local review round (`CLEARED ad0f876cb4ce5efdc26f8039385be863c05a5746`), landed by admin bypass pinned to that sha. Prose goes to the ex-post audit.

`.gitattributes` becomes the section 14 copy: the shared half is byte for byte btclib-org/.github's at a989db9, as `tests/verbatim_test.py` there compares it; what is this repository's own goes under `## This repository in particular`. Part of btclib-org/.github#102, which stays open until every copy agrees and the `EXPECTED_DRIFT` entry is deleted.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFB7QST7JN4J8RToymde1k

## Summary by Sourcery

Align `.gitattributes` with the organization-wide copy and preserve this repository’s specific file attribute rule.

Enhancements:
- Align `.gitattributes` with the organization-wide standard while isolating this repository’s vendored word-list rule under its repository-specific section.

Documentation:
- Document the `.gitattributes` standardization and repository-specific rule placement in the changelog.