### PR TITLE
claude-review.yml's prompt names a fallback for a review that reaches no verdict (closes #1372)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -166,8 +166,11 @@ jobs:
             Inline comments only for a finding a line is the subject of:
             `mcp__github_inline_comment__create_inline_comment` (with
             `confirmed: true`). Post nothing else as a GitHub comment and
-            never review text as a message: the verdict is a pull request
-            review, opened once every inline comment is posted --
+            never review text as a message, save where the review is a
+            reading and reaches no verdict: there the summary stays a
+            plain comment, `gh pr comment <n> --body "<summary>"`, exactly
+            as before. Where it does decide, the verdict is a pull
+            request review, opened once every inline comment is posted --
             `gh pr review <n> --approve --body "<summary>"` where the
             summary ends with `ACK <sha>`, or `gh pr review <n>
             --request-changes --body "<summary>"` where it ends with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -673,6 +673,17 @@ documented at release-notes length in the first place, and are still in
   refuse" rather than "used to be". The docstring now names `is_coinbase`
   and `Tx.assert_valid` as what reads the pair instead, matching
   `assert_valid`'s own docstring two lines below it.
+- **`claude-review.yml`'s prompt gives a review that reaches no verdict
+  a way to post its summary.** The paragraph instructing the two
+  decided-verdict forms also said "post nothing else as a GitHub
+  comment", leaving `REVIEWING.md`'s own legitimate third outcome — a
+  reading that declines to decide, "not an unfinished review" in its
+  own words — nowhere to post at all; #1356 dropped the fallback its
+  predecessor carried. The prompt now names the exception explicitly:
+  where the review is a reading and reaches no verdict, the summary
+  stays a plain comment, `gh pr comment`, exactly as before — the
+  wording `btclib-secp256k1`'s own port of the same fix kept explicit
+  (closes #1372).
 
 ### Packaging, linting and CI
 


### PR DESCRIPTION
#1356 dropped the fallback its predecessor carried: the prompt forbade
posting anything but a decided verdict as a GitHub comment, leaving
REVIEWING.md's own legitimate third outcome -- a reading that declines
to decide -- nowhere to post at all. Names the exception explicitly:
where the review reaches no verdict, the summary stays a plain
comment, gh pr comment, exactly as before -- the wording
btclib-secp256k1's own port of the same fix kept explicit.

Closes #1372

## Summary by Sourcery

Allow undecided reviews to post their summaries as plain pull request comments while retaining review submissions for decided verdicts.

Bug Fixes:
- Restore the review workflow’s fallback for posting summaries as plain comments when a review reaches no verdict.

Chores:
- Document the review prompt fallback in the changelog.