### PR TITLE
tests/ecc vendors Wycheproof's JWK-encoded ECDH file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2855,6 +2855,17 @@ documented at release-notes length in the first place, and are still in
   schema, and `tests/ecc/wycheproof_test.py` reads neither field, so the
   463 cases it does read are unchanged.
 
+- **`tests/ecc/_data/ecdh_secp256k1_webcrypto_test.json`, Wycheproof's
+  JWK-encoded twin of the vendored `ecdh_secp256k1_test.json`, is now
+  vendored too, with `tests/ecc/wycheproof_test.py`'s `test_ecdh_webcrypto`
+  reading it** (closes #1332). Its public and private keys are JWK (RFC
+  7517) where the sibling file's are X.509, so `_point_from_jwk` reads
+  `crv`, `x` and `y` the way `_point_from_spki` reads the OID and the
+  point octets, and a private key comes from the JWK `d` field through
+  the same base64url decoder. `tests/_data/README.md`'s entry for the
+  file replaces the "not vendored" one that recorded it as a measured
+  re-encoding.
+
 ## v2026.8.21
 
 ### Repository

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -1805,6 +1805,22 @@ Verdict: **identical**. Key agreement, with the public key X.509-encoded
 rather than a bare point: the invalid-curve, twist and wrong-curve cases
 `btclib.ecc.dh` has no other vectors for.
 
+### `tests/ecc/_data/ecdh_secp256k1_webcrypto_test.json`
+
+```text
+repo    C2SP/wycheproof
+path    testvectors_v1/ecdh_secp256k1_webcrypto_test.json
+commit  5722833ca004983abd1a91bcb6c24596d50ac0f9  2026-08-11
+blob    a675c5378e8d10aad7ae241ef5460f4aefa10d0b
+pulled  2026-08-25
+behind  0 revisions; last changed at e0df04e0, 2025-10-07
+```
+
+Verdict: **identical**. The same key agreement as `ecdh_secp256k1_test.json`
+above with the keys JWK-encoded (RFC 7517) rather than X.509: `WrongCurve`
+here attacks the JWK `crv` field where that file's attacks the DER OID,
+and its valid cases' shared secrets are exactly that file's own.
+
 ### `tests/ecc/_data/WYCHEPROOF_COPYING`
 
 ```text
@@ -1830,30 +1846,6 @@ which is false, the BIP and rustyrussell files beside it having their
 own terms and btclib's own `LICENSE` being at the root. The upstream
 name is in the entry above instead, where the pin already is. It is the
 name bitcoin-core/secp256k1 gives its copy for the same reason.
-
-### Not vendored: `ecdh_secp256k1_webcrypto_test.json`
-
-```text
-repo    C2SP/wycheproof
-path    testvectors_v1/ecdh_secp256k1_webcrypto_test.json
-commit  5722833ca004983abd1a91bcb6c24596d50ac0f9  2026-08-11
-pulled  never
-behind  0 revisions; that commit is the tip of the path
-```
-
-Verdict: **not vendored, measured to be a re-encoding**. It is the same
-agreement as `ecdh_secp256k1_test.json` above with the keys written as
-JWK -- `crv: "P-256K"`, base64url `x`, `y` and `d` -- rather than as
-X.509. Its valid cases yield 468 distinct shared secrets, and all 468
-are exactly that file's; its invalid cases are a strict subset of that
-file's classes, JWK having no ASN.1 for `InvalidAsn` or
-`InvalidEncoding` to attack.
-
-So what it would add is a base64url and JWK reader under `tests/`, and
-no arithmetic btclib does not already answer for. Recorded here rather
-than left silent because "we did not take it" and "we did not notice
-it" look the same in a directory listing, and a later refresh would
-otherwise have to measure this again.
 
 ## Chain data, not a repository
 
@@ -2215,8 +2207,6 @@ No upstream blob exists for the rest:
 - response bodies under `tests/fetch/_data/`, whose envelopes are
   composed from Core's and Esplora's own source and whose payload is
   chain data two of the entries above already hold.
-- deliberately not vendored, with an entry saying why it was measured
-  and left: Wycheproof's `ecdh_secp256k1_webcrypto_test.json`.
 - not vendored: `rfc6979.json` (an RFC), `electrum_test_vectors.json`,
   `electrum_language_vectors.json`, `fakeenglish.txt` and
   `btclib_test_vectors.json` (btclib's own). The last is the only one

--- a/tests/ecc/_data/ecdh_secp256k1_webcrypto_test.json
+++ b/tests/ecc/_data/ecdh_secp256k1_webcrypto_test.json
@@ -1,0 +1,11978 @@
+{
+  "algorithm": "ECDH",
+  "schema": "ecdh_webcrypto_test_schema_v1.json",
+  "numberOfTests": 496,
+  "header": [
+    "Test vectors of type EcdhWebTest are intended for",
+    "testing an ECDH implementations using jwk encoded",
+    "public and private keys."
+  ],
+  "notes": {
+    "AdditionChain": {
+      "bugType": "KNOWN_BUG",
+      "description": "The private key has an unusual bit pattern, such as high or low Hamming weight. The goal is to test edge cases for addition chain implementations."
+    },
+    "EdgeCaseDoubling": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains an EC point that hits an edge case (e.g. a coordinate 0) when doubled. The goal of the test vector is to check for arithmetic errors in these test cases.",
+      "effect": "The effect of such arithmetic errors is unclear and requires further analysis."
+    },
+    "EdgeCaseEphemeralKey": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains an ephemeral public key that is an edge case."
+    },
+    "EdgeCaseSharedSecret": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains a public key and private key such that the shared ECDH secret is a special case. The goal of this test vector is to detect arithmetic errors.",
+      "effect": "The seriousness of an arithmetic error is unclear. It requires further analysis to determine if the bug is exploitable."
+    },
+    "InvalidCurveAttack": {
+      "bugType": "CONFIDENTIALITY",
+      "description": "The point of the public key is not on the curve. ",
+      "effect": "If an implementation does not check whether a point is on the curve then it is likely that the implementation is susceptible to an invalid curve attack. Many implementations compute the shared ECDH secret over a curve defined by the point on the public key. This curve can be weak and hence leak information about the private key."
+    },
+    "InvalidPublic": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The public key has been modified and is invalid. An implementation should always check whether the public key is valid and on the same curve as the private key. The test vector includes the shared secret computed with the original public key if the public point is on the curve of the private key.",
+      "effect": "Generating a shared secret other than the one with the original key likely indicates that the bug is exploitable."
+    },
+    "ModifiedGroup": {
+      "bugType": "MODIFIED_PARAMETER",
+      "description": "The EC curve of the public key has been modified. EC curve primitives should always check that the keys are on the expected curve."
+    },
+    "ModifiedPublicPoint": {
+      "bugType": "MODIFIED_PARAMETER",
+      "description": "The public point of the key has been modified and is not on the curve.",
+      "effect": "Not checking that a public point is on the curve may allow an invalid curve attack."
+    },
+    "Normal": {
+      "bugType": "BASIC",
+      "description": "The test vector contains a pseudorandomly generated, valid test case. Implementations are expected to pass this test."
+    },
+    "WrongCurve": {
+      "bugType": "CONFIDENTIALITY",
+      "description": "The public key and private key use distinct curves. Implementations are expected to reject such parameters.",
+      "effect": "Computing an ECDH key exchange with public and private keys can in the worst case lead to an invalid curve attack. Hence, it is important that ECDH implementations check the input parameters. The severity of such bugs is typically smaller if an implementation ensures that the point is on the curve and that the ECDH computation is performed on the curve of the private key. Some of the test vectors with modified public key contain shared ECDH secrets, that were computed over the curve of the private key."
+    }
+  },
+  "testGroups": [
+    {
+      "type": "EcdhWebcryptoTest",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "curve": "P-256K",
+      "encoding": "webcrypto",
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "normal case",
+          "flags": [
+            "Normal"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "2Alq-KEeC4ADfh7mgka13LsK6xzxJE_XZ9uA8_on2is",
+            "y": "OWgS6haG50culpLq8-lY5Q6VANO0x3JD2x8qzWe6nMQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "9Lf_fMzJiBOmn6498iK_4_Tij3ZL-RtKENgJbORGslQ",
+            "x": "JDchdVTyxKQl0yCsuVGavln7SRJ5YwyNqo0ZvKptbTI",
+            "y": "_B2MI_66Cp6jkx-juqZoTYcKUUiFufhUuh0f2o-zPMM",
+            "kid": "none"
+          },
+          "shared": "544dfae22af6af939042b1d85b71a1e49e9a5614123c4d6ad0c8af65baf87d65",
+          "result": "valid"
+        },
+        {
+          "tcId": 2,
+          "comment": "shared secret has x-coordinate that satisfies x**2 + a = 1",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "ll_0LWVOBY7nMXzO18rwk_uxgNjTp0sNzZ2M1Ho51cs",
+            "y": "nCqk2qwBpL43wgRn7elkZi8SmD4LUnKkel8nhWhdgIc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "0000000000000000000000000000000000000000000000000000000000000001",
+          "result": "valid"
+        },
+        {
+          "tcId": 3,
+          "comment": "shared secret has x-coordinate that satisfies x**2 + a = 4",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "BsS4e6dsbcsQH1SgUKCGqiywci8DE331qSJHLxvcEbk",
+            "y": "guPHNcS2xIHQkmlVnwgK0IYy83CgVK8Swf0eztLqkhE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "0000000000000000000000000000000000000000000000000000000000000002",
+          "result": "valid"
+        },
+        {
+          "tcId": 4,
+          "comment": "shared secret has x-coordinate that satisfies x**2 + a = 9",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "u6MO73lnovLwii_62sDkH9TbEqk87wsEW1cG8oU4IeY",
+            "y": "1Qsr-Mv1MOYZhp4HwCHvFvaTz8CksNTtWo9GRpK_PW4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "0000000000000000000000000000000000000000000000000000000000000003",
+          "result": "valid"
+        },
+        {
+          "tcId": 5,
+          "comment": "shared secret has x-coordinate p-3",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "banrLNrAISLV8Fz2qM12jjePZk6kp4cdEOJfV-se4cw",
+            "y": "Wytav5xsZZb484PdvLO8wtWnzGBZhJMSOcqWaZRgMu4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2c",
+          "result": "valid"
+        },
+        {
+          "tcId": 6,
+          "comment": "shared secret has x-coordinate 2**16 + 0",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "8pdhVMT1POOS0f45qJGkYRuozwRgI82PG82f3S6SEZE",
+            "y": "slzzHK7fu0FTgWN7w_WZo0-6PhQT9kTLFmhGn0VYp3I",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "0000000000000000000000000000000000000000000000000000000000010000",
+          "result": "valid"
+        },
+        {
+          "tcId": 7,
+          "comment": "shared secret has x-coordinate 2**32 + 7",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "XkIv6mfMpeuurId0XIGxDvgHAwNn5vzgEiVBduyM8Zk",
+            "y": "iBWS9CwmQ3HhnjA3OIq2TzL6iHDmKQXnryBeQ7AqrRI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "0000000000000000000000000000000000000000000000000000000100000007",
+          "result": "valid"
+        },
+        {
+          "tcId": 8,
+          "comment": "shared secret has x-coordinate 2**64 + 1",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "u1e5oSMb4ELRhcA-2mkmpt7xd_5nRe2gAMUg1mWB8M0",
+            "y": "8dc8gEU_L-MHJa35UTkMc542_IZ3aR2xB4gTQmE9AKs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "0000000000000000000000000000000000000000000000010000000000000001",
+          "result": "valid"
+        },
+        {
+          "tcId": 9,
+          "comment": "shared secret has x-coordinate 2**96 + 1",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "VWPHbBk3djj31Re9vgrORn611N2ftL8YMyurjwex2Aw",
+            "y": "JhMy1G4xZxEni6zM2IAF7kwRX6hAif0ZBnRibl7R6_4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "0000000000000000000000000000000000000001000000000000000000000001",
+          "result": "valid"
+        },
+        {
+          "tcId": 10,
+          "comment": "shared secret has x-coordinate that satisfies x**2 + a = -6",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "iYOq6MAC8rVVrLI3CtubULpMrBv8yQOaElxwynxfwNE",
+            "y": "9u_riuS6jGlCnZMkQ4JEesU0iRxmCQAlKCZVcZvXJRI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "0b7beba34feb647da200bed05fad57c0348d249e2a90c88f31f9948bb65d5207",
+          "result": "valid"
+        },
+        {
+          "tcId": 11,
+          "comment": "shared secret has x-coordinate that satisfies x**2 + a = 2",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "I1VlZIUMUPulHx5k75g3jvXCL-r6KUmconYAxHPKzog",
+            "y": "nVZ56Rfap_THiZUX03gmKE8DHeAaYLyBNpZBTQRTGiE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "210c790573632359b1edb4302c117d8a132654692c3feeb7de3a86ac3f3b53f7",
+          "result": "valid"
+        },
+        {
+          "tcId": 12,
+          "comment": "shared secret has x-coordinate that satisfies x**2 + a = 8",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "3b-AfiLFahnPbEcoKRUDUHgQNKXt3sNlaU1L1chl6tE",
+            "y": "TmdBJwKMkdM5TKw3KTqGYFXRDw9Ao3Bq0Wtk_J1ZmL0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "4218f20ae6c646b363db68605822fb14264ca8d2587fdd6fbc750d587e76a7ee",
+          "result": "valid"
+        },
+        {
+          "tcId": 13,
+          "comment": "shared secret has x-coordinate that satisfies x**2 = 2**96 + 2",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "ZGiOrnqr0kj29EoNbixDjkEAABgT63H58IL609_kPig",
+            "y": "fas9q-fUNgAaD7djAV3tu5D4EQAOyPXymVPjr0L5IGU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "39f883f105ac7f09f4e7e4dcc84bc7ff4b3b74f301efaaaf8b638f47720fdaec",
+          "result": "valid"
+        },
+        {
+          "tcId": 14,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 2",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "xAThcUHRArui8csWu5VKIIeYsE3KjdE5qKt_AfDb7zk",
+            "y": "x7jlXyJXpIAHfkGQVwoATL5mggDJx46qU7YbIPzkxoU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "5555555555555555555555555555555555555555555555555555555555555550",
+          "result": "valid"
+        },
+        {
+          "tcId": 15,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 2",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "4WDofApWKh27WbTC9hRyDndTYIZy642IO5HiX4z8WEc",
+            "y": "RiPLpYThMkvEm83wiRFmtUW3cE4rvacF0Nc7dTDkeVI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "result": "valid"
+        },
+        {
+          "tcId": 16,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 4",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "XU0YKxh4KgJoXcx7Zx7HQs4wjHrMjmJg9n6BUW61Rug",
+            "y": "o48HVgdO6khXlTOYttBVl8fOteZeTozuMegcVliCTOQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "3333333333333333333333333333333333333333333333333333333333333333",
+          "result": "valid"
+        },
+        {
+          "tcId": 17,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 4",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "js1qJXb0JiZ5IHaTXi_pYVmeSEzSErziYjuDqiL1RtI",
+            "y": "p_hVsJvvKGvL6ei6sX_VbXBV32TzRDEMNSLo8ifkcsg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccb",
+          "result": "valid"
+        },
+        {
+          "tcId": 18,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 8",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "aCb3nvhNqANGCu0JGY0ru0LXiS7WCKrLsoGpWsrhFGU",
+            "y": "olgJGRqlvfphuJY76stOsTMmapDzPRsspPYVLTepT9g",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0c",
+          "result": "valid"
+        },
+        {
+          "tcId": 19,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 8",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "pUuyroAIYFOl-k_bGDaoxqxBeDZQsPeaVCjJj_ZNB4o",
+            "y": "Eru0y4ryDKdewVsuDUeoPKk_x4zZJkCgLoAClm8f6As",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0",
+          "result": "valid"
+        },
+        {
+          "tcId": 20,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 16",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "us5G7tSSdDxpPhozrbBGt3IsVc42nRQ45n-cWzQSeDE",
+            "y": "RSYt1KhsilJ7I_QRS4qbnzb5cBg19QtniyTSqRVevCw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff",
+          "result": "valid"
+        },
+        {
+          "tcId": 21,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 16",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AQVRR4Y6oGDA4QTiQ-wB7aKw4MaBTiMtZxq8upcV1c4",
+            "y": "DBMAaqeWDFT-PyAiC-92Z1bJEP0Fdkr8MYN1VAzvLVw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00",
+          "result": "valid"
+        },
+        {
+          "tcId": 22,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 30",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "WV5G7nwtcYP_Lqdg_9hHL7g07InAi270j_krRKE6bho",
+            "y": "5WPiOVPJfCZEEyPSUAyE6M7gTBXU1dLMRYcD0fLQLTE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "7fff0001fffc0007fff0001fffc0007fff0001fffc0007fff0001fffc0007fff",
+          "result": "valid"
+        },
+        {
+          "tcId": 23,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 30",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "akCtyBGwnoO6D7ipT-pQWRyp5Yu31HMElQ2_942td34",
+            "y": "470I90LX6OMM_zG8amzALIcX7iWDiqv_puSPZcznTYE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "8000fffe0003fff8000fffe0003fff8000fffe0003fff8000fffe0003fff7fff",
+          "result": "valid"
+        },
+        {
+          "tcId": 24,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 32",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "WjP-kdfjXbeHUgi-539MwABvFDnMhF9pW2oSZz3NA9E",
+            "y": "j4buEhxeoNo-sCEFCeEtuEUpYiXKlz4uGc4-PQFIYJA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000fffd",
+          "result": "valid"
+        },
+        {
+          "tcId": 25,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 32",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "9uuqtiw1_UuL7J2VvPxDPmvefA8NXvddb9MmqvKPI7A",
+            "y": "svTRwuiRcGt7raWfsPajK1RjmCqcjC2Oo4lUQYGDtjQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000fffefffe",
+          "result": "valid"
+        },
+        {
+          "tcId": 26,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 51",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "UkOSQW-M_F-E3Jty8oh8aE5L0keW8AZQeOGNFrxDtW4",
+            "y": "oCF4MReZ62GtOz59zaEEBNxFQcE-PeDOtAyap6-rxTs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "8000003ffffff0000007fffffe000000ffffffc000001ffffff8000003fffffd",
+          "result": "valid"
+        },
+        {
+          "tcId": 27,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 51",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "mZZcR3okCuu9Gc0JTItihS3oZj0MyfBu6zlf_JLRIfY",
+            "y": "SBGIL0BggNfQTqTzOb3dLl7wNFtYNBQvdbViFU1ex64",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "7fffffe000000ffffffc000001ffffff8000003ffffff0000007fffffdfffffe",
+          "result": "valid"
+        },
+        {
+          "tcId": 28,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 52",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "rT0XmHfnTuJYum-OEovCoARcBqPTww_M4Byo2eGv7k4",
+            "y": "o_5HFW-3J_wcVe-dtRbfZly7BzQFwsMBqP4dEPO5swA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "000003ffffff0000003ffffff0000003ffffff0000003ffffff0000003fffffc",
+          "result": "valid"
+        },
+        {
+          "tcId": 29,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 52",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "S7Gd6uY4_F-nBwzJDpabrD-DhKWeoRywG8CR7fGky9Y",
+            "y": "d-1r34lx0-Y8kD2ayrwot1r2YaA0VyYcWo1ZQK0CxQk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "fffffc000000ffffffc000000ffffffc000000ffffffc000000ffffffbfffffe",
+          "result": "valid"
+        },
+        {
+          "tcId": 30,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 60",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "JBdcB44wXTE55dq3J6arhYeybapHClKaI8EFhctWwDg",
+            "y": "vx8rk3rgdP-UsV9cteYOtdMq-6IHdTnbeUKUvKq3GoE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "ffff00000003fffffff00000003fffffff00000003fffffff00000003fffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 31,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 60",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "72ka_i7kqhioSFpxwOIO_xM3rgYirMCczaEPSVdK6EA",
+            "y": "uCcwuy7vWaF6sJWs0THl_Pi6ERUKlCG7q2ufFGqnj_s",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "0000fffffffc0000000fffffffc0000000fffffffc0000000fffffffbffffffd",
+          "result": "valid"
+        },
+        {
+          "tcId": 32,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 62",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Bn598J9eOPKygj9lprETXDKQWG_vbs7_ptWVlXSIefY",
+            "y": "aTKz9w1gMinhClc0Ts3lA6LfkwZRBGwvHStxm_yT4KE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "ff00000001fffffffc00000007fffffff00000001fffffffc00000007ffffffd",
+          "result": "valid"
+        },
+        {
+          "tcId": 33,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 62",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "uHIuzd58hTF-SGsDZWuDkQrDyIaHpCkei7mktqUsxuA",
+            "y": "LkFYpaiN4CPWoTW9BMFYXvRnQYkDdhNUU-xWLaWzdgs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "00fffffffe00000003fffffff80000000fffffffe00000003fffffff80000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 34,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 64",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "co4V1XghK8Qih8ARjILISxJvl9VJIjwQrQf06Yr5Ejg",
+            "y": "XSOxpucWklhVokexbv_pJ3MxUkGslRzf79-sDtFkZ_Y",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 35,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 64",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "w-81_UzaZujoUAleHml67lbezClISqRj-HnHtt12aeY",
+            "y": "JZRTUSdnGcXju45RT2kwW2CFt8eCoHsmqEKIfDOpPcY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "ffffffff00000000ffffffff00000000ffffffff00000000fffffffeffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 36,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 112",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "eEkHxr5iAncLmNAfH_4Rue0sl1FYQ_V8LAY2Op2txwE",
+            "y": "HeX7qnNWzzuijLe5MqB8gyEAfHxFOWdR_nByQ0PSsZ8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "ffffffff00000000000000ffffffffffffff00000000000000fffffffffffffe",
+          "result": "valid"
+        },
+        {
+          "tcId": 37,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 112",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "fAFt7otUEfjpUYTa-OMYEZ6ES4vccNde-5m40P8Qq3Q",
+            "y": "XpBRA9V9ZTeQjm6YZK7k8JF_W5INBvmAqoI_BD75E54",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "00000000ffffffffffffff00000000000000ffffffffffffff00000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 38,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 128",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "NuHnb_2-hXdSCwcW64jBjqcqSeWk5WgKfSkAk_hBy24",
+            "y": "cxByi1nHVyxLNftsKcNuur_FNVPAbs90f8--_PYRThw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "0000000000000000ffffffffffffffff0000000000000000ffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 39,
+          "comment": "shared secret has x-coordinate with repeating bit-pattern of size 128",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "ehlQHWRvyTMqhSWvTMeVI7V9c2tpuySwYnDBsdrfiM4",
+            "y": "g076G86FT_W8reQMvO6fQBVLwmA2rcXPh-UOo4ivKYc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "ffffffffffffffff0000000000000000fffffffffffffffefffffffffffffff5",
+          "result": "valid"
+        },
+        {
+          "tcId": 40,
+          "comment": "shared secret has an x-coordinate of approx p//3",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "9DthCipcX24rOVVnSJZXBZ4zUcb5p-Lr3lJjir_qAGo",
+            "y": "staQUT6Rh8DMkDzu4CLuQhxZSovXYQxozYFDrfx0Hd4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "55555555555555555555555555555555555555555555555555555554fffffebc",
+          "result": "valid"
+        },
+        {
+          "tcId": 41,
+          "comment": "shared secret has an x-coordinate of approx p//5",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "2Tv9qnl81L2B3qgNfHKiSSPOUOlL_E7hvV9fEO6j-Ow",
+            "y": "wLWUGJCibojlApwoPg-t7MwLmA-KUJiqeDXFyVjUceU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "33333333333333333333333333333333333333333333333333333332ffffff3c",
+          "result": "valid"
+        },
+        {
+          "tcId": 42,
+          "comment": "shared secret has an x-coordinate of approx p//7",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "CsHqein3rOijiy_tv-TQ2a5FNEQyqz614KW2Zxb2HGo",
+            "y": "qqOaXwmP1Eclh9FL33Kz3T6Wa18LbkAP_24OnIRT_Hk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "249249249249249249249249249249249249249249249249249249246db6dae2",
+          "result": "valid"
+        },
+        {
+          "tcId": 43,
+          "comment": "shared secret has an x-coordinate of approx p//9",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "vy6KYaIdludKKWs5flMETzc6y3Om6ko5jYnFZUnpa38",
+            "y": "6Eb9DfI5aR0GgrBnpQokI9iLTZcLHT2BQaBm0TwYb5Y",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "1c71c71c71c71c71c71c71c71c71c71c71c71c71c71c71c71c71c71c555554e8",
+          "result": "valid"
+        },
+        {
+          "tcId": 44,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Vrrx1yYGx69aX6EIYgsIOeLH3UC4Mu-EfltkyG7-GqU",
+            "y": "Y-WGpmemW7tWklAN8f-EA3NoOLMOqXkdnTkOPcZoniw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "800000000000000000000000009fa2f1ffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 45,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "gAAAAAAAAAAAAAAAAJ-i8f____________________8",
+            "y": "B-01PJ8QOe3MnMUzbANNwTGkCHaSwuVrwd0ZBOP___8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "7c07b199b6a62e7ac646c7e1dee94aca55de1a97251ddf92fcd4fe0145b40f12",
+          "result": "valid"
+        },
+        {
+          "tcId": 46,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Xkws8TIOyE74kghntAmpqR0t0AghaiguNr2E6IRyb6A",
+            "y": "Wl5K8Rz2POqqQqbcnkzLOUhSz4QoTo0mJ1cvvyLAuog",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "80000000000000000000000000a3037effffffffffffffffffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 47,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AqMML6vIfmcwYl3sLw0DiUOHt_dDzmnEc1Hr5e6YpIM",
+            "y": "B-t404dw_qGkT02nLCb4WxfzUBpPk5T-KYVsy_Ff0oQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "8000000000000000000000000124dcb0ffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 48,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "gAAAAAAAAAAAAAAAAKMDfv____________________8",
+            "y": "AAADGmvzRLhnMKxcVKd1Gu_boTV1m51TXKZBEfKYo40",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "5206c3de46949b9da160295ee0aa142fe3e6629cc25e2d671e582e30ff875082",
+          "result": "valid"
+        },
+        {
+          "tcId": 49,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "gAAAAAAAAAAAAAAAASTcsP____________________8",
+            "y": "AAABO8bwhDHnKe0oY_L0rIowJ5aVyBCcNAo5-ob0Uc0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "8a8c18b78e1b1fcfd22ee18b4a3a9f391a3fdf15408fb7f8c1dba33c271dbd2f",
+          "result": "valid"
+        },
+        {
+          "tcId": 50,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Xkws8TIOyE74kghntAmpqR0t0AghaiguNr2E6IRyb6A",
+            "y": "paG1DuMJwxVVvVkjYbM0xretMHvXsXLZ2KjQP90_Qac",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "80000000000000000000000000a3037effffffffffffffffffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 51,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AqMML6vIfmcwYl3sLw0DiUOHt_dDzmnEc1Hr5e6YpIM",
+            "y": "-BSHLHiPAV5bsLJY09kHpOgMr-WwbGsB1nqTMw6gKas",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "8000000000000000000000000124dcb0ffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 52,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "gAAAAAAAAAAAAAAAAKMDfv____________________8",
+            "y": "___85ZQMu0eYz1Ojq1iK5RAkXsqKZGKso1m-7Q1nWKI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "5206c3de46949b9da160295ee0aa142fe3e6629cc25e2d671e582e30ff875082",
+          "result": "valid"
+        },
+        {
+          "tcId": 53,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "gAAAAAAAAAAAAAAAASTcsP____________________8",
+            "y": "___-xDkPe84Y1hLXnA0LU3XP2GlqN-9jy_XGBHkLqmI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "8a8c18b78e1b1fcfd22ee18b4a3a9f391a3fdf15408fb7f8c1dba33c271dbd2f",
+          "result": "valid"
+        },
+        {
+          "tcId": 54,
+          "comment": "y-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCaseSharedSecret"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "VFDKzgQ4atxUoUNQeT6DvcXyZdbCkofs0H95GtJ4TEw",
+            "y": "69PCRFEyIzTY1RAz6dNLa7WSsZldB4Z4Y9EES9WddQE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "orZEKjf4o3ZK7_QBGkxCKziaHlCWacQ_J5yLfjLYDDo",
+            "x": "5PmP6NWWKNzK0al9AnyrtIM3t54tGs-pnwggXqijyBI",
+            "y": "sjeCPt9b0dObBwhL_Pco7O6J6tO_09NkO50dp3hwc00",
+            "kid": "none"
+          },
+          "shared": "80000000000000000000000001126b54ffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        },
+        {
+          "tcId": 55,
+          "comment": "y-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "gAAAAAAAAAAAAAAAARJrVP____________________8",
+            "y": "QQajaQaNRU6kucOsYXf4f8j9OqJAssy0iCvcy9QAAAA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "e59ddc7646e4aef0623c71c486f24d5d32f7257ef3dab8fa524b394eae19ebe1",
+          "result": "valid"
+        },
+        {
+          "tcId": 56,
+          "comment": "ephemeral key has x-coordinate that satisfies x**2 + a = 1",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+            "y": "QhjyCubGRrNj22hgWCL7FCZMqNJYf91vvHUNWH52p-4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "12c2ad36a59fda5ac4f7e97ff611728d0748ac359fca9b12f6d4f43519516487",
+          "result": "valid"
+        },
+        {
+          "tcId": 57,
+          "comment": "ephemeral key has x-coordinate that satisfies x**2 + a = 4",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAI",
+            "y": "ZvvnJ7K6CeCfWpjXCl786EJMX6Qlu9ocUR-GBle4U14",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "45aa9666757815e9974140d1b57191c92c588f6e5681131e0df9b3d241831ad4",
+          "result": "valid"
+        },
+        {
+          "tcId": 58,
+          "comment": "ephemeral key has x-coordinate that satisfies x**2 + a = 9",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM",
+            "y": "LyMzlciwejg0oOWb2kOUS13zeIUuVg68DyKHfp9Ju0s",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "b90964c05e464c23acb747a4c83511e93007f7499b065c8e8eccec955d8731f4",
+          "result": "valid"
+        },
+        {
+          "tcId": 59,
+          "comment": "ephemeral key has x-coordinate p-3",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_____________________________________v___Cw",
+            "y": "DplLFOpy-MPrlcce9pJXXndQWDMtflLQmVz4A4hxtn0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "e97fb4c4fb33d6a114da6e0d180e54f99ec1ece9ff558871054e99d221930d16",
+          "result": "valid"
+        },
+        {
+          "tcId": 60,
+          "comment": "ephemeral key has x-coordinate 2**16 + 0",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAA",
+            "y": "PIHockHZRR0obdvmWxTUcjQwe4DOdLiSGvfUk1cHVJ0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "1eea9c2756a3305bb5178f2c37436e7b41cf3805cd0a1087d2d02407fc553c09",
+          "result": "valid"
+        },
+        {
+          "tcId": 61,
+          "comment": "ephemeral key has x-coordinate 2**32 + 7",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAc",
+            "y": "FQmFmNwSzylOpawete6ukTn1z9PQ_9z6cpegHc4e6d8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "2f1c5c590f97f79351fb9d36c597d1c61f1c409fcdedaeae795112fa1a2c7453",
+          "result": "valid"
+        },
+        {
+          "tcId": 62,
+          "comment": "ephemeral key has x-coordinate 2**64 + 1",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAE",
+            "y": "Yb06OPcHcTuX6vjQGE4AeeKmLPunXUKLEybqhhqt6VA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "82b8e90e6b6441b7164c9725ac1a35f098788096af95c276fac3c5a383d6b56c",
+          "result": "valid"
+        },
+        {
+          "tcId": 63,
+          "comment": "ephemeral key has x-coordinate 2**96 + 1",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAE",
+            "y": "FYIOfiZnDGtFweDKqVHqsxJ1QYC6qfz_n3579G3up_w",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "8a955b6cf4d518558e59372444d3fd9b78933e2d3229dfdfa6f5f66403290e19",
+          "result": "valid"
+        },
+        {
+          "tcId": 64,
+          "comment": "ephemeral key has x-coordinate that satisfies x**2 + a = -6",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "C3vro0_rZH2iAL7QX61XwDSNJJ4qkMiPMfmUi7ZdUgc",
+            "y": "dDWmvvkbkq4yz1HXFJytA1OkZROFFCfDRDZTbsfq5IM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "5626bbf79f10827e23fa5aef9a26533f5f4e7472934ed9759b7b3a77cda04b82",
+          "result": "valid"
+        },
+        {
+          "tcId": 65,
+          "comment": "ephemeral key has x-coordinate that satisfies x**2 + a = 2",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "IQx5BXNjI1mx7bQwLBF9ihMmVGksP-633jqGrD87U_c",
+            "y": "X0UNu_cYpPZYLXr4OVMXCzA3-4GkUKXKWsvsdK1srIk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "1908ae936f53b9a8a2d09707ae414084090b175365401425479b10b8c3e8d1ba",
+          "result": "valid"
+        },
+        {
+          "tcId": 66,
+          "comment": "ephemeral key has x-coordinate that satisfies x**2 + a = 8",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "QhjyCubGRrNj22hgWCL7FCZMqNJYf91vvHUNWH52p-4",
+            "y": "NyaaZLvPOj8idjHHqM5TLHckWhwNtDQ_FqodM5_SWRo",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "5e13b3dc04e33f18d1286c606cb0191785f694e82e17796145c9e7b49bc2af58",
+          "result": "valid"
+        },
+        {
+          "tcId": 67,
+          "comment": "ephemeral key has x-coordinate that satisfies x**2 = 2**96 + 2",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "OfiD8QWsfwn05-TcyEvH_0s7dPMB76qvi2OPR3IP2uw",
+            "y": "JPUO_Tm4rnU26IBpJ-rG_VIhCiOftBKeC_7TM0dldeo",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "a995572ad174897ff1971e6d1e39f908448a5878da1e60f3901f57cacd49e5f6",
+          "result": "valid"
+        },
+        {
+          "tcId": 68,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 2",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVA",
+            "y": "E0p0_G59es71uyDpaau28CbsDLBN_zT3kWymSwf_9RE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "cd8427ea93f9fede38a70d0c39dbd96759613ba00f27b9db3971c80aec07e2d6",
+          "result": "valid"
+        },
+        {
+          "tcId": 69,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 2",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqo",
+            "y": "dpr-OXpXCSAb2lDOLTGhP95AdnIqhXcZkkAJzCgVmGk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "766b0752cd895b4b8543d44c9a348868ffff12aed632f8070e731d450d8a8c94",
+          "result": "valid"
+        },
+        {
+          "tcId": 70,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 4",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "MzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzM",
+            "y": "BDTod-qnE0CqXlfligHwsK7I0ktcZKp375X66bSVjF0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "09b0aa839893b7ad37cc83160e6f3c5506bbe323497c21505ae9937c75d943c8",
+          "result": "valid"
+        },
+        {
+          "tcId": 71,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 4",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "zMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMs",
+            "y": "LoCKi2xuW8Bo-WNI1oFx5mFZoO4nBzyC_D-VgaSh-yg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "3c2a61121f094d5eecddf7d3b0016c170b90fd3f2fea0b12e31db04ae7c279a2",
+          "result": "valid"
+        },
+        {
+          "tcId": 72,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 8",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Dw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDww",
+            "y": "HYVCEPeXxUe9Oz_szeHOPmfGHDQAFB2iBoUg4rrpv5A",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "9a641d5efa8be7dc723aa58e2e52a150c8efced2fa1084041249773c7562c66d",
+          "result": "valid"
+        },
+        {
+          "tcId": 73,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 8",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PA",
+            "y": "Iry_QNZYvz_wLZiupa5F1D7YX23pJo8OroUhDy_tgcY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "d32977eca64d223ea90f10f72f810ec64d661833acc4c839591da813ef86f736",
+          "result": "valid"
+        },
+        {
+          "tcId": 74,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 16",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AP8A_wD_AP8A_wD_AP8A_wD_AP8A_wD_AP8A_wD_AP8",
+            "y": "IQpGMEiBMpyYB7cbY5O6EEufJ9l2Bl6FJCn9Zk3pju4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "55137fecb21eb3ebed1b41fb2f7e1ca337009465f855f3f920bc7d0b73c2da32",
+          "result": "valid"
+        },
+        {
+          "tcId": 75,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 16",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_wD_AP8A_wD_AP8A_wD_AP8A_wD_AP8A_wD_AP8A_wA",
+            "y": "cBHW6FHlpT_eQcHzSGkMAYjyTBBdXPyltv88k9v975k",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "0bde659ed89281e6c8a5fbdab764d0499b86d19d33f4c978e260bbae587d4057",
+          "result": "valid"
+        },
+        {
+          "tcId": 76,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 30",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "f_8AAf_8AAf_8AAf_8AAf_8AAf_8AAf_8AAf_8AAf_8",
+            "y": "S2YAPHSC0PL9exyysLcHjNGZ8iCPw36y7yhsyy8SJOc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "3135a6283b97e7537a8bc208a355c2a854b8ee6e4227206730e6d725da044dee",
+          "result": "valid"
+        },
+        {
+          "tcId": 77,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 30",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "gAD__gAD__gAD__gAD__gAD__gAD__gAD__gAD__f_8",
+            "y": "CiMxiAyz-PkAS_aPw3m-tuOv-ty-gb1Pm_duSsWrLDc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "2a3d29ce049fc50b00fab50e7581b84d441d297be6515fbe83dc485bdf32b6dc",
+          "result": "valid"
+        },
+        {
+          "tcId": 78,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 32",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAD__wAA__8AAP__AAD__wAA__8AAP__AAD__wAA__0",
+            "y": "O2omKdWYoEW-KKFocojMTQw4nMb-Ynxcw6oquWPbdJU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "03c202a64e60ff5948d29816d68420c64c0518a7522a929381365b1245770a02",
+          "result": "valid"
+        },
+        {
+          "tcId": 79,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 32",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "__8AAP__AAD__wAA__8AAP__AAD__wAA__8AAP_-__4",
+            "y": "NeOdU9EBpqpKtDTFWnCwPSRLaiAloY1NVJ3qRRwDE5I",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "d07fcf7b89bd1ba24194caf977db68a5503a471a37d374e0917a5fe31d48c99e",
+          "result": "valid"
+        },
+        {
+          "tcId": 80,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 51",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "gAAAP___8AAAB____gAAAP___8AAAB____gAAAP___0",
+            "y": "Oqd09NKf793ZVGrR97K3nPQmNChPux18cC6fyj_gSa8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "ea9f3a53ab4053df0bae0156767a62ec5ba0de4373ef12cbfb19aa80c6bcd904",
+          "result": "valid"
+        },
+        {
+          "tcId": 81,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 51",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "f___4AAAD____AAAAf___4AAAD____AAAAf___3___4",
+            "y": "I-S8oJhNpCSmEgoT3Gdsd3YHVi0W7ZuPqUwh__cVHU4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "f0557be2b26ddb56d44d2cb852224a291de771418fe148a730a76dadf5882f18",
+          "result": "valid"
+        },
+        {
+          "tcId": 82,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 52",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAD____AAAAP___8AAAA____wAAAD____AAAAP___w",
+            "y": "KpXIElOsVUhGgS0qRBX27c-VQgkAjSYKgGuFq6dZ_3I",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "c68f07233efd0745d8bcd51a89158717c2dc532f75a9e4de2076e1b830654ec8",
+          "result": "valid"
+        },
+        {
+          "tcId": 83,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 52",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "___8AAAA____wAAAD____AAAAP___8AAAA____v___4",
+            "y": "AxU3_Kvl1eJRZaGLG9QIISy1I-_qD8D9HqxG6DsNC1I",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "6eec8a68eb5f9caf2ab3053a3047bbc08412a1d433d79eea65effc5e0cd583bf",
+          "result": "valid"
+        },
+        {
+          "tcId": 84,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 60",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "__8AAAAD____8AAAAD____8AAAAD____8AAAAD____8",
+            "y": "Y6iLLgyJh8YxDPgdDJNfACE_mKPa0vQ8gSj6MTqQ1Vs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "bbd9d305b99ff3db56f77fea9e89f32260ee7326040067ce05dd15e0dcc13ed8",
+          "result": "valid"
+        },
+        {
+          "tcId": 85,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 60",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAD____8AAAAD____8AAAAD____8AAAAD____7____0",
+            "y": "JAe93FpQsqe5aiiO-4OL92jGBm5gty8IqXgtouOb008",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "1f81aa3d70f8756b9495fba82921717d4006206a4451d8d59f3c9b8d95b548e8",
+          "result": "valid"
+        },
+        {
+          "tcId": 86,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 62",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_wAAAAH____8AAAAB_____AAAAAf____wAAAAH____0",
+            "y": "SvnMQGpGlD_-D-YwvSHyBe76BTVfOhPJlD1Y4W6IBDU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "66e707faf954d1ec84fe0f68f829beb2fe95058271b636362e3eb5c5d492cbf8",
+          "result": "valid"
+        },
+        {
+          "tcId": 87,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 62",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AP____4AAAAD____-AAAAA_____gAAAAP____4AAAAA",
+            "y": "J5bPe9423GsZUAASKLcknTQ4o1_lvphmElW_Y6h5s6U",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "42dd6d83bbce6afab5045e1393838a97a46161c25ae91db0143e985d29162faa",
+          "result": "valid"
+        },
+        {
+          "tcId": 88,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 64",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAP____8AAAAA_____wAAAAD_____AAAAAP____8",
+            "y": "c7CIZJau1w2zceLknbZAq7pUfl4MJ2O3OgpC-ENIprE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "ab43917a64c1b010159643c18e2eb06d25eedae5b78d02fa9b3debacbf31b777",
+          "result": "valid"
+        },
+        {
+          "tcId": 89,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 64",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_____wAAAAD_____AAAAAP____8AAAAA_____v____8",
+            "y": "ABOpvgy6qs9OD1PuRbxXPqpE2_SNX6_CaFa0TW0A4r4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "f39bf49011cb323ee00f77e0344a9b9da1256db92646dda0e342f8c1ad3741c5",
+          "result": "valid"
+        },
+        {
+          "tcId": 90,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 112",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_____wAAAAAAAAD_________AAAAAAAAAP________4",
+            "y": "blY7yoc71ZHJZjORyCYVB5XjxCzt0mnmj_Dlbclx1VQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "27860fa0679edd4556f0423a21cc21e1e3f1701da3e62a544974ae94f15f91a0",
+          "result": "valid"
+        },
+        {
+          "tcId": 91,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 112",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAP________8AAAAAAAAA_________wAAAAAAAAA",
+            "y": "W1suxVO-Z_1zrdTMK87U6-bQSgWw6SbjEgN7OVFmeEc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "2bcfc95bba84524d8093dce1092bc157ca1fa42a37aaca9b0759437f940c3e7d",
+          "result": "valid"
+        },
+        {
+          "tcId": 92,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 128",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAD__________wAAAAAAAAAA__________8",
+            "y": "Mc8TZxtXTjE8NSF1ZvGL0sX3WMFA0k6U5qT9p_THsSs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "1a32749dcf047a7e06194ccb34d7c9538a16ddabeeede74bea5f7ef04979f7f7",
+          "result": "valid"
+        },
+        {
+          "tcId": 93,
+          "comment": "ephemeral key has x-coordinate with repeating bit-pattern of size 128",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "__________8AAAAAAAAAAP_________-__________U",
+            "y": "OlQUFZgzRlDR-ZoShQdp9T00UpsHrlkSRMbtcC8aoXE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "119aa477afad550e98db77bfb4e71a4b6ec79ec4fe17b7283f9b8bb7b9fdb5ec",
+          "result": "valid"
+        },
+        {
+          "tcId": 94,
+          "comment": "ephemeral key has an x-coordinate of approx p//3",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVP___rw",
+            "y": "fJdr3asdGjAs-hdsJUNFWOx8rCOOc5yphJqhBDI7EGw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "21edb700cf62c1bb816a877988ee8c5bc16a8464bcb6454adb8abf8b5cef7ceb",
+          "result": "valid"
+        },
+        {
+          "tcId": 95,
+          "comment": "ephemeral key has an x-coordinate of approx p//5",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "MzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMv___zw",
+            "y": "eyvzcWqeM24WKWZZflxCO7nT0NDDwCueLcSqutF7_cs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "1ba54571d1d280f5fa2d0c5846ec392c721acd4ba7e4aadc3dc2353957abd80b",
+          "result": "valid"
+        },
+        {
+          "tcId": 96,
+          "comment": "ephemeral key has an x-coordinate of approx p//7",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJG222uI",
+            "y": "KBdYiqGfkQ6L7R-JprXqbN5IAN2b6yjRM2u0YHURgUQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "9d422ce42f74aa0272e5530b5dd094225f11d1100fed954ff714a2d471559cef",
+          "result": "valid"
+        },
+        {
+          "tcId": 97,
+          "comment": "ephemeral key has an x-coordinate of approx p//9",
+          "flags": [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHFVVVOg",
+            "y": "PE0WummRARzz-U_u_z9IrSntmiK874-sQNmyryXiuQk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "K8Fc85geq2HllOv1kSkKBFypMmqNPdSfPeEZDTknC7g",
+            "x": "lKA-vBLDAkbhDSmlii3fWM-bE1OfcxlCZGqN2bstPGM",
+            "y": "3zp08U9IM2Q-K1ylRtO7o5JWqLnxgxiUPZXMoHnQq0Q",
+            "kid": "none"
+          },
+          "shared": "a5ab2cc5bb6881f7e734d7ccc9d448127d9465fd342d81c8381572059b3aa2b7",
+          "result": "valid"
+        },
+        {
+          "tcId": 98,
+          "comment": "edge case for Jacobian and projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "WSlOi8VOdtSLVZTwH-RylWbZtt9jhZgvu1Mxg5IfGhI",
+            "y": "RUPkEQv0zSLh1ETYPiTF7Nsyipjy-T6O3LmbB9XZ-vw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "e976057e8a322dfdb2debd55d8e58802fb54425950b2dbfd00f0813de27105e4",
+          "result": "valid"
+        },
+        {
+          "tcId": 99,
+          "comment": "edge case for Jacobian and projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "KbV5aQJklUmFGHqqnqMT05tcgo4CKvzo_Qy3ZO1pNHM",
+            "y": "uozeGyvhdJz01bwN9XgAnJZQ5EtsOFxe4mIf__wgXLc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "09fa5a510558a12110daf75117af1e175f93d7c4d8ba41c5bf3efe95d829ff50",
+          "result": "valid"
+        },
+        {
+          "tcId": 100,
+          "comment": "edge case for Jacobian and projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "QVChEeBInMgtQ7pm9AS6DfKx-hP_6jYUQveFT5q7OBQ",
+            "y": "ZWJ-lvNy_QQA7KQhE4kMsRDBHtoiQFvNKVscqrnZOvc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "98bc618faef7c4311c3d8fd37b39e9baad780e14f0527fa69a3f4c2b66ac6394",
+          "result": "valid"
+        },
+        {
+          "tcId": 101,
+          "comment": "edge case for Jacobian and projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "p0ZGx5j9Wgr0QtppyCLN8RNK26Nh-QZj1iZIGqEOAAQ",
+            "y": "VnFgaWgYKGty8Bo-XoyspzYkkWDH3tad1RkTwwOi-pc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "8a0b2ddef3a1108f6ea367ed08079a0ec98494fe46cfad584bdc98e99e6d7f99",
+          "result": "valid"
+        },
+        {
+          "tcId": 102,
+          "comment": "edge case for Jacobian and projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "YRxl7s2ePeUo9jnotmmGiNsfT8jBFlCmAf5trspcWWY",
+            "y": "X6RaI0AGM7o2MCRKprAUTeKrO2KV49-hX1huQKhAU68",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "89b86329f0f13aab07a48d0d3b7afe530ad260a90de6c25ec3da8b6905502551",
+          "result": "valid"
+        },
+        {
+          "tcId": 103,
+          "comment": "edge case for Jacobian and projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "tJxnkWR5N1aMdXAGSFZCCDXUSvHO3daCln-9RPyXKUw",
+            "y": "0TVlG9fuOquVfroQ7Ut6XEDKANlZymYwgMTq8OGJvCE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "751b521de6384a017caafa10419fc35d58f6dbace86f6b533c117e38dab1d689",
+          "result": "valid"
+        },
+        {
+          "tcId": 104,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "xzxx2FbLlJoxwknB6ZsR_7aYy8Hb9AAulWzetlX4QEU",
+            "y": "cW6Y3sEKmQX6HTqFH08f5hc1bLVtVkOhSO7DdiN6J_E",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "f282a78942218fac638eeb0eb15098f5aabae15b3ddb7abdd40a8ad3b5540c8e",
+          "result": "valid"
+        },
+        {
+          "tcId": 105,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "rKvtvnYOkzCvNQggm6AIG5zgYTJ9HqC2_9xXfbryjiY",
+            "y": "nNABdjWIKCFdMK3gz_jNwIVshPzbQk_rk85YolVKm80",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "6aeb7004f6cf6b05f30bf481e8b32a1e25fc66d96a4a53165727bb304cc27baa",
+          "result": "valid"
+        },
+        {
+          "tcId": 106,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "TMkZe_3vF9M6nqdDv4N0e1ZNatEeYICVep06xEFl-nk",
+            "y": "POINE9QxBxvjZ-WS-KIviO3uHNUcrbCEXr6mSxHEVwg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "67b5a9926bc58025c8bc2b9504b72c3a8465173d70f5d5ec1580fe88c5a4887b",
+          "result": "valid"
+        },
+        {
+          "tcId": 107,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "-_QRr8iDWN_yuhVs4nPXsV0Lo5gKYKgus4v6WJleFj0",
+            "y": "V8YuUwcOjmyx3071CeslmNvbB6X_1xMB6qKJKtEjj0o",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "12182c05568a6b18a98ea19110330146e7dbc49274f324b5edef4eb861f72bec",
+          "result": "valid"
+        },
+        {
+          "tcId": 108,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "zXhjrd2vAJlkcTnOZMoLOdvTEsz5bBWmLyxJ5igkgjU",
+            "y": "mZ-Cr9D3bnRK_Q_KKqs28i_36-_Y5UH8tulycEuKxSE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "f75920e61e7d05c3cf4107e5e81f3c1be7ffb0637f0ac8b895d87361345d9a87",
+          "result": "valid"
+        },
+        {
+          "tcId": 109,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "vU_YV2QKa99dpC_8XCwXVcTBJamdOApZNescTDqcKjo",
+            "y": "R2DfJcpWFySoLj-cnXglNttDENbJx2n1G3M95EqcAvE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "373aca70b036b70cf8e46fc9457a8e19c6821be2f2d6c16edadd20d7b30eb3ba",
+          "result": "valid"
+        },
+        {
+          "tcId": 110,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "RWVLO2YGV0OshoVNqnfJ5c9xOkAvvUraNl9Plr8XF80",
+            "y": "Y88jugNd5DCiEo2rDSx7k51ExmYk9peSdc03zQI3Bmk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "caec9de4a74d76603c5d5d07de2df0d435bef2b9063b5123305d2fcbd5dbb318",
+          "result": "valid"
+        },
+        {
+          "tcId": 111,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "3aeT_n_epcdIHHVvWfv_SEgXd6VCGNleqiTnuG2KWFg",
+            "y": "_awYWQzZbhk9tRxQMH0mBmdNW4r8yC0bZy3Y4JcZpqw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "27980511f433feea84475b82281b1fa6b946c97c646738d5ac3345250f86037d",
+          "result": "valid"
+        },
+        {
+          "tcId": 112,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "LgQ7hR_FpfEt63b-lBgrmbvOcntHZ4P52GitOreseiU",
+            "y": "FGK0acLgJJHgWjpFI-Caa-jlstEEGct3YKhQOuTrfns",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "20b27f84ae128f674e144d82bcd1544146bfd0150b0843ea585314f59cc54aae",
+          "result": "valid"
+        },
+        {
+          "tcId": 113,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "PY_d9B5SMgyAgeDWD1OXmTq9-pecS16DKsYb88wub9k",
+            "y": "RQT-Mgfb0Y660rkhpSoWozZZk5wW-7kYbK9eLPMXA0Y",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "92592791ff90b595dd2ae7ec039bf6b7bfeae7f044761f5e7fa86564ebc46b2b",
+          "result": "valid"
+        },
+        {
+          "tcId": 114,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "ZRBv3KDECHOMIxbz7CI41FkVe6ssKFUyO5W9JxyR3tw",
+            "y": "2fwtaFRGeJgpJR0pOlDRUN9fH8GgYE5N76qajj-MkWk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "8e61b2e072bd1401da12a3f3d8164daedab0bf0ca795bcf56aff81d07caf7281",
+          "result": "valid"
+        },
+        {
+          "tcId": 115,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "MgyBNUgYOq2w59IaD_5HK_qbT_6BWt79CRgKOuLRX7w",
+            "y": "0MogYR0iMoR6qA5_dpHACP-IbfzlUPkMTBmYLtd5tGY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "a41170f616c5499e289b4893b3973e1155f66ff354ae6a812bcd0e33bd7dd5cc",
+          "result": "valid"
+        },
+        {
+          "tcId": 116,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "oOKxqSpq-p_mhCS8Y9ytYgt9yETkVx9UBKudGL8IVFw",
+            "y": "y6HB_0m_e6qb4fwKxLumO0G6ejdOFfw5uITYCnWwcJI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "b8cbc27d4ea1b25f2292292ae53a3bb954b7ca77ccca5b4dccf1b958b0aad163",
+          "result": "valid"
+        },
+        {
+          "tcId": 117,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "3JcTmj3RQR10YWFUqg1rznh8-vvY_QYLaAsEtCKw0i8",
+            "y": "arUOXGjgJ4BZU798O-QKj3ybVsbbvoYzfmFjraAdnWM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "4baaee93a752397bf2ad0be72ac82b0ad2417e167bfdfce4904f012d4c33fea6",
+          "result": "valid"
+        },
+        {
+          "tcId": 118,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "CXjULhWUVpWJtXgmbO22CIqEycybr_AHDcHZNDQmBeY",
+            "y": "LOgKlmtcoDRJgfQinHq2IqhTvZvFm2YuzZLfI45ORu0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "3b3d86187d05a0012d83be280987dc95b1c0c9b57f253b64530d1d4220aa4abf",
+          "result": "valid"
+        },
+        {
+          "tcId": 119,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "qGMKe9t4qXCgGyDD57ldJdPuvcjpTs_g9QjkE27KSa8",
+            "y": "pesSEUtQrHfWjUEM1e9RB7LmjwhgDl5pOMRS1R1pk7o",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "k489vjcTXNjIxIpnayiyM0tyo_CYFMjvtqRRvgDJPSM",
+            "x": "WHy-GsjfUTNUTcTZDst-oapmhJ2O0YKebuVuekxZ2eQ",
+            "y": "ypl0ClW1RBvbkY1LsCcRhbBAaGSDvbdyZnUM5xOwRbM",
+            "kid": "none"
+          },
+          "shared": "472d4b34f5be6b499f76b0d9e439e115f6a89b725d9e9e811185a615f14007d0",
+          "result": "valid"
+        },
+        {
+          "tcId": 120,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "xOqO0xq0qMmUqWXv1HcLu14m7lTLchf_0x-oiMEI_so",
+            "y": "BjxBUgEyndoTD0OXP0Qq0yDaDM8onNG3FInKCnIB1aY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "fa67f4a9ea34fde196a7dff6bc1a2917b1526d54950335bea2abe22e1edab410",
+          "result": "valid"
+        },
+        {
+          "tcId": 121,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "kXgNGQUxYQXWpqypSg1EiNE0-YX34preyxvGzQwhGng",
+            "y": "gDWwbkldHliwhb-2cgvKhFV7Zw3jRYffDX46rVu8gDo",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "95c131de0c89e5b17f91e56779c1571de2c8a20794084fa274eccc8eed1d3d65",
+          "result": "valid"
+        },
+        {
+          "tcId": 122,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "GWGhpLKWcfHYNbMT_-uk2CA9hBTNwOoR5H1hm0cDix0",
+            "y": "5QpjuJy8iValhwxsSDDiEC1Sgbm13BJ7EFL-ez4RxDg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "5bae6d6d23a68f283fe0de46f1d74c0f52e278cb181f55c4353f768ba162aac7",
+          "result": "valid"
+        },
+        {
+          "tcId": 123,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Kann8lEJqMS9gNvqBfu0aq3lh5fDsvpfAPDwgWaa450",
+            "y": "LHj7EWDebtpQ9HK6ZZ1PHbTqbilyRLauaKBR2W5i514",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b4fe1201a8647be6d6d59f406fa970cc858f5a46a50a6ae9d992c0e23f5e2ad3",
+          "result": "valid"
+        },
+        {
+          "tcId": 124,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "FhfcA9PupC6OosW9A0o4xaPXQWWlSAdLe1dlzNhGW38",
+            "y": "YQidbd5TQw80z4KF3bxYTRVD_ccMIzP8MV7tTpMKw6E",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b721ebc7eb1b09438d754ae80302b2a2bf40f866ec507540ab5120b22f868886",
+          "result": "valid"
+        },
+        {
+          "tcId": 125,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "IOehNYQ29nXzd01glUtWIRRbj1JgtVA2NvVIeOyq_40",
+            "y": "zK8v_8t8cITjJdrl4kv_WjTjeYDRciAW3WZn2nHxZMQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b8da5d1bf9419e2b876e708871a9a29574686689bae8d87985d72a4e573dded4",
+          "result": "valid"
+        },
+        {
+          "tcId": 126,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "J1m_TDNlATQMvGevtKj1dE-RMdlzlmqd5Q3tYPvgRRI",
+            "y": "G2ep6B5TsGSt7d0WpMAw27GJzNcBmzKdZ6UnwxFyNGk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "39aa2bbc4b6f30c268b19909d5070155c39c60649b7a2ebec266bdd18fff8cbf",
+          "result": "valid"
+        },
+        {
+          "tcId": 127,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "GbihD1Ah8R4p4YYR-oKEt-mj9nzzbuyOzE16W1SANBE",
+            "y": "MRqKThmdmOs1jhmifoDNpq8ULWCR3aqTcO1hBFOrxsg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e40396a908c2cca4504f4f40be394a12244ae184f6909ec725ce723485bbbb97",
+          "result": "valid"
+        },
+        {
+          "tcId": 128,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "m6hB9BJFrAiVWWZHBCVZMpC54dh72o9H3xkEjbjj2DA",
+            "y": "l_aJBfNgztJoAYcqf_Ekw2N7AsSllrg6uv57zlZ8oXc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "13a21dc50cdfaeabd572f2d94dc0f3f768f17f990ee59d7f16ace9bfad8a705c",
+          "result": "valid"
+        },
+        {
+          "tcId": 129,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "aK92HQU97mSspemPVH_rLftvXtuBOAEcf1wzgJtLngA",
+            "y": "Rm3XbLjO61EyhiBSrT4Iv-okXvFsoNAO0MS0X7a9MCg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "a82fb3bbdf6d69c7398ee9020fe006d5b28c632f2da357393fe58deb8d27fd08",
+          "result": "valid"
+        },
+        {
+          "tcId": 130,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "BdyLGLwobyAyE7ExlBPfpJEdbC4w88d4xV5OX12b_bo",
+            "y": "zQs7IJ52BJiVroD_Y8AiWlYyKM2ZJD9iip265w13PGY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "8fa44f09cfddef86aa9007cd4bea6f0bc9b5b2115256303df09f8a20909c5271",
+          "result": "valid"
+        },
+        {
+          "tcId": 131,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "ustgY4Sxkwu0t03tI20D07sXOaUbc_INwzSew7ODGAo",
+            "y": "aJbtWfoLZUqcQEs0_uLHZ74jg_S4sXHSNZgGsEtQLRY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "ef762992d22bacaf06aa1e482c0711046b52e0e40de2a21d4e38df0109ad67c0",
+          "result": "valid"
+        },
+        {
+          "tcId": 132,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "SKuJsqMS3lEKbTyayeTE9bRuBNP4WEM7dkbkYnPZTc4",
+            "y": "Sgx9phY4jx641V7OZKtpXlQF13nJLzvCWVwn1l3vjbk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "3b0936f22337ece971ee102178f37bca3cb69b50b8ec9c9b47334c68b5d4320b",
+          "result": "valid"
+        },
+        {
+          "tcId": 133,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_Z3jBOpfGN1kFRC5gJRz05ojc-1aRw_8XqfIMJORG0U",
+            "y": "QLqrudkSJ5rupEN5EQq-x1q3mUphg8YpS60nurW7-CE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "ec571878fb1e3b1f5d4f66b8b080bd4e50410b6eeea4dcd3cedd4622bf876160",
+          "result": "valid"
+        },
+        {
+          "tcId": 134,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "v4l2ooIhAA1_Uhn6jQb5-K5HvmJvicK7bE0DI78C-Ek",
+            "y": "DHi8lIxr-CoZHx3pcuV9s1sFkYWUzPvo2hm9RvrL2ng",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9f3d9de87d9cc5099ff4f56d913b98b5eb1260e2b3a2d7a3c5e01a7e68219d10",
+          "result": "valid"
+        },
+        {
+          "tcId": 135,
+          "comment": "edge case for Jacobian and projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "wyKcm09AmmU5SEFSs5U1xRKmZ0iXICUWX9iIw4g2n7M",
+            "y": "KYzEHdo2_LFaDZfKv3V78HN9rnCCn0uaHUmdnpkRZzo",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "23adda6571d4ad7e940c21023af3ffedef9d8f64e83cc1cf6e992d1da1451d91",
+          "result": "valid"
+        },
+        {
+          "tcId": 136,
+          "comment": "edge case for Jacobian and projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "byw92EtE2sqTai7a9DrcjBvV9CgBIxcY_Ob16U0URxc",
+            "y": "okdZjBHqosUHsOlt_dAylMukRyroohKONvHqvTFa6yU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "91e70bd8bf85bc6311b2cd7791b7edf00e22f9cb8bfd72571ec9a03bbf716f37",
+          "result": "valid"
+        },
+        {
+          "tcId": 137,
+          "comment": "edge case for Jacobian and projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "pRGwkzTwMswz7k3buDkwT2u_HapKgN5STKJOu2WgqS4",
+            "y": "TqSCQ89-Jt6vTed3nKcfdtncbIwbf0TPGQ_dvoLCyUA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "a7d2f3e3faa772d7a86026e2f183dbe7a298ae3d1bc3abcea0df3c11cae4ca60",
+          "result": "valid"
+        },
+        {
+          "tcId": 138,
+          "comment": "edge case for Jacobian and projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "fPSm7BENuJLkWnsqs4tBGmxB6G_SGmRVyhpMLiIgaBM",
+            "y": "CbPjma4wCYv4csmu1dtp0Uy3EUmrsFz1InpiDEsWt0A",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "c611d27e7cb52e7c56cfa9062e59f3defe7c1e225727b9049384a180bd1688a8",
+          "result": "valid"
+        },
+        {
+          "tcId": 139,
+          "comment": "edge case for Jacobian and projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Nsfc0VL7flP9FiKEZeoMQZ2inMbHn9QmYwOzvQaqC5A",
+            "y": "NjY6lZ-MC0ANpSWtdnRnf4KQkq5_fo2_iDl_zRkEevU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "661f5d36b57af48982e44ff89ae75f849a08b1daed6417a20212bea88c7f2f8a",
+          "result": "valid"
+        },
+        {
+          "tcId": 140,
+          "comment": "edge case for Jacobian and projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "th080nv6EmkjSnd-EY99sQo4ROjH0RYsCZqAmdiH37g",
+            "y": "SVIOmgOPi6iATUTyKzdFJRTwrv6pO6t73xgNtUSFqto",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "540e255f6cb58d237990a7437cc7aae770428796deb607bc29fbf0a4d11873c8",
+          "result": "valid"
+        },
+        {
+          "tcId": 141,
+          "comment": "edge case for Jacobian and projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "rJy8i9kXGSko2aBl-x-JvkvqhQGG_UZqepAUBmzgAsU",
+            "y": "GpBskO7lXLVpLwrARnRu5L0iBf5fQ10ecfGajLhVDz4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "ac6705af9d059cac9977967c0ce514d70dc51d88fde684123a921244933ba8ec",
+          "result": "valid"
+        },
+        {
+          "tcId": 142,
+          "comment": "edge case for Jacobian and projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "wFDQWKrankN2fx92Cr28QhriIP0B6DKugcYov7EnfJk",
+            "y": "01SD_mrqUd6pwBfDJrp7vUF1aHpy3FxPRJ7tDFOggFI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f7a5b69bc39a976bfa6644a152789c3149352093b1dcc4b6b06f6c4c7c90fdf3",
+          "result": "valid"
+        },
+        {
+          "tcId": 143,
+          "comment": "edge case for Jacobian and projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "OZVCiCyk1frjKCxO3_w8ftp8RR5Gre5CGQFekcjGnPg",
+            "y": "sSP47eSKt2_iySGDJssGVCqDLQoyt6wNSFtGKb-vDXY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f0587fbd10e332ad297b5e463d4f09d2167c8589c46dc6680c13b044a34485ea",
+          "result": "valid"
+        },
+        {
+          "tcId": 144,
+          "comment": "edge case for Jacobian and projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "v8ME_YitjxGAHTUoaklQXPNJQD2BAO_pA9B479XTpm4",
+            "y": "vwXW_ioUwGmQLw2OtoAEYHMdSDle-sRCjth7APP8b7A",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "2fb4991332a5d648df5ca6bbd08575c7553773a97312303440cfe7e43d3a268c",
+          "result": "valid"
+        },
+        {
+          "tcId": 145,
+          "comment": "edge case for Jacobian and projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "aIFnjWxtjOsB3l1mZKC1e0cPFJSS6OdRPhIfrYSauhs",
+            "y": "KtNNsCTM0mlOSX9q30089a2_UYx2ikYovC4VnQlJ8qo",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "cb65082df5f54cdc668625017cdf45f22f305a8f34ad91fabf36c071496c84cc",
+          "result": "valid"
+        },
+        {
+          "tcId": 146,
+          "comment": "edge case for Jacobian and projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "442snKTvWzXad9hGCT4NKcHKNQ5ytabOkBvtn0cuoZk",
+            "y": "-AX8MgKSB4L0n0tuclekNk3VRR2YLym2LV1LjgejMGg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "6441ac7be81c2fb6472655528f21454d40236a878fbac2ce31e4358ab4ed02cc",
+          "result": "valid"
+        },
+        {
+          "tcId": 147,
+          "comment": "edge case for Jacobian and projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "LYxnMuPQ4YIhkyQ7uew_wsfyZOlO5hspXeWzwQ25N_E",
+            "y": "NTQ0U4OBFKR1KlUUvPudzhD4PgGQxUD-8QZ1y0JYSgU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "0b586c442eaf016f382199729f60240ce50c0f7107c488a423d42794db5f6663",
+          "result": "valid"
+        },
+        {
+          "tcId": 148,
+          "comment": "edge case for Jacobian and projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "IL7I0rWq4flVt5khmLz-IIgElBUAWM9hUf4U9gcbrTE",
+            "y": "Mtwc5QOWm4JMWp4jrrRyJV3SP5fQL2goGtAmmBixfkk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b376d9bc1909eef92953cebc3bd6f2bc0cd6cca620c190141740f62239579334",
+          "result": "valid"
+        },
+        {
+          "tcId": 149,
+          "comment": "edge case for Jacobian and projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "9FaUZ3CvXQadYLJ5rlGeoY5xmrr1eHR2hzpeYflpB00",
+            "y": "R-snUg1y_OEGUNMSpUMbvWs_N81GdVt6jh7xp5b5CQg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "ae739f624ccb1f0ec964b2d1896d2df83ca1969ad6ca26b334342013d83282aa",
+          "result": "valid"
+        },
+        {
+          "tcId": 150,
+          "comment": "edge case for Jacobian and projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "0TkKlE0k8wD9q5vScrusoFb-txwMN0aOAyewhQTVXzo",
+            "y": "gKSyQFZapDvo8-IIm0eIBJxdN4tmfph-AaqKCKTNLJU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "3c25126ece58ad8e93ebfe6e7547b05b39c6d9858e559fc01ff6b6e50b0a22ac",
+          "result": "valid"
+        },
+        {
+          "tcId": 151,
+          "comment": "edge case for Jacobian and projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "PmH_JEPRCx4l-wzhn1euOSI9M_uw5e4rR0D6GThLfQ4",
+            "y": "FAgRmnCqmyMNnxgmnAZcU9TCYZZztJN3r0zdU2yTGq4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e47d658df5c1f9599d4e560954ab860e9a6377decb0b56ef3c13dee36185b2f3",
+          "result": "valid"
+        },
+        {
+          "tcId": 152,
+          "comment": "edge case for Jacobian and projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "sGAo1ykDlhf5EuhtHR9E6T5jqiFqsGQYE9BsFqPtruk",
+            "y": "edIVcvlUDXsHsKZmf34KlFL2-fNnHlIuK0l-7BOKRuo",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "d8279c1ec95189fe63d75d1c6d7fc312e411a3d11e4d671a49fa17fa36c3cee1",
+          "result": "valid"
+        },
+        {
+          "tcId": 153,
+          "comment": "edge case for Jacobian and projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Co90zuUNHoU6OMAm9if-R9gfwR-IYmizU3mjKtokm7k",
+            "y": "HWPPAZjhySa8tlziGBPk1yEYtwkqXovBUpCSIqwZYDo",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "077c7a4e606099d781cbe5a89caf7bdf4f448b1c0d7d3097263a045170275a3a",
+          "result": "valid"
+        },
+        {
+          "tcId": 154,
+          "comment": "edge case for Jacobian and projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "DttwIM9NarFLWj-PaY1m7_mDWIhG1xi0hF1nTnu_wO0",
+            "y": "2Son5A5asuDNLQrBq2eUAs428W0-v8D9nfgX2rFyktk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "2025808c609ab0b07924444ea4aa0fa52563858a53221f719c91b15576f49ea2",
+          "result": "valid"
+        },
+        {
+          "tcId": 155,
+          "comment": "edge case for Jacobian and projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "8Gx3ysJKbuUUIYY6DRRpQY8KZDDgYtoY8n3VdAHAthI",
+            "y": "Ayt-BZFFXKM7TknlP6z1hkQQugRrpdT8a6z-qaB4L_M",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9832405d565c97ba1d6ff46e1d8fe33886222cbaa69963868d12a8be07abac6d",
+          "result": "valid"
+        },
+        {
+          "tcId": 156,
+          "comment": "edge case for Jacobian and projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "yyud9N3EMN97C-_LWoJtoViaFb7xtrJfEgHaq1svpKw",
+            "y": "OAHifREvDzJ2ci3LWLi09IRKLmFN5J20QLfMdiCBJzQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "c4bbf44547e8128b9a46ed92ceb07df691e2e91d0b47dac0dc2afd14121e7a80",
+          "result": "valid"
+        },
+        {
+          "tcId": 157,
+          "comment": "edge case for Jacobian and projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "RSBrYuSjxEBMdK6Glc25BajmqUVtoJxyxy63cS2dUug",
+            "y": "HdwtVrY05Ktmt5jNtNuGz5TwIgj3RzBKs9WqK7El4Tc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "170a91aa8196df6f0d09ec197fc526996ffcb6792880f01018b3327a096fe638",
+          "result": "valid"
+        },
+        {
+          "tcId": 158,
+          "comment": "edge case for computation of x with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "WE0twli9RlDm-gT-nT0qXnaNeVlF7SMj-ETQqPoMb70",
+            "y": "X5Yla54bcmP6APp1jNa-Fdn2FX-tZscpqw2taUVk6DQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "ed527e31223f175aa786f146b3fe0561a41b1051d5eb32249790481eab1ef381",
+          "result": "valid"
+        },
+        {
+          "tcId": 159,
+          "comment": "edge case for computation of x with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "bFUniYroBn2lasgsrzOMnn9A7kSJEV2vCrqSOotuUB4",
+            "y": "Qw9ZcM6dAdA-wHb42vaFz01anM1euehJ1Dri828ugOU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "5a74555732d8541d2f73e3a59eb31a131c8d41464a1f2c37531a25f4a6d3bfe4",
+          "result": "valid"
+        },
+        {
+          "tcId": 160,
+          "comment": "edge case for computation of x with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Us2ZJHlf4qJRr3y1afZtkUHbiUVF15ig2z0w5Q8QD-I",
+            "y": "BOqByAhYfJDz8slNmTwtDMS-ZN1q653IHHDXiIWy93Y",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f2750c996f22762629a3f808da6eedd7cc72af4fb0bd816c86e636264bf57664",
+          "result": "valid"
+        },
+        {
+          "tcId": 161,
+          "comment": "edge case for computation of x with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "u62NpMAYvcFaWvjz2ks4TFMOp1Vgzf0kK_oyNdjTWV8",
+            "y": "c0y9hmSHuD_LhKSsdKxUjyU1t5tX0C8DoaN-J5GgluQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "5d2163ca850749991cf782c3852e86b05e6b05ec8662905b60cc7b7e37434fbd",
+          "result": "valid"
+        },
+        {
+          "tcId": 162,
+          "comment": "edge case for computation of x with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "OJqlIjUEO711mGiJi74nermW6pOHvXCYsAckQr0rQvU",
+            "y": "uCM2TpFEoe7x8QCT_aDDAWjzAE4sLqdP3kl486oaMcA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f8cf2cccdcb53b3d3c6d1990ae16c71ad9d141ca49f8574a72047ce6c2da950b",
+          "result": "valid"
+        },
+        {
+          "tcId": 163,
+          "comment": "edge case for computation of x with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_RusFENUz-HNTGSqOi938K76JsxRQQgmdjcKDx7JLNg",
+            "y": "_uZpktLS_Lh_kNoKZ0M3hGZlVRm8eC3XsKtXD27UUdg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "ccf6e14d1add6e4b5a4228e5aad0b31fac4b45e2112c1c767e933c6a0c3f2edb",
+          "result": "valid"
+        },
+        {
+          "tcId": 164,
+          "comment": "edge case for computation of x with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "eMkmsO4BwADCWoNjEhnwjYs0dF0uov3J69xaIoj6mwM",
+            "y": "BrwAqzeQUI5XBe6r-6oHRHGcm9e0Z8pKN6Bvb9vm2Gw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "57556459e9d32b75a13776bddc8f547cb64708133e7917b61e3697c392003de7",
+          "result": "valid"
+        },
+        {
+          "tcId": 165,
+          "comment": "edge case for computation of x with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "TK5WBrrWAT9_NhkNclTL8NWpKzOOSkdwKjyXozcdfsI",
+            "y": "gNJz3VmMIDksVA5YvsmxgEBvP6bmxSmoUbzyuW2POAk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e5490cb494bc6ab2108da2cb0b926cd878712f54bfa72b59f702c180c62b0c91",
+          "result": "valid"
+        },
+        {
+          "tcId": 166,
+          "comment": "edge case for computation of x with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "CMy9dPKX_nHKMRXAse9OBCG5nOkf_NS3KlMLIpk-GOk",
+            "y": "ugrhvb4cKDb_6aYa5aiZ8VLJC0KCNji-TVHcOvqZ5qA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b3ca753c1e1067b550736a66c0d6b6f47e9394c56bb80b5d4204fbec9e59b490",
+          "result": "valid"
+        },
+        {
+          "tcId": 167,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "qszvg09X5sVSb-knSM2M3BN1wqxxE59dJYcwW9P9080",
+            "y": "ll3VN0tqMZhQwj68Lsei3rf_PkKGedSvyd9-dfLgbk0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b0cf8c178ad95952520264d0f4a24389bf1b23dc7ac1b65d4e8fe822dcf20d67",
+          "result": "valid"
+        },
+        {
+          "tcId": 168,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "pYXh7W5HIkpHLPTtT_NOYlHGKsaC5LcJktUALwjZ4gM",
+            "y": "6beyiJW520AW5dlKn1k4XBbbc4qDuE5tQ-zvggxV1GI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "15e40dc49ed62d35e8c91999b05068f419238a222deba206df47d909d3a1f40f",
+          "result": "valid"
+        },
+        {
+          "tcId": 169,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "sQTQzEqYd3FlUQXPyEDxlXRuESM0xUgB_ZP0vosRSh0",
+            "y": "PNjLz0snQWb4LP5XOTBC41NOaN8vTD2tG3znK0fK0lY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e9458064d3bfc444417486ac1334a93c9aa4468031134ee0196ca6e31713956c",
+          "result": "valid"
+        },
+        {
+          "tcId": 170,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "gr7T1VIJjS_J4C8fPMMvXzHPbNEBu7i0K8b3MrrcGXY",
+            "y": "IpJX2SskHyAx7K66EPGsFU2KO-owkygjEnLraqAapl8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f4446e98a63b0598011baaa4f930513218e8370abfbd46f721c8dbf37e170d85",
+          "result": "valid"
+        },
+        {
+          "tcId": 171,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "XE-2gSE785to58qRTSgwsSp6MslqnHiK0ph8AJ4I0KM",
+            "y": "dqAsz1lMKJlc_LKF7V2R3e2SkhEIoLQJKEh80HGAqyE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "dca827687aa24f2fcbcab5c38069f4860dee6698fc23908b06c7dae713a141f9",
+          "result": "valid"
+        },
+        {
+          "tcId": 172,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "ayn4wAaGmra-eT6nK5cKzuu3pMS2-6_s0eNXE6KL8oQ",
+            "y": "x2sH3BTx3FM_HEzLCXPrU-UwI_Cw8aiRTHcIwtc9SBc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "19714f1d4aaf8bd61520b647633a8e53099499ac368c3dd6f1b084891619b0c0",
+          "result": "valid"
+        },
+        {
+          "tcId": 173,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "bmhJwrB6N8Tza-kRsyPkznDBixWQJhLE_A_m2R58GA0",
+            "y": "6SVUQ2PGgDVJjLsiNvXB7NDkssu1gBqMrE0Ig_ZRu9A",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "d7a2da8de2434e2ad264f9706b30d0657c727606d8285d2179800a970b4faee3",
+          "result": "valid"
+        },
+        {
+          "tcId": 174,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "M2SaHnTH_7Xtw5ScWLen9LU0goj2IcUPu9txT6Qqp5M",
+            "y": "y_2Wngd7AOrSEILwmAAJho955DDvHCFjlLsOntoTXpw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "853d4e01d4dd4c9d6e7820adc16f32ce7bfeec0d578deaf28af9cbb3315e8f1b",
+          "result": "valid"
+        },
+        {
+          "tcId": 175,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "v5du8gRTK_Z0Q-i42Zh6aDGE7CZCAym6Jo5U6QtIDeA",
+            "y": "vrEI3ybtqR60_SPSavby14pCgdXt4HXCxxX7HE-HZ4Q",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "35715befcfded16e67fc0dcebe945c6264ca0d91b3663bd3ec0722b585e5d652",
+          "result": "valid"
+        },
+        {
+          "tcId": 176,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "LENdn6pZgHC0kgJ3UGwQDeYqffBcNKOTF3hdYo103eM",
+            "y": "x_XQvt9Urxx9If-VUSgAL9UpYjc4RyP-8fuAbCptjqk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "2baf108668e82b7fcaf3f5e3272637b426c551d8af0e55f5d74bc317a4474767",
+          "result": "valid"
+        },
+        {
+          "tcId": 177,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "OBnfqrVTeGPI2_QGrBjdZ1YZyaelVGIK2KFEkrukJaM",
+            "y": "1o6MaBgVVeIjYkFclaMXJOv-iyvxdk4gnq6eU7P0YqA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "bba443b160997aa8b7fb2748911dc2154c0f6b986fbe9a49e0a2934fa5f32954",
+          "result": "valid"
+        },
+        {
+          "tcId": 178,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "cK06nJqdtx1CCrroTM2xJ2iFG6xqgv_QPYliGlCnwxE",
+            "y": "v_98ZkwhH5N2j4S1JV2Vx_Z4h8MwXXidf87cLSmYn5o",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b4831736601e7387050ba3d401aea241c3506b56a0473886c408b366c8696429",
+          "result": "valid"
+        },
+        {
+          "tcId": 179,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "WDkTYfvIEVyXjoIDeBTTGqOoiHPtbHTEquqXJ-MA2UU",
+            "y": "QpJMZ7XPgovoJ-WB2vy9FuZT5ypPLU0FUIBTh7lBfnc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "ecd0c9e1acb90ff8bde88f7757a089cc86cba27f0d15fdf737ab3b8ecf9fd9c8",
+          "result": "valid"
+        },
+        {
+          "tcId": 180,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "I6K-aEsLXwS-9cbKipkb91L1lk9v3zbXEpEA2vgPFDQ",
+            "y": "tvPKKl6FzgBeHLbSsTCUxDT9wcCVo65eU_ZJScpWaRs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "6b9ee618598f33c184cd63cf8930a4db3a2d4ea022d50e63cdfff85734a77ab4",
+          "result": "valid"
+        },
+        {
+          "tcId": 181,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "FHuKL7T26F7q2Bygs_IwuNjMIw3nMQfZyry8Wznk5-o",
+            "y": "2qROwe0LlfYQkiO8SA6RdBnYYPm5p1-B1vjKOto3dTM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "d801dc9354cb756e6c27de5a7cc88ed5cb214ac5091b4090624ee8afbcba35f9",
+          "result": "valid"
+        },
+        {
+          "tcId": 182,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Kz_mS7FCeJ6J4QkttGthMBK8-uV3WeqQgWXANi-ATzY",
+            "y": "wAU_rzJmrX7s7cskY2uZyTXxyOcxaPDus937ZggB5Vs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "03307ea557024686910d2d1d2d2760d82664413b8feec66ae8d2dbf1025f0c45",
+          "result": "valid"
+        },
+        {
+          "tcId": 183,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "xO1yRFRlzbRPWLDhrwgjIm6nnrLhvD8n-45M57hfSjA",
+            "y": "wjfldMWamSQG_VF_TZBeA9eisKQO-FqjxzvUahoGqRg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "dc2cd94321643e89dcc92acb0128d886b28cb7d66a0eaa5b96194465708780d6",
+          "result": "valid"
+        },
+        {
+          "tcId": 184,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "GO9OL62qwbmCp9LRLp1RSOzzNrHTd12i99-CKtSaEyQ",
+            "y": "vQcEaj-OlJ56DZYP6dmh3g9hSXy057Lzmu5oRDlvmX8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b831f4a0fb75927bdd2945c0081f11cce871c9d6dbf83b7895748c3f46375ac7",
+          "result": "valid"
+        },
+        {
+          "tcId": 185,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "OYyhqUQhChCx9XMgcSWVKN-H1C09ewBrxv2eHgn2-jA",
+            "y": "_tN52z8b2RXbK6JzhOwTcVQXRG7oT7X9Ckv2Qxz9PxU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "ed607a9e6d41a4bc0535c5161c98613edac6b519590b481420fb2ba1ed2c35e6",
+          "result": "valid"
+        },
+        {
+          "tcId": 186,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "0cGCrbEB6-X-w5EPgAWOCR0TJUM9T9O7s463W8ryaYo",
+            "y": "ISGPdUTOhNz-UugX7Aumv4RGD0mTKz7F7SdoLTN_Jw0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "64a68fad2378591a18f8f2a4e346faf59da29446ec16b3fb8c37aef2d79faea5",
+          "result": "valid"
+        },
+        {
+          "tcId": 187,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "P2jE5BLFfaAVVo4Kn8w9tJm3fmwPVQUIKMUMNUk69eM",
+            "y": "0LU_4wsMbPQs359PAdXJBY-BabJBveoiWTL5Az-Lxes",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "0fddd50bb27666d4d38e6ec18c8ae1be3d763be7dd11067213e997fa4059c67a",
+          "result": "valid"
+        },
+        {
+          "tcId": 188,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Vt1MKx16Gi1lWbUgP8uJdPqBvn1kzwrnoU_ZZd_WnN0",
+            "y": "6-HKeNVYP9o0hwQNzZR2T43GGejXSq6NlmXzQGk8IbM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9c412023b7a66ebc9579a8d16bfd3109ba085c42f3fd395e07534529ad2340a4",
+          "result": "valid"
+        },
+        {
+          "tcId": 189,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "4eUFO29DuHFKAlrPuGqPURlUiAmbH11jMQpr7NfMtH4",
+            "y": "8NFrwMMjRHD_qNRfWC_LZf-cyqpq4M1rVyvrqlDBd0E",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "28717726dc3674abb4f82b66837e8685ede16cb0cd965824352ac0a2f9d893a7",
+          "result": "valid"
+        },
+        {
+          "tcId": 190,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "GkZXGhQ4yiPceRKop7IkXXDIUqbp9NOF3WCEJ-w8Qec",
+            "y": "_gbi3t-6o3amFGV85hcBp9sYHlsfMTkEW4Qk7lSWS3o",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "2e74661109f0cbc6d587790330d67988658bcfabf1f7498a2b3279212828e207",
+          "result": "valid"
+        },
+        {
+          "tcId": 191,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "jOWjyL0lRGlaAFhBYSp8XQW-sHz3vKECcXKwMKz30nU",
+            "y": "-6DDOfdM420QT_-9WuHJxyWIaTGQ7Ss2h0MwhyE7W98",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "d202df6662ba06d3088363c60e341283f7b6300104d58cf6d707262be6972b59",
+          "result": "valid"
+        },
+        {
+          "tcId": 192,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "oKvNse8DXhhucgYGsH_WFVMgOSdawbbyJyC3VsD4V88",
+            "y": "duRlz97zBgKy4FWjA7xuF23-ly0GzG84IXgDh71jV8E",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "a54a81c18f4b7ab0f3702013678566ce29e91c4142114d62f867a5278f89cfff",
+          "result": "valid"
+        },
+        {
+          "tcId": 193,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "hZtr63BnGz5kmRu2YRgNu-g19jwKWHjD-D8JImYKfAk",
+            "y": "M4m_TOa1wcL4AchMVDkdU6qVPq1eUbd1ezUINFu0zes",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9a954112f52d76709d64739dc75e9ce7a76aa19242b306391fcf25ff92b76901",
+          "result": "valid"
+        },
+        {
+          "tcId": 194,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "NVENQ_TRoXOgRn1cs1pBcMP8QH5VtBa0384oZQ-IAq8",
+            "y": "6O8q296LQKFxQoYXbWdEib-ayy5Kg1On2uGp6Xy7QVA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "8763cb235f2780c1bbd35fe6c387d5505f72eb0a77b104c775c2b3b42786d7c9",
+          "result": "valid"
+        },
+        {
+          "tcId": 195,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "-krwicFNaovhiBE1mJQRYHFg0UGnqMtFRvNYp5fSqv0",
+            "y": "vgCGeWQ2NE2u7AY_T0pBSod55yqWCJIzWs37_UUvcno",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b9309ddc5eb64a4d819a8a332b061a59f163a5f50d4865697e4d123efc9b2b29",
+          "result": "valid"
+        },
+        {
+          "tcId": 196,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "PNyqCGQnAju9kbWy4hK-d95VkaGgwhDVTwSC8nxCZVg",
+            "y": "-OH0_m478DfA4D1AQ8HZslQ24IA7GkK23i5A2Z6DnGg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "87e9f5ec4a9091d94ac22a6a71408213f444be094c618d459682e17357631939",
+          "result": "valid"
+        },
+        {
+          "tcId": 197,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "162-MKVoKs-dOY9Y2o_TtYMoPZ7adK4Ge5tTPNbAgkw",
+            "y": "_lDQNxwOe1kEP_rSXhdEXPvfs_6kDlW8feGaxfJ8ZKI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "c69a00017184a13c713cc0a70e89c60174361d07dea5085fd707f4b5ed3faead",
+          "result": "valid"
+        },
+        {
+          "tcId": 198,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Ap4cbrN8OD-04n67MZdoj42K91Xbg7dijhdXnLP5DwU",
+            "y": "iiv1eFf1_2Mxzc-HRAtuacwbbkRM5UC4IiuVXJipmVU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "c139b75615e1010c920b07d14f6a1980ff4c97a0a9bb8a097aec2a456b6bc4ed",
+          "result": "valid"
+        },
+        {
+          "tcId": 199,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "OjXeITstwz6zSJSKIu1ak2APrQcbsBemolDmYJsT98o",
+            "y": "--wGtmOl9UaJ0O5nCf0NpGrP0mA4k1k190nW1LwhBg8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "70aab5e96e4991321faf440ca2dea861ba007df08ee46c6f579731ead51636da",
+          "result": "valid"
+        },
+        {
+          "tcId": 200,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "a5ENnplDy-_3F8qVRqpWd-BhGPXwSgJGtbq3NQV3XWU",
+            "y": "yHpMH9e8WExWmREZaZuQtLOlaOUI6qg_EYMy2pFSsTo",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e2ae03b844b3f279d5cd16bff20ab5cad07e4c984f21cbe73e1997a02bd2c291",
+          "result": "valid"
+        },
+        {
+          "tcId": 201,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "8QK5CtN4cl-3_-P8P-bvsyCnKKA84JqI7iW6ss8TPAQ",
+            "y": "ryz-5SjzkTyDUESYyos7beueKEJBuNAcZ4q3mtgJGIg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "0aab6b19e4205548f929362e72b077f2365667bdd81d93a404343e7a5f84c6ba",
+          "result": "valid"
+        },
+        {
+          "tcId": 202,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "f0IPzvk7C50Kn4ayxl4Yk44XqoTq3ip6ZECt7JFMsvY",
+            "y": "7BZjuquK8wgzM5mtzv-QjuM8j4az3575OlFSCTH4Uew",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "d96cdd08e6eeeca690989b659024f324e18c2faf5c50958da6985f70826095c5",
+          "result": "valid"
+        },
+        {
+          "tcId": 203,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "a4Ot9Yu_ANpLd7bEYVklz1qPe3KZetlpBIVUkINLz4I",
+            "y": "Ik25QLugKNvdrzy6lJ3EGw23lVFeNFSfrBGhg7idW7c",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "434bd68e45630ca1b3484517da080e3c3198ddec5ef1f7e9d2e3425df214b90d",
+          "result": "valid"
+        },
+        {
+          "tcId": 204,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "BBAjZ9xTV2qDhfxY7iM34rmvVH5pk0_j7Hl6hMIl3ww",
+            "y": "Yhzsxydmny5Vh2K2WzOzzz8ij-mpwiIjq3Hnf5BNaqk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "aea47444c897f7157f336c77b7401979066d6617b59a01988f78f6c9a98feedf",
+          "result": "valid"
+        },
+        {
+          "tcId": 205,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "JYNAEFhC6-dgxP3hPjHu_VLlGq75OMRHfRSLusbTdBI",
+            "y": "MB9LTRv-DnBGyx-ZOjWfkZH9e8p8U-A5-lHbihF--qM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "486cf8959f7d939c4c79a0715ba7bbf0cc3fa7b2a1d60e86ad097c91e5612e24",
+          "result": "valid"
+        },
+        {
+          "tcId": 206,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "2aUh2BR8HoPfgrnbYrJeb_FBfd1BrvP_sYKtI_J4Ivc",
+            "y": "sK2RdGLNKlq84uwsSk90VuvbZdsQ2WIFbnX2-IU9Kkw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "5a1f0674b1397b6e653ff6e473d641da4fb9e7bc90a73802739a0349148500fa",
+          "result": "valid"
+        },
+        {
+          "tcId": 207,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "C1gAbjcVcGhmWNRY8m-qNMz4tJ-6gjTr1zBMu6OrGyQ",
+            "y": "aHh-nH6jBD4L8nqpcwpavkcwYLd8U73ccOIB1_Wx2Jw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9a907514a9ecc85f9659b9e97909a38f972b0c9a7c009778b8190438a8ebc00a",
+          "result": "valid"
+        },
+        {
+          "tcId": 208,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Srj1rIjuz8sDlPbP5VKFlra0xP2sgkf9YpVyiRM-Yg4",
+            "y": "GvUYUuEbGdYTeFLiGP1k0uu1Z_j6kqHtQ6XjT1aUqUs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "941685fe4de816261157b2fe3d3ac28195d81fac6225fd3103ee60a0c24df472",
+          "result": "valid"
+        },
+        {
+          "tcId": 209,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "kDIBugg1O6YVjAbmbfC0E7dx0hrMCDIhO9A9WJV15nY",
+            "y": "d6kMzy8wec0qxsWcwCVqYSwHm4qRtZ7OHv0Hb1O_WwQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b203eb0365a40624a442572e0bad80e1f0c9958e5709512e76b28f4e0bfb2291",
+          "result": "valid"
+        },
+        {
+          "tcId": 210,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "yAIb4iaaLug4U-ShK7BoCCUIjZrA5W-1BRCfRwjdnV0",
+            "y": "2AKtaQ2Oi4F6gV3mB4Za-r--12UJiPkl7PI_5WVNDJw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e09d25f822471e647064b5b68cd2ae42d6be7b8765cdc026bb7696a524c83f49",
+          "result": "valid"
+        },
+        {
+          "tcId": 211,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "pT98QSwRrWo2K9K-Ln0fIEQCl76GWUq7y-ollN35NyM",
+            "y": "edsIrYe1NpOacFgmgst1cCY2VcwlopefhF_Wi-PYKVM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "97e3c29f69d9032e676933edb152f2438ec7dffb17641442ce9342e138f81667",
+          "result": "valid"
+        },
+        {
+          "tcId": 212,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Rv7tTlIpYxksvWxu2r1RddEPk5maWFoEWjAmtpu01Sg",
+            "y": "7X9qvXs55A4I4hJpke1BA5S_2r6pkKu3sspeufBI-k8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "cd7874612d68c907b434bd81bf1b1a83cf9429b24cee753cc228ecbdd6657388",
+          "result": "valid"
+        },
+        {
+          "tcId": 213,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Z9sR7gtzBxvzuBWGSheFga2j0QCRg2XnEg2b3snNnDM",
+            "y": "JfXrWhtmrRBKXJ5DsHr6SxUqdfoio-Qpr0HkWeeZPkU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "621ddb1893137c12147e909dff830859dcd73ddb00acdb4097f1d66e14fe366e",
+          "result": "valid"
+        },
+        {
+          "tcId": 214,
+          "comment": "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "FM3E8WwH1uYHTKqOzKJqAYY0fnI9zt-a_53G_Iw4Fb8",
+            "y": "XWT-LX5qvCCAKhwVgEDOvWFN7aA0eYfgzc_UHglhjPU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "19ad362ef44a36342cf9143b88470d5659fca6a3a30c904271f6d6bdc05e9407",
+          "result": "valid"
+        },
+        {
+          "tcId": 215,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "JBk8NQH_p36_HuYvfBGLKMBaHAqUb0QrIIqDBcanRfg",
+            "y": "hjYDKZ399dK9oZIwAH0OA65h_hyur6WE3a1M6m3H12o",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "43bd8cf370257bc88f38b0ded68af2f9d93977234a19fbf67abf2e0a4c09c120",
+          "result": "valid"
+        },
+        {
+          "tcId": 216,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "CBzqsdPNUxf8eCycjcMzmXBaumiZwLgE76lu1O6UTak",
+            "y": "AK31HNMbUADy0XVpXUihIhOuFZW5g3JkPsDrQA73nUE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9d920e7a6f61fe4140bbe56f4317e3892d21a80fb480a091a3c16a0a67a7a97d",
+          "result": "valid"
+        },
+        {
+          "tcId": 217,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "E-VrIHhV6rtLiiff6NHsiWRL58CW9sLzoSLJzQuLUIs",
+            "y": "tbeXDjoUEfT_43EUBexl75jbEqKzfYwYyNGYQTToVJI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "0796221792860298f1b4c5aa1561ec5db01ad876c3552bd96b00aa23ef47b71d",
+          "result": "valid"
+        },
+        {
+          "tcId": 218,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "XPleI-aBBZ8AizLfMm_7d5W990uzN_d8_1BS3ngmeUs",
+            "y": "XLA47B_e_eUfbGjcXhKhmKUc6GuSFniDaHslNBXW03o",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "8cec890842617de7789c3c2909e2d38031d5aad957d995bdec622b010ce9e0b7",
+          "result": "valid"
+        },
+        {
+          "tcId": 219,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "nEl1SkxF2X5bcNCTG5j2CzqZ9RqVSXU3vYXt5-mHlCk",
+            "y": "3K3-JzpAhsMN3kdVZnkj5YxGPo2Uy7fVbJ4PTeeebSE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "1d4c7c7aa359140edf907c8234ef16b92f201f562c2237aa32adbcbdc0cabd0c",
+          "result": "valid"
+        },
+        {
+          "tcId": 220,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_H_ZhN0Nw8k4Rvi0GwcpbqhUQBMl8VXxI28uRBSpudo",
+            "y": "Rz84pfhNCMCseh2rilaOrCEGYHSUdEmow9FvBVo3m_8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b15134b9e91996e228ea7ba6cb4500a117983c8eeb687174657354e59961e521",
+          "result": "valid"
+        },
+        {
+          "tcId": 221,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "M34uJgo1Zf-B4L6QDI2vss4jEGiMPutsAlysIIsIoYo",
+            "y": "RIT8X7AcLUBNqZtWpNwiZCDcPmdv0CI7o6RdQ83PNWI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "906acb96120ec7684e391100cf0bb747691678eb3e147f53db886ba0fc5aa70d",
+          "result": "valid"
+        },
+        {
+          "tcId": 222,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "4rFw0dxNnjKVFKVPENyB2QLzdSw6bi-L5dgg-v76nYs",
+            "y": "4Ifb05AVLrsExzuMUEuZSnaDctP5IKXO3EJCv4NMzG8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "73dd087b1cb3c5a07acdb9b0a4a02c64b7087ae97836e943439dbfdf41eac833",
+          "result": "valid"
+        },
+        {
+          "tcId": 223,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "ZwKrayV8JEQL9xnALSFh5OMeItVe2K0PM-WvlWisSpo",
+            "y": "v4eszHWFdziQQvW2UMN9trDHaCIDFW3nNyilgr7WptQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f73c49f6da537b2ff30ead7538c04726bc74152535d22b6baf92d06adb45e676",
+          "result": "valid"
+        },
+        {
+          "tcId": 224,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "DOwKpN4MFD9dTD023j20zXLo_g-9M23oeaVirIfmKNg",
+            "y": "510NCuPXtNhp5_b_Vk4h78MKFf8tTIdhgQT71C714As",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f4a757ceb0ba6cb9618acd8fef68d2c8fe9901fff14177f27b6e6b8c6bd34cb7",
+          "result": "valid"
+        },
+        {
+          "tcId": 225,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "knYVH7mZ_z9_z1QkkftiR5_R6uk_wufSLDjZRIZ8RH4",
+            "y": "8OcYXk1VocLq-iz40mJjbW5LNT_nGuPTzOaxWNhs9f4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "3eb4a634d0090175347613b7eed6d49b9b5944e70acc3ed98474989d30a4c299",
+          "result": "valid"
+        },
+        {
+          "tcId": 226,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "5lepGr3LZ7_6j3hWXseWtJAfKZHBJyLSe8pqAhfysAw",
+            "y": "m7LPX2xXgMcPqPAxWbyw1WCWruz1PqXijRBYw6UNIJE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "520dff4d04085871cff69b3a20a75b8f3b103da0e468365e8c9287c0a7ad7d9e",
+          "result": "valid"
+        },
+        {
+          "tcId": 227,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "fAUcHuvHZ0brJn6OkaR9irgbib07Op3m8cPmuY24HHs",
+            "y": "dd8IiIIVC5fiAUZUfuB7a1YgvOzk1ApT7u2E5dR3mh8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "c80ac13c5d2e6723e848edb023fc17ecae553781a4aac90f2577fae7511711cf",
+          "result": "valid"
+        },
+        {
+          "tcId": 228,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "2JBADxIw-oDY1MlRc5JOnns0WPflRoCrGDTlBaLcyyY",
+            "y": "9xQ3TJl4QygwuOG4J0LKhnd_m4toaxkk7lXnxXLCsRk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b0c28a9938cf095a4b0ebf3daa6a16e19e3f4199e3475ca3aa58746f651b921e",
+          "result": "valid"
+        },
+        {
+          "tcId": 229,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "9EhmuO4bk30YL_eareQbVJtx_xv6iCoZLskNyHpRd00",
+            "y": "XjNfGYgOhDi58gWTJmRRLNbdU9WkCnAI_FyYEkp9lVQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "78dbfec6b4aad2d0a99bdde7b90996324c0f7b9d136a6ede5c2995197d0d412a",
+          "result": "valid"
+        },
+        {
+          "tcId": 230,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_SmKuUSghwKBanOV-E5F7XgpaLcBg4tn-iUoERzU9BQ",
+            "y": "hZmGfIkXTwDM8wYngV5mGL0oRfNYGdsHVBgFNbtNSy8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "36a2e77f56c3e5b11e35bf4ba5de1885cf0264643cac5d6f7bfb1ae01e39a6c0",
+          "result": "valid"
+        },
+        {
+          "tcId": 231,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "e3jVmWftB8g_Dtf48LJjiNt2sIY7ZKwUt-y-2OOhvaI",
+            "y": "S0na4a35SIYHQTdskZz9UP_PdJZy8Z94rVZeiPYJbfY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9f4e92d9a959c09eeddd152f6d95ff2c3157446f477fbed214a00621d014f936",
+          "result": "valid"
+        },
+        {
+          "tcId": 232,
+          "comment": "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "eRyQF7OpPKLy0D_PGLQjAzH9w95XhehHyfUdIsr1DNs",
+            "y": "7ccpyS8KiCM6KaIlnn5iZbkqFDjAtZWRZ_viqkplpsA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "d0b16561349f182ef2792d0c2dd585601ce4e032754b7628b3d801f187c14fd4",
+          "result": "valid"
+        },
+        {
+          "tcId": 233,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "R1eGziFaGHPgSgxnZCwxmm0k3_sGpM_7sVqCVtLIEew",
+            "y": "Whu6f2YeONaU2aEVZLURr2xmMqXvyTNzJkLdXEkopBs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "5fd6d7f0ba317a36434e1a995bed54a42898d940ee5fa4578373e8d4c23f5567",
+          "result": "valid"
+        },
+        {
+          "tcId": 234,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "dZrncjOxGfs3iQWXYBEvOOjZ5p9DHPDo8LvmoG4jvFs",
+            "y": "GNabgJgPU7fox2ybgtxh8FzcA4JsLJY3zAKvKm2w5Po",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "bbe559b77e83905b08954dc3736a2752d56a5bc366a5fcd84e042a78c8af68d3",
+          "result": "valid"
+        },
+        {
+          "tcId": 235,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "OvK4Ypo0dSlO4NVDcyH81fpFVMeAtrGLhiQtPt829VE",
+            "y": "7eN8TqMZ1C-Pw8-Xz-fdF-hbpuEbomDtmRwi7okavCs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e62429b8eb322d24e4bdb9a72bf6e9c94d82962b26d99f633e1f21709b7eddbe",
+          "result": "valid"
+        },
+        {
+          "tcId": 236,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "yi3zs9fZWLDUbtbg_-O3SI8uE2YJUeuCHCQkbWx_LsI",
+            "y": "BV54DmpTT5_0abC6PI04lirArNx7Sz3AV8B-rT9LeqA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "5822c168aab9bb6ffe00b7c4c7be5551daa8304b8d2c0696e2d77fe50b9d8d8d",
+          "result": "valid"
+        },
+        {
+          "tcId": 237,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "7xesCEq60SSW34DYDb4h363ljjAqwDmAAsU0nYUlKMw",
+            "y": "7zRQAmal3T-0VIKO2FaEpi5usUL2X1SX5k0jFI91eXY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "bae26fa69da00aa03fd9028fa84d46b92c13d5e555b2e7b3db0d09bb95d41486",
+          "result": "valid"
+        },
+        {
+          "tcId": 238,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Ykz3RZo-CX8RQ4OhJcfN7DO5R8W8CiZ516rlCLXUZHk",
+            "y": "QIyseR8u1x2b1ZS9ZvbOcNko07IP4CtbZs90O1FzmnQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "97ce8c4b6e031776b19fc7c9577cb26f085274a58407267bca35a97692a2e8e6",
+          "result": "valid"
+        },
+        {
+          "tcId": 239,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "5B7FVrs_hc72ZRotsYFtqzvIKJiHFILb8cyAFAfOTR0",
+            "y": "7er-jDNyElC_dc25GB6ZBJLTcIDn2rQdoWc9Yqi4Nd8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "5eb5722f98aad0622097d944bb120e09e7a122498b20ae2bfff91c8b362daad2",
+          "result": "valid"
+        },
+        {
+          "tcId": 240,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "tcPLFG0w_s_X_tAJPcugGEaiiqUMf-PAz0uMWqg31bA",
+            "y": "sht2Bcrbx7Ygbl3UKJ4d6cw2vJgJT7GCI75jbm024Po",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f5c9b88d48112041334c574f93313670cdecbe0c0b6c2655778df8ff62025d3f",
+          "result": "valid"
+        },
+        {
+          "tcId": 241,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "s8YoSL6wY_yPKFwNpyB-cHxxRguPeSrgiQ8jYvyPAhA",
+            "y": "nPgMDg110vVKa__j_vOUQe0MvynIOXt2qCT_ns9Mdys",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "effa362fce62e271016d50a0e35c031455fca280b80ed2cce87c83e57e3cfd36",
+          "result": "valid"
+        },
+        {
+          "tcId": 242,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "B62M0FVSj-tLOlPTVMfHzAYWyj_3h7uwv3mQlgbSfoo",
+            "y": "cLTScevYNj2a2RDPTYTlIXG1s1l5L3_4qJxEJ_tq-iE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "59b8dcdc6676029109871fc67b466a7fb622225cd6c77bbc21b1b628464798a2",
+          "result": "valid"
+        },
+        {
+          "tcId": 243,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "fGb9Z7efiFMaB0cohybb6ymd2OEVlhK_8tl5_kvRBgw",
+            "y": "FcVMXPQLems29EAL26orbdBmnDtFpVklY1KHEWqq_xw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "42dd3a8e14dfe9fe2ebf80746989ba66f28e5460116a02bce24c549d117d6b0f",
+          "result": "valid"
+        },
+        {
+          "tcId": 244,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "lAZGmCgOfrbhTdge-p8KtSf-bO7e1gzU1CIWLDl9W60",
+            "y": "FjpjNCtEYp5XwJu0kBGLHa8GvAvR3kipjqesPok-RHA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b0e1025b39c5481a748a0461aa7773a6b342adead4b4587521a1953d4ff0296b",
+          "result": "valid"
+        },
+        {
+          "tcId": 245,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "tFQDk4SrsZHlk0Y5dt6pN0KLdqLyH4VTqZTg4joN4yg",
+            "y": "KIjU4i6qmG380g5aTJZmoqNB6q3N-GtuE3ZgyVVhVm8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9dd7118006ee56fccf307a31a6334be7e19db2deca68fd45b3f4f94f100de6a4",
+          "result": "valid"
+        },
+        {
+          "tcId": 246,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "1DtwS82m7SzYys1kpnGR2i9o8lpqmD3XkBCxBmlCcw8",
+            "y": "LqoNCTP3EJF-MiPy_rIziK3T_tOip94Yr1CAOwsg1sk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "1fb16336393ba603fb2eb701fed0e982ad32964afae7dbbfbc5a8112382e51e3",
+          "result": "valid"
+        },
+        {
+          "tcId": 247,
+          "comment": "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "nqPbRNPB4JcV7DMNNgegbP3BsLr09XD7rRXWPhqNGQs",
+            "y": "2ueKGkbtb9qgLqJ4XCutM6rOlTl7KQ63wmQo72hJSr8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9a6d03a17e68561a105da66d2fb1d9ec9e3ca6c686f65d9da926849d7af4fcb7",
+          "result": "valid"
+        },
+        {
+          "tcId": 248,
+          "comment": "edge case for computation of y with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "5Ms7Z9YhCGh8dLNqCBw625_E4Yi15hFycxK3CIboGnk",
+            "y": "Xtuk33G5xLBvewUrW0jZ4L6FX_zC8nkmUkyyL_u56GU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "3c03077e0098a845f7c9b22b73eecd495a2d6a0b34d211154ee3898634f823b4",
+          "result": "valid"
+        },
+        {
+          "tcId": 249,
+          "comment": "edge case for computation of y with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "boM9x4YDnLCByhIDSt-uQeNFTK0JdqCWEvGvTDkNWJ8",
+            "y": "FvSZu2ec5j0VvUuCE5Lmw965rCFj0CEaaKYWe8td0OI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b8454bcf8463c2bd59f7538b65f11b9c98c18c13438417cc08a39c8842a0b7ed",
+          "result": "valid"
+        },
+        {
+          "tcId": 250,
+          "comment": "edge case for computation of y with projective coordinates",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "k7DPZubFHsn1sCWJYHRDure5exjz3SycyDHAo1a2DCE",
+            "y": "-WC-v3mwwpV5QjfGBXbWp05faU2fzNwsSkaeALGBFaw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b4df5f335a0461a38852205ac73bc51512b5c7f6a8305f1a8d4f191cb6fd3b2a",
+          "result": "valid"
+        },
+        {
+          "tcId": 251,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Z_TXz1uFdPo27I09TKo2nv4FIf-eJXYM-ZiUxk8GTKM",
+            "y": "TbFZf72W17fjGSNuBmCwWADtmQmcjBAi1VvjqP0jHpY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "a9de6e92af14bf4eb11d7533bbcb28cf622ec5e52e4a2f4cde4ddc3d21babcee",
+          "result": "valid"
+        },
+        {
+          "tcId": 252,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Q5Y4rc2ocBN0Nu6wnifDJjcweSGXS2S59z4mbY6VOTA",
+            "y": "lM_PNQuYKCQ3l02z5AL9huPr3dxeI_zQcwOgpc8oK6Q",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "edcd8e48df11aa67a90c75614983466d244e4b5473f8ac01a41c146db13c4827",
+          "result": "valid"
+        },
+        {
+          "tcId": 253,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "vzJpPdd-GC2LJlA4KDLzf2dwCQEyqnen68GCFeAMRMA",
+            "y": "RkLqNGH_EOLhgA3DknONfQEXRnnJ0uOCqA7Ulh_ki2s",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "2c8dd74792ced281f9cb161d2f64d238cbac2d18f8661b0f5674d79cd5c6edb8",
+          "result": "valid"
+        },
+        {
+          "tcId": 254,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "0goCptBCSCD3wu1q_Rt8FJ9nYr-M5NulDe2XkjaNzqw",
+            "y": "xXTMYpj6HZbt0Xgwn3UIzoqr9p_AxJuFKZuvkSOeZmU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "503fb9bf4b57b00e0c239b3e8371f24660aa01cbf79f4c499e4fe1a155528ff9",
+          "result": "valid"
+        },
+        {
+          "tcId": 255,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "r9Mh6f97JNhWvxS7xa_vGVJ0SGfK5Knz449mc9qQiu0",
+            "y": "cUlm3-5a9bfd_Bd523SYfp6H9TK-p2osvtcXo2yRAOc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e61ad5f80632382b626f9a77fb7f5db020dbc084c888c6b09993e12fe4d31604",
+          "result": "valid"
+        },
+        {
+          "tcId": 256,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "z9bYQRP8kgtEv21ny4QWkduuB71nMuXewEXmDZC5j3E",
+            "y": "EMv4yf-u8289UxMrHBDbVnKs1d9bh8uY0Z2vh7DeNXM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "51c10b8332b33faf529c58cc2da45a23bbfecc1d4e0aa4ea54fd819b7e31e555",
+          "result": "valid"
+        },
+        {
+          "tcId": 257,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "8JYWgnuTtgF9dwx141sBYsVFXOI4DvL-xU4zbf6Uy7w",
+            "y": "89AbexAr7E_wJF24yUPGjCPPEXLGVUSqEXTkTNUk8Ek",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "98d67822c318db0653a470a6ed96e7c22a046a2a25664c19539af62ae1d3a96b",
+          "result": "valid"
+        },
+        {
+          "tcId": 258,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "v-ti1c23Mz4JdvrTolnductSWu7mgydleu1ZKFNS80c",
+            "y": "boi8l5nfTQwUK8YyyB1ASG_iN2OS4BgK-T3ry4LGOc0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "7c4648cd808df9a54f992b294a3ece562ba5efbeba7e1760f1f107ed1af8c187",
+          "result": "valid"
+        },
+        {
+          "tcId": 259,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "bYZKfLf446H-HICU44Uvj0PMTKapA5USsq3l8EDjtCM",
+            "y": "fJCOwcufvB9tSUYKwZ8tRSb2bgDbYNIHQIvUbJW___A",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "41b89b46f018a3ac884ad921e49fcf5d9677ae84e39e6ea8de844acc337d8481",
+          "result": "valid"
+        },
+        {
+          "tcId": 260,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_raPQegGojn2JEXSPRuSWXiptpbW8Mqp3Cn0BTmwc8w",
+            "y": "LJAq_7IAZtLCySDOuKRT5CzSRUmIwzLPDbkHu0_pWUM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "d155b0e0e37da1a19af0e85e68e7bb4180aab55b1e95501a1a3ae0cd95404aee",
+          "result": "valid"
+        },
+        {
+          "tcId": 261,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "V9BMZTMlpsuZj2HONHEJ7KDv_5oWpzQTSmnNHgsIGs4",
+            "y": "tDrqT3Gx8oAvvkEH0L-59vu9pGRQG4f_c8RxA-Ny9jU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "12bd72e952e6b81255ad79af19310da2e0ef9772003384a1f35753e6beab71d6",
+          "result": "valid"
+        },
+        {
+          "tcId": 262,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "YF_TOkLZIeAe5_dYBhBt5yy1A59l_zHWyi4e_WqoGhw",
+            "y": "lXifCSPXBf0Z1aiuGLZmh8spCR4XlEs30n85i9VUa9s",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "3514b8362ee1e70e846ede7ed57283f5d5891fdb9b0c5605da45dbc5c6f44e53",
+          "result": "valid"
+        },
+        {
+          "tcId": 263,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "MDzolqpXDPj5eVS6SPzCX18lKGfwGpue3s6qa_zO31Y",
+            "y": "ETTWKQ4WSbsCihbG9U6wbH5ySpR6YkgnSkv2pqoTkJY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f6c829ed9ca3dfdd1f165a204461e1c16620e752216e2b6e3aab6197f3dd2b3b",
+          "result": "valid"
+        },
+        {
+          "tcId": 264,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "HCymcxHcXEVNyDA4a3mX5QvGfj1f9SLT6KOfFEmY-IQ",
+            "y": "hiyXX1SKX1XdhQTatcnojw7TEjaI1HWyEdpaTWkg3WM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "3719f7afe82c3fa54c0c1260476246441d387970935e4c76965ced96da3a07de",
+          "result": "valid"
+        },
+        {
+          "tcId": 265,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "VjPLz990Mn3giD9Z4XiO7Xa7C54PnlXidp7JqjZaMOE",
+            "y": "2RO9Ux9KYcLQe4R9MY7pZILS-Pp6EqqzswPBCFHOf80",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "0a368c74c56c61aab02440e64b2699c24cdacb4dfbcdebe0b3cf801e86f1f74f",
+          "result": "valid"
+        },
+        {
+          "tcId": 266,
+          "comment": "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "GdU-RLBYwxf77b8QbJjzGDLN-4TyGt11PPITul3pAmo",
+            "y": "YUz3t7YOdZoVpsfYZO3extwlNRmXXffz6bwMd_2A5RA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "de5b6c29f2f4f17f8ed925f129159410e4557dffc5472944b8862c42bd2b180a",
+          "result": "valid"
+        },
+        {
+          "tcId": 267,
+          "comment": "edge case for computation of y with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "HJbMKyLlvbGVsqRxh_rV7mc2vZbc7-8gJZpVHphHteA",
+            "y": "xasFLIg25PfMe2VUV3XVWwx7DH-DDGU5kVy2JKUH2_4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "8fca30fc5d731f42d37664d52b64e022d98a25065fb1f8bd77853d7f2bbf07e0",
+          "result": "valid"
+        },
+        {
+          "tcId": 268,
+          "comment": "edge case for computation of y with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "czJCzEr7gicQNBEbgTCeFWrkRm5_L8X8EEL09uPET0M",
+            "y": "XG9hTUvhinMXDIWmtoqWFAUpNOHWEkZt1JIZiUdP9RM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "c9431b6deda0c9f92f368f7ca12986f0e07e012422b840c7aa784a0c713b501f",
+          "result": "valid"
+        },
+        {
+          "tcId": 269,
+          "comment": "edge case for computation of y with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "GiS2Ugr08CiCS-7OWbYD0V1tFc3gcZrS97jj_LbBNCw",
+            "y": "ftcCow6HWyQ22y8tNofZWA0717P40SgKgQcfPM1rQH0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "672c2339e4c39e36cfe13e2cfe352859e1ef66318fe9f97dd26d9d03a9171f7f",
+          "result": "valid"
+        },
+        {
+          "tcId": 270,
+          "comment": "edge case for computation of y with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "St5voT5ZEX4FSsG8o8pS9BQDVJOsLuexqBHx-1JSHoE",
+            "y": "Fq1hLNerDCHveJOJRdhw2sgnvstbhzyEIlxK7xWe5Ls",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "8cd11340313b978fa37749f4b367c087fd900f17941002de22ce4029aa550e7f",
+          "result": "valid"
+        },
+        {
+          "tcId": 271,
+          "comment": "edge case for computation of y with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "NLKsWj5JFtCB0e1AS1vM_gdqp_QeKdA2I5D38IRYtEw",
+            "y": "JZh7f3ohQyN2PhqhBEqHebv_xeIr5igTih2AJoNkaY4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "6f1cc2d07f6ee07d0b138b601c94deb20aa234e526fab3ee4adc98707085a73d",
+          "result": "valid"
+        },
+        {
+          "tcId": 272,
+          "comment": "edge case for computation of y with projective coordinates in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "WMJfQEd4K4FbQQAd6mNshu8Z1n7AVjJBJyJar2_xCDI",
+            "y": "dhMlxKcDB9zrm_RRx0BeQlgIaOZl8_JZmV-MNY6weZ0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "c2812eb9b456297572e8d870754b48489ea366f351f822759de831726815e582",
+          "result": "valid"
+        },
+        {
+          "tcId": 273,
+          "comment": "edge case for computation of y with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "49BfGv9yrP9w5NUbQgeIDsBrTCadsCdT1thYql5tVh4",
+            "y": "fHVvawzRBrtzLl8gyR3d5PJKNpnfESUgb8xHRJq7fR4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9cf1689a015ac3958dc95fc71cb0d103e81b4594684638933a5daaa99fb3b1fa",
+          "result": "valid"
+        },
+        {
+          "tcId": 274,
+          "comment": "edge case for computation of y with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "dWOMqe-folJCnSEkPHeL41W9Ewwe9iZZPKDCRM8rbvI",
+            "y": "U7iHZiMM6N7XkAlWpSkaaWfCpUJ5hEywfXxYXYfUBmE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "2d6049f8e46c67c17ddfc8178dd918b23fd1969e11c959b64ea42e39c9a87dea",
+          "result": "valid"
+        },
+        {
+          "tcId": 275,
+          "comment": "edge case for computation of y with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "RGguQ3RIcw9ZSoIOrSMsREP354Q3C_sDEwS4UZnEFZ8",
+            "y": "cVHs6qCmmNFXhcx6LoEq7aEvm6Qjin9edukw85BQFao",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9b7f8be262b9cd2751ef8eae2bad7b1ecf07cb76613cfe7088cc9bdef1d04436",
+          "result": "valid"
+        },
+        {
+          "tcId": 276,
+          "comment": "edge case for computation of y with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "yYsB_pL-rkQdn03lDU376XiXEdkRvm73zZxV9LPoyr0",
+            "y": "2eOq8WYFsKtQYy32wA7IVU827PQn0x35MNRFj-HLrxE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "52980b5980df38f7c2d59e4e307da25655d50c6e030234b241c098c935a5596d",
+          "result": "valid"
+        },
+        {
+          "tcId": 277,
+          "comment": "edge case for computation of y with projective coordinates in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "kXOuAUtkVyRYfuJuF7_rYfkSU_6GU9r72kOB2p-lfpg",
+            "y": "FakWbh38KoHL4SaiWU5R-5j77ns9ZYithqhkMRQURPQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "2f1f6990c30136d6f44de8145f191840c4b9efbcf87c39b7995c262bdcdf9d40",
+          "result": "valid"
+        },
+        {
+          "tcId": 278,
+          "comment": "point with coordinate x = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+            "y": "QhjyCubGRrNj22hgWCL7FCZMqNJYf91vvHUNWH52p-4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "afe5b60fe3e1dc873b3f3022893a359880e817537beb96b3d48d375766ab59e6",
+          "result": "valid"
+        },
+        {
+          "tcId": 279,
+          "comment": "point with coordinate x = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "5BAvFvp_OG6RLTp_d9zH3J-K9UyuEX3boQo9CWIO_4w",
+            "y": "aJwg4Szo94QSlF4dOsv5k15GU_sNzgKxSn1SahFPE4c",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "33150538973510827cafdfe9449e7a5a2e1a7946f4e485a00ff219b2cd58d801",
+          "result": "valid"
+        },
+        {
+          "tcId": 280,
+          "comment": "point with coordinate x = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "eqZ9ADMib7Kxv5ddRWjh8imegvLkWf8LbuPAxX29QEE",
+            "y": "fCBjRkSZO9hKo2EDfOi_P7ciht_fRIJFiwdqel9G0d0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b5523f9382b35ed9e1c4f2b420df9f61e6ac8f6d342213fa4d75458f5bd828d1",
+          "result": "valid"
+        },
+        {
+          "tcId": 281,
+          "comment": "point with coordinate x = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "gGlLp9atbvqK1c4ENaG9Il4CiLb8IqEecBOqDU6aSWs",
+            "y": "MW1n0ccObBMEIPV8tuDWDNoVTHN_ARgAfP6lwtW045c",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "ad9a53d05315009fb1487369f72fdc33e6dbba1485efaede2951433526d2fd0a",
+          "result": "valid"
+        },
+        {
+          "tcId": 282,
+          "comment": "point with coordinate x = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "BsZpcOU52a4Pj2enL0JsEAs7LPLidumwrqdbTvyYgyU",
+            "y": "JO6rK0E7oX24EfdA-fufw8c7XOUfHnTn4IvNirSNroM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "a88cca88b59cd86edda202cb4ea1b2d541d5c8c22c062a08f9db496d56257330",
+          "result": "valid"
+        },
+        {
+          "tcId": 283,
+          "comment": "point with coordinate x = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "QSd6byDYVa9qzsU-mSMhbXTuKu0YpBQFkeu7CzRVByY",
+            "y": "abx_GdZGR-dP8A0Mibv-UI4yK0OX3bhWTtKDLqpbLZI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b7f531b4a9ac00952bfcf2cbec41e58b54c4f412f464bcf1f1bf10a24b9b1974",
+          "result": "valid"
+        },
+        {
+          "tcId": 284,
+          "comment": "point with coordinate x = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "FG3uK8qlzAgX_hkbbRDe9iWd90Sv3J5bDd5SOzSKqrQ",
+            "y": "RbFUb3m3pqrfpUe_pBb2K1T3pHbW2IgFa5wFxy4BOfE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "473473518f0e843d1fb5105b16fe88edaa418b396cab7cb5532416d171f2e7bc",
+          "result": "valid"
+        },
+        {
+          "tcId": 285,
+          "comment": "point with coordinate x = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "xI7pD4_oAGZAhu1boSkwys36F1pnosQ5gWj2Jmmd640",
+            "y": "14w1pIBCqvvGx8rzpoOF3bXUBqzuhtlkA-dbr_7OAOM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "c2563f49e623b139a83c4cb71cb73deb06458385658bf8796bac0c2ed12c8a67",
+          "result": "valid"
+        },
+        {
+          "tcId": 286,
+          "comment": "point with coordinate x = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "c32S9drVHVgmGnfnVWeKsCsQeRIEHF0pX1gpy9EM2MU",
+            "y": "m1XdCE-Ek3wnVlqQdf4Qh0XhcAFmZ0PbVRQ25pHqgY0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "28c247ae91fdac1b29896415fec60f4252feed9c9ffa0216d31350d708646d89",
+          "result": "valid"
+        },
+        {
+          "tcId": 287,
+          "comment": "point with coordinate x = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "We_tdHMDiRuqsOHf3DLWmQbg_GgVsFba4O2iCAlXo-s",
+            "y": "8gX9KZxj5UnSTBU5NdlQFBw9wmma_ocxpGME4gPKwV0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "76e9e6f1339bff54b82a45980745526ff9249e942b1f836aab719fd959fc8099",
+          "result": "valid"
+        },
+        {
+          "tcId": 288,
+          "comment": "point with coordinate x = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "jvmnmXtxf9vF0qf5pn9wXl3uTILKODt-4tB8JIUDltA",
+            "y": "csmPfcFlj53DxDSp_dwvmGzA4-PvQJgnU3YX7mcQXys",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "0de82177c80f4e35f3b7a300e89ac288f30e01a8658933c16b8c90605e35d6c7",
+          "result": "valid"
+        },
+        {
+          "tcId": 289,
+          "comment": "point with coordinate x = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "BFaeyfs9a87cBZ5_0Eq30_a6xzCxt1oRdJ5DRkWPkpY",
+            "y": "oFHITVWNvSlXwVkHR3d2r2YKwBWCwAHcH4aOv8azsmQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f41de3a77597835fa904d1f05411368e6e878abd0485477d162b2c764ef045ac",
+          "result": "valid"
+        },
+        {
+          "tcId": 290,
+          "comment": "point with coordinate x = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "SymKPrpqCfzYQVl24PrqmX_VGf_TNjvSAQd1ISPhAUY",
+            "y": "artwwBO6I4nDcb4Z3TKW8GAOZPBXVeFc-JMgrH_7JdY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "c4dbe3b94e729b1e0ae34ffb0f6b0d95d7e619ab3943aa3836cf1e721a470a9e",
+          "result": "valid"
+        },
+        {
+          "tcId": 291,
+          "comment": "point with coordinate x = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "GL3geVLXvokU0rJUTGWj3r3d2efOipxGoD0SSs-4VIs",
+            "y": "AaShdaKoGvmOYCh3DQVeIvEBbfFUYrZfVaLUhQzEFeU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "83b31061f1b70148870a9282a4641cc8428943a3b10e0301955f5960c386fb04",
+          "result": "valid"
+        },
+        {
+          "tcId": 292,
+          "comment": "point with coordinate x = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "ACvrdV9pSgn2C85bNNw0fFw6ojbekAe83QcH6byAcWk",
+            "y": "T0Q7AEWZny9Ymcp5NCSptCOw7Ao-3Lv0r7nmZSbPibI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "5f74c066595fe9ea283274964ae83fba1a73ef9d29d24e6604a4aa0881fe390d",
+          "result": "valid"
+        },
+        {
+          "tcId": 293,
+          "comment": "point with coordinate x = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "lX5bzRH8RQv_zv5jbAtz8Q_oWF4Exseqf6C2A9JBYtk",
+            "y": "nlU-lAlWqgSiN6DCVwoMe8NxIXK494x7RwoEKuMfMiM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "c672601d951bdb550ea9cc58d2031337db39a3799de21af4e5c23e2fd7f537da",
+          "result": "valid"
+        },
+        {
+          "tcId": 294,
+          "comment": "point with coordinate x = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "xDsbQJnacPjTP7thto2bDpx67dT0dhxnIplmZpdOKY4",
+            "y": "l4wC6niZzdRqR0BawNif1qTWZxikUCQ4rUVGMmCXaEE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b2c2c00532d468d25374ae2e6ec9bc52bcb2e8df20ad1a40719b7d91746daeab",
+          "result": "valid"
+        },
+        {
+          "tcId": 295,
+          "comment": "point with coordinate x = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "3rhfYEvhkw26xmKcuWIQ9vvIfOKyYLZsx9ZhhhgGr-E",
+            "y": "Egu8-DVtz78d5Lu30gZsPd37rzMK91TFeFkTepzEpo4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e5fe7c96371878cf86db4210a487d7d33ac4bcc45b8df2152e82aa7228a991e2",
+          "result": "valid"
+        },
+        {
+          "tcId": 296,
+          "comment": "point with coordinate x = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "J4mf4kgRrchp1JrEUcshBjHRmv-Jcax8PdL-gmJiUH8",
+            "y": "2d3_70zJzYG90-q4rN1cKHqJNPgt_CVd3tGsHxEAqhc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "1bb9a501ab9d215230cd1072042b3c8271aec3b2c1da10d1a8c810fceaed47a4",
+          "result": "valid"
+        },
+        {
+          "tcId": 297,
+          "comment": "point with coordinate x = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "QwH1SzWS0eoqQJiclCYdKx0f4pftbtZBJe4kHeBdAEs",
+            "y": "x5AU8Vbpt7-za4rS1m1V86dTgpqd24YFW7kWbdOv9Fc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "fdc15a26abbade3416e1201a6d737128a2f897f0d88108645453a1b3ddd05688",
+          "result": "valid"
+        },
+        {
+          "tcId": 298,
+          "comment": "point with coordinate x = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "NrD2a_X5_Ust-c2uKvhzoHXFVJfX_sRzenyWQ8LHb-U",
+            "y": "2p9yh7PNTl8FuaGk9k6KjZbDFuRSWU0CpFkqIQfs6Qs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e36348e3a464bc518384806c548e156edd994cb6946473c265a24914d5559f1c",
+          "result": "valid"
+        },
+        {
+          "tcId": 299,
+          "comment": "point with coordinate x = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "gqu1ivti0mGHi97hJmTfFJm4JPHWD7AoEWQssC9K_10",
+            "y": "MHGYNdlvMtwDxJ2BX_ohKFczE39QfOMWzsZcpWLOKtA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "7d65684bdce4ac95db002fba350dc89d0d0fc9e12260d01868543f2a6c8c5b8d",
+          "result": "valid"
+        },
+        {
+          "tcId": 300,
+          "comment": "point with coordinate x = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "fee3z1xf9CQNrzGlCsbPaxaarQfSxZNsc7g-45h-IqE",
+            "y": "lAwb145L5mklhcmdyStHZx4sy88SqamFTGYH-YITwQg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "6ec6ba2374ab0a9ae663f3f73671158aaabac3ac689d6c2702ebdf4186597a85",
+          "result": "valid"
+        },
+        {
+          "tcId": 301,
+          "comment": "point with coordinate x = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "BvqTUnKUyFM6pAHOTmyK6wWmkhvEh5io4goPhKUIWvQ",
+            "y": "7Ego-DlNIt5DBDEXuFlfsRMkX3KFyzVDk4noVHoQUDk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "6d6e87787d0a947ecfbf7962142fde8ff9b590e472c0c46bbc5d39020e4f78a7",
+          "result": "valid"
+        },
+        {
+          "tcId": 302,
+          "comment": "point with coordinate x = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "ik9iUhC0SNyEatI5mzHNG8PxeIx77WnMHLeqyKso1Tk",
+            "y": "MAfG8R8-JI3mUcZiLeMI7lV2voTvHtjtkf0kTxT8IFM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "56ea4382f8e1abfcb211989f500676449abcebfe2cd2204dd8923deb530a6c7b",
+          "result": "valid"
+        },
+        {
+          "tcId": 303,
+          "comment": "point with coordinate x = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "iF5FLLsOSyqXaLdZbBUxmKki2ru40Modw_r08JfwkRM",
+            "y": "vpqqYwkY1QVgU-z3OI9Ei5EtnM--2A18ojwOeZGjSQE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "2c362c27b3107ea8a042c05cc50c4a8ddaae8cdc33d058492951a03f8d8f8194",
+          "result": "valid"
+        },
+        {
+          "tcId": 304,
+          "comment": "point with coordinate x = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "4ibfH898E3pBySD_dNYgT6ogk-7_xKnuCiP7LplAQcM",
+            "y": "RXEHRCzEs69jHE37X1PixWCL7QT_ZlO3cffNRnD4EDQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "0188da289ce8974a4f44520960fae8b353750aca789272e9f90d1215bacdd870",
+          "result": "valid"
+        },
+        {
+          "tcId": 305,
+          "comment": "point with coordinate x = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "9T6tlXXuu6Ow6w0DOst-mTiOhZC0rS216k9r2b3haZU",
+            "y": "tfOrFflzyp46qd_ikU7rvS4RAQtFVROQeQiAA5b7nRo",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f78bd7ff899c81b866be17c0a94bec592838d78d1f0c0cf532829b6c464c28ac",
+          "result": "valid"
+        },
+        {
+          "tcId": 306,
+          "comment": "point with coordinate x = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "iCdz7H4QYFyPni47hwCUO-JrzEydH-3yvc-zaZTyPH8",
+            "y": "jl0Fsv3SlUthiHNuvj9WRmAqWNl4txa1ME6lZ3dpHbM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "99f6151fba28067eac73354920fcc1fa17fea63225a583323cb6c3d4054ecaca",
+          "result": "valid"
+        },
+        {
+          "tcId": 307,
+          "comment": "point with coordinate x = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "pgtkWCVrONRkRFG0kL01f-ree7a4RTwfyJeU1aRfdo0",
+            "y": "ge7pBUilnl0s7NctSwteZXTWWp2DfHxZDR0SXuN8TVE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "68ca39de0cec2297529f56876bc3de7be370f300e87c2b09cdbb5120382d6977",
+          "result": "valid"
+        },
+        {
+          "tcId": 308,
+          "comment": "point with coordinate x = 2",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAI",
+            "y": "ZvvnJ7K6CeCfWpjXCl786EJMX6Qlu9ocUR-GBle4U14",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "1af254af90c16dbd217f3356f7fef9ad532d4902a6d67218e3188a9e840fc929",
+          "result": "valid"
+        },
+        {
+          "tcId": 309,
+          "comment": "point with coordinate x = 2",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "UtmkS_C8cp5fP_yKc6TaMy4pYrIgEzkbYOtm3m4bg0M",
+            "y": "HrDZxukqQkvCSrI8r5njzagwJjaJZTYm-L6RWQ-3XL0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9e232223afd0d57a7b150f65700ac60a78bae2aafc0cf9d1a820452ca1e57a14",
+          "result": "valid"
+        },
+        {
+          "tcId": 310,
+          "comment": "point with coordinate x = 2",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "eKmd_LffTZJ3-XteJOl59IqKqJg--d2Gdl3Mwz2K3p8",
+            "y": "mFfczOKn_wrEGyVeuN9F32G021j7Xpl2FL8NWrIX3ZA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "ec2f7542cc1df665764c5b9bff751208d668be9f3d61cd6c33b35ed0f4fe5a17",
+          "result": "valid"
+        },
+        {
+          "tcId": 311,
+          "comment": "point with coordinate x = 2 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "EWJCSqn6DUK_YOBqFrfn6kWsDi8H8eNnNb0NmMcLiFA",
+            "y": "aT8qwSj0fyEzIsX4hy3ekmGv_mFOPzZKeS0XsOhCGEA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b095e9c2f933a00053a95758dc20fe1e72a798462f90fd67fafbbd68d761dd67",
+          "result": "valid"
+        },
+        {
+          "tcId": 312,
+          "comment": "point with coordinate x = 2 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "MNLUKoU4W2SBfQkAvIyYRxaTRSkFbaAy1f3oRJFdZps",
+            "y": "Dl70DVZvWyOZITLErliAF-vRYOXb9IBPk2yw8lepNEY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "95484c5554b543f8eb2fc218cc46ffe648a3bfac41e6dfafca1ba11f8c53ed6e",
+          "result": "valid"
+        },
+        {
+          "tcId": 313,
+          "comment": "point with coordinate x = 2 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "p3olmlXtmNZD4aPhOATJXlQ8FVfmFB5O1H3PE7lBpvo",
+            "y": "i_pfh5qxSuunsqwG5acZyG9KLtORFgOAqjtvdBQc01Q",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f22ebb6843281b54b22a9ff1a91485c7db8f95db4bf8a1131f892b3bfce56662",
+          "result": "valid"
+        },
+        {
+          "tcId": 314,
+          "comment": "point with coordinate x = 2 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "-JRUWT26VyAWTRe8HKMvEN3Rp9N7e_AuXsDVl5T01j0",
+            "y": "NCaN4_aiwQhRSlJwL35n0ngp-gNAs8RxBlEpFIPIshM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "99623d9f447b66cb322488ea463b3e40d5620f4df78f89c62fe0ba8b90ff386e",
+          "result": "valid"
+        },
+        {
+          "tcId": 315,
+          "comment": "point with coordinate x = 2 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "sAvvy4aO611VjvLsLsZ53AguwVpXxYmTEReEJGdLj1A",
+            "y": "WIdCcopjhKGAUGuHOaecTOleEFXA0OqyJUylWxij57I",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "d611afb4046c9f4b2887b7dd4d45b80e9584eca93f5a855dc30e529eedbf5017",
+          "result": "valid"
+        },
+        {
+          "tcId": 316,
+          "comment": "point with coordinate x = 2 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "s-L5x_nwaMXaiIL9WB5xEuU4qgH-tfAXQzwA_IqCj8w",
+            "y": "xWo_aS47I3t8r0mGkAnmdD417FrtGdgUz8E4afeOuJU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "0438085ab0104fb47c696be5c08f95e319ed5507ab781fe1cdccd6ddb34bda67",
+          "result": "valid"
+        },
+        {
+          "tcId": 317,
+          "comment": "point with coordinate x = 2 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "5drpd54MFo5guEJQjiU9KsgOflBNrtn6wHe5tEnDaLU",
+            "y": "e9hmG7vM70ePBQ9P_siqR-1_mOiVFNkIP6zwp_L3tw8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "326dbabffe17c6efc710bdb8d04d16c8624c083d48bfa6e4411d221264d8277f",
+          "result": "valid"
+        },
+        {
+          "tcId": 318,
+          "comment": "point with coordinate x = 2 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Qg4Qu4Gzedcoh5_mAObxvyuF2AI4SKBAx2VKlzTaGsQ",
+            "y": "y-5WFXGmFrCUo4Q24Cxte1S0J5ojQZOoKOhuIea3HRY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f47a91e29ebe69baab6b340bb64a6dc34fca7546fd6eba53f5bbe41f6178c7c6",
+          "result": "valid"
+        },
+        {
+          "tcId": 319,
+          "comment": "point with coordinate x = 2 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "jb8bqHWXAEr1UjFyJZFqvz1x3_kP6eYfnShjpt4hjUo",
+            "y": "CJfjNAABObCEnXcnV7FQ5dhrVdegCnRLzLt8uNGmsHs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "cf83319c735348dd13c44b055f67a292f7afc5d9d2bd0706c966ad765368d422",
+          "result": "valid"
+        },
+        {
+          "tcId": 320,
+          "comment": "point with coordinate x = 2 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Gsy4W2EtMtWEWcrsC7Z2jwXOgJTjhiQip8EjQN0xvXM",
+            "y": "l-A3fTPM3Oi9hy-Ji-bLz3J0s77vtd18rd3wJ9DALC4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "41ee7801ccb702f2f633d1d0ec20d7c427936886df89ad33d19dbb56f66a2656",
+          "result": "valid"
+        },
+        {
+          "tcId": 321,
+          "comment": "point with coordinate x = 2 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "FO70G2fBex1KBAVUKHzWqeazCAM16k4Wgh29ZD7Gfbo",
+            "y": "bWfK3L0aPwInt8rywGBNKzUHrrlu2Ywy4jUP4pXtiZg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "af828d6bc21ad6b4570b5f68a6208d3a2f46edca69b1980fe5046792c68cab80",
+          "result": "valid"
+        },
+        {
+          "tcId": 322,
+          "comment": "point with coordinate x = 2 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "qZr13sPJlQgN3MFdeZTa_yZqpT8YH7pLzdUE0ga_yi8",
+            "y": "NzlYjwceQZK2FTYeyBc1_i7ykjxAVsQy9MJ4Ll1yIhU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "4ebf7f174cdb3fda94f99698317ffef5f4d4fb933f3292f1aaa782c354ba03e7",
+          "result": "valid"
+        },
+        {
+          "tcId": 323,
+          "comment": "point with coordinate x = 2 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "o1XY0X1Q9kKOCvNFkhZiWH4rYknu0eMmq7fIYFA2sds",
+            "y": "H9cu-sqQgrtvq0Q1n6f274pF0DaFKDLirenUHyghkUQ",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "1649f83c47a6640a94b773ab4309bd6964109433e3f3ee5b024d1915ef5139de",
+          "result": "valid"
+        },
+        {
+          "tcId": 324,
+          "comment": "point with coordinate x = 2 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "-lPltY1V6_UX2NsHsCHYCRjR8mD54LPQC9R7JKka5qs",
+            "y": "hasq3MMbmMquwmgahB1QvA7ah1Vh-rcMl5Rj_7ah10w",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f434c3ffe109528456c23d6cfe51ec0b10be606d7a26775fe2ff0a9b18f92f39",
+          "result": "valid"
+        },
+        {
+          "tcId": 325,
+          "comment": "point with coordinate x = 2 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "M_43lJN13r2XNPVLcDa3qXi8j8SuP-knpSH5QNnjXdM",
+            "y": "j4GpFgwF3wTjQpDbQMPgRbgyNzlByoW0M4VOQ8rtMj0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "bd02b9dfc8ef760708950bd972f2dc244893b61b6b46c3b19be1b2da7b034ac5",
+          "result": "valid"
+        },
+        {
+          "tcId": 326,
+          "comment": "point with coordinate x = 2 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "ubqERQZ9DoG9Mt2Z5rTqPUQtBjqOuYc1GO47sYwFNwY",
+            "y": "CZlktoiRBXhNnW2dmqecdraj0zdjFZU6_ctadDnnxwY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "412269bfc15d8b1fd7f25de33b1515ea67f2194e73ba06c85ef99bb42722f95d",
+          "result": "valid"
+        },
+        {
+          "tcId": 327,
+          "comment": "point with coordinate x = 2 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "eLJIY0Jwp6ZkC9DGRZXcTpit_mvbgRJZOkFz421Km0k",
+            "y": "aaHz0ZsyWJjjZFnEHrod6ZIpsLos8TN0YchDkdmuofw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "0ad7556a621074a771bf129163d09a2e9d2e174f2b8a4b6973e89ea138c9a603",
+          "result": "valid"
+        },
+        {
+          "tcId": 328,
+          "comment": "point with coordinate x = 2 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "x4iISshoWT2yQfWz6nATgQ084ooCaAqW_zV7Jh-tYRs",
+            "y": "7zU7DoLBxoxHH_HtXEdJ4Wjnr4WRpebatZm5ZiDeDt4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "76acc74dd60872ab29e1bcb99dd46365c7c7f792619c901c7ba5c68378b233f5",
+          "result": "valid"
+        },
+        {
+          "tcId": 329,
+          "comment": "point with coordinate x = 2 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "GGTjc6xgwjVD_qnh8jeVCoFp4HyBfbadUA5VktHfnVo",
+            "y": "ENpGUe_MxG035-rhbDashqmoa4itCHUajc0VBgAZcEs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "50e23b94fcc33d93dbcd71e955e195fe0bf6ac9b04b15f001e53b5dc7bad158e",
+          "result": "valid"
+        },
+        {
+          "tcId": 330,
+          "comment": "point with coordinate x = 2 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "3XMI0qZ1f5JNyXkGbnXub6UrAzk9KJL1l4jv-lU7aQ0",
+            "y": "H-8AwcIrqAuV1Sl4Lb71WmMEYXn7TvAP3M9bYs5VwTY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "3324bf2fb3486b1104fffa35ef38975faffba1ebe42c54399206face505448c7",
+          "result": "valid"
+        },
+        {
+          "tcId": 331,
+          "comment": "point with coordinate x = 2 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "V11Rvivd9b8atCQxun47XylHvFdN-fYKRIuNtcooySw",
+            "y": "2Db1XFVkQKffEl3mWZshrmjxXVufQi1u7IirL2VAa_k",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "235fd3e7216c92f73860f0ac0121b4264ff89d80bc75d59dd455298597c5f2ec",
+          "result": "valid"
+        },
+        {
+          "tcId": 332,
+          "comment": "point with coordinate x = 2 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "x0IqgK69tRi9LaumkdOaJeov5Jo1zfsqD5S9-63GYpo",
+            "y": "5VrHxACv0pdrfDsk9xJoB6Wgr7kxz6XGraH0_5hOpac",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "0bf758de27052319dac39b324a6ea55e928603a3ef9049ad147f8ca35f55b656",
+          "result": "valid"
+        },
+        {
+          "tcId": 333,
+          "comment": "point with coordinate x = 2 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "rUBiIW-E_9ZuMmSXvLyrmCKDSTOS7A9znO-M1-rzRTQ",
+            "y": "FMWiiahG4ovyBC6l3HsV4lL0jTz5gOfEdRzDVJOhwyg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "312eeaaee397224fc17dec7191ce69cef40e8fb373516c2b1edada0336c99c13",
+          "result": "valid"
+        },
+        {
+          "tcId": 334,
+          "comment": "point with coordinate x = 2 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "zKzRv3x_TqnH5ZvYAoBKnTNSYnFqwojG7v16cTU0mk8",
+            "y": "e4YS4r29Q7P8T6aUGsFajzfjT-eBCgwNQ8Ba-vtkgO8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "aa1691858e6a1a06c6df57ce10a4c730974c06d1e0106d1a31b51b915cd6b60e",
+          "result": "valid"
+        },
+        {
+          "tcId": 335,
+          "comment": "point with coordinate x = 2 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "mqfx-TR0-jcMTfOAW9KDkyiJWIDc4ZegbPkFLmq3ppM",
+            "y": "jJogizNb_aawEyHwKaDYPIu5ZWEghIH3r2xs8dJleEM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "5786d6ea09ffb21a63adb020b117096484ef995e8c4a72afa479cba95c959920",
+          "result": "valid"
+        },
+        {
+          "tcId": 336,
+          "comment": "point with coordinate x = 2 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "g7ev_OwRaF0VYU4tU8HnNQTj2YNEu9X8CthtxMNnBDI",
+            "y": "On9zoJUz0aEHaqnEryKmurkvPw12Z5jbeqQYPAN_huY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "ae0c7845b82995263c51e13e297412d17b650aa83dce4f55a069dbee671c16b8",
+          "result": "valid"
+        },
+        {
+          "tcId": 337,
+          "comment": "point with coordinate x = 2 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "ruvdlxz06Yj6vYBwx1xkqrkKg6NnNf7Ps4VgWXnACK4",
+            "y": "jDmIjw2vdPmM67sI9rkaUZP2hKVnYbnytj2H0_YEke0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e5e764a38b73816f6e11e7cf298b2be54d11249c615f0a71498a0a821b5736bb",
+          "result": "valid"
+        },
+        {
+          "tcId": 338,
+          "comment": "point with coordinate x = 3",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM",
+            "y": "LyMzlciwejg0oOWb2kOUS13zeIUuVg68DyKHfp9Ju0s",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "6aa7e74a7a838efa9607f3587d4117f1914c57fa924b441c27fb7a7c31fbaac4",
+          "result": "valid"
+        },
+        {
+          "tcId": 339,
+          "comment": "point with coordinate x = 3",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "447sTBpNgaXZlLDXeAMFr2UYksvwfzoHYo9OJHOoq3U",
+            "y": "S9qWYiRiiA01NtOQEyqF22FH-BTGLvtYCm9SlZiw3R4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "391b624f28eb398156666dbec1d635f8ff1753eb86297973a1c2831b1091e2df",
+          "result": "valid"
+        },
+        {
+          "tcId": 340,
+          "comment": "point with coordinate x = 3",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "EPAtSW6ah1jIMTiYkqRe0AkoLqHrIBq4yvCeby3p-ko",
+            "y": "zBJr7MIExBqUr_Ty6tdVLsI_xo8ABRR2JalWIrUhCQ0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e3f39d071b743c8041454d1dacba93dc9f3f12a5ae1bfbebaa59fc4cefee6b82",
+          "result": "valid"
+        },
+        {
+          "tcId": 341,
+          "comment": "point with coordinate x = 3 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "TIWa_zQsVqlQi4WasVCe3Kv2bgROICbMKTR0OJs9WME",
+            "y": "a8Bs-Z3W2CScXSQ4alWpchTqDNonCtlHCYbDo9Ajywc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "09d0d1b92af1e7111d223bf5efcdfa6df2622ab3cf161af0ebbf06ad00c09b6e",
+          "result": "valid"
+        },
+        {
+          "tcId": 342,
+          "comment": "point with coordinate x = 3 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "0etPfGgKJHoU89Z_hc2xxMbxPUSCH8RWySR6YGYir-w",
+            "y": "SVLPBf8G8G1wMOiJBHNwlsv43ZDkeKO13-0u5Iegg1w",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "a738727e0f5b20448009d1029ca727f2380d2c6e152a6e2da8ea50531ce39499",
+          "result": "valid"
+        },
+        {
+          "tcId": 343,
+          "comment": "point with coordinate x = 3 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "O_edbBog2FEV6XMHlwf1Ex7tL4O-VoPDTQ-z7uGuQN8",
+            "y": "0upPG3Nc9iNBg1pXIcJdqg3Bo4hqt172U_Ry2POqHpc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "a314e4ee9e303d970b4e9f0cdc262657d5c5192f055466b9d09d9c888d6b7256",
+          "result": "valid"
+        },
+        {
+          "tcId": 344,
+          "comment": "point with coordinate x = 3 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "sfgIKGpC7u6F1YXlTcKKuirr-5VoBfXAESe830NRVMs",
+            "y": "WxeP2liW2edQhmH-5-5V-pYjYQs9n0pZFWt22Id7TvE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "8f4e1bf8e5182a1fbcdeac924df1ba2f937162d48a206783c48132cb582c07db",
+          "result": "valid"
+        },
+        {
+          "tcId": 345,
+          "comment": "point with coordinate x = 3 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "oh6A0J4RrLzLyQnebJ8RWa3btd1HchG5CjcPjHVI5g0",
+            "y": "HXqstuRVvNwjAzHXmtlGSne3AshYQAkAy0SIy2wovWE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "16682c862cf53755b3c28adf7de052d5cf0e81e5d8acb346702a392bc6b2b1d5",
+          "result": "valid"
+        },
+        {
+          "tcId": 346,
+          "comment": "point with coordinate x = 3 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "UFWoxF6BOF9BRMe2-zIRk5WpTb0HZl7XvBzOHmLcR8g",
+            "y": "ttUKOaVdO46ZZiT7bsLylgx8K8C8lLKmPWUJb9mcpBo",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "cc33e840b5354bf6e088047e76dc168f15c0c1aa946731600f52d6f1c9299b27",
+          "result": "valid"
+        },
+        {
+          "tcId": 347,
+          "comment": "point with coordinate x = 3 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "r1IvwKYUQBc5RbkU1kBLGUC1R6b3aFUCgP4ovTMcnGY",
+            "y": "HSgkKfKREpj5xbgvh8f1BEcGdIwZA1aJshbWRHS_WtA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "d7b4f5e2dd1ebecfc92318d92085271be482fe65a03e83b2e358a397a597449b",
+          "result": "valid"
+        },
+        {
+          "tcId": 348,
+          "comment": "point with coordinate x = 3 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "7BqIZS3nFNIf3bVNtKNCNSGurVgouEO93ppCz0qL8SQ",
+            "y": "ppVoxmTi2TF6xzLJjENVSNzsDuuKsxAn7l8Wk8zZfGg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "1d88ed8e4579a4c62fed95eafe1528f8d5056041fc41f3ef063605ddc980ee09",
+          "result": "valid"
+        },
+        {
+          "tcId": 349,
+          "comment": "point with coordinate x = 3 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "SOTJzIimAetjn4H_pnlUC_HXvL6HapVec7-t4FU4QWA",
+            "y": "uuEwJD71_TKPZSeOAMrWABMnq0L987llSq1vJgVCsCs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "a6698578650dadb452d677c3983e6b809152d7d2d8fba349cec686e72e6f8693",
+          "result": "valid"
+        },
+        {
+          "tcId": 350,
+          "comment": "point with coordinate x = 3 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "6GE3nxwbB1QBVbv-9KaahL6BsUQdQ-eFDHrBAFqAQjg",
+            "y": "uzPHmB04OgbRt5VVKnsx9JFF-6k3h2_cnw0TiqWz8yI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "8e42c38902b25fa138b95f4f280b684c09e1212c4f06a2bc2c2b2b8790112034",
+          "result": "valid"
+        },
+        {
+          "tcId": 351,
+          "comment": "point with coordinate x = 3 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "tEic1JkWi9SM0sMRZ-2tJGxjhZv4tIOYYXp6BVY0Hjw",
+            "y": "Cw9m9mUDi6op24wpbU8q4HuauRk7_ACYHX3wWZzgZI0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "a19f1165d31c1695359929deebcd24846ccb9a3c2a38c10bdc7c855bf8a32df7",
+          "result": "valid"
+        },
+        {
+          "tcId": 352,
+          "comment": "point with coordinate x = 3 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "iE50iF6kUPWqsMyPBsAGYw6LGDoGvaUJMi_Nl7pdLSs",
+            "y": "AOE3PVM71ZIEJ9EGt_M-61PSG1z0bKAVHpGFnoEaOcs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "0a87935c036de666b7619f14ec58f9f78698cc23a667616f84c177f34661ebe2",
+          "result": "valid"
+        },
+        {
+          "tcId": 353,
+          "comment": "point with coordinate x = 3 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "xQIkqM86GdphM-dG0AIXKF34VYntM0tU2VsAW48DP30",
+            "y": "97xqXdxZ0DPwxmvtVxSaFg8lcjEXovzUE6_4ya2kO_k",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "90accd1c3af1cd782ea1e864a307aaef6a01fd3a6305a0adae37e76844b9ce10",
+          "result": "valid"
+        },
+        {
+          "tcId": 354,
+          "comment": "point with coordinate x = 3 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "xmqRf8Q1yfQcR0KOcYowF7PFyZK02UpmNgL3P9gl0EM",
+            "y": "oDy59YF0z_s1ni9UHPteVRxQ_YEbgjYurbIWpM_Q-MM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e164d88fcbd1ccdd654de0415bfbd2a171590713015f4a1755504e62f7a03870",
+          "result": "valid"
+        },
+        {
+          "tcId": 355,
+          "comment": "point with coordinate x = 3 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "9VpFHm4Nj3YAx798BXQcXlmFuP_k6rYtT_wErttyWmY",
+            "y": "6ULPSG7887hUiM881PsCSLggcDuTjOd6B0ovkoavA78",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "d4b6d4251ac1f8a0b0c75bbac3517a13ea0c857b5499b03d153be663a8715480",
+          "result": "valid"
+        },
+        {
+          "tcId": 356,
+          "comment": "point with coordinate x = 3 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "qWqiW-6MjLb2qvQL6YygR9okXo1Mrij8iSoDabKZy6M",
+            "y": "719Uu1n0rVioQzKgDYmhzz1WxObsnDpGekoqBK07zpc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f5270d0c4119f1ef467a37501688b4bf4a516e5f58a0f5a40f23ae70ee813c26",
+          "result": "valid"
+        },
+        {
+          "tcId": 357,
+          "comment": "point with coordinate x = 3 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "SfVy-ozfZ1Ctq8OrDka_I9161xFL8xnzWvpqLMvi59M",
+            "y": "Q8RPAY-O_J9SaRsnSoyJKD0TzpPRtYrqEdYsiFmcMJw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "1763eb5bd3677de88e98aad84038838422d6e55605a14761788cf305672eb670",
+          "result": "valid"
+        },
+        {
+          "tcId": 358,
+          "comment": "point with coordinate x = 3 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "s29rAr8dIT2avPyYwl_IGrO5jLE9Z42ocTEKoJOre1g",
+            "y": "pQsTSBgyGkj_we-fhiTjcd3weNiYP9psTrJ9-yVRdOk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "98c95ef9fded241da09392573144daf44b0332518f458167e09d672011ea4618",
+          "result": "valid"
+        },
+        {
+          "tcId": 359,
+          "comment": "point with coordinate x = 3 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "dPV_89qNYOwLOC5oZr5FAvaVaIOEtAXiF5qrYQZhltc",
+            "y": "0kBkGF1o3pW9crIZwMCpOHkyTymfsZIUszo-0vG_SCM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b0fe8fc6abe853b1ea6aa4f4b4490bcd94ffd3532c1d7cce36d059ac8f29cd67",
+          "result": "valid"
+        },
+        {
+          "tcId": 360,
+          "comment": "point with coordinate x = 3 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "kk_jQ501Qn4q2bH25nh37TRB10vdDrn4KuNgQ0vCBiQ",
+            "y": "U340AAB80tFA8sqg97YccRiruaxcdm7Ks_j3LqXZbN8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "4fdc7cc04b2459f73c856023e892699b9018baca1b8e3b040ec74324607c97c5",
+          "result": "valid"
+        },
+        {
+          "tcId": 361,
+          "comment": "point with coordinate x = 3 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "-w5Io4FaK4Dp5yUDaiOXV-nFmHhQqUHF9dK4m3dqrGg",
+            "y": "OttUgfzYXwAT_rIFBeu6_yft-EdKfPTZhexWc2XsvB0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "561138979956fe6a1aeae06277456c7e5e7e7d643910e247fb248dd7435691a0",
+          "result": "valid"
+        },
+        {
+          "tcId": 362,
+          "comment": "point with coordinate x = 3 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "5mmRXuFgaU6FWdeWX3z_lFwcsHbxlOyYlLGjixByb7A",
+            "y": "OJZ14xVbBps4Yto9ERIXmgSsy-fbtws8xIvtt1kdLqw",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "06c06abb603bff68f356ce496c17fcd0662fa040eb0cd45a98112e6c1eea11db",
+          "result": "valid"
+        },
+        {
+          "tcId": 363,
+          "comment": "point with coordinate x = 3 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "t2Df_0xcIArsGLkwsY3zQpe7QhuWAX75AhOf5rEjSfY",
+            "y": "zLjPg9KDfHUgMA8Ze0kcA2hHDuhvdMoDgWgrtq2ANE8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "319297f77a75381b65d73107e826eea0e69d85985db4568fea21d12dda696921",
+          "result": "valid"
+        },
+        {
+          "tcId": 364,
+          "comment": "point with coordinate x = 3 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "sOTekU_nG2FjbmE5FSjvrItsEe3NQcl2avhpPbtuQfI",
+            "y": "UXKTclVS8i3W4dt8LCQ_gMEHE_aqSPxeOVvZ7FHx6cU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "c3ef6eb91aad69456ede5174b0e5e3d6863c024aef3185d2258946362903e576",
+          "result": "valid"
+        },
+        {
+          "tcId": 365,
+          "comment": "point with coordinate x = 3 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "jrbuLungYay5MSrQFbGVTqR8owSizrt3879seGeMEUk",
+            "y": "2T_G6AVh8xEP0Olf3Azo2iw_Mvf1gfm2ZtdJALN2C58",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "a18b1fba4d496419ede70cc23ceed674526f34299e5b09c0ee2dd1669693fef9",
+          "result": "valid"
+        },
+        {
+          "tcId": 366,
+          "comment": "point with coordinate x = 3 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "kBIQIVRqlueHnVPnuFwh9AR99Jua2FAgEE8hbQEPUg0",
+            "y": "G7pudldCOVtMiU_Q6q-HJ10cd0lMAczogt4oBdGSLAs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9fc7fff3bb4d6e5a4d52eb0e3c513a3c9fa56014c030449546cda744aa126f6e",
+          "result": "valid"
+        },
+        {
+          "tcId": 367,
+          "comment": "point with coordinate x = 3 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "ZMFxLj6e9EDH6o-vBUDS5qBa3MvVOn-yT_FqlQKoGPc",
+            "y": "R8-v0iCUMOt3lPXakdbF4ttQW6KHvG7zl79_MMdHU2o",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "61cb2fb99b695ecbaf91a95e6e0c7e24633bc7613ebf518c6f1c8161dc75ea5f",
+          "result": "valid"
+        },
+        {
+          "tcId": 368,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "y7DeqxJXVPH9sgOLBDTtnLP7U6tzU5ESmZSlNdkl9nM",
+            "y": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "af306c993dee0dcfc441ebe53360b569e21f186052db8197f4a124fa77b98148",
+          "result": "valid"
+        },
+        {
+          "tcId": 369,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "JIAN6sP-THZbbeyA6imddxraTzDk4VazrLcg26NzlHE",
+            "y": "X-TGS7BkjibQXLnMmKyG1Ol7i_Evkrmy_cOuzY6mZIs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "aa7fc9fe60445eac2451ec24c1a44909842fa14025f2a1d3dd7f31019f962be5",
+          "result": "valid"
+        },
+        {
+          "tcId": 370,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "jzNlL1vaLDKVPr8tLsqV4FsXyKt9mWAb7kRd-ETUajY",
+            "y": "nPWsAHcRvb5cAzPcDAY2pkgj7kgBlGSUDR8n4FxCCN4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "082a43a8417782a795c8d4c70f43edcabbc245a8820ac01be90c1acf0343ba91",
+          "result": "valid"
+        },
+        {
+          "tcId": 371,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "FG07Za3Z9UzMooUzyI4svGP3RD4WWHg6tB-O-XwqELU",
+            "y": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "70810b4780a63c860427d3a0269f6c9d3c2ea33494c50e58a20b9480034bc7a0",
+          "result": "valid"
+        },
+        {
+          "tcId": 372,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "sDREGKRQTAfnkh7Z8AcUtdOQ5cteeTuxRl9zF09sJv4",
+            "y": "X-TGS7BkjibQXLnMmKyG1Ol7i_Evkrmy_cOuzY6mZIs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "a7d34ee25fbb354f8638d31850dab41e4b086886f7ed3f2d6e035bceb8cab8a0",
+          "result": "valid"
+        },
+        {
+          "tcId": 373,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "ipjBvGvnXFeWvksp3YhcNIXnXje0zKybNyUeZxdf8NY",
+            "y": "nPWsAHcRvb5cAzPcDAY2pkgj7kgBlGSUDR8n4FxCCN4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "3f09cbc12ed1701f59dd5aa83daef5e6676adf7fd235c53f69aeb5d5b67799e0",
+          "result": "valid"
+        },
+        {
+          "tcId": 374,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "H-Hl7z_OtcE1q3dBMzzlpugNaBZ2U_ayskvLz6qv9Qc",
+            "y": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e04e881f416bb5aa3796407aa5ffddf8e1b2446b185f700f6953468384faaf76",
+          "result": "valid"
+        },
+        {
+          "tcId": 375,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "K0ut_JexZ4G8__SlJc9N0xGUywO8pW2bDOlsDA0gQMA",
+            "y": "X-TGS7BkjibQXLnMmKyG1Ol7i_Evkrmy_cOuzY6mZIs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "adace71f40006c04557540c2ed8102d830c7f638e2201efeb47d732da79f13d9",
+          "result": "valid"
+        },
+        {
+          "tcId": 376,
+          "comment": "point with coordinate y = 1",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "5jPZFDg-d3XUAvWo860N6x8A2RzNmfNI2paDnqPLnVI",
+            "y": "nPWsAHcRvb5cAzPcDAY2pkgj7kgBlGSUDR8n4FxCCN4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b8cbf0968fb70d391059d090b30d1c4edcd2dad7abbf7aa4ad452f5a4644a7be",
+          "result": "valid"
+        },
+        {
+          "tcId": 377,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "0cG1Ccndt2IhoGaiKjwzP-5eHS0aS6veSh0z7CR6fqM",
+            "y": "AWL5VFNOrbG06pXFfUChAhTlt0buaqQZTtKyASty-X0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "07257245da4bc26696e245531c7a97c2b529f1ca2d8c051626520e6b83d7faf2",
+          "result": "valid"
+        },
+        {
+          "tcId": 378,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "dV2IRee0_ScDU_aZnpckIiQBVSe_P5TMLGk9G2uhIpg",
+            "y": "YE-BdONgW48YvtN0K2hxqM_84AbbMbjX2Db1DPzafRY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "d6aa401b9ce17ecf7dd7b0861dfeb36bb1749d12533991e66c0d942281ae13ab",
+          "result": "valid"
+        },
+        {
+          "tcId": 379,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "xvn8hkS6XJ6pvrEs4suRHFSH6LG-kdWhaDGPSuRNZoA",
+            "y": "e8M3ocguPF96KSeYe4-uE2JyN9Ig-vtAExI7-9lfC6U",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f43bfe4eccc24ebf6e36c5bcaca47b770c17bcb59ea788b15c74ae6c9dd055a1",
+          "result": "valid"
+        },
+        {
+          "tcId": 380,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "0xefzleB0MSc6EgKgR9vCOPxI9n2AQ-_YZtdhoqOqDM",
+            "y": "3fmmZr8AFbIOSRL3D2Ve8huCCHWWqh4vHihlNQ0VkYU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "009bc3abb3cf0aca214f0e8db5088d520b3d4aadb1d44c4a2be7f031461c9420",
+          "result": "valid"
+        },
+        {
+          "tcId": 381,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "ngmAlUY8kaxxB6kgzLJ21F4fckDvK5O5V-4JOT0y4AE",
+            "y": "UDr0ouOyYnlWT-2OdyoEPnVjDk44WZdu3oj_zxb1ynE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "8bcb07a3d0fa82af60c88a8d67810ebca0ea27548384e96d3483310212219312",
+          "result": "valid"
+        },
+        {
+          "tcId": 382,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "vzA0qZNRgto2JXAxUBFUSsLOipwid3wvx2esnFwNrus",
+            "y": "zzM1YvPgGIkjdDU2dN6EkPydMEJlmOtgB3kVS68q7Bc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "a09ddc7cfe023acd9571ef0754010289c804678c043f900f2691dd801b942ed4",
+          "result": "valid"
+        },
+        {
+          "tcId": 383,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "cJxxecK7J845hbpC_rhw8Gnazq2SlMgFV76IL7V3kEg",
+            "y": "Hm_iwacVFj76-G6oseVepXQtawQubL-KzGnJn4JxqQI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "da98054d51ac9615e9d4f5ceda1f1bad40302ac11603431efec13ab50e32fcf2",
+          "result": "valid"
+        },
+        {
+          "tcId": 384,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "JkwAotklFKbb5lXePHGldAzsT8slGqSMpnRdvqb1988",
+            "y": "wdXun8POSf1FCdM8Tc_MGiCmYFKfqevW5q_D1chMcrs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "d60795d8f310b155726534b8be3d0b8a7bc2ced468c6e64c8b9ae087b33ee00b",
+          "result": "valid"
+        },
+        {
+          "tcId": 385,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "oSEkYGvLuzPOzsf8jXiziXGSyoUVYMU55H3SdsY708I",
+            "y": "8goMphi6ATGi43PzH3Oz9V6RiNRv3bxjh-Mq77nzuhI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "675fef8f5680bf76220e91362613944099046b0ba07e5824e93f3e3cc2cc2758",
+          "result": "valid"
+        },
+        {
+          "tcId": 386,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "JEt6_n8xKJ-daq639w0pp7SaIox7sgJ2SrqU2qqjMyI",
+            "y": "cMYJdXSPDHSaiw-PweIi3cvTOE9taPC2tv9nm0Nc3LE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "76b439f8ea7b42f11cd59e6d91b2d2a72577c185386b6af6639be8e3864a7f27",
+          "result": "valid"
+        },
+        {
+          "tcId": 387,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "KsKdsuvE-pRztCvTNaYCJlecwYayxnajsBvGDliWFhY",
+            "y": "WqnA0bJA5t1CEeMjVCVjSyeK2I_t4DN9Ws8xNlh9hBM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "56e63fa788121d5efa0ce3caf4605af18d48c631496cdfa862c43ecf5e5fc127",
+          "result": "valid"
+        },
+        {
+          "tcId": 388,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "5iruUgWoBj465AHVPpNDAB5V619OTWtw4rhBWc8xV-Y",
+            "y": "S6LkIMq8Q7bo6GWQ_COD0Xgn3ZmmDCEfGQp0JpEAwUE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "cff3b5e19ed67e5111dd76e310a1f11d7f99a93fbe9cc5c6f3384086cacd1142",
+          "result": "valid"
+        },
+        {
+          "tcId": 389,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mdzm3nQfECZ_Lo89VypPSb5f5S_3v_PDtGRvOAdsBnU",
+            "y": "JwKlFamlDbHYb9Qq6gg02utivgPQzZAz-EucS1ahnxI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e29483884a74fb84f4601654885a0f574691394f064ea6937a846175ef081fc5",
+          "result": "valid"
+        },
+        {
+          "tcId": 390,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "ZRjNZrHYQeaJ1dxmdMfMfZZFdNFJD_95Br03NJR5FZk",
+            "y": "EEJ3FwaS-mvyJwWA1W0byBtU9HfYq2w_WEJlCscXbXE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9c6a4bcb2fc086aca8726d850fa79920214af4c151acea0fcf12a769ad1f3574",
+          "result": "valid"
+        },
+        {
+          "tcId": 391,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "lSqIzjGtTLCGl45sViHD2AI7LBFBjW_Q3O-N5yEj78E",
+            "y": "XTZ2iP3l4ILwl4VaDArcMF3Wz0b1DKdYWbskO3AklgU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "34b7abc3f3e36e37e2d5728a870a293a16403146ca67ff91cbabeee2bb2e038b",
+          "result": "valid"
+        },
+        {
+          "tcId": 392,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "KkPzNXO2GXGQmc9U9szLKNFt85kiOfrfecesucZPevA",
+            "y": "9NHSKvcYfI3huZKkBGxBm4Ac3lfWONMPLhrEk1MReiA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9bd1284f1bcb1934d483834cae41a77db28cd9553869384755b6983f4f3848a0",
+          "result": "valid"
+        },
+        {
+          "tcId": 393,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "GxsMdUCHhehHJ7DlXkuiDQ8lmcTtCEgtwfO131RWkTg",
+            "y": "AWL5VFNOrbG06pXFfUChAhTlt0buaqQZTtKyASty-X0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "167e3db6a912ac6117644525911fc8872ed33b8e0bbd50073dd3c17a744e61e0",
+          "result": "valid"
+        },
+        {
+          "tcId": 394,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "TdEoO8zTbMNALzqB4umw1qKysd67vUT_wfF5vUnPCn4",
+            "y": "YE-BdONgW48YvtN0K2hxqM_84AbbMbjX2Db1DPzafRY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "7c3020e279cb5af14184b4653cc87c1ddd7f49cd31cd371ae813681dd6617d0e",
+          "result": "valid"
+        },
+        {
+          "tcId": 395,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "pJnb9zLkOL4OsIS55q2HndeikEu7AEtAAnlpoXHy1CY",
+            "y": "e8M3ocguPF96KSeYe4-uE2JyN9Ig-vtAExI7-9lfC6U",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "acfdff566b8b55318869fa646f789f8036d40b90f0fc520ae2a5a27544f962c0",
+          "result": "valid"
+        },
+        {
+          "tcId": 396,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "rc8P-6nLbvDIAxxCkaQ0sY149C5F5iugH76R-Sc_CtE",
+            "y": "3fmmZr8AFbIOSRL3D2Ve8huCCHWWqh4vHihlNQ0VkYU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "5c6b01cff4e6ce81a630238b5db3662e77fb88bffdde61443a7d8554ba001ef2",
+          "result": "valid"
+        },
+        {
+          "tcId": 397,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "IXEnJdmAas9U06bIK_k8D-JJJoyp9C7OrBnpOl6rgFY",
+            "y": "UDr0ouOyYnlWT-2OdyoEPnVjDk44WZdu3oj_zxb1ynE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e7281d12b74b06eecb273ec3e0d8fe663e9ec1d5a50c2b6c68ec8b3693f23c4c",
+          "result": "valid"
+        },
+        {
+          "tcId": 398,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "HgIXaCS9Meq9zgOpQDx9PCrGMfmw6I2akkcBwbLym4U",
+            "y": "zzM1YvPgGIkjdDU2dN6EkPydMEJlmOtgB3kVS68q7Bc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "80643ed8b9052a2e746a26d9178fe2ccff35edbb81f60cd78004fb8d5f143aae",
+          "result": "valid"
+        },
+        {
+          "tcId": 399,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Y-ehrzbWtUCkknaqw_7Jy0Xta6sWfAawQZp3uROZ9hg",
+            "y": "Hm_iwacVFj76-G6oseVepXQtawQubL-KzGnJn4JxqQI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "75873ac544ad69d3ddc5c9cffe384d275e9da2949d6982da4b990f8bf2b76474",
+          "result": "valid"
+        },
+        {
+          "tcId": 400,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "HiZatbf3GZRw5TJlPSp7motyiXC4OBN8lpLtBpKJeyo",
+            "y": "wdXun8POSf1FCdM8Tc_MGiCmYFKfqevW5q_D1chMcrs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "355c9faca29cf7cc968853ee29ffe62d1127fcc1dc57e9ddaf0e0f447146064e",
+          "result": "valid"
+        },
+        {
+          "tcId": 401,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "VNKkOUwQn8vTy5iG_sOt1Ruk0uROHVZ25LmPDBNlX8U",
+            "y": "8goMphi6ATGi43PzH3Oz9V6RiNRv3bxjh-Mq77nzuhI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "fc175a5ef18595b69e45be2cda8ae00d9c8bdbefbcf7f692f91cefdc560e4722",
+          "result": "valid"
+        },
+        {
+          "tcId": 402,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "k_FFkgf7CcbwqIw5isgNEFKkzTPn7vVofamauXxgJLc",
+            "y": "cMYJdXSPDHSaiw-PweIi3cvTOE9taPC2tv9nm0Nc3LE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "46559146a93aae904dbcaaaa07e6cd1bb450f1b37c83929a994b45792333d5f6",
+          "result": "valid"
+        },
+        {
+          "tcId": 403,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "H6BJoYkrZ5hXxt_wivGdtwy8mbby17xRo0H-edFkf0o",
+            "y": "WqnA0bJA5t1CEeMjVCVjSyeK2I_t4DN9Ws8xNlh9hBM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "c64b07119054a37961c0a177158256081b38b0087b307e0cad7e30d790ceb0ce",
+          "result": "valid"
+        },
+        {
+          "tcId": 404,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "hOCxktYKv1Mego6IfTZthp4QM6FunH8RZ0WMgTTBD7o",
+            "y": "S6LkIMq8Q7bo6GWQ_COD0Xgn3ZmmDCEfGQp0JpEAwUE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "bea8cfc0bee8571ccf0c525654ef26d1fc782bb22deccf67ea4ea0803dc15daf",
+          "result": "valid"
+        },
+        {
+          "tcId": 405,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "L5cHxnEYckER77u78GtiOrL_2SWd3DVPyq-BugH2-ns",
+            "y": "JwKlFamlDbHYb9Qq6gg02utivgPQzZAz-EucS1ahnxI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "60451da4adfe5bb393109069efdc84415ec8a2c429955cbf22a4340f8fc48936",
+          "result": "valid"
+        },
+        {
+          "tcId": 406,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "rB-75CKTqfmuEE7i2gsKmzRk1dix6FTfGdPERWr4-aY",
+            "y": "EEJ3FwaS-mvyJwWA1W0byBtU9HfYq2w_WEJlCscXbXE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "d68e746f3d43feac5fd4898de943dc38205af7e2631ed732079bbfc8ab52511c",
+          "result": "valid"
+        },
+        {
+          "tcId": 407,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "uuEM-T_3ty1u2YUZYC6fA6pAMD-gZ0-z3e59LbHJK7I",
+            "y": "XTZ2iP3l4ILwl4VaDArcMF3Wz0b1DKdYWbskO3AklgU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "28daeaadc609386d770dff4c7120b2a87cab3e21fdb8a6e4dc1240a51d12e55c",
+          "result": "valid"
+        },
+        {
+          "tcId": 408,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "7bQojPVWdnPVChzZ5r6kUxeCPzA4P2DZvDue5CrCmHE",
+            "y": "9NHSKvcYfI3huZKkBGxBm4Ac3lfWONMPLhrEk1MReiA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "bb4110b734c8ef8a08bb6011acb35cbda9ae8e2ef6c4d0862576a68792667bb9",
+          "result": "valid"
+        },
+        {
+          "tcId": 409,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "EyM-gPWawrWXN-h4d3gqswJ8SQ34rAvz8-8WM4cu7FQ",
+            "y": "AWL5VFNOrbG06pXFfUChAhTlt0buaqQZTtKyASty-X0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e25c50037ca1913851b9758752659fb61c02d2a7c6b6aae29bda301907d99f5d",
+          "result": "valid"
+        },
+        {
+          "tcId": 410,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "PNFPfkt3lhW8fM7kfn8rBzlL-PmFAyY0EaVJJkqPzxk",
+            "y": "YE-BdONgW48YvtN0K2hxqM_84AbbMbjX2Db1DPzafRY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "ad259f01e953263f40a39b14a538d076710c19207af936feabdf03bda7f067a5",
+          "result": "valid"
+        },
+        {
+          "tcId": 411,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "lGwngohhaqNHkMoZNobnRdPVhwKGbd8elVUHEam_vbg",
+            "y": "e8M3ocguPF96KSeYe4-uE2JyN9Ig-vtAExI7-9lfC6U",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "5ec6025ac7b25c0f095f3fdee3e2e508bd1437b9705c2543c0e5af1c1d363ffd",
+          "result": "valid"
+        },
+        {
+          "tcId": 412,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "fxlQNf6ywEqbFJuy7TxcRY6V5_fEGMSgfqYQfk4yRVo",
+            "y": "3fmmZr8AFbIOSRL3D2Ve8huCCHWWqh4vHihlNQ0VkYU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "a2f93a84574a26b43880cde6ed440c7f7cc72c92504d5271999a8a78ffe3491d",
+          "result": "valid"
+        },
+        {
+          "tcId": 413,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "QIVYROBDA4Q6JLAXB1RNG7-XZzJm4D13-_gNi2Qhm9g",
+            "y": "UDr0ouOyYnlWT-2OdyoEPnVjDk44WZdu3oj_zxb1ynE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "8d0cdb4977ba7661d41036aeb7a5f2dd207716d5d76eeb26629043c559ec2900",
+          "result": "valid"
+        },
+        {
+          "tcId": 414,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Is2z7kfxSzsMDIwlb7IueRJrQ2osn_Y1plFRoPD_sb8",
+            "y": "zzM1YvPgGIkjdDU2dN6EkPydMEJlmOtgB3kVS68q7Bc",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "defde4aa48f89b03f623ea1f946f1aa938c5aab879ca6319596926f085578edc",
+          "result": "valid"
+        },
+        {
+          "tcId": 415,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "K3vs1wZuIvEh588SPUjFRFA3xadW7zFKZqcAFjbudc8",
+            "y": "Hm_iwacVFj76-G6oseVepXQtawQubL-KzGnJn4JxqQI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "afe0bfed69a600163865406127a8972b613232aa4c933a06b5a5b5bcff1596f8",
+          "result": "valid"
+        },
+        {
+          "tcId": 416,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "u42kp27j0cSzNHe8hmPe8WehJsQirUf2wvi1OcaAiTY",
+            "y": "wdXun8POSf1FCdM8Tc_MGiCmYFKfqevW5q_D1chMcrs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f49bca7a6a5256ddf712775917c30e4873153469bae12fd5c5571031db7b1205",
+          "result": "valid"
+        },
+        {
+          "tcId": 417,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Cgw3ZkgjpQBdZZ98c8OeoXLIYpacgeRPNsiefCZeyKg",
+            "y": "8goMphi6ATGi43PzH3Oz9V6RiNRv3bxjh-Mq77nzuhI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9c88b611b7f9aad33fabb09cff618bb1ca6fb904a289b1481da3d1e4e72589e4",
+          "result": "valid"
+        },
+        {
+          "tcId": 418,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "R8M_b3jTzZlx7MUOfirJR_jBED-cXwghN5vQatj8pFY",
+            "y": "cMYJdXSPDHSaiw-PweIi3cvTOE9taPC2tv9nm0Nc3LE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "42f634c06c4a0e7e956db6e86666603d26374cc74b11026f0318d1a25681a712",
+          "result": "valid"
+        },
+        {
+          "tcId": 419,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "tZ0Yq4sPndM0hPQ8P2hgIpumpMJaYc0KrKI7dtYFZs8",
+            "y": "WqnA0bJA5t1CEeMjVCVjSyeK2I_t4DN9Ws8xNlh9hBM",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "e2ceb946e7993f27a4327abdf61d4f06577e89c63b62a24aefbd905710d18669",
+          "result": "valid"
+        },
+        {
+          "tcId": 420,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "lPRgGyRNOm6mmW-iRDZPeUOZ4P9DFhV9tgIyIvwNkL4",
+            "y": "S6LkIMq8Q7bo6GWQ_COD0Xgn3ZmmDCEfGQp0JpEAwUE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "71637a5da2412a921f1636c69a6ee81083ee2b0e13766ad122791ef6f771896d",
+          "result": "valid"
+        },
+        {
+          "tcId": 421,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "nowRWxrIfZhu4bUGuGpOe46gQapqY9bsgOwPDPac-z8",
+            "y": "JwKlFamlDbHYb9Qq6gg02utivgPQzZAz-EucS1ahnxI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "bd265ed3078ca8c7788f594187c96c675aa623ecd01bfcad62d76a7881334f63",
+          "result": "valid"
+        },
+        {
+          "tcId": 422,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "7sd2tSuUFB_IGdS2sS0o5zVVtVYFB6un328EhACN6R8",
+            "y": "EEJ3FwaS-mvyJwWA1W0byBtU9HfYq2w_WEJlCscXbXE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "8d073fc592fb7aa6f7b908ed07148aa7be5a135c4b343ebe295198cba78e71ce",
+          "result": "valid"
+        },
+        {
+          "tcId": 423,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "r_RqOI5a_CIKjux6Sa-dJFOEo68eC0B7RSH06S0S3Os",
+            "y": "XTZ2iP3l4ILwl4VaDArcMF3Wz0b1DKdYWbskO3AklgU",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "a26d698e4613595aa61c8e2907d5241d6d14909737df59895841d07727bf1348",
+          "result": "valid"
+        },
+        {
+          "tcId": 424,
+          "comment": "point with coordinate y = 1 in left to right addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "6AfkPZbzcBqaXBPRInSQhBcPzTalhqRGyfy0YA7t5P0",
+            "y": "9NHSKvcYfI3huZKkBGxBm4Ac3lfWONMPLhrEk1MReiA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "a8edc6f9af6bf74122c11ca1a50afbc4a3c4987bd0d1f73284d2c1371e613405",
+          "result": "valid"
+        },
+        {
+          "tcId": 425,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "eYhopWkW00Hn1vljWa42WINuIhRZ9Pe3tjaU3hil6SQ",
+            "y": "dxP9sDqN6MbSnKOKn7qoLl4Cvq0vnuxptkRLetsFMzs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "17963de078996eb8503c7cc3e1a2d5147d7f0bfb251a020b4392033063587c8d",
+          "result": "valid"
+        },
+        {
+          "tcId": 426,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_0GZCdiozgqUFgUfTiViCMHcA1WBpTMS1WYTfiIQTpg",
+            "y": "d0IasB4A6DhBuUba5btaI5c9qpj-GoFyiDq8vtztcCE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "062799a19545d31b3ed72253bcde59762aa6104a88ac5e2fb68926b0f7146698",
+          "result": "valid"
+        },
+        {
+          "tcId": 427,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "i0gRnXCJ07lc0ur4yFWE-o9eVsTEzO5wN9dM2_iOVxc",
+            "y": "FMGqxfC_G0ikq88dkpG5qHdqAEOAVGpaHB8pRpD2GWk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9f42dd8fce13f8103b3b2bc15e61242e6820fe1325a20ef460fe64d9eb12b231",
+          "result": "valid"
+        },
+        {
+          "tcId": 428,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "4oiBGTebWyFRvXiFBd7x1r14YylDHK85cF2cv5akLqQ",
+            "y": "O7cyiDnSrsrGSxzbGC8IrcyqwyftAImHoQ7clzJBPO0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "d1b204e52d1fac6d504132c76ca233c87e377dcc79c893c970ddbb9f87b27fa0",
+          "result": "valid"
+        },
+        {
+          "tcId": 429,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "bcw5cb0gkT1ZqR8g2RL1bQfn8BQga-9KZT3f5dEoQsM",
+            "y": "m1Gxe3bqbME37r2TyBHmNtiuJscNBkZQ9yBahl0Bpu4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "c8d6bd28c1e65ae7c7a5debe67a7dfaf92b429ede368efc9da7d578a539b7054",
+          "result": "valid"
+        },
+        {
+          "tcId": 430,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "fr6kWFRWmh9-prlbgta-_vv2KW68h8gQtsupPAwSILI",
+            "y": "Pxh0-gimk7CGZD7yHrWddVYtqUItE9mjmwsX4kGwTTI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "0d1f905cc74720bde67ae84f582728588c75444c273dae4106fa20d1d6946430",
+          "result": "valid"
+        },
+        {
+          "tcId": 431,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "zqtZN5ANNPqIN403H0rKp8aiAothQyE0E_FrotxxR4c",
+            "y": "dxP9sDqN6MbSnKOKn7qoLl4Cvq0vnuxptkRLetsFMzs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "3f014e309192588fa83e47d4ac9685d2041204e2eaf633a1312812e51ae74cbd",
+          "result": "valid"
+        },
+        {
+          "tcId": 432,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "pP_qXiX3Xk9onIEISjXBIg6Oa5FMSC9KLo-Tz_ymlkc",
+            "y": "d0IasB4A6DhBuUba5btaI5c9qpj-GoFyiDq8vtztcCE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "68b404d556c82004c6c4bba4518ec00b1d4f1161cafe6c89aeb8494a9ba09db5",
+          "result": "valid"
+        },
+        {
+          "tcId": 433,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "3ogJ6g7M4dJKBDFClRA4Om9uWhxRzqMtgwxsNTBCYD4",
+            "y": "FMGqxfC_G0ikq88dkpG5qHdqAEOAVGpaHB8pRpD2GWk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "c331ade7a457df7f12a2f5c43d7ea9486c1563b81cd8a0f23f923c1a9fa612e3",
+          "result": "valid"
+        },
+        {
+          "tcId": 434,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "VmIJ8XTWv3lyC3Dtsn5RNQvusrC80IO7rnIU9xz4JNQ",
+            "y": "O7cyiDnSrsrGSxzbGC8IrcyqwyftAImHoQ7clzJBPO0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "17b5c7a311eea9d2ab7571f8b9f848d4705997cf3eaf9bdcbe0e34a670f81f45",
+          "result": "valid"
+        },
+        {
+          "tcId": 435,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "zDGBwBJxN1Ns7slP1FmWZX33Lg-XxEudrRR2POUG6dw",
+            "y": "m1Gxe3bqbME37r2TyBHmNtiuJscNBkZQ9yBahl0Bpu4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "2f0e4eccbc4518ace558e06604f9bff4787f5b019437b52195ecb6b82191a6ae",
+          "result": "valid"
+        },
+        {
+          "tcId": 436,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "1wUqHur8DnjXnn8mADqgpAkofPR2AH3yjSgbFCvhoOI",
+            "y": "Pxh0-gimk7CGZD7yHrWddVYtqUItE9mjmwsX4kGwTTI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "7494d864cb6ea9c5d982d40a5f103700d02dc982637753cfc7d8afe1beafff70",
+          "result": "valid"
+        },
+        {
+          "tcId": 437,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "t8w-Iwbb98OP8Xllhwb-_7Xv22BEx-cUNdf_fQrox7M",
+            "y": "dxP9sDqN6MbSnKOKn7qoLl4Cvq0vnuxptkRLetsFMzs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "a96873eef5d438b807853b6771c6a5197e6eef21efefca538b45e9e981c032e5",
+          "result": "valid"
+        },
+        {
+          "tcId": 438,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "W758mAFf06YDTXnYZ6Tc1S-VkRkyEp2i_ApYr-FJE38",
+            "y": "d0IasB4A6DhBuUba5btaI5c9qpj-GoFyiDq8vtztcCE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9124618913f20cdffa642207f192e67eb80ade53ac5535469abe90036d4af7e2",
+          "result": "valid"
+        },
+        {
+          "tcId": 439,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "li_keICpSnRZKOPEoppCywEzTx7pZG5iRRxG7NcvQQk",
+            "y": "FMGqxfC_G0ikq88dkpG5qHdqAEOAVGpaHB8pRpD2GWk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9d8b74888d942870b221de7a642032892bc99e34bd8550195f6f5f097547334a",
+          "result": "valid"
+        },
+        {
+          "tcId": 440,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "xxV09VON5WU8NxaNR6K89DaY6iYAEs0K4TBOR0xjpOY",
+            "y": "O7cyiDnSrsrGSxzbGC8IrcyqwyftAImHoQ7clzJBPO0",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "16983377c0f1a9c004495b3fd9658363116eea644787d059d1140fb907555d4a",
+          "result": "valid"
+        },
+        {
+          "tcId": 441,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "xgJEzjBuN285aBePUpN0LXog4dxHz8UX7a2p20nQy78",
+            "y": "m1Gxe3bqbME37r2TyBHmNtiuJscNBkZQ9yBahl0Bpu4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "081af40a81d48c6b530140db935e605bf4cc7b10885f5b148f95f1bc8ad2e52d",
+          "result": "valid"
+        },
+        {
+          "tcId": 442,
+          "comment": "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "qjwxiMCtV2epusd-fO6gXPrhWZzNd7n8vAw7rcgMNso",
+            "y": "Pxh0-gimk7CGZD7yHrWddVYtqUItE9mjmwsX4kGwTTI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "7e4b973e6d4a357c400243a648c8a0a6a35cf231754afdef312d2f4b6abb988f",
+          "result": "valid"
+        },
+        {
+          "tcId": 443,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "LM6N3-SCfcAw3fOPmYs_LtXgYh0LOAVmba9IyMMedeU",
+            "y": "GY2e9Olztr3r4RmjX6roYZGs11jB7YrMrx5watVdg9c",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "0f0235da2a06c8d408c27151f3f15342ed8c1945aaf84ed14993786d6ac5f570",
+          "result": "valid"
+        },
+        {
+          "tcId": 444,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "FL_D5aRraYgamjRtlYlEGGFO2RR2od3OSGdrfLq5ugI",
+            "y": "8zTWTyyvVhsGO8H3iJ6TcwKkVf9oXYrlfLJEShfa0Gg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "5622c2fbe8af5ad6cef72a01be186e554847576106f8979772fa56114d1160ab",
+          "result": "valid"
+        },
+        {
+          "tcId": 445,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "vUQvpaKo1y4T5E_SIiyFoAbwM3XgIRsnL1VQUrA9t1A",
+            "y": "vjRXN_fGtecOl9n-ncTKlPsYX0udKgDghsHUcnOzNgI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "bb95e0d0fbaad86c5bd87b95946c77ff1d65322a175ccf16419102c0a17f5a72",
+          "result": "valid"
+        },
+        {
+          "tcId": 446,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "DXo_9Jvaalh-0HaRRQQlqgLSU7pXOhathsYa9BLdPHc",
+            "y": "C207nlcLoASHfJpp5IH-IV3gOnASYwWkUoJuZtm1WD4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "4510683c7bfa251f0cb56bba7e0ab74d90f5e2ca01e91e7ca99312ccff2d90b6",
+          "result": "valid"
+        },
+        {
+          "tcId": 447,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "vepdKjrd598ug5_2P2JTSz8nyxkbtU36HTnL_3E7qe0",
+            "y": "MH2PHQLG8HFGZV5jg7DvMDW-5wZ8M2_bkTZeGXqXthY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "025485142ca1ced752289f772130fc10c75a4508c46bffdef9290ad3e7baf9ca",
+          "result": "valid"
+        },
+        {
+          "tcId": 448,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "1MBj48A29HyS9vVHCiaoNeGiRQWxTRspJ5BioWz29Ik",
+            "y": "GY2e9Olztr3r4RmjX6roYZGs11jB7YrMrx5watVdg9c",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "9067932150724965aa479c1ef1be55544bed9fa94500a3b67887ed91ae3b81e5",
+          "result": "valid"
+        },
+        {
+          "tcId": 449,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "PLnweZd1aFnpuahbaB-lDuIDV_U1wbMRxGN9Frdrnr8",
+            "y": "8zTWTyyvVhsGO8H3iJ6TcwKkVf9oXYrlfLJEShfa0Gg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "f8084a89adccdc3aef89e5091a0f07d6160a66cb9575241100c1d39bf0549ae2",
+          "result": "valid"
+        },
+        {
+          "tcId": 450,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "eTQS_2NsCKLQ9tYMxgjpqQmDSaJQH5HJX2kgELwSOLI",
+            "y": "vjRXN_fGtecOl9n-ncTKlPsYX0udKgDghsHUcnOzNgI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "4462558c89902117051cb2c599ad66f00887b54cae3da9c04d317a5b2afb463b",
+          "result": "valid"
+        },
+        {
+          "tcId": 451,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "vR6whJ4uahPVS3ZRjxG6h3XC12NNhRUlNLx8OvQWHvo",
+            "y": "C207nlcLoASHfJpp5IH-IV3gOnASYwWkUoJuZtm1WD4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "30b4741a64f87d28ec0029bd196b5a74555f2c9a976a46d628572474466a631d",
+          "result": "valid"
+        },
+        {
+          "tcId": 452,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Yks7S6mTqLk4ElaJ9s91c5LuOQ0UqQ_qbblEtajeuNA",
+            "y": "MH2PHQLG8HFGZV5jg7DvMDW-5wZ8M2_bkTZeGXqXthY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "3afc04ac92117e50b0913b09dbbb4e6c780c051500201fad512b79080bff39e2",
+          "result": "valid"
+        },
+        {
+          "tcId": 453,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_nEOPFtGjcM8KxcpXE4Ym0h9WN1Det9wasBUk8_qjfA",
+            "y": "GY2e9Olztr3r4RmjX6roYZGs11jB7YrMrx5watVdg9c",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "609637048586edc64cf5f28f1a505768c686471110070d783de499ffe6fe84da",
+          "result": "valid"
+        },
+        {
+          "tcId": 454,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "roZLoMQfLh37rCM3AlcW2LytzvZTnG8f8zUXa43ao24",
+            "y": "8zTWTyyvVhsGO8H3iJ6TcwKkVf9oXYrlfLJEShfa0Gg",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "b1d4f27a6983c8ee417ef0f527d889d4a1ae41d3639244578c43d650c299fcd1",
+          "result": "valid"
+        },
+        {
+          "tcId": 455,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "yYe9WvnrIC8bJNohF8qQtu-MgufPv1MPcUGPmpOwCFw",
+            "y": "vjRXN_fGtecOl9n-ncTKlPsYX0udKgDghsHUcnOzNgI",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "0007c9a27ac5067c9f0ad1a4d1e62110da1318893a658729713d82e333855b82",
+          "result": "valid"
+        },
+        {
+          "tcId": 456,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "NWcPhsX3K5Or5BMdK-ofzodq1OJbQNQtRH1oz_kMoL4",
+            "y": "C207nlcLoASHfJpp5IH-IV3gOnASYwWkUoJuZtm1WD4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "8a3b23a91f0d5db8074a6a886889ee3e19aaf09b66ac9aad2e15c8bdba68085c",
+          "result": "valid"
+        },
+        {
+          "tcId": 457,
+          "comment": "point with coordinate y = 1 in right to left addition chain",
+          "flags": [
+            "EdgeCaseDoubling"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "38pnihuOb2eZagl_yc43QS3p-9nPoaIbdQzvSOXllaE",
+            "y": "MH2PHQLG8HFGZV5jg7DvMDW-5wZ8M2_bkTZeGXqXthY",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "wXgdhsrCwFK4ZfIo5kvRzkM8eMp9_KnouBBHPizhfaU",
+            "x": "T1kiFy_kxAFvsDejK_kdoPg-hKY6OxSgxUkcmVytx10",
+            "y": "8Wl0jjcIwEUZ0KmUKYL8OuQJJFeGEBhRkr4kGK3K3F0",
+            "kid": "none"
+          },
+          "shared": "c2af763f414cb2d7fd46257f0313b582c099b5e23b73e073b5ab7c230c45c883",
+          "result": "valid"
+        },
+        {
+          "tcId": 458,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mr3ZeOtisfNppW0JSauFUaetUn2WAuiRzkV1hsKoVp4",
+            "y": "mB5n-uBTsD_DPhopHwo761j86y6FuxIF2s7hIy39MWs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM",
+            "x": "-TCKAZJYwxBJNE-F-J1SKbUxyEWDb5mwhgHxE7zgNvk",
+            "y": "OI97D2Mt6BQP4zfmKjfzVmUAqZk0wiMbbLn9dYS45nI",
+            "kid": "none"
+          },
+          "shared": "34005694e3cac09332aa42807e3afdc3b3b3bc7c7be887d1f98d76778c55cfd7",
+          "result": "valid"
+        },
+        {
+          "tcId": 459,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mr3ZeOtisfNppW0JSauFUaetUn2WAuiRzkV1hsKoVp4",
+            "y": "mB5n-uBTsD_DPhopHwo761j86y6FuxIF2s7hIy39MWs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "AAAAAP____________________________________8",
+            "x": "pJAKfBVOYR-__x6-BGEVzzH8fjtVOMAsrZQTQL9z14k",
+            "y": "NwDMVH5S6Ur1FHzunRDXdG0gZ9XbJRN3lzvW597oKr8",
+            "kid": "none"
+          },
+          "shared": "5841acd3cff2d62861bbe11084738006d68ccf35acae615ee9524726e93d0da5",
+          "result": "valid"
+        },
+        {
+          "tcId": 460,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mr3ZeOtisfNppW0JSauFUaetUn2WAuiRzkV1hsKoVp4",
+            "y": "mB5n-uBTsD_DPhopHwo761j86y6FuxIF2s7hIy39MWs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "x": "jCipe_gpi8DSPYx0lFKjLmlLZeMKlHKjlUqzD-UyTKo",
+            "y": "QKMEY6MwUZM3j-3zH3zA63rnhPBFHLlFnnHcc8vvlII",
+            "kid": "none"
+          },
+          "shared": "4348e4cba371ead03982018abc9aacecaebfd636dda82e609fd298947f907de8",
+          "result": "valid"
+        },
+        {
+          "tcId": 461,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mr3ZeOtisfNppW0JSauFUaetUn2WAuiRzkV1hsKoVp4",
+            "y": "mB5n-uBTsD_DPhopHwo761j86y6FuxIF2s7hIy39MWs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "f_________________________________________8",
+            "x": "Nw6_7UcxeBWf0Iw_e8B-EjAXkvvSUVVKgCmO_GZsZR0",
+            "y": "rQi3UWHFQuVQO3d2JcKWue-FRVdWun1YK8PACWXepKI",
+            "kid": "none"
+          },
+          "shared": "e56221c2b0dc33b98b90dfd3239a2c0cb1e4ad0399a3aaef3f9d47fb103daef0",
+          "result": "valid"
+        },
+        {
+          "tcId": 462,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mr3ZeOtisfNppW0JSauFUaetUn2WAuiRzkV1hsKoVp4",
+            "y": "mB5n-uBTsD_DPhopHwo761j86y6FuxIF2s7hIy39MWs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "x": "sjeQpCvmPhslGtbJT97wcnHsCq2jHbbD6L0yBD-L44Q",
+            "y": "_GtpSRnVXtvo1Q-IqoH5RRfwBPQUnstY0QpHPesZiA4",
+            "kid": "none"
+          },
+          "shared": "5b34a29b1c4ddcb2101162d34bed9f0702361fe5af505df315eff7befd0e4719",
+          "result": "valid"
+        },
+        {
+          "tcId": 463,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mr3ZeOtisfNppW0JSauFUaetUn2WAuiRzkV1hsKoVp4",
+            "y": "mB5n-uBTsD_DPhopHwo761j86y6FuxIF2s7hIy39MWs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "_____________________rqu3OavSKA6v9JejNA2QUE",
+            "x": "MyLUASQ8TiWCohR8EE1uy_d00WPbD15TE7fg50LQ5r0",
+            "y": "qRj4aBaZsQpAT-ZDsiUGSNf6CcFdeMUJ2wxdFZPXSY8",
+            "kid": "none"
+          },
+          "shared": "cece521b8b5a32bbee38936ba7d645824f238e561701a386fb888e010db54b2f",
+          "result": "valid"
+        },
+        {
+          "tcId": 464,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mr3ZeOtisfNppW0JSauFUaetUn2WAuiRzkV1hsKoVp4",
+            "y": "mB5n-uBTsD_DPhopHwo761j86y6FuxIF2s7hIy39MWs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "_____________________rqu3OavSKA7v8JejNA2QUE",
+            "x": "jnvNC9NZg6dxnMp3ZMqQZ3m1OgQ6m4vK7_lZ9DrYYEc",
+            "y": "70iI9NXCW0xr_O-981auuoYXcdG4ApdMFe_7gHufxQU",
+            "kid": "none"
+          },
+          "shared": "829521b79d71f5011e079756b851a0d5c83557866189a6258c1e78a1700c6904",
+          "result": "valid"
+        },
+        {
+          "tcId": 465,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mr3ZeOtisfNppW0JSauFUaetUn2WAuiRzkV1hsKoVp4",
+            "y": "mB5n-uBTsD_DPhopHwo761j86y6FuxIF2s7hIy39MWs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "_____________________rqu3OavSKA7v8pejNA2QUE",
+            "x": "j1BvC2wLbppXp_Ntlwyk40fLySFGInZCy-eB2fU2LTM",
+            "y": "uWBqotUFno5qzzq9sOPMl7cwbaK8RHFQz7eC8ngF1_A",
+            "kid": "none"
+          },
+          "shared": "8c5934793505a6a1f84d41283341680c4923f1f4d562989a11cc626fea5eda5a",
+          "result": "valid"
+        },
+        {
+          "tcId": 466,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mr3ZeOtisfNppW0JSauFUaetUn2WAuiRzkV1hsKoVp4",
+            "y": "mB5n-uBTsD_DPhopHwo761j86y6FuxIF2s7hIy39MWs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "_____________________rqu3OavSKA7v9Jei9A2QUE",
+            "x": "EA9E2mlucWcnkdCgm3veRZ8SFaKbPAO_79eDWzmkjbA",
+            "y": "MiYezm1f9IjRNwzP8_b5mUgAtecArmpT8EKjKNQ5oiY",
+            "kid": "none"
+          },
+          "shared": "356caee7e7eee031a15e54c3a5c4e72f9c74bb287ce601619ef85eb96c289452",
+          "result": "valid"
+        },
+        {
+          "tcId": 467,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mr3ZeOtisfNppW0JSauFUaetUn2WAuiRzkV1hsKoVp4",
+            "y": "mB5n-uBTsD_DPhopHwo761j86y6FuxIF2s7hIy39MWs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "_____________________rqu3OavSKA7v9JejNA2QMM",
+            "x": "bfe1p6EmphEuHgugGtGg-J8FXdPBx-UzaTitMsSUsxk",
+            "y": "YdpmS99n2spNbzC6zaUPS1fhBZS-tafBFPat9GfgHP0",
+            "kid": "none"
+          },
+          "shared": "09c7337df6c2b35edf3a21382511cc5add1a71a84cbf8d3396a5be548d92fa67",
+          "result": "valid"
+        },
+        {
+          "tcId": 468,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mr3ZeOtisfNppW0JSauFUaetUn2WAuiRzkV1hsKoVp4",
+            "y": "mB5n-uBTsD_DPhopHwo761j86y6FuxIF2s7hIy39MWs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "_____________________rqu3OavSKA7v9JejNA2QQM",
+            "x": "EIRDuUjRVTWEonEzP3-9BDxNZqkXBu3svwf2iUwE8pk",
+            "y": "sYSiVFywQwYPqq3yskc7YCn9fSzVIDWqpPu_wUan4ZA",
+            "kid": "none"
+          },
+          "shared": "d16caedd25793666f9e26f5331382106f54095b3d20d40c745b68ca76c0e6983",
+          "result": "valid"
+        },
+        {
+          "tcId": 469,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mr3ZeOtisfNppW0JSauFUaetUn2WAuiRzkV1hsKoVp4",
+            "y": "mB5n-uBTsD_DPhopHwo761j86y6FuxIF2s7hIy39MWs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "_____________________rqu3OavSKA7v9JejNA2QSM",
+            "x": "bSsIXp44LtELafwxGgP4ZBzP_yFXTeCSdROknZpoigA",
+            "y": "U0fRRsz2UuM4xiIFzJ-1fIidx1X0KgDbckU7hOgMczQ",
+            "kid": "none"
+          },
+          "shared": "b8ae1e21d8b34ce4caffed7167a26868ec80a7d4a6a98b639d4d05cd226504de",
+          "result": "valid"
+        },
+        {
+          "tcId": 470,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mr3ZeOtisfNppW0JSauFUaetUn2WAuiRzkV1hsKoVp4",
+            "y": "mB5n-uBTsD_DPhopHwo761j86y6FuxIF2s7hIy39MWs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "_____________________rqu3OavSKA7v9JejNA2QTM",
+            "x": "SZ_fnolecZz9ZOZ_B9OOMiaqe2NniUnm5JskGmDoI-Q",
+            "y": "NT0JO0qxeq5vD7sbWEwrm7m9hj2FwGpDOaC_KvxevNQ",
+            "kid": "none"
+          },
+          "shared": "02776315fe147a36a4b0987492b6503acdea60f926450e5eddb9f88fc82178d3",
+          "result": "valid"
+        },
+        {
+          "tcId": 471,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mr3ZeOtisfNppW0JSauFUaetUn2WAuiRzkV1hsKoVp4",
+            "y": "mB5n-uBTsD_DPhopHwo761j86y6FuxIF2s7hIy39MWs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "_____________________rqu3OavSKA7v9JejNA2QTs",
+            "x": "__l71XVe7qQgRToUNVI104L2Ry-FaKGLLwV6FGApdVY",
+            "y": "Ue2IhVMESd8MQWn-gLo6nyF_DwmucBtfw3jzyE-KCZg",
+            "kid": "none"
+          },
+          "shared": "3988c9c7050a28794934e5bd67629b556d97a4858d22812835f4a37dca351943",
+          "result": "valid"
+        },
+        {
+          "tcId": 472,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mr3ZeOtisfNppW0JSauFUaetUn2WAuiRzkV1hsKoVp4",
+            "y": "mB5n-uBTsD_DPhopHwo761j86y6FuxIF2s7hIy39MWs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "_____________________rqu3OavSKA7v9JejNA2QT4",
+            "x": "-TCKAZJYwxBJNE-F-J1SKbUxyEWDb5mwhgHxE7zgNvk",
+            "y": "x3CE8JzSF-vwHMgZ1cgMqZr_VmbLPdzkk0YCiXtHFb0",
+            "kid": "none"
+          },
+          "shared": "34005694e3cac09332aa42807e3afdc3b3b3bc7c7be887d1f98d76778c55cfd7",
+          "result": "valid"
+        },
+        {
+          "tcId": 473,
+          "comment": "edge case private key",
+          "flags": [
+            "AdditionChain"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "Mr3ZeOtisfNppW0JSauFUaetUn2WAuiRzkV1hsKoVp4",
+            "y": "mB5n-uBTsD_DPhopHwo761j86y6FuxIF2s7hIy39MWs",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "_____________________rqu3OavSKA7v9JejNA2QT8",
+            "x": "xgR_lEHtfW0wRUBulcB82Fx3jkuM7zynq6wJuVxwnuU",
+            "y": "5R6XAVnCPMZcOnvmuZMVEQgJzZrNmS8e3JvOVa8wFwU",
+            "kid": "none"
+          },
+          "shared": "4b52257d8b3ba387797fdf7a752f195ddc4f7d76263de61d0d52a5ec14a36cbf",
+          "result": "valid"
+        },
+        {
+          "tcId": 474,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "y": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "xsr7dOKlDIOz0jLEWFI39E1MVDPEs_UM6Xjmrto6T10",
+            "x": "WXjzLk1W8-x2M-bAMCcw5dpeJGoqVZVmqDUYzSwWnDA",
+            "y": "LmTWFQtxMTMb_OYxWBUOheh1YF6Mk6EI8vGaKvkvN6c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 475,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "y": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "xsr7dOKlDIOz0jLEWFI39E1MVDPEs_UM6Xjmrto6T10",
+            "x": "WXjzLk1W8-x2M-bAMCcw5dpeJGoqVZVmqDUYzSwWnDA",
+            "y": "LmTWFQtxMTMb_OYxWBUOheh1YF6Mk6EI8vGaKvkvN6c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 476,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "y": "_____________________________________v___C4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "xsr7dOKlDIOz0jLEWFI39E1MVDPEs_UM6Xjmrto6T10",
+            "x": "WXjzLk1W8-x2M-bAMCcw5dpeJGoqVZVmqDUYzSwWnDA",
+            "y": "LmTWFQtxMTMb_OYxWBUOheh1YF6Mk6EI8vGaKvkvN6c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 477,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "y": "_____________________________________v___C8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "xsr7dOKlDIOz0jLEWFI39E1MVDPEs_UM6Xjmrto6T10",
+            "x": "WXjzLk1W8-x2M-bAMCcw5dpeJGoqVZVmqDUYzSwWnDA",
+            "y": "LmTWFQtxMTMb_OYxWBUOheh1YF6Mk6EI8vGaKvkvN6c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 478,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+            "y": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "xsr7dOKlDIOz0jLEWFI39E1MVDPEs_UM6Xjmrto6T10",
+            "x": "WXjzLk1W8-x2M-bAMCcw5dpeJGoqVZVmqDUYzSwWnDA",
+            "y": "LmTWFQtxMTMb_OYxWBUOheh1YF6Mk6EI8vGaKvkvN6c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 479,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+            "y": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "xsr7dOKlDIOz0jLEWFI39E1MVDPEs_UM6Xjmrto6T10",
+            "x": "WXjzLk1W8-x2M-bAMCcw5dpeJGoqVZVmqDUYzSwWnDA",
+            "y": "LmTWFQtxMTMb_OYxWBUOheh1YF6Mk6EI8vGaKvkvN6c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 480,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+            "y": "_____________________________________v___C4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "xsr7dOKlDIOz0jLEWFI39E1MVDPEs_UM6Xjmrto6T10",
+            "x": "WXjzLk1W8-x2M-bAMCcw5dpeJGoqVZVmqDUYzSwWnDA",
+            "y": "LmTWFQtxMTMb_OYxWBUOheh1YF6Mk6EI8vGaKvkvN6c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 481,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+            "y": "_____________________________________v___C8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "xsr7dOKlDIOz0jLEWFI39E1MVDPEs_UM6Xjmrto6T10",
+            "x": "WXjzLk1W8-x2M-bAMCcw5dpeJGoqVZVmqDUYzSwWnDA",
+            "y": "LmTWFQtxMTMb_OYxWBUOheh1YF6Mk6EI8vGaKvkvN6c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 482,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_____________________________________v___C4",
+            "y": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "xsr7dOKlDIOz0jLEWFI39E1MVDPEs_UM6Xjmrto6T10",
+            "x": "WXjzLk1W8-x2M-bAMCcw5dpeJGoqVZVmqDUYzSwWnDA",
+            "y": "LmTWFQtxMTMb_OYxWBUOheh1YF6Mk6EI8vGaKvkvN6c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 483,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_____________________________________v___C4",
+            "y": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "xsr7dOKlDIOz0jLEWFI39E1MVDPEs_UM6Xjmrto6T10",
+            "x": "WXjzLk1W8-x2M-bAMCcw5dpeJGoqVZVmqDUYzSwWnDA",
+            "y": "LmTWFQtxMTMb_OYxWBUOheh1YF6Mk6EI8vGaKvkvN6c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 484,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_____________________________________v___C4",
+            "y": "_____________________________________v___C4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "xsr7dOKlDIOz0jLEWFI39E1MVDPEs_UM6Xjmrto6T10",
+            "x": "WXjzLk1W8-x2M-bAMCcw5dpeJGoqVZVmqDUYzSwWnDA",
+            "y": "LmTWFQtxMTMb_OYxWBUOheh1YF6Mk6EI8vGaKvkvN6c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 485,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_____________________________________v___C4",
+            "y": "_____________________________________v___C8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "xsr7dOKlDIOz0jLEWFI39E1MVDPEs_UM6Xjmrto6T10",
+            "x": "WXjzLk1W8-x2M-bAMCcw5dpeJGoqVZVmqDUYzSwWnDA",
+            "y": "LmTWFQtxMTMb_OYxWBUOheh1YF6Mk6EI8vGaKvkvN6c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 486,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_____________________________________v___C8",
+            "y": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "xsr7dOKlDIOz0jLEWFI39E1MVDPEs_UM6Xjmrto6T10",
+            "x": "WXjzLk1W8-x2M-bAMCcw5dpeJGoqVZVmqDUYzSwWnDA",
+            "y": "LmTWFQtxMTMb_OYxWBUOheh1YF6Mk6EI8vGaKvkvN6c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 487,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_____________________________________v___C8",
+            "y": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "xsr7dOKlDIOz0jLEWFI39E1MVDPEs_UM6Xjmrto6T10",
+            "x": "WXjzLk1W8-x2M-bAMCcw5dpeJGoqVZVmqDUYzSwWnDA",
+            "y": "LmTWFQtxMTMb_OYxWBUOheh1YF6Mk6EI8vGaKvkvN6c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 488,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_____________________________________v___C8",
+            "y": "_____________________________________v___C4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "xsr7dOKlDIOz0jLEWFI39E1MVDPEs_UM6Xjmrto6T10",
+            "x": "WXjzLk1W8-x2M-bAMCcw5dpeJGoqVZVmqDUYzSwWnDA",
+            "y": "LmTWFQtxMTMb_OYxWBUOheh1YF6Mk6EI8vGaKvkvN6c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 489,
+          "comment": "point is not on curve",
+          "flags": [
+            "InvalidCurveAttack"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "_____________________________________v___C8",
+            "y": "_____________________________________v___C8",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "xsr7dOKlDIOz0jLEWFI39E1MVDPEs_UM6Xjmrto6T10",
+            "x": "WXjzLk1W8-x2M-bAMCcw5dpeJGoqVZVmqDUYzSwWnDA",
+            "y": "LmTWFQtxMTMb_OYxWBUOheh1YF6Mk6EI8vGaKvkvN6c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 490,
+          "comment": "public key has invalid point of order 2 on secp256r1. The point of the public key is a valid on secp256k1.",
+          "flags": [
+            "WrongCurve"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "_____wAAAAEAAAAAAAAAAAAAAAD_______________8",
+            "y": "MtmODXfdDlQ3cOyZTAroN-e7NusdkQtYoUoqCNwYL4M",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "OyUSnzQQ7InMbcU5_XYBhzumq_cqbQI_GqkEF2VDDuY",
+            "x": "aIhcjAW8Rf7cnW7lalJlX8E_QDXJL22taiwkqt1Vl7A",
+            "y": "Tg0OyxYgsShy0PHK_uLjO3Ij7XLXd4RtTIVbKIZ8lVQ",
+            "kid": "none"
+          },
+          "shared": "1d3fc2b2e48b3e96c6323380fadb467825e69f5b9078a9e02173b477bc232cc1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 491,
+          "comment": "public point not on curve",
+          "flags": [
+            "ModifiedPublicPoint",
+            "InvalidPublic"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "ScJI7cZZ4YSCtxBXSKS5XTpGlSpbpy2g1wLcl6ZOmXk",
+            "y": "nYz_elxLkl5DYOziXM8wfXqacGMoa70W72TGX1RnV-Q",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "z-de52QZeqdzKlR4VWtHiJhCPSvA5ISm67NnSmA2pl0",
+            "x": "tQ40JEarfvpswtbKrZT5Pc9wsezCghgTT5indpCQbHA",
+            "y": "eCtq8YnoGsxN6V58f6lVsEdae0zSW8ax3bzWF3p3NCk",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 492,
+          "comment": "public point = (0,0)",
+          "flags": [
+            "ModifiedPublicPoint",
+            "InvalidPublic"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "y": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "z-de52QZeqdzKlR4VWtHiJhCPSvA5ISm67NnSmA2pl0",
+            "x": "tQ40JEarfvpswtbKrZT5Pc9wsezCghgTT5indpCQbHA",
+            "y": "eCtq8YnoGsxN6V58f6lVsEdae0zSW8ax3bzWF3p3NCk",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 493,
+          "comment": "using secp256r1",
+          "flags": [
+            "ModifiedGroup",
+            "InvalidPublic"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "y_ZgZZWj7lD5_OqieYwnQMglQFFrTlp9Nh_yTp3RU2Q",
+            "y": "5UCLLmefnVMQ0faJOzbOFrSlB1CRdfy1KupTt4FVazk",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "z-de52QZeqdzKlR4VWtHiJhCPSvA5ISm67NnSmA2pl0",
+            "x": "tQ40JEarfvpswtbKrZT5Pc9wsezCghgTT5indpCQbHA",
+            "y": "eCtq8YnoGsxN6V58f6lVsEdae0zSW8ax3bzWF3p3NCk",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 494,
+          "comment": "Public key uses wrong curve: secp256r1",
+          "flags": [
+            "WrongCurve"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "BjcoUlhAN3Iqf5v6rVZhrLYjFi1F9wpVLGF_QIDoc6o",
+            "y": "Q2CSdd_23KqhIqdF0PFUaB-cdyaGe0PnUjt_WrXqlj4",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "2vogng-BEZpK-j8bxG4veUc1TjcnxgiwXElQsQOGZDo",
+            "x": "eWx5IWNXTk94H28EIIraU7gCUaxE1Pgcm4_iNpoCB6w",
+            "y": "IaQvFiWjt8RdTus17eL1jkDwIA1JruExim_e7kseq_c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 495,
+          "comment": "Public key uses wrong curve: secp384r1",
+          "flags": [
+            "WrongCurve"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-384",
+            "x": "DvWARzHZGPA3UG7gC4YCuHfH1Qn_osCEeobnotNYunyYHCp0siQBrGFTB6besnVA",
+            "y": "L6bIIYwzdPipF1LS7_a9FK2MrlltLzfa6K7sCFdg7fT9qafPcCU4mKVBg0aQcqVh",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "2vogng-BEZpK-j8bxG4veUc1TjcnxgiwXElQsQOGZDo",
+            "x": "eWx5IWNXTk94H28EIIraU7gCUaxE1Pgcm4_iNpoCB6w",
+            "y": "IaQvFiWjt8RdTus17eL1jkDwIA1JruExim_e7kseq_c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 496,
+          "comment": "Public key uses wrong curve: secp521r1",
+          "flags": [
+            "WrongCurve"
+          ],
+          "public": {
+            "kty": "EC",
+            "crv": "P-521",
+            "x": "AJIdpXEQ2ybHg4pp1XT8mFiMXAenkss3n0ZmTMdzweH2-hYUhmd0jt4jLRofHOp_FSxdWGFyrL6qSEFry9cLsn8P",
+            "y": "AbRHfhrnS_TwkxhKnybxA3Esz2zrRaBQWxkWBtiX7a-HKzfw-QqTMACoD8MgcEgyPBaIOj1nqQqni8ycXljXhLm5",
+            "kid": "none"
+          },
+          "private": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "d": "2vogng-BEZpK-j8bxG4veUc1TjcnxgiwXElQsQOGZDo",
+            "x": "eWx5IWNXTk94H28EIIraU7gCUaxE1Pgcm4_iNpoCB6w",
+            "y": "IaQvFiWjt8RdTus17eL1jkDwIA1JruExim_e7kseq_c",
+            "kid": "none"
+          },
+          "shared": "",
+          "result": "invalid"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/ecc/wycheproof_test.py
+++ b/tests/ecc/wycheproof_test.py
@@ -74,6 +74,7 @@ so it runs once.
 
 from __future__ import annotations
 
+import base64
 from collections.abc import Callable
 from hashlib import sha3_256, sha3_512, sha256, sha512, shake_128, shake_256
 from io import BytesIO
@@ -101,6 +102,7 @@ _ECDSA_SHA512_P1363 = "ecdsa_secp256k1_sha512_p1363_test.json"
 _ECDSA_SHAKE128_P1363 = "ecdsa_secp256k1_shake128_p1363_test.json"
 _ECDSA_SHAKE256_P1363 = "ecdsa_secp256k1_shake256_p1363_test.json"
 _ECDH = "ecdh_secp256k1_test.json"
+_ECDH_WEBCRYPTO = "ecdh_secp256k1_webcrypto_test.json"
 
 # the DER tags the SubjectPublicKeyInfo below is made of
 _SEQUENCE = 0x30
@@ -197,6 +199,35 @@ def _point_from_spki(der: bytes) -> Point:
     if not key or key[0]:
         raise BTClibValueError("invalid unused bit count")
     return point_from_octets(key[1:], secp256k1)
+
+
+def _b64url(field: str) -> bytes:
+    """Decode one JWK field: base64url with the padding RFC 7517 omits.
+
+    `base64.urlsafe_b64decode` still asks for it, so it is put back here
+    rather than the call being told to tolerate its absence.
+    """
+    return base64.urlsafe_b64decode(field + "=" * (-len(field) % 4))
+
+
+def _point_from_jwk(jwk: dict[str, Any]) -> Point:
+    """Return the secp256k1 point a JWK EC public key carries.
+
+    Wycheproof's webcrypto file hands an ECDH public key JWK-encoded
+    (RFC 7517), where `_point_from_spki` above reads the same agreement's
+    X.509 form. `crv` is checked before `x` and `y` are decoded at all,
+    for the same reason `_point_from_spki` reads the curve OID before the
+    coordinates: `WrongCurve` cases carry a `crv` other than `P-256K`,
+    some of them at a coordinate width secp256k1 itself uses, so refusing
+    on the identifier is what makes the refusal about the curve the
+    attacker actually changed rather than a coincidence of size or of
+    the coordinates.
+    """
+    if jwk.get("kty") != "EC" or jwk.get("crv") != "P-256K":
+        raise BTClibValueError("not a secp256k1 EC JWK")
+    x = _b64url(jwk["x"])
+    y = _b64url(jwk["y"])
+    return point_from_octets(b"\x04" + x + y, secp256k1)
 
 
 def _digest(hf: HashF, data: bytes) -> bytes:
@@ -554,6 +585,50 @@ def test_ecdh(
     prv_key = int(vector["private"], 16)
     try:
         pub_key = _point_from_spki(bytes.fromhex(vector["public"]))
+        shared_key = dh.diffie_hellman(prv_key, pub_key, _KEY_SIZE)
+    except (BTClibValueError, BTClibRuntimeError):
+        assert vector["result"] != "valid"
+        return
+
+    assert vector["result"] != "invalid"
+    shared = bytes.fromhex(vector["shared"])
+    assert mult(prv_key, pub_key, secp256k1)[0] == int.from_bytes(
+        shared, byteorder="big"
+    )
+    assert shared_key == kdf.ansi_x9_63_kdf(shared, _KEY_SIZE, sha256, None)
+
+
+@pytest.mark.parametrize(
+    "vector, bindings",
+    [
+        pytest.param(
+            test, bindings, id=_vector_id("ecdh-webcrypto", test, bindings=bindings)
+        )
+        for group in load("ecc", "_data", _ECDH_WEBCRYPTO)["testGroups"]
+        for test in group["tests"]
+        # sha256, for the reason given at test_ecdh's own parametrization
+        for bindings in _paths(sha256)
+    ],
+)
+def test_ecdh_webcrypto(
+    vector: dict[str, Any], bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Agree on a shared key from JWK-encoded keys, or refuse the public one.
+
+    The webcrypto file's cases are `test_ecdh`'s own file (`_ECDH`)
+    re-encoded rather than a second set of agreements --
+    `tests/_data/README.md` is where the two were measured to share their
+    valid cases' shared secrets. What differs is the encoding, so
+    `_point_from_jwk` stands in for `_point_from_spki` and the private
+    key comes from the JWK `d` field rather than from a hex string; the
+    assertions below are `test_ecdh`'s own.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    prv_key = int.from_bytes(_b64url(vector["private"]["d"]), byteorder="big")
+    try:
+        pub_key = _point_from_jwk(vector["public"])
         shared_key = dh.diffie_hellman(prv_key, pub_key, _KEY_SIZE)
     except (BTClibValueError, BTClibRuntimeError):
         assert vector["result"] != "valid"


### PR DESCRIPTION
Closes #1332

C2SP/wycheproof publishes ecdh_secp256k1_webcrypto_test.json alongside
the ecdh_secp256k1_test.json this tree already vendors -- the JWK
variant had never been pulled in.

Vendors it at the pin every other wycheproof file here uses
(5722833ca004), verified byte-identical to upstream. Adds
test_ecdh_webcrypto to tests/ecc/wycheproof_test.py, parametrized the
same way as the existing test_ecdh, with a _point_from_jwk helper that
checks the JWK's crv field before decoding coordinates (four
WrongCurve cases in the file specifically exercise this) and a
_b64url padding-restoring decoder for the base64url-encoded fields.

Local review: CLEARED 05d0afc3 (rebased once, cleanly, onto origin/main
after #1270 landed; range-diff confirms the patch is unchanged, base
only).

Gates: pytest (30696 passed, 11 skipped, 100% coverage), pre-commit run
--all-files, sphinx-build -W --keep-going -- all exit 0.

## Summary by Sourcery

Extend Wycheproof ECDH coverage to include the vendored JWK-encoded secp256k1 test vectors.

New Features:
- Add Wycheproof's JWK-encoded secp256k1 ECDH vectors and exercise them in the ECC test suite.

Enhancements:
- Validate EC JWK curve metadata and decode its base64url-encoded key fields during ECDH vector testing.

Documentation:
- Document the vendored JWK ECDH vector source, revision, and provenance.

Tests:
- Add parametrized coverage for valid and invalid JWK-encoded secp256k1 ECDH cases.