### PR TITLE
Two pyproject.toml comments named a reason for an entry that the entry does not have

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -495,6 +495,26 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **Two `pyproject.toml` comments named a reason for an entry that the
+  entry does not have.** `[tool.uv.build-backend]`'s `source-include`
+  comment justified part of the list by saying the lint gate has to be
+  runnable from an unpacked sdist. It does not run there, and no
+  include pattern makes it so: `check-sdist`'s own `default-ignore.txt`
+  keeps `.github` out of every archive the backend builds, so
+  `check-hooks-apply` fails on `check-dependabot`, `actionlint` and
+  `zizmor`, each reading only that directory. The comment now says what
+  the list actually buys — a tool reading `.pre-commit-config.yaml`,
+  `.taplo.toml` or `.secrets.baseline` directly finds it in the sdist
+  too (issue #1276).
+
+  `[tool.typos.default.extend-words]`'s `CPY` entry credited an
+  occurrence in `pyproject.toml` itself, but typos skips the file
+  holding its own configuration, so nothing there asks for the entry.
+  The occurrence that does is `btclib/__init__.py`'s comment naming
+  `CPY001`: typos splits the code out of it and, run with
+  `--write-changes`, rewrites it into `COPY001`. The comment now names
+  that file (issue #1274).
+
 - **`pyroma` is no longer skipped on pre-commit.ci.** pyroma's own code
   (`pyroma/projectdata.py`) asks `build` for the project's metadata
   without isolation first, and only falls back to an isolated build —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -499,11 +499,14 @@ documented at release-notes length in the first place, and are still in
   entry does not have.** `[tool.uv.build-backend]`'s `source-include`
   comment justified part of the list by saying the lint gate has to be
   runnable from an unpacked sdist. It does not run there, and no
-  include pattern makes it so: `check-sdist`'s own `default-ignore.txt`
-  keeps `.github` out of every archive the backend builds, so
-  `check-hooks-apply` fails on `check-dependabot`, `actionlint` and
-  `zizmor`, each reading only that directory. The comment now says what
-  the list actually buys — a tool reading `.pre-commit-config.yaml`,
+  include pattern makes it so: nothing in the list names anything
+  under `.github/`, so the backend never puts it in the archive it
+  builds, and `check-hooks-apply` fails on `check-dependabot`,
+  `actionlint` and `zizmor`, each reading only that directory --
+  `check-sdist`'s own `default-ignore.txt` carrying `.github` is why
+  that absence is accepted rather than reported, and controls nothing
+  about what the backend packs. The comment now says what the list
+  actually buys — a tool reading `.pre-commit-config.yaml`,
   `.taplo.toml` or `.secrets.baseline` directly finds it in the sdist
   too (issue #1276).
 
@@ -526,6 +529,7 @@ documented at release-notes length in the first place, and are still in
   hook, the same range `pyproject.toml` declares, is what makes the
   non-isolated attempt succeed (btclib-org/btclib-benchmarks#165 is where
   that project made the same change).
+
 - **`normalize_sdist.py` also rewrites `mode`, and names every field it
   rewrites** (issue #1277). `member.mode` becomes `0o755` for a directory
   and `0o644` for a file, matching `bitcoin-core-rpc`'s copy of the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,9 +231,15 @@ module-root = ""
 # anchored, so `*.md` is the root's own markdown and reaches neither the
 # module's nor the website's, and `/**` is what recurses.
 #
-# The lint gate has to be runnable from an unpacked sdist, which is what
-# puts .pre-commit-config.yaml (`*.yaml`) in, and .taplo.toml (`*.toml`)
-# and .secrets.baseline, which hooks read, with it.
+# Not that the lint gate is runnable from an unpacked sdist: it is not,
+# and no pattern here can make it so -- check-sdist's own
+# default-ignore.txt keeps .github out of any archive it builds, so
+# check-hooks-apply fails there on check-dependabot, actionlint and
+# zizmor, each reading only that directory. What the list buys instead
+# is that a tool reading one of these files directly finds it in the
+# sdist too: .pre-commit-config.yaml (`*.yaml`) is a hook's own file,
+# and .taplo.toml (`*.toml`) and .secrets.baseline are what a hook of
+# it reads.
 #
 # The Jekyll sources of btclib.org, which is served from this
 # repository's root, are named nowhere here: they are tracked and
@@ -600,8 +606,9 @@ ands = "ands"
 # signature every other implementation refuses, written by a spell
 # checker into a wire format
 ful = "ful"
-# ruff's own name for flake8-copyright, in the comment above
-# [tool.ruff.lint.flake8-copyright] explaining why it is selected
+# btclib/__init__.py names ruff's CPY001 (flake8-copyright) rule by
+# code; without this entry the hook splits it and rewrites the comment
+# into one naming COPY001, a rule that does not exist
 CPY = "CPY"
 
 [tool.typos.type.verbatim]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,14 +232,18 @@ module-root = ""
 # module's nor the website's, and `/**` is what recurses.
 #
 # Not that the lint gate is runnable from an unpacked sdist: it is not,
-# and no pattern here can make it so -- check-sdist's own
-# default-ignore.txt keeps .github out of any archive it builds, so
-# check-hooks-apply fails there on check-dependabot, actionlint and
-# zizmor, each reading only that directory. What the list buys instead
-# is that a tool reading one of these files directly finds it in the
-# sdist too: .pre-commit-config.yaml (`*.yaml`) is a hook's own file,
-# and .taplo.toml (`*.toml`) and .secrets.baseline are what a hook of
-# it reads.
+# and no pattern here can make it so. .github is absent from the sdist
+# because nothing above names anything under it, not because
+# check-sdist's default-ignore.txt controls what the backend puts in
+# the archive -- that list only keeps a tracked-but-absent .github from
+# being reported as a mismatch, the role it plays for git-only below.
+# check-hooks-apply still fails on an unpacked sdist, on
+# check-dependabot, actionlint and zizmor, each reading only that
+# directory. What the list above buys instead is that a tool reading
+# one of these files directly finds it in the sdist too:
+# .pre-commit-config.yaml (`*.yaml`) is a hook's own file, and
+# .taplo.toml (`*.toml`) and .secrets.baseline are what a hook of it
+# reads.
 #
 # The Jekyll sources of btclib.org, which is served from this
 # repository's root, are named nowhere here: they are tracked and


### PR DESCRIPTION
Two stale/wrong comments in `pyproject.toml`, fixed together since both are in that one file.

`[tool.uv.build-backend] source-include`'s comment justified part of the list by saying the lint gate has to be runnable from an unpacked sdist. It does not, and no include pattern can make it so: `check-sdist`'s own `default-ignore.txt` carries `.github`, and nothing in `source-include` adds it, so `check-hooks-apply` fails on `check-dependabot`, `actionlint` and `zizmor` there. The comment now says what the list actually buys — a tool reading `.pre-commit-config.yaml`, `.taplo.toml` or `.secrets.baseline` directly finds it in the sdist too.

`[tool.typos.default.extend-words]`'s `CPY` entry credited an occurrence inside `pyproject.toml` itself — but typos skips the file holding its own configuration, so that occurrence asks for nothing. The real trigger is `btclib/__init__.py`'s comment naming ruff's `CPY001` rule, a file typos does read.

Also restores a blank line between two adjacent CHANGELOG.md bullets in the same section, dropped in an already-landed commit.

Closes #1276, closes #1274.

## Summary by Sourcery

Clarify the rationale for packaging and typo-checker configuration entries and tidy the changelog formatting.

Enhancements:
- Correct stale comments in `pyproject.toml` to accurately describe source inclusion and the `CPY` spelling exception.
- Restore the missing blank line between adjacent changelog entries.

Documentation:
- Document the corrected packaging and typo-configuration rationale in the changelog.