### PR TITLE
fuzz.yml's batch_fuzzing gains its schedule (closes btclib-org/.github#372)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -23,23 +23,24 @@ name: fuzz
 # runs the longer "batch" mode, which is what builds a corpus over time
 # and is meant for a schedule rather than for a pull request's own wait.
 #
-# `batch_fuzzing` carries no `schedule:` yet. Section 10's calendar is
-# one table for the whole organization, and asking for a row rather than
-# adding one unilaterally is btclib-org/.github#363's own precedent for
-# this exact situation, decided the same day this workflow was written;
-# the slot this file would want (Monday, 03) is proposed on
-# btclib-org/.github#372 and is not written here until the calendar
-# answers it. Not `push: branches: [main]` either, unlike `scorecard.yml`
-# under #363: `fuzz-seconds: 3600` below is an hour of fuzzing, and
-# ClusterFuzzLite's own docs call a push-triggered batch job "not
-# recommended" for exactly the reason that becomes -- one on every push
-# queues faster than an hour-long job drains. `workflow_dispatch` is what
-# runs it by hand until then, and it is required by this section
-# regardless of the above.
+# `batch_fuzzing` runs on the schedule below, which section 10 of the
+# organization standard, in btclib-org/.github, names for `fuzz`. Not
+# `push: branches: [main]` either, unlike `scorecard.yml`: `fuzz-seconds:
+# 3600` below is an hour of fuzzing, and ClusterFuzzLite's own docs call
+# a push-triggered batch job "not recommended" for exactly the reason
+# that becomes -- one on every push queues faster than an hour-long job
+# drains. `workflow_dispatch` is required by this section regardless of
+# the above, and is what runs a batch by hand between scheduled runs.
 on:
+  schedule:
+    # Day and hour are section 10's own workflow table; minute is this
+    # repository's own row in section 10's repository table.
+    # The time is section 10's grid in btclib-org/.github and not this
+    # file's to restate.
+    - cron: "4 3 * * 1"
+  workflow_dispatch:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, closed]
-  workflow_dispatch:
 
 # least privilege for the GITHUB_TOKEN: neither job writes to the
 # repository or to code scanning -- `output-sarif: true` below only
@@ -50,10 +51,13 @@ permissions:
 
 # named literally rather than through github.workflow, which in a called
 # workflow is the caller's name (section 10's "What every workflow
-# does"); a pull request run and a workflow_dispatch run of this same
-# workflow never collide, `github.event.pull_request.number` being unset
-# on the second, so the fallback to `github.ref` is what still gives the
-# manual run a group of its own
+# does"); a pull request run never collides with either of the other
+# two, `github.event.pull_request.number` being unset on both, so the
+# fallback to `github.ref` groups a schedule run and a workflow_dispatch
+# run together instead -- wanted, not merely tolerated:
+# cancel-in-progress below means a manual run does not wait behind the
+# scheduled batch's own hour for the numbers it was asked for, the same
+# design and the same reason `mutation.yml` already carries
 concurrency:
   group: fuzz-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -104,7 +108,7 @@ jobs:
 
   batch_fuzzing:
     name: Batch fuzzing
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     # the docker build plus one hour of fuzzing (fuzz-seconds below), far
     # above what either takes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **`fuzz.yml`'s `batch_fuzzing` gains a `schedule:` -- Monday, hour 03,
+  minute 04.** Monday and hour 03 are section 10 of the organization
+  standard's own workflow row for `fuzz`; minute 04 is this
+  repository's own row in section 10's repository table.
+  `workflow_dispatch` and the scheduled run share one concurrency
+  group, `mutation.yml`'s own design, so a manual run does not wait
+  behind the scheduled batch's own hour for the numbers it was asked
+  for. `CONTRIBUTING.md`'s *What runs when* table's `fuzz` row now
+  names both triggers, `pull request, weekly`, the same two-item shape
+  `os-ubuntu`'s and `pypi-install`'s own rows already use (closes
+  btclib-org/.github#372).
+
 - **`README.md`'s badge row follows the organization standard's section
   2: membership by property, never curation, in the fixed order with the
   sentinels in section 10's calendar order.** The row gained `wheel` and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -464,7 +464,7 @@ read by every checkout of this repository.
 | `website` | pull request, push, on website files | — |
 | `claude-review` | pull request, and `@claude` in a comment | — |
 | `codeql` | pull request, push to main, and weekly | 2 languages |
-| `fuzz` | pull request | — |
+| `fuzz` | pull request, weekly | — |
 | `scorecard` | weekly, push to main | — |
 | `os-ubuntu` | weekly, a release | ubuntu images and interpreters |
 | `os-macos` | weekly, a release | macOS images and interpreters |


### PR DESCRIPTION
Closes btclib-org/.github#372.

`fuzz.yml`'s `batch_fuzzing` gains `cron: "4 3 * * 1"`. Monday and hour
`03` are section 10's own workflow row for `fuzz`, landed in
btclib-org/.github#404; minute `04` is this repository's row in section
10's repository table. The job's `if:` now admits `schedule` alongside
`workflow_dispatch`, and the two share one concurrency group with
`cancel-in-progress`, `mutation.yml`'s own design, so a dispatch
preempts an hour-long scheduled batch rather than queueing behind it.

This is the second of the issue's two landings, so it carries the
keyword. The calendar row landed first, which is why the comment beside
the `cron:` cites a row that exists.

`CONTRIBUTING.md`'s *What runs when* table gains `weekly` on the `fuzz`
row. That row landed in #1396 naming the workflow's then-current single
trigger, and this change is what gives it a second, so the row is
corrected here rather than filed. The comma-only shape matches the ten
of twelve multi-item cells in that table that take no `and`.

## Summary by Sourcery

Run batch fuzzing weekly while preserving manual execution and accurate workflow documentation.

New Features:
- Schedule weekly batch fuzzing runs for `fuzz.yml` alongside manual dispatches.

Enhancements:
- Coordinate scheduled and manual batch fuzzing through shared cancel-in-progress concurrency.
- Update contributor documentation to reflect the fuzz workflow’s weekly trigger.

Documentation:
- Document the new fuzzing schedule and trigger behavior in the changelog.