### PR TITLE
script.toml's header comment stops counting the files it mutates (closes #1370)

### DIFF
--- a/.github/mutation/script.toml
+++ b/.github/mutation/script.toml
@@ -4,8 +4,8 @@
 # engine executes what `script.parse` produced and `sig_hash` hashes what
 # `script_pub_key` built -- and this profile is the half of
 # `src/btclib/script` neither one mutates: sig_hash.toml takes one file of
-# it and engine.toml the subdirectory, leaving these seven. Issue #219's
-# question on the layer below the one it opened.
+# it and engine.toml the subdirectory, leaving the rest of the package to
+# this one. Issue #219's question on the layer below the one it opened.
 
 [cosmic-ray]
 # named one by one rather than as `src/btclib/script` with the other two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -652,6 +652,13 @@ documented at release-notes length in the first place, and are still in
   than a count that ages the moment upstream adds, retires or
   reclassifies a check (closes #1368).
 
+- **`.github/mutation/script.toml`'s header comment stops counting the
+  files this profile mutates.** "leaving these seven" was a count of
+  `module-path`'s own entries that nothing checked; the comment now
+  names only what is excluded, `sig_hash.toml`'s one file and
+  `engine.toml`'s subdirectory, and leaves the rest of the package to
+  this profile without a number (closes #1370).
+
 ### Packaging, linting and CI
 
 - **`pyproject.toml`'s ruff configuration selects `["ALL"]`,** matching


### PR DESCRIPTION
"leaving these seven" counted module-path's own entries and has been
wrong since the file's first commit -- module-path lists eight, not
seven. Reworded to name only what is excluded (sig_hash.toml's one
file, engine.toml's subdirectory) and leave the rest to this profile,
without a number.

Closes #1370

## Summary by Sourcery

Correct the script mutation profile documentation to describe its scope without relying on an outdated file count.

Bug Fixes:
- Clarify the script mutation profile header so it no longer uses an inaccurate file count and correctly identifies the files handled by other profiles.

Chores:
- Document the correction in the changelog.