### PR TITLE
The question form names the link beside it, not a file without it (btclib-org/.github#101)

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -12,7 +12,7 @@ body:
         [documentation](https://btclib.readthedocs.io/) and the
         [README](https://github.com/btclib-org/btclib/blob/main/README.md)
         come first, and for a real-time answer there is the Slack channel
-        linked from CONTRIBUTING.md.
+        behind the *Chat with the developers* link on the new-issue page.
 
   - type: textarea
     id: question

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **The question form names the Slack link beside it rather than
+  `CONTRIBUTING.md`.** The sentence pointed at `CONTRIBUTING.md`, which
+  carries no such link: the channel is a contact link in
+  `.github/ISSUE_TEMPLATE/config.yml`, shown to the reader as *Chat with
+  the developers* on the page that offers the form
+  (btclib-org/.github#101).
+
 - **`CONTRIBUTING.md` says where the bare `ruff format` and
   `pre-commit run --all-files` disagree.** `ruff-pre-commit`'s
   `ruff-format` hook restricts itself to `types_or: [python, pyi,


### PR DESCRIPTION
`.github/ISSUE_TEMPLATE/question.yml` sent a reader to `CONTRIBUTING.md`
for a Slack link that `CONTRIBUTING.md` does not carry. The link is a
contact link in `.github/ISSUE_TEMPLATE/config.yml`, in the same
directory, shown on the same page the form is offered from.

```diff
-        linked from CONTRIBUTING.md.
+        behind the *Chat with the developers* link on the new-issue page.
```

It names the contact link rather than repeating the URL, which would put
the channel in two files of the same directory.

## Measured, not assumed

Read from the API rather than from a checkout:

- `question.yml` here still carries `linked from CONTRIBUTING.md`;
- `CONTRIBUTING.md` carries no Slack link — `grep -c -i 'slack\.com'`
  answers `0`;
- `config.yml` holds the channel under the name **`Chat with the
  developers`**, which is the exact string the new sentence italicizes,
  and it is the same name in both repositories.

GitHub's own documentation for *Configuring the template chooser* is
what says `contact_links` are rendered there, and it requires the file
to be on the default branch, which it is.

## This is one of two, and neither closes the issue

The same sentence, and the same misdirection, is in `btclib` and in
`bitcoin-core-rpc`. Fixed in one and left in the other, the organization
has two answers to *where does a question go*, which is the drift the
issue is about — so the two pull requests are companions and the
changed lines are byte-identical between them, verified by diffing the
two diffs rather than by reading them.

`https://github.com/btclib-org/.github/issues/101` lives on a third
repository and is closed by hand once both have landed. Neither commit
carries a closing keyword, and the reference is qualified rather than
bare.

## Finding declined

The reviewer preferred *on the page that offers the form* — the phrasing
this changelog bullet already uses — on the ground that a reader meets
this sentence with the form in front of them, having come *from* the
chooser. Both are defensible and the author's stands: GitHub serves the
chooser at `/issues/new/choose`, which is the new-issue page a reader
reaches from *New issue*, so the sentence names where the link is. It is
not worth re-running this tree's suite to reword.

## Checks

No workflow expected red.

Gates at the cleared sha, this tree's own, read by exit code — the three
its `CONTRIBUTING.md` last section names.

## Summary by Sourcery

Point question submitters to the Slack contact link shown alongside the form.

Bug Fixes:
- Correct the question form’s Slack guidance to reference the “Chat with the developers” link on the new-issue page instead of the unrelated CONTRIBUTING.md file.

Documentation:
- Document the corrected Slack contact-link guidance in the changelog.