### PR TITLE
CurveGroup.is_on_curve refuses a bool coordinate (issue #1249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2245,9 +2245,8 @@ documented at release-notes length in the first place, and are still in
   value `dsa.verify` refused as a type. Not an arm disagreement, that
   one: 1 is an x-coordinate of secp256k1, so both arms lifted the bool
   and both answered about it — two schemes disagreeing, where the
-  private side had one scheme answering two ways. A `Point` is the arm
-  this does not reach, `is_on_curve` reading a bool as the number beside
-  it, and is issue #1249.
+  private side had one scheme answering two ways. A `Point` was the
+  same gap one layer down, closed separately by issue #1249.
 
   It reads its int through `int_from_integer` now and says
   `"non-integer: True"`. Every entry point taking a `BIP340PubKey` moves
@@ -2273,6 +2272,25 @@ documented at release-notes length in the first place, and are still in
 
   Nothing in the package passed a bool, and no test did: the change
   costs the suite nothing and closes the arm disagreement.
+- **`CurveGroup.is_on_curve` refuses a bool coordinate** (issue #1249).
+  It recognizes the point at infinity through `Q[1] == 0`, and
+  `False == 0` in Python, so `is_on_curve((x, False))` read any x as
+  infinity; `is_on_curve((True, y))` answered True about the point at
+  x = 1, an x-coordinate nobody has the discrete log of. Neither
+  coordinate was checked for its type at all.
+
+  The check is `is_integer`, run on both coordinates before the
+  infinity check and before the range check, raising
+  `BTClibTypeError` — `"non-integer x-coordinate: True"` or
+  `"non-integer y-coordinate: True"`, naming which one. `is_on_curve`
+  is `CurveGroup`'s method rather than secp256k1's, so the refusal
+  holds for every curve; `curves.curve.PreparedPoint`'s constructor
+  calls `require_on_curve` before building any table, so a bool
+  coordinate there raises the same way. `to_pub_key.point_from_pub_key`,
+  `ecc.ssa._x_from_bip340pub_key` and `curves.sec_point.bytes_from_point`
+  are the three funnels that validate a `Point` through it, and each
+  now raises the same sentence rather than returning a point no caller
+  meant to ask for.
 - **`borromean.sign` refuses a scalar outside 1..n-1, and reads one
   however it is spelled** (issue #1243). `sign_keys[i]` reached step 2's
   `(k + sign_keys[i] * e[i][j_star]) % ec.n` exactly as the caller wrote

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -50,6 +50,15 @@ full year, short month, short day (YYYY-M-D)
 
   An `IntEnum` is unaffected and stays an integer. CHANGELOG.md has why
   a bool was reaching a key at all, and what the two arms did with it.
+- **A `Point`'s coordinates are no longer accepted as bools** (issue
+  #1249). `is_on_curve((x, False))` used to answer about the point at
+  infinity for any x, `False == 0` in Python; `is_on_curve((True, y))`
+  about the point at x = 1. Act on it if you build a `Point` tuple from
+  a value that could be a bool — a JSON decoder's `true`/`false`
+  included: `point_from_pub_key`, `point_from_bip340pub_key`,
+  `PreparedPoint` and `bytes_from_point` all raise `BTClibTypeError`
+  now, on every curve. CHANGELOG.md has which coordinate the message
+  names.
 - **`borromean.sign` refuses a private key or a nonce outside 1..n-1**
   (issue #1243). Neither sequence was read as a scalar, so a key of 0,
   of `n` or of `q + n` signed, where every other signer in `ecc`

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -24,7 +24,7 @@ from typing_extensions import override
 from btclib.alias import INF, INFJ, Integer, JacPoint, Point
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.number_theory import mod_inv_batch_var, mod_inv_var, mod_sqrt_var
-from btclib.utils import assert_type, hex_string, int_from_integer
+from btclib.utils import assert_type, hex_string, int_from_integer, is_integer
 
 __all__ = [
     "BOS_COSTER_THRESHOLD",
@@ -669,6 +669,14 @@ class CurveGroup:
         assert_type(Q, tuple, "point")
         if len(Q) != 2:
             raise BTClibValueError("point must be a tuple[int, int]")
+        # the type before the y==0 infinity check below: `False == 0`
+        # would read any x paired with a bool y as infinity, and
+        # `is_integer` is where this library says a bool is not a number
+        # (issue #1249)
+        if not is_integer(Q[0]):
+            raise BTClibTypeError(f"non-integer x-coordinate: {Q[0]}")
+        if not is_integer(Q[1]):
+            raise BTClibTypeError(f"non-integer y-coordinate: {Q[1]}")
         if Q[1] == 0:  # Infinity point in affine coordinates
             return True
         if not 0 < Q[1] < self.p:  # y cannot be zero

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -260,14 +260,13 @@ def _x_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve) -> int:
     # BIP340 key as integer, read through the library's one integer
     # coercion rather than taken as it comes: an x is a number, and a
     # bool is not one anywhere a number is (issue #326). This was the
-    # last int spelling of a key outside that rule -- the tuple arm below
-    # is not covered by it, `is_on_curve` reading a bool as the number
-    # beside it, which is issue #1249. `isinstance(True, int)` made
-    # `True` the key at x = 1, an x-coordinate of secp256k1, so both
-    # arms lifted it and both answered about it where `dsa.verify`
-    # refused the same value as a type: two schemes disagreeing and not
-    # two arms, where the private side of issue #1206 had one scheme
-    # answering two ways.
+    # last int spelling of a key outside that rule; the tuple arm below
+    # is covered by `is_on_curve`'s own refusal of a bool coordinate
+    # (issue #1249). `isinstance(True, int)` made `True` the key at
+    # x = 1, an x-coordinate of secp256k1, so both arms lifted it and
+    # both answered about it where `dsa.verify` refused the same value
+    # as a type: two schemes disagreeing and not two arms, where the
+    # private side of issue #1206 had one scheme answering two ways.
     if isinstance(x_Q, int):
         return int_from_integer(x_Q)
 

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -807,6 +807,15 @@ def test_is_on_curve() -> None:
         with pytest.raises(BTClibValueError, match="y-coordinate not in 1..p-1: "):
             ec.is_on_curve((Q[0], ec.p))
 
+        # a bool coordinate before either check above: `Q[1] == 0` is
+        # how infinity is recognized, and `False == 0` in Python, so a
+        # bool y used to be read as infinity for any x (issue #1249)
+        for y in (True, False):
+            with pytest.raises(BTClibTypeError, match="non-integer x-coordinate"):
+                ec.is_on_curve((y, Q[1]))
+            with pytest.raises(BTClibTypeError, match="non-integer y-coordinate"):
+                ec.is_on_curve((Q[0], y))
+
 
 def test_negate() -> None:
     """Verify P plus its negation is INF; refuse mixed coordinates."""

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -39,7 +39,13 @@ from btclib.block.block import bip34_commitment
 from btclib.block.block_context import BlockContext
 from btclib.block.mining import mine
 from btclib.block.proof_of_work import hash_rate, retarget_first_height
-from btclib.curves import mult, scalar_from_prv_key, secp256k1
+from btclib.curves import (
+    PreparedPoint,
+    bytes_from_point,
+    mult,
+    scalar_from_prv_key,
+    secp256k1,
+)
 from btclib.ecc.bms import sign as bms_sign
 from btclib.ecc.dsa import sign as dsa_sign
 from btclib.ecc.ssa import point_from_bip340pub_key
@@ -54,7 +60,7 @@ from btclib.number_theory import mod_inv, mod_inv_batch_var, mod_inv_var
 from btclib.psbt.psbt import PSBT_V2, Psbt
 from btclib.script import input_script_sig, sig_hash
 from btclib.to_prv_key import int_from_prv_key
-from btclib.to_pub_key import point_from_key
+from btclib.to_pub_key import point_from_key, point_from_pub_key
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from btclib.utils import (
     bytes_from_octets,
@@ -214,6 +220,23 @@ _CASES: list[tuple[str, Callable[[Any], object]]] = [
     # answers -- `BTClibTypeError` is a `TypeError` and the except there
     # takes `ValueError`, which is issue #814's rule
     ("BIP340 verification key", lambda v: ssa_verify(b"msg", v, _SSA_SIG)),
+    # `CurveGroup.is_on_curve` is the one funnel behind a `Point` tuple,
+    # `point_from_pub_key`, `_x_from_bip340pub_key`, `PreparedPoint` and
+    # `bytes_from_point` included, and it read a bool coordinate as an
+    # int -- `Q[1] == 0` marking infinity, so a bool `False` for y was
+    # read as infinity for any x (issue #1249). One case per funnel
+    # pins the reach; `secp256k1.G[1]` is a placeholder y that only the
+    # x-coordinate cases need on the curve, is_on_curve's type check
+    # running before the equation it would otherwise fail
+    ("point x-coordinate", lambda v: secp256k1.is_on_curve((v, secp256k1.G[1]))),
+    ("point y-coordinate", lambda v: secp256k1.is_on_curve((secp256k1.G[0], v))),
+    ("public key point", lambda v: point_from_pub_key((v, secp256k1.G[1]))),
+    (
+        "BIP340 x-only point",
+        lambda v: point_from_bip340pub_key((v, secp256k1.G[1])),
+    ),
+    ("prepared point", lambda v: PreparedPoint((v, secp256k1.G[1]))),
+    ("point to sec bytes", lambda v: bytes_from_point((v, secp256k1.G[1]))),
 ]
 
 _IDS = [case[0] for case in _CASES]
@@ -260,6 +283,29 @@ _WORDINGS = [
     ("base58 address key", p2pkh, "not a private or public key"),
     ("bech32 address key", p2wpkh, "not a private or public key"),
     ("BIP340 x-only key", point_from_bip340pub_key, "non-integer: True"),
+    # separate from the three families above: `is_on_curve`'s own
+    # refusal of a bool coordinate (issue #1249), one sentence per
+    # coordinate and shared by every funnel behind it
+    (
+        "point x-coordinate",
+        lambda v: secp256k1.is_on_curve((v, secp256k1.G[1])),
+        "non-integer x-coordinate: True",
+    ),
+    (
+        "point y-coordinate",
+        lambda v: secp256k1.is_on_curve((secp256k1.G[0], v)),
+        "non-integer y-coordinate: True",
+    ),
+    (
+        "public key point",
+        lambda v: point_from_pub_key((v, secp256k1.G[1])),
+        "non-integer x-coordinate: True",
+    ),
+    (
+        "prepared point",
+        lambda v: PreparedPoint((v, secp256k1.G[1])),
+        "non-integer x-coordinate: True",
+    ),
 ]
 
 
@@ -316,6 +362,10 @@ def test_the_integers_a_bool_refusal_must_not_take_with_it() -> None:
     assert bms_sign(b"msg", 1).dsa_sig.r
     assert point_from_bip340pub_key(secp256k1.G[0]) == secp256k1.G
     assert ssa_verify(b"msg", secp256k1.G[0], _SSA_SIG)
+    assert secp256k1.is_on_curve(secp256k1.G) is True
+    assert point_from_pub_key(secp256k1.G) == secp256k1.G
+    assert PreparedPoint(secp256k1.G).point == secp256k1.G
+    assert bytes_from_point(secp256k1.G).hex().startswith("02")
     assert str_from_index_int(1) == "1"
     assert bytes_from_octets(b"x", 1) == b"x"
     assert bytes_from_octets(b"xx", [1, 2]) == b"xx"


### PR DESCRIPTION
Closes #1249.

`CurveGroup.is_on_curve` checked neither coordinate's type: a bool x
was read as an int, and a bool y=False was read as the point at
infinity (`Q[1] == 0` and `False == 0` in Python), silently, for any
x. Both coordinates now run through `utils.is_integer` before the
infinity/range checks, raising `BTClibTypeError` naming which
coordinate — matching the policy issue #326 and issue #1206 established
for `Integer` parameters generally, one layer down at the point.

This is the single funnel behind `to_pub_key.point_from_pub_key`,
`ssa.point_from_bip340pub_key`, `curves.curve.PreparedPoint` (via
`.point`), and `curves.sec_point.bytes_from_point`, on every curve —
`CurveGroup` is not secp256k1-specific. `tests/integer_policy_test.py`'s
census gains the `Point`/`PreparedPoint` arms, and
`tests/curves/curve_test.py::test_is_on_curve`'s existing per-curve loop
is extended. issue #1206's CHANGELOG entry, which had called the bool
key case "the last int spelling of a key outside the rule," is
corrected now that this gap is closed too.

Local review at fresh context: `CLEARED a677e224513333da13da50ed19b2d007e65efc1`,
then rebased onto origin/main (`0014a896`, prose/workflow only) and a
non-blocking finding (RELEASE_NOTES.md naming a private helper in its
public-facing "act on it" list) fixed, current head `003bbd83`.

Gates on `003bbd83`, all exit 0: `pytest` (29677 passed, 11 skipped,
100.00% coverage), `pre-commit run --all-files`, and the Sphinx build
with `-W`. `git status --porcelain` empty.

## Summary by Sourcery

Reject boolean elliptic-curve point coordinates consistently before infinity and range validation.

Bug Fixes:
- Reject boolean point coordinates in `CurveGroup.is_on_curve` and all public point-validation paths with coordinate-specific `BTClibTypeError` exceptions.

Enhancements:
- Apply consistent integer-type validation to point coordinates across all supported curves and point conversion APIs.

Documentation:
- Document the boolean-coordinate validation fix in the changelog and release notes.

Tests:
- Extend curve and integer-policy coverage to validate boolean rejection and preserve valid point behavior across point APIs.