### PR TITLE
curves/__init__.py's docstring names the 1.13x figure's actual precondition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1826,6 +1826,12 @@ documented at release-notes length in the first place, and are still in
   for reading the schedule from one place rather than a copy per
   repository, with no number for the standard's table to outgrow again.
 
+- **`curves/__init__.py`'s module docstring stops calling
+  `btclib_secp256k1` a required dependency** (closes #1340). It is the
+  `secp256k1` extra, and the paragraph's 1.13x figure now says it was
+  measured with the bindings switched off, and that a caller who skips the
+  extra is already in that state, with nothing to switch.
+
 - **The Esplora module names the second deployment its own argument
   rests on** (issue #1130). Its docstring says the backend is an api and
   not a product, and gave "several operators run it" as the evidence --

--- a/src/btclib/curves/__init__.py
+++ b/src/btclib/curves/__init__.py
@@ -61,9 +61,9 @@ in this package is ecc.dh: 1.13x on secp256k1 and 1.03x on nistp256, the
 second being that measurement's own noise. Beside it, the blinded nonce
 inverse is 1.5 us of a 414 us signature, the projective blinding of
 curve_group._blinded_jac is 1%, and every verification is already _var.
-And btclib_secp256k1 is a required dependency, so the 1.13x is reached
-only by first switching the bindings off: a caller who does not is on
-the same program either way.
+The 1.13x was measured with the bindings switched off. btclib_secp256k1
+is the secp256k1 extra rather than a required dependency, so a caller who
+skips it is already in that state, with nothing to switch.
 
 They are implementations of one operation, kept side by side to be measured
 against each other, and a menu of them is not an API: a caller reading them


### PR DESCRIPTION
The module docstring said btclib_secp256k1 is a required dependency,
which became false once it moved to the secp256k1 extra. Restates the
1.13x figure's actual precondition (bindings switched off) instead.

Local review: CLEARED 4990b34d8ff0ff1bdd4d653c45e8e991bf516fd4.

Closes #1340.

## Summary by Sourcery

Correct the curves documentation to accurately describe the optional secp256k1 dependency and the conditions behind its performance comparison.

Bug Fixes:
- Correct the curves module documentation to identify `btclib_secp256k1` as an optional `secp256k1` extra rather than a required dependency.

Enhancements:
- Clarify that the documented 1.13x performance comparison was measured with bindings disabled and that omitting the optional extra already produces that configuration.

Documentation:
- Update the changelog and curves module docstring to reflect the corrected dependency and performance precondition.