### PR TITLE
to_prv_key.py's _PRV_KEY_TYPES comment points at its counterpart (closes #1262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2076,6 +2076,19 @@ documented at release-notes length in the first place, and are still in
 
 ### Documentation and the website
 
+- **`to_prv_key.py`'s comment above `_PRV_KEY_TYPES` points at
+  `to_pub_key._PUB_KEY_TYPES` instead of describing it** (closes #1262).
+  It called that tuple "the same list plus a Point and minus nothing",
+  where the run-time tuples read back as `_PUB_KEY_TYPES` being
+  `_PRV_KEY_TYPES` minus `int`, plus `tuple` and `PreparedPoint`. The
+  clause that was true — a public key can be a point and a private key
+  cannot — explained the addition and denied the omission, which is the
+  half worth a reader's attention: an `int` is the scalar, so it is a
+  private key and never a public one. `to_pub_key.py` already says that
+  beside the tuple it is about, so the comment here names the
+  counterpart rather than restating it, and cannot go stale again as
+  either tuple gains a spelling.
+
 - **The documentation site is themed with `furo`** (issue #1347,
   btclib-org/.github#329). The `docs` dependency group and `conf.py`'s
   `html_theme` both name it, in place of `sphinx_rtd_theme`: the

--- a/src/btclib/to_prv_key.py
+++ b/src/btclib/to_prv_key.py
@@ -42,8 +42,8 @@ __all__ = [
 PrvKey = int | Octets | BIP32KeyData
 
 # the union at run time, with the buffers bytes_from_octets accepts beside
-# bytes. `to_pub_key._PUB_KEY_TYPES` is the same list plus a Point and
-# minus nothing: a public key can be a point, a private key cannot
+# bytes. `to_pub_key._PUB_KEY_TYPES` is the counterpart, and is where the
+# int this list holds and that one does not is explained
 _PRV_KEY_TYPES = (int, bytes, bytearray, memoryview, str, BIP32KeyData)
 
 


### PR DESCRIPTION
Closes #1262

`src/btclib/to_prv_key.py`'s comment above `_PRV_KEY_TYPES` said that
`to_pub_key._PUB_KEY_TYPES` is "the same list plus a Point and minus
nothing". Read back from the tree, the two run-time tuples are

```
_PRV_KEY_TYPES  int, bytes, bytearray, memoryview, str, BIP32KeyData
_PUB_KEY_TYPES       bytes, bytearray, memoryview, str, BIP32KeyData, tuple, PreparedPoint
```

so `_PUB_KEY_TYPES` is `_PRV_KEY_TYPES` **minus `int`**, plus `tuple`
and `PreparedPoint`. The clause after the colon — a public key can be a
point, a private key cannot — was true and explained the addition, while
denying the omission, which is the half worth a reader's attention: an
`int` is the scalar, so it is a private key and never a public one.

## Why this points rather than corrects

`to_pub_key.py` already states the asymmetry, immediately above its own
tuple: *"An int is in one and not the other on purpose: in this library
an int is a private key, and never a public one."* Writing the corrected
description here would be a second wording of a fact that already has
one, which is `CONTRIBUTING.md`'s *One fact in one place* and is how the
first half of this comment went stale — `PreparedPoint` arrived after
the sentence was written. So the comment names the counterpart instead,
and does not go stale again as either tuple gains a spelling.

## Gates

Run in the branch's own worktree at this sha, after `uv sync --locked`:

| gate | exit |
|---|---|
| `uv run pytest -q` | 0 — 30704 passed, 11 skipped, coverage 100.00% |
| `uv run pre-commit run --all-files` | 0 |
| `uv run sphinx-build -n -W --keep-going docs/source …` | 0, build succeeded |

`git status --porcelain` empty after all three; `git log -1
--format='%G? %GS'` → `G`.

Local review at fresh context: `CLEARED 374a9cbf`, no findings. It
verified both tuples independently, the CHANGELOG group against the
`curves/__init__.py` precedent, and the `(closes #N)` token against the
standard's rule; it attributes the three gate runs to me rather than
vouching for them, the author and the dispatcher being the same person
on this branch.

## Summary by Sourcery

Clarify the relationship between private- and public-key type definitions without duplicating their existing explanation.

Enhancements:
- Update the private-key type comment to reference the public-key counterpart as the authoritative explanation of their intentional type asymmetry.

Documentation:
- Document the corrected `_PRV_KEY_TYPES` comment in the changelog.