### PR TITLE
release.yml's calling jobs are named after the workflow files as they are now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,16 +297,16 @@ jobs:
   # a regression outside that cell could otherwise sit on main until the
   # morning after the tag. Cheap in work and the slowest calls here in
   # wall clock, which a release is the one place worth paying for
-  ubuntu:
-    name: Run the ubuntu workflow
+  os-ubuntu:
+    name: Run the os-ubuntu workflow
     uses: ./.github/workflows/os-ubuntu.yml
 
-  macos:
-    name: Run the macos workflow
+  os-macos:
+    name: Run the os-macos workflow
     uses: ./.github/workflows/os-macos.yml
 
-  windows:
-    name: Run the windows workflow
+  os-windows:
+    name: Run the os-windows workflow
     uses: ./.github/workflows/os-windows.yml
 
   # and the one required check on main this workflow was not asking for.
@@ -317,13 +317,14 @@ jobs:
   # every one of them a required check too, made again here for exactly
   # that reason. integration-bitcoind.yml declared `workflow_call` for
   # this from the day it became a gate; nothing had ever called it
-  integration:
-    name: Run the integration workflow
+  integration-bitcoind:
+    name: Run the integration-bitcoind workflow
     uses: ./.github/workflows/integration-bitcoind.yml
 
   publish-testpypi:
     name: Publish to TestPyPI
-    needs: [test, lint, docs, ubuntu, macos, windows, integration]
+    needs:
+      [test, lint, docs, os-ubuntu, os-macos, os-windows, integration-bitcoind]
     if: github.event_name == 'workflow_dispatch' && github.repository == 'btclib-org/btclib'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -347,7 +348,8 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [test, lint, docs, ubuntu, macos, windows, integration]
+    needs:
+      [test, lint, docs, os-ubuntu, os-macos, os-windows, integration-bitcoind]
     if: github.event_name == 'push' && github.repository == 'btclib-org/btclib'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -376,8 +378,8 @@ jobs:
   # before it -- a release announcing files that do not install is worse
   # than a release announced a minute later, but the announcement is not
   # what makes them installable
-  published:
-    name: Install the published version from PyPI
+  pypi-install:
+    name: Run the pypi-install workflow
     needs: publish-pypi
     uses: ./.github/workflows/pypi-install.yml
     with:
@@ -571,7 +573,7 @@ jobs:
   # that succeeded, for as long as that takes somebody to notice. Two
   # releases went out undocumented that way, which is issue #574.
   # The rendered URL and not the v3 API, which is the reverse of what
-  # `published` above does with PyPI's: read the docs throttles an
+  # `pypi-install` above does with PyPI's: read the docs throttles an
   # unauthenticated caller to five requests a minute and warns that
   # requests from a cloud provider are blocked outright without a token, so
   # asking the API from a runner would mean storing a credential for a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -545,6 +545,18 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **`release.yml`'s calling jobs are named after the reusable workflows
+  they call, not after what those workflows were called before a rename**
+  (issue #1268). `ubuntu`, `macos` and `windows` become `os-ubuntu`,
+  `os-macos` and `os-windows`; `integration` becomes `integration-bitcoind`,
+  disambiguating it from `integration-hwi.yml`, which no job here calls;
+  `published` becomes `pypi-install`. The `needs:` lists gating
+  `publish-testpypi` and `publish-pypi` move with the renamed ids. None of
+  these job ids is a required check on `main` — `REPOSITORY.md`'s table names
+  only `test: every job passed`, `Lint and type-check`,
+  `Build the documentation` and `Regtest against Bitcoin Core` — so the
+  rename touches no branch ruleset.
+
 - **`CHANGELOG.md`'s own directive disabling MD022 and MD032 is gone**
   (closes #1319). It existed because this file is `merge=union`, so a
   rebase joins two branches' `###` blocks and drops the blank line


### PR DESCRIPTION
Closes #1268

release.yml called its reusable workflows by their current paths but named the calling jobs (id and name:) after what those files were called before a rename. Renames the five job ids/names to match: ubuntu→os-ubuntu, macos→os-macos, windows→os-windows, integration→integration-bitcoind (disambiguating from the sibling integration-hwi workflow), published→pypi-install, updating both needs: lists accordingly.

Verified no active ruleset requires these job ids as status checks (only required_signatures/required_linear_history/non_fast_forward/deletion and pull_request rules are active), and REPOSITORY.md's required-checks table names only test/lint/docs/regtest, none produced by release.yml — safe as one commit today.

Local review: CLEARED 0cf70559742c9e51b2e92af9281986b351d7f2d.

Gates: pytest (29702 passed, 11 skipped, 100% coverage), pre-commit run --all-files, sphinx-build -W --keep-going — all exit 0.

## Summary by Sourcery

Rename release workflow calling jobs to match their current reusable workflow names and update publishing dependencies accordingly.

Enhancements:
- Align release workflow calling job IDs and display names with the reusable workflows they invoke, including updating dependent publishing jobs and references.

Chores:
- Document the release workflow job renames in the changelog.