### PR TITLE
vendored-vectors.yml's --dry-run flag routes through env: (closes #1392)

### DIFF
--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -102,11 +102,23 @@ jobs:
       # token could not write the issue anyway, and a same-repository
       # pull request testing a change to this script or the README
       # should not close or edit whatever tracking issue is open at the
-      # time as a side effect of that test
+      # time as a side effect of that test.
+      # The flag reaches the shell through the environment rather than
+      # through a `${{ }}` inside the script, which would be text pasted
+      # into it: the value is this file's own, and the habit is what
+      # zizmor's template-injection rule is asking for (mutation.yml's
+      # own comment, around its "Check the baselines" step, is the same
+      # pattern). The array built from it, rather than an unquoted
+      # expansion, is release.yml's own shape for an optional flag
+      # (its "Check the public API against the previous release" step).
       - name: Re-check every pin already at upstream's tip
-        run: >-
-          python .github/scripts/check_vendored_vectors.py
-          tests/_data/README.md
-          ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
+        run: |
+          args=()
+          if [ -n "$DRY_RUN" ]; then
+            args=(--dry-run)
+          fi
+          python .github/scripts/check_vendored_vectors.py \
+            tests/_data/README.md "${args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2026,6 +2026,17 @@ documented at release-notes length in the first place, and are still in
   `check_vendored_vectors.py` makes on the tracking issue it maintains
   (closes #1389).
 
+- **`vendored-vectors.yml`'s `--dry-run` flag moves into an `env:` var,
+  `DRY_RUN`, instead of an interpolated `${{ }}` expression pasted
+  straight into the `run:` script**, matching `mutation.yml`'s own
+  pattern for the same audit. The step builds a shell array from it
+  rather than expanding the variable bare, `release.yml`'s own shape
+  for an optional flag, so `shellcheck`'s SC2086 (unquoted expansion)
+  has nothing to flag either. `--persona=auditor` flagged the
+  interpolation as a template-injection risk; the value is this file's
+  own `github.event_name` check, but the habit of routing it through
+  the environment is what the audit is asking for (closes #1392).
+
 ### Documentation and the website
 
 - **The documentation site is themed with `furo`** (issue #1347,


### PR DESCRIPTION
${{ github.event_name == 'pull_request' && '--dry-run' || '' }} was
interpolated straight into the run: script, flagged by --persona=auditor
as template-injection; mutation.yml already answers the same audit by
routing a value through env: instead. Built as a shell array expanded
quoted, release.yml's own shape for an optional flag, so shellcheck's
SC2086 has nothing to flag either.

Closes #1392

## Summary by Sourcery

Harden the vendored-vectors workflow's pull-request dry-run handling to satisfy template-injection and shell quoting audits.

Bug Fixes:
- Route the vendored-vectors workflow's optional `--dry-run` flag through an environment variable and safely handle it without inline script interpolation.

CI:
- Harden the vendored-vectors workflow against template-injection and unquoted-shell-expansion audit findings.

Chores:
- Document the workflow security hardening in the changelog.