### PR TITLE
ssa.challenge_ and dsa.recover_pub_key_ refuse a bool (closes #1248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3203,6 +3203,25 @@ documented at release-notes length in the first place, and are still in
   class's docstring now states the guarantee plainly instead of citing a
   closed issue (issue #1314).
 
+- **`ssa.challenge_` and `dsa.recover_pub_key_` refuse a bool, closing
+  the trailing-underscore layer's own gap in issue #1206's policy**
+  (closes #1248). Both take a bare `int` rather than an `Integer`, so
+  neither `int_from_integer` nor a key converter's type gate ever saw
+  them: `ssa.challenge_(b"msg", True, x_K, secp256k1, sha256)` read the
+  bool as the x-coordinate `x_Q` and `dsa.recover_pub_key_(True,
+  msg_hash, sig)` read it as the recovery id `1`, each silently equal to
+  its call with the number one.
+
+  The check is `is_integer`, run before either function does anything
+  with the value, raising `BTClibTypeError` — `"non-integer
+  x-coordinate: True"` for `challenge_`'s `x_Q`, `"non-integer nonce
+  x-coordinate: True"` for its `x_K`, and `"non-integer key_id: True"`
+  for `recover_pub_key_`. `CONTRIBUTING.md`'s *This repository in
+  particular* now states the rule once, for the trailing-underscore
+  layer as a whole: prepared is not unchecked, and a bare `int` still
+  refuses a `bool` the way `int_from_integer` does for every coerced
+  one. `tests/integer_policy_test.py`'s census carries both functions.
+
 ### Tests
 
 - **The tests exercising the pure-Python arm are named `test_the_py_arm_...`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1404,6 +1404,14 @@ two functions instead of two spellings, and a caller who reduced the
 message first quietly gets a different rule. The prepared argument is the
 one difference the pair exists for.
 
+Prepared is not unchecked, and a bare `int` the trailing underscore takes
+instead of an `Integer` still refuses a `bool`: `utils.is_integer` is the
+policy `int_from_integer` carries for every coerced parameter, and the
+underscore spelling asks it of what it is handed already prepared rather
+than skipping it -- `ssa.challenge_`'s `x_Q` and `x_K`, and
+`dsa.recover_pub_key_`'s `key_id`, both pinned in
+`tests/integer_policy_test.py`'s census (issue #1248).
+
 The exception is a boundary at which nothing can be invalid, and it is
 named rather than passed over: where a class's invariants are exactly the
 widths of its fields, the decoding enforces them by construction and the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -269,6 +269,18 @@ full year, short month, short day (YYYY-M-D)
   path directly rather than through `import btclib`. CHANGELOG.md has
   every file the move touched.
 
+- **`ssa.challenge_` and `dsa.recover_pub_key_` no longer accept a
+  bool** (issue #1248), the same rule issue #1206 gave the rest of the
+  library reaching two entry points it did not: both take a bare `int`
+  rather than an `Integer`, so `ssa.challenge_(msg, True, x_K, ec, hf)`
+  read the bool as the x-coordinate `x_Q` and
+  `dsa.recover_pub_key_(True, msg_hash, sig)` as the recovery id, each
+  as if it had been passed `1`.
+
+  Act on it if you pass `True` or `False` as `challenge_`'s `x_Q` or
+  `x_K`, or as `recover_pub_key_`'s `key_id`; both now raise
+  `BTClibTypeError`. CHANGELOG.md has the three wordings.
+
 ### Worth knowing, though nothing raises
 
 - **A `bytearray` and a `memoryview` are octets, and now the signatures

--- a/src/btclib/ecc/dsa.py
+++ b/src/btclib/ecc/dsa.py
@@ -77,6 +77,7 @@ from btclib.utils import (
     bytes_from_octets,
     bytesio_from_binarydata,
     hex_string,
+    is_integer,
 )
 
 __all__ = [
@@ -2221,6 +2222,12 @@ def recover_pub_key_(
     - https://crypto.stackexchange.com/questions/18105/how-does-recovering-the-public-key-from-an-ecdsa-signature-work/18106#18106
 
     """
+    # prepared is not unchecked, `is_integer`'s policy reaching this bare
+    # int the way `int_from_integer` reaches every coerced one
+    # (issue #1248, CONTRIBUTING.md's "This repository in particular")
+    if not is_integer(key_id):
+        raise BTClibTypeError(f"non-integer key_id: {key_id}")
+
     if isinstance(sig, Sig):
         sig.assert_valid()
     else:

--- a/src/btclib/ecc/ssa.py
+++ b/src/btclib/ecc/ssa.py
@@ -93,6 +93,7 @@ from btclib.utils import (
     hex_string,
     int_from_bits,
     int_from_integer,
+    is_integer,
 )
 
 __all__ = [
@@ -358,6 +359,15 @@ def challenge_(msg: Octets, x_Q: int, x_K: int, ec: Curve, hf: HashF) -> int:
     hf happens here.
     """
     _assert_valid_ec(ec)
+
+    # prepared is not unchecked: the trailing underscore skips the
+    # reduction of msg, not `is_integer`'s policy on x_K and x_Q, which
+    # `int_from_integer` would refuse a bool for on the coerced spelling
+    # (issue #1248, CONTRIBUTING.md's "This repository in particular")
+    if not is_integer(x_Q):
+        raise BTClibTypeError(f"non-integer x-coordinate: {x_Q}")
+    if not is_integer(x_K):
+        raise BTClibTypeError(f"non-integer nonce x-coordinate: {x_K}")
 
     # the message, of any size ("Messages of Arbitrary Size" in BIP340):
     # the tagged hash below absorbs any length unambiguously, x_K and x_Q

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -14,6 +14,7 @@ instead of failing beside the input that caused it.
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Callable
 from datetime import datetime, timezone
 from enum import IntEnum
@@ -47,7 +48,9 @@ from btclib.curves import (
     secp256k1,
 )
 from btclib.ecc.bms import sign as bms_sign
+from btclib.ecc.dsa import recover_pub_key_
 from btclib.ecc.dsa import sign as dsa_sign
+from btclib.ecc.ssa import challenge_ as ssa_challenge_
 from btclib.ecc.ssa import point_from_bip340pub_key
 from btclib.ecc.ssa import sign as ssa_sign
 from btclib.ecc.ssa import verify as ssa_verify
@@ -75,6 +78,9 @@ _TX_ID = "01" * 32
 _RATE = FeeRate(sats_per_kvbyte=1000)
 # the key is 1, so the x-only public key it verifies under is `secp256k1.G[0]`
 _SSA_SIG = ssa_sign(b"msg", 1)
+# the key is 1 as well, and key_id 1 is the candidate that recovers it
+_DSA_MSG_HASH = hashlib.sha256(b"msg").digest()
+_DSA_SIG = dsa_sign(b"msg", 1)
 _NOW = datetime(2026, 8, 4, tzinfo=timezone.utc)
 # a one-leaf tree and the prevout of the one input `_tx` builds: what the
 # two index parameters below have to be handed something valid to index
@@ -220,6 +226,22 @@ _CASES: list[tuple[str, Callable[[Any], object]]] = [
     # answers -- `BTClibTypeError` is a `TypeError` and the except there
     # takes `ValueError`, which is issue #814's rule
     ("BIP340 verification key", lambda v: ssa_verify(b"msg", v, _SSA_SIG)),
+    # the trailing-underscore layer, which took no bare `int` parameter
+    # through `int_from_integer` or a key converter's type gate and so sat
+    # outside the census until issue #1248: prepared is not unchecked, and
+    # `is_integer` is asked of what these two are handed already prepared
+    (
+        "BIP340 challenge x-coordinate",
+        lambda v: ssa_challenge_(b"msg", v, 1, secp256k1, hashlib.sha256),
+    ),
+    (
+        "BIP340 challenge nonce x-coordinate",
+        lambda v: ssa_challenge_(b"msg", 1, v, secp256k1, hashlib.sha256),
+    ),
+    (
+        "dsa recovery key_id",
+        lambda v: recover_pub_key_(v, _DSA_MSG_HASH, _DSA_SIG),
+    ),
     # `CurveGroup.is_on_curve` is the one funnel behind a `Point` tuple,
     # `point_from_pub_key`, `_x_from_bip340pub_key`, `PreparedPoint` and
     # `bytes_from_point` included, and it read a bool coordinate as an
@@ -283,6 +305,24 @@ _WORDINGS = [
     ("base58 address key", p2pkh, "not a private or public key"),
     ("bech32 address key", p2wpkh, "not a private or public key"),
     ("BIP340 x-only key", point_from_bip340pub_key, "non-integer: True"),
+    # separate from the three families above too: the trailing-underscore
+    # layer's own type gate on a bare `int` (issue #1248), one sentence per
+    # parameter and neither routed through `int_from_integer`
+    (
+        "BIP340 challenge x-coordinate",
+        lambda v: ssa_challenge_(b"msg", v, 1, secp256k1, hashlib.sha256),
+        "non-integer x-coordinate: True",
+    ),
+    (
+        "BIP340 challenge nonce x-coordinate",
+        lambda v: ssa_challenge_(b"msg", 1, v, secp256k1, hashlib.sha256),
+        "non-integer nonce x-coordinate: True",
+    ),
+    (
+        "dsa recovery key_id",
+        lambda v: recover_pub_key_(v, _DSA_MSG_HASH, _DSA_SIG),
+        "non-integer key_id: True",
+    ),
     # separate from the three families above: `is_on_curve`'s own
     # refusal of a bool coordinate (issue #1249), one sentence per
     # coordinate and shared by every funnel behind it
@@ -362,6 +402,8 @@ def test_the_integers_a_bool_refusal_must_not_take_with_it() -> None:
     assert bms_sign(b"msg", 1).dsa_sig.r
     assert point_from_bip340pub_key(secp256k1.G[0]) == secp256k1.G
     assert ssa_verify(b"msg", secp256k1.G[0], _SSA_SIG)
+    assert ssa_challenge_(b"msg", 1, 1, secp256k1, hashlib.sha256)
+    assert recover_pub_key_(1, _DSA_MSG_HASH, _DSA_SIG) == secp256k1.G
     assert secp256k1.is_on_curve(secp256k1.G) is True
     assert point_from_pub_key(secp256k1.G) == secp256k1.G
     assert PreparedPoint(secp256k1.G).point == secp256k1.G


### PR DESCRIPTION
Closes #1248

The trailing-underscore layer takes prepared inputs and does not
convert, so a bare `int` parameter there passes through none of the
three gates [ISS
1206](https://github.com/btclib-org/btclib/issues/1206) put the rule
behind — `int_from_integer` and the two key converters' type gates.
Two public functions sat outside all three, and read a bool as the
number it subclasses:

```python
ssa.challenge_(b"msg", True, x_K, secp256k1, sha256)
    == ssa.challenge_(b"msg", 1, x_K, secp256k1, sha256)   # x_Q = 1

dsa.recover_pub_key_(True, msg_hash, sig)
    == dsa.recover_pub_key_(1, msg_hash, sig)              # key_id = 1
```

`challenge_` hashed the bool as an x-coordinate; `recover_pub_key_`
returned the public key that recovery id selects. Both now raise
`BTClibTypeError`.

## The question the issue posed, and why it answers this way

ISS 1248 says the tree answers it two ways today and that whichever
answer is right, it should be one answer. It reads as open because the
underscore layer is documented as taking its input as it is, which makes
a check there look like the duplicate validation this tree avoids.

`CONTRIBUTING.md` had already settled it, in prose this branch did not
write: of the underscore pair it says they are *"not a way past the
validation above: `sign_` checks its `msg_hash` as `sign` checks its
`msg`."* So these two functions were the outlier against a standing
commitment, not an invitation to add validation the tree had decided
against. The rule is now stated once for the layer rather than
per function, in that same section.

`BTClibTypeError` is the class the rest of the policy uses —
`int_from_integer`'s own bool refusal and both key-converter type gates
all raise it.

## A premise in my brief was false, and the coder refuted it

I briefed the coder that bip32's `derive_from_account_` "already refuses
`True` as an index", implying an explicit check to copy. It measured
instead of taking my word: the refusal is real but incidental, falling
out of formatting the index into a path string and re-parsing it with
`int()`, and it answers `BTClibValueError` rather than `BTClibTypeError`.
`_assert_valid_branch` and `_assert_valid_address_index` never call
`is_integer`. The coder dropped my sentence before committing, so
nothing here rests on it, and filed the real gap as [ISS
1403](https://github.com/btclib-org/btclib/issues/1403). bip32 is the
outlier to reconcile, not the precedent to copy.

## Gates

Coder's runs on `a073cd60`: `pytest` exit 0 (30713 passed, 11 skipped,
coverage 100.00%), `pre-commit run --all-files` exit 0,
`sphinx-build -n -W --keep-going` exit 0.

Rebased onto `96663a8c` by me after [PR
1404](https://github.com/btclib-org/btclib/pull/1404) landed.
`git range-diff` reports `=` — the patch is identical and only the base
moved — so the review below stands on content that still exists, and I
re-ran all three gates myself on the rebased tip `3da3ec49`: `pytest`
exit 0 (30713 passed, 11 skipped, coverage 100.00%),
`pre-commit run --all-files` exit 0, `sphinx-build -n -W` exit 0, tree
clean, signature `G`. Both union files checked after the rebase for a
stacked entry and for a heading joined flush: one copy of each entry,
no heading damage.

Local review at fresh context: `CLEARED a073cd60`, no findings. It found
the `CONTRIBUTING.md` sentence quoted above independently, verified ISS
1403 says what the report claims and that no residue of my false premise
reached the landed prose, confirmed the edited paragraph is inside *This
repository in particular* by reading the file's own boundary statement
rather than by inference, and probed the post-fix behaviour through the
worktree's own venv.

## Summary by Sourcery

Close the remaining boolean-as-integer validation gap in the prepared ECC APIs.

Bug Fixes:
- Reject boolean values in `ssa.challenge_` coordinates and `dsa.recover_pub_key_` recovery IDs with `BTClibTypeError` instead of treating them as integer values.

Enhancements:
- Document the trailing-underscore layer's policy that prepared integer inputs still reject booleans.
- Extend the integer-policy test census and regression coverage for the affected parameters.

Documentation:
- Document the boolean-rejection behavior in the changelog and release notes.

Tests:
- Add coverage confirming valid integer inputs remain accepted and boolean inputs are rejected with the expected errors.