### PR TITLE
The bindings' distribution is spelled the way it names itself (issue btclib-org/.github#335)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
       value: >
         Not every bug reachable from btclib is a btclib bug: the elliptic
         curve operations are delegated to
-        [btclib_secp256k1](https://github.com/btclib-org/btclib-secp256k1/issues),
+        [btclib-secp256k1](https://github.com/btclib-org/btclib-secp256k1/issues),
         the Python bindings, and through them to
         [bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1/issues).
         A traceback ending in either belongs there. If in doubt, report it
@@ -49,7 +49,7 @@ body:
   - type: input
     id: bindings-version
     attributes:
-      label: btclib_secp256k1 version
+      label: btclib-secp256k1 version
       description: >
         `python -c "import btclib_secp256k1 as m; print(m.__version__)"`.
         Anything signing or verifying goes through it, so which one is

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,7 +11,7 @@ body:
         and prototyping as much as at production use: what belongs here is
         what a specification describes. Wrapping something libsecp256k1
         offers belongs in
-        [btclib_secp256k1](https://github.com/btclib-org/btclib-secp256k1/issues)
+        [btclib-secp256k1](https://github.com/btclib-org/btclib-secp256k1/issues)
         instead.
 
   - type: textarea

--- a/.github/workflows/deps-latest.yml
+++ b/.github/workflows/deps-latest.yml
@@ -12,7 +12,7 @@ name: deps-latest
 # uv.lock moves on a weekly dependabot pull request. A break upstream
 # therefore surfaces a week or more later, inside a pull request that has
 # to be reviewed anyway, and its cause is one entry in a diff of many.
-# btclib_secp256k1 is the entry that matters most here: a release of
+# btclib-secp256k1 is the entry that matters most here: a release of
 # the bindings is a release in another repository, which nothing in this
 # one has to change for the pair to stop working. suite-bindings-latest
 # below asks about that one entry alone, precisely, rather than folding
@@ -113,7 +113,7 @@ jobs:
           # something did is the week this job has work to do anyway
           enable-cache: true
           python-version: ${{ matrix.python }}
-      # --upgrade re-resolves every entry, btclib_secp256k1 included:
+      # --upgrade re-resolves every entry, btclib-secp256k1 included:
       # this is what carries the bindings to their newest release, which
       # nothing else off a pull request does.
       # It prints one "Update <pkg> vA -> vB" line per package it moves,
@@ -155,7 +155,7 @@ jobs:
 
   # narrower than suite-latest above, and for a different reason: that
   # job upgrades every dependency, so a red run there buries a release
-  # of btclib_secp256k1 behind a dozen other candidates. This
+  # of btclib-secp256k1 behind a dozen other candidates. This
   # upgrades only that one, so a red run here names it without a
   # bisect -- worth a job of its own because it is a sibling project
   # under the same org, released by the same maintainer, which makes
@@ -186,7 +186,7 @@ jobs:
           python-version: ${{ matrix.python }}
       # upgrades one entry rather than every one of them, which is the
       # whole difference from suite-latest above: it prints "Update
-      # btclib_secp256k1 vA -> vB" when a release moved it and
+      # btclib-secp256k1 vA -> vB" when a release moved it and
       # nothing when it did not, so the log names the suspect without a
       # diff of uv.lock. Harmless on an ephemeral checkout; worth
       # knowing before running the same command in a working tree
@@ -194,7 +194,7 @@ jobs:
         # this matrix includes windows-latest; see suite-latest above and
         # os-windows.yml's suite-windows job (issue #1148)
         shell: bash
-        run: uv lock --upgrade-package btclib_secp256k1
+        run: uv lock --upgrade-package btclib-secp256k1
       # test.yml's no-bindings job, with the sense reversed, and here for
       # the mirror image of its reason: asked before the suite, and asked
       # of the interpreter rather than of the resolver, because the step

--- a/.github/workflows/pypi-install.yml
+++ b/.github/workflows/pypi-install.yml
@@ -26,7 +26,7 @@ name: pypi-install
 # sentinel exists to cover, so a silence from it is worth a look at the
 # Actions tab before it is read as green.
 #
-# What this is not: a sentinel for whether the newest btclib_secp256k1
+# What this is not: a sentinel for whether the newest btclib-secp256k1
 # breaks this tree. That question -- issue #397 -- belongs to deps-latest.yml's
 # suite-bindings-latest job instead: it is about drift against a tree not
 # yet published, asked before publication rather than after, and asking
@@ -134,7 +134,7 @@ jobs:
           # interpreter, being the same sdist everywhere. Pure Python, so
           # nothing here compiles -- measured by hand against the
           # published 2026.8.21, this is a packaging step and nothing
-          # more, unlike btclib_secp256k1's own sdist cell, which compiles
+          # more, unlike btclib-secp256k1's own sdist cell, which compiles
           # a C library. Python 3.13 rather than a version already in the
           # base matrix, so this adds a job rather than a property to an
           # existing one
@@ -215,11 +215,11 @@ jobs:
       # while testing the wrong thing -- the failure mode issue #1153
       # named, and now the one thing a wheel cell here cannot become by
       # accident. Only btclib is constrained either way, never its
-      # dependencies: this install names no extra, so btclib_secp256k1 is
+      # dependencies: this install names no extra, so btclib-secp256k1 is
       # one of them and is left to resolve however pip normally would,
       # and neither flag here names it. install-published-secp256k1,
       # below, is the job that names the extra and is entitled to
-      # constrain btclib_secp256k1 too, with its own --only-binary --
+      # constrain btclib-secp256k1 too, with its own --only-binary --
       # the same flag applied a second time rather than a reason to
       # change this one. An
       # environment variable and a shell conditional rather than a ${{ }}
@@ -310,7 +310,7 @@ jobs:
         # stays install-published's own instead of shrinking to one, the
         # thing issue #1143 asks to be argued rather than assumed.
         # 3.14 and not install-published's 3.10 floor: the same JSON API
-        # answer says btclib_secp256k1 ships no win_arm64 wheel below
+        # answer says btclib-secp256k1 ships no win_arm64 wheel below
         # cp311, which is what makes install-published fetch an emulated
         # win_amd64 interpreter for its 3.10 cell on windows-11-arm (see
         # that job's own comment). 3.14 has a native win_arm64 wheel, so
@@ -345,7 +345,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       # --only-binary on both packages: btclib for the reason
-      # install-published's own comment gives, and btclib_secp256k1 for
+      # install-published's own comment gives, and btclib-secp256k1 for
       # the same one applied to the package this job adds. Without it, a
       # wheel the bindings have not published for this cell demotes the
       # install to a source build -- a C toolchain question a hosted
@@ -356,7 +356,7 @@ jobs:
         run: |
           uv venv --python ${{ matrix.python }}
           uv pip install --verbose \
-            --only-binary btclib --only-binary btclib_secp256k1 \
+            --only-binary btclib --only-binary btclib-secp256k1 \
             "btclib[secp256k1]"
       # is_libsecp256k1_serving is the assertion install-published's own
       # comment says it is not entitled to, that job's install naming no

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ on:
       check-newest-bindings:
         description: >
           Whether the `dist` job's smoke test also asks about the newest
-          published btclib_secp256k1, unconstrained by uv.lock. Only
+          published btclib-secp256k1, unconstrained by uv.lock. Only
           release.yml sets this: the question is not one a required
           check can afford (a released binding would redden every open
           pull request), so a direct trigger of this workflow leaves it
@@ -342,7 +342,7 @@ jobs:
 
   # the configuration issue #966 exists for, and the one thing that keeps
   # its guard from being a claim nobody checks: btclib installed without
-  # btclib_secp256k1, answering on its own Python arithmetic. The suite
+  # btclib-secp256k1, answering on its own Python arithmetic. The suite
   # reaches those arms locally by clearing the seam, which is not the same
   # configuration -- an unguarded import would fail before a seam could be
   # cleared, and every arm gated on availability alone is chosen here by
@@ -670,7 +670,7 @@ jobs:
         run: uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz
       # what none of the three above does: install the wheel, and install
       # it alone, from an empty directory. The wheel is the only thing
-      # asked for, so what pulls btclib_secp256k1 in is the
+      # asked for, so what pulls btclib-secp256k1 in is the
       # `Requires-Dist` the wheel itself carries, resolved from the index
       # -- which is the question, metadata being what the three checks
       # above only read.
@@ -689,7 +689,7 @@ jobs:
       # the wheel's metadata doing the work while pinning the outcome to
       # what uv.lock resolved -- and pinning it is what keeps a required
       # check deterministic, since with the floor alone uv takes the
-      # newest release and a btclib_secp256k1 published this morning
+      # newest release and a btclib-secp256k1 published this morning
       # would redden every open pull request, none of which caused it.
       # Every package, then, including the two siblings: what made them
       # an exception was the direct reference, the lock exporting the
@@ -713,7 +713,7 @@ jobs:
       # bind a version and request no package, so the only thing that
       # installs the bindings at all is the wheel's own `Requires-Dist`
       # for the extra: a wheel that stopped declaring it resolves
-      # nothing, and a btclib_secp256k1 the lock pins that this tree
+      # nothing, and a btclib-secp256k1 the lock pins that this tree
       # cannot import lands in `_libsecp256k1`'s `except ImportError`.
       # Either way `is_libsecp256k1_serving` is False while the Python
       # arithmetic answers the version and the signature correctly --
@@ -765,7 +765,7 @@ jobs:
       # `inputs.check-newest-bindings`, which only release.yml sets, so
       # no pull request and no ordinary push to main waits on it -- it can
       # afford the question a required check cannot, whether the newest
-      # published btclib_secp256k1 satisfies the wheel about to be
+      # published btclib-secp256k1 satisfies the wheel about to be
       # published, which is what a user installing it resolves. A release
       # stopping on that answer is the outcome wanted.
       # `github.event_name != 'pull_request'` was the alternative

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -582,6 +582,18 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **Every place naming the bindings' distribution — the `secp256k1`
+  extra's requirement spec, the `bindings` dependency group, and the
+  prose describing both — spells it `btclib-secp256k1`, the hyphen the
+  sibling project's own name carries.** PEP 503 normalises both forms to
+  the same distribution, so `pip` and `uv` resolved the underscore
+  spelling correctly throughout; section 14 of the organization standard
+  is what makes the divergence a defect, one spelling being the rule
+  regardless of what a resolver tolerates. The `btclib_secp256k1` Python
+  module import, and the wheel and sdist filenames PEP 427 forces to the
+  same underscore, are untouched, those two naming the module and the
+  file rather than the distribution (issue btclib-org/.github#335).
+
 - **The importable package moves from the repository root to
   `src/btclib/`,** matching section 2 of the organization standard. A
   package at the repository root sits on `sys.path` whenever anything

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ uv sync
 
 **The declared dependencies are `bitcoin-core-rpc>=2026.8.13`,
 `typing-extensions>=4.4` and, as the `secp256k1` extra,
-`btclib_secp256k1>=0.8.0.4`, with no upper bound**, and the absence of a
+`btclib-secp256k1>=0.8.0.4`, with no upper bound**, and the absence of a
 ceiling is a decision. `typing-extensions` backports `typing.override`,
 which 3.12 has and the 3.10 floor does not, and its floor is the release
 that adds it. The other two are btclib-org projects developed by the same
@@ -263,7 +263,7 @@ new is therefore the same commit that raises the floor in both of its
 places, with the reason written beside it.
 
 Calling an entry point merged upstream but not yet released is what a
-`[tool.uv.sources]` entry pointing `btclib_secp256k1` at its `main`
+`[tool.uv.sources]` entry pointing `btclib-secp256k1` at its `main`
 branch is for, and it is a state to leave rather than to keep.
 `[tool.uv]` is not distribution metadata, so `dependencies` still
 publishes a plain floor and PyPI still accepts a release — where a
@@ -664,7 +664,7 @@ a dependency executes its code, and a compromised one must not reach a
 `dist/` that still has to be handed on, so what the publish jobs will
 download is frozen before the twine, check-wheel-contents and pyroma
 steps below install anything at all. The two smoke tests ask for the
-wheel and nothing else, so what pulls btclib_secp256k1 in is the
+wheel and nothing else, so what pulls btclib-secp256k1 in is the
 `Requires-Dist` the wheel carries for the `secp256k1` extra — which they
 name on both sides, a wheel installed without it declaring nothing to
 resolve. The first pins the lock as constraints, which bind a version
@@ -769,7 +769,7 @@ coverage — which reads as a dependency this tree has not caught up with
 rather than as the answer the job was asked for:
 
 ```shell
-uv lock --upgrade-package btclib_secp256k1
+uv lock --upgrade-package btclib-secp256k1
 uv run --locked --no-default-groups --group test python -c \
     "from btclib.curves import is_libsecp256k1_serving; \
      assert is_libsecp256k1_serving(), \
@@ -809,7 +809,7 @@ python -c "from btclib.mnemonic.bip39 import seed_from_mnemonic; \
 ```
 
 `install-published-secp256k1` installs `btclib[secp256k1]` instead,
-wheels only for both `btclib` and `btclib_secp256k1`, so a wheel the
+wheels only for both `btclib` and `btclib-secp256k1`, so a wheel the
 index does not have for a platform fails the job rather than falling
 back to a source build that answers a different question. Naming the
 extra is what entitles it to the assertion the other job cannot make: a
@@ -819,7 +819,7 @@ so this one asks `is_libsecp256k1_serving()` first, and the signature
 after it is meaningful because of that:
 
 ```shell
-python -m pip install --only-binary btclib --only-binary btclib_secp256k1 \
+python -m pip install --only-binary btclib --only-binary btclib-secp256k1 \
     "btclib[secp256k1]"
 python -c "import btclib; \
     from btclib.curves import is_libsecp256k1_serving; \

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ including the few vectors that are btclib's own, having no upstream.
 
 The library is not limited to secp256k1, and for that curve it always
 calls
-[btclib_secp256k1](https://github.com/btclib-org/btclib-secp256k1),
+[btclib-secp256k1](https://github.com/btclib-org/btclib-secp256k1),
 FFI bindings to Bitcoin Core's optimized C library
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1). They are the
 recommended install and what `pip install "btclib[secp256k1]"` asks for,

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -143,7 +143,7 @@ unconstrained — and publishes the very files those checks passed to
 its weekly cron, because what it answers is cheaper to know before a version
 is consumed than after. It gates nothing, so it will not stop you:
 reading it is the point. Its `suite-bindings-latest` job is the one worth
-reading closely: it asks about the newest btclib_secp256k1 release
+reading closely: it asks about the newest btclib-secp256k1 release
 alone, precisely, rather than folding it into the broader upgrade the
 rest of the workflow makes — a release of the bindings is a release in
 another repository, which nothing here has to change for the pair to
@@ -187,7 +187,7 @@ chose to leave it". State the choice in the release pull request, next
 to `deps-latest`'s own result.
 
 1. Make sure the newest release of **each btclib-org dependency** —
-   btclib_secp256k1 and bitcoin-core-rpc — is the one this release
+   btclib-secp256k1 and bitcoin-core-rpc — is the one this release
    should depend on, and that `pyproject.toml`'s pin says so. Two
    questions, not one: whether the pin *resolves*, which the wheel smoke
    test of the `dist` job already answers on every pull request by
@@ -583,7 +583,7 @@ a mismatch as tampering:
   published where they say they are. The attestation the rehearsal
   writes covers those, and no digest is shared with the release.
 
-`btclib_secp256k1` is not a third bound. It is a runtime dependency,
+`btclib-secp256k1` is not a third bound. It is a runtime dependency,
 resolved by whoever installs the wheel, and the only trace of it in either
 distribution file is the `Requires-Dist` pyproject.toml already spells and
 the pin `uv.lock` carries into the sdist — both of them text belonging to
@@ -612,7 +612,7 @@ above needs no `uv sync` to produce the published bytes.
   nothing was uploaded, but retagging would rebuild what was never at
   fault. A registration that matched once goes stale on its own — a
   repository rename is enough — and nothing here flags it before the
-  upload tries; sibling repository btclib_secp256k1 hit exactly this
+  upload tries; sibling repository btclib-secp256k1 hit exactly this
   on a real tag rather than a rehearsal. Fix the registration and re-run
   the publish job alone against what is already built:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ equally welcome.
 
 Signing, verification and generator multiplication on secp256k1 are
 delegated to
-[btclib_secp256k1](https://github.com/btclib-org/btclib-secp256k1/security/advisories/new),
+[btclib-secp256k1](https://github.com/btclib-org/btclib-secp256k1/security/advisories/new),
 the Python bindings, and through them to
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1/security/advisories/new)
 itself, which has its own security policy and its own address. A flaw in

--- a/docs/proposals/cli.md
+++ b/docs/proposals/cli.md
@@ -485,7 +485,7 @@ carries it, and what the split costs.
   refactored for improved clarity, without care for backward
   compatibility" is exactly why the new repository needs an explicit
   compatibility contract — a supported btclib version range, declared
-  and tested, the way `btclib_secp256k1` is pinned from this side
+  and tested, the way `btclib-secp256k1` is pinned from this side
   (issue #325) — where the in-tree design had a rename break the
   command in the same commit and needed no such contract at all.
 
@@ -748,7 +748,7 @@ this one's conventions rather than sharing its configuration:
 The CLI's own documentation -- its README, its own sphinx or mkdocs
 pages if it has any -- lives in the new repository, not here.
 btclib's side of this is what a dependent project's is: at most a
-mention where README.md already lists `btclib_secp256k1`, once the
+mention where README.md already lists `btclib-secp256k1`, once the
 new repository exists to link to. Nothing in this repository's own
 CHANGELOG.md or RELEASE_NOTES.md is owed an entry for a project the CLI's
 repository, not this one, releases and versions.

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -62,7 +62,7 @@ Installing
    python -m pip install --upgrade "btclib[secp256k1]"
 
 btclib requires python 3.10 or later. The ``secp256k1`` extra pulls in
-``btclib_secp256k1``, and it is the recommended install: it needs one of
+``btclib-secp256k1``, and it is the recommended install: it needs one of
 that package's wheels or a C toolchain to build it. Plain ``pip install
 btclib`` works and installs no C at all — btclib then answers on its own
 Python arithmetic, tens of times more slowly and not in constant time,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ secp256k1 = [
     # silently, tens of times slower and not in constant time. A floor
     # naming 0.8.0.3 while this tree imports `musig` describes exactly
     # that install, which is issue #1116
-    "btclib_secp256k1>=0.8.0.4",
+    "btclib-secp256k1>=0.8.0.4",
 ]
 
 [project.urls]
@@ -166,7 +166,7 @@ pull_requests = "https://github.com/btclib-org/btclib/pulls"
 # refuses the day the two stop agreeing. What the group buys is that no
 # documented command had to grow an `--extra`, and that the job of issue
 # #991 is those same commands with this group left out
-bindings = ["btclib_secp256k1>=0.8.0.4"]
+bindings = ["btclib-secp256k1>=0.8.0.4"]
 # what runs the suite, without what the suite delegates to: `test` is the
 # two together and is what every documented command asks for, while
 # `harness` alone is the environment the no-bindings job of test.yml

--- a/tests/build_system_test.py
+++ b/tests/build_system_test.py
@@ -131,4 +131,4 @@ def test_the_bindings_extra_and_group_ask_for_the_same_thing() -> None:
     extra, group = _bindings_requirements()
     assert extra == group, f"the extra asks {extra}, the group asks {group}"
     assert len(extra) == 1, f"the extra names more than the bindings: {extra}"
-    assert extra[0].startswith("btclib_secp256k1"), extra[0]
+    assert extra[0].startswith("btclib-secp256k1"), extra[0]


### PR DESCRIPTION
Every place naming the bindings' distribution spells it
`btclib-secp256k1`, which is what that project calls itself.

Cites btclib-org/.github#335 without closing it: that issue's *Done when*
reaches every tree in the organization.

## Why this is a defect, given that nothing is broken

PEP 503 normalises a requirement's name for matching, so both spellings
resolve and install the same distribution. Nothing fails — which is
exactly why it survived. Section 14 of the standard is what makes it a
defect: one answer for every tree by default, and a convention differing
between two repositories with no stated reason is a defect rather than a
choice either tree keeps.

## The distinction the diff rests on

The distribution is `btclib-secp256k1`; the module it installs is
`btclib_secp256k1`. The underscore is correct wherever the module is
meant, so this is a classification and not a substitution.
`git grep -n 'btclib[-_]secp256k1'` is the census, and it was read hit by
hit rather than rewritten.

Changed, naming the distribution: `pyproject.toml`'s `secp256k1` extra
and `bindings` group, `CONTRIBUTING.md`'s mirror of both, the
`--upgrade-package` and `--only-binary` arguments, the issue templates,
`SECURITY.md`, `RELEASING.md`, `README.md`, the guide and the CLI
proposal.

Left with the underscore, naming the module or a filename: every import,
every `sys.modules` check and its paired assert message, and every "wheel
of X" phrase — PEP 427 escapes the name into wheel and sdist filenames
regardless of what the project calls itself.

`tests/generate_sbom_test.py` keeps its underscore-spelled fixtures on
purpose: they are inputs proving the generator's own PEP 503
normalisation, and rewriting them would delete the case that proves
normalisation runs.

`tests/build_system_test.py`'s assertion reads `pyproject.toml`'s own
text and compares it to a literal, so it follows the file it tests.

## No RELEASE_NOTES.md entry, measured rather than argued

A wheel built from the underscore spelling already published
`Requires-Dist: btclib-secp256k1`, and `uv.lock` already stored the
hyphen — which is why the lock file does not move in this diff. Nothing a
caller resolves changes, so no caller has anything to act on.

## Gates

`uv run pytest` exit 0 at 100% coverage, `pre-commit run --all-files`
exit 0, the sphinx `-W` build exit 0 with its dangling-anchor grep empty.

Locally reviewed at fresh context over two rounds, the second after a
rebase onto a main that had moved. `main` has since moved again, touching
`SECURITY.md` and `CHANGELOG.md`; both overlaps were measured rather than
assumed — main renumbers `file:line` citations at lines 116-170 where
this changes a link's display text at line 20, the CHANGELOG entries land
under a non-adjacent heading, and nothing main added names the
distribution.

## Summary by Sourcery

Use the bindings distribution’s canonical hyphenated name consistently across project metadata, automation, and documentation.

Enhancements:
- Standardize references to the bindings distribution as `btclib-secp256k1` while preserving the underscore spelling for the installed Python module and generated artifact names.

CI:
- Update CI workflow documentation and package arguments to use the canonical distribution name.

Documentation:
- Update project documentation, contribution guidance, release instructions, security guidance, issue templates, and CLI proposal references to use the canonical distribution name.

Tests:
- Update the build-system assertion to validate the hyphenated distribution requirement.

Chores:
- Record the naming standardization in the changelog without changing dependency resolution behavior.