### PR TITLE
CONTRIBUTING.md credits the wrong step for wheel/sdist reproducibility across checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1557,6 +1557,19 @@ documented at release-notes length in the first place, and are still in
   `uv build --sdist -o dist && tar tzf dist/*.tar.gz | grep readthedocs`
   lists `.readthedocs.yaml`, confirming the dotted spelling is the one
   that ships, for the reason now written beside it.
+- **CONTRIBUTING.md credits `test.yml`'s two `dist`-job commands for what
+  they actually buy** (issue #1297). It read the "Pin the build timestamp
+  to the commit" step and `normalize_sdist.py`'s step as why two
+  checkouts of one commit produce the same wheel and the same sdist; they
+  are not, `uv_build` already writing the same fixed metadata into both
+  archives regardless of `SOURCE_DATE_EPOCH` — measured by building this
+  tree twice, once with the variable set and once without, and comparing
+  the four resulting digests, which agree in pairs. What the two commands
+  buy instead is that the published bytes are this repository's own
+  choice rather than the backend's, which is what lets a rebuild of a
+  released tag reproduce what was *published* rather than only itself —
+  the property `test.yml`'s own comment above the second step already
+  states correctly (issues #1277, #1278).
 
 - **CONTRIBUTING.md's documented mypy command and its workflow-schedule
   sentence match the tree** (issues #1281, #1271). The mypy invocation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -612,9 +612,15 @@ then installs one. This is the one build there is (issue #1166):
 same job, and its own `publish-testpypi` and `publish-pypi` jobs download
 the `dist` artifact this job uploads rather than building a second copy —
 so what the checks below judge is what an index ends up serving, byte for
-byte. The first two commands after the build are what make the wheel and
-the sdist reproducible — the first is why two checkouts of one commit
-produce the same wheel, the second why they produce the same sdist — and
+byte. The first two commands after the build do not make two checkouts of
+one commit agree: `uv_build` ignores `SOURCE_DATE_EPOCH` and writes the
+same fixed metadata into the wheel and the sdist either way, so those two
+archives are already byte for byte the same file across checkouts before
+either command runs. What the two buy instead is that the published bytes
+are this repository's own choice rather than the backend's — the first
+pins `mtime` to the commit date, and the second, `normalize_sdist.py`,
+rewrites the sdist's member metadata to it — so a rebuild of a released
+tag reproduces what was *published* rather than only reproducing itself.
 `sha256sum` after them is the digest a rebuild from the tag is compared
 against. The two after that read the *members* of the two archives,
 which the three checks further down do not: an allowlist of what may be


### PR DESCRIPTION
CONTRIBUTING.md's `dist` job paragraph credited the `SOURCE_DATE_EPOCH` export and `normalize_sdist.py`'s step with making "two checkouts of one commit produce the same wheel"/"the same sdist" — false: both already agree with neither step run, since `uv_build` writes fixed metadata into both archives regardless of `SOURCE_DATE_EPOCH` (confirmed: two builds, with and without the variable set, are byte-identical).

What the two steps actually buy is that a rebuild of a released tag reproduces the *published* bytes — this repository's own chosen values rather than whatever the backend wrote — which is the property `RELEASING.md`'s "Rebuild a release from its tag" relies on.

Collateral from #1277/#1278 (PR #1301).

Closes #1297.

## Summary by Sourcery

Correct the documentation of distribution reproducibility so release rebuilds are distinguished from inherent cross-checkout build consistency.

Bug Fixes:
- Correct the contributor documentation's explanation of archive reproducibility so it no longer attributes cross-checkout consistency to the timestamp and sdist-normalization steps.

Enhancements:
- Clarify that the distribution checks establish reproducibility of published release artifacts from a tag, while the build backend already provides byte-identical outputs across checkouts.
- Document the roles of commit-date timestamp pinning and sdist metadata normalization more accurately.

Documentation:
- Update CONTRIBUTING.md to accurately describe the reproducibility guarantees provided by the distribution workflow.

Chores:
- Record the documentation correction and related issue references in the changelog.