### PR TITLE
tests/script_engine: correct the stale pragma comment (closes #1350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3120,6 +3120,18 @@ documented at release-notes length in the first place, and are still in
   Updater writes from a descriptor, and `script.toml` is the profile
   covering the half of `src/btclib/script` neither `sig_hash.toml` nor
   `engine.toml` mutates.
+- **`tests/script_engine/python_path_test.py`'s `# pragma: no cover` on
+  `test_verify_answers_false_for_what_cannot_be_parsed`'s `bindings`-arm
+  skip states today's reason instead of naming closed issue #990**
+  (closes #1350). The branch stays unreachable by every job `test.yml`
+  runs, but not for the stale one: with the bindings installed
+  `curve._libsecp256k1_available` is `True` and the branch is never
+  taken, and without them the module's own `pytestmark = needs_bindings`
+  skips the whole test before its body runs, so `no-bindings` never
+  reaches it either — confirmed by combining a bindings run's coverage
+  data with a no-bindings run's the way `coverage-union` does and
+  reporting the combination at `--fail-under=100` with the pragma
+  removed, which still fails on this line.
 
 ## v2026.8.21
 

--- a/tests/script_engine/python_path_test.py
+++ b/tests/script_engine/python_path_test.py
@@ -18,14 +18,12 @@ job: neither #129 defect was "this function is lax" -- one was
 hybrid key -- and both only became visible as a whole engine accepting a
 whole transaction it must refuse.
 
-It is not the same thing as a CI job installing without the bindings, and
-does not replace one: every bindings import is a plain import, so `import
-btclib` fails without them and there is nothing for such a job to run
-until the optional-bindings install arrives. Issue #966 is that work,
-issue #989 the step it waits on, and issue #991 the job. What this module
-does that no job will is run the two implementations over the same
-vectors in the same session, which is what makes a disagreement visible
-as a disagreement rather than as two red suites nobody compares.
+It is not the same thing as `test.yml`'s `no-bindings` job, and does not
+replace it: that job runs the whole suite once, with `btclib_secp256k1`
+absent and one implementation available to it. What this module does
+that no job will is run the two implementations over the same vectors in
+the same session, which is what makes a disagreement visible as a
+disagreement rather than as two red suites nobody compares.
 """
 
 from typing import Any
@@ -149,8 +147,12 @@ def test_verify_answers_false_for_what_cannot_be_parsed(
         # both answer False here, so nothing would go red and half the
         # parametrization would check the same thing twice. Skipped rather
         # than asserted, this file having to pass wherever it is run --
-        # and unreachable while the bindings are a required dependency,
-        # which is what the pragma is for and what issue #990 changes
+        # and unreachable in every job that runs it: with the bindings
+        # installed, `_libsecp256k1_available` is True and the branch is
+        # never taken; without them, this module's own `pytestmark =
+        # needs_bindings` above skips the whole function before its body
+        # runs, so `no-bindings` never reaches it either, and neither does
+        # `coverage-union`'s combination of the two runs' data
         pytest.skip("the bindings are not serving in this configuration")
     if not delegated:
         monkeypatch.setattr(curve, "_libsecp256k1_available", False)


### PR DESCRIPTION
The `# pragma: no cover` on `python_path_test.py`'s bindings-check branch
cited closed issue #990 as the reason the branch would become reachable —
stale since the bindings became optional. Investigating whether the
branch is actually reachable by any current CI job found it is not, for
two independent reasons rather than one: with the bindings installed the
branch is never taken, and without them the whole test function is
skipped at collection by the module's own `pytestmark = needs_bindings`,
which `no-bindings`'s reproduction hadn't exercised. The pragma stays;
its comment now states the real reason.

Also corrected the module docstring's references to issues #966/#989/#991
as pending, all three now closed with the `no-bindings` job in place.

Closes #1350

## Summary by Sourcery

Update script-engine test documentation to accurately describe why the bindings branch remains excluded from coverage.

Bug Fixes:
- Correct the stale coverage pragma rationale in the script-engine path tests and update related documentation to reflect the current CI behavior.

Chores:
- Record the issue-reference and coverage-comment corrections in the changelog.