### PR TITLE
README.md's badge row is badges by property, not by curation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **`README.md`'s badge row follows the organization standard's section
+  2: membership by property, never curation, in the fixed order with the
+  sentinels in section 10's calendar order.** The row gained `wheel` and
+  `implementation`, both read off the index, `github/v/release`, read
+  off the forge and paired beside the PyPI version badge so the two can
+  be compared, a `docs` workflow badge, and one badge per calendar
+  workflow this tree runs — `links`, `vendored-vectors`, `codeql`,
+  `py-arm-authority`, `deps-latest`, `pypi-install`, `os-ubuntu`,
+  `integration-hwi`, `os-macos`, `os-windows`, `mutation` and
+  `integration-bitcoind`; `alignment` and `bootstrap-dns` are not among
+  them, this tree holding neither workflow (issue #1347,
+  btclib-org/.github#338).
+
 - **`CONTRIBUTING.md`'s shared half is the organization's copy byte for
   byte.** Section 14 of the standard is what makes everything above
   `## This repository in particular` the same file in every repository;

--- a/README.md
+++ b/README.md
@@ -1,21 +1,37 @@
 # A Python library for 'bitcoin cryptography'
 
 <!-- The badges are what the reader decides with: the first line says what
-this is and whether it can be used, the second whether it works. A badge
-that reports no state -- "we use ruff", "we use uv" -- reports a choice
-instead, and those are in CONTRIBUTING.md, beside the prose that says how
-the choice is enforced. One badge per line keeps a change to one line and
-every line inside MD013; the site renders the line break as a space, its
-kramdown having hard_wrap off. -->
+this is and whether it can be used, the second whether it works, the third
+where the code is and where to ask about it. A badge that reports no state
+-- "we use ruff", "we use uv" -- reports a choice instead, and those are in
+CONTRIBUTING.md, beside the prose that says how the choice is enforced. One
+badge per line keeps a change to one line and every line inside MD013,
+whose 80 columns bind only where a space follows them. -->
 [![PyPI version](https://img.shields.io/pypi/v/btclib.svg?logo=pypi)](https://pypi.python.org/pypi/btclib/)
 [![downloads](https://static.pepy.tech/badge/btclib)](https://pepy.tech/project/btclib)
 [![development status](https://img.shields.io/pypi/status/btclib.svg)](https://pypi.python.org/pypi/btclib/)
 [![license](https://img.shields.io/github/license/btclib-org/btclib.svg)](https://github.com/btclib-org/btclib/blob/main/LICENSE)
 [![supported Python versions](https://img.shields.io/pypi/pyversions/btclib.svg?logo=python)](https://pypi.python.org/pypi/btclib/)
+[![wheel](https://img.shields.io/pypi/wheel/btclib.svg)](https://pypi.python.org/pypi/btclib/)
+[![implementation](https://img.shields.io/pypi/implementation/btclib.svg)](https://pypi.python.org/pypi/btclib/)
+[![GitHub release](https://img.shields.io/github/v/release/btclib-org/btclib.svg)](https://github.com/btclib-org/btclib/releases)
 
 [![test workflow status](https://github.com/btclib-org/btclib/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/test.yml)
 [![lint workflow status](https://github.com/btclib-org/btclib/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/lint.yml)
+[![docs workflow status](https://github.com/btclib-org/btclib/actions/workflows/docs.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/docs.yml)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib/main.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib/main)
+[![links workflow status](https://github.com/btclib-org/btclib/actions/workflows/links.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/links.yml)
+[![vendored-vectors workflow status](https://github.com/btclib-org/btclib/actions/workflows/vendored-vectors.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/vendored-vectors.yml)
+[![codeql workflow status](https://github.com/btclib-org/btclib/actions/workflows/codeql.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/codeql.yml)
+[![py-arm-authority workflow status](https://github.com/btclib-org/btclib/actions/workflows/py-arm-authority.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/py-arm-authority.yml)
+[![deps-latest workflow status](https://github.com/btclib-org/btclib/actions/workflows/deps-latest.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/deps-latest.yml)
+[![pypi-install workflow status](https://github.com/btclib-org/btclib/actions/workflows/pypi-install.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/pypi-install.yml)
+[![os-ubuntu workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-ubuntu.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/os-ubuntu.yml)
+[![integration-hwi workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-hwi.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/integration-hwi.yml)
+[![os-macos workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-macos.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/os-macos.yml)
+[![os-windows workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-windows.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/os-windows.yml)
+[![mutation workflow status](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml)
+[![integration-bitcoind workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml)
 [![documentation build](https://app.readthedocs.org/projects/btclib/badge/?version=latest)](https://btclib.readthedocs.io)
 
 [![GitHub repository: btclib-org/btclib](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib-181717?logo=github)](https://github.com/btclib-org/btclib/)


### PR DESCRIPTION
Rebuilds the badge row per section 2 of the organization standard:
membership decided by what the tree is, fixed order, sentinels in
section 10's calendar order. Adds pypi/wheel, pypi/implementation,
github/v/release (paired against the PyPI version badge), a docs
workflow badge, and one badge per calendar workflow this tree runs
(twelve of the calendar's fourteen rows).

Local review: CLEARED df5844e8154eccd6b4a63bed7d2d55cf9b32a736.

(issue #1347, btclib-org/.github#338)

## Summary by Sourcery

Align the README badge row with the organization standard and expand its coverage of package metadata and repository health.

New Features:
- Add PyPI metadata, GitHub release, documentation, and applicable calendar workflow badges to the README.

Enhancements:
- Reorganize the README badge row to follow the organization standard's property-based membership and fixed ordering.
- Clarify the README badge guidance to distinguish project identity, usability, health, and repository information.

Documentation:
- Document the standardized README badge arrangement and newly represented project and workflow statuses in the changelog.