### PR TITLE
A verb-unfiltered sweep closes the used-to construction to zero (closes #1382)

### DIFF
--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -140,11 +140,12 @@ def _latest_commit(repo: str, path: str) -> tuple[str, str] | None:
 
     None where upstream has no commit touching it at all, which means the
     path has been renamed or deleted: the sharpest drift there is, a pin
-    naming a file that is not there any more. This used to unpack one
-    commit out of an empty list and raise `ValueError` instead, so the
-    run went red and `report` was never reached -- no issue opened, on
-    the one kind of drift nobody would otherwise notice, which is what
-    this workflow exists for.
+    naming a file that is not there any more. Answering None rather than
+    unpacking one commit out of an empty list is what lets `report` see
+    it as drift with no tip to name, instead of the run going red on a
+    bare `ValueError` and no issue ever opening -- the one kind of drift
+    nobody would otherwise notice, which is what this workflow exists
+    for.
     """
     result = subprocess.run(  # noqa: S603
         [
@@ -274,8 +275,8 @@ def main() -> int:
     dry_run = len(args) != len(sys.argv) - 1
     if len(args) != 1:
         # a human running this by hand is the only way here, the workflow
-        # passing the path every time: an IndexError naming a list is
-        # what they used to get
+        # passing the path every time: without this check, `args[0]`
+        # below would answer with an IndexError naming a list instead
         print(
             f"usage: {Path(sys.argv[0]).name} <README path> [--dry-run]",
             file=sys.stderr,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -681,6 +681,19 @@ documented at release-notes length in the first place, and are still in
   error class, `OutPoint`'s own history re-narrated a second time — which
   is why #1369's `"used to be"` sweep missed all four. The reasoning
   itself is unchanged in every case.
+- **Comments and docstrings in `check_vendored_vectors.py`, `bip32.py`,
+  `curve.py`, `borromean.py`, `ssa.py`, `psbt.py`, `utils.py`,
+  `key_wallet.py`, `all_test.py`, `amount_test.py` and
+  `serialization_boundary_test.py` state their reasoning in the present
+  tense** (closes #1382). #1369 and #1379 both filtered `used to` by a
+  fixed list of verbs, which is why `used to read`, `used to write` and
+  `used to price` — none of them on either list — survived both rounds;
+  a broad `used to \w+` sweep, read rather than filtered by verb, is
+  what this one runs instead. `borromean.py`'s comment and one test
+  docstring each complete a sentence the construction had left
+  grammatically incomplete. A test describing the defect a regression
+  test exists to catch is a different construction and is left alone,
+  the distinction #1369 already drew.
 - **`claude-review.yml`'s prompt gives a review that reaches no verdict
   a way to post its summary.** The paragraph instructing the two
   decided-verdict forms also said "post nothing else as a GitHub

--- a/src/btclib/bip32/bip32.py
+++ b/src/btclib/bip32/bip32.py
@@ -180,8 +180,8 @@ def _assert_valid_key(version: bytes, key: bytes) -> None:
         # describes, and the square root it exists not to pay was paid
         # once per extended key, so by every level of every derivation
         # path (issue 615). A predicate has no exception to chain, so
-        # the message below is the whole of the error where it used to
-        # be raised from curve_group's "invalid x-coordinate"
+        # the message below states the error on its own, independent
+        # of curve_group's own "invalid x-coordinate" wording
         x = int.from_bytes(key[1:], byteorder="big", signed=False)
         if not _is_x_coordinate_var(x, secp256k1):
             raise BTClibValueError(f"invalid public key: 0x{key.hex()}")

--- a/src/btclib/curves/curve.py
+++ b/src/btclib/curves/curve.py
@@ -1021,7 +1021,9 @@ def _double_mult_python(
     `fixed` is the points whose tables are memoized, passed down rather
     than read off `ec` at the bottom: a verification under a
     `PreparedPoint` names the key there, and every other caller names
-    `ec._fixed_points`, which is what the bottom used to read for itself.
+    `ec._fixed_points`, so passing it down is what lets a `PreparedPoint`'s
+    own superset reach the bottom instead of a direct read of
+    `ec._fixed_points` losing it.
     """
     if ec == secp256k1:
         return _double_mult_endomorphism_secp256k1_var(
@@ -1082,9 +1084,9 @@ def _sum_var(points: Sequence[Point], ec: Curve) -> Point:
 
     Infinity is the identity and libsecp256k1 has no public key for it,
     so a term at infinity is dropped rather than handed over, and a sum
-    at infinity comes back as the None `pubkey_sum` answers with -- which
-    is the whole of what used to keep these callers on the Python
-    arithmetic, an intermediate sum at infinity being a BIP352 vector.
+    at infinity comes back as the None `pubkey_sum` answers with --
+    both handled below rather than left to the C call, an intermediate
+    sum at infinity being a real BIP352 vector.
     """
     for Q in points:
         ec.require_on_curve(Q)

--- a/src/btclib/ecc/borromean.py
+++ b/src/btclib/ecc/borromean.py
@@ -106,13 +106,13 @@ __all__ = [
 
 
 def _hash(m: bytes, R: bytes, i: int, j: int, hf: HashF) -> bytes:
-    # R (the nonce point, or e0 closing the rings) before m: zkp's
-    # secp256k1_borromean_hash writes e || m || ring || pos, and this
-    # used to write m || R -- the two swapped, a byte-for-byte different
-    # preimage over identical inputs (issue #1070). Aligning it is a
-    # hard break with no migration: every signature this module ever
-    # produced was made with the old order and stops verifying under
-    # this one
+    # R (the nonce point, or e0 closing the rings) before m, matching
+    # zkp's secp256k1_borromean_hash order of e || m || ring || pos:
+    # swapping the two produces a byte-for-byte different preimage over
+    # identical inputs (issue #1070), so this exact order is a hard
+    # break with no migration -- every signature this module produces
+    # is bound to it, and one made under the swapped order does not
+    # verify
     temp = b"".join(
         [R, m, i.to_bytes(4, "big", signed=False), j.to_bytes(4, "big", signed=False)]
     )
@@ -414,9 +414,9 @@ def sign(
     # drawn uniformly in [0, ec.n), the same distribution the real
     # s-value has once step 2 reduces it: randbits(256) is uniform over
     # [0, 2**256), not over the scalars, and the two ranges diverge by
-    # more than a 2**-127 fraction on a low-cardinality curve -- one
-    # forged this way and the real one reduced would then disagree in
-    # the same distinguishing way the unreduced real value used to
+    # more than a 2**-127 fraction on a low-cardinality curve -- forging
+    # with randbits(256) instead would leave the same distinguishing
+    # gap that step 2's `% ec.n` closes for the real value
     s = [
         [secrets.randbelow(ec.n) for _ in range(len(pubk_ring))]
         for pubk_ring in pubk_rings

--- a/src/btclib/ecc/ssa.py
+++ b/src/btclib/ecc/ssa.py
@@ -495,12 +495,12 @@ def sign_(
         aux = commit_entropy_(aux + bytes_from_octets(commit_hash), _S2C_DATA_TAG, hf)
 
     # the curve and the hash function decide this, and the size of the
-    # message does not. `libsecp256k1_ssa.sign` is the 32-byte entry point
-    # the length used to gate on -- "the message hash must be 32 bytes",
-    # measured on 0.7.1rc1 -- but `sign_custom` beside it takes BIP340's
-    # message of any size, so every length now reaches the constant-time C
-    # instead of the Python arithmetic SECURITY.md publishes as not being
-    # constant time.
+    # message does not. `libsecp256k1_ssa.sign` accepts only a 32-byte
+    # message -- "the message hash must be 32 bytes", measured on
+    # 0.7.1rc1 -- but `sign_custom` beside it takes BIP340's message of
+    # any size, so every length reaches the constant-time C instead of
+    # the Python arithmetic SECURITY.md publishes as not being constant
+    # time.
     #
     # One call rather than a branch on the length: for a 32-byte message
     # the two answer the same signature octet for octet, and the

--- a/src/btclib/psbt/psbt.py
+++ b/src/btclib/psbt/psbt.py
@@ -1427,11 +1427,11 @@ class Psbt:
         """Build a Psbt from its base64 text, stripping whitespace.
 
         The coercion before the strip, as `bms.Sig.b64decode` does it and
-        for the reason issue #814 gives: what is neither text nor bytes
-        used to reach `base64.b64decode` untouched, and left as its
-        "argument should be a bytes-like object or ASCII string" -- a
-        complaint about a builtin rather than about the psbt that was
-        passed.
+        for the reason issue #814 gives: without it, what is neither text
+        nor bytes reaches `base64.b64decode` untouched, and is left
+        facing its own "argument should be a bytes-like object or ASCII
+        string" -- a complaint about a builtin rather than about the psbt
+        that was passed.
         """
         psbt_str = str_from_string(psbt_str, "base64 psbt").strip()
 

--- a/src/btclib/utils.py
+++ b/src/btclib/utils.py
@@ -192,9 +192,10 @@ def bytesio_from_binarydata(stream: BinaryData) -> BytesIO:
         return stream
 
     # the refusal of what is neither a stream nor octets is
-    # bytes_from_octets's to give: what is neither used to go through
-    # untouched and be returned as it came, so `parse` answered a None
-    # with a None and the caller failed on `.read`
+    # bytes_from_octets's to give: without it, what is neither would go
+    # through untouched and be returned as it came, so `parse` would
+    # answer a None with a None and the caller would fail on `.read`
+    # rather than here
     return BytesIO(bytes_from_octets(stream))
 
 

--- a/src/btclib/wallet/key_wallet.py
+++ b/src/btclib/wallet/key_wallet.py
@@ -336,8 +336,8 @@ class BIP32KeyWallet(KeyWallet, RangedWallet):
 
         # `derive_` rather than bip32's private `_derive`: the public
         # spelling, and the one that answers the key -- where `derive`
-        # answered its Base58Check text for this line to decode straight
-        # back, which was the b58 round trip this comment used to price
+        # answers its Base58Check text, which this line would decode
+        # straight back, paying a b58 round trip for nothing
         return derive_(xkey, indexes[xkey.depth :])
 
     @property
@@ -369,12 +369,12 @@ class BIP32KeyWallet(KeyWallet, RangedWallet):
         `bip32.derive_from_account_` is what imposes them -- branch 0 or 1,
         index at most 65535 -- and the message on a violation is its own.
 
-        The key and not its xprv/xpub text, which is what this used to
-        answer: all three callers hand it to something that decodes it --
-        an address builder, `ScriptPubKey.p2wpkh`, `b58.wif_from_prv_key`
-        -- and a `BIP32KeyData` is in the `Key` and `PrvKey` unions those
-        take. So the text was built and read back inside one line, three
-        times over (issue 886)
+        The key and not its xprv/xpub text: all three callers hand it to
+        something that decodes it -- an address builder,
+        `ScriptPubKey.p2wpkh`, `b58.wif_from_prv_key` -- and a
+        `BIP32KeyData` is in the `Key` and `PrvKey` unions those take.
+        Answering text instead would make each of them build it and read
+        it back inside one line (issue 886)
         """
         return derive_from_account_(self._xkey, branch, index)
 

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -72,8 +72,8 @@ UNEXPORTED = {
 # of the transport under it, and btclib depends on it rather than carrying a
 # copy; the first two modules below are where those objects were before it was
 # a package of its own, and they alias them rather than declaring a second of
-# anything. A transport has one bounded-read policy, and an import path that
-# used to work still does.
+# anything. A transport has one bounded-read policy, and an import path
+# published here stays valid.
 #
 # `btclib.consensus` is the second: a transaction's counts and a witness
 # stack's are arithmetic on the block weight, and neither `btclib.tx` nor
@@ -597,11 +597,11 @@ def test_every_exported_name_exists() -> None:
 
     Every module and package of the library, found rather than listed: one
     added to btclib is one this checks, where a list here would be one more
-    thing to keep true -- and it is what caught `btclib.script` being
-    outside the four names this used to hold. The whole tree is walked,
-    which imports every module of the library; tests/imports_test.py does
-    that deliberately and one module at a time, for the cycle a bulk import
-    hides, and this one asks a question that needs them all loaded.
+    thing to keep true, and a module missing `__all__` is what this catches
+    that a fixed list cannot. The whole tree is walked, which imports every
+    module of the library; tests/imports_test.py does that deliberately
+    and one module at a time, for the cycle a bulk import hides, and this
+    one asks a question that needs them all loaded.
 
     An empty list is a legitimate answer, and the assertion says when: a
     module with nothing public of its own -- a package `__init__` that only

--- a/tests/amount_test.py
+++ b/tests/amount_test.py
@@ -181,10 +181,10 @@ def test_what_is_no_decimal_number_is_refused_as_btclib_refuses_things(
 def test_a_nan_does_not_leave_through_the_range_check() -> None:
     """The NaNs are why `is_finite` is there and a `try` is not enough.
 
-    `Decimal("nan")` is valid syntax and constructs without a word: what
-    used to raise `InvalidOperation` was the *comparison* in the range
-    check, so catching the constructor alone would have left every
-    spelling of a NaN leaking an ArithmeticError out of a validator.
+    `Decimal("nan")` is valid syntax and constructs without a word: the
+    *comparison* in the range check is what raises `InvalidOperation`,
+    so catching the constructor alone would leave every spelling of a
+    NaN leaking an ArithmeticError out of a validator.
     """
     for nan in (float("nan"), "nan", "sNaN", Decimal("NaN")):
         with pytest.raises(BTClibValueError, match="invalid BTC amount"):

--- a/tests/serialization_boundary_test.py
+++ b/tests/serialization_boundary_test.py
@@ -423,9 +423,9 @@ def test_from_dict_names_the_field_it_has_not_got(case: _JsonCase) -> None:
     txid, a header's difficulty, the psbt's derived "tx" -- is one whose
     absence is no error at all, which is why the assertion is on what a
     failure may be rather than on which keys fail. What must never happen
-    is the `KeyError` that used to: `exceptions.py`'s guarantee is that
-    no public function lets a native exception reach a caller, and this
-    family was where a `KeyError` once did.
+    is a bare `KeyError` reaching the caller: `exceptions.py`'s guarantee
+    is that no public function lets a native exception through, and this
+    is the family the guarantee has to hold for.
 
     The count is asserted too, or a `from_dict` that stopped reading its
     mapping would pass this by never failing.


### PR DESCRIPTION
#1369 and #1379 each swept a fixed verb list, and each next reading
outran it. This round reads every "used to \w+" hit by hand, source
and tests, with no verb filter, rewrites genuine history-narration
present-tense (two of them grammatically incomplete sentences, repaired
rather than merely retensed), and verifies what remains against each
side's own sanctioned exception: an external or ecosystem convention
(base58.py, musig2.py, script_pub_key.py) outside source, and a
regression test naming the defect it guards against inside tests.

Closes #1382

## Summary by Sourcery

Modernize historical comments and docstrings across the project while preserving sanctioned exception cases and improving vendored-vector drift diagnostics.

Enhancements:
- Update comments and docstrings across source and tests to use present-tense explanations and repair incomplete historical statements.
- Clarify the vendored-vector checker’s handling of missing paths and invalid manual invocation so drift reporting remains effective.