### PR TITLE
Electrum's own passphrase_hex pins the encoding step (issue #1284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2456,6 +2456,20 @@ documented at release-notes length in the first place, and are still in
   assertion that verifies it is the next line, so the run fails in the
   same breath the sentence goes wrong. Introduced by 2f887453 (#1179).
 
+- **`tests/mnemonic/electrum_test.py`'s passphrase-bearing `SEED_VECTORS`
+  carry electrum's own `passphrase_hex`, and `test_seed_vectors` asserts
+  `passphrase.encode("utf8") == bytes.fromhex(passphrase_hex)` before
+  either reaches the seed computation** (issue #1284), the way upstream's
+  own `test_mnemonic_to_seed` does. Every one of the five was ASCII or
+  already exercised by the seed match, but the check is on the
+  passphrase's exact bytes and not only on the seed they produce, and it
+  found one row failing: the spanish passphrase's ñ, í, ó, é and á were
+  precomposed, where upstream's own literal and `passphrase_hex` hold
+  each as a base letter plus a combining accent. `_seed_from_mnemonic`
+  normalizes either form to the same NFKD before hashing, which is why
+  the seed comparison alone never caught it. Fixed by matching upstream's
+  bytes.
+
 ## v2026.8.21
 
 ### Repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -474,8 +474,15 @@ skip = "*/_data/*.json,*/_data/*.csv,*/_data/*.txt,*/_data/*.bin,*/_generated_fi
 # written in the backticks the rule below hides a deliberate misspelling
 # in. Every *prose* mention of either is backticked and already invisible
 # to this hook; what these two entries cover is the two lines that
-# configure the other one
-ignore-words-list = "wit,nd,ser,unser"
+# configure the other one.
+# "te" is what electrum's own NFD spelling of "término" tokenizes into:
+# base "e" and the combining acute accent on it are two codepoints, so
+# the word splits into "te" and "rmino" at the mark, and "te" alone is in
+# codespell's dictionary as a typo for "the"/"be"/"we"/"to". The
+# passphrase in tests/mnemonic/electrum_test.py needs that exact NFD
+# spelling -- issue #1284 has why -- so the split is fixed here rather
+# than by composing the accent away
+ignore-words-list = "wit,nd,ser,unser,te"
 # a misspelling written on purpose goes in backticks, and that is a
 # convention of this repository rather than a preference: prose that
 # documents a spell checker has to name what it catches, and the prose

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -2006,6 +2006,25 @@ spesmilo/electrum's own, inline — the `SEED_TEST_CASES` seeds and the
 vendored as files here: each block is small enough to read, and a
 citation two lines above the values is one that gets checked.
 
+`SEED_VECTORS`' five passphrase-bearing rows each carry the
+`passphrase_hex` field upstream's own `SeedTestCase` publishes beside
+them where it publishes one — `spesmilo/electrum`'s
+`300b986782c754be462788a30e0355301683c0ed` (2024-06-10, the tip of
+`tests/test_mnemonic.py`) and, for the japanese row's
+`UNICODE_HORROR_HEX`, `b57327fb3e6d62941b833f8ce9b3b91c34c9ec76`
+(2026-07-01, the tip of `tests/test_wallet_vertical.py`) — and
+`test_seed_vectors` asserts `passphrase.encode("utf8") ==
+bytes.fromhex(passphrase_hex)` before either reaches the seed
+computation, the way upstream's own `test_mnemonic_to_seed` does.
+`english_with_passphrase` publishes no such field upstream, its
+passphrase being plain ASCII, so that row's stays `None`. The check
+found the spanish row's passphrase composed rather than decomposed — a
+precomposed ñ, í, ó, é and á where upstream's own literal holds the
+accent as a separate combining character — invisible to the seed
+assertion, since `_seed_from_mnemonic` normalizes either form to the
+same NFKD before hashing, and caught only by comparing raw bytes. The
+fix was to match upstream's bytes, not to drop the check.
+
 The pre-2.0 scheme is the same arrangement and four more of upstream's
 values, added for issue #208. The scheme has no specification — it
 predates the BIPs — so a vector btclib generated would be testing btclib

--- a/tests/mnemonic/electrum_test.py
+++ b/tests/mnemonic/electrum_test.py
@@ -35,7 +35,10 @@ from tests import load, vector_id
 # the passphrase electrum stretches its japanese vector with, kept as the
 # hex electrum states it in: an editor that normalizes or reflows the
 # characters would change the seed and the vector would be testing btclib
-# against btclib
+# against btclib. `UNICODE_HORROR_HEX` in `spesmilo/electrum`'s
+# `tests/test_wallet_vertical.py`, pinned at
+# b57327fb3e6d62941b833f8ce9b3b91c34c9ec76 (2026-07-01, the tip of that
+# path), which is also the same string passed below as `passphrase_hex`
 UNICODE_HORROR = bytes.fromhex(
     "e282bf20f09f988020f09f98882020202020e3818620e38191e3819fe381be20"
     "e3828fe3828b2077cda2cda2cd9d68cda16fcda2cda120ccb8cda26bccb5cd9f"
@@ -71,7 +74,14 @@ ENGLISH = (
 # and a PBKDF2 and needs no word-list at all. These are the cases that
 # make the normalization visible -- the CJK ones have their words joined,
 # the Spanish ones have their accents dropped, and none of them would
-# survive a bare whitespace clean
+# survive a bare whitespace clean.
+#
+# `passphrase_hex` is the fifth field wherever upstream's own SeedTestCase
+# publishes one: the UTF-8 bytes the passphrase above must encode to,
+# checked before either is used, at `spesmilo/electrum`'s
+# 300b986782c754be462788a30e0355301683c0ed (2024-06-10, the tip of
+# `tests/test_mnemonic.py`). Upstream gives no such field for the plain
+# ASCII passphrase of `english-passphrase`, so that row keeps `None`.
 SEED_VECTORS = [
     pytest.param(
         ENGLISH,
@@ -79,6 +89,7 @@ SEED_VECTORS = [
         "segwit",
         "aac2a6302e48577ab4b46f23dbae0774e2e62c796f797d0a1b5faeb528301e306"
         "4342dafb79069e7c4c6b8c38ae11d7a973bec0d4f70626f8cc5184a8d0b0756",
+        None,
         id="english",
     ),
     pytest.param(
@@ -87,6 +98,7 @@ SEED_VECTORS = [
         "segwit",
         "4aa29f2aeb0127efb55138ab9e7be83b36750358751906f86c662b21a1ea1370"
         "f949e6d1a12fa56d3d93cadda93038c76ac8118597364e46f5156fde6183c82f",
+        None,
         id="english-passphrase",
     ),
     pytest.param(
@@ -95,6 +107,7 @@ SEED_VECTORS = [
         "standard",
         "d3eaf0e44ddae3a5769cb08a26918e8b308258bcb057bb704c6f69713245c0b3"
         "5cb92c03df9c9ece5eff826091b4e74041e010b701d44d610976ce8bfb66a8ad",
+        None,
         id="japanese",
     ),
     pytest.param(
@@ -103,6 +116,15 @@ SEED_VECTORS = [
         "standard",
         "251ee6b45b38ba0849e8f40794540f7e2c6d9d604c31d68d3ac50c034f8b64e4"
         "bc037c5e1e985a2fed8aad23560e690b03b120daf2e84dceb1d7857dda042457",
+        "e282bf20f09f988020f09f98882020202020e3818620e38191e3819fe381be20"
+        "e3828fe3828b2077cda2cda2cd9d68cda16fcda2cda120ccb8cda26bccb5cd9f"
+        "6eccb4cd98c7ab77ccb8cc9b73cd9820cc80cc8177cd98cda2e1b8a9ccb561d2"
+        "89cca1cda27420cca7cc9568cc816fccb572cd8fccb5726f7273cca120ccb6cd"
+        "a1cda06cc4afccb665cd9fcd9f20ccb6cd9d696ecda220cd8f74cc9568ccb7cc"
+        "a1cd9f6520cd9fcd9f64cc9b61cd9c72cc95cda16bcca2cca820cda168ccb465"
+        "cd8f61ccb7cca2cca17274cc81cd8f20ccb4ccb7cda0c3b2ccb5ccb666ccb820"
+        "75cca7cd986ec3adcc9bcd9c63cda2cd8f6fccb7cd8f64ccb8cda265cca1cd9d"
+        "3fcd9e",
         id="japanese-unicode-horror",
     ),
     pytest.param(
@@ -111,6 +133,7 @@ SEED_VECTORS = [
         "segwit",
         "0b9077db7b5a50dbb6f61821e2d35e255068a5847e221138048a20e12d80b673"
         "ce306b6fe7ac174ebc6751e11b7037be6ee9f17db8040bb44f8466d519ce2abf",
+        None,
         id="chinese",
     ),
     pytest.param(
@@ -119,6 +142,7 @@ SEED_VECTORS = [
         "segwit",
         "6c03dd0615cf59963620c0af6840b52e867468cc64f20a1f4c8155705738e87b"
         "8edb0fc8a6cee4085776cb3a629ff88bb1a38f37085efdbf11ce9ec5a7fa5f71",
+        "e7bb99e68891e4b880e4ba9be6b58be8af95e59091e9878fe8b0b7e6ad8c",
         id="chinese-passphrase",
     ),
     pytest.param(
@@ -127,14 +151,21 @@ SEED_VECTORS = [
         "standard",
         "18bffd573a960cc775bbd80ed60b7dc00bc8796a186edebe7fc7cf1f316da0fe"
         "937852a969c5c79ded8255cdf54409537a16339fbe33fb9161af793ea47faa7a",
+        None,
         id="spanish",
     ),
+    # upstream's own literal is NFD, combining accents rather than
+    # the precomposed form a font renders the same way, and this one
+    # matches it: passphrase_hex below is the check an NFC copy of
+    # this string would fail
     pytest.param(
         SPANISH,
-        "araña difícil solución término cárcel",
+        "araña difícil solución término cárcel",
         "standard",
         "363dec0e575b887cfccebee4c84fca5a3a6bed9d0e099c061fa6b85020b031f8"
         "fe3636d9af187bf432d451273c625e20f24f651ada41aae2c4ea62d87e9fa44c",
+        "6172616ecc83612064696669cc8163696c20736f6c7563696fcc816e207465"
+        "cc81726d696e6f206361cc817263656c",
         id="spanish-passphrase",
     ),
     pytest.param(
@@ -143,6 +174,7 @@ SEED_VECTORS = [
         "segwit",
         "001ebce6bfde5851f28a0d44aae5ae0c762b600daf3b33fc8fc630aee0d20764"
         "6b6f98b18e17dfe3be0a5efe2753c7cdad95860adbbb62cecad4dedb88e02a64",
+        None,
         id="spanish-segwit",
     ),
     pytest.param(
@@ -152,6 +184,10 @@ SEED_VECTORS = [
         "segwit",
         "c274665e5453c72f82b8444e293e048d700c59bf000cacfba597629d202dcf3a"
         "ab1cf9c00ba8d3456b7943428541fed714d01d8a0a4028fc3a9bb33d981cb49f",
+        "c2a1566976612045737061c3b16121207265706974656e207665696e746520"
+        "707565626c6f73207920616c206861626c61722064616e2066652064656c20"
+        "c3a16e696d6f2065737061c3b16f6c2e2e2e20c2a14d61727175656e206172"
+        "61646f206d617274696c6c6f207920636c6172c3ad6e",
         id="spanish-segwit-passphrase",
     ),
 ]
@@ -393,9 +429,15 @@ def test_word_order() -> None:
     assert int(reversed_entr, 2) == 0xFB0A779F83FEDDB0E39AA0DDE898CC384
 
 
-@pytest.mark.parametrize("mnemonic, passphrase, version, seed", SEED_VECTORS)
-def test_seed_vectors(mnemonic: str, passphrase: str, version: str, seed: str) -> None:
-    """Reproduce electrum's SEED_TEST_CASES, version and seed alike."""
+@pytest.mark.parametrize(
+    "mnemonic, passphrase, version, seed, passphrase_hex", SEED_VECTORS
+)
+def test_seed_vectors(
+    mnemonic: str, passphrase: str, version: str, seed: str, passphrase_hex: str | None
+) -> None:
+    """Reproduce electrum's SEED_TEST_CASES: passphrase, version and seed."""
+    if passphrase_hex is not None:
+        assert passphrase.encode("utf8") == bytes.fromhex(passphrase_hex)
     assert electrum._seed_from_mnemonic(mnemonic, passphrase) == (
         version,
         bytes.fromhex(seed),


### PR DESCRIPTION
Closes #1284.

`tests/mnemonic/electrum_test.py`'s `SEED_VECTORS` already carries the
five passphrase-bearing rows Electrum's own `SEED_TEST_CASES` publishes
(added by #1198's b9a2f5d9, inline rather than in
`tests/mnemonic/_data/`, per that module's own stated citation policy),
so nothing about that vendoring changes here — what was missing is
Electrum's `passphrase_hex` alongside each passphrase, and an
assertion that `passphrase.encode("utf8")` matches it, mirroring
Electrum's own `test_mnemonic_to_seed`. Fetched from
`spesmilo/electrum` at `300b986782c754be462788a30e0355301683c0ed`
(`tests/test_mnemonic.py`) and `b57327fb3e6d62941b833f8ce9b3b91c34c9ec76`
(`tests/test_wallet_vertical.py`), both pinned in
`tests/_data/README.md`.

That assertion caught a real, pre-existing defect: the `término`
Spanish passphrase literal here was NFC-composed where Electrum's own
literal (and its `passphrase_hex`) are NFD; `_seed_from_mnemonic`
NFKD-normalizes before hashing, so the resulting seed matched either
way and the gap was invisible to a seed-only check. Fixed to Electrum's
NFD bytes. `pyproject.toml`'s codespell `ignore-words-list` gains `te`,
which is what NFD `término` tokenizes into and which codespell's
dictionary otherwise flags.

Local review at fresh context: `CLEARED 3168e494510ca52c8e4142885799d64b4e48cfc1`,
then rebased onto origin/main (`9789545b`, #1294) with no conflicts;
current head `99e6acb7`.

Gates on `99e6acb7`, all exit 0: `mypy`, `pytest` (29677 passed, 11
skipped, 100.00% coverage), `pre-commit run --all-files`, and the
Sphinx build with `-W`. `git status --porcelain` empty.

Collateral opened separately, unrelated to this diff: #1293.

## Summary by Sourcery

Match Electrum's passphrase byte representations and verify them independently from derived seed values.

Bug Fixes:
- Correct the Spanish Electrum passphrase test vector to use the upstream NFD Unicode representation, fixing a mismatch that seed-only validation did not detect.

Enhancements:
- Validate passphrase UTF-8 bytes against Electrum's published passphrase_hex values for passphrase-bearing seed vectors.
- Document the pinned upstream Electrum test-vector sources and support the required NFD spelling in codespell configuration.

Tests:
- Extend Electrum mnemonic vectors with upstream passphrase_hex data and assert exact passphrase byte encoding before seed derivation.