### PR TITLE
CONTRIBUTING.md matches the tree it documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1476,6 +1476,17 @@ documented at release-notes length in the first place, and are still in
 
 ### Documentation and the website
 
+- **CONTRIBUTING.md's documented mypy command and its workflow-schedule
+  sentence match the tree** (issues #1281, #1271). The mypy invocation
+  named a root `scripts` directory; `git ls-files` finds none there, and
+  running the command as printed exits 2, where `.pre-commit-config.yaml`'s
+  own mypy hook, which does not carry that path, passes. The sentence
+  pointing a contributor at the organization standard's schedule table
+  stated how many repositories share that calendar — the shape
+  CONTRIBUTING.md itself asks against — and now keeps only the reasoning
+  for reading the schedule from one place rather than a copy per
+  repository, with no number for the standard's table to outgrow again.
+
 - **The Esplora module names the second deployment its own argument
   rests on** (issue #1130). Its docstring says the backend is an api and
   not a product, and gave "several operators run it" as the evidence --

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -341,7 +341,7 @@ These requirements are easily checked (and partially fixed) with:
 ```shell
 uv run ruff check --fix
 uv run ruff format
-uv run mypy btclib tests .github/scripts scripts
+uv run mypy btclib tests .github/scripts
 uv run pytest
 ```
 
@@ -449,8 +449,8 @@ and `docs` share a row and report one each. They run one image on one
 interpreter: `ubuntu-latest`, and the version `.python-version` names.
 Which day each of the rest runs is section 10 of the organization
 standard, in `btclib-org/.github`, and not this file's to restate — one
-calendar covering six repositories is one thing to remember, and six
-copies of it are six things to keep true.
+calendar in one place is one thing to keep true, where a copy of it in
+every repository would be one more.
 
 Why so little gates is one number: the ceiling GitHub Free puts on an
 organization's concurrent jobs, twenty shared across every repository in


### PR DESCRIPTION
Two stale references in CONTRIBUTING.md, fixed together since both are in that one file.

- The documented mypy command named a root `scripts` directory that no longer exists (`86770585` / #861 moved it out); running the command as printed exits 2. Drops `scripts` from the command so it matches `.pre-commit-config.yaml`'s own mypy hook, which never carried that path.
- The schedule-calendar sentence stated a repository count ("six"), against this file's own no-stated-counts rule and factually wrong (the organization standard's table lists eight today). Drops the number, keeps the reasoning.

Closes #1281, closes #1271.

## Summary by Sourcery

Align CONTRIBUTING.md with the current repository structure and organization scheduling guidance.

Bug Fixes:
- Correct the documented mypy command so it no longer references the removed root scripts directory.
- Remove the outdated repository count from the workflow-schedule guidance while preserving its rationale.

Documentation:
- Update the changelog to record the CONTRIBUTING.md documentation corrections.