### PR TITLE
CLAUDE.md's Non-obvious facts names two more of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -580,6 +580,18 @@ documented at release-notes length in the first place, and are still in
   and `links.yml`'s own comment no longer points at the removed
   `iacr.org` entries as an example (issue #1308).
 
+- **`CLAUDE.md`'s *Non-obvious facts* section gains two bullets.** One
+  names why `[tool.coverage.run] source = ["btclib", "tests"]` stayed
+  `"btclib"` through the `src/` layout move: coverage.py's `InOrOut`
+  tests each `source` entry with `os.path.isdir` and matches what fails
+  that test against import names rather than paths, so `"btclib"` was
+  never a path to begin with (issue #1345). The other names that
+  `SECURITY.md`'s `file:line` citations are unchecked by any gate and
+  drift silently, since an unrelated edit to a cited file shifts the
+  line with nothing red; `awk 'NR==N' <file>` against the claimed
+  content is what settles one, a citation landing inside the right
+  function being too weak a check on its own (issue #1346).
+
 ### Packaging, linting and CI
 
 - **Every place naming the bindings' distribution — the `secp256k1`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,17 @@ Do not use Fable unless explicitly instructed.
   `btclib.__version__` reads it back with `importlib.metadata`, and
   `docs/source/conf.py` parses the file (not the metadata, which would
   need the package installed).
+- **`[tool.coverage.run] source` names the imported package, not a
+  path.** coverage.py's `InOrOut.__init__` (`coverage/inorout.py`) tests
+  each entry with `os.path.isdir`: `"btclib"` fails that test and is
+  matched against import names instead, which is why the `src/` layout
+  move left the line unchanged.
+- **`SECURITY.md`'s file:line citations are unchecked by any gate and
+  drift silently.** An unrelated edit to a cited file shifts the line
+  with nothing red; verify with `awk 'NR==N' <file>` against the
+  claimed content, not against which function the line lands in — a
+  citation landing inside the right function has still been off by
+  several lines.
 
 ## Conventions to match
 


### PR DESCRIPTION
Adds two bullets to CLAUDE.md's *Non-obvious facts that will otherwise
waste a session*: `[tool.coverage.run] source` resolves by import name
rather than by filesystem path, and SECURITY.md's six `file:line`
citations are unchecked by any gate and drift silently.

Bundled per one file, one decision.

Local review: CLEARED 3eb32f3d33edf3154c587681a579a5551032b1f7.

Closes #1345, closes #1346.

## Summary by Sourcery

Document coverage source resolution and the lack of automated validation for SECURITY.md line citations.

Enhancements:
- Document two non-obvious project facts in CLAUDE.md: coverage source entries resolve by import name when they are not filesystem paths, and SECURITY.md file-and-line citations can drift without automated validation.

Documentation:
- Record the new CLAUDE.md guidance in the changelog.