### PR TITLE
SECURITY.md's file:line citations name their line again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1921,6 +1921,17 @@ documented at release-notes length in the first place, and are still in
   what the siblings answer is btclib-org/.github#26's subject, and each
   of their copies of this file now says so where it is read.
 
+- **`SECURITY.md`'s three drifted `file.py:LINE` citations name the
+  line they describe again.** `src/btclib/ecc/musig2.py:812` pointed at
+  a comment line above `sign`'s own `s = ...` line, which is at `:813`;
+  `src/btclib/bip32/bip32.py:624` pointed at a `CKDpriv` docstring
+  paragraph rather than `bip32.derive`'s buffer read, at `:666`; and
+  `src/btclib/script/taproot.py:429` pointed at a blank line before
+  `output_prvkey` rather than `_tweaked_prvkey`'s own definition, at
+  `:442`. A full read of the file's other three citations —
+  `commit_nonce.py:145`, `ellswift.py:346`, `dsa.py:1346` — found each
+  still landing inside the function named beside it (closes #1329).
+
 ### The public API and the module layout
 
 - **`HwiSigner.register_descriptor` wraps HWI's `registerdescriptor`**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1921,16 +1921,21 @@ documented at release-notes length in the first place, and are still in
   what the siblings answer is btclib-org/.github#26's subject, and each
   of their copies of this file now says so where it is read.
 
-- **`SECURITY.md`'s three drifted `file.py:LINE` citations name the
-  line they describe again.** `src/btclib/ecc/musig2.py:812` pointed at
-  a comment line above `sign`'s own `s = ...` line, which is at `:813`;
-  `src/btclib/bip32/bip32.py:624` pointed at a `CKDpriv` docstring
-  paragraph rather than `bip32.derive`'s buffer read, at `:666`; and
+- **`SECURITY.md`'s `file.py:LINE` citations name the line they
+  describe.** Five of the file's six citations pointed away from the
+  code the surrounding prose describes: `src/btclib/ecc/musig2.py:812`
+  pointed at a comment line above `sign`'s own `s = ...` line, which is
+  at `:813`; `src/btclib/bip32/bip32.py:624` pointed at a `CKDpriv`
+  docstring paragraph rather than `bip32.derive`'s buffer read, at
+  `:666`; `src/btclib/ecc/commit_nonce.py:145` pointed at a comment
+  rather than `commit_nonce_`'s own read, at `:155`;
   `src/btclib/script/taproot.py:429` pointed at a blank line before
-  `output_prvkey` rather than `_tweaked_prvkey`'s own definition, at
-  `:442`. A full read of the file's other three citations —
-  `commit_nonce.py:145`, `ellswift.py:346`, `dsa.py:1346` — found each
-  still landing inside the function named beside it (closes #1329).
+  `output_prvkey` rather than `_tweaked_prvkey`'s own read, at `:461`;
+  and `src/btclib/ecc/ellswift.py:346` pointed at a blank docstring line
+  rather than `xdh`'s own return through the bindings, at `:362`. The
+  sixth, `src/btclib/ecc/dsa.py:1346`, named the line opening the
+  assignment its own paragraph describes rather than the quoted
+  expression inside it, at `:1347` (closes #1329).
 
 ### The public API and the module layout
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -116,7 +116,7 @@ used to teach and to prototype as much as to build:
     measured rather than assumed: the point-multiplication side has
     been regular since #254, and `sign`'s own line, `s = (k_1_ +
     values.b * k_2_ + values.e * a * d) % secp256k1.n`
-    (`src/btclib/ecc/musig2.py:812`), spreads 1.016x over uniform scalars
+    (`src/btclib/ecc/musig2.py:813`), spreads 1.016x over uniform scalars
     in `[1, n-1]` -- the magnitude leak that remains shows only for
     scalars with zero high bits, keys already lost for other reasons.
     The gain left is narrower than that figure suggests: delegating
@@ -144,9 +144,9 @@ used to teach and to prototype as much as to build:
     `ssa.nonce_bip340`. btclib passes none of them, and that is a
     decision, not an oversight. These call sites read one of those
     straight into a Python `int`: `bip32.derive`
-    (`src/btclib/bip32/bip32.py:624`), `commit_nonce.commit_nonce_`
+    (`src/btclib/bip32/bip32.py:666`), `commit_nonce.commit_nonce_`
     (`src/btclib/ecc/commit_nonce.py:145`) and `taproot._tweaked_prvkey`
-    (`src/btclib/script/taproot.py:429`). A caller-owned buffer can be
+    (`src/btclib/script/taproot.py:442`). A caller-owned buffer can be
     wiped once the call that filled it returns; the `int` it is read
     into cannot be, and outlives the call regardless —
     `bip32.derive` keeps `prv_key_int` for the life of the key

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -145,8 +145,8 @@ used to teach and to prototype as much as to build:
     decision, not an oversight. These call sites read one of those
     straight into a Python `int`: `bip32.derive`
     (`src/btclib/bip32/bip32.py:666`), `commit_nonce.commit_nonce_`
-    (`src/btclib/ecc/commit_nonce.py:145`) and `taproot._tweaked_prvkey`
-    (`src/btclib/script/taproot.py:442`). A caller-owned buffer can be
+    (`src/btclib/ecc/commit_nonce.py:155`) and `taproot._tweaked_prvkey`
+    (`src/btclib/script/taproot.py:461`). A caller-owned buffer can be
     wiped once the call that filled it returns; the `int` it is read
     into cannot be, and outlives the call regardless —
     `bip32.derive` keeps `prv_key_int` for the life of the key
@@ -154,7 +154,7 @@ used to teach and to prototype as much as to build:
     signature and buy nothing, short of btclib no longer holding a
     private key as a Python `int`, which is a change to that
     representation and not to a call site. `ellswift.xdh`
-    (`src/btclib/ecc/ellswift.py:346`) is the one of them that returns
+    (`src/btclib/ecc/ellswift.py:362`) is the one of them that returns
     octets rather than an `int`, so a caller-owned buffer there would
     hold what it wiped: taking it means growing `xdh`'s public
     signature with `into=` and owning the contract that comes with
@@ -162,7 +162,7 @@ used to teach and to prototype as much as to build:
     function then returns. btclib declines that too, for the reason
     the bullet above already gives: no Python object holding a secret
     is zeroized, on either path, and this one is no exception to it.
-    `dsa.Signer.__init__` (`src/btclib/ecc/dsa.py:1346`) crosses the same
+    `dsa.Signer.__init__` (`src/btclib/ecc/dsa.py:1347`) crosses the same
     boundary the other way, once, at construction: the plain `int`
     `int_from_prv_key` already produced becomes a transient `bytes` via
     `self._q.to_bytes(32, "big")` on the way into the owned buffer


### PR DESCRIPTION
Closes #1329

Three of SECURITY.md's file:line citations pointed at the wrong line
(found while working ISS #1322's src/ layout move -- the path prefix
had already been fixed by that move, but the line numbers had drifted).
Re-derived each correct line against the current tree rather than
trusting the stated numbers, and fixed:

- musig2.py:812 -> :813
- bip32.py:624 -> :666
- taproot.py:429 -> :442, later corrected again to :461 on re-check
  (:442 was the def line, not the read the surrounding sentence
  describes)

A full sweep of every file:line citation in SECURITY.md, re-verified
individually with an unambiguous single-line read rather than eyeballed
sed output, found two more drifted citations the first pass had marked
correct:

- commit_nonce.py:145 -> :155
- ellswift.py:346 -> :362
- dsa.py:1346 -> :1347

All six citations now land on the exact line the surrounding prose
describes.

Local review: CLEARED 0ccb96debcb99ae05d8581da628cda1c6f5a2378 (round 2;
rebased once more onto current origin/main after #1341 landed, a clean
union-driver join on CHANGELOG.md verified to touch nothing of this
branch's own content).

Gates: pytest (30698 passed, 11 skipped, 100% coverage), pre-commit run
--all-files, sphinx-build -W --keep-going -- all exit 0.

## Summary by Sourcery

Correct SECURITY.md source citations to accurately identify the relevant security-sensitive code.

Bug Fixes:
- Correct all six SECURITY.md file-and-line citations so they point to the exact source lines described by the surrounding security guidance.

Documentation:
- Document the corrected SECURITY.md citations in the changelog.