### PR TITLE
OutPoint's class docstring states in the present tense why checking the pair is not what assert_valid does (closes #1376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -666,6 +666,14 @@ documented at release-notes length in the first place, and are still in
   the organization standard, same as #1360 and #1365. The reasoning
   itself is unchanged in every case.
 
+- **`OutPoint`'s class docstring states in the present tense why
+  checking the pair is not what `assert_valid` does** (closes #1376).
+  It carried "used to refuse (issue 513)", the same construction #1369
+  fixed elsewhere in this file, missed there because it reads "used to
+  refuse" rather than "used to be". The docstring now names `is_coinbase`
+  and `Tx.assert_valid` as what reads the pair instead, matching
+  `assert_valid`'s own docstring two lines below it.
+
 ### Packaging, linting and CI
 
 - **`pyproject.toml`'s ruff configuration selects `["ALL"]`,** matching

--- a/src/btclib/tx/out_point.py
+++ b/src/btclib/tx/out_point.py
@@ -43,7 +43,10 @@ class OutPoint:
     What is refused is a field no four bytes or thirty-two hold, and
     nothing about the pair: an all-zero tx_id with a real vout, and a
     real tx_id with the sentinel vout, are both outpoints Bitcoin Core
-    accepts and this class used to refuse (issue 513).
+    accepts, checking the pair here being stricter than consensus.
+    `is_coinbase` reads the pair instead, and it is what
+    `Tx.assert_valid` uses to refuse a coinbase input in a transaction
+    that is not one.
     """
 
     tx_id: bytes


### PR DESCRIPTION
It carried "used to refuse (issue 513)", the same construction #1369
fixed elsewhere in this file, missed there because it reads "used to
refuse" rather than "used to be". Now names is_coinbase and
Tx.assert_valid as what reads the pair instead, matching assert_valid's
own docstring two lines below it (in the documentation's alphabetical
member order).

Closes #1376

## Summary by Sourcery

Clarify `OutPoint` validation responsibilities and align its documentation with current behavior.

Enhancements:
- Update the `OutPoint` class documentation to clarify that pair validation is handled by `is_coinbase` and `Tx.assert_valid`, while `OutPoint` accepts pairs permitted by consensus.

Documentation:
- Revise the `OutPoint` docstring and changelog to use present-tense, accurate validation guidance.