### PR TITLE
vendored-vectors.yml's issues: write scopes to the job that uses it (closes #1389)

### DIFF
--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -53,7 +53,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 # head_ref falls back to ref rather than being used bare: it is set only
 # for pull_request events, to the PR's head branch, so a scheduled or
@@ -78,6 +77,13 @@ jobs:
     if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # the elevation, on the job that needs it and nowhere else: no other
+    # job in this workflow declares permissions, so no other job elevates.
+    # issues: write is what the script's gh issue create/edit/close calls
+    # below take, on the tracking issue this run opens or updates
+    permissions:
+      contents: read
+      issues: write # gh issue create/edit/close, in the step below
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2017,6 +2017,15 @@ documented at release-notes length in the first place, and are still in
   now gives the command to re-run instead of a number that was already
   wrong when written (closes #1253).
 
+- **`vendored-vectors.yml`'s `issues: write` moves from the workflow
+  level into the `vectors` job's own `permissions:` block**, matching
+  `codeql.yml`'s shape: one elevation on the job that needs it, with
+  `contents: read` as the workflow default. `--persona=auditor` flagged
+  the workflow-level grant as overly broad; the permission itself is
+  genuinely needed, for the `gh issue create`/`edit`/`close` calls
+  `check_vendored_vectors.py` makes on the tracking issue it maintains
+  (closes #1389).
+
 ### Documentation and the website
 
 - **The documentation site is themed with `furo`** (issue #1347,

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -465,9 +465,10 @@ it — redundant while this repository is public, and written down so that
 the file does not quietly stop working the day it is not. Every
 workflow's aggregate job needs none of that and declares none of it: one
 elevation per job is the shape to keep — the job that writes releases holds
-no OIDC token, and the job that signs writes no release — and
-`vendored-vectors.yml` is the one place that departs from it, declaring
-`issues: write` at the workflow level where its only job would do.
+no OIDC token, and the job that signs writes no release.
+`vendored-vectors.yml`'s `vectors` job has one such declaration of its
+own: `issues: write`, for the `gh issue create`/`edit`/`close` calls its
+script makes on the tracking issue it maintains.
 The workflow-level `permissions: contents: read` is belt and braces; keep
 it, it is what makes the intent readable in the file.
 


### PR DESCRIPTION
Declared at the workflow level, --persona=auditor flags it as overly
broad; every other workflow that elevates scopes the grant to the job
that needs it, contents: read left as the default. Moved into the
vectors job, matching codeql.yml's shape -- the grant itself is
genuinely used, by check_vendored_vectors.py's gh issue create/edit/close
calls.

Closes #1389

## Summary by Sourcery

Restrict the vendored vectors workflow’s elevated issue permissions to the job that requires them.

Enhancements:
- Scope the vendored vectors workflow’s issue-write permission to the `vectors` job while retaining read-only contents access as the workflow default.

Documentation:
- Document the job-level permission scope and its use by the tracking-issue maintenance steps.