### PR TITLE
scorecard.yml's comment stops stating a check count (closes #1368)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,11 +1,11 @@
 ---
 name: scorecard
 
-# OpenSSF Scorecard: eighteen checks against this repository's
-# supply-chain posture, computed by a third party rather than by
-# anything this organization asked itself. btclib-org/.github#339 is
-# where this sentinel and its permissions are decided; this file adopts
-# it, and does not restate the reasoning.
+# OpenSSF Scorecard: a third-party, external audit of this repository's
+# supply-chain posture, run independently rather than by anything this
+# organization asked itself. btclib-org/.github#339 is where this
+# sentinel and its permissions are decided; this file adopts it, and
+# does not restate the reasoning.
 #
 # This repository is public and is not a fork, which is the property
 # section 10 of the standard keys the sentinel on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -644,6 +644,13 @@ documented at release-notes length in the first place, and are still in
   #1366). The file says the command is "exactly as `.readthedocs.yaml`
   does" and had drifted from it since `-n` was added to the other three
   in #1359.
+- **`scorecard.yml`'s opening comment no longer states how many checks
+  OpenSSF Scorecard runs.** The full check-definition list and the
+  narrower set `publish_results: true` feeds disagree on the total, so
+  no single re-derivable number answered both; the comment now
+  describes the audit itself — external, run by a third party — rather
+  than a count that ages the moment upstream adds, retires or
+  reclassifies a check (closes #1368).
 
 ### Packaging, linting and CI
 


### PR DESCRIPTION
The opening comment stated "eighteen checks", a stated count section 9
of the organization standard forbids. Neither the check-definition set
nor the narrower API-fed subset OpenSSF Scorecard actually runs matches
that number. Dropped rather than corrected to a different number, which
would date just as fast.

Closes #1368

## Summary by Sourcery

Describe the Scorecard workflow as an external supply-chain audit without asserting a fixed number of checks.

Bug Fixes:
- Remove the outdated and inaccurate OpenSSF Scorecard check count from the workflow comment.

Chores:
- Update the changelog to document the Scorecard comment change.