### PR TITLE
scorecard.yml runs the OpenSSF Scorecard against this tree

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,107 @@
+---
+name: scorecard
+
+# OpenSSF Scorecard: eighteen checks against this repository's
+# supply-chain posture, computed by a third party rather than by
+# anything this organization asked itself. btclib-org/.github#339 is
+# where this sentinel and its permissions are decided; this file adopts
+# it, and does not restate the reasoning.
+#
+# This repository is public and is not a fork, which is the property
+# section 10 of the standard keys the sentinel on:
+#
+#   gh api repos/btclib-org/btclib --jq '.fork, .private'
+#
+# answers `false` and `false`.
+
+on:
+  push:
+    # only the default branch is analysed -- ossf/scorecard-action's own
+    # README names this and schedule as the supported triggers and calls
+    # workflow_dispatch experimental, so unlike every other workflow here
+    # this one carries no dispatch and no pull_request: its triggers are
+    # the action's, not section 10's general rule
+    branches: [main]
+  # No schedule: yet. Section 10's calendar is two tables read by
+  # btclib-org/.github's own tests/grid_test.py, and neither names
+  # "scorecard" today -- not because the sentinel is structurally exempt
+  # (that sentence in section 10 is about which *trigger types* it
+  # supports, push and schedule rather than pull_request and
+  # workflow_dispatch, and says nothing about the day/hour grid), but
+  # because btclib-org/portanode was the first tree in the organization
+  # to adopt the workflow and no repository had a row before it.
+  # btclib-org/.github#201 is the landed precedent for exactly this gap,
+  # on bootstrap-dns.yml: a sentinel ships with no schedule trigger
+  # until an issue proposes a day and an hour and section 10's table
+  # gains the row, at which point a schedule: block is added here to
+  # match it. Until then a cron naming "scorecard" would be a row
+  # grid_test.py's test_every_cron_is_the_instant_the_calendar_names
+  # cannot find, which fails not this repository's own gate but
+  # btclib-org/.github's weekly alignment sentinel, against every tree
+  # it clones. The push trigger above already runs the analysis on every
+  # push to main, which is what feeds the badge and the published score
+  # in the meantime. btclib-org/.github#363 proposes the row -- Saturday,
+  # hour 03, open rather than decided as of this file.
+
+# least privilege for the GITHUB_TOKEN at the workflow level, with one
+# elevation on the job below: the analysis reads the tree, requests a
+# transparency-log entry for its own result and files that result as
+# code-scanning alerts, and pushes nothing back to the tree.
+permissions:
+  contents: read
+
+concurrency:
+  # named literally, never through github.workflow. A run with no pull
+  # request -- every run of this workflow, since it carries none -- has
+  # no number and groups by github.ref, which is refs/heads/main for the
+  # one trigger this workflow has, so two pushes in quick succession
+  # supersede each other -- wanted, since they ask the same question of
+  # the same tree
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # the transparency-log entry publish_results below asks for
+      id-token: write
+      # SARIF results filed as code-scanning alerts
+      security-events: write
+      # elevation-per-job: this job writes neither a release nor
+      # anything else to the tree, so contents stays at its workflow
+      # default of read
+      actions: read
+      contents: read
+    # a run past this is hung rather than analysing
+    timeout-minutes: 15
+    steps:
+      # every action pinned to a commit SHA with the tag in the comment:
+      # a tag, let alone a branch, is a name its owner can move
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # the analysis reads the tree and nothing pushes it back
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # feeds the score api.scorecard.dev/projects/... serves, which
+          # is what README.md's badge and the scorecard.dev viewer read
+          publish_results: true
+
+      - name: Upload the SARIF as a workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload the SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,20 @@ documented at release-notes length in the first place, and are still in
   them, this tree holding neither workflow (issue #1347,
   btclib-org/.github#338).
 
+- **`scorecard.yml` runs the OpenSSF Scorecard against this tree**,
+  section 10's sentinel keyed on a repository being public and not a
+  fork. `publish_results: true` feeds the score `api.scorecard.dev`
+  serves and files what it finds as code-scanning alerts;
+  `id-token: write` is the transparency-log entry the publish asks for,
+  `security-events: write` the alert upload. Its triggers are the
+  action's own rather than section 10's usual set — `push:` on `main`
+  only, no `pull_request`, no `workflow_dispatch` — and it carries no
+  `schedule:` yet, section 10's calendar naming no day or hour for it
+  until btclib-org/.github#363 is answered. `README.md`'s badge sits
+  last among the sentinel badges, after every workflow the calendar does
+  order, per btclib-org/.github#358 (issue #1347,
+  btclib-org/.github#339).
+
 - **`CONTRIBUTING.md`'s shared half is the organization's copy byte for
   byte.** Section 14 of the standard is what makes everything above
   `## This repository in particular` the same file in every repository;

--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ where the code is and where to ask about it. A badge that reports no state
 -- "we use ruff", "we use uv" -- reports a choice instead, and those are in
 CONTRIBUTING.md, beside the prose that says how the choice is enforced. One
 badge per line keeps a change to one line and every line inside MD013,
-whose 80 columns bind only where a space follows them. -->
+whose 80 columns bind only where a space follows them.
+Scorecard is placed last among the sentinel badges rather than in the
+calendar order the rest follow: section 10 names it the one sentinel whose
+triggers are the action's own rather than the standard's, and it has no
+row in section 10's day/hour table yet -- btclib-org/.github#363 proposes
+one, and btclib-org/.github#358 is where this placement is asked to become
+the stated rule rather than this tree's own reading of a silent one. -->
 [![PyPI version](https://img.shields.io/pypi/v/btclib.svg?logo=pypi)](https://pypi.python.org/pypi/btclib/)
 [![downloads](https://static.pepy.tech/badge/btclib)](https://pepy.tech/project/btclib)
 [![development status](https://img.shields.io/pypi/status/btclib.svg)](https://pypi.python.org/pypi/btclib/)
@@ -32,6 +38,7 @@ whose 80 columns bind only where a space follows them. -->
 [![os-windows workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-windows.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/os-windows.yml)
 [![mutation workflow status](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml)
 [![integration-bitcoind workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/btclib-org/btclib/badge)](https://scorecard.dev/viewer/?uri=github.com/btclib-org/btclib)
 [![documentation build](https://app.readthedocs.org/projects/btclib/badge/?version=latest)](https://btclib.readthedocs.io)
 
 [![GitHub repository: btclib-org/btclib](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib-181717?logo=github)](https://github.com/btclib-org/btclib/)


### PR DESCRIPTION
Publishes the Scorecard analysis on every push to main, files results
as code scanning alerts, and adds the badge. Push-only trigger, per
ossf/scorecard-action's own guidance and the calendar-row question
(btclib-org/.github#363) still being open.

Local review: CLEARED a9b3e3dfecb58a4c8a9a54a6771491c955ffecaf.

(issue #1347, btclib-org/.github#339)

## Summary by Sourcery

Add OpenSSF Scorecard analysis and surface its repository security results through code scanning and the project README.

New Features:
- Add an OpenSSF Scorecard workflow that analyzes pushes to `main`, publishes results, uploads SARIF artifacts, and reports findings to code scanning.
- Add an OpenSSF Scorecard status badge to the project README.

CI:
- Configure least-privilege permissions, pinned action versions, concurrency cancellation, and a timeout for Scorecard analysis.

Documentation:
- Document the Scorecard workflow and badge in the changelog and README.