### PR TITLE
vendored-vectors.yml has unnamed steps, where every other workflow here names them

### DIFF
--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -79,11 +79,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1532,6 +1532,13 @@ documented at release-notes length in the first place, and are still in
   `reorder_keys` goes the same way, `btclib-org/.github` having no
   `pyproject.toml` at all.
 
+- **`vendored-vectors.yml`'s checkout and Python setup steps now carry a
+  `name:`** (issue #1273), matching every other workflow in this
+  repository: `actions/checkout` is named `Checkout code` throughout, and
+  this is the one job in the tree that sets up Python with
+  `actions/setup-python` rather than `astral-sh/setup-uv`, since the
+  script it runs has no project dependency to lock.
+
 ### Documentation and the website
 
 - **CONTRIBUTING.md's documented mypy command and its workflow-schedule


### PR DESCRIPTION
`.github/workflows/vendored-vectors.yml` had two steps with no `name:` — an `actions/checkout` and an `actions/setup-python` — where every other workflow in this repository names all of theirs. This is the org's baseline other repositories' workflows are measured against for the convention (btclib-org/btclib-secp256k1#300), so the inconsistency here undercuts that claim.

Names the checkout step `Checkout code`, matching every other checkout step in this repository. Names the setup-python step `Setup Python`: `actions/setup-python` appears nowhere else here (every other Python-interpreter step uses `astral-sh/setup-uv`, named `Setup uv`), so there's no direct precedent to match — this job has no project dependency to lock, hence no `uv`.

Closes #1273.

## Summary by Sourcery

Standardize step names in the vendored-vectors workflow.

Enhancements:
- Name the checkout and Python setup steps in the vendored-vectors GitHub Actions workflow for consistent workflow step labeling.

Chores:
- Record the workflow naming consistency improvement in the changelog.