### PR TITLE
Two more comments state their reasoning in the present tense

### DIFF
--- a/.github/mutation/script.toml
+++ b/.github/mutation/script.toml
@@ -2,10 +2,10 @@
 # templates, the taproot tree and control block, the witness stack and the
 # signature-operation count. What the consensus profiles sit on -- the
 # engine executes what `script.parse` produced and `sig_hash` hashes what
-# `script_pub_key` built -- and until now the half of `src/btclib/script` no
-# profile mutated: sig_hash.toml takes one file of it and engine.toml the
-# subdirectory, leaving these seven. Issue #219's question on the layer
-# below the one it opened.
+# `script_pub_key` built -- and this profile is the half of
+# `src/btclib/script` neither one mutates: sig_hash.toml takes one file of
+# it and engine.toml the subdirectory, leaving these seven. Issue #219's
+# question on the layer below the one it opened.
 
 [cosmic-ray]
 # named one by one rather than as `src/btclib/script` with the other two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3082,6 +3082,16 @@ documented at release-notes length in the first place, and are still in
   file replaces the "not vendored" one that recorded it as a measured
   re-encoding.
 
+- **`test_a_taproot_script_path_is_finalizable_only_after_the_updater`'s
+  docstring and `.github/mutation/script.toml`'s header comment state
+  their reasoning in the present tense** (closes #1365). Both carried
+  "until now", dating the sentence to the commit that wrote it, against
+  section 9 of the organization standard, same as #1360. The reasoning
+  itself is unchanged: the Finalizer's witness comes from what the
+  Updater writes from a descriptor, and `script.toml` is the profile
+  covering the half of `src/btclib/script` neither `sig_hash.toml` nor
+  `engine.toml` mutates.
+
 ## v2026.8.21
 
 ### Repository

--- a/tests/descriptors/descriptors_test.py
+++ b/tests/descriptors/descriptors_test.py
@@ -2052,9 +2052,10 @@ def test_a_taproot_script_path_is_finalizable_only_after_the_updater() -> None:
     """The gap issue 306 names: a psbt cannot invent a leaf script.
 
     The Finalizer builds the witness of a script path spend out of the
-    leaf script and the control block the input carries, and until now
-    nothing wrote them there from a descriptor. With them, the psbt
-    finalizes to the very bytes `satisfy` builds from the same signature.
+    leaf script and the control block the input carries, and a
+    descriptor writes them there only through the Updater. With them,
+    the psbt finalizes to the very bytes `satisfy` builds from the same
+    signature.
     """
     descriptor = parse(f"tr({XONLY_A},{{pk({XONLY_B}),pk({XONLY_C})}})")
     psbt = descriptor.update_psbt_input(psbt_spending(descriptor), 0)


### PR DESCRIPTION
Same pattern as #1360: a taproot descriptor test's docstring and the
mutation profile's header comment both dated themselves with "until
now" rather than stating what's true today.

Local review: CLEARED 808aa5939e19a9997a137831ab7c71b4a43c1af3.

Closes #1365.

## Summary by Sourcery

Keep explanatory comments current by replacing time-dependent reasoning with present-tense statements.

Enhancements:
- Update the taproot descriptor test docstring and mutation profile comment to describe their reasoning in the present tense.

Chores:
- Record the documentation wording updates in the changelog.