### PR TITLE
CLAUDE.md's Non-obvious facts names three more of them, learned this campaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **`CLAUDE.md`'s *Non-obvious facts* section gains three bullets,**
+  learned running this campaign: `btclib-org/.github`'s weekly calendar
+  is two tables and either can move mid-campaign, so a row's day/hour or
+  a repository's minute is re-fetched rather than trusted from earlier
+  in the same session; `git merge-tree --write-tree` answers a
+  `merge=union` file's mergeability where GitHub's own
+  `mergeStateStatus` can report `DIRTY` for no real conflict; and
+  `git grep -E` silently drops `\b`, answering a false zero a sweep
+  needs `--perl-regexp` to avoid.
+
 - **`fuzz.yml`'s `batch_fuzzing` gains a `schedule:` -- Monday, hour 03,
   minute 04.** Monday and hour 03 are section 10 of the organization
   standard's own workflow row for `fuzz`; minute 04 is this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,25 @@ Do not use Fable unless explicitly instructed.
   claimed content, not against which function the line lands in — a
   citation landing inside the right function has still been off by
   several lines.
+- **`btclib-org/.github`'s weekly calendar is two tables, and either can
+  move mid-campaign.** Section 10 splits day/hour (per workflow) from
+  minute (per repository, `btclib` is `04`); the issue proposing one
+  workflow's row can close and land days into a campaign that started
+  before it did. Re-fetch the table
+  (`gh api repos/btclib-org/.github/contents/README.md -H 'Accept:
+  application/vnd.github.raw'`) rather than trusting a value read
+  earlier in the same session.
+- **`git merge-tree --write-tree` answers a `merge=union` file's
+  mergeability better than GitHub's own `mergeStateStatus`.** The
+  server-side check does not apply the driver `CHANGELOG.md` carries, so
+  it can report `DIRTY`/`CONFLICTING` on a branch a local rebase
+  resolves without one conflicting line. Run `merge-tree` first to tell
+  a real conflict from this one before spending a rebase on it.
+- **`git grep -E` silently drops `\b` word-boundary anchors.** A pattern
+  like `\bused to \w+\b` compiles and runs without error under `-E` and
+  answers zero on a file that has real matches; `--perl-regexp` is what
+  actually honors `\b`. Prove a sweep's zero against a known positive
+  before trusting it.
 
 ## Conventions to match
 


### PR DESCRIPTION
The org standard's weekly calendar is two tables and either can move
mid-campaign: a workflow's row and a repository's minute are re-fetched
rather than trusted from earlier in the same session. git merge-tree
--write-tree answers a merge=union file's mergeability where GitHub's
own mergeStateStatus can report DIRTY for no real conflict. And git
grep -E silently drops \b, answering a false zero a sweep needs
--perl-regexp to avoid.

Local review: CLEARED ca8a3c541e15adc044dc4dcb95bf27b0d09b1829.

## Summary by Sourcery

Document additional non-obvious facts learned during the campaign to improve repository maintenance and review accuracy.

Enhancements:
- Document three campaign-review lessons in `CLAUDE.md`, covering dynamic calendar data, local mergeability checks, and reliable word-boundary searches.

Documentation:
- Update the changelog to record the newly documented non-obvious repository facts.