### PR TITLE
Configuration the standard has since changed: two inert ruff ignores, show_error_codes, check-sdist's backend, a pydoclint comment, .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,11 @@
 # a count is exactly such an edit, and union would have kept both numbers.
 # Section 9 of the organization standard, btclib-org/.github's README.md,
 # is where this rule is recorded.
+#
+# Both lines are in every repository's copy, a tree carrying no
+# RELEASE_NOTES.md included: section 2 of that README.md gives the
+# release notes to a repository that publishes, and an attribute on a
+# path the tree does not hold matches nothing.
 CHANGELOG.md merge=union
 RELEASE_NOTES.md merge=union
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -638,19 +638,43 @@ repos:
       - id: uv-lock
   # what is tracked and not in the sdist, and what is in the sdist and not
   # tracked, both ways round, against the patterns of
-  # [tool.uv.build-backend]. Nothing is configured here: the hook's own
-  # manifest already passes --no-isolation and --inject-junk and installs
-  # uv, which is the whole of what this needs. --no-isolation is what
-  # pre-commit.ci requires -- an isolated build environment cannot be
-  # created there (no ensurepip in the interpreter, read-only virtualenv
-  # app data) -- and it costs nothing to build without one, the backend
-  # being the copy bundled in that uv. --inject-junk drops a cache
-  # directory and an egg-info beside the sources for the length of the
-  # run, which is what the exclusions in [tool.uv.build-backend] answer
+  # [tool.uv.build-backend]. --no-isolation is in the hook's own manifest
+  # entry and is what pre-commit.ci requires: an isolated build
+  # environment cannot be created there, the interpreter having no
+  # ensurepip and the virtualenv app data being read-only.
+  #
+  # --installer=pip is what brings the build under [build-system]. The
+  # default installer is uv, and `uv build` on a project declaring
+  # build-backend = "uv_build" packs the archive with the copy of the
+  # backend bundled in the running uv and not with the environment's:
+  # the manifest installs uv and no uv_build, and the archive is built
+  # regardless. So an additional_dependencies line on its own would
+  # decide nothing.
+  #
+  # With the pip installer check-sdist runs `python -m build
+  # --no-isolation` instead, which does read the environment and refuses
+  # one that does not satisfy `requires`, so the backend that packs the
+  # archive is one pyproject.toml admits.
+  #
+  # What that does not keep is the two specifiers equal: a `requires`
+  # widened past the line below leaves that line still satisfying it, and
+  # the hook still green. The failure catches the environment falling
+  # outside `requires` and never `requires` growing past the environment.
+  #
+  # --inject-junk is repeated because args: replaces the manifest's list
+  # rather than adding to it. It drops a cache directory and an egg-info
+  # beside the sources for the length of the run, which is what the
+  # exclusions in [tool.uv.build-backend] answer. additional_dependencies
+  # replaces the manifest's list the same way, and what the manifest names
+  # there is uv, which the pip path never looks for. The specifier below
+  # is [build-system]'s own range and not a pin, as pyroma's is: what the
+  # build has to satisfy is a declaration
   - repo: https://github.com/henryiii/check-sdist
     rev: v1.6.0
     hooks:
       - id: check-sdist
+        args: [--inject-junk, --installer=pip]
+        additional_dependencies: ["uv_build>=0.12.5,<0.13"]
   - repo: https://github.com/regebro/pyroma
     # the newest *stable* tag: 5.1b1 and 5.1b2 sit above it, and
     # `pre-commit autoupdate` offers a prerelease as readily as a release,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **`.gitattributes`'s shared half is the organization's copy byte for
+  byte.** Section 14 of the standard in `btclib-org/.github` makes the
+  file the same in every repository up to `## This repository in
+  particular`, and that copy carries a sentence this one did not: both
+  `merge=union` lines belong in every repository's copy, a tree holding
+  no `RELEASE_NOTES.md` included, because an attribute on a path the
+  tree does not hold matches nothing. `tests/verbatim_test.py` there
+  compares the two halves after stripping the blank line before the
+  marker, and this copy matches the standard's under it
+  (btclib-org/.github#192).
+
 - **The question form names the Slack link beside it rather than
   `CONTRIBUTING.md`.** The sentence pointed at `CONTRIBUTING.md`, which
   carries no such link: the channel is a contact link in
@@ -510,6 +521,49 @@ documented at release-notes length in the first place, and are still in
   where the edit stopped.
 
 ### Packaging, linting and CI
+
+- **`check-sdist` builds the archive with the backend `[build-system]`
+  declares.** The hook's manifest entry drives `uv build`, and given
+  `build-backend = "uv_build"` that packs the archive with the copy of
+  the backend bundled in the running uv and not with the environment's:
+  the manifest installs `uv` and no `uv_build`, and the archive is built
+  regardless. So the `uv_build>=0.12.5,<0.13` range `requires` names
+  governed nothing the gate ran.
+  `args: [--inject-junk, --installer=pip]` sends check-sdist through
+  `python -m build --no-isolation` instead, which does read the
+  environment, and `additional_dependencies` puts that range in it: an
+  environment outside `requires` now fails the hook with `ERROR Missing
+  dependencies`. `--inject-junk` is repeated because `args:` replaces
+  the manifest's list rather than adding to it. What the failure does
+  not catch is a `requires` widened past the hook's line, which leaves
+  that line still satisfying it (btclib-org/.github#197).
+
+- **`[tool.ruff.lint] ignore` no longer names two rules the declared
+  convention settles.** `incorrect-blank-line-before-class` and
+  `multi-line-summary-second-line` are each the disabled half of a pair
+  ruff calls incompatible, and `[tool.ruff.lint.pydocstyle] convention =
+  "pep257"` settles both: with a convention declared ruff reports
+  neither rule and prints no warning about either pair, so the entries
+  read as an enforced choice and decided nothing. Section 5 of the
+  standard in `btclib-org/.github` is where that is written down
+  (btclib-org/.github#178).
+
+- **`[tool.mypy]` no longer sets `show_error_codes`.** mypy carries no
+  such option: `Options` has `hide_error_codes`, `False` before any
+  configuration file is read, and `config_parser.py`'s generic
+  `show_`/`hide_` inversion is the whole of what accepts the key. The
+  line stated a check mypy already performs, which section 6 of the
+  standard in `btclib-org/.github` keeps out of the block
+  (btclib-org/.github#191).
+
+- **The `[tool.pydoclint]` comment names the form this package's
+  docstrings take.** Section 4 of the standard in `btclib-org/.github`
+  decides `skip-checking-short-docstrings` by whether a tree states a
+  docstring's contract in a section or in prose, and this package states
+  it in prose: a summary saying what the call returns, with the
+  paragraphs under it carrying whatever a parameter needs. The comment
+  argued instead the size of the rewrite `false` would ask for, which is
+  issue #1178's to hold (btclib-org/.github#198).
 
 - **Two `pyproject.toml` comments named a reason for an entry that the
   entry does not have.** `[tool.uv.build-backend]`'s `source-include`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -727,7 +727,6 @@ fail_under = 100.0
 [tool.mypy]
 strict = true
 show_column_numbers = true
-show_error_codes = true
 # the organization's list, the same in every repository that runs mypy
 # (section 6 of the standard, btclib-org/.github#165), and nothing else
 # in this key: a code that finds nothing today is a ratchet, catching the
@@ -898,14 +897,6 @@ ignore = [
     # class, and a magic method by the data model it implements
     "undocumented-magic-method",
     "undocumented-public-init",
-    # pydocstyle offers each of these as a mutually exclusive alternative
-    # to a rule the "D" family above already selects -- D211
-    # (blank-line-before-class) and D212 (multi-line-summary-first-line)
-    # in order -- so no docstring can satisfy both sides of either pair
-    # and disabling one is permanent, not a count that a future cleanup
-    # could shrink
-    "incorrect-blank-line-before-class",
-    "multi-line-summary-second-line",
     # code length is enforced by the formatter, which reflows to its 88
     # columns everything it is allowed to rewrite. What is left for this
     # rule to find is what no width can break, almost all of it a test
@@ -1061,18 +1052,19 @@ style = "google"
 # the docstring is a second place to be wrong, and the one nothing checks
 arg-type-hints-in-docstring = false
 check-return-types = false
-# the default, and not the false sibling btclib-secp256k1 sets. There it
-# is right: every docstring of a wrapper is a line, so switching the skip
-# off is what makes the check reach any of them at all. Here what it
-# reaches is `Args` and `Returns` sections that do not exist rather than
-# sections that disagree with a signature, which is a rewrite of the
-# whole package's prose and not a lint fix. Left at the default, this
-# gates the docstrings that do carry sections, which is where the silent
-# drift is: a signature grows a parameter and the section above it still
-# lists the old ones. Issue #1178 is the stricter setting, how many
-# findings it reaches, and the command that counts them -- no figure is
-# repeated here, a count beside no way of re-measuring it being a line
-# every change to the package can falsify in silence
+# the default, and what decides it is the form a docstring's contract
+# takes here: prose. A summary saying what the call returns, and the
+# paragraphs under it carrying whatever a parameter needs said about it,
+# rather than an `Args` list and a `Returns` list. pydoclint reads a
+# section and not a sentence, so `false` asks for each of those facts a
+# second time in a shape it can parse, which section 9 of the standard
+# refuses as one fact in two places. Nor does it find what is actually
+# missing: prose that leaves a parameter unmentioned states no contract
+# for it, and `false` reports that docstring exactly as it reports the
+# prose naming every parameter. Left at the default, this gates the
+# docstrings that do carry sections, which is where the drift is silent:
+# a signature grows a parameter and the section above it still lists the
+# old ones. Issue #1178 is the stricter setting and what it would cost
 skip-checking-short-docstrings = true
 # pep257 -- ruff's convention here -- neither asks for a docstring on
 # __init__ nor forbids one, and this package writes its constructors out


### PR DESCRIPTION
The organization's standard has moved on five points this tree carries.
None of them changes what a gate here accepts; each is a key or a comment
that reads as a decision and is not one.

**Two `ignore` entries the convention already decides** —
btclib-org/.github#178. `incorrect-blank-line-before-class` (D203) and
`multi-line-summary-second-line` (D213) sat in `[tool.ruff.lint] ignore`
beside a declared `convention = "pep257"`, which disables both. Section 5
now says it in terms: the convention is what settles the pairs ruff calls
incompatible, so `ignore` does not name the half it disables. Measured
with the ruff this tree pins rather than with `uvx`: `ruff check
--select D` gives a byte-identical diagnostic set with and without the two
entries, and the incompatibility warning appears only where nothing
settles the pair.

**`show_error_codes` is on already** — btclib-org/.github#191. There is no
such option: `Options` carries `hide_error_codes`, `False` before any
config file is read, and `config_parser.py`'s generic `show_`/`hide_`
inversion is what accepts the key at all. Checked against the mypy
`uv.lock` pins. `show_column_numbers` stays — a real option, defaulting
to `False`, and section 6's sample carries it.

**`check-sdist` built with whatever `uv` the hook found** —
btclib-org/.github#197. The hook now carries
`args: [--inject-junk, --installer=pip]` and `additional_dependencies`
naming `[build-system]`'s own specifier. The measurement that matters is
that the obvious half of the fix is not one: with the manifest's args and
`additional_dependencies` naming a range that **disagrees** with
`requires`, the hook still passes, silently. `--installer=pip` is what
makes the environment decide — check-sdist then runs
`python -m build --sdist --no-isolation`, which refuses a backend
`requires` does not admit and says so:
`ERROR Missing dependencies: uv_build<0.13,>=0.12.5`. Both directions
were run, and `requires` widened past the environment still passes, so
the check catches the environment falling outside `requires` and never
the reverse.

**A comment arguing cost where the key asks about form** —
btclib-org/.github#198. Section 4 decides
`skip-checking-short-docstrings` by the form a docstring's contract takes
in the tree; the comment argued the size of the rewrite instead, which is
what btclib-org/btclib#1178 holds. It now gives the form, measured here:
`Args:` appears in exactly two modules and `Returns:` in none, the rest
stating the contract in prose. The value is unchanged.

**The `.gitattributes` reasoning** — btclib-org/.github#192. Section 14
makes that file verbatim, and the standard's copy now says both
`merge=union` lines are in every copy, a tree with no `RELEASE_NOTES.md`
included, because an attribute on a path the tree does not hold matches
nothing. Copied by concatenation and compared byte for byte with the
`shared()` normalisation, this tree's `-whitespace` line kept under
*This repository in particular*.

**What was deliberately not written.** Section 12 says a `requires`
excluding the running uv makes `uv build` warn and build anyway. That is
true of one shape only: a `requires` whose ceiling is below the running uv
warns and builds, where one whose floor is above it gives
`ModuleNotFoundError` and fails. Rather than repeat the clause in a
comment here, it was cut and filed against the standard as
btclib-org/.github#242 — a comment should not carry a claim its own tree
falsifies. The review reproduced all three shapes independently.

**`pyroma` needed nothing.** btclib-org/.github#197's second half says
this tree skips it in the `ci:` block; the `skip:` list is `[mypy]` only
and the hook already carries the backend, which is a finding that the
issue is stale rather than a change.

**This pull request closes nothing here.** All five issues live in
`btclib-org/.github`, where a closing keyword is a link and not a close,
so none is written.

Local review: CLEARED 2f3ef00d, no blocking findings, with ISS 242's three
shapes, ISS 197's four configurations, the `.gitattributes` normalisation
and ruff's behaviour all run rather than read. Two corrections came out of
it and are in: the commit message cited ruff 0.16.4 where this tree pins
0.16.3 — the substance reproduced identically on the pinned version — and
the reviewer disagreed with the reasoning for leaving *still* in the
surviving comment while agreeing with the outcome, its antecedent being
in the same sentence rather than in the deleted block.

Gates, this repository's own four: `uv run pre-commit run --all-files`
exit 0, `validate-config` exit 0, `uv run pytest` exit 0 at 29702 passed
/ 11 skipped with coverage at 100%, and the docs `sphinx-build -W
--keep-going` exit 0 — that last one not in the brief, run because
`CONTRIBUTING.md` names it. Tree clean.

## Summary by Sourcery

Align repository configuration, source-distribution checks, and shared attributes with the current organizational standards.

Enhancements:
- Align repository configuration with updated organization standards by removing redundant Ruff and mypy settings and clarifying the pydoclint rationale.
- Update the check-sdist hook to validate distributions using the declared build-system dependencies.
- Synchronize the shared .gitattributes content with the organizational standard.

Documentation:
- Document the configuration and packaging-standard alignment in the changelog.