### PR TITLE
mypy's enable_error_code is the organization's list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -486,6 +486,17 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **mypy's `enable_error_code` is the organization's list.** The same in
+  every repository that runs mypy (btclib-org/.github#165):
+  `explicit-override` and `unused-awaitable` enter, and
+  `narrowed-type-not-subtype` leaves the key, being a check the locked
+  mypy runs unasked. `explicit-override` is the code that reported:
+  every method overriding one of a base class now carries `@override`,
+  imported from `typing_extensions` — the backport of `typing.override`,
+  which 3.12 has and the 3.10 floor does not — so `typing-extensions>=4.4`
+  joins the declared dependencies, its floor the release that adds the
+  decorator.
+
 - **`links.yml` accepts every status lychee accepts unasked, and passes
   no `--cache`.** `--accept 200,206,429` replaced lychee's default of
   `100..=103,200..=299` rather than extending it, so a 201, a 202 or a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,10 +191,12 @@ tools, including those needed to build the documentation, is then created with:
 uv sync
 ```
 
-**The declared dependencies are `bitcoin-core-rpc>=2026.8.13` and, as
-the `secp256k1` extra, `btclib_secp256k1>=0.8.0.4`, with no upper
-bound**, and the absence of a
-ceiling is a decision. Both are btclib-org projects developed by the same
+**The declared dependencies are `bitcoin-core-rpc>=2026.8.13`,
+`typing-extensions>=4.4` and, as the `secp256k1` extra,
+`btclib_secp256k1>=0.8.0.4`, with no upper bound**, and the absence of a
+ceiling is a decision. `typing-extensions` backports `typing.override`,
+which 3.12 has and the 3.10 floor does not, and its floor is the release
+that adds it. The other two are btclib-org projects developed by the same
 people, and the bindings' whole purpose is to be the bindings this library
 calls, so a breaking change there is coordinated with the release here —
 which is what a version ceiling substitutes for when it cannot be. A
@@ -215,7 +217,7 @@ is supported, covered by CI and documented — and nothing stands behind
 so a `fetch` extra would leave `btclib.fetch` importable and unable to
 answer, which is the shape an extra exists to avoid.
 
-**Both floors name a release PyPI serves**, so `pyproject.toml` carries
+**Both sibling floors name a release PyPI serves**, so `pyproject.toml` carries
 no `[tool.uv.sources]` table and uv resolves the bindings from the index
 like anything else: `uv.lock` pins a version and its wheels, every job
 passes `--locked`, and `uv sync` downloads rather than compiling

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -29,6 +29,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from typing_extensions import override
+
 from btclib import base58
 from btclib._libsecp256k1 import keys as libsecp256k1_keys
 from btclib.alias import BinaryData, Octets, String
@@ -219,6 +221,7 @@ class BIP32KeyData:
         """Answer whether the key is private, by its 0x00 prefix."""
         return self.key[0] == 0
 
+    @override
     def __repr__(self) -> str:
         # never echo private key material: mask key and chain_code
         # (key[:1], not is_private, so that repr cannot raise on an

--- a/btclib/bip32/key_origin.py
+++ b/btclib/bip32/key_origin.py
@@ -10,6 +10,8 @@ from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
 from io import BytesIO
 
+from typing_extensions import override
+
 from btclib.alias import Octets
 from btclib.bip32.der_path import (
     DerPath,
@@ -147,6 +149,7 @@ class BIP32KeyOrigin:
         data = data.strip()
         return cls(data[:8], data[9:], check_validity=check_validity)
 
+    @override
     def __hash__(self: BIP32KeyOrigin) -> int:
         return hash(self.serialize())
 

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -35,6 +35,8 @@ from math import isqrt
 from pathlib import Path
 from typing import Any
 
+from typing_extensions import override
+
 from btclib._libsecp256k1 import ENABLED as _bindings_enabled
 from btclib._libsecp256k1 import INSTALLED as _bindings_installed
 from btclib._libsecp256k1 import (
@@ -288,6 +290,7 @@ class Curve(CurveGroup):
 
         self.name = name
 
+    @override
     def __str__(self) -> str:
         result = super().__str__()
         # the generator is rendered as the curve is, in hex above the
@@ -306,6 +309,7 @@ class Curve(CurveGroup):
         result += f"\n cofactor = {self.cofactor}"
         return result
 
+    @override
     def __repr__(self) -> str:
         result = super().__repr__()[:-1]
         if self.p > HEX_THRESHOLD:
@@ -320,6 +324,7 @@ class Curve(CurveGroup):
         result += ")"
         return result
 
+    @override
     def _eq_key(self) -> tuple[int, ...]:
         # name is not part of the curve: the same curve is catalogued as
         # secp256r1 by SEC 2 and as P-256 by NIST, and weakness_check and

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -19,6 +19,8 @@ import secrets
 from collections.abc import Sequence
 from math import ceil
 
+from typing_extensions import override
+
 from btclib.alias import INF, INFJ, Integer, JacPoint, Point
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.number_theory import mod_inv_batch_var, mod_inv_var, mod_sqrt_var
@@ -193,6 +195,7 @@ class CurveGroup:
         # none -- it has no generator -- and Curve fills this in
         self._fixed_points: frozenset[JacPoint] = frozenset()
 
+    @override
     def __str__(self) -> str:
         # the class name, not the literal "Curve": the two classes hold
         # different parameters, so a CurveGroup announcing itself as a
@@ -214,6 +217,7 @@ class CurveGroup:
 
         return result
 
+    @override
     def __repr__(self) -> str:
         result = f"{type(self).__name__}("
         result += f"'{hex_string(self.p)}'" if self.p > HEX_THRESHOLD else f"{self.p}"
@@ -234,6 +238,7 @@ class CurveGroup:
         """
         return self.p, self._a, self._b
 
+    @override
     def __eq__(self, other: object) -> bool:
         # a curve is its parameters: two objects built from the same ones
         # are the same curve, whatever the catalogue they came from. This
@@ -252,6 +257,7 @@ class CurveGroup:
             return NotImplemented
         return self._eq_key() == other._eq_key()
 
+    @override
     def __hash__(self) -> int:
         # __eq__ without __hash__ would set __hash__ to None, and curves
         # are lru_cache keys in _cached_multiples below; equal curves

--- a/btclib/descriptors/descriptors.py
+++ b/btclib/descriptors/descriptors.py
@@ -143,6 +143,8 @@ from copy import deepcopy
 from dataclasses import dataclass, fields, replace
 from typing import Any, cast
 
+from typing_extensions import override
+
 from btclib.alias import BIP44ScriptType, Octets, ScriptList, TaprootScriptTree
 from btclib.bip32.bip32 import (
     BIP32Key,
@@ -375,6 +377,7 @@ class MultiA:
     # to agree on an address
     sort: bool = False
 
+    @override
     def __str__(self) -> str:
         """Return the ``multi_a()`` or ``sortedmulti_a()`` leaf as text."""
         name = "sortedmulti_a" if self.sort else "multi_a"
@@ -724,6 +727,7 @@ class Descriptor(ABC):
         """Return every KEY expression the descriptor holds."""
 
     @abstractmethod
+    @override
     def __str__(self) -> str:
         """Return the descriptor as text, without its checksum.
 
@@ -1089,17 +1093,21 @@ class PkDescriptor(Descriptor):
 
     key: KeyExpression
 
+    @override
     def __str__(self) -> str:
         return _expression("pk", str(self.key))
 
     @property
+    @override
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return the one KEY expression, as the base class's tuple."""
         return (self.key,)
 
+    @override
     def _scripts(self, index: int, prv_keys: PrvKeys | None) -> list[bytes]:
         return [ScriptPubKey.p2pk(self.key.sec(index, self.network, prv_keys)).script]
 
+    @override
     def _stack(
         self,
         signatures: Mapping[bytes, bytes],
@@ -1120,17 +1128,21 @@ class PkhDescriptor(Descriptor):
 
     key: KeyExpression
 
+    @override
     def __str__(self) -> str:
         return _expression("pkh", str(self.key))
 
     @property
+    @override
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return the one KEY expression, as the base class's tuple."""
         return (self.key,)
 
+    @override
     def _scripts(self, index: int, prv_keys: PrvKeys | None) -> list[bytes]:
         return [ScriptPubKey.p2pkh(self.key.sec(index, self.network, prv_keys)).script]
 
+    @override
     def _stack(
         self,
         signatures: Mapping[bytes, bytes],
@@ -1150,17 +1162,21 @@ class WpkhDescriptor(Descriptor):
 
     key: KeyExpression
 
+    @override
     def __str__(self) -> str:
         return _expression("wpkh", str(self.key))
 
     @property
+    @override
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return the one KEY expression, as the base class's tuple."""
         return (self.key,)
 
+    @override
     def _scripts(self, index: int, prv_keys: PrvKeys | None) -> list[bytes]:
         return [ScriptPubKey.p2wpkh(self.key.sec(index, self.network, prv_keys)).script]
 
+    @override
     def _stack(
         self,
         signatures: Mapping[bytes, bytes],
@@ -1173,6 +1189,7 @@ class WpkhDescriptor(Descriptor):
         sec = self.key.sec(index, self.network, prv_keys)
         return [_required_signature(signatures, sec), sec]
 
+    @override
     def _satisfy(
         self,
         signatures: Mapping[bytes, bytes],
@@ -1193,17 +1210,21 @@ class ShDescriptor(Descriptor):
 
     inner: Descriptor
 
+    @override
     def __str__(self) -> str:
         return _expression("sh", str(self.inner))
 
     @property
+    @override
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return the wrapped SCRIPT's KEY expressions."""
         return self.inner.key_expressions
 
+    @override
     def _scripts(self, index: int, prv_keys: PrvKeys | None) -> list[bytes]:
         return [ScriptPubKey.p2sh(self.inner.redeem_script(index, prv_keys)).script]
 
+    @override
     def _satisfy(
         self,
         signatures: Mapping[bytes, bytes],
@@ -1225,6 +1246,7 @@ class ShDescriptor(Descriptor):
         redeem_script = self.inner.redeem_script(index, prv_keys)
         return script_sig + serialize(cast(ScriptList, [redeem_script])), witness
 
+    @override
     def _update_map(
         self, psbt_map: PsbtIn | PsbtOut, index: int, prv_keys: PrvKeys | None
     ) -> None:
@@ -1245,17 +1267,21 @@ class WshDescriptor(Descriptor):
 
     inner: Descriptor
 
+    @override
     def __str__(self) -> str:
         return _expression("wsh", str(self.inner))
 
     @property
+    @override
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return the wrapped SCRIPT's KEY expressions."""
         return self.inner.key_expressions
 
+    @override
     def _scripts(self, index: int, prv_keys: PrvKeys | None) -> list[bytes]:
         return [ScriptPubKey.p2wsh(self.inner.redeem_script(index, prv_keys)).script]
 
+    @override
     def _satisfy(
         self,
         signatures: Mapping[bytes, bytes],
@@ -1273,6 +1299,7 @@ class WshDescriptor(Descriptor):
         stack = self.inner._stack(signatures, index, prv_keys, spend)
         return b"", Witness([*stack, self.inner.redeem_script(index, prv_keys)])
 
+    @override
     def _update_map(
         self, psbt_map: PsbtIn | PsbtOut, index: int, prv_keys: PrvKeys | None
     ) -> None:
@@ -1306,17 +1333,21 @@ class MiniscriptDescriptor(Descriptor):
 
     node: Miniscript
 
+    @override
     def __str__(self) -> str:
         return str(self.node)
 
     @property
+    @override
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return the KEY expressions of the fragments, left to right."""
         return self.node.key_expressions
 
+    @override
     def _scripts(self, index: int, prv_keys: PrvKeys | None) -> list[bytes]:
         return [self.node.script(index, self.network, prv_keys)]
 
+    @override
     def _stack(
         self,
         signatures: Mapping[bytes, bytes],
@@ -1351,11 +1382,13 @@ class MultiDescriptor(Descriptor):
     # the participants need not agree on an order to agree on an address
     sort: bool = False
 
+    @override
     def __str__(self) -> str:
         name = "sortedmulti" if self.sort else "multi"
         return _expression(name, str(self.threshold), *map(str, self.keys))
 
     @property
+    @override
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return the KEY expressions, in descriptor order."""
         return self.keys
@@ -1371,6 +1404,7 @@ class MultiDescriptor(Descriptor):
         pub_keys = [key.sec(index, self.network, prv_keys) for key in self.keys]
         return sorted(pub_keys) if self.sort else pub_keys
 
+    @override
     def _scripts(self, index: int, prv_keys: PrvKeys | None) -> list[bytes]:
         script_pub_key = ScriptPubKey.p2ms(
             self.threshold,
@@ -1380,6 +1414,7 @@ class MultiDescriptor(Descriptor):
         )
         return [script_pub_key.script]
 
+    @override
     def _stack(
         self,
         signatures: Mapping[bytes, bytes],
@@ -1422,14 +1457,17 @@ class ComboDescriptor(Descriptor):
 
     key: KeyExpression
 
+    @override
     def __str__(self) -> str:
         return _expression("combo", str(self.key))
 
     @property
+    @override
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return the one KEY expression, as the base class's tuple."""
         return (self.key,)
 
+    @override
     def _scripts(self, index: int, prv_keys: PrvKeys | None) -> list[bytes]:
         pub_key = self.key.sec(index, self.network, prv_keys)
         scripts = [
@@ -1441,6 +1479,7 @@ class ComboDescriptor(Descriptor):
             scripts += [p2wpkh, ScriptPubKey.p2sh(p2wpkh).script]
         return scripts
 
+    @override
     def _satisfy(
         self,
         signatures: Mapping[bytes, bytes],
@@ -1458,6 +1497,7 @@ class ComboDescriptor(Descriptor):
         err_msg = "combo() is four scripts: satisfy the one being spent"
         raise BTClibValueError(err_msg)
 
+    @override
     def _update_map(
         self, psbt_map: PsbtIn | PsbtOut, index: int, prv_keys: PrvKeys | None
     ) -> None:
@@ -1479,17 +1519,21 @@ class AddrDescriptor(Descriptor):
 
     addr: str
 
+    @override
     def __str__(self) -> str:
         return _expression("addr", self.addr)
 
     @property
+    @override
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return no KEY expression, the descriptor fixing none."""
         return ()
 
+    @override
     def _scripts(self, index: int, prv_keys: PrvKeys | None) -> list[bytes]:
         return [ScriptPubKey.from_address(self.addr).script]
 
+    @override
     def _satisfy(
         self,
         signatures: Mapping[bytes, bytes],
@@ -1506,6 +1550,7 @@ class AddrDescriptor(Descriptor):
         """
         raise BTClibValueError("addr() cannot be satisfied: it holds no key")
 
+    @override
     def _update_map(
         self, psbt_map: PsbtIn | PsbtOut, index: int, prv_keys: PrvKeys | None
     ) -> None:
@@ -1524,17 +1569,21 @@ class RawDescriptor(Descriptor):
 
     script: bytes
 
+    @override
     def __str__(self) -> str:
         return _expression("raw", self.script.hex())
 
     @property
+    @override
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return no KEY expression, the descriptor fixing none."""
         return ()
 
+    @override
     def _scripts(self, index: int, prv_keys: PrvKeys | None) -> list[bytes]:
         return [self.script]
 
+    @override
     def _satisfy(
         self,
         signatures: Mapping[bytes, bytes],
@@ -1551,6 +1600,7 @@ class RawDescriptor(Descriptor):
         """
         raise BTClibValueError("raw() cannot be satisfied: it holds no key")
 
+    @override
     def _update_map(
         self, psbt_map: PsbtIn | PsbtOut, index: int, prv_keys: PrvKeys | None
     ) -> None:
@@ -1570,18 +1620,21 @@ class TrDescriptor(Descriptor):
     internal_key: KeyExpression
     tree: DescriptorTree | None = None
 
+    @override
     def __str__(self) -> str:
         if self.tree is None:
             return _expression("tr", str(self.internal_key))
         return _expression("tr", str(self.internal_key), _tree_expression(self.tree))
 
     @property
+    @override
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return the internal key and every leaf key, in tree order."""
         if self.tree is None:
             return (self.internal_key,)
         return (self.internal_key, *_tree_keys(self.tree))
 
+    @override
     def _scripts(self, index: int, prv_keys: PrvKeys | None) -> list[bytes]:
         script_tree = (
             None
@@ -1683,6 +1736,7 @@ class TrDescriptor(Descriptor):
             self.key_expressions, leaf_hashes, index, self.network, prv_keys
         )
 
+    @override
     def _satisfy(
         self,
         signatures: Mapping[bytes, bytes],
@@ -1758,6 +1812,7 @@ class TrDescriptor(Descriptor):
         scripts = _leaf_scripts(self.tree, 0, index, self.network, prv_keys)
         return [(depth, _TAPSCRIPT_LEAF_VERSION, script) for depth, script in scripts]
 
+    @override
     def _update_map(
         self, psbt_map: PsbtIn | PsbtOut, index: int, prv_keys: PrvKeys | None
     ) -> None:
@@ -1786,6 +1841,7 @@ class TrDescriptor(Descriptor):
             **_musig2_participants(self.key_expressions, index, self.network, prv_keys),
         }
 
+    @override
     def _update(self, psbt_in: PsbtIn, index: int, prv_keys: PrvKeys | None) -> None:
         """Add what an input carries: the merkle root and the leaf scripts.
 
@@ -1801,6 +1857,7 @@ class TrDescriptor(Descriptor):
             **self.taproot_leaf_scripts(index, prv_keys),
         }
 
+    @override
     def _update_out(
         self, psbt_out: PsbtOut, index: int, prv_keys: PrvKeys | None
     ) -> None:
@@ -1835,14 +1892,17 @@ class RawTrDescriptor(Descriptor):
 
     key: KeyExpression
 
+    @override
     def __str__(self) -> str:
         return _expression("rawtr", str(self.key))
 
     @property
+    @override
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return the one KEY expression, as the base class's tuple."""
         return (self.key,)
 
+    @override
     def _scripts(self, index: int, prv_keys: PrvKeys | None) -> list[bytes]:
         # not ScriptPubKey.p2tr, which computes an output key from an
         # internal one: here the key already is the output key, and
@@ -1850,6 +1910,7 @@ class RawTrDescriptor(Descriptor):
         output_key = self.key.sec(index, self.network, prv_keys)[1:]
         return [serialize(["OP_1", output_key])]
 
+    @override
     def _satisfy(
         self,
         signatures: Mapping[bytes, bytes],
@@ -1874,6 +1935,7 @@ class RawTrDescriptor(Descriptor):
             raise BTClibValueError("no signature for the rawtr() output key")
         return b"", Witness([signature])
 
+    @override
     def _update_map(
         self, psbt_map: PsbtIn | PsbtOut, index: int, prv_keys: PrvKeys | None
     ) -> None:

--- a/btclib/descriptors/key_expression.py
+++ b/btclib/descriptors/key_expression.py
@@ -31,6 +31,8 @@ import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 
+from typing_extensions import override
+
 from btclib.bip32.bip32 import (
     BIP328_CHAIN_CODE,
     BIP32KeyData,
@@ -240,6 +242,7 @@ class KeyExpression:
             key_agg(self.participant_keys(index, network, prv_keys)).Q, secp256k1
         )
 
+    @override
     def __str__(self) -> str:
         """Return the KEY expression, in the spelling it was read in.
 

--- a/btclib/descriptors/miniscript.py
+++ b/btclib/descriptors/miniscript.py
@@ -69,6 +69,8 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from typing import TypeVar
 
+from typing_extensions import override
+
 from btclib.alias import Octets, ScriptList
 from btclib.descriptors.key_expression import (
     KeyExpression,
@@ -1438,6 +1440,7 @@ class Miniscript:
             raise BTClibValueError(err_msg)
         return list(satisfaction.stack)
 
+    @override
     def __str__(self) -> str:
         """Return the expression as BIP379 writes it.
 

--- a/btclib/exceptions.py
+++ b/btclib/exceptions.py
@@ -61,6 +61,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from typing_extensions import override
+
 __all__ = [
     "BTClibException",
     "BTClibRuntimeError",
@@ -149,6 +151,7 @@ class HttpError(FetchError):
         self.status = status
         super().__init__(message, status)
 
+    @override
     def __str__(self) -> str:
         # the message alone, which is what BaseException returns for a
         # single argument and not for the two this carries
@@ -180,6 +183,7 @@ class RpcError(FetchError):
         self.data = data
         super().__init__(message, code, data)
 
+    @override
     def __str__(self) -> str:
         return f"{self.args[0]} (rpc error code {self.code})"
 
@@ -211,6 +215,7 @@ class SignerError(BTClibRuntimeError):
         self.code = code
         super().__init__(message, code)
 
+    @override
     def __str__(self) -> str:
         if self.code is None:
             return str(self.args[0])
@@ -275,6 +280,7 @@ class IncompleteMessageError(BTClibRuntimeError):
         self.missing = missing
         super().__init__(message, missing)
 
+    @override
     def __str__(self) -> str:
         return f"{self.args[0]}: {self.missing} more bytes wanted"
 
@@ -295,6 +301,7 @@ class ScriptError(BTClibValueError):
         self.stack_depth = stack_depth
         super().__init__(message, index, stack_depth)
 
+    @override
     def __str__(self) -> str:
         where = f"command {self.index}, stack depth {self.stack_depth}"
         return f"{self.args[0]} ({where})"
@@ -386,6 +393,7 @@ class InvalidContributionError(BTClibRuntimeError):
         self.contrib = contrib
         super().__init__(signer, contrib)
 
+    @override
     def __str__(self) -> str:
         who = "the aggregator" if self.signer is None else f"signer {self.signer}"
         return f"invalid {self.contrib} from {who}"
@@ -421,6 +429,7 @@ class BorromeanRingError(BTClibRuntimeError):
         self.position = position
         super().__init__(message, ring, position)
 
+    @override
     def __str__(self) -> str:
         if self.ring is None:
             return str(self.args[0])

--- a/btclib/fetch/bitcoin_core.py
+++ b/btclib/fetch/bitcoin_core.py
@@ -30,6 +30,7 @@ from bitcoin_core_rpc import (
     cookie_auth,
     magic_from_signet_challenge,
 )
+from typing_extensions import override
 
 from btclib.alias import Octets
 from btclib.exceptions import BTClibValueError
@@ -169,6 +170,7 @@ class BitcoinCoreFetcher(Fetcher):
         with client_errors():
             return self.client.call(method, params, **bound)
 
+    @override
     def get_tx(self, tx_id: Octets) -> Tx:
         """Return the transaction with this id.
 
@@ -183,6 +185,7 @@ class BitcoinCoreFetcher(Fetcher):
         raw = self._call("getrawtransaction", [hex_], max_body_size=None)
         return tx_from_raw(raw, hex_, self.network)
 
+    @override
     def get_block_count(self) -> int:
         """Return the height of the node's best chain tip."""
         self._verify_once()
@@ -190,6 +193,7 @@ class BitcoinCoreFetcher(Fetcher):
             reply = self._call("getblockcount", None, max_body_size=_MAX_SMALL_REPLY)
             return int(reply)
 
+    @override
     def get_best_block_id(self) -> bytes:
         """Return the hash of the node's best chain tip, display order."""
         self._verify_once()

--- a/btclib/fetch/esplora.py
+++ b/btclib/fetch/esplora.py
@@ -38,6 +38,8 @@ expects text is not compatible in the way that matters.
 
 from __future__ import annotations
 
+from typing_extensions import override
+
 from btclib.alias import Octets
 from btclib.exceptions import HttpError
 from btclib.fetch.fetcher import (
@@ -148,17 +150,20 @@ class EsploraFetcher(Fetcher):
             raise HttpError(f"HTTP {status} from {url}: {text}", status)
         return text
 
+    @override
     def get_tx(self, tx_id: Octets) -> Tx:
         """Return the transaction, parsed and checked against its txid."""
         hex_ = tx_id_hex(tx_id)
         raw = self.text(f"/tx/{hex_}/hex", _MAX_TX_BODY)
         return tx_from_raw(raw, hex_, self.network)
 
+    @override
     def get_block_count(self) -> int:
         """Return the height of the server's best chain tip."""
         with fetch_errors("blocks/tip/height"):
             return int(self.text("/blocks/tip/height", _MAX_HEIGHT_BODY))
 
+    @override
     def get_best_block_id(self) -> bytes:
         """Return the hash of the server's best chain tip, display order."""
         with fetch_errors("blocks/tip/hash"):

--- a/btclib/key.py
+++ b/btclib/key.py
@@ -66,6 +66,8 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import Any
 
+from typing_extensions import override
+
 from btclib.alias import Octets, Point
 from btclib.curves import Curve, bytes_from_prv_key_int, point_from_octets
 from btclib.exceptions import BTClibTypeError, BTClibValueError
@@ -245,6 +247,7 @@ class PrvKeyData:
         if check_validity:
             self.assert_valid()
 
+    @override
     def __repr__(self) -> str:
         # never echo private key material, as BIP32KeyData's repr does not
         masked = f"{type(self).__name__}(q=..., network={self.network!r}"

--- a/btclib/p2p/address.py
+++ b/btclib/p2p/address.py
@@ -56,6 +56,8 @@ from dataclasses import dataclass
 from enum import IntFlag
 from ipaddress import IPv4Address, IPv6Address, ip_address
 
+from typing_extensions import override
+
 from btclib import var_int
 from btclib.alias import BinaryData
 from btclib.exceptions import BTClibTypeError, BTClibValueError
@@ -452,6 +454,7 @@ class Addr(Payload):
                 raise BTClibTypeError(err_msg)
             address.assert_valid()
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the count, then that many timestamped addresses."""
         if check_validity:

--- a/btclib/p2p/addrv2.py
+++ b/btclib/p2p/addrv2.py
@@ -114,6 +114,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import IntEnum
 
+from typing_extensions import override
+
 from btclib import var_bytes, var_int
 from btclib.alias import BinaryData, Octets
 from btclib.exceptions import BTClibTypeError, BTClibValueError
@@ -449,6 +451,7 @@ class AddrV2(Payload):
                 raise BTClibTypeError(err_msg)
             address.assert_valid()
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the count, then that many BIP155 entries."""
         if check_validity:
@@ -514,6 +517,7 @@ class SendAddrV2(Payload):
     def assert_valid(self) -> None:
         """Accept: a message with no fields has none to refuse."""
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the empty payload a `sendaddrv2` is."""
         if check_validity:

--- a/btclib/p2p/block_filters.py
+++ b/btclib/p2p/block_filters.py
@@ -119,6 +119,8 @@ from dataclasses import dataclass
 from enum import IntEnum
 from typing import TypeVar
 
+from typing_extensions import override
+
 from btclib import var_bytes, var_int
 from btclib.alias import BinaryData, Octets
 from btclib.block.block_filter import BasicBlockFilter, filter_header
@@ -273,6 +275,7 @@ class _FilterRangeRequest(Payload):
 
         _assert_valid_hash(self.stop_hash, "stop_hash length")
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the type, the height, then the stop hash."""
         if check_validity:
@@ -417,6 +420,7 @@ class CFilter(Payload):
         _assert_valid_type(self.filter_type)
         _assert_valid_hash(self.block_hash, "block_hash length")
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the type, the block hash, then the filter behind a length."""
         if check_validity:
@@ -548,6 +552,7 @@ class CFHeaders(Payload):
         for filter_hash in self.filter_hashes:
             _assert_valid_hash(filter_hash, "filter hash length")
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the type, the two hashes, then the count and the vector."""
         if check_validity:
@@ -638,6 +643,7 @@ class GetCFCheckpt(Payload):
         _assert_valid_type(self.filter_type)
         _assert_valid_hash(self.stop_hash, "stop_hash length")
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the type code, then the stop hash."""
         if check_validity:
@@ -739,6 +745,7 @@ class CFCheckpt(Payload):
         for header in self.filter_headers:
             _assert_valid_hash(header, "filter header length")
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the type, the stop hash, then the count and the vector."""
         if check_validity:

--- a/btclib/p2p/compact_blocks.py
+++ b/btclib/p2p/compact_blocks.py
@@ -139,6 +139,8 @@ import hashlib
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+from typing_extensions import override
+
 from btclib import var_int
 from btclib.alias import BinaryData, Octets
 from btclib.block.block import Block
@@ -387,6 +389,7 @@ class SendCmpct(Payload):
         if not 0 <= self.version <= _MAX_VERSION:
             raise BTClibValueError(f"invalid version: {self.version}")
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the announce octet, then the eight of the version."""
         if check_validity:
@@ -651,6 +654,7 @@ class CmpctBlock(Payload):
         _assert_valid_count(self.tx_count, "transaction")
         _assert_positions(self.prefilled_txns, self.tx_count)
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the header, the nonce, then the two vectors."""
         if check_validity:
@@ -762,6 +766,7 @@ class GetBlockTxn(Payload):
             _assert_valid_index(index, "index")
         _assert_increasing(self.indexes, "indexes")
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the block hash, the count, then the differences."""
         if check_validity:
@@ -846,6 +851,7 @@ class BlockTxn(Payload):
         for tx in self.transactions:
             _assert_valid_transaction(tx, "transaction")
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the block hash, the count, then the transactions."""
         if check_validity:

--- a/btclib/p2p/data.py
+++ b/btclib/p2p/data.py
@@ -92,6 +92,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from typing_extensions import override
+
 from btclib.alias import BinaryData
 from btclib.block.block import Block
 from btclib.exceptions import BTClibTypeError
@@ -150,6 +152,7 @@ class TxPayload(Payload):
 
         self.tx.assert_valid()
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the transaction, witness or not as the field says."""
         if check_validity:
@@ -212,6 +215,7 @@ class BlockPayload(Payload):
 
         self.block.assert_valid()
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the block, its witnesses written or stripped."""
         if check_validity:

--- a/btclib/p2p/handshake.py
+++ b/btclib/p2p/handshake.py
@@ -67,6 +67,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from io import BytesIO
 
+from typing_extensions import override
+
 from btclib import var_bytes
 from btclib.alias import BinaryData, Octets
 from btclib.exceptions import BTClibTypeError, BTClibValueError
@@ -256,6 +258,7 @@ class Version(Payload):
             err_msg = f"invalid relay type: {type(self.relay).__name__}"  # type: ignore[unreachable]
             raise BTClibTypeError(err_msg)
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the payload, the relay octet written only if there is one."""
         if check_validity:
@@ -387,6 +390,7 @@ class Verack(Payload):
     def assert_valid(self) -> None:
         """Accept: a message with no fields has none to refuse."""
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the empty payload a `verack` is."""
         if check_validity:

--- a/btclib/p2p/inventory.py
+++ b/btclib/p2p/inventory.py
@@ -102,6 +102,8 @@ from dataclasses import dataclass
 from enum import IntEnum
 from typing import TypeVar
 
+from typing_extensions import override
+
 from btclib import var_int
 from btclib.alias import BinaryData, Octets
 from btclib.block.block_header import BlockHeader
@@ -387,6 +389,7 @@ class _InventoryPayload(Payload):
                 raise BTClibTypeError(err_msg)
             item.assert_valid()
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the count, then that many inventory entries."""
         if check_validity:
@@ -532,6 +535,7 @@ class _LocatorPayload(Payload):
 
         _assert_valid_hash(self.hash_stop, "hash_stop length")
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the version, the locator, then the stop hash."""
         if check_validity:
@@ -647,6 +651,7 @@ class Headers(Payload):
                 raise BTClibTypeError(err_msg)
             header.assert_valid()
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the count, then each header and the zero after it."""
         if check_validity:

--- a/btclib/p2p/keepalive.py
+++ b/btclib/p2p/keepalive.py
@@ -34,6 +34,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TypeVar
 
+from typing_extensions import override
+
 from btclib.alias import BinaryData
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.p2p.payload import Payload
@@ -90,6 +92,7 @@ class _NoncePayload(Payload):
         if not 0 <= self.nonce <= _MAX_NONCE:
             raise BTClibValueError(f"invalid nonce: {self.nonce}")
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the eight octets of the nonce, little-endian."""
         if check_validity:

--- a/btclib/p2p/negotiation.py
+++ b/btclib/p2p/negotiation.py
@@ -76,6 +76,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from typing_extensions import override
+
 from btclib.alias import BinaryData
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.p2p.payload import Payload
@@ -127,6 +129,7 @@ class GetAddr(Payload):
     def assert_valid(self) -> None:
         """Accept: a message with no fields has none to refuse."""
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the empty payload a `getaddr` is."""
         if check_validity:
@@ -170,6 +173,7 @@ class Mempool(Payload):
     def assert_valid(self) -> None:
         """Accept: a message with no fields has none to refuse."""
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the empty payload a `mempool` is."""
         if check_validity:
@@ -216,6 +220,7 @@ class SendHeaders(Payload):
     def assert_valid(self) -> None:
         """Accept: a message with no fields has none to refuse."""
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the empty payload a `sendheaders` is."""
         if check_validity:
@@ -269,6 +274,7 @@ class WtxidRelay(Payload):
     def assert_valid(self) -> None:
         """Accept: a message with no fields has none to refuse."""
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the empty payload a `wtxidrelay` is."""
         if check_validity:
@@ -331,6 +337,7 @@ class FeeFilter(Payload):
         if not _MIN_INT64 <= self.feerate <= _MAX_INT64:
             raise BTClibValueError(f"invalid feerate: {self.feerate}")
 
+    @override
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the eight octets of the fee rate, little-endian."""
         if check_validity:

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
+from typing_extensions import override
+
 from btclib import b32, b58, var_bytes
 from btclib.alias import Octets, ScriptList, ScriptType, String, TaprootScriptTree
 from btclib.curves import point_from_octets
@@ -569,6 +571,7 @@ class ScriptPubKey(Script):
         except BTClibValueError:
             return [self.address]
 
+    @override
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ScriptPubKey):
             return NotImplemented
@@ -590,6 +593,7 @@ class ScriptPubKey(Script):
             return False
         return super().__eq__(other)
 
+    @override
     def __hash__(self) -> int:
         # the script and the network *type*, which is what __eq__ above
         # compares: hashing the network *name* would put a signet
@@ -615,6 +619,7 @@ class ScriptPubKey(Script):
         # the script a second time
         super().__init__(script, check_validity=check_validity)
 
+    @override
     def assert_valid(self) -> None:
         """Run Script's checks, then refuse a network name not in NETWORKS."""
         super().assert_valid()

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -13,6 +13,8 @@ from io import SEEK_CUR
 from math import ceil
 from typing import Any
 
+from typing_extensions import override
+
 from btclib import var_int
 from btclib.alias import BinaryData
 from btclib.amount import _MAX_SATOSHI
@@ -243,6 +245,7 @@ class Tx:  # noqa: PLW1641
         if check_validity:
             self.assert_valid()
 
+    @override
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Tx):
             return NotImplemented

--- a/btclib/wallet/descriptor_wallet.py
+++ b/btclib/wallet/descriptor_wallet.py
@@ -53,6 +53,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 
+from typing_extensions import override
+
 from btclib.alias import BIP44ScriptType, Octets
 from btclib.bip32.bip32 import BIP32Key
 from btclib.bip32.der_path import DerPath
@@ -184,11 +186,13 @@ class DescriptorWallet(RangedWallet):
         )
 
     @property
+    @override
     def branches(self) -> tuple[int, ...]:
         """The chains, which are the branches the descriptors came under."""
         return tuple(self._descriptors)
 
     @property
+    @override
     def is_watch_only(self) -> bool:
         """Whether the wallet was handed no private key.
 
@@ -213,9 +217,11 @@ class DescriptorWallet(RangedWallet):
         self._assert_position(branch, 0)
         return self._descriptors[branch]
 
+    @override
     def _script_pub_key(self, branch: int, index: int) -> ScriptPubKey:
         return self._descriptors[branch].script_pub_key(index, self.prv_keys)
 
+    @override
     def redeem_script(self, branch: int = 0, index: int = 0) -> bytes:
         """Return the script a ``sh()`` at this position embeds.
 
@@ -230,6 +236,7 @@ class DescriptorWallet(RangedWallet):
             return b""
         return descriptor.inner.redeem_script(index, self.prv_keys)
 
+    @override
     def witness_script(self, branch: int = 0, index: int = 0) -> bytes:
         """Return the script a ``wsh()`` at this position embeds.
 
@@ -245,6 +252,7 @@ class DescriptorWallet(RangedWallet):
             return b""
         return descriptor.inner.redeem_script(index, self.prv_keys)
 
+    @override
     def position_of(
         self, script_pub_key: Octets | ScriptPubKey, last_index: int = _LAST_INDEX
     ) -> tuple[int, int] | None:

--- a/btclib/wallet/key_wallet.py
+++ b/btclib/wallet/key_wallet.py
@@ -44,6 +44,8 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
+from typing_extensions import override
+
 from btclib import b58
 from btclib.alias import BIP44ScriptType, Octets, String
 from btclib.bip32.bip32 import (
@@ -183,6 +185,7 @@ class KeyWallet(Wallet):
             self.add(key)
 
     @property
+    @override
     def is_watch_only(self) -> bool:
         """Whether the wallet holds no private key at all."""
         return not self._prv_keys
@@ -338,6 +341,7 @@ class BIP32KeyWallet(KeyWallet, RangedWallet):
         return derive_(xkey, indexes[xkey.depth :])
 
     @property
+    @override
     def branches(self) -> tuple[int, ...]:
         """The receiving and change chains, which is what BIP44 defines.
 
@@ -348,6 +352,7 @@ class BIP32KeyWallet(KeyWallet, RangedWallet):
         return (0, 1)
 
     @property
+    @override
     def is_watch_only(self) -> bool:
         """Whether the wallet holds no private key at all.
 
@@ -373,6 +378,7 @@ class BIP32KeyWallet(KeyWallet, RangedWallet):
         """
         return derive_from_account_(self._xkey, branch, index)
 
+    @override
     def _address(self, branch: int, index: int) -> str:
         # checked again for the narrowing and not for the check, which the
         # constructor already made: see `add` above
@@ -380,6 +386,7 @@ class BIP32KeyWallet(KeyWallet, RangedWallet):
             self._derived_xkey(branch, index), self.network
         )
 
+    @override
     def _script_pub_key(self, branch: int, index: int) -> ScriptPubKey:
         """Return the output of a position, read back from its address.
 
@@ -392,9 +399,11 @@ class BIP32KeyWallet(KeyWallet, RangedWallet):
         """
         return ScriptPubKey.from_address(self._address(branch, index))
 
+    @override
     def _der_path(self, branch: int, index: int) -> str:
         return f"{self.der_path}/{branch}/{index}"
 
+    @override
     def redeem_script(self, branch: int = 0, index: int = 0) -> bytes:
         """Return the p2wpkh script a `p2wpkh-p2sh` output commits to.
 
@@ -408,6 +417,7 @@ class BIP32KeyWallet(KeyWallet, RangedWallet):
         self._assert_position(branch, index)
         return ScriptPubKey.p2wpkh(self._derived_xkey(branch, index)).script
 
+    @override
     def prv_key(self, address: String) -> str:
         """Return the WIF of the private key signing for an address."""
         info = self.address_info(address)

--- a/btclib/wallet/script_wallet.py
+++ b/btclib/wallet/script_wallet.py
@@ -128,6 +128,8 @@ from copy import deepcopy
 from dataclasses import replace
 from typing import Any
 
+from typing_extensions import override
+
 from btclib.alias import Command, EmbeddedScriptType, KeyOrder, ScriptList
 from btclib.bip32.bip32 import (
     BIP32Key,
@@ -404,6 +406,7 @@ class KeyGroup:
         self.threshold = threshold
         self.verify = verify
 
+    @override
     def __repr__(self) -> str:
         """Return the quorum, and no key: one of them may be an xprv."""
         verify = ", verify=True" if self.verify else ""
@@ -474,6 +477,7 @@ class ScriptWallet(RangedWallet):
             raise BTClibValueError(err_msg)
 
     @property
+    @override
     def branches(self) -> tuple[int, ...]:
         """The receiving and change chains, which is what BIP44 defines.
 
@@ -484,6 +488,7 @@ class ScriptWallet(RangedWallet):
         return (0, 1)
 
     @property
+    @override
     def is_watch_only(self) -> bool:
         """Whether no key of any group is a private one."""
         return not any(
@@ -551,9 +556,11 @@ class ScriptWallet(RangedWallet):
                 commands.append(command)
         return serialize(commands)
 
+    @override
     def _script_pub_key(self, branch: int, index: int) -> ScriptPubKey:
         return self._output(self._script(branch, index), self.network)
 
+    @override
     def redeem_script(self, branch: int = 0, index: int = 0) -> bytes:
         """Return the script a p2sh output at this position commits to.
 
@@ -571,6 +578,7 @@ class ScriptWallet(RangedWallet):
             return script
         return ScriptPubKey.p2wsh(script, self.network).script
 
+    @override
     def witness_script(self, branch: int = 0, index: int = 0) -> bytes:
         """Return the script a p2wsh output at this position commits to.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ requires-python = ">=3.10"
 # the reasoning, beside the ceiling argument it already makes.
 dependencies = [
     "bitcoin-core-rpc>=2026.8.13",
+    # `typing.override` is 3.12's and the floor is 3.10, so the decorator
+    # explicit-override asks for comes from the backport; 4.4 is the
+    # release that adds it
+    "typing-extensions>=4.4",
 ]
 keywords = [
     # The GitHub repository topics, in the same order, and the order is by
@@ -706,36 +710,25 @@ fail_under = 100.0
 strict = true
 show_column_numbers = true
 show_error_codes = true
-# the optional error codes strict does not turn on, surveyed one by one
-# over btclib and tests. ignore-without-code makes every "type: ignore"
-# name the rule it silences, so a blanket one cannot creep in, and
-# deprecated reports a stdlib API on its way out, which on a 3.10 to 3.14
-# spread is the same early warning filterwarnings = ["error"] buys at
-# runtime.
-#
-# redundant-expr and possibly-undefined are the two more --enable-error-code
-# adds beyond what a first pass found clean, and warn_unreachable below is
-# the flag mypy exposes the third one through rather than through this
-# list. All three found something: a runtime isinstance guard on a value
-# whose static type promises more than an untrusted source -- unvalidated
-# json in network.py's from_dict, a caller ignoring an annotation in
-# bip21.py, an operator's own dispatch protocol in script.py's __add__ --
-# can guarantee. Each of those sites carries its own
-# `# type: ignore[...]` naming the code rather than a second global
-# exemption: the check is worth having everywhere else, and a blanket
-# ignore-list entry would have silenced it there too
+# the organization's list, the same in every repository that runs mypy
+# (section 6 of the standard, btclib-org/.github#165), and nothing else
+# in this key: a code that finds nothing today is a ratchet, catching the
+# next line written after it. Where a check and not the annotation has to
+# yield, the line carries a `# type: ignore[code]` with the reason,
+# rather than the code leaving this list
 enable_error_code = [
     "deprecated",
     "exhaustive-match",
+    "explicit-override",
     "ignore-without-code",
     "mutable-override",
-    "narrowed-type-not-subtype",
     "possibly-undefined",
     "redundant-expr",
     "redundant-self",
     "truthy-bool",
     "truthy-iterable",
     "unimported-reveal",
+    "unused-awaitable",
 ]
 warn_unreachable = true
 # the oldest interpreter this package supports, and also the oldest mypy

--- a/tests/check_validity_test.py
+++ b/tests/check_validity_test.py
@@ -37,6 +37,7 @@ import pathlib
 from typing import Any
 
 import pytest
+from typing_extensions import override
 
 from btclib.amount import _MAX_SATOSHI
 from btclib.curves import secp256k1
@@ -344,10 +345,12 @@ def test_a_nested_object_is_left_the_flag_it_was_given() -> None:
     """
 
     class RejectingWitness(Witness):
+        @override
         def assert_valid(self) -> None:
             raise BTClibValueError("invalid witness")
 
     class RejectingTxOut(TxOut):
+        @override
         def assert_valid(self) -> None:
             raise BTClibValueError("invalid output")
 

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -8,6 +8,7 @@ import random
 from functools import partial
 
 import pytest
+from typing_extensions import override
 
 from btclib.alias import INF, INFJ, JacPoint, Point
 from btclib.curves import Curve, CurveGroup, find_all_points, secp256k1
@@ -439,10 +440,12 @@ class _CountingGroup(CurveGroup):
         super().__init__(secp256k1.p, 0, 7)
         self.additions = 0
 
+    @override
     def add_jac(self, Q: JacPoint, R: JacPoint) -> JacPoint:
         self.additions += 1
         return super().add_jac(Q, R)
 
+    @override
     def add_jac_aff(self, Q: JacPoint, R: Point) -> JacPoint:
         # counted beside add_jac and not apart from it: what the test
         # below is about is how many additions a scalar costs, and the

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -16,6 +16,7 @@ from math import ceil, isqrt, sqrt
 from typing import Any
 
 import pytest
+from typing_extensions import override
 
 from btclib.alias import INF, INFJ, Integer, JacPoint, Point
 from btclib.curves import (
@@ -503,32 +504,40 @@ class _CountedInt(int):
 
     calls = 0
 
+    @override
     def __mul__(self, other: int) -> "_CountedInt":
         _CountedInt.calls += 1
         return _CountedInt(int(self) * int(other))
 
+    @override
     def __rmul__(self, other: int) -> "_CountedInt":
         return self * other
 
+    @override
     def __mod__(self, other: int) -> "_CountedInt":
         _CountedInt.calls += 1
         return _CountedInt(int(self) % int(other))
 
+    @override
     def __rmod__(self, other: int) -> "_CountedInt":
         _CountedInt.calls += 1
         return _CountedInt(int(other) % int(self))
 
+    @override
     def __add__(self, other: int) -> "_CountedInt":
         _CountedInt.calls += 1
         return _CountedInt(int(self) + int(other))
 
+    @override
     def __radd__(self, other: int) -> "_CountedInt":
         return self + other
 
+    @override
     def __sub__(self, other: int) -> "_CountedInt":
         _CountedInt.calls += 1
         return _CountedInt(int(self) - int(other))
 
+    @override
     def __rsub__(self, other: int) -> "_CountedInt":
         _CountedInt.calls += 1
         return _CountedInt(int(other) - int(self))

--- a/tests/fetch/__init__.py
+++ b/tests/fetch/__init__.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 from pathlib import Path
 from urllib.request import Request
 
+from typing_extensions import override
+
 from btclib.alias import Octets
 from btclib.fetch.fetcher import Fetcher
 from btclib.tx import Tx
@@ -96,15 +98,18 @@ class StubFetcher(Fetcher):
         self.tx = tx
         self.asked: list[str] = []
 
+    @override
     def get_tx(self, tx_id: Octets) -> Tx:
         """Record the tx_id asked for and answer the fixed transaction."""
         self.asked.append(bytes(tx_id).hex() if not isinstance(tx_id, str) else tx_id)
         return self.tx
 
+    @override
     def get_block_count(self) -> int:
         """Answer the tip height the recorded responses report."""
         return TIP_HEIGHT
 
+    @override
     def get_best_block_id(self) -> bytes:
         """Answer the tip block id the recorded responses report."""
         return bytes.fromhex(TIP_ID)

--- a/tests/fetch/bitcoin_core_test.py
+++ b/tests/fetch/bitcoin_core_test.py
@@ -34,6 +34,7 @@ from bitcoin_core_rpc import (
     chain_from_network,
     network_from_chain,
 )
+from typing_extensions import override
 
 from btclib.exceptions import BTClibValueError, FetchError, HttpError, RpcError
 from btclib.fetch.bitcoin_core import BitcoinCoreFetcher
@@ -81,6 +82,7 @@ def echoed(body: bytes, request_id: str) -> bytes:
 class Echoing(Recorded):
     """A Recorded answering with the request's own id, as a node does."""
 
+    @override
     def __call__(self, request: Request, timeout: float) -> tuple[int, bytes]:
         """Answer the next scripted reply, with this request's id in it."""
         status, body = super().__call__(request, timeout)

--- a/tests/mnemonic/mnemonic_test.py
+++ b/tests/mnemonic/mnemonic_test.py
@@ -10,6 +10,7 @@ from typing import Any, get_args
 from unicodedata import normalize
 
 import pytest
+from typing_extensions import override
 
 from btclib.alias import MnemonicLang
 from btclib.exceptions import BTClibValueError
@@ -318,6 +319,7 @@ def test_load_lang_is_not_a_race() -> None:
     class BlockingDict(dict[str, list[str]]):
         """Block inside the assignment the race needed to interleave."""
 
+        @override
         def __setitem__(self, key: str, value: list[str]) -> None:
             # `no branch`: this test loads one language, so the guard is
             # never false here. It is what keeps the block to the

--- a/tests/psbt/psbt_view_test.py
+++ b/tests/psbt/psbt_view_test.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from typing_extensions import override
 
 from btclib import var_int
 from btclib.exceptions import BTClibValueError
@@ -315,6 +316,7 @@ class _CountingStream(BytesIO):
         super().__init__(initial_bytes)
         self.read_count = 0
 
+    @override
     def read(self, size: int | None = -1, /) -> bytes:
         data = super().read(size)
         self.read_count += len(data)
@@ -470,6 +472,7 @@ def test_a_stream_that_cannot_seek_is_refused() -> None:
     """
 
     class Pipe(BytesIO):
+        @override
         def seekable(self) -> bool:
             return False
 

--- a/tests/psbt_signer_contract_test.py
+++ b/tests/psbt_signer_contract_test.py
@@ -16,6 +16,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import pytest
+from typing_extensions import override
 
 from btclib.bip32.bip32 import derive
 from btclib.bip32.key_origin import BIP32KeyOrigin
@@ -119,6 +120,7 @@ def test_a_fingerprint_of_the_wrong_width_is_refused() -> None:
 
     class _TooLong(_Wrapper):
         @property
+        @override
         def master_fingerprint(self) -> bytes:
             return b"\x00" * 5
 
@@ -129,6 +131,7 @@ def test_a_fingerprint_of_the_wrong_width_is_refused() -> None:
     # three-byte fingerprint is what a key origin would then be written to
     class _TooShort(_Wrapper):
         @property
+        @override
         def master_fingerprint(self) -> bytes:
             return b"\x00" * 3
 
@@ -145,6 +148,7 @@ def test_a_fingerprint_that_changes_is_refused() -> None:
             self._asked = 0
 
         @property
+        @override
         def master_fingerprint(self) -> bytes:
             self._asked += 1
             return bytes([self._asked, 0, 0, 0])
@@ -161,6 +165,7 @@ def test_a_fingerprint_that_changes_is_refused() -> None:
             self._asked = 4
 
         @property
+        @override
         def master_fingerprint(self) -> bytes:
             self._asked -= 1
             return bytes([self._asked, 0, 0, 0])
@@ -173,6 +178,7 @@ def test_an_xpub_that_is_not_an_extended_key_is_refused() -> None:
     """A string is a string: that it spells a key is not a type."""
 
     class _Nonsense(_Wrapper):
+        @override
         def xpub(self, der_path: DerPath) -> str:
             return "not a key at all"
 
@@ -184,6 +190,7 @@ def test_an_xpub_that_is_private_is_refused() -> None:
     """The one answer that is not merely wrong."""
 
     class _Leaking(_Wrapper):
+        @override
         def xpub(self, der_path: DerPath) -> str:
             return derive(bip39.mxprv_from_mnemonic(_MNEMONIC, "", "mainnet"), der_path)
 
@@ -199,6 +206,7 @@ def test_an_xpub_that_changes_is_refused() -> None:
             super().__init__()
             self._asked = 0
 
+        @override
         def xpub(self, der_path: DerPath) -> str:
             self._asked += 1
             return self._signer.xpub(f"m/84h/0h/{self._asked}h")
@@ -213,6 +221,7 @@ def test_an_xpub_that_changes_is_refused() -> None:
             super().__init__()
             self._asked = 4
 
+        @override
         def xpub(self, der_path: DerPath) -> str:
             self._asked -= 1
             return self._signer.xpub(f"m/84h/0h/{self._asked}h")
@@ -232,6 +241,7 @@ def test_signing_an_input_of_another_master_is_refused() -> None:
     """
 
     class _Rogue(_Wrapper):
+        @override
         def sign_psbt(self, psbt: Psbt) -> Psbt:
             answer = deepcopy(psbt)
             psbt_in = answer.inputs[0]
@@ -251,6 +261,7 @@ def test_a_signer_that_signs_nothing_it_was_said_to_sign_is_refused() -> None:
     """The end-to-end half: the caller says it can, so it has to."""
 
     class _Idle(_Wrapper):
+        @override
         def sign_psbt(self, psbt: Psbt) -> Psbt:
             return deepcopy(psbt)
 
@@ -272,6 +283,7 @@ def test_a_conforming_signer_is_closed_twice() -> None:
     closed = 0
 
     class _Counting(_Wrapper):
+        @override
         def close(self) -> None:
             nonlocal closed
             closed += 1
@@ -303,6 +315,7 @@ def test_capabilities_that_change_are_refused() -> None:
             self._asked = 0
 
         @property
+        @override
         def capabilities(self) -> SignerCapabilities:
             self._asked += 1
             return SignerCapabilities(taproot=self._asked % 2 == 0)
@@ -377,6 +390,7 @@ def test_a_signer_that_adds_nothing_to_a_signed_quorum_is_refused() -> None:
     """
 
     class _Idle(_Wrapper):
+        @override
         def sign_psbt(self, psbt: Psbt) -> Psbt:
             return deepcopy(psbt)
 

--- a/tests/psbt_signer_test.py
+++ b/tests/psbt_signer_test.py
@@ -18,6 +18,7 @@ from base64 import b64encode
 from copy import deepcopy
 
 import pytest
+from typing_extensions import override
 
 from btclib.alias import Octets
 from btclib.bip32 import fingerprint
@@ -297,6 +298,7 @@ def test_an_xpub_that_is_not_the_account_is_refused() -> None:
     """
 
     class _WrongAccount(_Signer):
+        @override
         def xpub(self, der_path: DerPath) -> str:
             """Answer with the next account, whatever was asked."""
             return xpub_from_xprv(derive(self.xprv, "m/84h/0h/1h"))
@@ -475,6 +477,7 @@ class _Counting(_Signer):
         super().__init__()
         self.requests: list[Psbt] = []
 
+    @override
     def sign_psbt(self, psbt: Psbt) -> Psbt:
         """Record the request, then sign it as the double does."""
         self.requests.append(psbt)
@@ -492,6 +495,7 @@ class _Refusing(SignerDecorator):
         super().__init__(signer)
         self.limit = limit
 
+    @override
     def sign_psbt(self, psbt: Psbt) -> Psbt:
         """Sign, unless an output pays more than the limit allows."""
         for out in psbt.tx.vout:

--- a/tests/script/script_test.py
+++ b/tests/script/script_test.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from typing_extensions import override
 
 from btclib.alias import ScriptList
 from btclib.exceptions import BTClibValueError
@@ -208,6 +209,7 @@ def test_pushdata4_and_the_only_length_left_to_refuse() -> None:
 
     # __len__ lies rather than have the test allocate four gibibytes
     class TooLong(bytes):
+        @override
         def __len__(self) -> int:
             return 4294967296
 

--- a/tests/tx/tx_in_test.py
+++ b/tests/tx/tx_in_test.py
@@ -8,6 +8,7 @@ from dataclasses import FrozenInstanceError
 from pathlib import Path
 
 import pytest
+from typing_extensions import override
 
 from btclib import var_int
 from btclib.consensus import WITNESS_SCALE_FACTOR
@@ -123,6 +124,7 @@ def test_an_empty_witness_is_still_validated() -> None:
     """Validation dispatches to a witness even when its stack is empty."""
 
     class RejectingWitness(Witness):
+        @override
         def assert_valid(self) -> None:
             raise BTClibValueError("invalid witness")
 

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from typing_extensions import override
 
 from btclib import var_int
 from btclib.consensus import MAX_BLOCK_WEIGHT, WITNESS_SCALE_FACTOR
@@ -865,6 +866,7 @@ def test_eq_witness(monkeypatch: pytest.MonkeyPatch) -> None:
     class TxInIgnoringWitness(TxIn):  # noqa: PLW1641
         """A TxIn compared on everything but its witness."""
 
+        @override
         def __eq__(self, other: object) -> bool:
             if not isinstance(other, TxIn):
                 return NotImplemented

--- a/tests/wallet/wallet_test.py
+++ b/tests/wallet/wallet_test.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import pytest
+from typing_extensions import override
 
 from btclib.bip32 import bip32
 from btclib.exceptions import BTClibTypeError, BTClibValueError
@@ -372,13 +373,16 @@ def test_a_span_of_one_output_repeated_is_no_span() -> None:
         """A wallet paying to the same anyone-can-spend script everywhere."""
 
         @property
+        @override
         def is_watch_only(self) -> bool:
             return True
 
         @property
+        @override
         def branches(self) -> tuple[int, ...]:
             return (0,)
 
+        @override
         def _script_pub_key(self, branch: int, index: int) -> ScriptPubKey:
             return ScriptPubKey(b"\x51")
 
@@ -404,9 +408,11 @@ def test_a_wallet_that_names_no_branches_is_not_a_wallet() -> None:
         """A wallet with an output at every position and no chains."""
 
         @property
+        @override
         def is_watch_only(self) -> bool:
             return True
 
+        @override
         def _script_pub_key(self, branch: int, index: int) -> ScriptPubKey:
             return ScriptPubKey(b"\x51")
 
@@ -419,6 +425,7 @@ def test_a_wallet_that_names_no_branches_is_not_a_wallet() -> None:
         """The same wallet, on the receiving chain alone."""
 
         @property
+        @override
         def branches(self) -> tuple[int, ...]:
             return (0,)
 

--- a/uv.lock
+++ b/uv.lock
@@ -314,6 +314,7 @@ version = "2026.9"
 source = { editable = "." }
 dependencies = [
     { name = "bitcoin-core-rpc" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -394,6 +395,7 @@ test = [
 requires-dist = [
     { name = "bitcoin-core-rpc", specifier = ">=2026.8.13" },
     { name = "btclib-secp256k1", marker = "extra == 'secp256k1'", specifier = ">=0.8.0.4" },
+    { name = "typing-extensions", specifier = ">=4.4" },
 ]
 provides-extras = ["secp256k1"]
 


### PR DESCRIPTION
Under btclib-org/.github#34's regime: local gates the gate (pre-commit 0, `sphinx -W` 0, mypy 0 over 308 source files, and the whole suite 0 — 29661 passed, 100% — run by the reviewer on this sha as `REVIEWING.md` now asks), one local review round (`CLEARED 53ab9e93c4d6a2ec09246171a6f0fa5890a94bfe`), landed by admin bypass pinned to that sha.

btclib-org/.github#165, the maintainer's decision: `enable_error_code` is section 6's list, the same in every tree. Here that adds `explicit-override` and `unused-awaitable` and drops `narrowed-type-not-subtype`, which the locked mypy turns on unasked (measured, both by the author and the review). `explicit-override` is the code that had findings: `@override` on every method that overrides one, innermost where decorators stack, so it decorates the function and not the property. `typing.override` is 3.12 and the floor is 3.10, so `typing-extensions>=4.4` — the release that adds the decorator — becomes a declared dependency, the import being in `btclib/` at runtime; `uv.lock` moves two lines, the package having already been in the graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFB7QST7JN4J8RToymde1k

## Summary by Sourcery

Align mypy enforcement with the organization's shared error-code policy and mark all overriding methods explicitly.

Enhancements:
- Standardize mypy's enabled error-code configuration across the organization by adding explicit override and unused awaitable checks while removing the redundant narrowed-type-not-subtype entry.
- Annotate overriding methods throughout the library and tests with the typing-extensions override decorator.

Build:
- Add typing-extensions>=4.4 as a runtime dependency for Python 3.10 compatibility with typing.override.

Documentation:
- Document the new typing-extensions dependency and mypy configuration in contributor guidance and the changelog.

Tests:
- Update test helper classes and fixtures to satisfy explicit override checking.