### PR TITLE
pyproject.toml's uv floors and pep257 exemption comments stand on their own reasoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1731,15 +1731,20 @@ documented at release-notes length in the first place, and are still in
   `actions/setup-python` rather than `astral-sh/setup-uv`, since the
   script it runs has no project dependency to lock.
 
-- **`[build-system]`'s floor comment named the wrong version for the
-  behavior it argues for.** The sdist's `pyproject.toml` becomes a
-  normalized copy of this file, with the verbatim source kept beside it
-  as `pyproject.toml.orig`, starting at `uv_build==0.12.5`: built with
-  `0.11.31`, the sdist's `pyproject.toml` is the verbatim file itself
-  and carries no `.orig` -- measured by pinning each version in a
-  minimal package and listing what its sdist holds. `requires` already
-  carried `0.12.5`; only the comment beside it still argued for
-  `0.11.31` (issue #1267).
+- **`[build-system]`'s floor comment names the version where the sdist's
+  own `pyproject.toml` actually becomes normalized.** Measured by
+  calling `uv_build`'s `build_sdist` hook directly for each version --
+  `uv build` falls back silently to the running uv's own bundled
+  backend when `requires` names a version it does not satisfy, so it
+  cannot be used to probe the boundary -- the sdist gains the
+  normalized `pyproject.toml` and the verbatim `pyproject.toml.orig`
+  beside it at `uv_build==0.12.0`, not at `0.12.5`: `0.11.33`, the last
+  `0.11`, still ships the verbatim file with no `.orig`. `requires`
+  stays at `>=0.12.5` regardless -- `.pre-commit-config.yaml`'s
+  `uv-pre-commit` hook pins that exact rev, so the backend building the
+  sdist matches the uv whose lock format its `uv-lock` hook writes --
+  and the comment now says so, instead of naming `0.12.5` as the
+  boundary itself (issue #1267).
 
 - **`[tool.uv] required-version` rises from `>=0.11.31` to `>=0.12.1`,
   the highest floor Dependabot's own uv-ecosystem updater allows.** The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1731,6 +1731,32 @@ documented at release-notes length in the first place, and are still in
   `actions/setup-python` rather than `astral-sh/setup-uv`, since the
   script it runs has no project dependency to lock.
 
+- **`[build-system]`'s floor comment named the wrong version for the
+  behavior it argues for.** The sdist's `pyproject.toml` becomes a
+  normalized copy of this file, with the verbatim source kept beside it
+  as `pyproject.toml.orig`, starting at `uv_build==0.12.5`: built with
+  `0.11.31`, the sdist's `pyproject.toml` is the verbatim file itself
+  and carries no `.orig` -- measured by pinning each version in a
+  minimal package and listing what its sdist holds. `requires` already
+  carried `0.12.5`; only the comment beside it still argued for
+  `0.11.31` (issue #1267).
+
+- **`[tool.uv] required-version` rises from `>=0.11.31` to `>=0.12.1`,
+  the highest floor Dependabot's own uv-ecosystem updater allows.** The
+  updater bundles `0.12.1` and runs `uv lock` with exactly that version,
+  so a floor above it would silently stop every lock update it
+  attempts; a floor below it is safe and buys nothing past where it
+  sits. The comment beside it now points at section 1 and section 15 of
+  the organization standard instead of restating the Dependabot argument
+  in full (issue #1320).
+
+- **The `ignore` comment for `undocumented-magic-method` and
+  `undocumented-public-init` now says why `convention = "pep257"` does
+  not turn either off by itself.** The convention leaves both rules
+  enabled (btclib-org/.github#178): the two `ignore` entries are what
+  exempts `__init__` and a magic method, and the previous wording gave
+  only the reason each is exempt without saying that (issue #1318).
+
 ### Documentation and the website
 
 - **`.readthedocs.yaml` justifies its own name with the setting that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,15 @@
 [build-system]
 # glob patterns in the [tool.uv.build-backend] table below, beside the
-# rest of the configuration, in place of the separate include and
-# exclude language of a MANIFEST.in. The floor is where the sdist's own
-# pyproject.toml became a normalized copy of this file, with the
-# verbatim one kept beside it as pyproject.toml.orig: below 0.12.5 the
-# sdist's pyproject.toml is the verbatim file itself, with no .orig, so
-# a lower floor would leave what the sdist holds with two different
-# shapes. The ceiling is the next minor, which is where uv's versioning
-# policy puts a breaking change, this backend releasing with uv and
-# versioned by it
+# rest of the configuration, in place of the separate include and exclude
+# language of a MANIFEST.in. The sdist's own pyproject.toml becomes a
+# normalized copy of this file at 0.12.0, with the verbatim source kept
+# beside it as pyproject.toml.orig; below it, pyproject.toml is that
+# verbatim file itself, with no .orig. This floor sits above the boundary
+# on purpose, at the rev .pre-commit-config.yaml's uv-pre-commit hook
+# pins, so the backend building the sdist matches the uv whose lock
+# format that hook's uv-lock writes. The ceiling is the next minor, which
+# is where uv's versioning policy puts a breaking change, this backend
+# releasing with uv and versioned by it
 requires = ["uv_build>=0.12.5,<0.13"]
 build-backend = "uv_build"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,12 @@
 # rest of the configuration, in place of the separate include and
 # exclude language of a MANIFEST.in. The floor is where the sdist's own
 # pyproject.toml became a normalized copy of this file, with the
-# verbatim one kept beside it as pyproject.toml.orig: 0.11.31 puts the
-# same members in the wheel and neither of those two in the sdist, so a
-# lower floor would leave what the sdist holds with two answers. The
-# ceiling is the next minor, which is where uv's versioning policy puts
-# a breaking change, this backend releasing with uv and versioned by it
+# verbatim one kept beside it as pyproject.toml.orig: below 0.12.5 the
+# sdist's pyproject.toml is the verbatim file itself, with no .orig, so
+# a lower floor would leave what the sdist holds with two different
+# shapes. The ceiling is the next minor, which is where uv's versioning
+# policy puts a breaking change, this backend releasing with uv and
+# versioned by it
 requires = ["uv_build>=0.12.5,<0.13"]
 build-backend = "uv_build"
 
@@ -203,21 +204,12 @@ dev = [
 ]
 
 [tool.uv]
-# the oldest uv Dependabot's own uv-ecosystem updater bundles: it runs
-# `uv lock` with exactly that version regardless of this key, so any
-# higher floor fails every update it attempts before it starts. That
-# version already understands the lock format the uv-lock hook of
-# .pre-commit-config.yaml writes -- the hook pins a newer rev that
-# pre-commit.ci moves on its own schedule, and regenerates the committed
-# file, so this floor only has to stay low enough for Dependabot rather
-# than match the hook. Declared here the floor still holds for every uv
-# command, not the hook alone, so an uv older than this refuses rather
-# than rewriting the lock in a format a newer one cannot read -- uv is
-# pre-1.0 and has changed that format before. It also reaches CI without
-# a second pin: setup-uv, given no version input, reads this key, and a
-# bare minimum specifier makes it install the latest uv, so the runners
-# are never behind the floor and there is nothing here to go stale
-required-version = ">=0.11.31"
+# The highest floor Dependabot's own uv-ecosystem updater still allows,
+# so its `uv lock` keeps running rather than silently refusing every
+# update. Section 1 of the organization standard states that argument
+# once; section 15 carries the command that re-derives the ceiling
+# (btclib-org/.github#312)
+required-version = ">=0.12.1"
 
 [tool.uv.build-backend]
 # btclib/ sits at the root of the repository, where the backend looks
@@ -894,7 +886,11 @@ ignore = [
     # carry one -- D100/D104 and the D101/D102/D103 left out of this
     # list enforce exactly that (issue #290). The two still ignored are
     # the ones pep257 does not ask for: __init__ is documented by its
-    # class, and a magic method by the data model it implements
+    # class, and a magic method by the data model it implements. Neither
+    # is off because of `convention = "pep257"` below -- that convention
+    # leaves both rules enabled, so it is these two entries doing the
+    # exempting, and dropping either would gate a docstring on every
+    # __init__ or magic method (btclib-org/.github#178)
     "undocumented-magic-method",
     "undocumented-public-init",
     # code length is enforced by the formatter, which reflows to its 88


### PR DESCRIPTION
pyproject.toml's [build-system] comment argued for its uv_build floor by
describing behaviour that actually starts at a different version than
what it named, and [tool.uv] required-version's own floor was copied
from that same reasoning rather than derived on its own terms.

[build-system]'s comment now names 0.12.0 as the version where the
sdist's own pyproject.toml actually becomes normalized (measured by
calling uv_build's build_sdist hook directly -- uv build silently falls
back to the running uv's own bundled backend when requires names a
version it does not satisfy, so it cannot be used to probe the
boundary). requires stays at >=0.12.5 regardless: .pre-commit-config.yaml's
uv-pre-commit hook pins that exact rev, so the backend building the
sdist matches the uv whose lock format its uv-lock hook writes, and the
comment now says so instead of naming 0.12.5 as the boundary itself
(issue #1267).

required-version rises from >=0.11.31 to >=0.12.1, the highest floor
Dependabot's own uv-ecosystem updater allows -- verified against
dependabot-core's uv Dockerfile. The comment beside it now points at
section 1 and section 15 of the organization standard instead of
restating the Dependabot argument in full (issue #1320).

The ignore comment for undocumented-magic-method and
undocumented-public-init now says why convention = "pep257" does not
turn either off by itself -- the convention leaves both rules enabled
(btclib-org/.github#178), and the two ignore entries are what exempts
__init__ and a magic method (issue #1318).

Closes #1267, closes #1320, closes #1318.

Local review: CLEARED 6499f6c4 (round 2, after correcting the boundary
from 0.12.5 to the measured 0.12.0).

Gates: pytest (29702 passed, 11 skipped, 100% coverage), pre-commit run
--all-files, sphinx-build -W --keep-going -- all exit 0.

## Summary by Sourcery

Align project configuration comments and version floors with the independently validated uv and pep257 requirements.

Enhancements:
- Clarify the uv build backend version rationale and align the required uv version with Dependabot’s supported floor.
- Clarify why the pydocstyle exemptions for magic methods and public initializers are required under the pep257 convention.