### PR TITLE
pyproject.toml's check-wheel-contents comment states what is true now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1893,6 +1893,17 @@ documented at release-notes length in the first place, and are still in
   the organization standard leaves both choices to this tree
   (issue #1347, btclib-org/.github#326).
 
+- **`[tool.check-wheel-contents]`'s comment states its reasoning in the
+  present tense.** "It was left unconfigured here on purpose until now"
+  and "no longer accepts that trade" dated the comment to the commit
+  that wrote them, against section 9 of the organization standard,
+  which reserves that account for `git log` and this file. The
+  reasoning itself is unchanged: `check-sdist` and
+  `verify_dist_contents.py` chained imply tree == sdist == wheel, and
+  that implication does not stand in for the flag where the flag
+  applies, the two checks sitting in different workflows (issue #1200,
+  btclib-org/.github#51) (closes #1360).
+
 ### Documentation and the website
 
 - **The documentation site is themed with `furo`** (issue #1347,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,17 +298,16 @@ source-exclude = [
 # `_data/*.json` dropped by a packaging change builds, installs and
 # imports cleanly and is reported clean.
 #
-# It was left unconfigured here on purpose until now, and the reason was
-# redundancy rather than inapplicability: `check-sdist` below gates this
-# tree against the sdist and `verify_dist_contents.py` gates the sdist
-# against the wheel, so chained they imply tree == sdist == wheel.
-# The organization standard's section 12 no longer accepts that trade
-# (btclib-org/.github#51, issue #1200): some other check implying the
-# same diff does not stand in for the flag where the flag applies,
-# because the implication is the same assertion bought with code to
-# maintain, and the two hops here sit in different workflows -- a
-# pre-commit hook under the lint gate, and `test.yml`'s `dist` job -- so
-# the chain holds only while both run.
+# `package` is set because the redundancy does not substitute for the
+# flag: `check-sdist` below gates this tree against the sdist and
+# `verify_dist_contents.py` gates the sdist against the wheel, so
+# chained they imply tree == sdist == wheel. The organization
+# standard's section 12 (btclib-org/.github#51, issue #1200) treats
+# that implication as the same assertion bought with code to
+# maintain, not as a substitute for the flag itself: the two hops
+# here sit in different workflows -- a pre-commit hook under the
+# lint gate, and `test.yml`'s `dist` job -- so the chain holds only
+# while both run.
 #
 # No `ignore`: nothing ships outside `btclib/`, so neither W003 nor W009
 # can fire, unlike btclib-secp256k1, whose dynamic wheel carries a shared


### PR DESCRIPTION
The comment above package = ["src/btclib"] narrated its own history
("It was left unconfigured here on purpose until now"). Restates the
reasoning in the present tense, per section 9.

Local review: CLEARED d2ebf7aecf25643308e81847a6525910dffdbf08.

Closes #1360.

## Summary by Sourcery

Clarify the present-tense rationale for enabling check-wheel-contents package validation.

Enhancements:
- Update the check-wheel-contents configuration comment to state its current rationale for enabling package validation despite existing distribution checks.

Chores:
- Record the comment clarification and its rationale in the changelog.