### PR TITLE
Documentation is themed with furo, and the build runs -n as well as -W

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -104,11 +104,15 @@ jobs:
       # defect issue 151 was opened for, read the docs having installed
       # sphinx alone and rendered 70 empty module headings.
       # -W makes a failed import a failed build, and --keep-going reports
-      # every problem in one run instead of one per push
+      # every problem in one run instead of one per push. -n turns an
+      # unresolved cross-reference into a warning for -W to fail on --
+      # without it a renamed class or a moved function in a :class: role
+      # builds green and links nowhere. conf.py's intersphinx_mapping and
+      # nitpick_ignore are what -n is checked against
       - name: Build the docs
         run: >
           uv run --locked --no-default-groups --group docs
-          sphinx-build -W --keep-going -b html docs/source docs/build/html
+          sphinx-build -n -W --keep-going -b html docs/source docs/build/html
       # the one defect the build above cannot report on itself: a link
       # myst cannot resolve is rendered as an anchor on the page it is
       # already on -- an id nothing has -- so -W passes over a dead link

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -61,10 +61,12 @@ build:
   # resolving something else.
   # -W turns a failed import into a failed build, which is the point
   # of the whole file; --keep-going comes first so one broken module
-  # reports every other problem in the same run instead of one per push
+  # reports every other problem in the same run instead of one per push.
+  # -n is docs.yml's own flag, kept in step here so the site this file
+  # publishes is built by the same command that gates a merge
   commands:
     - pip install uv
     - uv sync --locked --no-default-groups --group docs
     - >-
       uv run --locked --no-default-groups --group docs
-      sphinx-build -W --keep-going -b html docs/source $READTHEDOCS_OUTPUT/html
+      sphinx-build -n -W --keep-going -b html docs/source $READTHEDOCS_OUTPUT/html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1866,6 +1866,33 @@ documented at release-notes length in the first place, and are still in
 
 ### Documentation and the website
 
+- **The documentation site is themed with `furo`** (issue #1347,
+  btclib-org/.github#329). The `docs` dependency group and `conf.py`'s
+  `html_theme` both name it, in place of `sphinx_rtd_theme`: the
+  organization standard's section 2 gives `pip`, `black`, `urllib3` and
+  `attrs` as what the rest of this ecosystem reads as ordinary, against
+  the theme it replaces being where a Read the Docs project starts by
+  default and no more than that.
+
+- **The documentation build runs `-n` alongside `-W`** (issue #1347,
+  btclib-org/.github#324), in `docs.yml`, `.readthedocs.yaml` and the
+  command CONTRIBUTING.md documents, so an unresolved cross-reference is
+  a warning for `-W` to fail the build on rather than a link that
+  resolves to nothing on a build that stays green. `conf.py` gained
+  `sphinx.ext.intersphinx`, with a mapping for python ahead of the flag
+  so it resolves this tree's use of the standard library rather than
+  measuring it as broken, and a `nitpick_ignore` list for what stays
+  genuinely unresolvable: a subscripted generic sphinx's own
+  type-to-xref splitter cannot fully parse, measured against sphinx
+  9.1.0, and names this tree documents nowhere — `alias.py`'s bare type
+  aliases and the `p2p` module's private payload classes — each entry
+  carrying its own reason rather than a regex that would give up the
+  check. Property and attribute docstrings whose opening line read
+  `<phrase>: <text>` are reworded, one word in each: napoleon reads that
+  colon as the member's own type declaration, which is what turned every
+  one of them into its own unresolved reference once `-n` was on to
+  report it.
+
 - **`.readthedocs.yaml` justifies its own name with the setting that
   actually controls it** (issue #1275). The comment gave `MANIFEST.in`'s
   `include *.yml` as the reason the dotted spelling ships, in a tree

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1012,11 +1012,17 @@ page — and what catches invalid reStructuredText in a docstring, which no
 hook can: markdownlint does not read `.rst`, and ruff's pydocstyle rules
 check the form of a docstring rather than whether its body parses. A name
 ending in an underscore is the trap to know about, rst reading it as a link
-reference, so write it in double backticks:
+reference, so write it in double backticks. `-n` is what turns an
+unresolved cross-reference — a renamed class in a `:class:` role, a moved
+function — into a warning for `-W` to fail the build on, rather than a
+link that resolves to nothing on a green build; `conf.py`'s
+`intersphinx_mapping` is what it resolves the standard library against,
+and its `nitpick_ignore` carries the entries that reason cannot reach,
+each with the reason beside it:
 
 ```shell
 uv run --locked --no-default-groups --group docs \
-    sphinx-build -W --keep-going -b html docs/source docs/build/html
+    sphinx-build -n -W --keep-going -b html docs/source docs/build/html
 ```
 
 That job has a second step, which reads the pages the first one wrote and

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,6 +55,7 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.coverage",
     "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
 ]
@@ -65,6 +66,58 @@ extensions = [
 # into a failed build -- the open questions belong in the issue tracker
 
 source_suffix = [".rst", ".md"]
+
+# -n on the build (CONTRIBUTING.md's documented command, and docs.yml)
+# turns an unresolved cross-reference into a warning for -W to fail on.
+# Without an inventory to resolve against, a name from outside this tree
+# -- collections.abc.Sequence, pathlib.Path, os.getcwd -- reports as this
+# tree's own broken link; sphinx's own domain answers for the builtins
+# (int, bytes, str), so no mapping is needed for those. typing_extensions
+# carries no public inventory, but the only name this tree imports from
+# it is the `override` decorator, which never appears in a signature or
+# a docstring type field, so it draws no reference for -n to raise on
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
+
+# What the mapping above does not answer for is two shapes, neither an
+# inventory can fix, and each entry below carries its own reason rather
+# than a nitpick_ignore_regex that would give the check up entirely:
+#
+# - a subscripted generic written inline in a signature -- Callable's
+#   argument list, a bare tuple[int, ...], a union built out of either --
+#   where sphinx's own type-to-xref splitter (measured against sphinx
+#   9.1.0) stops at the first nested bracket and reports the truncated
+#   fragment as the unresolved class, rather than resolving the pieces on
+#   either side of it. No mapping answers a target that is not a name to
+#   begin with
+# - a name this tree documents nowhere. alias.py's Octets and
+#   TaprootScriptTree, bip32.py's BIP32Key, der_path.py's DerPath and
+#   descriptors.py's DescriptorTree are bare module-level assignments
+#   with no docstring of their own, so `:members:` renders no page for a
+#   signature naming them to link to; the p2p payload classes below are
+#   private, and automodule does not document a name beginning with an
+#   underscore at all
+nitpick_ignore = [
+    ("py:class", "collections.abc.Callable[[]"),
+    ("py:class", "tuple[int"),
+    ("py:class", "collections.abc.Mapping[bytes"),
+    (
+        "py:class",
+        (
+            "bytes | str | bytearray | memoryview | "
+            "~btclib.bip32.bip32.BIP32KeyData | tuple[int"
+        ),
+    ),
+    ("py:class", "int | bytes | str | bytearray | memoryview | tuple[int"),
+    ("py:class", "Octets"),
+    ("py:class", "DerPath"),
+    ("py:class", "BIP32Key"),
+    ("py:class", "TaprootScriptTree"),
+    ("py:class", "DescriptorTree"),
+    ("py:class", "btclib.p2p.inventory._InventoryPayload"),
+    ("py:class", "btclib.p2p.inventory._LocatorPayload"),
+    ("py:class", "btclib.p2p.keepalive._NoncePayload"),
+    ("py:class", "btclib.p2p.block_filters._FilterRangeRequest"),
+]
 
 # no suppress_warnings, and myst.xref_missing least of all: the transform
 # at the bottom of this file resolves every link the included root files
@@ -87,7 +140,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"
 
 # no html_static_path: this project overrides no stylesheet and ships no
 # image, so the "_static" the sphinx template declares was a directory that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,9 +192,9 @@ check = ["check-sdist", "check-wheel-contents", "pyroma", "twine"]
 mutation = ["cosmic-ray"]
 docs = [
     { include-group = "bindings" },
+    "furo",
     "myst-parser",
     "sphinx",
-    "sphinx_rtd_theme",
 ]
 dev = [
     { include-group = "test" },

--- a/src/btclib/bip32/bip32.py
+++ b/src/btclib/bip32/bip32.py
@@ -246,7 +246,7 @@ class BIP32KeyData:
 
     @property
     def is_root(self) -> bool:
-        """Answer whether this is a master key: no depth, index, parent."""
+        """Answer whether this is a master key, no depth, index, parent."""
         return (
             self.depth == 0
             and self.index == 0

--- a/src/btclib/bip32/key_origin.py
+++ b/src/btclib/bip32/key_origin.py
@@ -52,7 +52,7 @@ class BIP32KeyOrigin:
 
     @property
     def description(self) -> str:
-        """Return the descriptor spelling: fingerprint/path, h for hardened."""
+        """Return the descriptor spelling, fingerprint/path, h for hardened."""
         return str_from_der_path(self.der_path, self.master_fingerprint)
 
     def __init__(

--- a/src/btclib/block/block.py
+++ b/src/btclib/block/block.py
@@ -165,7 +165,7 @@ class Block:
 
     @property
     def vsize(self) -> int:
-        """Return the virtual size: the weight over four, rounded up."""
+        """Return the virtual size, the weight over four rounded up."""
         return ceil(self.weight / 4)
 
     @property

--- a/src/btclib/p2p/message.py
+++ b/src/btclib/p2p/message.py
@@ -165,12 +165,13 @@ class Message:
 
     @property
     def checksum(self) -> bytes:
-        """Return the four octets the header carries: hash256(payload)[:4].
+        """Return the four octets the header carries.
 
-        Bitcoin Core's `V1Transport::GetMessageHash`. It is what the
-        payload says it is, so it is derived here and never stored;
-        `parse` is the one place the two can disagree, and it refuses the
-        octets rather than building the disagreement.
+        The first four octets of hash256(payload), Bitcoin Core's
+        `V1Transport::GetMessageHash`. It is what the payload says it
+        is, so it is derived here and never stored; `parse` is the one
+        place the two can disagree, and it refuses the octets rather
+        than building the disagreement.
         """
         return hash256(self.payload)[:_CHECKSUM_SIZE]
 

--- a/src/btclib/tx/tx.py
+++ b/src/btclib/tx/tx.py
@@ -188,7 +188,7 @@ class Tx:  # noqa: PLW1641
 
     @property
     def weight(self) -> int:
-        """Return the BIP141 weight: 3x the stripped size plus the size."""
+        """Return the BIP141 weight, 3x the stripped size plus the size."""
         return 3 * self._serialized_size(include_witness=False) + self._serialized_size(
             include_witness=True
         )
@@ -224,7 +224,7 @@ class Tx:  # noqa: PLW1641
 
     @property
     def is_coinbase(self) -> bool:
-        """Answer whether this is a coinbase: one input, spending nothing."""
+        """Answer whether this is a coinbase, one input spending nothing."""
         return len(self.vin) == 1 and self.vin[0].is_coinbase
 
     def __init__(

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,18 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "accessible-pygments"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c1/bbac6a50d02774f91572938964c582fff4270eee73ab822a4aeea4d8b11b/accessible_pygments-0.0.5.tar.gz", hash = "sha256:40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872", size = 1377899, upload-time = "2024-05-10T11:23:10.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl", hash = "sha256:88ae3211e68a1d0b011504b2ffc1691feafce124b845bd072ab6f9f66f34d4b7", size = 1395903, upload-time = "2024-05-10T11:23:08.421Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -300,6 +312,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
 name = "bitcoin-core-rpc"
 version = "2026.8.20"
 source = { registry = "https://pypi.org/simple" }
@@ -338,6 +363,7 @@ dev = [
     { name = "check-wheel-contents" },
     { name = "cosmic-ray" },
     { name = "coverage" },
+    { name = "furo" },
     { name = "hypothesis" },
     { name = "mypy" },
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -352,17 +378,16 @@ dev = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-rtd-theme" },
     { name = "twine" },
 ]
 docs = [
     { name = "btclib-secp256k1" },
+    { name = "furo" },
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "myst-parser", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-rtd-theme" },
 ]
 harness = [
     { name = "coverage" },
@@ -413,6 +438,7 @@ dev = [
     { name = "check-wheel-contents" },
     { name = "cosmic-ray" },
     { name = "coverage" },
+    { name = "furo" },
     { name = "hypothesis" },
     { name = "mypy" },
     { name = "myst-parser" },
@@ -424,14 +450,13 @@ dev = [
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "sphinx" },
-    { name = "sphinx-rtd-theme" },
     { name = "twine" },
 ]
 docs = [
     { name = "btclib-secp256k1", specifier = ">=0.8.0.4" },
+    { name = "furo" },
     { name = "myst-parser" },
     { name = "sphinx" },
-    { name = "sphinx-rtd-theme" },
 ]
 harness = [
     { name = "coverage" },
@@ -1305,6 +1330,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "furo"
+version = "2025.12.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accessible-pygments" },
+    { name = "beautifulsoup4" },
+    { name = "pygments" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx-basic-ng" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl", hash = "sha256:bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f", size = 339262, upload-time = "2025-12-19T17:34:38.905Z" },
 ]
 
 [[package]]
@@ -2867,6 +2910,15 @@ wheels = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/99/a6ca3beb3ccacb41fb3321d8a60e5566f9e6467601ef8eba6a17e1b89778/soupsieve-2.9.2.tar.gz", hash = "sha256:4a55d8cf158a9c2e587fa4922f1bbb91d68ac829e2d6f25403a85747c71daf74", size = 122445, upload-time = "2026-08-07T00:57:24.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/dc/ad025c1ee131eba60c69f4dd5779b18fcf1e6b21a343e2162a84d5d133c7/soupsieve-2.9.2-py3-none-any.whl", hash = "sha256:8089a26fd974ca7a1f30276d3d8492ab266ab15af581642dfe8aa162e0c1c823", size = 37370, upload-time = "2026-08-07T00:57:23.524Z" },
+]
+
+[[package]]
 name = "sphinx"
 version = "8.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2963,20 +3015,17 @@ wheels = [
 ]
 
 [[package]]
-name = "sphinx-rtd-theme"
-version = "3.1.0"
+name = "sphinx-basic-ng"
+version = "1.0.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jquery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/68/a1bfbf38c0f7bccc9b10bbf76b94606f64acb1552ae394f0b8285bfaea25/sphinx_rtd_theme-3.1.0.tar.gz", hash = "sha256:b44276f2c276e909239a4f6c955aa667aaafeb78597923b1c60babc76db78e4c", size = 7620915, upload-time = "2026-01-12T16:03:31.17Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/c7/b5c8015d823bfda1a346adb2c634a2101d50bb75d421eb6dcb31acd25ebc/sphinx_rtd_theme-3.1.0-py2.py3-none-any.whl", hash = "sha256:1785824ae8e6632060490f67cf3a72d404a85d2d9fc26bce3619944de5682b89", size = 7655617, upload-time = "2026-01-12T16:03:28.101Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl", hash = "sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b", size = 22496, upload-time = "2023-07-08T18:40:52.659Z" },
 ]
 
 [[package]]
@@ -3004,20 +3053,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-jquery"
-version = "4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/de/f3/aa67467e051df70a6330fe7770894b3e4f09436dea6881ae0b4f3d87cad8/sphinxcontrib-jquery-4.1.tar.gz", hash = "sha256:1620739f04e36a2c779f1a131a2dfd49b2fd07351bf1968ced074365933abc7a", size = 122331, upload-time = "2023-03-14T15:01:01.944Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/85/749bd22d1a68db7291c89e2ebca53f4306c3f205853cf31e9de279034c3c/sphinxcontrib_jquery-4.1-py2.py3-none-any.whl", hash = "sha256:f936030d7d0147dd026a4f2b5a57343d233f1fc7b363f68b3d4f1cb0993878ae", size = 121104, upload-time = "2023-03-14T15:01:00.356Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Switches the docs group from sphinx_rtd_theme to furo, adds intersphinx
so -n has an inventory to resolve against, and adds a nitpick_ignore
list with a reason beside every entry. Fixes six docstrings a
Napoleon-parser quirk was misreading as :type: fields. -n joins -W in
docs.yml, .readthedocs.yaml and CONTRIBUTING.md.

Local review: CLEARED 208283f7254a1731bdae9c084a15a448c4fd4cbf.

(issue #1347, btclib-org/.github#329, btclib-org/.github#324)

## Summary by Sourcery

Strengthen documentation validation and refresh the documentation site theme.

New Features:
- Adopt the Furo theme for the documentation site.
- Enable strict unresolved-reference checking with Sphinx intersphinx support and documented, reasoned exceptions.

Bug Fixes:
- Fix docstrings that Napoleon misinterpreted as type fields.

Build:
- Update the documentation dependency group to use Furo instead of sphinx_rtd_theme.

CI:
- Run documentation builds with Sphinx -n alongside -W in GitHub Actions, Read the Docs, and contributor instructions.

Documentation:
- Document the stricter cross-reference validation and its configuration.