### PR TITLE
Comments in curve.py, entropy.py, to_pub_key.py and utils.py state their reasoning in the present tense (closes #1379)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -673,6 +673,14 @@ documented at release-notes length in the first place, and are still in
   refuse" rather than "used to be". The docstring now names `is_coinbase`
   and `Tx.assert_valid` as what reads the pair instead, matching
   `assert_valid`'s own docstring two lines below it.
+
+- **Comments in `curve.py`, `entropy.py`, `to_pub_key.py` and `utils.py`
+  state their reasoning in the present tense** (closes #1379). Each
+  carried "used to X" rather than "used to be" — a former routing
+  decision, a former accidental type acceptance, a former inference-based
+  error class, `OutPoint`'s own history re-narrated a second time — which
+  is why #1369's `"used to be"` sweep missed all four. The reasoning
+  itself is unchanged in every case.
 - **`claude-review.yml`'s prompt gives a review that reaches no verdict
   a way to post its summary.** The paragraph instructing the two
   decided-verdict forms also said "post nothing else as a GitHub

--- a/src/btclib/curves/curve.py
+++ b/src/btclib/curves/curve.py
@@ -1142,14 +1142,13 @@ def _tweak_add_var(P: Point, t: int, ec: Curve) -> Point:
     infinity -- which libsecp256k1 has no public key for and `add_var`
     returns.
 
-    A zero tweak is not in that list and was: libsecp256k1 takes a tweak
-    "valid according to secp256k1_ec_seckey_verify *or 32 zero bytes*",
-    which its own header says of `secp256k1_ec_pubkey_tweak_add`, and
-    answers P. Sending it to the Python pair instead is what the
-    condition on `t` used to do, and it cost 131.40 us against 5.01: the
-    tweak is zero, so `mult` has the scalar libsecp256k1 declines and
-    takes the fixed-base ladder for an answer that is the point already
-    in hand.
+    A zero tweak is not in that list: libsecp256k1 takes a tweak "valid
+    according to secp256k1_ec_seckey_verify *or 32 zero bytes*", which
+    its own header says of `secp256k1_ec_pubkey_tweak_add`, and answers
+    P directly, at 5.01 us against the 131.40 that routing it to the
+    Python pair instead would cost -- there `mult` has the scalar
+    libsecp256k1 declines and takes the fixed-base ladder for an answer
+    that is the point already in hand.
     """
     ec.require_on_curve(P)
     t %= ec.n

--- a/src/btclib/mnemonic/entropy.py
+++ b/src/btclib/mnemonic/entropy.py
@@ -382,9 +382,9 @@ def bin_str_entropy_from_rolls(
     carried from there to a wallet that reads dice are shifted by one,
     by whoever carries them.
     """
-    # a float used to work by accident, `math.log2` taking one: the
-    # integer arithmetic below does not, and an AttributeError on
-    # `bit_length` is not what a caller passing 6.0 should hear
+    # `_bits_per_digit` below takes `base.bit_length()`, which a float
+    # has no method named, so a caller passing 6.0 would hear a bare
+    # AttributeError rather than this module's own message
     if not is_integer(dice_sides):
         err_msg = f"invalid dice base type: {type(dice_sides).__name__}"
         raise BTClibTypeError(err_msg)

--- a/src/btclib/to_pub_key.py
+++ b/src/btclib/to_pub_key.py
@@ -81,10 +81,12 @@ _KEY_TYPES = (int, *_PUB_KEY_TYPES)
 def _assert_pub_key_type(pub_key: PubKey) -> None:
     """Refuse a type no spelling of a public key has.
 
-    Asked at the top of a converter, and not inferred from whichever
-    spelling failed last, which is what these two used to do: every
-    refusal was a BTClibValueError, so "this key is not on the curve"
-    and "this is not a key at all" arrived as one class.
+    Asked at the top of a converter, not inferred from whichever
+    spelling failed last: a value of no key type at all is a
+    BTClibTypeError here, kept apart from the BTClibValueError a
+    spelling raises once its type is right and its content is not, so
+    "this key is not on the curve" and "this is not a key at all"
+    answer as two different classes rather than one.
 
     The difference is what a boolean verification reads, and issue #814
     is where it is stated: `dsa.verify` answers False about a value of a

--- a/src/btclib/utils.py
+++ b/src/btclib/utils.py
@@ -35,10 +35,9 @@ are exactly the widths of its fields, nothing can. The decoding enforces
 them by construction, so at that boundary the flag is unreachable by
 design rather than unchecked, and the class is one in good order rather
 than one missing a check. `OutPoint` is such a class: 32 octets of
-tx_id and four of vout, every value of which is a valid outpoint since
-Bitcoin Core was found to accept the shapes it used to refuse. A class
-whose only invalidable child is one -- `TxIn`, whose own fields are of
-the same kind -- inherits the property.
+tx_id and four of vout, and every value of that shape is an outpoint
+Bitcoin Core accepts. A class whose only invalidable child is one --
+`TxIn`, whose own fields are of the same kind -- inherits the property.
 
 The two are not the same question asked twice, which is why an object
 can be asked one and not the other: an invalidity of *type* rather than


### PR DESCRIPTION
Each carried "used to X" rather than "used to be" -- a former routing
decision, a former accidental type acceptance, a former
inference-based error class, OutPoint's own history re-narrated a
second time -- which is why #1369's "used to be" sweep missed all
four. The reasoning itself is unchanged in every case.

Closes #1379

## Summary by Sourcery

Clarify historical reasoning in selected code comments by rewriting it in the present tense while preserving the existing behavior and rationale.

Enhancements:
- Update explanatory comments across curve handling, entropy validation, public-key type checking, and OutPoint validation to describe their current behavior in the present tense without changing the underlying logic.

Chores:
- Record the comment wording updates in the changelog.