### PR TITLE
btclib's HWI wrapper gains register_descriptor, and INVALID_POLICY joins its error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1923,6 +1923,31 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **`HwiSigner.register_descriptor` wraps HWI's `registerdescriptor`**
+  (closes #1331). It sends a checksummed, ranged descriptor and a name,
+  and returns the registration HWI answers with -- an HMAC on a Ledger,
+  nothing at all on a device that needs none -- for a caller to persist
+  and pass back as `--registration` on a later `displayaddress`.
+  Policy-mode `displayaddress` -- `--registration`, `--index`,
+  `--multipath-index`/`--change` -- stays unwrapped: what
+  `psbt_signer`'s own `display_address` does is compare a device's
+  screen with the address a `Descriptor` computes, and a BIP388 policy's
+  address is not one this library computes yet, so wiring those flags
+  through would leave nothing to check the device's answer against.
+  `tests/_data/README.md`'s `hwilib/_cli.py` pin moves to the commit
+  that added both.
+
+- **`HWI_ERROR_CODES` carries `INVALID_POLICY` (-19)**, HWI's own code
+  for a descriptor `registerdescriptor` refuses (closes #1335). It
+  reaches a caller the way every other code does, as a `SignerError`
+  carrying the number, with nothing added to `hwi.py` for it: `_run`
+  reads `{"error": …, "code": …}` uniformly, and `register_descriptor`
+  is where a caller meets this one in practice. `tests/_data/README.md`'s
+  `hwilib/errors.py` pin stays where it is, on the rule
+  `pyproject.toml`'s `UNKNWON_DEVICE_TYPE` comment states, so the table
+  in `tests/hwi_test.py` is ahead of that pin by this one code until a
+  full re-check reconciles both.
+
 - **The messages by which a peer says what it wants sent to it**:
   `btclib.p2p.negotiation` carries `getaddr`, `mempool`, `sendheaders`,
   `wtxidrelay` and `feefilter` (issue #1119). `getaddr` wants addresses,

--- a/src/btclib/hwi.py
+++ b/src/btclib/hwi.py
@@ -653,8 +653,10 @@ class HwiSigner:
         module does not wrap: there is nothing here to compare it against.
         `psbt_signer.display_address` checks a device's screen against the
         address a `Descriptor` computes, and a BIP388 policy's address is
-        not one this library computes -- issue #187 is the fragment
-        parsing that would let it, registration is not that.
+        not one this library computes: `descriptors` reads the fragments
+        a policy template may hold (issue #187) without building the
+        template or deriving its address, which registration does not
+        change.
 
         The descriptor goes out ranged, whole rather than at one index:
         registration is of the policy, and `displayaddress --index` is

--- a/src/btclib/hwi.py
+++ b/src/btclib/hwi.py
@@ -9,8 +9,10 @@ https://github.com/bitcoin-core/HWI
 HWI speaks to Trezor, Ledger, KeepKey, Digital Bitbox, Coldcard, BitBox02
 and Jade over HID, USB, serial and emulator transports, and publishes a
 JSON command line so that other software need not. This module is that
-other software: it runs `hwi` as a subprocess and turns five of its
-commands into the contract `btclib.psbt_signer` defines.
+other software: it runs `hwi` as a subprocess. Five of its commands
+answer the contract `btclib.psbt_signer` defines; a sixth,
+`registerdescriptor`, is wrapped beside them with no protocol of its own
+to answer -- registering a policy is not a question `psbt_signer` asks.
 
 **Nothing is imported from hwilib, and nothing has to be installed for
 btclib to work.** HWI declares `hidapi`, `libusb1`, `cbor2`, `pyserial`,
@@ -61,29 +63,29 @@ when a caller deciding what to offer at all has to have the answer: a
 refusal is the right answer to a question that was asked, and the wrong
 way to find out there was nothing to ask.
 
-## Wallet policies, and the multisig this cannot register
+## Wallet policies, and the address this still cannot verify
 
 A Ledger will not display or sign a multisig it has not been shown
 first. BIP388 wallet policies are how it is shown, and registration is a
 one-time exchange ending in an HMAC the host keeps and replays on every
-later call. `hwilib`'s ledger driver does that; `hwilib/_cli.py` does
-not expose it, so this module cannot -- issue #381 delegates policy
-registration to HWI on purpose, and the command line is where the
-delegation stops. A caller with a Ledger multisig registers it out of
-band, with HWI's Python API or Ledger's own tooling, and then this
-module signs for it: the psbt path needs no policy, only the
-registration does.
+later call. `hwilib/_cli.py` exposes `registerdescriptor` for that
+exchange, and `HwiSigner.register_descriptor` wraps it the way `getxpub`
+and `signmessage` are wrapped: one request, one opaque answer, nothing
+here to check it against.
 
-Whether btclib could grow it rather than route around it is one fact,
-and it is not about the transport. A policy is a descriptor *template* --
-`wsh(sortedmulti(2,@0/**,@1/**))` -- with the keys lifted out into a
-vector beside it, which is a rewriting of what `descriptors` already
-builds: the fragments a template may hold are BIP388's fixed set plus
-miniscript inside `wsh()` in Ledger's app, and both halves of that are
-read here now (issue #187). So the locking script with an `OP_IF` branch
-and a `CHECKSEQUENCEVERIFY` in it that asked the question is expressible,
-and what stands between a caller and a registered policy is the template
-rewriting rather than the language or the transport.
+`displayaddress`'s BIP388 policy mode -- `--registration`, `--index`,
+`--multipath-index` -- is not wrapped. `psbt_signer.display_address`
+exists to compare a device's screen with the address a `Descriptor`
+computes, and a BIP388 policy's address is not one this library
+computes: `descriptors` reads the fragments a policy template may hold
+(issue #187) without building the template or deriving its address.
+Wiring those flags through with nothing to compare the device's answer
+against is the one thing `display_address`'s own docstring warns
+against -- "a caller that shows the user its own answer instead has
+checked nothing" -- so it stays out until that comparison exists. A
+caller with a registered policy still reads the address off the
+device's own screen; that is what the screen is for, whether or not
+this module checks it too.
 
 Staying aligned with a project this does not import is two things, and
 neither is a copy of it. `tests/hwi_test.py` writes out the surface used
@@ -453,7 +455,8 @@ class HwiSigner:
     is checked by the functions of that module -- `request_signatures`,
     `display_address`, `sign_message` -- and not here: this is the
     transport, and a transport that also decided what to trust would be
-    two things.
+    two things. `register_descriptor` is a sixth command with no protocol
+    of its own; the module docstring's "Wallet policies" says why.
 
     The fingerprint is what a device is named by. Passing one selects it;
     passing none enumerates and refuses unless exactly one device is
@@ -638,6 +641,31 @@ class HwiSigner:
         """
         text = add_checksum(str(at_index(descriptor, index)))
         return self._answer(["displayaddress", "--desc", text], "address")
+
+    def register_descriptor(self, name: str, descriptor: Descriptor) -> str:
+        """Register a wallet policy with the device: HWI's `registerdescriptor`.
+
+        A Ledger will not display or sign a multisig it has not been shown
+        first (module docstring, "Wallet policies"); this is that showing.
+        What comes back is opaque -- an HMAC on Ledger, nothing at all on a
+        device that needs none -- and is the caller's to persist and pass
+        back as `--registration` on a later `displayaddress`, which this
+        module does not wrap: there is nothing here to compare it against.
+        `psbt_signer.display_address` checks a device's screen against the
+        address a `Descriptor` computes, and a BIP388 policy's address is
+        not one this library computes -- issue #187 is the fragment
+        parsing that would let it, registration is not that.
+
+        The descriptor goes out ranged, whole rather than at one index:
+        registration is of the policy, and `displayaddress --index` is
+        what later asks for one address of it.
+
+        Checksummed, which is what HWI's parser requires of anything it is
+        given, `--desc` included.
+        """
+        assert_type(name, str, "name")
+        text = add_checksum(str(descriptor))
+        return self._answer(["registerdescriptor", name, text], "registration")
 
     @property
     def capabilities(self) -> SignerCapabilities:

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -1235,28 +1235,38 @@ transcription it is checked against.
 ```text
 repo    bitcoin-core/HWI
 path    hwilib/_cli.py
-commit  27c1b4272a137af1dfd6f4fd12db2cc9143e0b16  2024-03-30
-pulled  2026-08-07
+commit  d8b0d995e6ac23d39372b893266f2b59adc7354b  2026-08-21
+pulled  2026-08-25
 behind  0 revisions; that commit is the tip of the path
 ```
 
 Verdict: **transcribed**, and a subset by design. `tests/hwi_test.py`
-holds the five commands `btclib.hwi` runs — `enumerate`, `getxpub`,
-`signtx`, `signmessage`, `displayaddress` — with the positional arguments
-of each, the three global flags it passes (`--chain`, `--fingerprint`,
-`--emulators`), the `--desc` of `displayaddress`, the four chains
-`--chain` takes, and the keys read out of each answer. The other eleven
-commands are the device lifecycle — setup, wipe, restore, backup, the PIN
-and passphrase flows — which issue #381 keeps out of the signing surface
-deliberately, and `getdescriptors`, `getkeypool` and `getmasterxpub`,
-which btclib computes for itself: `descriptors.account_descriptors` and
+holds the six commands `btclib.hwi` runs — `enumerate`, `getxpub`,
+`signtx`, `signmessage`, `displayaddress`, `registerdescriptor` — with
+the positional arguments of each, the three global flags it passes
+(`--chain`, `--fingerprint`, `--emulators`), the `--desc` of
+`displayaddress`, the four chains `--chain` takes, and the keys read out
+of each answer. The other eleven commands are the device lifecycle —
+setup, wipe, restore, backup, the PIN and passphrase flows — which
+issue #381 keeps out of the signing surface deliberately, and
+`getdescriptors`, `getkeypool` and `getmasterxpub`, which btclib
+computes for itself: `descriptors.account_descriptors` and
 `btclib.core_import` are those three, on btclib's own types.
 
-The parser has moved twice since 2021 and both times additively:
-`--emulators` in 2024 (the pin), `--chain` and `--expert` on enumerate in
-2022. `signtx` gained a second answer key, `signed`, in 2021 — which is
-how this pin earned itself: btclib read only `psbt` until the surface was
-written down, and now checks the two against each other.
+Not transcribed on purpose: `displayaddress`'s BIP388 policy arguments,
+`--registration`, `--index` and `--multipath-index`/`--change`, added in
+this pin alongside `registerdescriptor` itself. `btclib.hwi`'s module
+docstring, "Wallet policies, and the address this still cannot verify",
+is why — there is nothing yet in this library to check the address a
+policy-mode `displayaddress` would answer against.
+
+The parser has moved four times since 2021 and every time additively:
+`--emulators` in 2024, `--chain` and `--expert` on enumerate in 2022,
+`registerdescriptor` in 2026-08, and the BIP388 policy arguments on
+`displayaddress` in 2026-08 (the pin). `signtx` gained a second answer
+key, `signed`, in 2021 — which is how this pin earned itself: btclib
+read only `psbt` until the surface was written down, and now checks the
+two against each other.
 
 ### Not vendored as a file: HWI's error codes
 
@@ -1268,13 +1278,18 @@ pulled  2026-08-07
 behind  0 revisions; that commit is the tip of the path
 ```
 
-Verdict: **transcribed**, complete: all eighteen numbers with the names
-HWI gives them, in `tests/hwi_test.py`, and one test per number that a
-`{"error": …, "code": …}` answer arrives as an `exceptions.SignerError`
-carrying it. The numbers are what a caller acts on — -14 is somebody
-pressing the button that says no, -3 is a cable, -9 is a model that will
-never do it — so an adapter that dropped them would leave a caller
-matching on the text of a message.
+Verdict: **transcribed**, and ahead of this pin by one: `INVALID_POLICY`
+(-19), which upstream added after the commit above, is in
+`tests/hwi_test.py`'s table too — issue #1335 added it without moving
+the pin, on the rule `pyproject.toml`'s `UNKNWON_DEVICE_TYPE` comment
+states, so the two move apart on purpose until a full re-check reconciles
+both at once. Nineteen numbers with the names HWI gives them, in
+`tests/hwi_test.py`, and one test per number that a `{"error": …, "code":
+…}` answer arrives as an `exceptions.SignerError` carrying it. The
+numbers are what a caller acts on — -14 is somebody pressing the button
+that says no, -3 is a cable, -9 is a model that will never do it — so an
+adapter that dropped them would leave a caller matching on the text of a
+message.
 
 The last change to the values was in 2019, and the file has not been
 touched since a docstring pass in 2021: of everything btclib depends on

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -1291,10 +1291,6 @@ that says no, -3 is a cable, -9 is a model that will never do it — so an
 adapter that dropped them would leave a caller matching on the text of a
 message.
 
-The last change to the values was in 2019, and the file has not been
-touched since a docstring pass in 2021: of everything btclib depends on
-here, this is the stillest.
-
 ## bitcoin-core/qa-assets
 
 ### `tests/script/_data/script_assets_test.json`

--- a/tests/hwi_test.py
+++ b/tests/hwi_test.py
@@ -43,7 +43,7 @@ import pytest
 
 from btclib.bip32 import fingerprint
 from btclib.bip32.bip32 import derive, xpub_from_xprv
-from btclib.descriptors import Descriptor, at_index, parse
+from btclib.descriptors import Descriptor, add_checksum, at_index, parse
 from btclib.exceptions import BTClibValueError, SignerError, SignerNotFoundError
 from btclib.hwi import (
     _HWI_CHAIN,
@@ -109,6 +109,8 @@ elif command == "displayaddress":
     from btclib.descriptors import parse
     descriptor = parse(args[args.index("--desc") + 1])
     print(json.dumps({{"address": signer.display_address(descriptor)}}))
+elif command == "registerdescriptor":
+    print(json.dumps({{"registration": "deadbeef"}}))
 else:
     print(json.dumps({{"error": "unknown command " + command, "code": -13}}))
 """
@@ -131,6 +133,7 @@ HWI_COMMANDS = {
     "signtx": ("psbt",),
     "signmessage": ("message", "path"),
     "displayaddress": (),
+    "registerdescriptor": ("name", "descriptor"),
 }
 
 # the global flags, which HWI's parser takes before the command, and the
@@ -145,6 +148,7 @@ HWI_ANSWER_KEYS = {
     "signtx": ("psbt", "signed"),
     "signmessage": ("signature",),
     "displayaddress": ("address",),
+    "registerdescriptor": ("registration",),
 }
 
 # the chains `--chain` takes, which is what decides the version bytes of
@@ -172,6 +176,7 @@ HWI_ERROR_CODES = {
     -16: "NEED_TO_BE_ROOT",
     -17: "HELP_TEXT",
     -18: "DEVICE_NOT_INITIALIZED",
+    -19: "INVALID_POLICY",
 }
 
 
@@ -402,6 +407,46 @@ def test_an_address_is_asked_for_at_the_index_it_is_wanted(tmp_path: Path) -> No
     )
     with pytest.raises(BTClibValueError, match="the signer displayed"):
         display_address(lying, receive, 5)
+
+
+def test_a_descriptor_is_registered_and_the_receipt_is_opaque(tmp_path: Path) -> None:
+    """`registerdescriptor` is the one command with nothing to check the answer.
+
+    What comes back is HWI's own receipt of an exchange this module has
+    no opinion about -- an HMAC on a Ledger, nothing at all on a device
+    that needs none -- so `register_descriptor` reads it the way
+    `getxpub` reads an xpub: one field, taken as answered.
+    """
+    hwi = stand_in(tmp_path, {"registerdescriptor": {"registration": "cafe"}})
+    device = signer(hwi)
+    ranged = export_account(device, "m/84h/0h/0h")[0]
+
+    assert device.register_descriptor("my wallet", ranged) == "cafe"
+    # sent whole, ranged rather than at one index: registration is of the
+    # policy, and displayaddress --index is what later asks for one
+    # address of it
+    argv = last_argv(hwi)
+    assert argv[argv.index("registerdescriptor") + 1 :] == [
+        "my wallet",
+        add_checksum(str(ranged)),
+    ]
+
+    wrong = signer(stand_in(tmp_path, {"registerdescriptor": {"not-a": "key"}}))
+    with pytest.raises(SignerError, match="did not answer a registration"):
+        wrong.register_descriptor("my wallet", ranged)
+
+    # the device refused the policy itself, HWI's own INVALID_POLICY
+    invalid = signer(
+        stand_in(
+            tmp_path,
+            {"registerdescriptor": {"error": "Invalid policy", "code": -19}},
+        )
+    )
+    with pytest.raises(
+        SignerError, match=r"Invalid policy \(signer error code -19\)"
+    ) as e:
+        invalid.register_descriptor("my wallet", ranged)
+    assert e.value.code == -19
 
 
 def test_a_message_signature_is_verified_against_the_address(hwi: list[str]) -> None:
@@ -640,7 +685,7 @@ def test_whether_the_command_line_is_there_is_asked_before_it_is_run(
 
 
 def test_btclib_runs_the_commands_hwi_publishes(tmp_path: Path) -> None:
-    """Every command sent is one of the five, spelled as HWI takes it.
+    """Every command sent is one of the six, spelled as HWI takes it.
 
     The argv is read back from what crossed the process boundary, so what
     is compared with the table is what a device would have received: the
@@ -660,6 +705,8 @@ def test_btclib_runs_the_commands_hwi_publishes(tmp_path: Path) -> None:
     ran["signmessage"] = last_argv(hwi)
     device.display_address(receive, 0)
     ran["displayaddress"] = last_argv(hwi)
+    device.register_descriptor("wallet", receive)
+    ran["registerdescriptor"] = last_argv(hwi)
 
     for command, argv in ran.items():
         assert command in HWI_COMMANDS
@@ -746,7 +793,7 @@ def test_signtx_answers_a_psbt_and_whether_it_signed(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("code", sorted(HWI_ERROR_CODES))
 def test_every_error_code_arrives_with_its_number(tmp_path: Path, code: int) -> None:
-    """All eighteen, because the number is what a caller acts on.
+    """All nineteen, because the number is what a caller acts on.
 
     -14 is somebody pressing the button that says no and is not worth a
     retry, -3 is a cable and is worth one, -9 says this model will never


### PR DESCRIPTION
HWI gained a registerdescriptor command and BIP388 policy-registration
args on displayaddress since btclib's HWI wrapper was written, plus a
new INVALID_POLICY error code.

HwiSigner.register_descriptor(name, descriptor) wraps registerdescriptor
the same way getxpub/signmessage are already wrapped: checksummed,
ranged descriptor + name out, opaque registration field back.
displayaddress's BIP388 policy args are deliberately not wrapped:
psbt_signer.display_address exists to compare a device's screen against
an address btclib itself computes from a Descriptor, and btclib has no
way to build/derive an address from a BIP388 policy template yet
(issue #187 only parses the fragments) -- wiring the flags through with
nothing to check the answer against would contradict that module's own
principle. Confirmed against hwilib's own source that its driver does
the @N template rewriting internally, so registerdescriptor itself needs
no template handling here.

HWI_ERROR_CODES gains -19: "INVALID_POLICY"; the count claim its
docstring makes is checked by the existing parametrized test. No change
to hwi.py's own error surfacing -- the existing generic {"error",
"code"} handling reaches a caller for any code, including this one.

Local review: CLEARED a960ef3325e486605f95da38d954ef7294fe5667 (round 2,
after dropping a sentence the diff's own addition had made false in
tests/_data/README.md, and clarifying that issue #187, cited as the
reason displayaddress's policy mode stays unwrapped, is closed --
fragment reading is done, building/deriving the address is the
remaining gap, now tracked by #1339).

Closes #1331, closes #1335.

Gates: pytest (30698 passed, 11 skipped, 100% coverage), pre-commit run
--all-files, sphinx-build -W --keep-going -- all exit 0.

## Summary by Sourcery

Extend the HWI wrapper with descriptor registration while preserving the existing address-verification boundary for BIP388 policy mode.

New Features:
- Add `HwiSigner.register_descriptor` support for registering ranged descriptors through HWI and returning the device’s registration response.

Enhancements:
- Expose HWI’s `INVALID_POLICY` error code (-19) through the existing signer error handling.

Documentation:
- Document descriptor registration, the new error code, and why BIP388 policy-mode `displayaddress` arguments remain unsupported.

Tests:
- Extend HWI command and error-code coverage with registration behavior, opaque responses, invalid-policy errors, and descriptor argument validation.