### PR TITLE
generate_sbom.py describes a vendored submodule at its pinned commit

### DIFF
--- a/.github/scripts/generate_sbom.py
+++ b/.github/scripts/generate_sbom.py
@@ -29,6 +29,22 @@ bytes here too, and the attestation over the release assets covers this
 file as well. Nothing is read from the clock, and nothing is random:
 `uuid4` would make a rebuild differ in the one field nobody could check.
 
+**`Requires-Dist` is not the only source.** It says what a distribution
+*declares*, and for a wheel that vendors a git submodule -- object code
+baked in at build time, never named in the wheel's own metadata -- that
+is not what the wheel *contains*. `.gitmodules` and the gitlink `git
+ls-tree` reads from the tree are, so a submodule pinned to a commit is
+read from there and reported as its own component: a `library` with a
+`pkg:github/<owner>/<repo>@<sha>` purl, a `vcs` externalReference naming
+the upstream repository, and `version` set to that sha. A commit is a
+narrower pin than any `==` this script otherwise grants a version to, so
+withholding one here would be the stricter rule protecting the weaker
+case; the sha rather than an upstream tag name, because the sha is what
+the gitlink actually stores and every commit has one, where resolving a
+tag would be a network call this script otherwise makes none of, for a
+result that may not exist. btclib vendors no submodule, so this is a
+no-op here and exists for a repository that does (issue #1280).
+
 Run it on a freshly built dist directory, after `uv build` and after the
 sdist normalizer, whose rewrite changes the digest this records:
 
@@ -43,11 +59,14 @@ and verifies it against the attestation.
 
 from __future__ import annotations
 
+import configparser
 import datetime
 import hashlib
 import json
 import os
 import re
+import shutil
+import subprocess
 import sys
 import zipfile
 from email import message_from_bytes
@@ -90,6 +109,24 @@ REFERENCE_TYPES = {
     "issues": "issue-tracker",
     "repository": "vcs",
 }
+
+# the two forms `git submodule add` writes into `.gitmodules` for a GitHub
+# url, https and ssh, with or without the `.git` suffix -- anything else
+# is refused, for the same reason an unreadable `Requires-Dist` line is:
+# a submodule this cannot name is one the document would omit in silence
+GITHUB_SUBMODULE_URL = re.compile(
+    r"^(?:https://github\.com/|git@github\.com:)"
+    r"(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$"
+)
+
+# a gitlink, which is what a submodule is recorded as in the tree that
+# carries it, whether or not the submodule was ever checked out
+GITLINK = re.compile(r"^160000 commit (?P<sha>[0-9a-f]{40})\t")
+
+# resolved once: S607 is what a bare "git" in a subprocess list would be,
+# a partial executable path relying on PATH's own search order rather
+# than naming what actually runs
+_GIT = shutil.which("git") or "git"
 
 
 def canonical_name(name: str) -> str:
@@ -249,7 +286,74 @@ def distribution_reference(path: Path) -> dict[str, Any]:
     }
 
 
-def build_sbom(wheel: Path, sdist: Path, epoch: int) -> dict[str, Any]:
+def submodule_commit(repo_root: Path, path: str) -> str:
+    """Return the commit a gitlink in the tree pins a submodule path to.
+
+    Read with `git ls-tree` rather than from a checkout of the submodule,
+    which need not exist: a gitlink is recorded in the parent repository's
+    own tree regardless of whether `git submodule update` ever ran.
+    """
+    result = subprocess.run(  # noqa: S603
+        [_GIT, "ls-tree", "HEAD", "--", path],
+        cwd=repo_root,
+        capture_output=True,
+        check=True,
+        encoding="utf-8",
+    )
+    match = GITLINK.match(result.stdout)
+    if match is None:
+        msg = f"{path} is declared in .gitmodules but is not a pinned submodule"
+        raise SystemExit(msg)
+    return match["sha"]
+
+
+def submodule_component(path: str, url: str, sha: str) -> dict[str, Any]:
+    """Return the component a vendored, commit-pinned submodule describes."""
+    match = GITHUB_SUBMODULE_URL.match(url)
+    if match is None:
+        msg = f"cannot read the submodule url {url!r}"
+        raise SystemExit(msg)
+    reference = f"pkg:github/{match['owner']}/{match['repo']}@{sha}"
+    return {
+        "type": "library",
+        "bom-ref": reference,
+        "name": match["repo"],
+        "purl": reference,
+        # the sha, not an upstream tag name: see the module docstring for
+        # why a network call to resolve one buys nothing a rebuild can
+        # check, where the sha is what the gitlink already states
+        "version": sha,
+        "scope": "required",
+        "externalReferences": [{"type": "vcs", "url": url}],
+        "properties": [{"name": "btclib:submodule-path", "value": path}],
+    }
+
+
+def submodule_components(repo_root: Path) -> list[dict[str, Any]]:
+    """Return one component per git submodule pinned to a commit.
+
+    `.gitmodules` names the path and the upstream url of every submodule
+    the repository declares; `submodule_commit` reads the commit each is
+    pinned to straight from the tree. A repository with no `.gitmodules`
+    -- btclib itself -- makes this a no-op.
+    """
+    gitmodules = repo_root / ".gitmodules"
+    if not gitmodules.is_file():
+        return []
+
+    config = configparser.ConfigParser()
+    config.read(gitmodules, encoding="utf-8")
+    return [
+        submodule_component(
+            config[section]["path"],
+            config[section]["url"],
+            submodule_commit(repo_root, config[section]["path"]),
+        )
+        for section in config.sections()
+    ]
+
+
+def build_sbom(wheel: Path, sdist: Path, epoch: int, repo_root: Path) -> dict[str, Any]:
     """Return the CycloneDX document describing the two files."""
     metadata = wheel_metadata(wheel)
     name = metadata["Name"]
@@ -301,7 +405,8 @@ def build_sbom(wheel: Path, sdist: Path, epoch: int) -> dict[str, Any]:
         declared = reading(requirement)
         by_name.setdefault(declared.name, []).append(declared)
     components = sorted(
-        (component(readings) for readings in by_name.values()),
+        [component(readings) for readings in by_name.values()]
+        + submodule_components(repo_root),
         key=lambda dependency: str(dependency["bom-ref"]),
     )
     serial = f"{reference}:{file_hash(wheel)}:{file_hash(sdist)}"
@@ -357,7 +462,11 @@ def main(argv: list[str]) -> int:
     dist_dir = Path(argv[1])
     wheel = one_of(dist_dir, "*.whl")
     sdist = one_of(dist_dir, "*.tar.gz")
-    sbom = build_sbom(wheel, sdist, int(epoch))
+    # this file's own location within the checked-out tree, so the
+    # submodule scan finds the repository root regardless of the caller's
+    # working directory
+    repo_root = Path(__file__).resolve().parents[2]
+    sbom = build_sbom(wheel, sdist, int(epoch), repo_root)
 
     # named after the wheel's own first two fields, {distribution} and
     # {version}, so the caller needs to know neither -- which in a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -498,6 +498,25 @@ documented at release-notes length in the first place, and are still in
   `analyze`'s two matrix cells are the whole of the checks it
   contributes to a commit.
 
+- **`generate_sbom.py` reads a component from a vendored git submodule's
+  pinned commit, not only from `Requires-Dist`** (issue #1280). A
+  submodule is content a wheel can bake in without declaring it as a
+  Python dependency -- `btclib-secp256k1`'s statically-linked
+  libsecp256k1 is exactly this, and was `RELEASING.md`'s own reason for
+  that sibling shipping no bill of materials. `.gitmodules` names the
+  path and the upstream url of each submodule a repository declares, and
+  `git ls-tree HEAD <path>` reads the commit its gitlink pins regardless
+  of whether the submodule was ever checked out; the component built
+  from the two is a `library` with a `pkg:github/<owner>/<repo>@<sha>`
+  purl and a `vcs` externalReference naming the upstream repository.
+  `version` is the sha rather than an upstream tag name: the sha is what
+  the gitlink states and every commit has one, where resolving a tag
+  would cost a network call this script otherwise makes none of, for a
+  result that may not exist. btclib carries no submodule, so the scan
+  is a no-op on this repository's own release; `RELEASING.md`'s
+  bill-of-materials step is corrected to say so, in place of the
+  limitation it named before.
+
 - **mypy's `enable_error_code` is the organization's list.** The same in
   every repository that runs mypy (btclib-org/.github#165):
   `explicit-override` and `unused-awaitable` enter, and

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -478,23 +478,25 @@ to `deps-latest`'s own result.
    bill of materials there would be an empty `components` list restating
    a fact CI checks more directly. btclib-secp256k1's interesting
    dependency is the vendored libsecp256k1 C library at the commit its
-   `secp256k1` submodule pins, which this generator cannot describe — it
-   reads `Requires-Dist`, and the submodule is not a Python dependency.
-   That holds for both wheel kinds it ships and not only the static one:
-   a static build links the library into the extension, a dynamic
-   (ABI-mode) build ships it as a shared object beside the extension
-   instead, and `Requires-Dist` says nothing about the pin either way.
-   Naming the linkage would invite the opposite conclusion, that the
-   dynamic build escapes the gap — where what is missing is the pinned
-   commit however the object code arrives.
-   A bill of materials built the way this one is
-   would name `cffi` and say nothing about the pin a verifier of that
-   package would most want described, which is worse than omitting the
-   document. Issue #1159 has the evaluation. What would change it is
-   btclib-org/.github#24, open because the premise is this repository's
-   own script: `generate_sbom.py` learning to describe a component
-   `Requires-Dist` cannot express would put the asymmetry above back in
-   question.
+   `secp256k1` submodule pins. That holds for both wheel kinds it ships
+   and not only the static one: a static build links the library into the
+   extension, a dynamic (ABI-mode) build ships it as a shared object
+   beside the extension instead, and `Requires-Dist` says nothing about
+   the pin either way. Naming the linkage would invite the opposite
+   conclusion, that the dynamic build escapes the gap — where what is
+   missing is the pinned commit however the object code arrives. A bill
+   of materials built from `Requires-Dist` alone would name `cffi` and
+   say nothing about the pin a verifier of that package would most want
+   described, which is worse than omitting the document — issue #1159
+   has that evaluation.
+
+   `generate_sbom.py` no longer has the limitation that evaluation rested
+   on: it reads a commit-pinned submodule from `.gitmodules` and the
+   tree's own gitlink, and reports it as a `pkg:github/<owner>/<repo>@<sha>`
+   component (issue #1280). The premise `btclib-org/.github#24` named as
+   what would reopen the question has therefore changed; whether
+   btclib-secp256k1 adopts this and what its own `RELEASING.md` then says
+   is that repository's decision, tracked at issue #1159.
 
 1. Read the release run's `published` job, which is this workflow called
    with the tag rather than a dispatch to remember: it has no checkout, so

--- a/tests/generate_sbom_test.py
+++ b/tests/generate_sbom_test.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 import importlib.util
 import json
 import runpy
+import shutil
+import subprocess
 import sys
 import zipfile
 from pathlib import Path
@@ -40,6 +42,10 @@ from typing import Any
 import pytest
 
 _SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "generate_sbom.py"
+
+# resolved once, for the reason generate_sbom.py's own `_GIT` is: a bare
+# "git" in a subprocess list is a partial executable path
+_GIT = shutil.which("git") or "git"
 
 # an instant in August 2026, as SOURCE_DATE_EPOCH carries one: seconds
 _EPOCH = 1786407122
@@ -84,10 +90,64 @@ def write_dist(
 
 
 def sbom(script: ModuleType, directory: Path, **kwargs: Any) -> dict[str, Any]:
-    """Return the document for a dist directory written on the spot."""
+    """Return the document for a dist directory written on the spot.
+
+    `directory` doubles as the repository root the submodule scan reads:
+    a fresh `tmp_path` carries no `.gitmodules` unless a test writes one
+    with `make_submodule_repo` first, which is the no-op every other test
+    here relies on without saying so.
+    """
     wheel, sdist = write_dist(directory, **kwargs)
-    document: dict[str, Any] = script.build_sbom(wheel, sdist, _EPOCH)
+    document: dict[str, Any] = script.build_sbom(wheel, sdist, _EPOCH, directory)
     return document
+
+
+def make_submodule_repo(
+    root: Path,
+    *,
+    url: str = "https://github.com/bitcoin-core/secp256k1.git",
+    sha: str = "6e2c8bc4ecdc6e71dbe7a368f360d8d453ce435d",
+    path: str = "secp256k1",
+    commit_gitlink: bool = True,
+) -> Path:
+    """Turn `root` into a git repository declaring one submodule.
+
+    `.gitmodules` and the gitlink are independent facts in git's own
+    model -- the file can be edited without the tree changing what it
+    pins -- so both are written by hand rather than through `git
+    submodule add`, which would need to reach the url it clones.
+    """
+    subprocess.run([_GIT, "init", "-q"], cwd=root, check=True)  # noqa: S603
+    (root / ".gitmodules").write_text(
+        f'[submodule "{path}"]\n\tpath = {path}\n\turl = {url}\n', encoding="utf-8"
+    )
+    subprocess.run(  # noqa: S603
+        [_GIT, "add", ".gitmodules"], cwd=root, check=True
+    )
+    if commit_gitlink:
+        subprocess.run(  # noqa: S603
+            [_GIT, "update-index", "--add", "--cacheinfo", f"160000,{sha},{path}"],
+            cwd=root,
+            check=True,
+        )
+    subprocess.run(  # noqa: S603
+        [
+            _GIT,
+            "-c",
+            "user.email=test@example.org",
+            "-c",
+            "user.name=test",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-q",
+            "-m",
+            "vendor a submodule",
+        ],
+        cwd=root,
+        check=True,
+    )
+    return root
 
 
 def test_the_document_describes_the_distribution(
@@ -269,6 +329,92 @@ def test_a_dependency_split_by_marker_is_one_component(
         {"name": "btclib:requires-dist", "value": requirement}
         for requirement in requirements
     ]
+
+
+def test_a_submodule_pinned_to_a_commit_is_a_component(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """A vendored submodule is a component `Requires-Dist` never carries."""
+    make_submodule_repo(tmp_path)
+    document = sbom(script, tmp_path)
+
+    (component,) = document["components"]
+    sha = "6e2c8bc4ecdc6e71dbe7a368f360d8d453ce435d"
+    assert component["type"] == "library"
+    assert component["name"] == "secp256k1"
+    assert component["purl"] == f"pkg:github/bitcoin-core/secp256k1@{sha}"
+    assert component["bom-ref"] == component["purl"]
+    assert component["version"] == sha
+    assert component["scope"] == "required"
+    assert component["externalReferences"] == [
+        {"type": "vcs", "url": "https://github.com/bitcoin-core/secp256k1.git"}
+    ]
+    assert component["properties"] == [
+        {"name": "btclib:submodule-path", "value": "secp256k1"}
+    ]
+
+
+def test_a_submodule_ssh_url_is_read_too(script: ModuleType, tmp_path: Path) -> None:
+    """The form `git submodule add` writes for a private remote."""
+    make_submodule_repo(tmp_path, url="git@github.com:bitcoin-core/secp256k1.git")
+    document = sbom(script, tmp_path)
+
+    (component,) = document["components"]
+    assert component["name"] == "secp256k1"
+    assert component["purl"].startswith("pkg:github/bitcoin-core/secp256k1@")
+
+
+def test_a_submodule_url_that_is_not_github_stops_it(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """Refused rather than guessed at, an unreadable url's own rule."""
+    make_submodule_repo(tmp_path, url="https://gitlab.com/o/r.git")
+
+    with pytest.raises(SystemExit, match="cannot read the submodule url"):
+        sbom(script, tmp_path)
+
+
+def test_a_submodule_without_a_gitlink_stops_it(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """A path `.gitmodules` names but the tree does not pin is not skipped."""
+    make_submodule_repo(tmp_path, commit_gitlink=False)
+
+    with pytest.raises(SystemExit, match="is not a pinned submodule"):
+        sbom(script, tmp_path)
+
+
+def test_submodule_components_is_a_no_op_for_this_repository(
+    script: ModuleType,
+) -> None:
+    """Btclib vendors no submodule, so a scan of its own tree finds none."""
+    assert script.submodule_components(_SCRIPT.parents[2]) == []
+
+
+def test_a_submodule_component_sorts_beside_requires_dist_components(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """One `components` list, sorted by `bom-ref` across both sources."""
+    make_submodule_repo(tmp_path)
+    document = sbom(script, tmp_path, requirements=("btclib_secp256k1>=0.8.0",))
+
+    refs = [c["bom-ref"] for c in document["components"]]
+    assert refs == sorted(refs)
+    names = {c["name"] for c in document["components"]}
+    assert names == {"secp256k1", "btclib-secp256k1"}
+
+
+def test_the_dependency_graph_names_a_submodule_component(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """A submodule component is a dependency the root depends on too."""
+    make_submodule_repo(tmp_path)
+    document = sbom(script, tmp_path)
+
+    (component,) = document["components"]
+    root, *leaves = document["dependencies"]
+    assert component["bom-ref"] in root["dependsOn"]
+    assert leaves == [{"ref": component["bom-ref"], "dependsOn": []}]
 
 
 def test_the_references_of_a_document_are_distinct(


### PR DESCRIPTION
`generate_sbom.py` built its CycloneDX components purely from a wheel's `Requires-Dist` metadata — what a distribution declares rather than what it contains. For this package the two coincide; for `btclib-secp256k1`, which vendors libsecp256k1 as a git submodule pinned to a commit, they do not, and that gap is the stated reason that repository publishes no SBOM.

Adds `submodule_components()`: reads `.gitmodules`, resolves each submodule's pinned commit with `git ls-tree HEAD -- <path>` (a gitlink, readable without a checkout), and emits a `library` component with `purl = pkg:github/<owner>/<repo>@<sha>`, `version = <sha>` (the raw commit, not an upstream tag — always present, no extra network call, reasoning in the docstring), and a `vcs` external reference. No-op on this repository, which has no submodule.

The other half of the issue (a dependency named on several `Requires-Dist` lines becoming one component) was already fixed on main by #1197 — verified independently, no new work needed there.

`RELEASING.md` is corrected accordingly: the paragraph saying the generator "cannot describe" a submodule-pinned component is what this diff falsifies.

Local review (fresh context) came back CLEARED, with one non-blocking finding: a `.gitmodules` section missing `path=`/`url=` raises a raw `KeyError` instead of the script's own `SystemExit(msg)` convention for malformed input. Declining to act on it — it can't occur from a `.gitmodules` written by `git submodule add`, and it already fails loud rather than producing a wrong SBOM.

Closes #1280.

## Summary by Sourcery

Extend SBOM generation to describe vendored Git submodules at their pinned commits.

New Features:
- Include vendored Git submodules pinned to commits as CycloneDX library components with GitHub package URLs and VCS references.

Enhancements:
- Read submodule metadata and pinned commits directly from the repository without requiring a checkout or network access.
- Update release guidance to reflect that submodule-pinned components are now represented in generated SBOMs.

Documentation:
- Correct the release documentation describing the SBOM generator's submodule limitations.

Tests:
- Add coverage for submodule component generation, supported URL forms, invalid metadata, missing gitlinks, sorting, dependency relationships, and the no-submodule case.

Chores:
- Document the SBOM submodule support in the changelog.