### PR TITLE
scorecard.yml gains a schedule: trigger, cron 4 3 * * 6 (issue #1347)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,26 +22,16 @@ on:
     # this one carries no dispatch and no pull_request: its triggers are
     # the action's, not section 10's general rule
     branches: [main]
-  # No schedule: yet. Section 10's calendar is two tables read by
-  # btclib-org/.github's own tests/grid_test.py, and neither names
-  # "scorecard" today -- not because the sentinel is structurally exempt
-  # (that sentence in section 10 is about which *trigger types* it
-  # supports, push and schedule rather than pull_request and
-  # workflow_dispatch, and says nothing about the day/hour grid), but
-  # because btclib-org/portanode was the first tree in the organization
-  # to adopt the workflow and no repository had a row before it.
-  # btclib-org/.github#201 is the landed precedent for exactly this gap,
-  # on bootstrap-dns.yml: a sentinel ships with no schedule trigger
-  # until an issue proposes a day and an hour and section 10's table
-  # gains the row, at which point a schedule: block is added here to
-  # match it. Until then a cron naming "scorecard" would be a row
-  # grid_test.py's test_every_cron_is_the_instant_the_calendar_names
-  # cannot find, which fails not this repository's own gate but
-  # btclib-org/.github's weekly alignment sentinel, against every tree
-  # it clones. The push trigger above already runs the analysis on every
-  # push to main, which is what feeds the badge and the published score
-  # in the meantime. btclib-org/.github#363 proposes the row -- Saturday,
-  # hour 03, open rather than decided as of this file.
+  schedule:
+    # Saturday, hour 03: section 10's calendar, decided by
+    # btclib-org/.github#363 and landed via btclib-org/.github#382. The
+    # minute is this repository's own row in the same table.
+    # The time is section 10's grid in btclib-org/.github and not this
+    # file's to restate.
+    # The push trigger above already runs the analysis on every push to
+    # main, which is what feeds the badge and the published score between
+    # scheduled runs; this covers what push cannot -- a week with none.
+    - cron: "4 3 * * 6"
 
 # least privilege for the GITHUB_TOKEN at the workflow level, with one
 # elevation on the job below: the analysis reads the tree, requests a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -724,6 +724,12 @@ documented at release-notes length in the first place, and are still in
   `claude-review` as the table's exception to the `workflow_dispatch`
   sentence below it: `ossf/scorecard-action`'s own triggers are push
   and schedule, not section 10's general rule (closes #1391).
+- **`scorecard.yml` gains a `schedule:` trigger, `cron: '4 3 * * 6'`.**
+  Saturday, hour 03, is section 10's calendar row for `scorecard`,
+  decided by btclib-org/.github#363 and landed via
+  btclib-org/.github#382; minute 04 is this repository's own row in the
+  same table. `CONTRIBUTING.md`'s *What runs when* table's `scorecard`
+  row now reads `weekly, push to main` (issue #1347).
 
 ### Packaging, linting and CI
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -465,7 +465,7 @@ read by every checkout of this repository.
 | `claude-review` | pull request, and `@claude` in a comment | — |
 | `codeql` | pull request, push to main, and weekly | 2 languages |
 | `fuzz` | pull request | — |
-| `scorecard` | push to main | — |
+| `scorecard` | weekly, push to main | — |
 | `os-ubuntu` | weekly, a release | ubuntu images and interpreters |
 | `os-macos` | weekly, a release | macOS images and interpreters |
 | `os-windows` | weekly, a release | Windows images and interpreters |


### PR DESCRIPTION
btclib-org/.github#363, deciding scorecard | Saturday | 03 in the org
standard's calendar, landed via btclib-org/.github#382. This
repository's own minute is 04, so the schedule is 4 3 * * 6, added
alongside the existing push trigger. ISS #1347's tracking issue is
updated to check off this row; fuzz.yml's own row
(btclib-org/.github#372) is still undecided, so the umbrella stays
open.

issue #1347

## Summary by Sourcery

Run the Scorecard workflow weekly as well as on pushes to main.

New Features:
- Add a weekly scheduled run to the Scorecard workflow alongside its existing push-to-main trigger.

Enhancements:
- Update the workflow documentation and changelog to reflect the new weekly Scorecard execution schedule.