### PR TITLE
pedersen.commit refuses an unblinded commitment (issue #1250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2337,6 +2337,31 @@ documented at release-notes length in the first place, and are still in
   does: a ring's size is a fact the caller has to be told, and a key of
   0 is one they can see in the sequence they passed.
 
+- **`pedersen.commit` refuses a blinding factor of 0 mod n** (issue
+  #1250). `commit(0, v)` returned `v*H`, a point anyone who guesses `v`
+  can recompute, and `commit(ec.n, v)` the same point, `double_mult_var`
+  reducing mod `n` on its own. #1243's `1..n-1` range check is not the
+  instrument here: a Pedersen commitment is additively homomorphic, so
+  the sum of two blinding factors is routinely `>= ec.n` and is still a
+  valid one, and `tests/ecc/pedersen_test.py::test_commitment` asserts
+  exactly that identity. `r % ec.n == 0` is the one value refused; `v`
+  is untouched, a commitment to `v = 0` being an ordinary one.
+
+  The check replaces the module's separate refusal of `r` and `v` both
+  landing on infinity: with `r % ec.n == 0` excluded, `Q` lands there
+  only when `v` is 0 mod `n` too, which the new check already covers,
+  the discrete log of `H` being unknown to make any other pair land
+  there. `assert_as_valid` recomputes through `commit`, and `verify`
+  already turns the `BTClibValueError` this raises into `False`, so
+  neither needed a check of its own.
+
+  `commit`, `assert_as_valid` and `verify` take `r` and `v` as `Integer`
+  now rather than `int`: the octet and hex spellings already reached
+  `double_mult_var`, which takes `Integer`, so the annotation was
+  narrower than what the functions accepted. A bool is refused already,
+  `int_from_integer` being where issue #1206 put that rule for every
+  `Integer` parameter.
+
 - **`taproot.py` gets back the import a merge dropped.**
   `check_output_pubkey`'s translation reads `HEX_THRESHOLD`, added with
   it in #1228; #1219 rewrote `_tweaked_pubkey`'s arm in the same file

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -83,6 +83,20 @@ full year, short month, short day (YYYY-M-D)
   `OverflowError` and `TypeError`. `sign_key_idx` is still
   `Sequence[int]`: it indexes a ring.
 
+- **`pedersen.commit` refuses a blinding factor of 0 mod n** (issue
+  #1250). `commit(0, v)` and `commit(ec.n, v)` returned `v*H`, a
+  commitment with no blinding in it that anyone can recompute by
+  guessing `v`, and now raise `BTClibValueError: invalid (unblinded)
+  commitment: r is 0 mod n`. `assert_as_valid` raises the same error,
+  recomputing through `commit`; `verify` answers `False` instead of
+  raising, as it already does for every other invalid `(r, v)`.
+
+  Act on it if you construct a blinding factor that can land on 0 mod
+  n — the sum of two blinding factors chosen to cancel each other is
+  the case to watch; a blinding factor drawn at random and never
+  summed to that value is unaffected. `v` is not checked: `commit(r,
+  0)` is untouched.
+
 - **`ecc` no longer takes a WIF or an extended key as a private key**
   (issue #1188). The entry points that took a private key however it was
   spelled — every one in `dsa`, `ssa`, `musig2`, `dleq`, `ecies`,

--- a/btclib/ecc/pedersen.py
+++ b/btclib/ecc/pedersen.py
@@ -27,11 +27,11 @@ the discrete logarithm of H with respect to G must be unknown.
 from functools import lru_cache
 from hashlib import sha256
 
-from btclib.alias import HashF, Point
+from btclib.alias import HashF, Integer, Point
 from btclib.curves import Curve, bytes_from_point, double_mult_var, secp256k1
 from btclib.curves.curve import _assert_valid_ec
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
-from btclib.utils import assert_type, int_from_bits
+from btclib.utils import assert_type, int_from_bits, int_from_integer
 
 __all__ = [
     "assert_as_valid",
@@ -100,24 +100,34 @@ def second_generator(ec: Curve = secp256k1, hf: HashF = sha256) -> Point:
             return x_H, y_H
 
 
-def commit(r: int, v: int, ec: Curve = secp256k1, hf: HashF = sha256) -> Point:
+def commit(r: Integer, v: Integer, ec: Curve = secp256k1, hf: HashF = sha256) -> Point:
     """Commit to v under blinding factor r, returning rG+vH.
 
     H is `second_generator`, whose docstring has why nobody can open
-    this to a different (r, v).
+    this to a different (r, v). r=0 mod n is refused: it commits with no
+    blinding at all, Q is then v*H, a point anyone who guesses v can
+    recompute. The check is on r alone and not on its range, because the
+    sum of two blinding factors is a blinding factor too -- a Pedersen
+    commitment is additively homomorphic -- and is routinely >= ec.n
+    (issue #1250). It also subsumes the former separate check for r and
+    v both landing on INF: with r=0 mod n excluded, Q lands there only if
+    v is 0 mod n too, which is an ordinary commitment to a zero value and
+    not a blinding failure.
+
+    Checked here and nowhere else in the module: `assert_as_valid`
+    recomputes the commitment through this function, and `verify`
+    already turns the `BTClibValueError` this raises into `False`, the
+    same way it does for every other invalid (r, v).
     """
     H = second_generator(ec, hf)
-    Q = double_mult_var(v, H, r, ec.G, ec)
-    # r and v both zero mod n commit here; anything else would need
-    # the discrete log of H
-    if Q[1] == 0:
-        err_msg = "invalid (INF) key"
-        raise BTClibRuntimeError(err_msg)
-    return Q
+    if int_from_integer(r) % ec.n == 0:
+        err_msg = "invalid (unblinded) commitment: r is 0 mod n"
+        raise BTClibValueError(err_msg)
+    return double_mult_var(v, H, r, ec.G, ec)
 
 
 def assert_as_valid(
-    r: int, v: int, commitment: Point, ec: Curve = secp256k1, hf: HashF = sha256
+    r: Integer, v: Integer, commitment: Point, ec: Curve = secp256k1, hf: HashF = sha256
 ) -> None:
     """Refuse a commitment that (r, v) does not open.
 
@@ -138,7 +148,7 @@ def assert_as_valid(
 
 
 def verify(
-    r: int, v: int, commitment: Point, ec: Curve = secp256k1, hf: HashF = sha256
+    r: Integer, v: Integer, commitment: Point, ec: Curve = secp256k1, hf: HashF = sha256
 ) -> bool:
     """Open the commitment and return True if valid."""
     # ValueError and BTClibRuntimeError, as `ecc.dsa.verify_` catches them

--- a/tests/ecc/pedersen_test.py
+++ b/tests/ecc/pedersen_test.py
@@ -11,7 +11,7 @@ import pytest
 from btclib.curves import secp256k1
 from btclib.curves.curve import CURVES
 from btclib.ecc import pedersen
-from btclib.exceptions import BTClibRuntimeError
+from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 
 secp256r1 = CURVES["secp256r1"]
 secp384r1 = CURVES["secp384r1"]
@@ -94,12 +94,44 @@ def test_commitment() -> None:
     with pytest.raises(TypeError):
         pedersen.commit(sha256, v1, ec, hf)  # type: ignore[arg-type]
 
+    # r and v take every spelling `Integer` does, octets included
+    r_hex = "00" * 31 + "03"
+    assert pedersen.commit(r_hex, v1, ec, hf) == pedersen.commit(3, v1, ec, hf)
 
-def test_commit_to_infinity() -> None:
-    """Refuse r and v both zero mod n: the commitment is INF.
 
-    Any other opening of INF would need the discrete log of H.
+def test_commit_unblinded() -> None:
+    """Refuse r = 0 mod n: the commitment then carries no blinding at all.
+
+    v is not checked on its own: commit(0, 0) is refused by this same
+    check, being the r = 0 mod n case of an unblinded commitment.
     """
-    err_msg = r"invalid \(INF\) key"
-    with pytest.raises(BTClibRuntimeError, match=err_msg):
+    err_msg = r"invalid \(unblinded\) commitment"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        pedersen.commit(0, 5, secp256k1, sha256)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        pedersen.commit(secp256k1.n, 5, secp256k1, sha256)
+    with pytest.raises(BTClibValueError, match=err_msg):
         pedersen.commit(0, 0, secp256k1, sha256)
+
+    assert not pedersen.verify(0, 5, pedersen.commit(5, 5, secp256k1, sha256))
+
+
+def test_commit_blinding_factor_sum() -> None:
+    """A range check on r would break the additive homomorphism.
+
+    r_1 + r_2 lands past ec.n and is still a valid blinding factor for
+    the summed commitment; only a sum landing on 0 mod n -- the second
+    factor chosen to cancel the first -- is the unblinded case.
+    """
+    ec = secp256k1
+    r_1, r_2 = ec.n - 3, 10
+    C1, C2 = pedersen.commit(r_1, 4, ec), pedersen.commit(r_2, 5, ec)
+
+    assert not 1 <= r_1 + r_2 < ec.n
+    R = pedersen.commit(r_1 + r_2, 9, ec)
+    assert ec.add_var(C1, C2) == R
+    assert pedersen.verify(r_1 + r_2, 9, R, ec)
+
+    err_msg = r"invalid \(unblinded\) commitment"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        pedersen.commit(r_1 + 3, 9, ec)  # r_1 + 3 == ec.n

--- a/tests/input_validation_test.py
+++ b/tests/input_validation_test.py
@@ -166,6 +166,7 @@ _A_BOOL_ANSWERS_FALSE = (
 _ANSWERS_FALSE: dict[str, str] = {
     "btclib.b32.is_segwit_prefixed": _A_BOOL_ANSWERS_FALSE,
     "btclib.ecc.dleq.verify_proof": _A_BOOL_ANSWERS_FALSE,
+    "btclib.ecc.pedersen.verify": _A_BOOL_ANSWERS_FALSE,
     "btclib.script.script_pub_key.is_nulldata": _A_BOOL_ANSWERS_FALSE,
     "btclib.script.script_pub_key.is_p2ms": _A_BOOL_ANSWERS_FALSE,
     "btclib.script.script_pub_key.is_p2pk": _A_BOOL_ANSWERS_FALSE,


### PR DESCRIPTION
Closes #1250.

`pedersen.commit(r, v)` accepted `r % ec.n == 0`, producing `v*H` with
no blinding at all — trivially recomputable by anyone who guesses `v`.
`commit` now refuses exactly that reduced value, raising
`BTClibValueError`. `v` is untouched: `v = 0` is an ordinary value, and
`commit(0, 0)` (landing on infinity) is still refused, now as a
consequence of the same check rather than a separate `Q[1] == 0` test
— with `r % n == 0` excluded, reaching infinity needs `H`'s discrete
log unless `v` is also `0 mod n`, a case the new check already
catches, so the old test covered no input the new one misses.

Not a `1..n-1` range check: the sum of two valid blinding factors
routinely exceeds `n` (`tests/ecc/pedersen_test.py::test_commitment`
already asserts the additive homomorphism across that wrap), so a
signing-key-style range check would break it. `commit`,
`assert_as_valid` and `verify` are widened from `int` to `Integer` to
match what they already pass to `double_mult_var`.

Placement: the check lives in `commit` alone. `assert_as_valid`
recomputes through `commit`, so it raises for free; `verify` already
wraps `assert_as_valid` in `except (ValueError, BTClibRuntimeError):
return False`, and `BTClibValueError` is a `ValueError`, so `verify`
answers `False` for this case with no new code — issue #814's rule for
verify-style functions.

Local review at fresh context: `CLEARED d6a653a183c9ea9d51660e4cdd4effdd5a8cb348`
(a follow-up check confirmed no stray reference to the removed INF
test remained). Rebased onto origin/main (#1291, #1292, #1294, #1295,
none touching this module) with no conflicts; current head
`9947ef6a`.

Gates on `9947ef6a`, all exit 0: `pytest` (29684 passed, 11 skipped,
100.00% coverage), `pre-commit run --all-files`, and the Sphinx build
with `-W`. `git status --porcelain` empty.

## Summary by Sourcery

Prevent unblinded Pedersen commitments while preserving valid homomorphic blinding factors and consistent validation behavior.

Bug Fixes:
- Reject Pedersen commitments whose blinding factor is 0 modulo the curve order, preventing creation of trivially recomputable unblinded commitments.

Enhancements:
- Accept the full Integer input type for Pedersen commitment, validation, and verification APIs while preserving additive homomorphism for factors outside the canonical range.

Documentation:
- Document the new unblinded-commitment validation and its behavior in the changelog and release notes.

Tests:
- Add coverage for zero-modulo-order blinding factors, Integer spellings, verification failure behavior, and valid blinding-factor sums beyond the curve order.