### PR TITLE
btclib.bip85 derives a NIP-19 Nostr key, application 128002'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1963,6 +1963,22 @@ documented at release-notes length in the first place, and are still in
   `pyproject.toml`'s `UNKNWON_DEVICE_TYPE` comment states, so the table
   in `tests/hwi_test.py` is ahead of that pin by this one code until a
   full re-check reconciles both.
+- **`btclib.bip85` derives a Nostr key**, `nsec_from_root_key`, BIP85's
+  application 128002' (issue #1330). The path is
+  `m/83696968h/128002h/{identity}h/{account_index}h`; the leading 256
+  bits of the entropy are the secp256k1 secret key, exactly as in the
+  hdseed WIF application, and NIP-19 bech32-encodes them with the `nsec`
+  human-readable part -- plain bech32, not bech32m, and with no
+  witness-version digit the way a segwit address carries one. `identity`
+  and `account_index` must each be 1 or more: the BIP reserves 0' of
+  either for a future NIP's key-management use and defines no signing
+  key there. A scalar of zero or beyond the curve order is refused
+  before it is encoded, through `to_prv_key.int_from_prv_key`, the same
+  hard failure `wif_from_root_key` already raises for the same
+  curve-order footnote the BIP's Nostr section cross-references from
+  its HD-Seed WIF one. The three vectors BIP85 published for this
+  application are now in `tests/_data/bip85_test_vectors.json`, pinned
+  in `tests/_data/README.md`.
 
 - **The messages by which a peer says what it wants sent to it**:
   `btclib.p2p.negotiation` carries `getaddr`, `mempool`, `sendheaders`,

--- a/src/btclib/bip85.py
+++ b/src/btclib/bip85.py
@@ -20,17 +20,18 @@ both as a key and as entropy would otherwise leak the one through the
 other.
 
 The module sits at the top level, beside `bip44` and `slip132`, and for
-the same reason: the applications below need `b58` for a WIF and
-`mnemonic.bip39` for a sentence, and both of those are above `bip32`,
-which `btclib/bip32/` may not import back. Nothing in the library
-imports this module.
+the same reason: the applications below need `b58` for a WIF, `b32` for
+a bech32-encoded key and `mnemonic.bip39` for a sentence, and all of
+those are above `bip32`, which `btclib/bip32/` may not import back.
+Nothing in the library imports this module.
 
 `entropy_from_der_path` is the derivation itself and answers for any
 path, the applications no function here formats included. Every
 application BIP85 defines is formatted beside it: 39' (a BIP39
-mnemonic), 2' (the Bitcoin Core hdseed WIF), 32' (an xprv), 128169'
-(raw bytes, which the BIP calls HEX), 707764' and 707785' (a base64 and
-a base85 password), 89101' (dice rolls) and 828365' (RSA).
+mnemonic), 2' (the Bitcoin Core hdseed WIF), 32' (an xprv), 128002' (a
+NIP-19 Nostr nsec), 128169' (raw bytes, which the BIP calls HEX), 707764'
+and 707785' (a base64 and a base85 password), 89101' (dice rolls) and
+828365' (RSA).
 
 The last two read BIP85-DRNG-SHAKE256 rather than the 64 bytes: a
 function whose appetite is not known in advance needs a stream, so the
@@ -50,7 +51,9 @@ from base64 import b64encode, b85encode
 from hashlib import shake_256
 
 from btclib.alias import Octets
+from btclib.b32 import power_of_2_base_conversion
 from btclib.b58 import wif_from_prv_key
+from btclib.bech32 import _BECH32_1_CONST, encode
 from btclib.bip32.bip32 import (
     BIP32Key,
     BIP32KeyData,
@@ -67,6 +70,7 @@ from btclib.exceptions import BTClibValueError
 from btclib.mnemonic.bip39 import mnemonic_from_entropy
 from btclib.mnemonic.mnemonic import Mnemonic
 from btclib.network import network_from_name, network_from_xkeyversion
+from btclib.to_prv_key import int_from_prv_key
 from btclib.utils import bytes_from_octets
 
 __all__ = [
@@ -77,6 +81,7 @@ __all__ = [
     "drng_from_der_path",
     "entropy_from_der_path",
     "mnemonic_from_root_key",
+    "nsec_from_root_key",
     "rolls_from_root_key",
     "rsa_drng_from_root_key",
     "wif_from_root_key",
@@ -139,6 +144,14 @@ _MAX_B85_LEN = 80
 # at 2**31 - 1, and `str_from_index_int` refuses the rest
 _MIN_SIDES = 2
 _MIN_ROLLS = 1
+
+# Nostr's two path levels, identity and account_index, both start at 1':
+# 0' of either is reserved by the BIP for a future NIP's key-management
+# use rather than for a signing key
+_MIN_NOSTR_INDEX = 1
+
+# NIP-19's human-readable part for a bech32-encoded Nostr secret key
+_NSEC_HRP = "nsec"
 
 # BIP85-DRNG-SHAKE256's seed size, which the BIP fixes at the HMAC's own
 # output and requires to be exactly that
@@ -315,6 +328,43 @@ def xprv_from_root_key(root_key: BIP32Key, index: int = 0) -> str:
         key=b"\x00" + entropy[32:],
     )
     return derived.b58encode()
+
+
+def nsec_from_root_key(root_key: BIP32Key, identity: int, account_index: int) -> str:
+    """Return a NIP-19 nsec, BIP85's application 128002'.
+
+    The path is `m/83696968h/128002h/{identity}h/{account_index}h`: the
+    leading 256 bits of the entropy are the secp256k1 secret key, exactly
+    as in the HD-Seed WIF application above, and NIP-19 bech32-encodes
+    them with the `nsec` human-readable part -- plain bech32, not
+    bech32m, and with no witness-version digit in front of the key the
+    way a segwit address carries one.
+
+    `identity` is an independent, unlinkable Nostr key namespace and
+    `account_index` a distinct key within it. Both must be 1 or more:
+    the BIP reserves index 0' of either for a future NIP's key-management
+    use -- proof-of-linkage between an identity's keys, rotation,
+    revocation -- and defines no signing key there, so neither defaults.
+
+    A scalar of zero or beyond the curve order is refused rather than
+    encoded, the same hard failure `wif_from_root_key` documents and the
+    same curve-order footnote this section of the BIP cross-references
+    from the WIF one: at odds of about 2**-127 the answer is for the
+    caller to move to the next index.
+    """
+    if identity < _MIN_NOSTR_INDEX:
+        raise BTClibValueError(f"invalid nostr identity: {identity}")
+    if account_index < _MIN_NOSTR_INDEX:
+        raise BTClibValueError(f"invalid nostr account index: {account_index}")
+
+    xkey = _key_data_from_bip32_key(root_key)
+    der_path = f"m/{_PURPOSE}h/128002h/{identity}h/{account_index}h"
+    entropy = _entropy_from_der_path(xkey, der_path)
+    # the hard failure the docstring above documents, raised before the
+    # bech32 encoding rather than after it
+    int_from_prv_key(entropy[:32])
+    data = power_of_2_base_conversion(entropy[:32], 8, 5)
+    return encode(_NSEC_HRP, data, _BECH32_1_CONST).decode("ascii")
 
 
 def bytes_entropy_from_root_key(

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -828,8 +828,8 @@ which the BIP names as their source.
 ```text
 repo    bitcoin/bips
 path    bip-0085.mediawiki
-commit  97781eae4d368024b65d11b4b4301e3885d3bc05  2026-02-13
-pulled  2026-08-13
+commit  6209768676bf85d7ef5ffb4055543d6286d79b96  2026-08-03
+pulled  2026-08-25
 behind  0 revisions; that commit is the tip of the path
 ```
 
@@ -838,8 +838,9 @@ verbatim in the pinned text, and every vector the BIP publishes is in
 our copy: the master root key, the two entropy cases of the
 specification's own section with the derived key of each, the 80-byte
 BIP85-DRNG read, the three BIP39 mnemonics, the hdseed WIF, the xprv,
-the 64 hex bytes, the base64 and base85 passwords, and the ten dice
-rolls. `tests/bip85_test.py` runs all of them.
+the 64 hex bytes, the base64 and base85 passwords, the ten dice rolls,
+and the three Nostr nsecs of application 128002'. `tests/bip85_test.py`
+runs all of them.
 
 RSA (828365') is the one application with no vector here, because the
 BIP publishes none for it: it defines the path and says the key

--- a/tests/_data/bip85_test_vectors.json
+++ b/tests/_data/bip85_test_vectors.json
@@ -86,5 +86,28 @@
       "derived_entropy": "5e41f8f5d5d9ac09a20b8a5797a3172b28c806aead00d27e36609e2dd116a59176a738804236586f668da8a51b90c708a4226d7f92259c69f64c51124b6f6cd2",
       "derived_rolls": "1,0,0,2,0,1,5,5,2,4"
     }
+  ],
+  "nostr": [
+    {
+      "path": "m/83696968'/128002'/1'/1'",
+      "identity": 1,
+      "account_index": 1,
+      "derived_entropy": "ff6eb0fcdf1ef87a2a06b0d7884d495b486d0faa210e9f80f23fd649d6e114d27873d12f3b57c469f684e4dc9f4abf10beeacb59b385fde8e33f1947bc5c6c17",
+      "derived_nsec": "nsec1lahtplxlrmu852sxkrtcsn2ftdyx6ra2yy8flq8j8ltyn4hpznfq23uvqz"
+    },
+    {
+      "path": "m/83696968'/128002'/1'/2'",
+      "identity": 1,
+      "account_index": 2,
+      "derived_entropy": "917628689652288f6983c8a01db516d0697d5198dcf9de9010597f5e322fba6e435a731d85fbcc5768c06ff95ff34bf577f63f415cb170473659753acf14722d",
+      "derived_nsec": "nsec1j9mzs6yk2g5g76vrezspmdgk6p5h65vcmnuaayqst9l4uv30hfhqje0jyh"
+    },
+    {
+      "path": "m/83696968'/128002'/2'/1'",
+      "identity": 2,
+      "account_index": 1,
+      "derived_entropy": "fa2e784291b1fd347ba3624672e3090cb2cee34b8567180336e3aa290d02715b8f4b18f02f07cb2aa3023afd34735282cc6594370f47e6e1fa48d8d0dda93096",
+      "derived_nsec": "nsec1lgh8ss53k87ng7arvfr89ccfpjevac6ts4n3sqekuw4zjrgzw9dsq3uelh"
+    }
   ]
 }

--- a/tests/bip85_test.py
+++ b/tests/bip85_test.py
@@ -27,12 +27,14 @@ reach no further than the path it is seeded from.
 
 from __future__ import annotations
 
+import hmac
 from typing import Any
 
 import pytest
 
 from btclib.bip32 import BIP32KeyData, derive, rootxprv_from_seed, xpub_from_xprv
 from btclib.bip85 import (
+    _HMAC_KEY,
     _LANGUAGE_INDEXES,
     BIP85DRNG,
     base64_password_from_root_key,
@@ -41,11 +43,13 @@ from btclib.bip85 import (
     drng_from_der_path,
     entropy_from_der_path,
     mnemonic_from_root_key,
+    nsec_from_root_key,
     rolls_from_root_key,
     rsa_drng_from_root_key,
     wif_from_root_key,
     xprv_from_root_key,
 )
+from btclib.curves import secp256k1 as ec
 from btclib.exceptions import BTClibValueError
 from btclib.mnemonic.bip39 import entropy_from_mnemonic
 from btclib.network import NETWORKS
@@ -317,6 +321,84 @@ def test_a_roll_is_a_face_of_the_die(sides: int) -> None:
     rolls = rolls_from_root_key(_ROOT, 32, sides)
     assert len(rolls) == 32
     assert all(0 <= roll < sides for roll in rolls)
+
+
+@pytest.mark.parametrize("vector", **_ids("nostr"))
+def test_nostr_application(vector: dict[str, Any]) -> None:
+    """Application 128002': the leading 256 bits, bech32-encoded as an nsec.
+
+    The BIP prints DERIVED ENTROPY for this application as the whole 64
+    bytes, unlike the HD-Seed WIF section it otherwise mirrors, so the
+    assertion is against the whole of it and not a 32-byte slice.
+    """
+    entropy = entropy_from_der_path(_ROOT, vector["path"])
+    assert entropy.hex() == vector["derived_entropy"]
+
+    nsec = nsec_from_root_key(_ROOT, vector["identity"], vector["account_index"])
+    assert nsec == vector["derived_nsec"]
+    assert nsec.startswith("nsec1")
+
+
+def test_nostr_identity_and_account_index_are_reserved_at_zero() -> None:
+    """0' of either level is the BIP's reserved key-management slot."""
+    with pytest.raises(BTClibValueError, match="invalid nostr identity: 0"):
+        nsec_from_root_key(_ROOT, 0, 1)
+    with pytest.raises(BTClibValueError, match="invalid nostr account index: 0"):
+        nsec_from_root_key(_ROOT, 1, 0)
+
+
+class _ForcedHmac:
+    """An hmac whose digest is chosen rather than computed."""
+
+    def __init__(self, digest: bytes) -> None:
+        self._digest = digest
+
+    def digest(self) -> bytes:
+        return self._digest
+
+
+def _force_bip85_entropy(monkeypatch: pytest.MonkeyPatch, leading_32: bytes) -> None:
+    """Make bip85's own entropy hmac -- and only that one -- see leading_32.
+
+    `_entropy_from_der_path` derives the path first, through bip32's own
+    hardened-derivation hmacs, and only computes its own hmac afterwards,
+    keyed with `_HMAC_KEY`: patching `hmac.new` indiscriminately, as
+    `bip32_test.py`'s own `_force_hmac` does for bip32 itself, would also
+    dictate those path-derivation hmacs and trip BIP32's own "not a valid
+    scalar" rejection before bip85's is ever reached. So only the call
+    keyed with `_HMAC_KEY` is answered with the chosen digest; every
+    other key reaches the real `hmac.new`, which is what lets the path
+    derivation above it complete undisturbed.
+
+    Zero and the curve order are each about 2**-127 odds, which is why
+    the branch refusing them as a Nostr secret key can only be tested
+    this way. The trailing 32 bytes play no part in `nsec_from_root_key`,
+    so they are left zero.
+    """
+    real_new = hmac.new
+    digest = leading_32 + bytes(32)
+
+    def _new(key: bytes, msg: bytes, digestmod: str) -> hmac.HMAC | _ForcedHmac:
+        if key == _HMAC_KEY:
+            return _ForcedHmac(digest)
+        return real_new(key, msg, digestmod)
+
+    monkeypatch.setattr(hmac, "new", _new)
+
+
+@pytest.mark.parametrize("leading", [0, ec.n])
+def test_a_nostr_key_outside_the_curve_order_is_refused(
+    leading: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The curve-order footnote WIF documents, which Nostr cross-references.
+
+    `wif_from_root_key` already refuses the same two scalars through
+    `wif_from_prv_key`; this is the same hard failure on the application
+    that bech32-encodes the key instead of formatting it as a WIF.
+    """
+    _force_bip85_entropy(monkeypatch, leading.to_bytes(32, byteorder="big"))
+    with pytest.raises(BTClibValueError, match="private key not in 1..n-1"):
+        nsec_from_root_key(_ROOT, 1, 1)
 
 
 def test_the_rsa_drng_is_the_stream_of_its_path() -> None:


### PR DESCRIPTION
Closes #1330

BIP85 gained a Nostr key-derivation application, 128002', with three
test vectors, since btclib's bip85 module was written -- btclib had no
code path for it.

nsec_from_root_key follows path m/83696968h/128002h/{identity}h/
{account_index}h; the leading 256 bits of the entropy are the secp256k1
secret key, exactly as in the HD-Seed WIF application, NIP-19
bech32-encoded (plain bech32, not bech32m) with the nsec
human-readable part. identity and account_index must each be 1 or
more, matching the BIP's own reservation of 0' for future use. A scalar
of zero or beyond the curve order is refused before encoding, through
to_prv_key.int_from_prv_key -- the same hard failure wif_from_root_key
already raises for the identical curve-order footnote BIP85's Nostr
section cross-references from its HD-Seed WIF one.

The three vectors BIP85 published are vendored into
tests/_data/bip85_test_vectors.json.

Local review: CLEARED 3a3452f9a8b38840bcb8b41f124db4204431c1c0 (round
2, after adding the curve-order validation the round-1 review found
missing -- reviewer mutation-tested the fix by removing it and
confirming the new test catches the regression). Rebased once more onto
current origin/main after #1329 landed, a clean union-driver join on
CHANGELOG.md verified to touch nothing of this branch's own content.

Gates: pytest (30704 passed, 11 skipped, 100% coverage), pre-commit run
--all-files, sphinx-build -W --keep-going -- all exit 0.

## Summary by Sourcery

Support deriving validated NIP-19 Nostr secret keys through the BIP85 application 128002'.

New Features:
- Add BIP85 application 128002' support for deriving NIP-19 Nostr secret keys (`nsec`) from root keys.

Enhancements:
- Validate Nostr identity and account indexes and reject invalid secp256k1 private-key scalars before encoding.

Documentation:
- Document the new Nostr key derivation application and update the vendored BIP85 source metadata.

Tests:
- Add the three published BIP85 Nostr test vectors and coverage for reserved indexes and invalid curve scalars.