### PR TITLE
links.yml accepts every success code and keeps no cache

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -119,8 +119,25 @@ jobs:
           # commit, and both are prose for a reader rather than a citation
           # in a comment.
           # --no-progress because the log is not a terminal; the retries,
-          # the timeout and the cache are what keep a slow or throttling
+          # the wait and the timeout are what keep a slow or throttling
           # host from being reported as a dead one.
+          # No --cache: lychee keeps it on disk under the workspace, a
+          # run starts from a fresh one and no step here restores it, so
+          # across runs the flag decides nothing -- and a restore step
+          # would not make it decide much, lychee's default
+          # --max-cache-age of 1d discarding the whole of it on a weekly
+          # schedule. Within a run lychee collapses repeated URLs by
+          # itself: `lychee --offline --no-progress "*.md"` answers more
+          # links in Total than Unique with no cache anywhere.
+          # `--accept` is lychee's own default range with 429 added to it,
+          # rather than a list of codes: the flag replaces the default
+          # instead of extending it, and `lychee --help` gives that
+          # default as 100..=103,200..=299, so a list naming fewer, a
+          # "200,206,429", makes a 201 or a 204 a dead link -- a host
+          # that starts answering 204 to a HEAD does it with nobody
+          # touching the tree -- to add a 206 the default already covers.
+          # 429 is the one code worth adding, a rate limit being an
+          # answer from a host that is alive.
           # --timeout 45, against lychee's default of 20, is not a guess:
           # www.esat.kuleuven.be timed out three times in one run -- 20
           # seconds each, so the retries did happen -- while answering in
@@ -136,9 +153,7 @@ jobs:
             --max-retries 3
             --retry-wait-time 10
             --timeout 45
-            --cache
-            --max-cache-age 1d
-            --accept 200,206,429
+            --accept 100..=103,200..=299,429
             "*.md" "docs/**/*.rst" "docs/**/*.md" "tests/**/*.md"
           # fail the job, rather than only summarizing: a green run that
           # found dead links is the state this workflow exists to end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -474,6 +474,24 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **`links.yml` accepts every status lychee accepts unasked, and passes
+  no `--cache`.** `--accept 200,206,429` replaced lychee's default of
+  `100..=103,200..=299` rather than extending it, so a 201, a 202 or a
+  204 read as a dead link to the weekly run, and the 206 the list
+  spent a slot on was one the default already covered; the list is now
+  that default with 429 added, a rate limit being an answer from a host
+  that is alive (btclib-org/.github#110). `--cache --max-cache-age 1d`
+  went: no step restored `.lycheecache` across runs, so the flag
+  decided nothing, and the comment beside it credited the cache with
+  keeping a throttling host from reading as dead — a mechanism the job
+  did not have (btclib-org/.github#111). Restoring the cache was the
+  other answer and was refused: the schedule is weekly and the age one
+  day, so a restored cache would be discarded whole on every run.
+  Measured on this tree with lychee 0.24.2: `lychee --help` gives the
+  default range, and `lychee --offline --no-progress "*.md"` reports
+  more links in Total than Unique with no cache anywhere, the
+  deduplication within a run being lychee's own.
+
 - **`COPYRIGHT` is a file of the repository, not of the distribution.**
   `project.license-files` names `LICENSE` and `AUTHORS.md`; the sdist
   loses its root `COPYRIGHT` and the wheel its


### PR DESCRIPTION
Under btclib-org/.github#34's regime: local gates the gate (pre-commit 0, pytest 0 — 29661 passed, 100% — `sphinx -W` 0), one local review round (`CLEARED 179bc9867a93f01d2284b76897fdd5a2facfee46`), landed by admin bypass pinned to that sha. Prose goes to the ex-post audit.

Two rows of the organization audit's backlog (btclib-org/.github#161's suite), measured by the test's by-hand command before and after; neither issue closed here: btclib-org/.github#110 — `links.yml` accepts lychee's default range plus 429; btclib-org/.github#111 — `--cache` and `--max-cache-age` dropped, no step having kept the cache. btclib-org/.github#129 is left as it is here: `bindings`, `harness` and `check` are right, and section 1's table is what changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFB7QST7JN4J8RToymde1k

## Summary by Sourcery

Make the weekly link checker correctly accept successful and rate-limited responses without relying on an unpersisted cache.

Bug Fixes:
- Update the links workflow to recognize lychee’s full default success-status range and treat rate-limit responses as reachable.
- Remove ineffective link-checking cache options that were not persisted between workflow runs.

CI:
- Adjust the weekly link-check workflow’s accepted status codes and cache configuration.

Documentation:
- Document the link-checking workflow corrections in the changelog.