### PR TITLE
REVIEWING.md excepts no gate from the run a reviewer relies on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,12 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
-- **`REVIEWING.md` says the reviewer runs the whole suite, every time.**
-  The organization's copy, shared half byte for byte (section 14): the
-  test suite is run whole on the sha under review, never a subset and
-  never relied on from the author's run.
+- **`REVIEWING.md`'s *The gates are the evidence* excepts no gate from
+  the run a reviewer may rely on, the test suite included.** The
+  organization's copy, shared half byte for byte (section 14): a run is
+  whole whoever makes it — never a module on its own, a `-k`, a `--lf`,
+  a deselect or a marker in its place — and one that was narrowed or cut
+  short is reported as no run (btclib-org/.github#168).
 
 - **`REVIEWING.md` is the organization's copy.** A review reads the prose
   that stays in the tree, treats a commit message or a pull request's

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -278,26 +278,24 @@ a pipe into `grep -v Passed` hides the failure it was meant to find.
 **What the gates of this tree are is `CONTRIBUTING.md`'s last
 section**, and so is every way a run of them lies — a suite run over a
 subset that is not the coverage gate, a hook set that is not the whole
-of what CI runs. A reviewer who names a
-gate this repository does not have has reported nothing.
+of what CI runs. A reviewer who names a gate this repository does not
+have has reported nothing.
 
-**The whole suite, every time.** The test suite is run whole, on the
-sha under review, by the reviewer — never a module on its own, a `-k`,
-a `--lf`, a deselect or a marker in its place, and never relied on from
-somebody else's run. What a change breaks is found by the test that did
-not expect to be touched by it, and a subset is chosen by what the
-author expected. Where the suite is long it runs in the background with
-a ceiling, and what is reported is its exit code; a run that was cut
-short or narrowed is reported as no run.
+**Whole, whoever runs it.** A suite is run whole — never a module on
+its own, a `-k`, a `--lf`, a deselect or a marker in its place. What a
+change breaks is found by the test that did not expect to be touched by
+it, and a subset is chosen by what the author expected, so a run that
+was narrowed or cut short is no run and is reported as none. Where the
+suite is long it runs in the background with a ceiling, and what is
+reported is its exit code.
 
-**The other gates, unless they have already been run on this sha and
-that run is on the record.** Then rely on it, and say whose it is. Two
-runs qualify: the workflows of the required checks, running beside a
-review on the same commit — `CONTRIBUTING.md` names which checks those
-are — and an author handing over a branch they gated themselves and
-said so. What is relied on is that those gates run and hold the merge,
-not the colour of a check, which stays none of a reviewer's business
-for the reason below.
+**Unless they have already been run on this sha and that run is on the
+record.** Then rely on it, and say whose it is. Two runs qualify: the
+workflows of the required checks, running beside a review on the same
+commit — `CONTRIBUTING.md` names which checks those are — and an author
+handing over a branch they gated themselves and said so. What is relied
+on is that those gates run and hold the merge, not the colour of a
+check, which stays none of a reviewer's business for the reason below.
 
 The sha is the whole of the condition: a run on another tree is not a run
 on this one, so a rebase voids it — the branch was gated, and then the


### PR DESCRIPTION
`REVIEWING.md` is a section 14 verbatim file, and this is its shared half
brought back to the organization's copy, `btclib-org/.github` at
`d0c7c48685bb62f12259250f1d3e8db7f10ab9a8`. The tail from
`## This repository in particular` on is untouched, byte for byte.

What changed there: *The gates are the evidence* no longer excepts the
test suite from the run a reviewer may rely on. The exception cost a
second full run of what the author had already run and bought nothing
the record did not carry. The paragraph now says what a run has to be
rather than who has to make it — whole, never a module or a `-k`, a
`--lf`, a deselect or a marker in its place, and a run narrowed or cut
short is reported as no run. Where nothing is on the record the reviewer
still runs it.

The `CHANGELOG.md` bullet replaces its predecessor rather than sitting
beside it: that bullet stated the withdrawn rule, and this diff is what
makes it false, so it is this diff's to fix. Its section is unreleased in
every tree, so nothing released is rewritten.

The copy was verified by the audit suite's own slicing — `shared ==
canon`, where `shared` is `body[:body.find(b"\n## This repository in
particular\n")]` — twice: in the worktree before the commit, and read
back from the API on the pushed branch. The blank line before the marker
that btclib-org/.github#160 is about was already present and needed no
change.

## Summary by Sourcery

Allow reviewers to rely on recorded complete gate runs, including the test suite, while rejecting narrowed or incomplete runs.

Enhancements:
- Clarify that all review gates, including the full test suite, may be relied on when run whole on the reviewed commit and recorded, regardless of who ran them.

Documentation:
- Update the shared reviewing guidance to define partial or interrupted gate runs as no run and preserve the existing recorded-run requirements.

Chores:
- Align the unreleased changelog entry with the revised reviewing policy.