### PR TITLE
Tests exercising the py arm are named test_the_py_arm_...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2790,6 +2790,16 @@ documented at release-notes length in the first place, and are still in
 
 ### Tests
 
+- **The tests exercising the pure-Python arm are named `test_the_py_arm_...`,
+  matching the spelling `tests/py_arm_authority_test.py` and its census
+  already carry** (closes #1270). Every test under `tests/bip32/`,
+  `tests/ecc/` and `tests/script/` whose name cited `python_arm` is
+  renamed, and `src/btclib/bip32/bip32.py` and `src/btclib/ecc/dsa.py`
+  cite the new names in the docstrings and comment that name them
+  verbatim. `src/btclib/curves/curve.py`, `SECURITY.md` and
+  `CONTRIBUTING.md` keep saying "Python arm": that is prose, not an
+  identifier, and stays outside this rename.
+
 - **`test_the_flag_still_switches_the_check_off`'s docstring stops
   counting the registry** (issue #1212). It said "the nine in
   `NETWORKS`", where `NETWORKS` holds five — a number nothing in the

--- a/src/btclib/bip32/bip32.py
+++ b/src/btclib/bip32/bip32.py
@@ -756,7 +756,7 @@ class _PythonPubKeyTweakChain:
     `mult` and the lift inside `point_from_octets` gate on
     `_libsecp256k1_serves(secp256k1, None)`, which is the call that chose
     this implementation, and cannot answer it differently -- and
-    `test_the_python_arm_reaches_no_bindings` checks that rather than
+    `test_the_py_arm_reaches_no_bindings` checks that rather than
     trusting it, a dispatch made finer-grained one day being what would
     end it silently.
     """

--- a/src/btclib/ecc/dsa.py
+++ b/src/btclib/ecc/dsa.py
@@ -563,7 +563,7 @@ def _grind_low_r(attempt: Callable[[int], Sig], grind: bool, ec: Curve) -> Sig:
     btclib walks where that arm cannot be taken -- a nonce of the
     caller's, a commitment, a curve of its own, or no bindings at all.
     The two are held to the same signature by
-    `test_the_delegated_grind_is_the_sequence_the_python_arm_walks`, and
+    `test_the_delegated_grind_is_the_sequence_the_py_arm_walks`, and
     that test is why the sequence may be written twice at all.
 
     No attempt cap. Core has none, and one would answer an event of
@@ -708,7 +708,7 @@ def _libsecp256k1_sign_(
     # argument: the argument is that Core's counter stopped being written
     # twice on the one arm that has a library implementing it.
     # The two are held to the same signature by
-    # `test_the_delegated_grind_is_the_sequence_the_python_arm_walks`,
+    # `test_the_delegated_grind_is_the_sequence_the_py_arm_walks`,
     # which is the defence this delegation rests on: identical on 500 of
     # 500 keys and messages -- 998 draws taken and 14 in the worst case,
     # reported in btclib-org/btclib#1005 where that run is -- so a change

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -820,7 +820,7 @@ def test_derivation_is_the_arithmetic_bip32_defines() -> None:
 
 
 @needs_bindings
-def test_the_python_arm_reaches_no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_the_py_arm_reaches_no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
     """The Python arm must be Python throughout, or it has no reason to be.
 
     A mixed arm is the one shape that is never right: with libsecp256k1
@@ -871,7 +871,7 @@ def test_the_python_arm_reaches_no_bindings(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 @needs_bindings
-def test_the_python_arm_answers_what_the_primitive_answers(
+def test_the_py_arm_answers_what_the_primitive_answers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Each arm of the two sums, against the call the other one makes.

--- a/tests/ecc/bms_test.py
+++ b/tests/ecc/bms_test.py
@@ -1070,7 +1070,7 @@ def test_the_python_path_answers_the_same(
 
 
 @needs_bindings
-def test_the_python_arm_reaches_no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_the_py_arm_reaches_no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
     """The recovery gated on availability alone must be Python throughout.
 
     A mixed arm is the one shape that is never right: with libsecp256k1 in

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -2031,7 +2031,7 @@ def test_a_fault_is_not_reported_as_a_wrong_key() -> None:
 
 
 @needs_bindings
-def test_the_delegated_grind_is_the_sequence_the_python_arm_walks() -> None:
+def test_the_delegated_grind_is_the_sequence_the_py_arm_walks() -> None:
     """The defence the delegation rests on, and the reason it is here.
 
     `sign_` no longer grinds on the delegated arm: libsecp256k1's own

--- a/tests/ecc/musig2_test.py
+++ b/tests/ecc/musig2_test.py
@@ -867,7 +867,7 @@ def test_partial_sig_verify_refuses_a_foreign_pub_key() -> None:
         musig2.partial_sig_verify_(psig, pub_nonce, pk_2, session_ctx)
 
 
-def test_partial_sig_verify_takes_the_python_arm_for_an_adaptor_session() -> None:
+def test_partial_sig_verify_takes_the_py_arm_for_an_adaptor_session() -> None:
     """A session with an adaptor is not delegated even where bindings serve.
 
     The bindings have no adaptor extension at all (this module's own

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -1573,7 +1573,7 @@ def test_a_signer_answers_what_the_free_function_answers(
         assert signer.sign_(reduce_to_hlen(msg, hf), aux, verify=False) == expected
 
 
-def test_the_python_arm_refuses_a_signature_that_does_not_verify() -> None:
+def test_the_py_arm_refuses_a_signature_that_does_not_verify() -> None:
     """The check is wired to the raise, not merely written near it.
 
     No input reaches it -- a fresh signature verifies under the key that

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -298,7 +298,7 @@ def test_the_python_prvkey_tweak_lifts_nothing(
 
 
 @needs_bindings
-def test_the_python_arm_reaches_no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_the_py_arm_reaches_no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
     """Both tweaks this module gates must be Python throughout.
 
     A mixed arm is the one shape that is never right: with libsecp256k1 in


### PR DESCRIPTION
Closes #1270

The census/workflow half of this issue landed already in #1272
(py_arm/py-arm spelling in the workflow, its script and the census
test module). This finishes the remainder: the tests that exercise the
arm itself, and the docstrings/comments citing them by name, still said
python_arm.

Renamed the test_the_python_arm_...-style functions to the py_arm
spelling across tests/bip32/bip32_test.py, tests/ecc/bms_test.py,
tests/ecc/dsa_test.py, tests/ecc/musig2_test.py, tests/ecc/ssa_test.py,
tests/script/taproot_test.py, and updated the verbatim citations in
src/btclib/bip32/bip32.py and src/btclib/ecc/dsa.py.
git grep -n 'python_arm' -- src/btclib tests now answers nothing outside
CHANGELOG.md's own historical entries.

Local review: CLEARED 2bc4a598 (round 2, after fixing a stale
btclib/curves/curve.py path in the CHANGELOG entry -- src/btclib/ after
the #1333 layout move).

Gates: pytest (29704 passed, 11 skipped, 100% coverage), pre-commit run
--all-files, sphinx-build -W --keep-going -- all exit 0.

## Summary by Sourcery

Align pure-Python arm test identifiers and their references with the established `py_arm` naming convention.

Enhancements:
- Standardize pure-Python arm test names and update source references to use the `py_arm` spelling.

Tests:
- Rename tests that exercise the pure-Python arm across BIP32, ECC, and Taproot test suites.

Chores:
- Record the naming cleanup in the changelog.