### PR TITLE
CONTRIBUTING.md's What runs when table gains rows for fuzz and scorecard (closes #1391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -715,6 +715,15 @@ documented at release-notes length in the first place, and are still in
   checks the excluded-constants list at all. The other three modules in
   `REEXPORTED` — `btclib.fetch.transport`, `btclib.p2p.magic` and
   `btclib.psbt.psbt` — carry no such count in their own docstrings.
+- **`CONTRIBUTING.md`'s *What runs when* table carries a row each for
+  `fuzz` and `scorecard`.** Both cells read `—` for what they vary,
+  matching `links` and `mutation`; the *when* is each workflow's own
+  current trigger — pull request for `fuzz`, push to main for
+  `scorecard` — rather than a schedule day, neither workflow's own file
+  carrying a `schedule:` block yet. `scorecard` also joins
+  `claude-review` as the table's exception to the `workflow_dispatch`
+  sentence below it: `ossf/scorecard-action`'s own triggers are push
+  and schedule, not section 10's general rule (closes #1391).
 
 ### Packaging, linting and CI
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -464,6 +464,8 @@ read by every checkout of this repository.
 | `website` | pull request, push, on website files | — |
 | `claude-review` | pull request, and `@claude` in a comment | — |
 | `codeql` | pull request, push to main, and weekly | 2 languages |
+| `fuzz` | pull request | — |
+| `scorecard` | push to main | — |
 | `os-ubuntu` | weekly, a release | ubuntu images and interpreters |
 | `os-macos` | weekly, a release | macOS images and interpreters |
 | `os-windows` | weekly, a release | Windows images and interpreters |
@@ -523,9 +525,12 @@ green is that platform; red in both is the upgrade. Every workflow in the
 table also takes `workflow_dispatch`, the gates included: a branch whose
 pull request is not open yet has no other way to ask, and for the three
 platform workflows it is the only way to ask about a branch at all.
-`claude-review` is the exception, and takes none: both its jobs read
-the pull request or the comment that triggered them, so a manual dispatch
-would start a run with nothing to read.
+`claude-review` and `scorecard` are the exceptions, and take none: both
+of `claude-review`'s jobs read the pull request or the comment that
+triggered them, so a manual dispatch would start a run with nothing to
+read; `scorecard`'s triggers are `ossf/scorecard-action`'s own, whose
+README names push and schedule as supported and calls `workflow_dispatch`
+experimental.
 
 ### Reproducing what CI runs
 


### PR DESCRIPTION
Both workflows landed this campaign without a row. what it varies
reads -- for both, matching links and mutation; the when is each
workflow's own current trigger rather than a schedule day, neither
file carrying a schedule: block yet. scorecard also joins claude-review
as the table's exception to the workflow_dispatch sentence below it.

Closes #1391

## Summary by Sourcery

Document the `fuzz` and `scorecard` workflow triggers and their exceptions to the manual-dispatch guidance.

Enhancements:
- Document the `fuzz` and `scorecard` workflows in CONTRIBUTING.md's “What runs when” table and clarify their trigger and manual-dispatch behavior.

Documentation:
- Update the changelog to record the workflow documentation additions and exceptions.