### PR TITLE
docs/README.rst matches the authoritative sphinx-build command (closes #1366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -639,6 +639,12 @@ documented at release-notes length in the first place, and are still in
   it approving one; the job stays what it was, not a required check
   (issue #1347, btclib-org/.github#340).
 
+- **`docs/README.rst`'s quoted `sphinx-build` command carries `-n`,
+  matching `.readthedocs.yaml`, `docs.yml` and `CONTRIBUTING.md`** (closes
+  #1366). The file says the command is "exactly as `.readthedocs.yaml`
+  does" and had drifted from it since `-n` was added to the other three
+  in #1359.
+
 ### Packaging, linting and CI
 
 - **`pyproject.toml`'s ruff configuration selects `["ALL"]`,** matching

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -21,7 +21,7 @@ Build from the project root, exactly as ``.readthedocs.yaml`` does:
 .. sourcecode:: bash
 
     $ uv run --locked --no-default-groups --group docs \
-          sphinx-build -W --keep-going -b html docs/source docs/build/html
+          sphinx-build -n -W --keep-going -b html docs/source docs/build/html
 
 Open ``docs/build/html/index.html`` in a browser to see the result. The
 ``Makefile`` and ``make.bat`` here drive the same build, from within this


### PR DESCRIPTION
docs/README.rst quoted `sphinx-build -W --keep-going ...`, missing the
`-n` (nitpicky) flag that `.readthedocs.yaml`, `.github/workflows/docs.yml`
and CONTRIBUTING.md already carry since #1359. Brought into line.

Closes #1366

## Summary by Sourcery

Keep the documented Sphinx build command consistent with the project's configured documentation build command.

Enhancements:
- Align the documented `sphinx-build` command in `docs/README.rst` with the authoritative documentation build configuration by including nitpicky mode.

Documentation:
- Update the documentation build command example and changelog to reflect the required `-n` flag.