### PR TITLE
tests/all_test.py's REEXPORTED comment states no count, and states what is true (closes #1384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3187,6 +3187,18 @@ documented at release-notes length in the first place, and are still in
   Updater writes from a descriptor, and `script.toml` is the profile
   covering the half of `src/btclib/script` neither `sig_hash.toml` nor
   `engine.toml` mutates.
+
+- **`tests/all_test.py`'s comment above `REEXPORTED` and
+  `test_no_module_exports_a_name_it_imported`'s docstring stop stating
+  how many entries the dict holds or how many modules alias each
+  canonical package** (closes #1384), against section 9's no-counts
+  rule. Both are rewritten around the three decisions instead:
+  `bitcoin-core-rpc`, `btclib.consensus` and `psbt_utils`. The stated
+  "these four ... three decisions" and "the first two modules below"
+  had already gone false without a test noticing: `btclib.p2p.magic`
+  joined `btclib.fetch.bitcoin_core` and `btclib.fetch.transport`
+  aliasing `bitcoin-core-rpc` with #1092, leaving three modules where
+  the prose still said two.
 - **`tests/script_engine/python_path_test.py`'s `# pragma: no cover` on
   `test_verify_answers_false_for_what_cannot_be_parsed`'s `bindings`-arm
   skip states today's reason instead of naming closed issue #990**

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -67,31 +67,38 @@ UNEXPORTED = {
 }
 
 # what a module exports without defining it, which for a module rather than a
-# package is a leak -- and these four are the exception, on three decisions.
-# The `bitcoin-core-rpc` package is the canonical source of the rpc client and
-# of the transport under it, and btclib depends on it rather than carrying a
-# copy; the first two modules below are where those objects were before it was
-# a package of its own, and they alias them rather than declaring a second of
-# anything. A transport has one bounded-read policy, and an import path
-# published here stays valid.
+# package is a leak -- and REEXPORTED below is the exception, one entry per
+# re-exporting module, grouped here by the decision each belongs to rather
+# than counted: a module recorded there is not leaking, it is aliasing the
+# canonical object under the name a caller already had.
 #
-# `btclib.consensus` is the second: a transaction's counts and a witness
-# stack's are arithmetic on the block weight, and neither `btclib.tx` nor
-# `btclib.script` can import `btclib.block`, so the two constants they divide
-# by are defined below all three. `btclib.block.limits` names them still,
-# being where the rest of Core's header is and where a caller reading a
-# block's own rules goes.
+# The `bitcoin-core-rpc` package is the canonical source of the rpc client
+# and of the transport under it, and btclib depends on it rather than
+# carrying a copy. Some of the modules below aliasing it held those objects
+# themselves before it became a package of its own; others were written
+# afterwards, aliasing it from the start rather than ever declaring a second
+# copy. Either way, each states its own reasoning in its own docstring -- a
+# transport has one bounded-read policy, and an import path published here
+# stays valid.
 #
-# `btclib.psbt.psbt_utils` is the third, and it is the same shape: the two
-# psbt versions decide what an input and an output map write and read, and
-# neither `psbt_in` nor `psbt_out` can import `psbt`, so the pair is defined
-# below all three. `btclib.psbt.psbt` names them still, being where the rest
-# of the format's constants are.
+# `btclib.consensus` is the second decision: a transaction's counts and a
+# witness stack's are arithmetic on the block weight, and neither `btclib.tx`
+# nor `btclib.script` can import `btclib.block`, so the two constants they
+# divide by are defined below all three. `btclib.block.limits` names them
+# still, being where the rest of Core's header is and where a caller reading
+# a block's own rules goes.
 #
-# So a name here is not a name about to leak: it is the same object under the
-# name a caller already had, which each entry records its canonical module for
-# and the test below asserts. What would be a leak is a *fifth* module, or a
-# name in these four that the canonical module does not export
+# `btclib.psbt.psbt_utils` is the third: the two psbt versions decide what
+# an input and an output map write and read, and neither `psbt_in` nor
+# `psbt_out` can import `psbt`, so the pair is defined below all three.
+# `btclib.psbt.psbt` names them still, being where the rest of the format's
+# constants are.
+#
+# So a name here is not a name about to leak: it is the same object under
+# the name a caller already had, which each entry records its canonical
+# module for and the test below asserts. What would be a leak is a module
+# not listed here, or a listed module exporting a name its recorded
+# canonical module does not
 REEXPORTED = {
     "btclib.fetch.bitcoin_core": (
         bitcoin_core_rpc,
@@ -631,13 +638,14 @@ def test_no_module_exports_a_name_it_imported() -> None:
     module with a reason to re-export something is a conversation to have
     with this test, not around it.
 
-    `REEXPORTED` is that conversation, held three times: the two modules
-    whose objects moved into the `bitcoin-core-rpc` package alias them back
-    under the names callers had, a transport having one bounded-read policy
-    to keep; `btclib.block.limits` names the two constants `btclib.consensus`
-    defines below the package, which is where a caller reading a block's
-    rules looks for them; and `btclib.psbt.psbt` names the two psbt versions
-    that `psbt_utils` defines below the maps taking one as an argument.
+    `REEXPORTED` is that conversation, grouped by decision rather than by
+    module: every module aliasing an object the `bitcoin-core-rpc` package
+    canonically holds keeps the name a caller already had, a transport
+    having one bounded-read policy to keep; `btclib.block.limits` names the
+    two constants `btclib.consensus` defines below the package, which is
+    where a caller reading a block's rules looks for them; and
+    `btclib.psbt.psbt` names the two psbt versions that `psbt_utils` defines
+    below the maps taking one as an argument.
 
     Asserted both ways, because a skip list is only half a table: it says
     which names may be re-exported and nothing about whether they still are,


### PR DESCRIPTION
"these four ... on three decisions" and "the first two modules below"
were both a stated count section 9 forbids and, since #1092 added a
third bitcoin-core-rpc alias without updating either sentence,
currently false. Restructured around the three decisions rather than
an enumerated module list, so a further alias to an existing decision
needs no edit here. Folded in a matching stale count nearby, in
test_no_module_exports_a_name_it_imported's own docstring.

Closes #1384

## Summary by Sourcery

Make re-export documentation count-independent while preserving the rationale for the permitted aliases.

Enhancements:
- Update re-export documentation to describe the three aliasing decisions without fragile module or entry counts.

Documentation:
- Clarify the `REEXPORTED` comment and related test docstring so they remain accurate when additional aliases are added.

Chores:
- Document the stale-count correction in the changelog.