### PR TITLE
CONTRIBUTING.md's shared half converges, and its tail stops recounting

### DIFF
--- a/.github/workflows/os-macos.yml
+++ b/.github/workflows/os-macos.yml
@@ -83,7 +83,8 @@ jobs:
           - macos-latest
         # the interpreter set os-ubuntu.yml names, unchanged: this workflow
         # moves the platform and nothing else, so a difference against it
-        # is attributable to the platform
+        # is attributable to the platform. tests/interpreters_test.py holds
+        # the three sweeps to one another
         python:
           - "3.10"
           - "3.11"

--- a/.github/workflows/os-windows.yml
+++ b/.github/workflows/os-windows.yml
@@ -88,7 +88,8 @@ jobs:
           - windows-11-arm
         # the interpreter set os-ubuntu.yml names, unchanged: this workflow
         # moves the platform and nothing else, so a difference against it
-        # is attributable to the platform
+        # is attributable to the platform. tests/interpreters_test.py holds
+        # the three sweeps to one another
         python:
           - "3.10"
           - "3.11"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,32 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **`CONTRIBUTING.md`'s shared half is the organization's copy byte for
+  byte.** Section 14 of the standard is what makes everything above
+  `## This repository in particular` the same file in every repository;
+  this copy was behind by a new subsection, `### The landing queue`
+  under *Pull requests*, and a rewritten paragraph in *Documentation and
+  comments* on what a commit message becomes once it lands
+  (issue #1317, btclib-org/.github#281).
+
+- **`CONTRIBUTING.md`'s tail no longer restates the prose style's three
+  habits to delete on sight.** Section 9 of the standard, now carried by
+  the sync above, already states all three under its own headings — *One
+  fact in one place*, the sentence that only introduces the next one
+  under *Tone*, and the tour of alternatives under the bullet on what a
+  comment carries — so the paragraph under *Prose in this tree* restated
+  what the shared half now says (issue #1300).
+
+- **The *What runs when* table's three platform sweeps say what varies,
+  not how many.** `os-ubuntu`, `os-macos` and `os-windows` each named an
+  image and interpreter count the other two rows in the same table do
+  not; the cells now read `ubuntu images and interpreters` and the like,
+  matching the style of *a node* and *platforms sampled, deps upgraded*
+  beside them. `tests/interpreters_test.py` already holds the three
+  workflow files' own interpreter lists to one another, so `os-macos.yml`
+  and `os-windows.yml` now say so next to the comment that used to
+  assert it unchecked (issue #1269).
+
 - **`.gitattributes`'s shared half is the organization's copy byte for
   byte.** Section 14 of the standard in `btclib-org/.github` makes the
   file the same in every repository up to `## This repository in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,9 +36,9 @@ restated here: a second wording is the one that goes stale, which is
 that section's own *One fact in one place*.
 
 A commit message is prose this tree ships too, though section 9 does not
-say so: squash is the only merge method and the landing commit carries
-the messages, so what is written in one is read on `main` long after the
-branch is gone.
+say so: [the only merge method the rule accepts][s11] puts it on `main`
+as the landing commit's body, so what is written in one is read there
+long after the branch is gone.
 
 ## Pull requests
 
@@ -84,6 +84,36 @@ because a plain rebase replays the base's old commit inside the child,
 and the forge then shows the base's old text as additions with nothing
 red anywhere. Read the child's diff afterwards rather than trusting the
 rebase, and retarget each child onto `main` as its parent lands.
+
+### The landing queue
+
+Where more than one pull request is open against this repository, only
+one is carried to `main` at a time: rebased onto the tip, reviewed on
+that head, and landed, while every other one waits, untouched, for its
+turn. This governs which of several *already open* pull requests reaches
+`main` next; *One subject, opened as soon as it is written* above governs
+the moment before that, when a finished one is opened — the two do not
+conflict, since a pull request is still opened without delay and still
+waits its turn once several are open.
+
+The reason is CI throughput, not the ack a waiting pull request keeps —
+`REVIEWING.md`'s *The verdict* states what an ack belongs to, and
+*Landing it* below states which rebase voids one. Every rebase queues
+this repository's whole check matrix against the organization's ceiling
+on concurrent jobs, so rebasing every waiting pull request after each
+landing spends that capacity on runs the next landing invalidates
+anyway, and delays the one pull request that is actually next: work
+spent on a pull request that is not next is work that delays the one
+that is.
+
+Order is cheapest and least contended first, most invasive last, so that
+a large change does not sit at the head blocking everything behind it.
+
+The maintainer may declare a bounded exception — several pull requests in
+flight against one repository, for a named piece of work — trading the
+cost above for throughput; it is recorded as a comment in
+[btclib-org/.github](https://github.com/btclib-org/.github/issues), by
+*The issue tracker* above, and holds only for the work it names.
 
 ### The review
 
@@ -434,9 +464,9 @@ read by every checkout of this repository.
 | `website` | pull request, push, on website files | — |
 | `claude-review` | pull request, and `@claude` in a comment | — |
 | `codeql` | push to main, and weekly | 2 languages |
-| `os-ubuntu` | weekly, a release | 2 ubuntu images × 7 interpreters |
-| `os-macos` | weekly, a release | 2 macOS images × 7 interpreters |
-| `os-windows` | weekly, a release | 2 Windows images × 7 interpreters |
+| `os-ubuntu` | weekly, a release | ubuntu images and interpreters |
+| `os-macos` | weekly, a release | macOS images and interpreters |
+| `os-windows` | weekly, a release | Windows images and interpreters |
 | `deps-latest` | weekly | platforms sampled, deps upgraded |
 | `integration-hwi` | weekly, push to main | two device emulators |
 | `links`, `mutation` | weekly | — |
@@ -1486,17 +1516,6 @@ is that one — which channel, measured how, and what is left.
 *Documentation and comments* above says why it is not restated. What
 follows is what this tree adds to it, and it holds for docstrings,
 comments, the sphinx pages and a pull request reply alike.
-
-**Length is a cost, and the reason is what buys it.** One sentence where
-one will carry it, and a paragraph only where a shorter one would leave
-the reader wrong. Three habits lengthen prose here without adding to it,
-and each is worth deleting on sight:
-
-- the same reason in a second wording — not emphasis, but a second copy
-  to keep true, and the one that drifts;
-- the sentence that only introduces the next one;
-- the tour of alternatives, where the rejected one and the thing that
-  rejects it are the whole of the negative result.
 
 **Most readers of a docstring here are new to btclib: write for them.**
 


### PR DESCRIPTION
The shared half -- everything above `## This repository in particular`
-- was behind btclib-org/.github's own copy by a new subsection,
`### The landing queue` under *Pull requests*, and a rewritten paragraph
in *Documentation and comments* on what a commit message becomes once it
lands. Replaced byte for byte with the standard's copy, verified against
the same hash comparison section 14's `tests/verbatim_test.py` runs
(issue #1317, btclib-org/.github#281 stays open until every tree
converges).

*Prose in this tree*, in the newly-synced tail, restated three habits
that lengthen prose -- a second wording of the same reason, the sentence
that only introduces the next one, the tour of alternatives -- as
btclib's own rule. Section 9 of the standard, now carried by the sync
above, already states all three under its own headings, so the paragraph
is deleted; the two paragraphs beside it that are btclib's own,
*write for a reader new to btclib* and the rule on timings, stay
(issue #1300).

The *What runs when* table's `os-ubuntu`, `os-macos` and `os-windows`
rows named an image and interpreter count that the table's other rows
already avoid naming as a number; the cells now say what varies, matching
*a node* and *platforms sampled, deps upgraded* beside them.
`tests/interpreters_test.py::test_every_sweep_runs_the_same_interpreters`
already holds the three workflow files' interpreter lists to one another,
so `os-macos.yml` and `os-windows.yml` now say so next to the comment
that used to assert the equality unchecked (issue #1269).

Closes #1300, closes #1269, closes #1317.

Local review: CLEARED f49141e90d56f904f3eed5e4c498ba0ccdf7d7b6 (round 2).

Gates: pytest (29702 passed, 11 skipped, 100% coverage), pre-commit run --all-files, sphinx-build -W --keep-going -- all exit 0.

## Summary by Sourcery

Synchronize contribution guidance with the organization standard and clarify workflow coverage without changing execution behavior.

New Features:
- Align the shared portion of CONTRIBUTING.md with the organization-wide contribution guidelines, including landing-queue guidance and updated commit-message guidance.

Bug Fixes:
- Remove duplicated prose-style guidance from the repository-specific contribution section.

Enhancements:
- Clarify the workflow table's platform sweep descriptions and document that macOS and Windows interpreter sets are kept synchronized with Ubuntu.

Documentation:
- Update CONTRIBUTING.md to incorporate the standardized guidance and simplify repository-specific prose rules.

Chores:
- Record the contribution-guide and workflow documentation updates in the changelog.