### PR TITLE
bytes_from_octets refuses a non-contiguous memoryview, and a shared is_octets guard serves two callers (closes #1260, closes #1261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3202,6 +3202,29 @@ documented at release-notes length in the first place, and are still in
   states that no function of the library reaches one any more, so the
   class's docstring now states the guarantee plainly instead of citing a
   closed issue (issue #1314).
+- **`bytes_from_octets` refuses a non-contiguous `memoryview`, with a
+  `BTClibValueError` naming it, rather than handing it back** (closes
+  #1260). A strided slice such as `mv[::2]` is `Octets` to the
+  annotation and was returned untouched, so the failure reached whichever
+  consumer used the buffer next instead of the library's own exception
+  contract -- `hash160` with a bare `BufferError` being one of them. The
+  refusal is raised once, at the coercion every `Octets` parameter
+  passes; a contiguous `memoryview` is unaffected.
+- **`BasicBlockFilter.from_block` and `descriptors.satisfaction_sizer`
+  refuse every `Octets` spelling where a sequence of them was meant, with
+  the message that names the shape rather than one from underneath**
+  (closes #1261). Each guard named only the spellings `Octets` held when
+  it was written: `from_block`'s missed `bytearray` and `memoryview`, and
+  `satisfaction_sizer`'s missed `memoryview`. Neither buffer built a
+  filter or a sizer from the wrong data -- a single script or key of
+  either shape still failed, either on the count check or on
+  `bytes_from_octets` refusing the `int` each single-byte iteration
+  produces -- but by accident, and with a complaint naming an `int` or a
+  count rather than the actual mistake. `utils.is_octets` asks the
+  underlying question once -- is this one `Octets` rather than a sequence
+  of them -- so both callers raise the on-point message for every
+  spelling, and a spelling `Octets` gains later is refused the same way
+  at both instead of by whichever accident is available.
 
 - **`ssa.challenge_` and `dsa.recover_pub_key_` refuse a bool, closing
   the trailing-underscore layer's own gap in issue #1206's policy**

--- a/src/btclib/block/block_filter.py
+++ b/src/btclib/block/block_filter.py
@@ -30,7 +30,12 @@ from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash256, siphash
 from btclib.tx import OutPoint, TxOut
 from btclib.tx.limits import MAX_TX_OUT_COUNT
-from btclib.utils import bytes_from_octets, bytesio_from_binarydata, is_integer
+from btclib.utils import (
+    bytes_from_octets,
+    bytesio_from_binarydata,
+    is_integer,
+    is_octets,
+)
 
 __all__ = [
     "BASIC_FILTER_M",
@@ -403,10 +408,10 @@ class BasicBlockFilter:
         `prevout_scripts_from_utxos` builds the list from a mapping for
         a caller that holds one.
         """
-        # a str is a Sequence, and Octets is a str: passing one script
-        # instead of a list of them would zip through its characters and
-        # count them as inputs, so the shape is refused by name
-        if isinstance(prevout_scripts, str | bytes):
+        # every Octets is a Sequence too: passing one script instead of a
+        # list of them would zip through its bytes and count them as
+        # inputs, so the shape is refused by name
+        if is_octets(prevout_scripts):
             err_msg = "invalid previous output scripts type: "
             err_msg += type(prevout_scripts).__name__
             raise BTClibTypeError(err_msg)

--- a/src/btclib/descriptors/descriptors.py
+++ b/src/btclib/descriptors/descriptors.py
@@ -207,7 +207,7 @@ from btclib.script.taproot import (
 )
 from btclib.script.witness import Witness
 from btclib.tx.tx_in import TxIn
-from btclib.utils import assert_type, bytes_from_octets
+from btclib.utils import assert_type, bytes_from_octets, is_octets
 
 __all__ = [
     "AddrDescriptor",
@@ -2595,11 +2595,10 @@ def satisfaction_sizer(keys: Iterable[Octets]) -> SolutionSizer:
     then falls back exactly as it would for any other sizer answering
     "not mine".
     """
-    # a str and a bytes are each an `Octets` and each an iterable of one,
-    # so `Iterable[Octets]` accepts either as far as the annotation goes:
-    # one key handed where the list was meant is as many keys as it has
-    # characters, and each of them invalid
-    if isinstance(keys, (str, bytes, bytearray)):
+    # an Octets is itself iterable, so `Iterable[Octets]` accepts one as
+    # far as the annotation goes: one key handed where the list was meant
+    # is as many keys as it has octets, and each of them invalid
+    if is_octets(keys):
         raise BTClibTypeError(f"invalid keys type: {type(keys).__name__}")
     if not isinstance(keys, Iterable):
         raise BTClibTypeError(f"invalid keys type: {type(keys).__name__}")

--- a/src/btclib/utils.py
+++ b/src/btclib/utils.py
@@ -72,12 +72,25 @@ __all__ = [
     "int_from_integer",
     "int_from_json_number",
     "is_integer",
+    "is_octets",
     "list_from_json_array",
     "read_exactly",
     "str_from_string",
 ]
 
 NoneOneOrMoreInt = int | Iterable[int] | None
+
+
+def _assert_contiguous(octets: bytes | bytearray | memoryview) -> None:
+    """Refuse a non-contiguous memoryview, the one buffer that can be one.
+
+    `bytes` and `bytearray` are always C-contiguous; a `memoryview` need
+    not be -- a strided slice such as `mv[::2]` is not, and is returned
+    by `bytes_from_octets` untouched unless refused here.
+    """
+    if isinstance(octets, memoryview) and not octets.c_contiguous:
+        err_msg = "invalid octets: non-contiguous memoryview"
+        raise BTClibValueError(err_msg)
 
 
 def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> bytes:
@@ -87,6 +100,14 @@ def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> byte
     also ensures required output size: one size, or any iterable of them,
     and a bool is neither -- `out_size=True` would accept a single octet
     and say it had checked a size.
+
+    A non-contiguous `memoryview` -- what a strided slice such as
+    `mv[::2]` gives -- is refused here rather than handed back: every
+    other consumer of the buffer this returns needs a C-contiguous one,
+    `hash160` failing with a bare `BufferError` being one of them, so the
+    refusal is raised through the exception contract at the one place
+    every `Octets` parameter passes rather than left to whichever
+    consumer trips over it first.
     """
     if isinstance(octets, str):  # hex string
         # `bytes.fromhex` raises a bare ValueError -- the same class the
@@ -101,7 +122,9 @@ def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> byte
             octets = bytes.fromhex(octets)
         except ValueError as e:
             raise BTClibValueError(f"invalid hex string: {e}") from e
-    elif not isinstance(octets, (bytes, bytearray, memoryview)):
+    elif isinstance(octets, (bytes, bytearray, memoryview)):
+        _assert_contiguous(octets)
+    else:
         # what is neither went through untouched and reached whatever the
         # caller went on to do with it: `len` of a tuple of 33 ints is 33,
         # so `taproot.assert_valid_control_block` accepted one as a
@@ -271,6 +294,20 @@ def is_integer(value: Any) -> bool:
     subclass excluded, and by name.
     """
     return isinstance(value, int) and not isinstance(value, bool)
+
+
+def is_octets(value: Any) -> bool:
+    """Return whether the value is one Octets, rather than a sequence of them.
+
+    An `Octets` -- `str`, `bytes`, `bytearray` or `memoryview` -- is
+    itself iterable, so a function that takes a sequence of them and
+    guards against being handed one instead cannot ask `isinstance(value,
+    Sequence)`: every `Octets` answers that too. The guard asks this
+    question instead, once, so a spelling `Octets` gains later is refused
+    at every caller of this rather than at whichever remembered to list
+    it (issue #1261).
+    """
+    return isinstance(value, Octets)
 
 
 def int_from_json_number(value: Any, what: str) -> int:

--- a/tests/block/block_filter_test.py
+++ b/tests/block/block_filter_test.py
@@ -225,14 +225,23 @@ def test_one_script_is_not_a_list_of_scripts() -> None:
     A caller passing the single script it resolved, rather than a list
     holding it, would otherwise have its length counted as a number of
     inputs -- and for a block with that many, a filter built from
-    single characters. A hex string is the half mypy cannot refuse: `str`
-    is a `Sequence[str]` and `str` is `Octets`, so the annotation admits
-    it and only the guard does not.
+    single octets. A hex string is the half mypy cannot refuse: `str` is
+    a `Sequence[str]` and `str` is `Octets`, so the annotation admits it
+    and only the guard does not. All four `Octets` spellings are driven,
+    `bytearray` and `memoryview` included (issue #1261): with block 170's
+    single non-coinbase input, the two used to walk past the guard and be
+    counted as 67 scripts, one per octet, catching them only because the
+    block does not have that many inputs.
     """
     block = _block_170()
     script = block.transactions[0].vout[0].script_pub_key.script
 
-    for wrong in (cast("Any", script), script.hex()):
+    for wrong in (
+        cast("Any", script),
+        script.hex(),
+        cast("Any", bytearray(script)),
+        cast("Any", memoryview(script)),
+    ):
         with pytest.raises(
             BTClibTypeError, match="invalid previous output scripts type"
         ):

--- a/tests/built_object_contract_test.py
+++ b/tests/built_object_contract_test.py
@@ -297,13 +297,21 @@ def test_an_origin_that_is_no_origin_is_refused_as_a_type() -> None:
 def test_the_keys_a_satisfaction_sizer_is_built_from() -> None:
     """The factory's own argument, which the table cannot reach.
 
-    `Iterable[Octets]` accepts a `str` and a `bytes`, each of them being an
-    `Octets` and an iterable of one, so a single key handed where the list
-    was meant is as many keys as it has characters -- and each of those
-    would be refused as octets, which reports the wrong mistake.
+    `Iterable[Octets]` accepts every `Octets` spelling, each of them being
+    an iterable of one, so a single key handed where the list was meant
+    is as many keys as it has octets -- and each of those would be
+    refused as octets, which reports the wrong mistake. All four
+    spellings are driven, `bytearray` and `memoryview` included (issue
+    #1261).
     """
     assert satisfaction_sizer(_SIGNER_KEYS)(_PSBT_IN, _TX_IN) == [0, 72, 72, 71]
-    for wrong in (*_WRONG_TYPES, _SIGNER_KEYS[0], _SIGNER_KEYS[0].hex()):
+    single_key_spellings = (
+        _SIGNER_KEYS[0],
+        _SIGNER_KEYS[0].hex(),
+        bytearray(_SIGNER_KEYS[0]),
+        memoryview(_SIGNER_KEYS[0]),
+    )
+    for wrong in (*_WRONG_TYPES, *single_key_spellings):
         with pytest.raises(BTClibTypeError, match="invalid keys type"):
             satisfaction_sizer(wrong)  # type: ignore[arg-type]
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -10,6 +10,7 @@ from io import BytesIO
 import pytest
 
 from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.hashes import hash160
 from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
@@ -19,6 +20,7 @@ from btclib.utils import (
     int_from_bits,
     int_from_integer,
     int_from_json_number,
+    is_octets,
     read_exactly,
 )
 
@@ -293,3 +295,40 @@ def test_octets_are_bytes_or_the_hex_string_of_bytes_and_nothing_else() -> None:
             int_from_integer(not_hex)
     with pytest.raises(BTClibValueError, match="invalid hex integer: "):
         int_from_integer("0xzz")
+
+
+def test_a_non_contiguous_memoryview_is_refused_at_the_coercion() -> None:
+    """A strided slice is `Octets` to the annotation, `BufferError` underneath.
+
+    `mv[::2]` is not C-contiguous, and `bytes_from_octets` used to hand it
+    back untouched, so the failure reached whichever consumer used the
+    buffer next -- `hash160` with a bare `BufferError`, a public entry
+    point rather than this module. The refusal is raised here instead,
+    once, at the coercion every `Octets` parameter passes (issue #1260).
+    """
+    raw = bytes(range(64))
+    strided = memoryview(raw)[::2]
+    assert not strided.c_contiguous
+
+    with pytest.raises(BTClibValueError, match="invalid octets: non-contiguous"):
+        bytes_from_octets(strided)
+    with pytest.raises(BTClibValueError, match="invalid octets: non-contiguous"):
+        hash160(strided)
+
+    # a contiguous slice is untouched, same as any other buffer
+    contiguous = memoryview(raw)[:32]
+    assert bytes_from_octets(contiguous) == raw[:32]
+    assert hash160(contiguous) == hash160(raw[:32])
+
+
+def test_is_octets_answers_one_octets_not_a_sequence_of_them() -> None:
+    """The question `bytes_from_octets` embeds, and two other callers ask.
+
+    Every `Octets` spelling is itself iterable, which is what makes a
+    single one hard to tell from a sequence of them by shape alone; a
+    `list` or a `tuple` of `Octets` is not one itself.
+    """
+    for one in (b"\x00\x01", "0001", bytearray(b"\x00\x01"), memoryview(b"\x00\x01")):
+        assert is_octets(one)
+    for many in ([b"\x00"], (b"\x00", b"\x01"), []):
+        assert not is_octets(many)


### PR DESCRIPTION
Closes #1260, closes #1261

Two guards in the same layer, both stale for the same reason: each named
the `Octets` spellings that existed when it was written, and `Octets`
gained two.

## `bytes_from_octets` refuses a non-contiguous memoryview

A strided slice — `mv[::2]`, what a caller holds after slicing a
strided field — satisfies the `Octets` annotation and was handed back
untouched, so the failure landed wherever the octets were next used, in
whatever shape that consumer produced: `BufferError` from `hash160`,
`TypeError` from a concatenation. Public entry points reached it.

The refusal is now raised once, at the coercion every `Octets` parameter
passes, naming the argument. A contiguous `memoryview` is unaffected.
This is the issue's own option 1; the return annotation and its two
`type: ignore[return-value]` comments are deliberately untouched, those
being [ISS 1255](https://github.com/btclib-org/btclib/issues/1255).

## One `Octets` where a sequence was meant, asked once

`BasicBlockFilter.from_block` and `descriptors.satisfaction_sizer` each
guarded against being handed a single `Octets` — both are iterable, so
the mistake is silent rather than a type error — and each named its own
incomplete list. `utils.is_octets` now asks that question once, so the
next spelling `Octets` gains is added in one place. This is the issue's
own closing suggestion rather than the one-line fix that goes stale
again.

## A claim in ISS 1261 is false, and the landed prose says the smaller thing

The issue says of `from_block` that for a block whose non-coinbase input
count happens to match the byte length of a single script, "nothing
catches it: the filter is built from single octets."

Measured against the pre-fix guard, it always raised. Iterating a
`bytes`, `bytearray` or `memoryview` yields one `int` per byte, and
`bytes_from_octets` refuses an `int` unconditionally — so the
coincidental-match case fails too. The defect was never a wrong filter;
it was a complaint naming an `int` or a count instead of the actual
mistake. The coder measured this and wrote the corrected version into
`CHANGELOG.md`; the reviewer re-derived it independently from the
pre-fix blobs and agreed.

That is also why **`RELEASE_NOTES.md` is untouched**: every path
measured already raised before this change. The file's own precedent
splits exactly here — `#1206`, `#1249`, `#1243`, `#1250` (silently
succeeded, now refused) are listed; `#1214`, `#1216`, `#1218` (already
raised, now through btclib's own contract) are not. Both fixes here are
the second shape.

## Gates

Coder's runs on `708bf233`: `pytest` exit 0 (30708 passed, 11 skipped,
coverage 100.00%), `pre-commit run --all-files` exit 0,
`sphinx-build -n -W --keep-going` exit 0.

Rebased onto `f9fb60de` by me. `git range-diff` reports `!` rather than
`=`, and that is the union driver alone: comparing the branch's own
patch with `CHANGELOG.md` excluded, as added and removed lines rather
than as a diff, gives the same hash at both shas over 124 lines, and the
entry's own text is unchanged at both. I re-ran all three gates on the
rebased tip `d0d0d2fe`: `pytest` exit 0 (30717 passed, 11 skipped,
coverage 100.00%), `pre-commit run --all-files` exit 0,
`sphinx-build -n -W` exit 0, tree clean, signature `G`. One copy of each
entry, no heading joined flush.

Local review at fresh context: `CLEARED 708bf233`, no blocking findings.
It re-measured the refuted hazard claim itself from the pre-fix blobs,
verified `is_octets`'s placement in `__all__` and that `Octets`
including `str` is right for the guard's question, confirmed the
complexity ceiling that motivated the private helper, and checked that
no fragment of an intermediate commit the coder made and self-repaired
survives in the diff.

Collateral: [ISS
1405](https://github.com/btclib-org/btclib/issues/1405), the tree's
other `Sequence[Octets]` parameters, which carry no shape guard at all
and can now share this one.

## Summary by Sourcery

Tighten Octets validation so invalid buffer layouts and single-value sequence arguments fail early with consistent errors.

Bug Fixes:
- Reject non-contiguous memoryviews during octet coercion with a clear library error instead of deferring failures to downstream consumers.
- Correctly reject all Octets representations when APIs expect sequences of octets, providing consistent type errors in block filter and satisfaction sizing calls.

Enhancements:
- Centralize Octets detection in a reusable `is_octets` utility for consistent validation across callers.

Documentation:
- Document the corrected behavior for non-contiguous memoryviews and single-Octets arguments in the changelog.

Tests:
- Expand validation coverage to include bytearray and memoryview inputs and contiguous versus non-contiguous memoryviews.