### PR TITLE
CLAUDE.md's primary-checkout paragraph names the read that cannot go stale (issue btclib-org/.github#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -519,6 +519,14 @@ documented at release-notes length in the first place, and are still in
   alone on a line of its own; `REPOSITORY.md`'s CodeQL paragraph had "pull
   request here". Each came of reflowing part of a paragraph and stopping
   where the edit stopped.
+- **`CLAUDE.md`'s primary-checkout paragraph names the read that cannot
+  go stale.** It said reading the checkout was fine and so was `git
+  fetch`, without saying `git fetch` moves `refs/remotes/origin/main`
+  and leaves the work tree where it was, so a `grep` or a `Read` against
+  the checkout answered for whenever it was last brought forward. The
+  paragraph now names `git show origin/main:<path>` as the read that
+  does not go stale, and gives the fast-forward that brings a clean
+  checkout forward without working in it (btclib-org/.github#255).
 
 ### Packaging, linting and CI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,13 +68,12 @@ looking at are theirs, and one working tree has one index and one HEAD to
 lose. Reading it is fine — `git log`, `git show`, `git diff`, `gh`, and a
 `git fetch`, which writes refs and leaves the work tree alone.
 
-**But `git fetch` moves `refs/remotes/origin/main` without moving the work
-tree**, so a `grep` or a `Read` against the checkout's files answers for
-whenever it was last brought forward, not for now. The read that cannot go
-stale is `git show origin/main:<path>`: it answers from the ref `git
-fetch` just moved, never from the tree. Where the checkout has to be
-current rather than merely readable, a fast-forward of a clean `main`
-brings it up:
+So a `grep` or a `Read` against the checkout's files answers for whenever
+it was last brought forward, not for now. The read that cannot go stale
+is `git show origin/main:<path>`: it answers from the ref `git fetch`
+just moved, never from the tree. Where the checkout has to be current
+rather than merely readable, a fast-forward of a clean `main` brings it
+up:
 
 ```shell
 git fetch origin && git merge --ff-only origin/main   # clean main only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,23 @@ looking at are theirs, and one working tree has one index and one HEAD to
 lose. Reading it is fine — `git log`, `git show`, `git diff`, `gh`, and a
 `git fetch`, which writes refs and leaves the work tree alone.
 
+**But `git fetch` moves `refs/remotes/origin/main` without moving the work
+tree**, so a `grep` or a `Read` against the checkout's files answers for
+whenever it was last brought forward, not for now. The read that cannot go
+stale is `git show origin/main:<path>`: it answers from the ref `git
+fetch` just moved, never from the tree. Where the checkout has to be
+current rather than merely readable, a fast-forward of a clean `main`
+brings it up:
+
+```shell
+git fetch origin && git merge --ff-only origin/main   # clean main only
+```
+
+That writes no commit, switches no branch and runs no hook, so it is on
+the permitted side of *never work in it*, not an exception to it. Stop if
+the checkout is not on `main` or is not clean: that is no longer bringing
+it forward.
+
 **Every session works in a worktree**, its own, from the first edit:
 
 ```shell


### PR DESCRIPTION
`CLAUDE.md`'s primary-checkout paragraph said reading the checkout was
fine and listed `git fetch` among what is safe. It did not say that
`git fetch` moves `refs/remotes/origin/main` and leaves the work tree
where it was, so a `grep` or a `Read` against the checkout answers for
whenever it was last brought forward rather than for now — a stale answer
that carries nothing saying it is stale.

The paragraph now states that asymmetry, names `git show origin/main:<path>`
as the read that cannot go stale, and gives the fast-forward for where
the working copy itself has to be current, with the condition to stop on.

`btclib-org/.github#255` tracks the same paragraph across the
organization and stays open for the trees still owed it.

## Summary by Sourcery

Clarify how to obtain current repository content and safely advance the primary checkout without working in it.

Bug Fixes:
- Clarify that reading checkout files can return stale content after `git fetch`, and identify `git show origin/main:<path>` as the current, non-stale read.

Enhancements:
- Document the safe fast-forward procedure for bringing a clean `main` checkout up to date, including when to stop.

Documentation:
- Update `CLAUDE.md` with guidance for distinguishing ref-based reads from working-tree reads and safely refreshing the primary checkout.