### PR TITLE
pre-commit-config.yaml's zizmor comment drops a stale count for the command that re-derives it (closes #1253)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -535,9 +535,10 @@ repos:
   # restored into the job that builds what gets published, an expression
   # interpolated into a shell script, a trigger that runs a fork's code
   # with write access. The default persona is the gate; --persona=auditor
-  # adds advice (12 notes today, none of them a defect: 8 in release.yml
-  # and 4 in test.yml, all of them unnamed jobs) and is worth
-  # running by hand rather than on every commit
+  # adds advisory notes beyond what the gate flags, worth running by hand
+  # rather than on every commit:
+  #
+  #   uvx zizmor@1.29.0 --persona=auditor --no-progress .github/workflows/
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.29.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2010,6 +2010,13 @@ documented at release-notes length in the first place, and are still in
   applies, the two checks sitting in different workflows (issue #1200,
   btclib-org/.github#51) (closes #1360).
 
+- **`.pre-commit-config.yaml`'s zizmor hook comment drops the stale count
+  of `--persona=auditor` findings.** It stated "12 notes today, 8 in
+  `release.yml` and 4 in `test.yml`, all of them unnamed jobs"; the
+  auditor persona's own findings move with the workflows, so the comment
+  now gives the command to re-run instead of a number that was already
+  wrong when written (closes #1253).
+
 ### Documentation and the website
 
 - **The documentation site is themed with `furo`** (issue #1347,


### PR DESCRIPTION
"12 notes today, 8 in release.yml and 4 in test.yml" was already wrong
when written and moves with the workflows it audits. Replaced with the
command to re-run it -- codeql.yml's own stale count from this same
issue was already fixed by #1355, earlier in this campaign.

Closes #1253

## Summary by Sourcery

Keep the zizmor auditor guidance accurate by replacing its outdated finding count with a reproducible command.

Bug Fixes:
- Remove the stale zizmor auditor finding count from the pre-commit configuration comment and replace it with a command for regenerating current findings.

Chores:
- Document the refreshed zizmor comment in the changelog.