### PR TITLE
codeql.yml's aggregate job names a context no branch rule can require

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,10 +56,12 @@ on:
   # Free gives an organization twenty concurrent jobs, a commit used to ask
   # for thirty-nine, and this workflow's three of them were held while a
   # pull request waited for a slot -- so the analysis now lands on the merge
-  # commit rather than before it, and the aggregate below is no longer a
-  # required check on main. REPOSITORY.md's "Required checks on main" is
-  # where that rule is written down, and dropping the context there is a
-  # token operation that had to come first.
+  # commit rather than before it, and nothing this workflow produces can be
+  # a required check on main: a required check has to report on the pull
+  # request's own run, and this trigger produces none. REPOSITORY.md's
+  # "Required checks on main" is where that rule is written down, and
+  # dropping the `CodeQL` context there is a token operation that had to
+  # come first.
   # What still reads a branch before it merges is lint.yml: zizmor is a
   # pre-commit hook and reads exactly these files for an injected
   # expression, which is the finding this workflow would otherwise be alone
@@ -122,8 +124,8 @@ jobs:
     # far above what either language needs; what it bounds is a hung job
     # holding a runner for six hours
     timeout-minutes: 20
-    # the elevation, on the job that needs it and nowhere else: the
-    # aggregate below declares nothing and inherits the workflow default.
+    # the elevation, on the job that needs it and nowhere else: no other
+    # job in this workflow declares permissions, so no other job elevates.
     # security-events: write is what uploading a SARIF to code scanning
     # takes, and the whole reason this job cannot run on the read-only
     # token. actions: read is redundant while this repository is public --
@@ -197,45 +199,11 @@ jobs:
           # rather than starting again
           category: "/language:${{ matrix.language }}"
 
-  # one answer to read per commit rather than one per language, which is
-  # what this job is for now that main's branch protection does not require
-  # it -- REPOSITORY.md's table is where that changed, and why. Kept rather
-  # than deleted because the name is then still produced: requiring this
-  # workflow again is a patch to the rule and nothing in the tree, which is
-  # the half of the exchange that cannot be made in a pull request.
-  # The matrix above produces one check per language, and a rule naming
-  # those directly would mean a setting to edit -- one no pull request can
-  # review -- every time the matrix moves. This job depends on the matrix
-  # instead, so adding a language is enough to be covered by it
-  codeql-passed:
-    # the name is what branch protection matches, and it carries the
-    # workflow on purpose: a context is keyed by name alone, so two
-    # workflows with a job named "every job passed" would produce one
-    # ambiguous check. The pattern, and the reasoning behind every line of
-    # it, is test.yml's own aggregate -- which is still required, so the two
-    # names must not converge
-    name: "codeql: every job passed"
-    needs: [analyze]
-    # not success(): a job whose dependencies failed is skipped, and a
-    # skipped check reports "skipped", which reads as satisfied wherever a
-    # check is read at all. The gate has to run to be able to fail
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      # the condition reads the whole needs context rather than testing
-      # each job by name, so a job added to needs above is covered
-      # without touching this. "skipped" is a failure here too: nothing
-      # in this workflow is conditional, so a skip means something
-      # upstream did not run.
-      # What a run of it costs, whenever the number is wanted again:
-      #   gh api repos/btclib-org/btclib/actions/runs/<id>/jobs \
-      #     --jq '.jobs[] | "\(.name) \(.started_at) \(.completed_at)"'
-      - name: Fail unless every job above succeeded
-        if: >-
-          contains(needs.*.result, 'failure') ||
-          contains(needs.*.result, 'cancelled') ||
-          contains(needs.*.result, 'skipped')
-        run: |
-          echo "::error::a job this gate depends on did not succeed"
-          exit 1
+  # no aggregate job, where test.yml has one. Section 10 of
+  # btclib-org/.github's README.md conditions one on a workflow whose
+  # answer gates a pull request: a branch rule can only name a context a
+  # pull request's own run produces, and the `on:` block above has no
+  # `pull_request` trigger, so no rule could ever require a name this
+  # workflow produces. `analyze`'s two matrix cells are therefore the
+  # whole of the checks list this workflow contributes to a commit, one
+  # per language rather than one aggregate over both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -488,6 +488,16 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **`codeql.yml` no longer carries an aggregate job.** `codeql-passed`
+  produced `codeql: every job passed`, a context branch protection has
+  never named — `codeql.yml`'s `on:` block has no `pull_request` trigger,
+  and a required check has to report on the pull request's own run.
+  Section 10 of `btclib-org/.github`'s README.md now conditions an
+  aggregate on a workflow whose answer gates a pull request rather than
+  on a matrix (btclib-org/.github#90), and this workflow's does not;
+  `analyze`'s two matrix cells are the whole of the checks it
+  contributes to a commit.
+
 - **mypy's `enable_error_code` is the organization's list.** The same in
   every repository that runs mypy (btclib-org/.github#165):
   `explicit-override` and `unused-awaitable` enter, and

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -84,12 +84,13 @@ for 1375 of 2100 seconds — so a pull request's wall clock was the wait
 for a slot and not the work. That is the measurement the gate and the
 weekly sweeps are arranged around.
 
-`codeql: every job passed` is not among the required checks, and that is
-the one place a check was traded for the wait it cost. `codeql.yml` now
-runs on `main` and on its schedule, the analysis landing on the merge
-commit rather than ahead of it, and it still produces that aggregate:
-the name is available, so requiring it again is a patch to the rule and
-nothing in the tree.
+`codeql.yml` carries no required check at all, and that is the one place
+a check was traded for the wait it cost. It runs on `main` and on its
+schedule rather than on a pull request, the analysis landing on the merge
+commit rather than ahead of it — and a required check has to report on
+the pull request's own run, which this trigger never produces. Section 10
+of `btclib-org/.github`'s README.md is where that rule, and the aggregate
+job it stops this workflow from needing, are written down.
 
 What still reads a branch before it merges is the workflow half of the same
 question: `zizmor` is a pre-commit hook, so `lint.yml` audits these very
@@ -160,20 +161,20 @@ CodeQL analyses from advanced configurations cannot be processed when the
 default setup is enabled
 ```
 
-So while the setting is on, the analysing jobs and the aggregate are red
-rather than absent — which is why the exchange has an order. These four
-steps are the order that never leaves `main` unmergeable, and 1 and 2 are a
-token rather than a pull request, so only a human can perform them:
+So while the setting is on, the analysing jobs are red rather than
+absent — which is why the exchange has an order. These four steps are
+the order that never leaves `main` unmergeable, and 1 and 2 are a token
+rather than a pull request, so only a human can perform them:
 
 1. patch the rule to drop the `CodeQL` context, every other one staying;
 1. disable default setup;
 1. re-run the pull request's checks: the upload that was refused is
-   accepted now, so `codeql: every job passed` goes green;
+   accepted now, so `Analyze actions` and `Analyze python` go green;
 1. merge.
 
-There is no fifth step adding `codeql: every job passed` to the rule, and
-the section above is why: that context is not required, so what the rule
-holds is what step 1 leaves it with.
+There is no fifth step adding a `codeql.yml` check to the rule: neither
+matrix cell is required, and this workflow carries no aggregate that
+could be either.
 
 Step 2 is what makes the setting let go of the analysis. It is not the
 command that enabled default setup and there is no need to keep that one:


### PR DESCRIPTION
`.github/workflows/codeql.yml`'s aggregate job `codeql-passed` exists to give a branch rule one context to require, but the workflow's `on:` block has no `pull_request` trigger (only `push: branches: [main]`, `schedule:` and `workflow_dispatch:`), so it never runs on a pull request and no rule can ever require it — confirmed against `main`'s branch protection (`required_status_checks.checks` names no codeql context) and against the organization's settled answer in btclib-org/.github#90 / PR btclib-org/.github#183, which lists this repository among the ones carrying the now-pointless pattern. `btclib-benchmarks`'s `codeql.yml` already has no aggregate job.

Removes the aggregate job and the two comments that referenced it, and corrects `REPOSITORY.md`'s "Required checks on main" paragraph and default-setup-toggle runbook, both of which named the now-gone job.

Closes #1290.

## Summary by Sourcery

Remove the unused CodeQL aggregate check and align repository documentation with the workflow's actual pull-request status checks.

Bug Fixes:
- Remove the ineffective CodeQL aggregate status job that could not be required by pull-request branch protection.

Enhancements:
- Update repository guidance and runbooks to describe the CodeQL matrix checks and the absence of a required aggregate check.

CI:
- Simplify the CodeQL workflow to expose only its per-language analysis checks.

Documentation:
- Document the removal of the CodeQL aggregate job and correct the required-check and default-setup instructions.