### PR TITLE
The concurrency ceiling is stated once and pointed at from five sites (issue #1256)

### DIFF
--- a/.github/workflows/os-ubuntu.yml
+++ b/.github/workflows/os-ubuntu.yml
@@ -10,11 +10,12 @@ name: os-ubuntu
 # What the gate gives up is the point of the arrangement rather than a
 # cost it hides. The gate does not refuse a regression on 3.10, on arm or
 # on PyPy: one sits on main until this runs, at most six days. What that
-# buys is every pull request. GitHub Free gives an organization twenty
-# concurrent jobs, shared across every repository in it, and a gate wider
-# than one cell spends a review's wall clock waiting for a slot rather
-# than running the suite; REPOSITORY.md has that measurement,
-# os-windows.yml the runner seconds and os-macos.yml the queueing.
+# buys is every pull request. A gate wider than one cell spends a
+# review's wall clock waiting for a slot against the ceiling GitHub Free
+# puts on an organization's concurrent jobs, shared across every
+# repository in it, rather than running the suite; REPOSITORY.md has
+# that measurement, os-windows.yml the runner seconds and os-macos.yml
+# the queueing.
 #
 # What a matrix buys here is not the pure Python, which is the same
 # everywhere: every (os, architecture, interpreter) triple selects a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -753,6 +753,22 @@ documented at release-notes length in the first place, and are still in
   same table. `CONTRIBUTING.md`'s *What runs when* table's `scorecard`
   row now reads `weekly, push to main` (issue #1347).
 
+- **The concurrent-job ceiling GitHub Free gives the organization is
+  stated once, in `REPOSITORY.md`'s dated measurement, and the other
+  sites that used to restate it now point there instead.**
+  `REPOSITORY.md`'s own second copy, in the Code quality section, keeps
+  the local reasoning about that section's own job count and drops the
+  restated number and date; `os-ubuntu.yml`'s header keeps its argument
+  for a single-cell gate and drops the number, and `CONTRIBUTING.md`'s
+  own "why so little gates" paragraph drops the number it carried right
+  beside its own pointer to `REPOSITORY.md`, matching the shape
+  `os-windows.yml`'s header already uses.
+  `codeql.yml`'s own restatement is gone already, replaced by a pointer
+  to `REPOSITORY.md` when #1355 rewrote its triggers.
+  `claude-review.yml`'s copy is untouched here: that file needs a pull
+  request of its own, `claude-review.yml:170-181` being why (issue
+  #1256).
+
 ### Packaging, linting and CI
 
 - **`pyproject.toml`'s ruff configuration selects `["ALL"]`,** matching

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -495,8 +495,8 @@ calendar in one place is one thing to keep true, where a copy of it in
 every repository would be one more.
 
 Why so little gates is one number: the ceiling GitHub Free puts on an
-organization's concurrent jobs, twenty shared across every repository in
-it. REPOSITORY.md measures what a wider gate cost against that ceiling,
+organization's concurrent jobs, shared across every repository in it.
+REPOSITORY.md measures what a wider gate cost against that ceiling,
 and the consequence is this table's: at that ceiling a pull request's
 wall clock is the wait for a slot rather than the suite. `os-macos.yml` and
 `os-windows.yml` each carry the measurement for their own cells, the

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -232,11 +232,11 @@ gh api -X PATCH repos/btclib-org/btclib/code-quality/setup \
   -F state=not-configured
 ```
 
-What decided it is the concurrency ceiling and not the queries. GitHub
-Free gives an organization twenty concurrent jobs (as of 2026-08-21), a
-pull request here asks for twenty-one on purpose, and `Analyze (python)`
-and `Analyze (ruby)` were two more on every pull request and every push
-to `main` — `Code Quality: PR #N` in the run list, 80 seconds and 32.
+What decided it is the concurrency ceiling measured above, not the
+queries: a pull request here asks for twenty-one jobs on purpose, and
+`Analyze (python)` and `Analyze (ruby)` were two more on every pull
+request and every push to `main` — `Code Quality: PR #N` in the run
+list, 80 seconds and 32.
 
 What they produced in exchange cannot be read from here at all. There is
 no `code-quality/alerts` and no `code-quality/analyses`, both 404, and a


### PR DESCRIPTION
Part of issue #1256, which stays open: this branch repairs five of the
six sites that repeat the concurrency ceiling and deliberately leaves
the sixth, `claude-review.yml`, to the branch that ports that whole file
from the organization's canonical copy. **No closing keyword here, by
design** — the issue closes on that branch, not this one.

`REPOSITORY.md` records the ceiling GitHub Free gives the organization,
dated, with the measurement that gives it its point. The number was then
restated where nothing checks it, so an edit to one copy leaves the rest
quietly disagreeing.

## Per site

- **`REPOSITORY.md`**, the *Code quality* section's second copy: now
  points at the canonical statement above it. The facts local to that
  section — a pull request here asking for twenty-one jobs on purpose,
  and what `Analyze (python)` and `Analyze (ruby)` cost — stay, being
  arguments rather than restatements.
- **`os-ubuntu.yml`**: the header drops the ceiling sentence and keeps
  its own argument, that a gate wider than one cell spends a review's
  wall clock waiting for a slot rather than running the suite.
- **`CONTRIBUTING.md`**: drops "twenty" from the sentence that was
  already pointing at `REPOSITORY.md` beside it.
- **`os-windows.yml`** is kept as written, which the issue said was part
  of the question. Its header already points at `REPOSITORY.md` carrying
  no number; the line in question *uses* the ceiling in a local argument
  about scheduling this file an hour after `os-macos.yml`, rather than
  recording it as a fact.
- **`codeql.yml`** needed nothing: `f1061a23` ([PR
  1355](https://github.com/btclib-org/btclib/pull/1355)) rewrote that
  comment block for an unrelated reason after the issue was filed, and
  replaced the restatement with a pointer in passing.

## The issue's census was wrong in two ways, both measured

The filenames are `os-ubuntu.yml` and `os-windows.yml`, not `ubuntu.yml`
and `windows.yml`.

More usefully: `CONTRIBUTING.md` is cited in the issue as one of the
three examples showing "the shape the others should take ... carrying no
number of their own", and it was never that. Read at `eb120165`, the
commit that was `HEAD` eight minutes before the issue was filed, the
paragraph already said "the ceiling GitHub Free puts on an organization's
concurrent jobs, twenty shared across every repository in it" — the
number one line above its own pointer. So the file held up as the healthy
example was a seventh instance of the defect. It is repaired here rather
than filed: same defect, same subsystem, same paragraph's neighbourhood
as the diff already at hand.

A census over the whole of `.github/workflows`, `REPOSITORY.md` and
`CONTRIBUTING.md` at this tip finds nothing else: what remains is
`claude-review.yml` (deferred on purpose), `os-windows.yml` (kept on
purpose), `REPOSITORY.md`'s canonical statement and its local
twenty-one, and two sentences about "twenty minutes" of mutation budget
and "twenty lines" of reviewer diff, neither about this ceiling.

## Gates

Run by the coder on this exact sha, after a clean rebase onto
`a2c77421`:

| gate | exit |
|---|---|
| `uv run pre-commit run --all-files` | 0 — every hook, `actionlint` and `zizmor` included |
| `uv run pytest` | 0 — 30704 passed, 11 skipped, coverage 100.00% |
| `sphinx-build -n -W --keep-going` | 0, build succeeded |

`git status --porcelain` empty after the last; commit signed. The suite
ran twice, at load average 10.30 before the rebase and 38.27 after, with
identical pass, skip and coverage counts.

Local review at fresh context: `CLEARED d1a5e82f`, no findings. It
re-derived the `CONTRIBUTING.md` history independently and found the
issue's citation wrong from the day it was filed rather than merely
stale-numbered; confirmed `claude-review.yml` byte-identical to `main`
and still carrying its copy, which is what makes the citation token
right; and ran the whole-tree census above itself.

## Summary by Sourcery

Consolidate the documented GitHub Free concurrency ceiling around REPOSITORY.md and align dependent references without changing workflow behavior.

Enhancements:
- Centralize the GitHub Free concurrent-job ceiling in REPOSITORY.md and remove redundant numeric restatements from related documentation and workflow commentary while preserving local scheduling rationale.

Documentation:
- Update the changelog to document the centralized concurrency-ceiling statement and the intentionally deferred claude-review.yml update.