### PR TITLE
The vendored vectors that need no code catch up to upstream

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3544,56 +3544,56 @@
         "filename": "tests/psbt/_data/bip375_test_vectors.json",
         "hashed_secret": "51541f3fe86cecf9a60c92f73a6b3dfce80d5ad5",
         "is_verified": false,
-        "line_number": 626
+        "line_number": 643
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/psbt/_data/bip375_test_vectors.json",
         "hashed_secret": "e1bddd32df24bde21a5161937ef1ff12e1b55401",
         "is_verified": false,
-        "line_number": 1472
+        "line_number": 1489
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/psbt/_data/bip375_test_vectors.json",
         "hashed_secret": "e72c7d2f2483cc853d537ef84aba879ee78289b4",
         "is_verified": false,
-        "line_number": 1484
+        "line_number": 1501
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/psbt/_data/bip375_test_vectors.json",
         "hashed_secret": "3365554b46428f5585e1aef6a97f3eb844c3ddb8",
         "is_verified": false,
-        "line_number": 1496
+        "line_number": 1513
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/psbt/_data/bip375_test_vectors.json",
         "hashed_secret": "bab62912ccce1c8ba1bbd153d6db8f94800b6b4c",
         "is_verified": false,
-        "line_number": 1508
+        "line_number": 1525
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/psbt/_data/bip375_test_vectors.json",
         "hashed_secret": "bb5f9e837d0363f8876956a6487e87122fd31561",
         "is_verified": false,
-        "line_number": 1520
+        "line_number": 1537
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/psbt/_data/bip375_test_vectors.json",
         "hashed_secret": "a72bb6d063076709a1802e8cd76d636ad57163f4",
         "is_verified": false,
-        "line_number": 1532
+        "line_number": 1549
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/psbt/_data/bip375_test_vectors.json",
         "hashed_secret": "028b50c52e02548b32df411ea2f7770e09adc3a2",
         "is_verified": false,
-        "line_number": 1544
+        "line_number": 1561
       }
     ],
     "tests/script/_data/taproot_test_vector.json": [
@@ -3697,5 +3697,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-13T15:49:26Z"
+  "generated_at": "2026-08-25T09:54:09Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2820,6 +2820,31 @@ documented at release-notes length in the first place, and are still in
   the seed comparison alone never caught it. Fixed by matching upstream's
   bytes.
 
+- **`tests/psbt/_data/bip375_test_vectors.json` carries upstream's new
+  valid case, "input eligibility: bare OP_2 script is not a segwit v2
+  witness program", and the file now ends on a newline of its own, so
+  `tests/_data/README.md` no longer notes the trailing-newline exception
+  for it** (issue #1312). The case carries its own `checks:
+  ["input_eligibility"]`, isolating one of BIP375's four checks the way
+  an existing invalid case already does; `tests/psbt/silent_payments_test.py`'s
+  valid-vector test now honors that field for a valid case too, running
+  only the checks a case names instead of the whole protocol when it
+  names any.
+
+- **`src/test/miniscript_tests.cpp`'s and `src/test/descriptor_tests.cpp`'s
+  pins in `tests/_data/README.md` move to their paths' current tips**
+  (issue #1312), each verified content-unchanged for the vectors this
+  tree transcribes: the miniscript diff is entirely a `BOOST_CHECK` split
+  into `BOOST_REQUIRE`/`BOOST_CHECK` inside the same function, and the
+  descriptor one adds cases past what this tree transcribes rather than
+  changing any of them (issue #1334 tracks whether btclib's own musig
+  derivation needs the fix those new cases exercise).
+  `ecdsa_secp256k1_sha256_bitcoin_test.json`'s pin moves too: upstream
+  replaced its top-level `generatorVersion` field
+  with a `source` object per test group and gave the file its own
+  schema, and `tests/ecc/wycheproof_test.py` reads neither field, so the
+  463 cases it does read are unchanged.
+
 ## v2026.8.21
 
 ### Repository

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -131,7 +131,10 @@ two BIP322 files on 2026-08-08, and the Wycheproof files with the licence
 beside them, the two BIP374 csv files, BIP352's
 `send_and_receive_test_vectors.json` and BIP375's
 `bip375_test_vectors.json` on 2026-08-13, and Core's `siphash.json` on
-2026-08-20.
+2026-08-20. BIP375's `bip375_test_vectors.json`, Core's
+`miniscript_fixed_tests.json` pin and `descriptor_tests.cpp` pin, and
+Wycheproof's `ecdsa_secp256k1_sha256_bitcoin_test.json` were pulled again
+on 2026-08-25, each at the tip of its path that day.
 
 A vector btclib fails is vendored anyway and marked `xfail`, never left
 out: an absent vector hides the defect it would have shown, and
@@ -689,21 +692,22 @@ one is.
 ```text
 repo    bitcoin/bips
 path    bip-0375/bip375_test_vectors.json
-commit  b217897a628e3d5db369497d2697f76e5bab7f4d  2026-04-09
-blob    3f16f51b23dfa36940737bfb80a8465421237ec0
-pulled  2026-08-13
+commit  e726d13ade44e2184635935c84a83d4082da3a63  2026-08-13
+blob    38511f65b4f100c4f56ac12371ebe4d8888f1e0d
+pulled  2026-08-25
 behind  0 revisions; that commit is the tip of the path
 ```
 
-Verdict: **identical but for a trailing newline** -- upstream's file ends
-on its closing brace, `end-of-file-fixer` adds the newline as it is
-staged, so our blob is `54929764` rather than the one above. The same
-exception `script_assets_test.json` and `vectors.json` document.
+Verdict: **identical** -- upstream's file ends on a newline after its
+closing brace, so `end-of-file-fixer` leaves it untouched as it is staged
+and our blob matches the one above. `script_assets_test.json` and
+`vectors.json` are the files that still document the "identical but for a
+trailing newline" exception.
 
 The only psbt vector file here that has an upstream file at all -- the
 other five are transcribed from mediawiki prose -- so the `bip375_` prefix
 is upstream's own name and this repository's naming rule at once, which is
-the one place the two coincide. 41 psbts, 22 invalid and 19 valid, the
+the one place the two coincide. 42 psbts, 22 invalid and 20 valid, the
 valid ones split between "can finalize" and "in progress".
 
 Each case carries a `supplementary` object of private keys, public keys
@@ -720,15 +724,18 @@ ahead of the rest -- while a psbt map has no normative order at all,
 BIP174 requiring only that a key not repeat. So the comparison is one
 level up: the maps read out of upstream's bytes and the maps read out of
 btclib's hold the same set of pairs, and btclib's own bytes are stable
-under a second parse. Measured on all 36 psbts that parse.
+under a second parse. Measured on all 37 psbts that parse.
 
-All 22 invalid psbts are refused and all 19 valid ones pass, and it takes
+All 22 invalid psbts are refused and all 20 valid ones pass, and it takes
 two test modules to say so: `tests/psbt/bip375_test.py` holds the codec to
 the file -- the field shapes, which is five of the six "PSBT Structure"
 cases -- and `tests/psbt/silent_payments_test.py` holds the two roles to
-it, which is the other seventeen. Each case's category is read off its own
-description, so a psbt refused by the wrong check fails there rather than
-counting as a pass.
+it, which is the other seventeen. Each invalid case's category is read off
+its own description, so a psbt refused by the wrong check fails there
+rather than counting as a pass; a valid case can carry a `checks` field of
+its own instead, naming the one check it isolates itself to -- one case
+does, "input eligibility: bare OP_2 script is not a segwit v2 witness
+program".
 
 **The file and the BIP disagree about one rule, and the file wins here.**
 BIP375 says the codes of one scan key are sorted lexicographically to
@@ -1137,9 +1144,9 @@ a tool at hand, not a refresh.
 ```text
 repo    bitcoin/bitcoin
 path    src/test/miniscript_tests.cpp
-commit  128456b62d5e38abea031f97f823d5b28aef9357  2026-08-08
-blob    6dac2aa907f853099dcf210ccb360792b89e9fca
-pulled  2026-08-08
+commit  e8691056c0140f8fa850fc6837dde915ebeb22cc  2026-08-03
+blob    d593fc3bf813ac27dce422d596ae9bf4b8b9e777
+pulled  2026-08-25
 behind  0 revisions; that commit is the tip of the path
 ```
 
@@ -1150,6 +1157,12 @@ miniscript, the script it compiles to under P2WSH and under tapscript, the
 and execution-stack numbers where the call gives them. The regex that
 produced it is not committed -- a one-off pass over C++ source is not a
 tool -- and what re-derives the file is reading those calls again.
+
+The pin between here and the commit this file was previously pinned to
+(`128456b62d5e`) touches none of those calls: every changed line is
+`BOOST_CHECK(a && b && c)` split into one `BOOST_REQUIRE`/`BOOST_CHECK` per
+condition, inside the "Misc unit tests" block below `fixed_tests`'s own
+vectors, not inside a `Test(...)` call. The vendored JSON is unchanged.
 
 Not vendored as the file itself because there is no data file upstream:
 the vectors are arguments to a C++ function. The blob above is that source
@@ -1173,8 +1186,8 @@ measure.
 ```text
 repo    bitcoin/bitcoin
 path    src/test/descriptor_tests.cpp
-commit  8ecbe270f0dee68b7eec6cea1714f453c5e215ad  2026-07-29
-pulled  2026-08-02, rawtr() added 2026-08-06
+commit  994c17d6c0a1453a1d7cc44ee2bbc49afa2d1155  2026-08-24
+pulled  2026-08-25, rawtr() added 2026-08-06
 behind  0 revisions; that commit is the tip of the path
 ```
 
@@ -1195,6 +1208,12 @@ also holds `CheckUnparsable` cases, which this module has as `UNPARSABLE`
 with btclib's own messages, and the `musig()` cases of BIP390, which are
 transcribed from the BIP itself above rather than from here. Matched
 against the pinned file on 2026-08-06.
+
+Not matched since: the commit above adds four cases -- a `musig()`
+duplicate-key check fix and a PSBT origin-path doubling fix, neither a
+refactor -- which
+[ISS 1334](https://github.com/btclib-org/btclib/issues/1334) tracks,
+including whether btclib's own musig derivation shares either defect.
 
 ## bitcoin-core/HWI
 
@@ -1585,20 +1604,23 @@ is the same test, `challenge_` reading the leftmost `nlen` bits of a
 digest whose longer forms have these very bytes as their prefix --
 measured, all four files verify identically at 32 and at 64.
 
-`ecdsa_secp256k1_sha256_bitcoin_test.json` is the one file of the four
-with no schema in upstream's `schemas/`, its own README listing it among
-those still missing one, and it is frozen at `generatorVersion 0.9rc5`.
-Vendored as it is regardless, which is what bitcoin-core/secp256k1 and
-secp256k1lab both do with it.
+`ecdsa_secp256k1_sha256_bitcoin_test.json` names its own schema now,
+`ecdsa_bitcoin_verify_schema.json`, which upstream added beside it;
+upstream's own README still lists the file as missing one, unrenewed in
+the same commit. No longer frozen at `generatorVersion 0.9rc5` either:
+that top-level field is gone, replaced by a `source: {name, version}`
+object per test group, `version` carrying the same string. Vendored
+regardless of the schema's presence or absence, which is what
+bitcoin-core/secp256k1 and secp256k1lab both do with it.
 
 ### `tests/ecc/_data/ecdsa_secp256k1_sha256_bitcoin_test.json`
 
 ```text
 repo    C2SP/wycheproof
 path    testvectors_v1/ecdsa_secp256k1_sha256_bitcoin_test.json
-commit  5722833ca004983abd1a91bcb6c24596d50ac0f9  2026-08-11
-blob    f737aabce273eb9485f21b84d32aa01d3e8b0246
-pulled  2026-08-13
+commit  234d9689d0cbb77a21fd603d6055ab47498bff69  2026-08-17
+blob    88097c48ba49f358179ac3aa6c6a64562d0f4e65
+pulled  2026-08-25
 behind  0 revisions; that commit is the tip of the path
 ```
 
@@ -1608,6 +1630,11 @@ twin of a valid signature is `invalid`. btclib's parser is the strict one
 and its verifier no longer applies that rule, so two of these verdicts
 are exempted rather than asserted — `wycheproof_test.py` reads which two
 out of the file below.
+
+The pin between here and the file's previous commit (`5722833ca004`)
+replaces the top-level `generatorVersion` with a `source` object per test
+group and adds the file's own `schema` field; every test group and every
+case is otherwise the same 463 cases, `numberOfTests` included.
 
 ### `tests/ecc/_data/ecdsa_secp256k1_sha256_test.json`
 
@@ -2161,10 +2188,10 @@ Against a pinned upstream blob:
   `base58_encode_decode.json`, `siphash.json`, `blockfilters.json`,
   `checkblock_valid.json`, `checkblock_invalid.json`,
   `bip39_test_vectors.json`, the eight BIP327 vector files,
-  `send_and_receive_test_vectors.json`, and the Wycheproof vector files.
+  `send_and_receive_test_vectors.json`, `bip375_test_vectors.json`, and
+  the Wycheproof vector files.
 - identical but for a trailing newline:
-  `script_assets_test.json`, `vectors.json`, `WYCHEPROOF_COPYING`,
-  `bip375_test_vectors.json`.
+  `script_assets_test.json`, `vectors.json`, `WYCHEPROOF_COPYING`.
 - identical but for CRLF against LF: `bip340_test_vectors.csv`, the two
   BIP324 vector files and the two BIP374 vector files -- every csv
   vendored from bitcoin/bips, so far.

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -1209,7 +1209,7 @@ with btclib's own messages, and the `musig()` cases of BIP390, which are
 transcribed from the BIP itself above rather than from here. Matched
 against the pinned file on 2026-08-06.
 
-Not matched since: the commit above adds four cases -- a `musig()`
+Not matched since: the commit above adds five cases -- a `musig()`
 duplicate-key check fix and a PSBT origin-path doubling fix, neither a
 refactor -- which
 [ISS 1334](https://github.com/btclib-org/btclib/issues/1334) tracks,

--- a/tests/ecc/_data/ecdsa_secp256k1_sha256_bitcoin_test.json
+++ b/tests/ecc/_data/ecdsa_secp256k1_sha256_bitcoin_test.json
@@ -1,7 +1,6 @@
 {
   "algorithm": "ECDSA",
   "schema": "ecdsa_bitcoin_verify_schema.json",
-  "generatorVersion": "0.9rc5",
   "numberOfTests": 463,
   "header": [
     "Test vectors of type EcdsaBitcoinVerify are meant for the verification",
@@ -122,6 +121,10 @@
   "testGroups": [
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -3588,6 +3591,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -3624,6 +3631,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -3650,6 +3661,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -3676,6 +3691,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -3702,6 +3721,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -3729,6 +3752,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -3756,6 +3783,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -3783,6 +3814,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -3810,6 +3845,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -3837,6 +3876,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -3874,6 +3917,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -3900,6 +3947,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -3926,6 +3977,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -3952,6 +4007,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -3978,6 +4037,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4004,6 +4067,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4030,6 +4097,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4056,6 +4127,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4082,6 +4157,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4108,6 +4187,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4134,6 +4217,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4160,6 +4247,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4196,6 +4287,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4223,6 +4318,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4250,6 +4349,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4277,6 +4380,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4304,6 +4411,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4331,6 +4442,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4358,6 +4473,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4385,6 +4504,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4412,6 +4535,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4439,6 +4566,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4466,6 +4597,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4493,6 +4628,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4520,6 +4659,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4547,6 +4690,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4574,6 +4721,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4601,6 +4752,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4628,6 +4783,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4654,6 +4813,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4680,6 +4843,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4706,6 +4873,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4732,6 +4903,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4758,6 +4933,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4784,6 +4963,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4810,6 +4993,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4836,6 +5023,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4862,6 +5053,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4888,6 +5083,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4914,6 +5113,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4940,6 +5143,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4966,6 +5173,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -4992,6 +5203,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5018,6 +5233,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5044,6 +5263,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5070,6 +5293,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5096,6 +5323,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5122,6 +5353,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5148,6 +5383,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5174,6 +5413,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5200,6 +5443,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5226,6 +5473,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5252,6 +5503,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5278,6 +5533,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5304,6 +5563,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5330,6 +5593,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5356,6 +5623,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5382,6 +5653,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5408,6 +5683,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5434,6 +5713,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5460,6 +5743,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5486,6 +5773,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5512,6 +5803,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5538,6 +5833,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5564,6 +5863,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5590,6 +5893,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5616,6 +5923,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5642,6 +5953,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5668,6 +5983,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5694,6 +6013,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5720,6 +6043,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5746,6 +6073,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5772,6 +6103,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5798,6 +6133,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5824,6 +6163,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5850,6 +6193,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5876,6 +6223,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5902,6 +6253,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5928,6 +6283,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5954,6 +6313,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -5990,6 +6353,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -6026,6 +6393,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -6082,6 +6453,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -6128,6 +6503,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -6174,6 +6553,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -6220,6 +6603,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -6266,6 +6653,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",
@@ -6312,6 +6703,10 @@
     },
     {
       "type": "EcdsaBitcoinVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
       "publicKey": {
         "type": "EcPublicKey",
         "curve": "secp256k1",

--- a/tests/psbt/_data/bip375_test_vectors.json
+++ b/tests/psbt/_data/bip375_test_vectors.json
@@ -569,6 +569,23 @@
   ],
   "valid": [
     {
+      "description": "input eligibility: bare OP_2 script is not a segwit v2 witness program",
+      "psbt": "cHNidP8B+wQCAAAAAQIEAgAAAAEEAQEBBQEBAQYBAAABDiAYpxdmOwurFLEqGncTI/8eQHndUy5d0T4o6hCBxwCYSgEPBAAAAAABAQqghgEAAAAAAAFSIgICyBe7dSGvw16pbzv7Jw5utQ3f+lVgYnuWH+wA8pllCL9HMEQCIHLzeIUvuENyYHLyUHbw53Vg7UwuBHFm7mpibHW/2znWAiAhKq5fCVdONB9YhvX/8y9XFuq5AwpKU3nmAWtqTULcJAEBAwQBAAAAIgYCyBe7dSGvw16pbzv7Jw5utQ3f+lVgYnuWH+wA8pllCL8IAAAAgAAAAAABEAT+////Ih0Cekh/wZ+3aYd7h0LW6hgRjzxOcrHqjG3mAqetSkHb4GghA+yk/xG3KOLg9gzmIilDpv9VudlfYnv5qZ0IS8hy1QpbIh4Cekh/wZ+3aYd7h0LW6hgRjzxOcrHqjG3mAqetSkHb4GhAihOzmFVF9yvW6JcUrrkJs+NUqEKpu4tWzQ7e0h34oZlZizEiikngvX6VzhBT98WyistUOmhwdgDjzomCLuMgIQABAwgYcwEAAAAAAAEEIlEgMm31D+Cge3rLcgcL6ztjLrmtFbppXMHlqmqgB7YUb9gBCUICekh/wZ+3aYd7h0LW6hgRjzxOcrHqjG3mAqetSkHb4GgDYeGx6d5eQssgB/fKVLng1X7ROTj61W0/GeV1E6j84DkA",
+      "supplementary": {
+        "inputs": [
+          {
+            "input_index": 0,
+            "prevout_scriptpubkey": "52",
+            "amount": 100000,
+            "witness_utxo": "a0860100000000000152"
+          }
+        ]
+      },
+      "checks": [
+        "input_eligibility"
+      ]
+    },
+    {
       "description": "can finalize: one P2PKH input single-signer",
       "psbt": "cHNidP8B+wQCAAAAAQIEAgAAAAEEAQEBBQEBAQYBAAABDiBSJ0jrF3ZNKMpJSBXsjUnn0w1SvHNCLHyG63TjlwVylAEPBAAAAAABAFUCAAAAAfTCEtWu0ef2/2M/LOCcZHxXvt2TAxTZjed1A9WOlAszAAAAAAD/////AaCGAQAAAAAAGXapFB4q14ctMpQTpW3wlovjOCIngxY7iKwAAAAAIgICyBe7dSGvw16pbzv7Jw5utQ3f+lVgYnuWH+wA8pllCL9HMEQCIDnBDcvHz0XG2UNW/1DBK42GqVUM8DcXPZzr94cU5nx1AiBxlVpC7SBTJDIHI8TwFCXc6J9CX4NwKEy0J2z9tt6jrAEBAwQBAAAAIgYCyBe7dSGvw16pbzv7Jw5utQ3f+lVgYnuWH+wA8pllCL8IAAAAgAAAAAABEAT+////Ih0Cekh/wZ+3aYd7h0LW6hgRjzxOcrHqjG3mAqetSkHb4GghA+yk/xG3KOLg9gzmIilDpv9VudlfYnv5qZ0IS8hy1QpbIh4Cekh/wZ+3aYd7h0LW6hgRjzxOcrHqjG3mAqetSkHb4GhAihOzmFVF9yvW6JcUrrkJs+NUqEKpu4tWzQ7e0h34oZlZizEiikngvX6VzhBT98WyistUOmhwdgDjzomCLuMgIQABAwgYcwEAAAAAAAEEIlEg4UDSh7RbRs1OqvpDdwYVcLq+g9G4vJUKdKn+oJIz16YBCUICekh/wZ+3aYd7h0LW6hgRjzxOcrHqjG3mAqetSkHb4GgDYeGx6d5eQssgB/fKVLng1X7ROTj61W0/GeV1E6j84DkA",
       "supplementary": {

--- a/tests/psbt/silent_payments_test.py
+++ b/tests/psbt/silent_payments_test.py
@@ -8,12 +8,15 @@ The vectors are BIP375's own `bip375_test_vectors.json`, already vendored
 under `tests/psbt/_data/` for `bip375_test.py`, which holds the codec to
 them; this module holds the two roles to the same file, and where that one
 had to say that seventeen of the invalid psbts are accepted, here **all 22
-are refused and all 19 valid ones pass**.
+are refused and all 20 valid ones pass**.
 
 The `checks` field of a case names which of BIP375's four checks it is
-about, so each is asserted against the check that should refuse it rather
-than against "something raised": a psbt refused for the wrong reason is a
-psbt this module got right by accident.
+about, so each invalid case is asserted against the check that should
+refuse it rather than against "something raised": a psbt refused for the
+wrong reason is a psbt this module got right by accident. A valid case
+naming `checks` is isolating one of them instead -- the rest of the psbt
+is not necessarily complete for the others -- so only the named check
+runs.
 
 **The k ordering is measured here, not assumed**, because BIP375's prose
 and its own vectors disagree and the disagreement is load-bearing. The
@@ -68,6 +71,17 @@ def _category(description: str) -> str:
     raise AssertionError(msg)
 
 
+# the same field `checks` names, for a vector that restricts itself to one
+# of BIP375's four checks rather than asking for the whole protocol; the
+# vocabulary is upstream's own test runner's, `CHECK_FUNCTIONS` in
+# `bip-0375/test_runner.py`
+_ONLY_CHECK = {
+    "ecdh_coverage": role.assert_shares_as_valid,
+    "input_eligibility": role.assert_eligibility_as_valid,
+    "output_scripts": role.assert_output_scripts_as_valid,
+}
+
+
 @pytest.mark.parametrize("vector", _VALID, ids=_VALID_IDS)
 def test_every_valid_psbt_passes_every_check(vector: dict[str, Any]) -> None:
     """The whole file's valid half, both roles applied.
@@ -75,8 +89,17 @@ def test_every_valid_psbt_passes_every_check(vector: dict[str, Any]) -> None:
     Including the "in progress" ones, which is the half that says the
     checks know what a psbt under construction looks like: an output whose
     script is not derived yet is not an output whose script is wrong.
+
+    A vector naming its own `checks` is isolating one of them, so only that
+    one runs: the rest of the psbt is not necessarily complete for the
+    others.
     """
     psbt = Psbt.b64decode(vector["psbt"])
+    checks = vector.get("checks")
+    if checks is not None:
+        for name in checks:
+            _ONLY_CHECK[name](psbt)
+        return
     role.assert_as_valid(psbt)
     # and each check on its own, so that a pass is not one check masking
     # another's opinion


### PR DESCRIPTION
Refreshes the vendored/cited pins in ISS #1312 (Vendored vectors behind
upstream) that need no code to consume -- the ones that do (BIP85's new
Nostr application, HWI's registerdescriptor/BIP388 policy args, and
wycheproof's unvendored webcrypto ecdh file) are split into #1330, #1331
and #1332 and stay out of this branch. #1312 stays open until those
land too.

bip375_test_vectors.json gains one new valid case from upstream tip
e726d13ade44 ("bare OP_2 script is not a segwit v2 witness program"),
which surfaced a real gap: silent_payments_test.py's
test_every_valid_psbt_passes_every_check ran the whole protocol against
every valid vector unconditionally, and the new case is deliberately
partial. It now honors a case's own checks field, matching how the
invalid-vector test already does.

miniscript_fixed_tests.json's pin bumps with no vector change (the
upstream diff is a pure BOOST_CHECK -> BOOST_REQUIRE assertion-style
refactor). Core's descriptor derivation citation bumps to the true
current tip, 994c17d6c0a1 -- the issue's own cited tip was itself
stale -- which merged two real bug fixes with five new test cases;
those aren't mirrored here (out of "no code" scope) and are tracked in
#1334 instead. HWI's error-code citation is deliberately left where it
is: pyproject.toml's own comment says the pinned revision is what a
related identifier has to match regardless of upstream fixing it;
#1335 tracks adding the new INVALID_POLICY code itself. The ten
wycheproof ECDSA/ECDH files and WYCHEPROOF_COPYING needed no edit --
their pins were already current, the issue's staleness reading was a
bookkeeping artifact. ecdsa_secp256k1_sha256_bitcoin_test.json's new
schema (generatorVersion -> per-group source) is pulled in since
btclib's loader never reads that field.

Local review: CLEARED 0b84ff26 (round 2, after correcting a case count
in tests/_data/README.md and in #1334's body: five new cases, not
four).

Gates: pytest (29704 passed, 11 skipped, 100% coverage), pre-commit run
--all-files, sphinx-build -W --keep-going -- all exit 0.

## Summary by Sourcery

Refresh no-code vendored test vectors and align BIP375 validation with upstream partial-vector semantics.

New Features:
- Refresh vendored BIP375, Bitcoin Core, and Wycheproof test data to current upstream revisions, including one additional valid BIP375 vector and updated ECDSA vector metadata.

Bug Fixes:
- Respect per-vector check selection when validating partial valid BIP375 vectors.

Enhancements:
- Update provenance and consistency documentation for refreshed upstream pins and vector counts.

Documentation:
- Document the refreshed vector revisions, schemas, and unchanged-case verification results.

Tests:
- Extend BIP375 coverage to 42 vectors while preserving validation of all existing cases.

Chores:
- Refresh vendored test-vector citations without incorporating upstream changes that require code updates.