### PR TITLE
btclib/exceptions.py's BTClibException docstring drops its stale #776 citation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2707,6 +2707,14 @@ documented at release-notes length in the first place, and are still in
   construction. `_tweaked_prvkey` and `tweak_add_check`, the two other
   calls in this module, are the first and the last of those.
 
+- **`BTClibException`'s docstring cited issue #776 as the open tracker
+  for public functions still letting a native `KeyError`, `IndexError`
+  or `OverflowError` through; it closed 2026-08-14.** No open issue
+  tracks that gap, and `tests/input_validation_test.py`'s own docstring
+  states that no function of the library reaches one any more, so the
+  class's docstring now states the guarantee plainly instead of citing a
+  closed issue (issue #1314).
+
 ### Tests
 
 - **`test_the_flag_still_switches_the_check_off`'s docstring stops

--- a/btclib/exceptions.py
+++ b/btclib/exceptions.py
@@ -23,20 +23,15 @@ which one answers a question the base cannot carry -- whether the value
 was wrong, the type was, or neither was and a check failed anyway. A
 caller with something to do about that difference names the specific
 class; `except BTClibException` is for the caller who only needs to know
-it came from here.
+it came from here, and it catches every failure of btclib's: no public
+function lets a native `KeyError`, `IndexError` or `OverflowError`
+escape uncaught.
 
-That every failure of btclib's *is* one is not yet true: issue #776
-carries the public functions still letting a native `KeyError`,
-`IndexError` or `OverflowError` through, and until that is closed this
-class catches most of what the library raises rather than all of it.
-
-So a caller is usually better off catching the regular ValueError,
-TypeError or RuntimeError, and does not lose anything by doing so.
-
-The exceptions to that are the few classes below carrying a field: what
-a peer got wrong, the node's rpc error code, an HTTP status. Those are
-values a caller acts on, and reading them back out of a message is what
-the field spares them.
+The exception is the few classes below carrying a field: what a peer got
+wrong, the node's rpc error code, an HTTP status. Those are values a
+caller acts on, and reading them back out of a message is what the field
+spares them, so a caller after one of them still names the specific
+class rather than the base.
 
 Each of those hands every constructor argument to
 `BaseException.__init__` and composes its message in `__str__`, which is

--- a/tests/serialization_boundary_test.py
+++ b/tests/serialization_boundary_test.py
@@ -423,9 +423,9 @@ def test_from_dict_names_the_field_it_has_not_got(case: _JsonCase) -> None:
     txid, a header's difficulty, the psbt's derived "tx" -- is one whose
     absence is no error at all, which is why the assertion is on what a
     failure may be rather than on which keys fail. What must never happen
-    is the `KeyError` that used to: `exceptions.py` lists it as one of
-    the native exceptions still reaching a caller, and this family was
-    where it did.
+    is the `KeyError` that used to: `exceptions.py`'s guarantee is that
+    no public function lets a native exception reach a caller, and this
+    family was where a `KeyError` once did.
 
     The count is asserted too, or a `from_dict` that stopped reading its
     mapping would pass this by never failing.


### PR DESCRIPTION
Closes #1314

BTClibException's docstring cited issue #776 as the open tracker for public functions still letting a native KeyError, IndexError or OverflowError through; #776 closed 2026-08-14 (superseded via #856 into #867/#868, all closed). No open issue tracks that gap, and tests/input_validation_test.py's own docstring states no function of the library reaches one any more, so the docstring now states the guarantee plainly instead of citing a closed issue.

Also updates tests/serialization_boundary_test.py's test_from_dict_names_the_field_it_has_not_got docstring, which asserted the old exceptions.py still listed this as an open gap — a claim this branch's own change to exceptions.py made false.

Local review: CLEARED 5e3f5ae0 (round 2, after fixing the serialization_boundary_test.py finding from round 1).

Gates (re-run after a rebase onto the current origin/main): pytest (29702 passed, 11 skipped, 100% coverage), pre-commit run --all-files, sphinx-build -W --keep-going — all exit 0.

## Summary by Sourcery

Clarify BTClib's exception-handling guarantee and remove outdated issue references from documentation and test descriptions.

Enhancements:
- Update BTClibException documentation to guarantee that public functions do not expose native KeyError, IndexError, or OverflowError exceptions.
- Align serialization boundary test documentation with the updated exception guarantee.

Documentation:
- Remove the stale reference to closed issue #776 from the BTClibException docstring and document the current exception-handling guarantee plainly.

Chores:
- Record the documentation correction in the changelog.