### PR TITLE
codeql.yml runs on pull_request, and the prose that assumed it never would

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,33 +51,37 @@ name: codeql
 # `CodeQL` before the setting goes off rather than after.
 
 on:
-  # main and the schedule below, and no pull_request trigger: this analysis
-  # is the one gate that was worth trading for the queue it held. GitHub
-  # Free gives an organization twenty concurrent jobs, a commit used to ask
-  # for thirty-nine, and this workflow's three of them were held while a
-  # pull request waited for a slot -- so the analysis now lands on the merge
-  # commit rather than before it, and nothing this workflow produces can be
-  # a required check on main: a required check has to report on the pull
-  # request's own run, and this trigger produces none. REPOSITORY.md's
-  # "Required checks on main" is where that rule is written down, and
-  # dropping the `CodeQL` context there is a token operation that had to
-  # come first.
-  # What still reads a branch before it merges is lint.yml: zizmor is a
-  # pre-commit hook and reads exactly these files for an injected
-  # expression, which is the finding this workflow would otherwise be alone
-  # in making. What is deferred by a merge is the rest -- the python
-  # queries, and whatever zizmor does not model -- and the window is the
-  # time between a merge and the next run of this workflow, which for main
-  # is that merge itself.
-  # No `paths` filter, on either trigger: a filter buys nothing now that
-  # nothing waits on the answer, and it would have to name every path a
-  # query reads
+  # push and schedule cover main and what a diff cannot; pull_request adds
+  # the analysis on the branch itself, ahead of the merge rather than
+  # landing after it, which is what the OpenSSF Scorecard's SAST check
+  # asks for: it reads a merged pull request's own commits, and this
+  # repository was scoring "SAST configuration detected: CodeQL" beside
+  # "0 commits out of 29 are checked with a SAST tool" while the trigger
+  # below produced no run against a branch at all.
+  # Adding pull_request is a trade made in the opposite direction from the
+  # one this file used to make against the concurrency ceiling
+  # REPOSITORY.md measures: two more matrix cells on every push to a
+  # branch, and a check its author now waits on.
+  # What still reads a branch before this workflow does is lint.yml:
+  # zizmor is a pre-commit hook and reads exactly these files for an
+  # injected expression, which is one of the findings this workflow makes;
+  # the python queries, and whatever zizmor does not model, are the rest.
+  # No `paths` filter, on any of the three triggers: a filter would have
+  # to name every path a query reads
   push:
-    # a merge creates a commit that no pull request analysed, and code
-    # scanning compares a branch's alerts against the default branch's, so
-    # without a run here there is no baseline for any other run to be read
-    # against
+    # a merge creates a commit that its own pull request did not analyse
+    # -- squashed to a sha the branch never had, or pushed to main
+    # directly -- and code scanning compares a branch's alerts against
+    # the default branch's, so without a run here there is no baseline
+    # for any other run to be read against
     branches: [main]
+  pull_request:
+    # ready_for_review and closed, the same two types test.yml and
+    # lint.yml carry and for the same reasons given there: a pull request
+    # marked ready gets the run the draft condition below withheld while
+    # it was a draft, and a closed one is taken only to supersede a run
+    # its own concurrency group is still holding
+    types: [opened, reopened, synchronize, ready_for_review, closed]
   schedule:
     # Weekly, as default setup was: what a scheduled analysis catches is
     # a query CodeQL added since the last commit, which arrives with the
@@ -87,9 +91,8 @@ on:
     # Cron runs from the default branch only, so this asks nothing until
     # it reaches main; elsewhere the dispatch below is the way in
     - cron: "4 4 * * 2"
-  # the escape hatch, and with no pull_request trigger above it is the only
-  # way to analyse a branch before it is merged: worth reaching for on one
-  # that touches a workflow, which is what the actions queries read
+  # the escape hatch: a run on demand for a branch whose pull request is
+  # not open yet
   workflow_dispatch:
 
 # least privilege for the GITHUB_TOKEN: everything running in a job
@@ -100,13 +103,19 @@ on:
 permissions:
   contents: read
 
-# cancel superseded runs on the same branch, which is main or whatever a
-# dispatch names.
+# cancel superseded runs on the same branch or pull request.
 # The group is named literally rather than with github.workflow, which in
 # a called workflow is the caller's name: nothing calls this one today,
-# and the expression would be a trap for whatever does
+# and the expression would be a trap for whatever does.
+# github.event.pull_request.number, not github.ref alone: for a closed,
+# merged pull request's run, github.ref resolves to the base branch's ref
+# rather than refs/pull/N/merge, which would collide with the push
+# trigger's own group -- PR 1023's bug, recorded in test.yml's and
+# lint.yml's own copy of this comment. A pull_request run of any kind,
+# closed included, now groups by the pull request's own number instead,
+# which a push never carries and so still groups by github.ref, unchanged
 concurrency:
-  group: codeql-${{ github.ref }}
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -116,10 +125,15 @@ jobs:
     # reader into the log to find out which half broke -- and so the two
     # run in parallel, which is what default setup did too
     name: Analyze ${{ matrix.language }}
-    # no draft condition, where every job of test.yml carries one: this
-    # workflow no longer runs on a pull request at all, so there is no draft
-    # to skip and `github.event.pull_request.draft` is an expression that
-    # could only read empty here
+    # a draft pull request is work in progress: every push to one would
+    # spend this analysis on a tree its author is not asking anyone to
+    # review yet. A run on the merge result still happens the moment the
+    # pull request is marked ready, which is why ready_for_review is a
+    # trigger type above.
+    # A closed pull request spends no runner either, for the reason the
+    # trigger above gives: closed is taken only to supersede a run this
+    # ref's group is still holding
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     # far above what either language needs; what it bounds is a hung job
     # holding a runner for six hours
@@ -199,11 +213,14 @@ jobs:
           # rather than starting again
           category: "/language:${{ matrix.language }}"
 
-  # no aggregate job, where test.yml has one. Section 10 of
-  # btclib-org/.github's README.md conditions one on a workflow whose
-  # answer gates a pull request: a branch rule can only name a context a
-  # pull request's own run produces, and the `on:` block above has no
-  # `pull_request` trigger, so no rule could ever require a name this
-  # workflow produces. `analyze`'s two matrix cells are therefore the
-  # whole of the checks list this workflow contributes to a commit, one
-  # per language rather than one aggregate over both
+  # no aggregate job, where test.yml has one. REPOSITORY.md's "Required
+  # checks on main" states "Never name matrix contexts in the branch
+  # rule": a matrix cell's own name is not a context a branch rule can
+  # bind to safely, so neither `Analyze actions` nor `Analyze python` can
+  # be required on its own, the same reason test.yml needs
+  # `test: every job passed` while lint.yml and docs.yml, each a single
+  # job, need no aggregate of their own. This workflow has none, so
+  # `analyze`'s two matrix cells are the whole of the checks list it
+  # contributes to a commit and neither gates a merge; adding an
+  # aggregate, and naming it in the branch rule, is REPOSITORY.md's own
+  # section to decide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -582,6 +582,23 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **`codeql.yml` runs on `pull_request` too, alongside `push` on `main`
+  and the weekly `schedule`.** The OpenSSF Scorecard's `SAST` check
+  reads a merged pull request's own commits and found CodeQL configured
+  but never run against one, the previous triggers landing the analysis
+  on the merge commit rather than on the branch being decided.
+  `pull_request` carries the same `types`, and the `analyze` job the
+  same draft- and closed-skip condition, as `test.yml` and `lint.yml`;
+  the concurrency group now keys on the pull request's own number for
+  the reason those two files' comments give (PR 1023's bug). `Analyze
+  actions` and `Analyze python` are still not required checks:
+  REPOSITORY.md's "Never name matrix contexts in the branch rule" holds
+  regardless, and this workflow has no aggregate job to bind one to.
+  `CONTRIBUTING.md`'s workflow table, its two `codeql`-specific
+  paragraphs and `REPOSITORY.md`'s own account of why `codeql.yml`
+  carries no required check move with it, each having stated the
+  trigger this bullet changes (issue #1347, btclib-org/.github#349).
+
 - **Every place naming the bindings' distribution — the `secp256k1`
   extra's requirement spec, the `bindings` dependency group, and the
   prose describing both — spells it `btclib-secp256k1`, the hyphen the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -463,7 +463,7 @@ read by every checkout of this repository.
 | `integration-bitcoind` | pull request, push, weekly | a node |
 | `website` | pull request, push, on website files | — |
 | `claude-review` | pull request, and `@claude` in a comment | — |
-| `codeql` | push to main, and weekly | 2 languages |
+| `codeql` | pull request, push to main, and weekly | 2 languages |
 | `os-ubuntu` | weekly, a release | ubuntu images and interpreters |
 | `os-macos` | weekly, a release | macOS images and interpreters |
 | `os-windows` | weekly, a release | Windows images and interpreters |
@@ -498,9 +498,14 @@ it. REPOSITORY.md measures what a wider gate cost against that ceiling,
 and the consequence is this table's: at that ceiling a pull request's
 wall clock is the wait for a slot rather than the suite. `os-macos.yml` and
 `os-windows.yml` each carry the measurement for their own cells, the
-queueing and the runner seconds. `codeql` is off the gate for the same
-arithmetic, with `zizmor` in `lint` still reading these workflows on
-every pull request.
+queueing and the runner seconds. `codeql` spends against that same
+ceiling on every pull request too now, for the OpenSSF Scorecard's
+`SAST` check rather than for this table's arithmetic — REPOSITORY.md has
+that trade — but it still does not gate the merge, no matrix cell of its
+`analyze` job being nameable in the branch rule on its own and the
+workflow carrying no aggregate that could be. `zizmor` in `lint` reads
+these same workflow files for an injected expression on every pull
+request, which is a different question from what `codeql` asks.
 
 The trade, stated here rather than discovered later: the gate does not
 refuse a regression on `3.10`, on arm, on PyPy or on a platform. It sits
@@ -516,9 +521,9 @@ and whoever asked what ran would have to re-derive the hole from
 the platform; `deps-latest` moves both. Red in one of the three with `deps-latest`
 green is that platform; red in both is the upgrade. Every workflow in the
 table also takes `workflow_dispatch`, the gates included: a branch whose
-pull request is not open yet has no other way to ask, and for `codeql` and
-the three platform workflows it is the only way to ask about a branch at
-all. `claude-review` is the exception, and takes none: both its jobs read
+pull request is not open yet has no other way to ask, and for the three
+platform workflows it is the only way to ask about a branch at all.
+`claude-review` is the exception, and takes none: both its jobs read
 the pull request or the comment that triggered them, so a manual dispatch
 would start a run with nothing to read.
 
@@ -1044,11 +1049,10 @@ something already known to the world.
 The only check with no local equivalent is `codeql`: the analysis needs the
 CodeQL bundle and a database, which is a download rather than a `uv`
 command, so `.github/workflows/codeql.yml` is where it is configured and
-GitHub's runners are where it happens. It is also the one check no pull
-request runs — `workflow_dispatch` is how a branch asks — so its findings
-arrive under the Security tab after a merge rather than before it, and
-`REPOSITORY.md` has both why the workflow is in the tree and what that
-timing was traded for.
+GitHub's runners are where it happens. It runs on every pull request now,
+alongside `push` to `main` and its weekly schedule, so its findings reach
+a branch before a merge rather than only after one; `REPOSITORY.md` has
+why it is still not a required check.
 
 ### The website
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -84,19 +84,19 @@ for 1375 of 2100 seconds — so a pull request's wall clock was the wait
 for a slot and not the work. That is the measurement the gate and the
 weekly sweeps are arranged around.
 
-`codeql.yml` carries no required check at all, and that is the one place
-a check was traded for the wait it cost. It runs on `main` and on its
-schedule rather than on a pull request, the analysis landing on the merge
-commit rather than ahead of it — and a required check has to report on
-the pull request's own run, which this trigger never produces. Section 10
-of `btclib-org/.github`'s README.md is where that rule, and the aggregate
-job it stops this workflow from needing, are written down.
+`codeql.yml` carries no required check at all. It runs on `main`, on its
+schedule and on every pull request now — the OpenSSF Scorecard's `SAST`
+check is why, and `codeql.yml`'s own `on:` block comment carries that
+story — but neither cell of its `analyze` job's matrix can be named in
+the branch rule on its own, the bullet above being why, and the workflow
+has no aggregate job that could be. The Code scanning section below
+states that in its own terms, at the point where default setup's own
+`CodeQL` context is dropped from the rule instead.
 
-What still reads a branch before it merges is the workflow half of the same
-question: `zizmor` is a pre-commit hook, so `lint.yml` audits these very
-files for an injected expression on every pull request, and that check is
-required. What a merge now defers is the rest of the analysis, for the time
-between that merge and the next run — which for `main` is the merge itself.
+What still reads a branch before it merges, `codeql.yml` itself included
+now, is the workflow half of the same question: `zizmor` is a pre-commit
+hook, so `lint.yml` audits these very files for an injected expression on
+every pull request, and that check is required.
 
 Renaming or dropping a required check is the one change that cannot be made
 in a pull request: the workflow in the branch stops producing the name while


### PR DESCRIPTION
Adds a pull_request trigger to codeql.yml (kept push and schedule), so
the OpenSSF Scorecard's SAST check finds an analysis on the branch
itself rather than only after it merges. Matches test.yml/lint.yml's
draft-skip condition and PR-number concurrency grouping. Corrects
REPOSITORY.md's and CONTRIBUTING.md's prose (four spots) that assumed
codeql.yml never runs on a pull request's own head.

Local review: CLEARED 62342004f0831163c1374eed4e843c42c27a62f1.

(issue #1347, btclib-org/.github#349)

## Summary by Sourcery

Run CodeQL on pull requests and align repository documentation with its new branch-level analysis behavior.

New Features:
- Run CodeQL analysis on pull requests in addition to main pushes and scheduled scans to provide branch-level SAST coverage.

Bug Fixes:
- Correct documentation that described CodeQL as running only after merges and update the related workflow and check behavior descriptions.

Enhancements:
- Align pull-request event handling, draft and closed-run filtering, and concurrency grouping with the repository’s other pull-request workflows while retaining CodeQL as a non-required check.

CI:
- Update CI workflow documentation and changelog entries to reflect CodeQL’s pull-request trigger and current gating behavior.

Documentation:
- Revise CONTRIBUTING.md and REPOSITORY.md to accurately document CodeQL triggers, timing, concurrency, and non-required matrix checks.