### PR TITLE
A regression test guards the typos verbatim backtick pairing (issue #1302)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -366,9 +366,16 @@ repos:
         # single unbreakable word and its 100-column rule exempts it. A
         # block scalar rather than a quoted one for the same reason a
         # folded scalar was rejected: folding joins lines with a space,
-        # which would land inside the regex
+        # which would land inside the regex.
+        # The lookbehind's backtick is "\x60" for the same reason its
+        # space is "\x20": a lone backtick here makes this file's own
+        # total an odd number, and [tool.typos.type.verbatim] in
+        # pyproject.toml pairs this file's backticks two at a time across
+        # the whole thing to protect the misspellings it quotes -- an odd
+        # total leaves one of those quotations unpaired with whatever
+        # backtick follows it (issue #1302)
         entry: |-
-          (?<![`!\[])(?:!?\[(?:[^]]|\]\([^)]*\))*\]\(|^\x20{0,3}\[[^]]+\]:\s*)(?!\./|#|[A-Za-z][A-Za-z0-9+.-]*:)[^)\s]
+          (?<![\x60!\[])(?:!?\[(?:[^]]|\]\([^)]*\))*\]\(|^\x20{0,3}\[[^]]+\]:\s*)(?!\./|#|[A-Za-z][A-Za-z0-9+.-]*:)[^)\s]
         types: [markdown]
       # a line that ends inside a word, at that word's own hyphen.
       # Section 4 of the organization standard is the rule: what such a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ documented at release-notes length in the first place, and are still in
   jupyter]`, so `pre-commit` never reformats a `.md` file; the bare
   command has no such filter and reformats a fenced-code Python block it
   finds inside `CHANGELOG.md` or `RELEASE_NOTES.md` (issue #1293).
+- **A test asserts an even backtick count in every file
+  `[tool.typos.type.verbatim]` covers.** `typos-cli` pairs a file's
+  backticks two at a time over the whole buffer it reads, not per line
+  and not per code span (`Ignores::new` in `crates/typos-cli/src/file.rs`
+  at the pinned v1.49.0), so an odd count anywhere desyncs every pairing
+  after it; `.pre-commit-config.yaml`'s `local-link-prefix` lookbehind
+  carried exactly one such backtick, now written `\x60`, the escape
+  `\x20` beside it in the same entry already uses for its own space
+  (issue #1302).
 
 - **`REVIEWING.md`'s *The gates are the evidence* excepts no gate from
   the run a reviewer may rely on, the test suite included.** The

--- a/tests/typos_verbatim_backtick_parity_test.py
+++ b/tests/typos_verbatim_backtick_parity_test.py
@@ -1,0 +1,88 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+r"""Every file `[tool.typos.type.verbatim]` covers has an even backtick count.
+
+That section's `extend-ignore-re` (a backtick, no backtick, then a
+backtick, applied with `--write-changes`) is what keeps `typos` from
+correcting a misspelling `CHANGELOG.md` quotes on purpose instead of
+using. `typos-cli` (pinned in `.pre-commit-config.yaml`) applies it with
+`Ignores::new`, in `crates/typos-cli/src/file.rs`: `ignore.find_iter`
+runs once over the whole file read into one string, pairing backticks
+two at a time from the start, not per line and not per code span. A file
+with an odd number of raw backtick characters has one left over, and
+every pairing after the line it sits on shifts by one -- a quotation
+many lines below, already backticked and previously matched, stops
+being one, and `typos` offers to correct it again.
+
+Issue #1302 is where that happened: a `CHANGELOG.md` draft quoted a
+literal triple-backtick fence marker inside a single-backtick span,
+five backticks on one line, and two of the file's own already-quoted
+misspellings, both untouched and lines away, started failing.
+`.pre-commit-config.yaml` had the same defect independently:
+`local-link-prefix`'s lookbehind matched one raw backtick byte in a
+character class, the only backtick in the file outside a matched pair,
+and writing it `\x60` instead is what turned the file's count back to
+even. Regex cannot assert "an even count" on its own -- `regex::Regex`,
+the crate `typos` compiles `extend-ignore-re` with, has no counting or
+backreferences -- so the correction is in the files this reads, once,
+rather than in that pattern.
+"""
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).parents[1]
+_PYPROJECT = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+# scoped to the section rather than matched anywhere in the file, so a
+# later `extend-glob` under a different `[tool.typos...]` table --
+# `[tool.typos.type.mixed-case-vectors]` already has one -- is not read
+# as this one's list
+_SECTION = re.compile(
+    r"^\[tool\.typos\.type\.verbatim\]\n"
+    r"(?:^(?:#.*)?\n)*"
+    r'^extend-glob = \[(?P<files>(?:"[^"]*", ?)*"[^"]*")\]$',
+    re.MULTILINE,
+)
+
+
+def _verbatim_files() -> tuple[Path, ...]:
+    """Return the paths `[tool.typos.type.verbatim]`'s `extend-glob` names."""
+    section = _SECTION.search(_PYPROJECT)
+    assert section, (
+        "pyproject.toml's [tool.typos.type.verbatim] table or its"
+        " extend-glob key was not found where this test expects it"
+    )
+    names = re.findall(r'"([^"]*)"', section["files"])
+    return tuple(_ROOT / name for name in names)
+
+
+def test_the_section_was_found() -> None:
+    """The regex above found a non-empty list, so the check below runs.
+
+    A renamed key or a reindented table would leave `_verbatim_files()`
+    empty and the check below vacuously true.
+    """
+    assert _verbatim_files(), "[tool.typos.type.verbatim]'s extend-glob names no file"
+
+
+def test_every_verbatim_file_has_an_even_backtick_count() -> None:
+    r"""A raw backtick left unpaired desyncs every pairing after it.
+
+    Not a claim that every backtick in these files delimits a code span
+    -- `.pre-commit-config.yaml` quotes one as a regex character, escaped
+    as `\\x60` rather than written literally for exactly this reason --
+    only that the total stays a multiple of two, which is what keeps
+    `find_iter`'s left-to-right pairing from drifting past where a human
+    reader would still see two matched code spans.
+    """
+    odd = {
+        path.name: count
+        for path in _verbatim_files()
+        if (count := path.read_text(encoding="utf-8").count("`")) % 2
+    }
+    assert not odd, (
+        f"an odd backtick count desyncs typos' pairing for the rest of the file: {odd}"
+    )


### PR DESCRIPTION
Closes #1302.

`[tool.typos.type.verbatim]`'s `extend-ignore-re = ['`[^`]*`']` is
applied by typos-cli once over an entire file's bytes
(`Ignores::new`/`Identifiers::check_file` in `crates/typos-cli/src/
file.rs`, read at the pinned v1.49.0), pairing backticks left-to-right
across the whole file rather than per line or per markdown code span.
An unpaired backtick anywhere earlier in one of those files — from a
stray draft edit (issue #1293's own near-miss) or, as found here, a
raw backtick used as a regex character-class literal — desyncs every
pairing after it, so previously-safe backticked text later in the same
file can spuriously start failing (or stop being checked by) `typos`.
Rust's `regex` crate has no backreferences, so an ignore-pattern that
requires an even backtick count cannot be expressed; the answer lives
in the test suite instead.

Re-measuring found the defect already live, independent of #1293:
`.pre-commit-config.yaml` (`extend-glob`'s third file) has an odd
backtick total, traced by simulating the same sequential pairing to
the `local-link-prefix` hook's lookbehind `(?<![`!\[])`. Rewritten as
`\x60`, matching that same file's own existing convention (`\x20` for
a literal space in the same hook, for the same reason) — verified
behaviorally identical against every link/badge/reference shape the
hook's own comments already enumerate.

`tests/typos_verbatim_backtick_parity_test.py` reads
`[tool.typos.type.verbatim]`'s `extend-glob` list directly out of
`pyproject.toml`, so it cannot drift from what that section actually
names, and asserts an even backtick count in each file it lists —
converting a silent, load-bearing invariant into an immediate, named
CI failure. No hand-maintained exception list.

Local review at fresh context: `CLEARED da11ba16caebab628d8de34f741b92df0187596a`
— the reviewer independently re-derived the upstream mechanism from
source, re-simulated the pairing to confirm the `.pre-commit-config.yaml`
defect and its exact line, and ran the new test against both the fixed
and reverted tree to confirm it catches the defect it claims to.
Rebased onto origin/main (#1306, #1307) with no conflicts; current head
`066d4bf7`.

Gates on `066d4bf7`, all exit 0: `pytest` (29702 passed, 11 skipped,
100.00% coverage), `pre-commit run --all-files`, and the Sphinx build
with `-W`. `git status --porcelain` empty.

## Summary by Sourcery

Guard typos' file-wide verbatim backtick pairing against regressions by correcting the offending regex literal and enforcing even backtick counts in covered files.

Bug Fixes:
- Prevent typos verbatim-ignore pairing from being desynchronized by an unpaired backtick in `.pre-commit-config.yaml`.
- Add a regression test that verifies every file covered by `[tool.typos.type.verbatim]` has an even number of backticks.

Documentation:
- Document the backtick-parity invariant and the corrected regex literal in the changelog.

Tests:
- Add coverage that reads the configured verbatim file list from `pyproject.toml` and fails when any listed file has an odd backtick count.