### PR TITLE
REVIEWING.md's ack of record is an approving review, not never a forge one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,15 @@ documented at release-notes length in the first place, and are still in
   `\x20` beside it in the same entry already uses for its own space
   (issue #1302).
 
+- **`REVIEWING.md`'s *The verdict* names the ack of record as an
+  approving review, not a forge approval GitHub refuses outright.** The
+  organization's copy, shared half byte for byte (section 14): the
+  refusal is GitHub's rule against a pull request's author approving
+  their own branch, which explained why an author's own verdict is a
+  comment here but never why the workflow's was; section 11 now has
+  `claude-review.yml` post its verdict as an approving review, and that
+  review is the ack of record (btclib-org/.github#353).
+
 - **`REVIEWING.md`'s *The gates are the evidence* excepts no gate from
   the run a reviewer may rely on, the test suite included.** The
   organization's copy, shared half byte for byte (section 14): a run is

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -374,11 +374,11 @@ CHANGES REQUESTED <sha>
 ACK <sha>
 ```
 
-Nothing else is an ack — not "looks good", and not a forge approval,
-which section 11 of the standard records GitHub as refusing to the author
-of the pull request. That refusal is why the record of a review here is a
-comment at all. It names the sha because an ack belongs to a tree and
-not to a branch.
+Nothing else is an ack — not "looks good", and not a forge approval by
+the author of the pull request, which section 11 of the standard records
+GitHub as refusing. The ack of record is an approving review and section
+11 says whose; a verdict from anybody else is this comment, and either
+names the sha because an ack belongs to a tree and not to a branch.
 
 **A review that does not decide ends without one, and is not an
 unfinished review.** Somebody who reads a diff and says what they found


### PR DESCRIPTION
Converges btclib's REVIEWING.md with the organization standard's own
corrected wording: the ack of record is an approving review, whoever
posts it; the refusal that used to be read as "a forge approval is
never an ack" is scoped to the pull request's own author (GitHub's
self-approval rule), not to every reviewer.

Local review: CLEARED 5ca7ada6763e2ad97efa3401ea9710075a00df3b.

(issue #1347)

## Summary by Sourcery

Clarify that the workflow's approving review is the acknowledgment of record and limit the forge-approval exception to pull request authors.

Bug Fixes:
- Correct the review guidance so the record-of-acknowledgment is an approving review, while GitHub's self-approval restriction applies only to the pull request author.

Documentation:
- Align REVIEWING.md with the organization standard's corrected wording for acknowledgments and approval reviews.

Chores:
- Document the review-policy correction in the changelog.