### PR TITLE
CHANGELOG.md's own directive is gone, and codespell fixes in place (#1319)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -237,7 +237,7 @@ repos:
     rev: v2.4.3
     hooks:
       - id: codespell
-        name: codespell (prose and comments)
+        name: codespell (prose and comments, in place fixes)
         # the "clear" dictionary alone, where codespell's default is
         # "clear,rare": measured over this tree, the other four builtins add
         # 13 findings and one of them is a typo. "rare" reports "lets" (as
@@ -247,8 +247,15 @@ repos:
         # "code" and "names" add nothing this code base contains. A hook
         # whose findings are mostly wrong gets an ignore list long enough to
         # hide a real typo, so the one it did find, "fro" for "from", was
-        # corrected by hand instead
-        args: [--builtin, clear]
+        # corrected by hand instead.
+        #
+        # --write-changes puts this hook with the others that correct
+        # rather than report, which is what section 4 asks of a hook that
+        # can. A spell checker's repairs are guesses where a formatter's
+        # are deterministic, so the flag went on against a measurement
+        # rather than on principle: run with --builtin clear over the
+        # whole tree it rewrites nothing here
+        args: [--builtin, clear, --write-changes]
   # the second spell checker, and not a replacement for the one above:
   # codespell matches whole words and keeps the hyphen inside the token, so
   # `y-simmetry` and `hex-strin` were invisible to it with every builtin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-<!-- markdownlint-disable MD022 MD032 -->
-<!-- This file is merge=union, so a rebase joins two sections and drops
-     the blank line between them without a conflict: the rule is off
-     here for the duration of btclib-org/.github#33, and goes back on
-     when that queue is empty. btclib-org/.github#138 is the record. -->
-
 # Changelog
 
 <!-- markdownlint-configure-file
@@ -550,6 +544,25 @@ documented at release-notes length in the first place, and are still in
   beside it (btclib-org/.github#98).
 
 ### Packaging, linting and CI
+
+- **`CHANGELOG.md`'s own directive disabling MD022 and MD032 is gone**
+  (closes #1319). It existed because this file is `merge=union`, so a
+  rebase joins two branches' `###` blocks and drops the blank line
+  between them with no conflict, and the two rules reported that gap
+  without a mechanism to close it. `markdownlint-cli2` now runs with
+  `--fix`, so the same drop is repaired on the hook's next run instead
+  of failing a gate with nothing behind it — measured by reproducing
+  the drop and letting the hook restore the line. Both rules apply to
+  this file again.
+
+- **`codespell` now corrects in place, with `--write-changes`,** joining
+  `markdownlint-cli2`'s `--fix` and `typos`'s inherited
+  `--write-changes --force-exclude`: every hook here with a fix mode
+  fixes. The flag went on against a measurement rather than on
+  principle, a spell checker's repairs being guesses where a
+  formatter's are not: run with `--builtin clear` over the whole tree
+  it rewrites nothing, checked against a positive control that both
+  catches and fixes a real misspelling.
 
 - **`check-sdist` builds the archive with the backend `[build-system]`
   declares.** The hook's manifest entry drives `uv build`, and given


### PR DESCRIPTION
CHANGELOG.md opened with a directive turning MD022 and MD032 off for
itself. The reason was real: the file is merge=union, so a rebase joins
two branches' `###` blocks and drops the blank line between them
without a conflict, and a rule reporting a gap it will not close is a
red gate with nothing behind it a machine can repair.

`markdownlint-cli2` runs with `--fix`, so that is no longer what
happens: the same drop is now the hook's own repair on its next run.
Measured by reproducing the drop on this branch's own CHANGELOG.md
section and running the hook on it alone — the blank line came back,
and the working tree returned to this branch's committed content
byte for byte.

`typos` already carried `--write-changes --force-exclude`, and
`markdownlint-cli2` already carried `--fix`. `codespell` did not: it
now carries `--write-changes` too, so every hook here with a fix mode
fixes. `codespell --builtin clear --write-changes` over the whole tree
rewrites nothing, checked against a positive control (a file seeded
with "recieve" and "seperate") that the tool does catch and fix a
real misspelling.

`btclib-org/.github` did this in `672c6f21`, which is the shape this
branch matches; `btclib-org/bbt#66` (closed by `bbt@d93d6f4`) is the
same port in a sibling repository, and its CHANGELOG entry's shape is
what this one follows too.

## Gates, all on `36a484d2`

- `uv run pre-commit run --all-files` — exit 0, twice in a row, the
  first run rewriting nothing (this tree's CHANGELOG.md history carries
  no existing MD022/MD032 violation for the fixer to repair).
- `uv run pytest --basetemp=...` — exit 0, 29702 passed, 11 skipped,
  100.00% coverage.
- `uv run sphinx-build -W --keep-going -b html docs/source
  docs/build/html` — exit 0 (`build succeeded`).
- `grep -rn 'href="#\./' docs/build/html --include='*.html'` — exit 1
  (no match).

Closes #1319.

## Summary by Sourcery

Restore full CHANGELOG.md markdown linting and make codespell apply safe spelling corrections automatically.

Enhancements:
- Re-enable markdownlint checks for CHANGELOG.md now that the pre-commit fixer can restore required spacing after merges.
- Enable in-place corrections for codespell so all configured fix-capable hooks automatically repair their findings.

Documentation:
- Document the restored CHANGELOG.md linting and codespell auto-fix behavior in the changelog.