### PR TITLE
normalize_sdist.py fixes mode too, and test.yml stops calling it a belt

### DIFF
--- a/.github/scripts/normalize_sdist.py
+++ b/.github/scripts/normalize_sdist.py
@@ -2,33 +2,41 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Rewrite an sdist so that two builds of one commit are the same bytes.
+"""Rewrite an sdist's member metadata to this repository's own values.
 
-The backend already does that, and this runs anyway. `uv_build` writes a
-fixed timestamp into every member of both archives and ignores
-`SOURCE_DATE_EPOCH` entirely, which is measurable in one command:
+Four of the five fields it rewrites already hold those values coming out
+of `uv build --sdist`, measurable with `tarfile.getmembers()`: `uid` and
+`gid` are `0`, `uname` and `gname` are `""`, and the mode is `0o644` for
+a file and `0o755` for a directory. The fifth, `mtime`, is not: every
+member is `0`, and `uv_build` ignores `SOURCE_DATE_EPOCH` entirely --
 
     uv build -o a && SOURCE_DATE_EPOCH=1000000000 uv build -o b \
       && shasum -a 256 a/* b/*
 
-answers with one digest per artefact across the two directories, and
-`tarfile` reports a single distinct `mtime` of 0 in the `.tar.gz` against
-`(1980, 1, 1)` in the wheel's zip entries. Nothing here has to be done for
-the archive to be reproducible today.
+answers with one digest per artefact across the two directories. So
+rewriting `mtime` to `SOURCE_DATE_EPOCH` is where this step changes the
+published bytes: building this tree once and running this script against
+that build with `SOURCE_DATE_EPOCH` set gives a second, different sha256
+for the one archive, on any commit whose timestamp is not `0`. This step
+is not insurance layered over a backend that already does the same
+thing -- on `mtime` it does what `uv_build` does not, today.
 
-What this buys is that the property belongs to this repository rather than
-to the backend. A fixed `mtime` of 0 is uv's choice and uv is free to
-revisit it, while a release rebuilt from its tag has to give the bytes the
-attestation vouches for however many backends later that is. Rewriting the
-metadata to a value derived from the commit makes the answer this tree's,
-and turns a backend change from a broken rebuild into a no-op.
+What running it on the other four buys is that they stay this
+repository's choice regardless of what a future `uv_build` writes there,
+the same reason a release rebuilt from its tag has to give the
+attestation the bytes it vouches for however many backends later that
+is. RELEASING.md's "Rebuild a release from its tag" runs this script for
+that reason: skip it there and the rebuild's `mtime` disagrees with the
+published archive, whatever the other four fields do.
 
-What is *in* the archive is already deterministic; what is not is the
-metadata of the members. This rewrites that metadata and nothing else:
-every timestamp becomes `SOURCE_DATE_EPOCH`, ownership becomes root with
-no names, and the gzip header carries the same timestamp instead of the
-moment it was compressed. The order of the members and every byte of
-their content are the archive's own.
+What is *in* the archive is already deterministic; only the metadata of
+the members is rewritten here, and nothing else: `mtime` becomes
+`SOURCE_DATE_EPOCH`, ownership becomes root with no names, mode becomes
+`0o644` for a file and `0o755` for a directory -- nothing in the sdist
+needs the executable bit, no source file here opening with a shebang --
+and the gzip header carries the same timestamp instead of the moment it
+was compressed. The order of the members and every byte of their
+content are the archive's own.
 
 `PAX_FORMAT` with the extended headers cleared, rather than
 `USTAR_FORMAT`: an integral timestamp needs no PAX record, so the two
@@ -73,6 +81,12 @@ def normalize(archive: Path, epoch: int) -> None:
             member.mtime = epoch
             member.uid = member.gid = 0
             member.uname = member.gname = ""
+            # beside the ownership, and for the same reason: the value
+            # the archive came with is the backend's to choose, and this
+            # is where it becomes this repository's. `0o755`/`0o644` are
+            # digest-preserving against uv_build, which already writes
+            # exactly those two
+            member.mode = 0o755 if member.isdir() else 0o644
             # the records this exists to remove: tarfile writes one per
             # field it cannot express in the ustar header, and the
             # sub-second mtime above was such a field. Replaced rather than

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -544,16 +544,18 @@ jobs:
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: ${{ !inputs.disable-dist-cache }}
-      # what the sbom and the sdist normalizer below read. It no longer
-      # makes the wheel reproducible, and nothing has to: uv_build ignores
-      # the variable and writes a fixed timestamp into every member of
-      # both archives -- (1980, 1, 1) in the zip, 0 in the tar -- so one
-      # commit gives one digest whether the variable is exported or not.
-      # Measured by building this tree twice, once with SOURCE_DATE_EPOCH
-      # unset and once with it set to an arbitrary second: the two sdists
-      # and the two wheels are byte for byte the same file. What still
-      # needs a date is the sbom, whose timestamp and serial number derive
-      # from it. The commit date, not the tag's: `git log
+      # what the sdist normalizer and the sbom below read. `uv build`
+      # itself ignores it: it writes a fixed timestamp into every member
+      # of both archives -- (1980, 1, 1) in the zip, 0 in the tar --
+      # regardless of whether the variable is exported, so this step does
+      # not make either archive it is about to build reproducible, and
+      # nothing has to. Measured by building this tree twice, once with
+      # SOURCE_DATE_EPOCH unset and once with it set to an arbitrary
+      # second: the two sdists and the two wheels are byte for byte the
+      # same file. What reads the variable afterwards are the sdist
+      # normalizer, which stamps every member's mtime with it in place of
+      # uv_build's 0, and the sbom, whose timestamp and serial number
+      # derive from it. The commit date, not the tag's: `git log
       # -1` on a shallow clone reads the tip, which is the commit the tag
       # points at, and a lightweight tag has no date of its own to prefer.
       # RELEASING.md has the command that rebuilds a released tag and
@@ -582,17 +584,21 @@ jobs:
       # git's index rather than against a list anyone maintains
       - name: Build the distribution files
         run: uv build
-      # a belt over a backend that already writes fixed timestamps. What
-      # this step buys is that the archive's determinism is this
-      # repository's property and not the backend's: uv_build's mtime of 0
-      # is a choice it is free to revisit, and a release rebuilt from its
-      # tag two backends later still has to give the bytes the attestation
-      # vouches for. The script rewrites member metadata and no content,
-      # and its docstring has the measurement that says what it finds
-      # there today. --no-project, so this runs on the interpreter uv
+      # this changes the archive `uv build` just wrote: its mtime of 0
+      # becomes the commit date the step above exported, a different
+      # value on any commit, so the sha256sum below differs from what
+      # `uv build` alone produced -- this is not a check that the archive
+      # is already reproducible, it is what makes the published mtime
+      # this repository's choice rather than a backend default it is
+      # free to revisit. A release rebuilt from its tag gives the
+      # attestation the same bytes back only by running this step too;
+      # RELEASING.md's "Rebuild a release from its tag" does. The script
+      # rewrites member metadata and no content, and its docstring has
+      # the measurement that says which fields uv_build already writes
+      # the same way. --no-project, so this runs on the interpreter uv
       # already fetched and installs nothing into the tree it is about to
       # publish
-      - name: Make the sdist reproducible too
+      - name: Make the sdist's determinism this tree's own
         run: |
           uv run --no-project --python 3.14 \
             .github/scripts/normalize_sdist.py dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -499,6 +499,23 @@ documented at release-notes length in the first place, and are still in
   hook, the same range `pyproject.toml` declares, is what makes the
   non-isolated attempt succeed (btclib-org/btclib-benchmarks#165 is where
   that project made the same change).
+- **`normalize_sdist.py` also rewrites `mode`, and names every field it
+  rewrites** (issue #1277). `member.mode` becomes `0o755` for a directory
+  and `0o644` for a file, matching `bitcoin-core-rpc`'s copy of the
+  script; those are also the values `uv_build` already writes today, so
+  the line joins `uid`, `gid`, `uname` and `gname` as fields this
+  repository fixes independently of the backend rather than ones it
+  merely reads off it. `mtime` does not join them: it is the one field
+  where `uv_build`'s own value, `0`, is not what this script writes,
+  `SOURCE_DATE_EPOCH` instead. `test.yml`'s step comment stopped
+  describing the step as *"a belt over a backend that already writes
+  fixed timestamps"* — a framing that has cost a deleted script and a
+  second wrong "no-op" comment already, per btclib-org/.github#118 —
+  since running it changes the sdist's sha256: building this tree once
+  and then normalizing that same build with `SOURCE_DATE_EPOCH` set to
+  the commit's date gives two different digests for the one archive
+  (issue #1278). `RELEASING.md`'s "Rebuild a release from its tag" is
+  why the step is not optional there.
 
 - **`codeql.yml` no longer carries an aggregate job.** `codeql-passed`
   produced `codeql: every job passed`, a context branch protection has

--- a/tests/normalize_sdist_test.py
+++ b/tests/normalize_sdist_test.py
@@ -1,0 +1,250 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for `.github/scripts/normalize_sdist.py`.
+
+The script is loaded by path, `.github/scripts` being no package, as the
+other scripts under it are tested.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import runpy
+import sys
+import tarfile
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "normalize_sdist.py"
+
+_EPOCH = 1_700_000_000
+
+
+@pytest.fixture
+def script() -> ModuleType:
+    """Return the script, imported by path."""
+    spec = importlib.util.spec_from_file_location("normalize_sdist", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_archive(
+    path: Path,
+    *,
+    mtime: int = 12345,
+    file_mode: int = 0o664,
+    dir_mode: int = 0o700,
+    uid: int = 1000,
+    gid: int = 1000,
+    uname: str = "builder",
+    gname: str = "builder",
+) -> None:
+    """Write a two-member sdist: one directory, one file, given metadata.
+
+    The defaults are not `uv_build`'s: a normalization that only ever sees
+    the values it is about to write proves nothing about the rewrite.
+    """
+    with tarfile.open(path, "w:gz") as archive:
+        directory = tarfile.TarInfo("pkg")
+        directory.type = tarfile.DIRTYPE
+        directory.mtime = mtime
+        directory.mode = dir_mode
+        directory.uid, directory.gid = uid, gid
+        directory.uname, directory.gname = uname, gname
+        archive.addfile(directory)
+
+        content = b"content"
+        member = tarfile.TarInfo("pkg/module.py")
+        member.mtime = mtime
+        member.mode = file_mode
+        member.uid, member.gid = uid, gid
+        member.uname, member.gname = uname, gname
+        member.size = len(content)
+        archive.addfile(member, io.BytesIO(content))
+
+
+def read_members(path: Path) -> list[tarfile.TarInfo]:
+    """Read every member of an archive back, for the test to inspect."""
+    with tarfile.open(path, "r:gz") as archive:
+        return archive.getmembers()
+
+
+def test_normalize_rewrites_mtime_ownership_and_mode(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """Every member's mtime, ownership and mode move to the fixed values."""
+    archive = tmp_path / "pkg-1.0.tar.gz"
+    write_archive(archive)
+
+    script.normalize(archive, _EPOCH)
+
+    directory, file_member = read_members(archive)
+    assert {directory.mtime, file_member.mtime} == {_EPOCH}
+    assert {directory.uid, file_member.uid} == {0}
+    assert {directory.gid, file_member.gid} == {0}
+    assert {directory.uname, file_member.uname} == {""}
+    assert {directory.gname, file_member.gname} == {""}
+    assert directory.isdir()
+    assert directory.mode == 0o755
+    assert file_member.isfile()
+    assert file_member.mode == 0o644
+
+
+def test_normalize_preserves_order_and_content(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """The member order and their bytes are the archive's own, untouched."""
+    archive = tmp_path / "pkg-1.0.tar.gz"
+    write_archive(archive)
+
+    script.normalize(archive, _EPOCH)
+
+    members = read_members(archive)
+    assert [m.name for m in members] == ["pkg", "pkg/module.py"]
+    with tarfile.open(archive, "r:gz") as reopened:
+        extracted = reopened.extractfile("pkg/module.py")
+        assert extracted is not None
+        assert extracted.read() == b"content"
+
+
+def test_normalize_clears_pax_headers(script: ModuleType, tmp_path: Path) -> None:
+    """A PAX record from a sub-second mtime does not survive the rewrite.
+
+    `member.mtime = epoch` alone leaves the old extended header in place --
+    it is `member.pax_headers` that carries it, not `member.mtime` -- which
+    is why the script clears it explicitly rather than relying on the new
+    value being an integer.
+    """
+    archive = tmp_path / "pkg-1.0.tar.gz"
+    with tarfile.open(archive, "w:gz", format=tarfile.PAX_FORMAT) as source:
+        member = tarfile.TarInfo("pkg/module.py")
+        member.mtime = 12345.5
+        content = b"content"
+        member.size = len(content)
+        source.addfile(member, io.BytesIO(content))
+    with tarfile.open(archive, "r:gz") as reopened:
+        (before,) = reopened.getmembers()
+    assert before.pax_headers == {"mtime": "12345.5"}
+
+    script.normalize(archive, _EPOCH)
+
+    (after,) = read_members(archive)
+    assert after.pax_headers == {}
+    assert after.mtime == _EPOCH
+
+
+def test_normalize_matches_what_uv_build_already_writes_but_for_mtime(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """`mtime` is the one field the rewrite changes against `uv_build`.
+
+    `uv_build` already writes root ownership and the same two modes this
+    script picks (ISS 1277); only its `mtime` of `0` is not `SOURCE_DATE_EPOCH`
+    -- so an archive built exactly like that changes digest on the `mtime`
+    rewrite alone (ISS 1278), which is what a rebuild without this step
+    would miss.
+    """
+    archive = tmp_path / "pkg-1.0.tar.gz"
+    write_archive(
+        archive,
+        mtime=0,
+        file_mode=0o644,
+        dir_mode=0o755,
+        uid=0,
+        gid=0,
+        uname="",
+        gname="",
+    )
+    before = hashlib.sha256(archive.read_bytes()).hexdigest()
+
+    script.normalize(archive, _EPOCH)
+
+    after = hashlib.sha256(archive.read_bytes()).hexdigest()
+    assert before != after
+    directory, file_member = read_members(archive)
+    assert directory.mode == 0o755
+    assert file_member.mode == 0o644
+
+
+def test_main_says_how_to_be_called_when_it_is_not(
+    script: ModuleType, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No dist directory, or two of them, is the usage rather than a crash."""
+    assert script.main(["prog"]) == 2
+    assert capsys.readouterr().err == "usage: prog <dist directory>\n"
+
+
+def test_main_refuses_to_default_source_date_epoch_to_now(
+    script: ModuleType,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset is a failure, not "now": the script's own docstring has why."""
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+
+    assert script.main(["prog", str(tmp_path)]) == 1
+    assert "SOURCE_DATE_EPOCH is not set" in capsys.readouterr().err
+
+
+def test_main_names_a_dist_directory_with_no_sdist(
+    script: ModuleType,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A directory with a wheel and no sdist is named, not silently skipped."""
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", str(_EPOCH))
+    (tmp_path / "btclib-1.0-py3-none-any.whl").write_bytes(b"")
+
+    assert script.main(["prog", str(tmp_path)]) == 1
+    assert f"no sdist in {tmp_path}" in capsys.readouterr().err
+
+
+def test_main_normalizes_every_sdist_and_reports_it(
+    script: ModuleType,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The success path: every `*.tar.gz` in the directory is rewritten."""
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", str(_EPOCH))
+    archive = tmp_path / "pkg-1.0.tar.gz"
+    write_archive(archive)
+
+    assert script.main(["prog", str(tmp_path)]) == 0
+
+    assert f"normalized {archive}" in capsys.readouterr().out
+    directory, file_member = read_members(archive)
+    assert directory.mtime == _EPOCH
+    assert file_member.mtime == _EPOCH
+
+
+def test_the_main_guard_runs_the_script_as___main__(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cover `if __name__ == "__main__":` without a subprocess.
+
+    This project collects no coverage from a child interpreter, so a real
+    subprocess would leave the guard as uncovered as it is in
+    `mutation_counts.py`. `runpy.run_path` executes the file fresh with
+    `__name__` set to `"__main__"` in this one.
+    """
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", str(_EPOCH))
+    archive = tmp_path / "pkg-1.0.tar.gz"
+    write_archive(archive)
+    monkeypatch.setattr(sys, "argv", ["prog", str(tmp_path)])
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(_SCRIPT), run_name="__main__")
+
+    assert excinfo.value.code == 0


### PR DESCRIPTION
Two related fixes to `.github/scripts/normalize_sdist.py`, same file, same decision — what the script normalizes and how that's described.

`uv_build` already writes `0o644`/`0o755`, the way it already writes root ownership with no names — that value is a backend choice, not a guarantee, which is the same argument the script's docstring already made for the other four fields it rewrites, and mode was the one left reading whatever the backend wrote. Adds `member.mode = 0o755 if member.isdir() else 0o644` to the same loop, matching bitcoin-core-rpc's copy of the script (#1277).

`test.yml`'s comment above the step called it "a belt over a backend that already writes fixed timestamps" — read as a no-op, which it is not: `uv_build` writes `mtime=0`, this script rewrites it to `SOURCE_DATE_EPOCH`, and running it changes the sdist's sha256 (measured: build once, normalize that build, the two digests differ). The comment and the script's own docstring now say which fields are already fixed by `uv_build` (mode, uid/gid, uname/gname) and which is not (mtime) (#1278).

Adds `tests/normalize_sdist_test.py` — the one script under `.github/scripts` with no matching test file, aside from `wait_for_hwi_device.py` (exercised only by `integration-hwi.yml`).

Closes #1277, closes #1278.

## Summary by Sourcery

Make sdist metadata determinism an explicit repository guarantee by normalizing member modes and documenting the timestamp rewrite.

Bug Fixes:
- Normalize sdist member modes to repository-defined file and directory permissions, alongside timestamps and ownership metadata.

Enhancements:
- Clarify that normalization intentionally changes backend-generated mtimes while enforcing repository-owned archive metadata.
- Add comprehensive tests covering metadata normalization, archive preservation, PAX header cleanup, command-line validation, and script execution.

CI:
- Update the distribution workflow comments and step name to accurately describe the sdist normalization behavior.

Documentation:
- Document the sdist metadata normalization change and its effect on release rebuilds in the changelog.

Tests:
- Add dedicated coverage for `.github/scripts/normalize_sdist.py`.