### PR TITLE
README.md ends with section 2's support line (issue btclib-org/.github#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -528,6 +528,12 @@ documented at release-notes length in the first place, and are still in
   does not go stale, and gives the fast-forward that brings a clean
   checkout forward without working in it (btclib-org/.github#255).
 
+- **`README.md` ends with the line naming who supports the work.** The
+  organization standard states the line as tier 1's, for the reason
+  `SECURITY.md` is: the archive leaves github.com, and a reader who has
+  it and not the repository meets the project with no organization
+  beside it (btclib-org/.github#98).
+
 ### Packaging, linting and CI
 
 - **`check-sdist` builds the archive with the backend `[build-system]`

--- a/README.md
+++ b/README.md
@@ -345,3 +345,8 @@ PowerShell, `source venv_btclib/Scripts/activate` in Git bash.
 [CONTRIBUTING](./CONTRIBUTING.md) is for development,
 [REVIEWING](./REVIEWING.md) for what a pull request is answered against,
 [SECURITY](./SECURITY.md) for reporting a vulnerability.
+
+---
+
+The btclib organization and its projects are actively supported by
+[DGI](https://dgi.io) and [CheckSig](https://checksig.com).


### PR DESCRIPTION
Part of [btclib-org/.github#98](https://github.com/btclib-org/.github/issues/98).

Section 2 of the standard says `README.md` ends with the line naming
who supports the work, and gives the text verbatim. This adds it.

The line is tier 1's, for the reason `SECURITY.md` is: the archive
leaves github.com, and a reader who has only the sdist has only what
the repository shipped. That is three repositories, not the seven the
issue's own loop iterates over — section 2's tier table and its
"every repository that publishes" are what scope it, and this is one
of the three.

No closing keyword: section 11 says a keyword naming another
repository's issue is a link and not a close, so #98 stays open until
its last tree lands and somebody closes it by hand.

Local review CLEARED at this head.

## Summary by Sourcery

Add the organization support statement required by the project standard to the README.

New Features:
- Add a support statement naming DGI and CheckSig to the end of the README.

Documentation:
- Document the organization’s active support in the README and record the change in the changelog.