### PR TITLE
.lycheeignore's entries excluded URLs the links workflow never reads

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -18,5 +18,8 @@ contact_links:
     url: https://github.com/btclib-org/btclib-secp256k1/issues
     about: Signing, verification and curve arithmetic are delegated there.
   - name: Chat with the developers
+    # a Slack workspace invite, which answers only to a signed-in member: a
+    # checker sees the sign-in redirect and cannot tell a live invite from
+    # a dead one, which is why nothing here checks it automatically
     url: https://bbt-training.slack.com/archives/C01CCJ85AES
     about: The Slack channel, for what is faster asked than written up.

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -146,8 +146,7 @@ jobs:
           # unreachable for one minute is the failure mode this workflow was
           # built not to gate on, and 45 seconds is the cheapest way to stop
           # reporting it. If a URL times out run after run it belongs in
-          # .lycheeignore with that measurement, as the iacr.org entries do,
-          # and not here
+          # .lycheeignore with that measurement, and not here
           args: >-
             --no-progress
             --max-retries 3

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,27 +2,3 @@
 # be checked rather than the reason it is inconvenient. Anything merely
 # slow or occasionally throttled belongs in that workflow's --max-retries
 # and --accept, not here.
-#
-# Both entries are the same host behind Cloudflare, and it took two failed
-# runs to describe it correctly, so here is what was actually measured
-# rather than what seemed likely.
-#
-# From a GitHub runner, every iacr.org URL answers 403, whatever the path.
-# From a developer machine, the landing pages answer 200 and only the .pdf
-# paths answer 403, with Cloudflare's "Just a moment..." challenge that no
-# HTTP client passes. The first observation is the one that matters here:
-# what is being judged is the caller's address, so no rewriting of these
-# URLs can make the workflow able to check them.
-#
-# The citations were still moved to eprint.iacr.org/<year>/<id> rather than
-# the .pdf, because that form is canonical and is the one that resolves for
-# a reader. It just does not resolve for this runner, which is why the
-# exclusion stays.
-
-https://iacr\.org/.*
-https://eprint\.iacr\.org/.*
-
-# a Slack workspace invite, which answers only to a signed-in member: a
-# checker sees the sign-in redirect and cannot tell a live invite from a
-# dead one
-https://bbt-training\.slack\.com/.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -543,6 +543,17 @@ documented at release-notes length in the first place, and are still in
   it and not the repository meets the project with no organization
   beside it (btclib-org/.github#98).
 
+- **`.lycheeignore`'s two entries excluded URLs the `links` workflow
+  never reads.** Its lychee invocation scans only `"*.md"
+  "docs/**/*.rst" "docs/**/*.md" "tests/**/*.md"`; the `bbt-training`
+  URL lives only in `.github/ISSUE_TEMPLATE/config.yml`, a `.yml`, and
+  the `iacr` URLs live only in `.py` source and test files, left out of
+  prose-link-checking by that workflow's own comment. Both patterns
+  matched nothing, so `.lycheeignore` now holds neither; the Slack
+  invite's reasoning moved to a comment beside its URL in `config.yml`,
+  and `links.yml`'s own comment no longer points at the removed
+  `iacr.org` entries as an example (issue #1308).
+
 ### Packaging, linting and CI
 
 - **`CHANGELOG.md`'s own directive disabling MD022 and MD032 is gone**


### PR DESCRIPTION
Closes #1308

.lycheeignore excluded a bbt-training Slack-invite URL and an iacr.org URL, but the links workflow's lychee scan only reads "*.md" "docs/**/*.rst" "docs/**/*.md" "tests/**/*.md", and neither URL lives in a file matching those globs (bbt-training is only in .github/ISSUE_TEMPLATE/config.yml, iacr only in .py source/test files). Both entries were inert.

Deletes both entries; moves the still-relevant Slack sign-in-redirect reasoning to a comment beside the bbt-training URL in config.yml, where it actually applies. Does not relocate the iacr.org reasoning (it explained a status code lychee was never going to see). Fixes links.yml's own comment, which referenced "the iacr.org entries" in .lycheeignore and would have dangled once they were removed.

Local review: CLEARED 62a8e0a92bc37b3d11df3325ae1890e068f0bfe.

Gates: pytest run twice (29702 passed, 11 skipped, 100% coverage both times), pre-commit run --all-files, sphinx-build -W --keep-going — all exit 0.

## Summary by Sourcery

Remove ineffective link exclusions and preserve accurate documentation for the URLs and workflow that govern link checking.

Bug Fixes:
- Remove inert `.lycheeignore` entries for URLs that are not scanned by the links workflow.

Enhancements:
- Keep the Slack invite’s link-checking rationale beside the URL where it applies and update the workflow comment to remove the obsolete reference to iacr.org entries.

Documentation:
- Document the removal of the ineffective ignore entries and the relocated Slack-link rationale in the changelog.