### PR TITLE
Comments in bip32.py, curve.py, curve_group.py, musig2.py, psbt_utils.py, out_point.py and utils.py state their reasoning in the present tense (closes #1369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -659,6 +659,13 @@ documented at release-notes length in the first place, and are still in
   `engine.toml`'s subdirectory, and leaves the rest of the package to
   this profile without a number (closes #1370).
 
+- **Comments in `bip32.py`, `curve.py`, `curve_group.py`, `musig2.py`,
+  `psbt_utils.py`, `out_point.py` and `utils.py` state their reasoning
+  in the present tense** (closes #1369). Each carried "used to be",
+  dating the sentence to the commit that wrote it, against section 9 of
+  the organization standard, same as #1360 and #1365. The reasoning
+  itself is unchanged in every case.
+
 ### Packaging, linting and CI
 
 - **`pyproject.toml`'s ruff configuration selects `["ALL"]`,** matching

--- a/src/btclib/bip32/bip32.py
+++ b/src/btclib/bip32/bip32.py
@@ -1024,9 +1024,9 @@ def derive_(
     """
     derived = _derive(_key_data_from_bip32_key(xkey), der_path, forced_version)
     # the output check the wrapper is entitled to, and the only validation
-    # of the derived key. `b58encode` used to be where it happened, its
-    # `serialize` being the half of it that validates: this is that half,
-    # 0.64 us of the 6.73 the encoding costs
+    # of the derived key: `derive` calls `b58encode(check_validity=False)`,
+    # skipping the check `serialize` would otherwise run, so this is where
+    # it happens -- 0.64 us of the 6.73 the encoding costs
     derived.assert_valid()
     return derived
 

--- a/src/btclib/curves/curve.py
+++ b/src/btclib/curves/curve.py
@@ -533,14 +533,14 @@ def _x_octets(x: int, ec: Curve) -> bytes | None:
     element, `xonly` taking no x-coordinate at or above ec.p and
     x.to_bytes raising OverflowError rather than answering for one.
 
-    An x-only key and nothing built around it. What crosses used to be
-    0x02 || x, a compressed public key assembled here so that the
-    question could be put through the public-key API, there being no
-    x-only call to put it through; `xonly.pubkey_verify` and
-    `xonly.to_pubkey` are those calls, and the concatenation is theirs
-    now -- libsecp256k1 converting a point to an x-only key and offering
-    nothing the other way, so the lift is a rule and belongs where the
-    other x-only rules are.
+    An x-only key and nothing built around it: `xonly.pubkey_verify` and
+    `xonly.to_pubkey` are the x-only calls this feeds, and neither wants
+    a compressed public key (0x02 || x) built around x. That
+    concatenation belongs to `_multi_mult_x_only_var` instead, which
+    needs a point for `pubkey_tweak_mul_sum`'s public-key API and has no
+    x-only multiplication to reach for -- libsecp256k1 converts a point
+    to an x-only key and offers nothing the other way, so the lift is
+    that caller's rule, not this one's.
     """
     if not _libsecp256k1_serves(ec, None) or not 0 <= x < ec.p:
         return None

--- a/src/btclib/curves/curve_group.py
+++ b/src/btclib/curves/curve_group.py
@@ -1666,10 +1666,10 @@ def _multi_mult_w_NAF_var(
         tables[i] = aff[at : at + len(jac)]
         at += len(jac)
 
-    # one doubling per position and the additions that position has, where
-    # every wNAF used to be asked for a digit at every position: see
-    # `_additions_by_position`, which is also where a digit becomes the
-    # point it names
+    # one doubling per position and the additions that position has:
+    # `_additions_by_position` groups them this way rather than asking
+    # every wNAF for a digit at every position, and is also where a
+    # digit becomes the point it names
     R = INFJ
     for additions in reversed(_additions_by_position(nafs, tables, ec)):
         R = ec.double_jac(R)

--- a/src/btclib/ecc/musig2.py
+++ b/src/btclib/ecc/musig2.py
@@ -750,14 +750,14 @@ def session_values(session_ctx: SessionContext) -> SessionValues:
 
 
 def _session_key_agg_coeff(session_ctx: SessionContext, pub_key: bytes) -> int:
-    # issue #1069: this used to be three O(n) traversals of pub_keys per
-    # call -- the membership test, `_hash_pub_keys`'s join-and-hash and
-    # `_second_pub_key`'s scan -- and ran 2n times per session, once per
-    # signer from `sign` and once per signer from `partial_sig_verify_`.
-    # `session_values` now derives `L`, `second` and `pub_keys_set` once
-    # per session instead, the same fixed-input shape issue #1045 solved
-    # for the curve arithmetic above; what is left here is an O(1)
-    # frozenset membership test and one hash of constant size.
+    # issue #1069: `session_values` derives `L`, `second` and
+    # `pub_keys_set` once per session -- the same fixed-input shape
+    # issue #1045 exploits for the curve arithmetic above -- so this is
+    # an O(1) frozenset membership test and one hash of constant size,
+    # not the three O(n) traversals of pub_keys (the membership test,
+    # `_hash_pub_keys`'s join-and-hash and `_second_pub_key`'s scan) that
+    # would otherwise run 2n times per session, once per signer from
+    # `sign` and once per signer from `partial_sig_verify_`.
     #
     # The membership test stays a check of its own rather than folding
     # into the frozenset lookup below it: `_SIGNER_PK_ERR` is one of

--- a/src/btclib/psbt/psbt_utils.py
+++ b/src/btclib/psbt/psbt_utils.py
@@ -840,11 +840,11 @@ def deserialize_tx(
     # two values and two behaviours, and the flag is read as a truth
     # below: `not include_witness` is false for True alone, so True is
     # the one that accepts either encoding and False is the one that
-    # demands the round trip. None used to be declared here as well,
-    # documented as "either encoding" and doing what False does, since
-    # `not None` is `not False` -- a third spelling of the second
-    # behaviour, unreachable from any caller in this tree and a trap for
-    # the first one to read the comment (issue 1190)
+    # demands the round trip. The type is `bool`, not `bool | None`,
+    # because `not None` is `not False`: a `None` would be a third
+    # spelling of the second behaviour, documented as "either encoding"
+    # while doing what False does -- a trap for whoever trusts the
+    # comment over the type (issue 1190)
     assert_type(include_witness, bool, "include_witness")
     assert_type(unsigned_template, bool, "unsigned_template")
     if len(k) != 1:

--- a/src/btclib/tx/out_point.py
+++ b/src/btclib/tx/out_point.py
@@ -80,8 +80,8 @@ class OutPoint:
     def assert_valid(self) -> None:
         """Refuse a tx_id not of 32 bytes and a vout no 4 bytes hold.
 
-        The two fields and not the pair, which is where this used to be
-        stricter than consensus. Core's `COutPoint::IsNull` is the
+        The two fields and not the pair, since checking the pair here
+        would be stricter than consensus. Core's `COutPoint::IsNull` is the
         *conjunction* -- `hash.IsNull() && n == NULL_INDEX` -- and
         `CheckTransaction` refuses a null outpoint in a non-coinbase and
         nothing else, so `000...000:0` is a transaction Core parses and

--- a/src/btclib/utils.py
+++ b/src/btclib/utils.py
@@ -350,10 +350,11 @@ def fields_from_json_object(dict_: Any, what: str) -> Mapping[str, Any]:
     The first line of every `from_dict`, and it answers the two questions
     that boundary owes its caller before a field is read:
 
-    - a `Mapping[str, Any]` is what the signature declares, and what is
-      not one used to be walked anyway: `dict_["version"]` on a None is a
-      TypeError about subscripting, on a str a TypeError about string
-      indices, and neither says btclib refused anything
+    - a `Mapping[str, Any]` is what the signature declares, and the check
+      refuses what is not one before it is walked: without it,
+      `dict_["version"]` on a None is a TypeError about subscripting, on
+      a str a TypeError about string indices, and neither says btclib
+      refused anything
     - a mapping that is one and has not got the field is a value no valid
       input carries, so it is a `BTClibValueError` naming the field --
       `from_dict` is fed whatever a schema mistake produced, and a bare


### PR DESCRIPTION
Each carried "used to be", dating the sentence to the commit that wrote
it, against section 9 of the organization standard, same as #1360 and
#1365. The reasoning itself is unchanged in every case; only the tense.

Closes #1369

## Summary by Sourcery

Clarify code comments by expressing their reasoning as current behavior across the affected modules.

Enhancements:
- Update explanatory comments across BIP32, elliptic-curve, MuSig2, PSBT, transaction, and utility modules to describe current behavior in the present tense without changing the underlying reasoning.

Documentation:
- Record the comment-tense cleanup in the changelog.