### PR TITLE
readthedocs.yaml justifies its name with a MANIFEST.in directive it does not have

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,8 +3,13 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 #
 # The dotted name is the canonical one; readthedocs.yml is honored too,
-# but documented as deprecated, and "include *.yml" would drag it into
-# the sdist beside the Jekyll configuration.
+# but documented as deprecated. [tool.uv.build-backend] source-include
+# in pyproject.toml names "*.yaml" and not "*.yml", which is why the
+# dotted spelling, and not the other, is what the sdist carries:
+#
+#   uv build --sdist -o dist && tar tzf dist/*.tar.gz | grep readthedocs
+#
+# lists it.
 #
 # The build has to install btclib itself, not sphinx alone: every autodoc
 # directive in docs/source imports its module, a failed import is a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1534,6 +1534,16 @@ documented at release-notes length in the first place, and are still in
 
 ### Documentation and the website
 
+- **`.readthedocs.yaml` justifies its own name with the setting that
+  actually controls it** (issue #1275). The comment gave `MANIFEST.in`'s
+  `include *.yml` as the reason the dotted spelling ships, in a tree
+  that has no `MANIFEST.in` and is built by `uv_build`, whose
+  `[tool.uv.build-backend] source-include` names `*.yaml` and not
+  `*.yml` — the opposite pairing from the one the sentence stated.
+  `uv build --sdist -o dist && tar tzf dist/*.tar.gz | grep readthedocs`
+  lists `.readthedocs.yaml`, confirming the dotted spelling is the one
+  that ships, for the reason now written beside it.
+
 - **CONTRIBUTING.md's documented mypy command and its workflow-schedule
   sentence match the tree** (issues #1281, #1271). The mypy invocation
   named a root `scripts` directory; `git ls-files` finds none there, and


### PR DESCRIPTION
`.readthedocs.yaml`'s comment explained the dotted spelling's canonicity with a `MANIFEST.in`-style `include *.yml` directive that would "drag it into the sdist" — but this repo has no `MANIFEST.in` (it's on `uv_build`), and the mechanism that actually controls sdist membership is `[tool.uv.build-backend] source-include`, which matches `*.yaml` and not `*.yml`. The comment had the logic backwards: the dotted spelling is the one that ships, and the undotted spelling it warned about is the one that would not.

Rewords the comment to state the actual mechanism, with the verifying command inline. Confirmed by building the sdist and listing it: `.readthedocs.yaml` is genuinely a member.

Closes #1275.

## Summary by Sourcery

Clarify the source-distribution behavior of the Read the Docs configuration and update the changelog accordingly.

Bug Fixes:
- Correct the `.readthedocs.yaml` comment to accurately explain why the dotted configuration file is included in source distributions.

Documentation:
- Document the actual `uv_build` source-include setting and provide a command to verify `.readthedocs.yaml` is included in the sdist.
- Record the documentation correction in the changelog.