### PR TITLE
Two docstrings drop stated counts nothing re-derives (closes #1386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -705,6 +705,16 @@ documented at release-notes length in the first place, and are still in
   stays a plain comment, `gh pr comment`, exactly as before — the
   wording `btclib-secp256k1`'s own port of the same fix kept explicit
   (closes #1372).
+- **`src/btclib/fetch/bitcoin_core.py`'s module docstring drops "The five"
+  from what it re-exports, and `src/btclib/block/limits.py`'s drops
+  "Three" from what it excludes** (closes #1386), against section 9's
+  no-counts rule, the same shape #1384 fixed in `tests/all_test.py`'s
+  `REEXPORTED` comment. Neither count was checked by any test:
+  `tests/all_test.py`'s `REEXPORTED["btclib.fetch.bitcoin_core"]` would
+  not fail on a sixth re-exported name joining the module, and nothing
+  checks the excluded-constants list at all. The other three modules in
+  `REEXPORTED` — `btclib.fetch.transport`, `btclib.p2p.magic` and
+  `btclib.psbt.psbt` — carry no such count in their own docstrings.
 
 ### Packaging, linting and CI
 

--- a/src/btclib/block/limits.py
+++ b/src/btclib/block/limits.py
@@ -23,7 +23,7 @@ to hold them, and neither `btclib.tx` nor `btclib.script` can import this
 package. `btclib.consensus` says why; a caller reading a block's rules
 still names this module, which is where the rest of Core's header is.
 
-Three of `consensus.h`'s constants are deliberately absent.
+Some of `consensus.h`'s constants are deliberately absent.
 `MAX_BLOCK_SERIALIZED_SIZE` is marked in Core's own comment as a buffer
 bound and not a network rule, the weight being what consensus caps.
 `COINBASE_MATURITY` is a rule about spending an output, so it needs the

--- a/src/btclib/fetch/bitcoin_core.py
+++ b/src/btclib/fetch/bitcoin_core.py
@@ -10,7 +10,7 @@ of btclib. What this module adds is the integration -- the answers turned
 into btclib transactions, and the chain the node serves compared with the
 network those transactions are labelled for.
 
-The five names it re-exports are the package's own, unchanged, so that
+The names it re-exports are the package's own, unchanged, so that
 `from btclib.fetch.bitcoin_core import BitcoinCoreRpcClient` keeps
 resolving. Their behaviour is the package's too, exceptions included: a
 `client.call` reached that way raises `bitcoin_core_rpc.RpcError`, not


### PR DESCRIPTION
bitcoin_core.py's "The five names it re-exports" and block/limits.py's
"Three of consensus.h's constants" are each a count no test checks --
a sixth re-export or a fourth excluded constant would go silently
stale. Both dropped, same shape as #1384. The other three REEXPORTED
modules (transport.py, p2p/magic.py, psbt/psbt.py) carry no such count.

Closes #1386

## Summary by Sourcery

Remove stale counts from module documentation so it remains accurate as the documented names and constants change.

Enhancements:
- Remove unverified numeric counts from the Bitcoin Core re-export and consensus-constant exclusion module docstrings.

Documentation:
- Update the changelog to document the removal of the stale docstring counts.