### PR TITLE
REVIEWING.md is the organization's copy, the reviewer running the whole suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **`REVIEWING.md` says the reviewer runs the whole suite, every time.**
+  The organization's copy, shared half byte for byte (section 14): the
+  test suite is run whole on the sha under review, never a subset and
+  never relied on from the author's run.
+
 - **`REVIEWING.md` is the organization's copy.** A review reads the prose
   that stays in the tree, treats a commit message or a pull request's
   body as a finding only where it decides something, and asks a stated

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -281,13 +281,23 @@ subset that is not the coverage gate, a hook set that is not the whole
 of what CI runs. A reviewer who names a
 gate this repository does not have has reported nothing.
 
-**Unless they have already been run on this sha and that run is on the
-record.** Then rely on it, and say whose it is. Two runs qualify: the
-workflows of the required checks, running beside a review on the same
-commit — `CONTRIBUTING.md` names which checks those are — and an author
-handing over a branch they gated themselves and said so. What is relied on is
-that those gates run and hold the merge, not the colour of a check, which
-stays none of a reviewer's business for the reason below.
+**The whole suite, every time.** The test suite is run whole, on the
+sha under review, by the reviewer — never a module on its own, a `-k`,
+a `--lf`, a deselect or a marker in its place, and never relied on from
+somebody else's run. What a change breaks is found by the test that did
+not expect to be touched by it, and a subset is chosen by what the
+author expected. Where the suite is long it runs in the background with
+a ceiling, and what is reported is its exit code; a run that was cut
+short or narrowed is reported as no run.
+
+**The other gates, unless they have already been run on this sha and
+that run is on the record.** Then rely on it, and say whose it is. Two
+runs qualify: the workflows of the required checks, running beside a
+review on the same commit — `CONTRIBUTING.md` names which checks those
+are — and an author handing over a branch they gated themselves and
+said so. What is relied on is that those gates run and hold the merge,
+not the colour of a check, which stays none of a reviewer's business
+for the reason below.
 
 The sha is the whole of the condition: a run on another tree is not a run
 on this one, so a rebase voids it — the branch was gated, and then the


### PR DESCRIPTION
Asked for by the maintainer, under btclib-org/.github#34's regime: local gate (pre-commit 0), landed by admin bypass pinned to the reviewed sha; a section 14 copy of prose, no local review round.

`REVIEWING.md`'s shared half is btclib-org/.github's at 29b53ab (btclib-org/.github#168), byte for byte up to `## This repository in particular`: the reviewer runs the whole test suite on the sha under review, every time. What is under the marker is this repository's and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFB7QST7JN4J8RToymde1k

## Summary by Sourcery

Require reviewers to run the entire test suite on the commit under review and synchronize the repository review guidance with the organization's policy.

Enhancements:
- Align the repository review guidance with the organization's shared copy and require reviewers to run the complete test suite on the exact commit under review.

Documentation:
- Document that the full test suite must be run by the reviewer for every review, while other gates may only be relied upon when recorded for the same commit.

Chores:
- Record the updated review-policy requirements in the changelog.