### PR TITLE
The release path checks a break in the public surface with griffe check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,6 +232,105 @@ jobs:
           echo "run $GITHUB_RUN_NUMBER attempt $GITHUB_RUN_ATTEMPT: $suffix"
           echo "version-suffix=$suffix" >> "$GITHUB_OUTPUT"
 
+  # walks the public API of the release before this one against the one
+  # being cut and reports what broke: a removed object, a changed
+  # parameter kind or default, a narrowed type. It runs here rather than
+  # as a merge gate -- btclib-org/.github#326's own decision -- because
+  # before 1.0 the surface breaks deliberately and often, and a gate
+  # reporting every such break on every pull request has nothing to say
+  # about which ones are allowed; that needs the deprecation policy
+  # btclib-org/btclib#651 has not settled yet. Here the answer arrives
+  # while RELEASE_NOTES.md is already being written, so a break with no
+  # entry is refused at the moment somebody is already writing entries.
+  # Ahead of the build/test matrix below: a broken surface is worth
+  # knowing before the platform sweeps and the smoke tests spend the
+  # wall clock they take
+  public-api:
+    name: Check the public API against the last release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # the previous tag has to be reachable in this checkout for the
+          # step below to find it, and a single-commit checkout -- what
+          # every other job's checkout takes -- would not carry it
+          fetch-depth: 0
+          fetch-tags: true
+      # a release tag is already on the remote by the time this job runs,
+      # so the "latest tag" griffe would resolve on its own is the release
+      # being cut, not the one before it -- comparing a tag against itself
+      # reports no break whatever changed. The previous tag is resolved
+      # explicitly instead, by walking the ref's own ancestry rather than
+      # a version sort, so a tag pushed on a branch this history never
+      # merged is not picked up as "previous". A rehearsal has no tag of
+      # its own, so it asks from HEAD directly rather than HEAD^
+      - name: Resolve the previous release
+        id: previous
+        env:
+          REF: >-
+            ${{ github.event_name == 'push' && format('{0}^', github.ref_name)
+            || 'HEAD' }}
+        run: |
+          if tag=$(git describe --tags --abbrev=0 --match 'v*' "$REF" 2>&1); then
+            echo "previous release: $tag"
+            echo "tag=$tag" >> "$GITHUB_OUTPUT"
+            echo "has-previous=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no previous v* tag reachable from $REF: $tag"
+            echo "has-previous=false" >> "$GITHUB_OUTPUT"
+          fi
+      # caching off, as in version-check above: this job runs on the same
+      # tag-push and workflow_dispatch triggers that job's own comment
+      # gives for downloading fresh rather than trusting a cache entry
+      # written by a run this one cannot vouch for
+      - name: Setup uv
+        if: steps.previous.outputs.has-previous == 'true'
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: false
+      # griffe runs from PyPI through uvx rather than from a pyproject.toml
+      # dependency group: unlike pre-commit -- pinned by uv.lock because
+      # every contributor's own run has to agree with the gate's -- this
+      # runs at release time only, on one maintainer's own action, so a
+      # dependency group buys reproducibility nothing here needs. The
+      # version pin on the line below is what still keeps this
+      # comparison from answering differently on two release days for a
+      # reason that has nothing to do with either release.
+      # -s . -s src covers both layouts this repository has published
+      # under: every tag through v2026.8.21 has btclib/ at the
+      # repository root, and the working tree has moved it under src/ --
+      # a search path that finds nothing in one reference is skipped in
+      # favour of the other, so this does not have to change once a
+      # future tag adopts the src layout too.
+      # No base ref on a rehearsal: workflow_dispatch has no tag to check
+      # a public surface at, so the comparison falls back to griffe's own
+      # default, the current code
+      - name: Check the public API against the previous release
+        if: steps.previous.outputs.has-previous == 'true'
+        env:
+          PREVIOUS_TAG: ${{ steps.previous.outputs.tag }}
+          BASE_REF: ${{ github.event_name == 'push' && github.ref_name || '' }}
+        run: |
+          base_args=()
+          if [ -n "$BASE_REF" ]; then
+            base_args=(-b "$BASE_REF")
+          fi
+          if ! uvx griffe==2.2.0 check btclib -s . -s src \
+              -a "$PREVIOUS_TAG" "${base_args[@]}" -f github; then
+            msg="the public API changed since $PREVIOUS_TAG:"
+            echo "::error::$msg add a breaking-changes bullet to" \
+              "RELEASE_NOTES.md, or say here why the change is not one"
+            exit 1
+          fi
+      - name: Skip the check (no previous release to compare against)
+        if: steps.previous.outputs.has-previous == 'false'
+        run: |
+          echo "::notice::no previous v* tag is reachable; nothing to" \
+            "compare this release's public API against"
+
   # the whole build/test matrix, exactly as a pull request runs it, and
   # now the build too: test.yml's `dist` job builds the distribution
   # files, checks them and uploads them, so this call is what makes them
@@ -324,7 +423,16 @@ jobs:
   publish-testpypi:
     name: Publish to TestPyPI
     needs:
-      [test, lint, docs, os-ubuntu, os-macos, os-windows, integration-bitcoind]
+      [
+        public-api,
+        test,
+        lint,
+        docs,
+        os-ubuntu,
+        os-macos,
+        os-windows,
+        integration-bitcoind,
+      ]
     if: github.event_name == 'workflow_dispatch' && github.repository == 'btclib-org/btclib'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -349,7 +457,16 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     needs:
-      [test, lint, docs, os-ubuntu, os-macos, os-windows, integration-bitcoind]
+      [
+        public-api,
+        test,
+        lint,
+        docs,
+        os-ubuntu,
+        os-macos,
+        os-windows,
+        integration-bitcoind,
+      ]
     if: github.event_name == 'push' && github.repository == 'btclib-org/btclib'
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1852,6 +1852,18 @@ documented at release-notes length in the first place, and are still in
   exempts `__init__` and a magic method, and the previous wording gave
   only the reason each is exempt without saying that (issue #1318).
 
+- **`release.yml` gains a `public-api` job that runs `griffe check`
+  between the previous `v*` tag and the one being cut, or the working
+  tree on a `workflow_dispatch` rehearsal.** A break it finds fails the
+  job — `RELEASE_NOTES.md`'s breaking-changes list is what a maintainer
+  seeing the failure is pointed at — and `publish-testpypi` and
+  `publish-pypi` both depend on it, so an unreleased break blocks
+  publication the same way a failing platform sweep already does. Where
+  no `v*` tag is reachable the step is skipped with a log line rather
+  than failing, there being nothing to compare against. Section 12 of
+  the organization standard leaves both choices to this tree
+  (issue #1347, btclib-org/.github#326).
+
 ### Documentation and the website
 
 - **`.readthedocs.yaml` justifies its own name with the setting that


### PR DESCRIPTION
A new public-api job compares the tag being cut against the tag before
it, via uvx griffe check, and blocks publish-testpypi/publish-pypi on
a finding. No previous tag skips with a notice rather than failing.

Local review: CLEARED 6216a4d5d96fe2a282a3b8514873c2766d02f91b.

(issue #1347, btclib-org/.github#326)

## Summary by Sourcery

Add a release-gating public API compatibility check so breaking changes are identified before publication.

New Features:
- Add a release-time public API compatibility check against the previous reachable release tag or the rehearsal baseline.

Enhancements:
- Prevent TestPyPI and PyPI publication when the public API check reports an unacknowledged breaking change.
- Skip the comparison with a notice when no previous release tag is available.

CI:
- Run the public API check before the release test matrix and make both publishing jobs depend on it.

Documentation:
- Document the new release public API check and its publication-blocking behavior in the changelog.