### PR TITLE
CONTRIBUTING.md states ruff format and pre-commit disagree on markdown (issue #1293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **`CONTRIBUTING.md` says where the bare `ruff format` and
+  `pre-commit run --all-files` disagree.** `ruff-pre-commit`'s
+  `ruff-format` hook restricts itself to `types_or: [python, pyi,
+  jupyter]`, so `pre-commit` never reformats a `.md` file; the bare
+  command has no such filter and reformats a fenced-code Python block it
+  finds inside `CHANGELOG.md` or `RELEASE_NOTES.md` (issue #1293).
+
 - **`REVIEWING.md`'s *The gates are the evidence* excepts no gate from
   the run a reviewer may rely on, the test suite included.** The
   organization's copy, shared half byte for byte (section 14): a run is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -351,6 +351,16 @@ or, in one go, with [pre-commit](https://pre-commit.com/):
 uv run pre-commit run --all-files
 ```
 
+**The two are not the same for `ruff format`.** The bare command above
+has no path argument, so it walks the whole tree and reformats a
+fenced-code Python block it finds inside a `.md` file, `CHANGELOG.md`
+and `RELEASE_NOTES.md` included; the `ruff-format` hook in
+`.pre-commit-config.yaml` restricts itself to `ruff-pre-commit`'s own
+`types_or: [python, pyi, jupyter]`, so `pre-commit run --all-files`
+never hands it a `.md` file and leaves those fences untouched. `git
+status` after running the bare command shows the difference; the gate
+CI runs is the pre-commit one.
+
 The suite writes nothing: it runs against a read-only checkout, and from an
 installed sdist. The one exception is deliberate and has to be asked for.
 Several modules compare a dataclass's `to_dict()` against a json file


### PR DESCRIPTION
Closes #1293.

`CONTRIBUTING.md` calls `uv run pre-commit run --all-files` the "one
go" equivalent of running `ruff check --fix`, `ruff format`, `mypy` and
`pytest` by hand. False for `ruff format`: the pinned `ruff-format`
hook (v0.16.3) declares `types_or: [python, pyi, jupyter]`, so
pre-commit never hands it a `.md` file, but a bare `ruff format`
reformats the fenced Python blocks it finds inside markdown —
demonstrably on `CHANGELOG.md` and `RELEASE_NOTES.md` today
(`ruff format --diff` over every tracked `.md` file finds a diff only
in those two). `CONTRIBUTING.md` now says so plainly, and
`CHANGELOG.md` gets a matching entry.

Kept the doc-only fix (the issue's option A) over widening the hook's
`types_or` to `markdown` (option B): pre-commit already has no
`pytest` hook, so the "one go" claim was already partial regardless of
markdown, and this repo's pattern (#1285-#1289) is to correct an
inaccurate process sentence rather than re-engineer the gate it
describes for a footprint of two files.

Local review at fresh context: `CLEARED 16738c821f304eba1fd9faf69ffc6014e78c884a`.
Rebased onto origin/main (#1301) with no conflicts; current head
`89686709`.

Gates on `89686709`, all exit 0: `pytest` (29700 passed, 11 skipped,
100.00% coverage), `pre-commit run --all-files`, and the Sphinx build
with `-W`. `git status --porcelain` empty.

Collateral opened while writing this, unrelated to this diff: #1302.

## Summary by Sourcery

Clarify the different Markdown formatting coverage of direct Ruff execution and the pre-commit gate.

Enhancements:
- Clarify in contributor guidance that bare `ruff format` can reformat fenced Python in Markdown while the pre-commit hook does not process Markdown files.

Documentation:
- Document the Ruff formatting discrepancy in `CONTRIBUTING.md` and record it in the changelog.