### PR TITLE
pyroma is skipped on pre-commit.ci for an isolated build it only falls back to

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,21 +21,10 @@ ci:
   # lands on
   autoupdate_commit_msg: "Update the pinned pre-commit hook revisions"
   autoupdate_schedule: weekly
-  # the hooks pre-commit.ci cannot run, each covered by the lint workflow,
-  # which is the required check and runs them all. mypy shells out to uv,
-  # which is not installed there. pyroma builds the project to read its
-  # metadata and gives `build` no way to skip isolation, so it asks for a
-  # virtual environment and gets
-  # "No module named ensurepip" from the interpreter pre-commit.ci offers:
-  #
-  #     https://results.pre-commit.ci/run/github/133639679/
-  #
-  # is where that answer was read. Under the previous backend the build
-  # requirement resolved to setuptools and the isolated environment was
-  # never asked for; uv_build is bundled in the uv binary, and pyroma does
-  # not know to look there. `test.yml`'s dist job runs the same check
-  # against the built archives, where a build environment exists
-  skip: [mypy, pyroma]
+  # the hook pre-commit.ci cannot run, covered by the lint workflow, which
+  # is the required check and runs it: mypy shells out to uv, which is not
+  # installed there
+  skip: [mypy]
 
 repos:
   # this file checking itself, and the only two hooks here with no
@@ -664,3 +653,22 @@ repos:
     rev: "5.0.1"
     hooks:
       - id: pyroma
+        # the backend, in pyroma's own environment. pyroma's command line
+        # has no isolation flag, but its code asks `build` for the
+        # metadata without isolation first and only falls back to an
+        # isolated build when that raises -- and an isolated build is a
+        # virtual environment pre-commit.ci cannot create, the same
+        # constraint the check-sdist hook above answers with
+        # --no-isolation. Without this line the backend named in
+        # [build-system] is not importable in the hook's own environment,
+        # the first attempt raises, and the fallback is what pre-commit.ci
+        # refuses.
+        #
+        # The specifier is [build-system]'s and has to stay it: `build`
+        # skips isolation only when the environment already satisfies
+        # what pyproject.toml requires, so a version here outside that
+        # range puts the fallback back. Not pinned, unlike the additional
+        # dependencies elsewhere in this file: what this has to match is
+        # a range rather than a release, and the isolated build it
+        # replaces would have resolved the same range itself
+        additional_dependencies: ["uv_build>=0.12.5,<0.13"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -497,8 +497,8 @@ documented at release-notes length in the first place, and are still in
   importable in the hook's own environment, so the first attempt always
   raised. `additional_dependencies: ["uv_build>=0.12.5,<0.13"]` on the
   hook, the same range `pyproject.toml` declares, is what makes the
-  non-isolated attempt succeed (btclib-org/.github#118 is where
-  btclib-benchmarks made the same change).
+  non-isolated attempt succeed (btclib-org/btclib-benchmarks#165 is where
+  that project made the same change).
 
 - **`codeql.yml` no longer carries an aggregate job.** `codeql-passed`
   produced `codeql: every job passed`, a context branch protection has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -488,6 +488,18 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **`pyroma` is no longer skipped on pre-commit.ci.** pyroma's own code
+  (`pyroma/projectdata.py`) asks `build` for the project's metadata
+  without isolation first, and only falls back to an isolated build —
+  which pre-commit.ci cannot create — when that raises. The fallback is
+  what pre-commit.ci was refusing, not an inability to skip isolation at
+  all: `[build-system] requires` names `uv_build`, which was not
+  importable in the hook's own environment, so the first attempt always
+  raised. `additional_dependencies: ["uv_build>=0.12.5,<0.13"]` on the
+  hook, the same range `pyproject.toml` declares, is what makes the
+  non-isolated attempt succeed (btclib-org/.github#118 is where
+  btclib-benchmarks made the same change).
+
 - **`codeql.yml` no longer carries an aggregate job.** `codeql-passed`
   produced `codeql: every job passed`, a context branch protection has
   never named — `codeql.yml`'s `on:` block has no `pull_request` trigger,


### PR DESCRIPTION
`.pre-commit-config.yaml`'s `ci: skip:` carries `pyroma` with a comment claiming it "gives `build` no way to skip isolation" — true only of pyroma's command line. pyroma's own code (`pyroma/projectdata.py`) tries a non-isolated build first and falls back to an isolated one (which pre-commit.ci refuses) only when the current environment lacks a `[build-system] requires` dependency. This repo requires `uv_build`, which wasn't importable in the hook's own environment, so the fallback was always taken.

Adds `additional_dependencies: ["uv_build>=0.12.5,<0.13"]` to the pyroma hook (the same specifier `pyproject.toml` declares), removes `pyroma` from `ci: skip:`, and corrects the comment. Matches the configuration already landed in btclib-benchmarks (btclib-org/btclib-benchmarks#165).

Not verifiable locally: whether pre-commit.ci's own restricted environment installs `uv_build`'s binary wheel without complaint — only the next run on this branch shows that.

Closes #1279.

## Summary by Sourcery

Run pyroma on pre-commit.ci by providing its declared build backend dependency and correcting the related CI guidance.

Bug Fixes:
- Enable the pyroma pre-commit.ci check by making the project build backend available in the hook environment, avoiding the unsupported isolated-build fallback.

CI:
- Stop skipping pyroma on pre-commit.ci while retaining the skip for mypy.

Documentation:
- Document why pyroma can run on pre-commit.ci and how its build dependency supports the check.