### PR TITLE
A bytearray or memoryview derivation path is read as packed octets (closes #1258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3357,6 +3357,20 @@ documented at release-notes length in the first place, and are still in
   reporting the combination at `--fail-under=100` with the pragma
   removed, which still fails on this line.
 
+### Curves, signatures and keys
+
+- **`indexes_from_der_path` reads a `bytearray` or a `memoryview` as
+  packed 4-byte indexes, the same as `bytes`** (closes #1258). The
+  narrowing test was `isinstance(der_path, bytes)`, which a `bytearray`
+  and a `memoryview` both fail while also satisfying `Sequence[int]`, so
+  either fell through to the iterable branch and was read one index per
+  byte: `indexes_from_der_path(bytearray(raw))` and
+  `indexes_from_der_path(raw)` disagreed on the same octets, deriving a
+  different key, with nothing raised or warned either way. `DerPath`'s
+  buffer arm is now `bytes | bytearray | memoryview`, `alias.Octets`'s
+  own buffer union, and `_indexes_from_der_path` narrows on it before
+  the iterable branch.
+
 ## v2026.8.21
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -310,6 +310,21 @@ full year, short month, short day (YYYY-M-D)
   UnicodeDecodeError` around `bms.sign` stops catching it.
   CHANGELOG.md lists them.
 
+- **A BIP32 derivation path held as a `bytearray` or a `memoryview` is
+  read as packed 4-byte indexes, the same as `bytes`** (closes #1258).
+  `indexes_from_der_path` narrowed the packed-octets arm to `bytes`
+  alone, so either buffer fell through to the iterable branch and was
+  read one index per byte instead, deriving a different key from the
+  same octets with nothing raised or warned.
+
+  Act on it if you pass a derivation path as a `bytearray` or a
+  `memoryview` anywhere `DerPath` is accepted — `bip32.derive`,
+  `bip44`, `bip85`'s derivation functions, `psbt_signer` and `hwi`
+  among them: a path that previously derived through the byte-per-index
+  reading now derives through the packed one, a different key for the
+  same octets. A path held as `bytes`, or as a string or a plain
+  sequence of `int`, is unaffected.
+
 ## v2026.8.21
 
 ### Breaking changes

--- a/src/btclib/bip32/bip32.py
+++ b/src/btclib/bip32/bip32.py
@@ -1041,7 +1041,7 @@ def derive(
     - string like "m/44h/0'/1H/0/10"
     - iterable integer indexes
     - one single integer index
-    - bytes in multiples of the 4-bytes index
+    - bytes, bytearray or memoryview in multiples of the 4-bytes index
 
     DerPath is case/blank/extra-slash insensitive
     (e.g. "M /44h / 0' /1H // 0/ 10 / ").

--- a/src/btclib/bip32/der_path.py
+++ b/src/btclib/bip32/der_path.py
@@ -8,7 +8,7 @@ A BIP32 derivation path can be represented as:
 
 - "m/44h/0'/1H/0/10" or "44h/0'/1H/0/10" string
 - sequence of integer indexes (even a single int)
-- bytes (multiples of 4-bytes index)
+- bytes, bytearray or memoryview (multiples of 4-bytes index)
 
 Three hardening symbols are read and two are written, which is not an
 oversight: BIP32 spells its own test vectors "m/0H/1/2H", while BIP380
@@ -175,7 +175,11 @@ def _indexes_from_der_path_str(der_path: str, skip_m: bool) -> list[int]:
     return _pairs_from_der_path_str(der_path, skip_m, bip380_enforced=False)[0]
 
 
-DerPath = str | Sequence[int] | int | bytes
+# the buffer arm is `bytes | bytearray | memoryview`, the same union
+# `alias.Octets` spells for every other packed-octets consumer -- not
+# `Octets` itself, which also admits `str`, a spelling this alias already
+# gives a different meaning (the path string, not packed octets)
+DerPath = str | Sequence[int] | int | bytes | bytearray | memoryview
 
 
 def _pairs_from_der_path(
@@ -221,13 +225,19 @@ def hardenings_from_der_path(
     return _pairs_from_der_path(der_path, bip380_enforced=bip380_enforced)[1]
 
 
-def _indexes_from_der_path(der_path: Sequence[int] | int | bytes) -> list[int]:
+def _indexes_from_der_path(
+    der_path: Sequence[int] | int | bytes | bytearray | memoryview,
+) -> list[int]:
     """Return the indexes of every DerPath spelling that is not a string."""
     if isinstance(der_path, int):
         _assert_valid_index(der_path)
         return [der_path]
 
-    if isinstance(der_path, bytes):
+    # a buffer means packed octets everywhere else this tree reads Octets,
+    # so a bytearray or a memoryview -- a caller's slice out of a larger
+    # field, say -- is read the same way bytes is, not as one index per
+    # byte: `Sequence[int]` below is for a genuine sequence of indexes
+    if isinstance(der_path, (bytes, bytearray, memoryview)):
         if len(der_path) % 4 != 0:
             err_msg = f"index are not a multiple of 4-bytes: {len(der_path)}"
             raise BTClibValueError(err_msg)

--- a/tests/bip32/der_path_test.py
+++ b/tests/bip32/der_path_test.py
@@ -230,6 +230,22 @@ def test_an_iterable_of_indexes_is_checked_element_by_element() -> None:
         hardenings_from_der_path("0H/1", bip380_enforced=True)
 
 
+def test_a_bytearray_or_memoryview_reads_as_packed_octets() -> None:
+    """A buffer means packed octets, whatever buffer type it is.
+
+    `isinstance(der_path, bytes)` alone leaves a `bytearray` and a
+    `memoryview` unmatched, so each fell through to the iterable branch
+    and was read one index per byte instead of one index per 4 bytes --
+    issue #1258.
+    """
+    raw = (2**31).to_bytes(4, "little") + (1).to_bytes(4, "little")
+    packed = [2**31, 1]
+
+    assert indexes_from_der_path(raw) == packed
+    assert indexes_from_der_path(bytearray(raw)) == packed
+    assert indexes_from_der_path(memoryview(raw)) == packed
+
+
 def test_an_index_outside_the_32_bits_a_step_holds_is_refused() -> None:
     """The bound the text spelling enforces, on the spellings that are not.
 


### PR DESCRIPTION
Closes #1258

`DerPath` names two spellings that a `bytearray` and a `memoryview`
satisfy at once: they are buffers, and they are also a `Sequence[int]`.
`_indexes_from_der_path` chose between them with `isinstance(der_path,
bytes)`, which both fail, so both were read as a sequence of indexes
rather than as packed four-byte ones:

```python
raw = (2**31).to_bytes(4, "little") + (1).to_bytes(4, "little")

indexes_from_der_path(raw)             # [2147483648, 1]        -> m/0'/1
indexes_from_der_path(bytearray(raw))  # [0, 0, 0, 128, 1, 0, 0, 0]
indexes_from_der_path(memoryview(raw)) # [0, 0, 0, 128, 1, 0, 0, 0]
```

Nothing raised and nothing warned — an eight-level path is a valid path
— so a caller holding their path in a buffer, which is what a
`memoryview` is for, derived from a path they had not asked for. A
different path is a different key.

## Which of the issue's three options, and why this one

The issue leans towards (3), dropping `Sequence[int]` from `DerPath`, as
"the only one that removes the question rather than answering it". This
branch takes (1) instead: a buffer is read as packed octets, and
`Sequence[int]` stays for genuine index sequences.

The reason is consistency with the rest of the tree. Every other
`Octets` consumer reads a buffer as packed octets, so a caller who
learns that rule once should not find `DerPath` the exception; and
dropping `Sequence[int]` would remove the natural spelling for a caller
building a path programmatically, which is a real use rather than an
accident of the alias. `DerPath`'s buffer arm is now spelled
`bytes | bytearray | memoryview` — `Octets` minus `str`, `str` already
having a different meaning here as the path string.

**This decision is mine as orchestrator, not the issue's**, and the
reviewer was asked explicitly to overrule it if the reasoning did not
hold. It re-derived it independently and did not.

## What a caller has to act on

`RELEASE_NOTES.md` carries an entry: this is a silent change of a return
value, not a new exception. A caller who passed a `bytearray` and
relied on the byte-per-index reading gets a different key from today.
The entry names the paths reached — `bip32.derive`, `bip44`, `bip85`,
`psbt_signer`, `hwi` — without claiming the list is exhaustive.

## Review

Two rounds with the same reviewer at fresh context.

Round 1 cleared the content and raised one non-blocking finding:
`bip32.py:1044`, `derive`'s own docstring, carried a second enumeration
of `DerPath`'s spellings whose buffer line still said only `bytes`.
Nothing in it was false — it had become *incomplete*, and this diff is
what made it so, which is why it went into the branch rather than into
an issue. Round 2: `CLEARED 2535ec6a`, the delta confirmed as exactly
that one line, matching the wording already chosen in `der_path.py`
rather than a second phrasing.

The reviewer also independently reproduced both the defect and the fix,
loading `der_path.py` at each sha in throwaway worktrees it then
removed, and confirmed the five callers named in the release note all
genuinely take a `DerPath`.

## Gates

Coder's runs on `2535ec6a`: `pre-commit run --all-files` exit 0,
`pytest` exit 0 (30705 passed, 11 skipped, coverage 100.00%),
`sphinx-build -n -W --keep-going` exit 0. The coder disclosed that a
sibling suite started in the same instant as its own, taking the load
average from 39.94 to 82.91, and reported the overlap rather than a
clean single-suite number; the reviewer weighed that and declined to ask
for a re-run, on the ground that the round's whole delta is a docstring
literal that cannot alter what any test exercises.

Rebased onto `8f75f605` by me. Proved base-only: the branch's own patch
with both union files excluded hashes identically at the two shas over
30 lines, with a non-empty control on each side. I re-ran all three
gates on the rebased tip `a797f5c0`, uncontended this time: `pytest`
exit 0 (30718 passed, 11 skipped, coverage 100.00%),
`pre-commit run --all-files` exit 0, `sphinx-build -n -W` exit 0, tree
clean, signature `G`. Both `CHANGELOG.md` and `RELEASE_NOTES.md`
checked afterwards for a stacked entry and for a heading joined flush by
the union driver: one copy of each entry, no heading damage, and the new
`### Curves, signatures and keys` heading correctly spaced.

## Summary by Sourcery

Treat bytearray and memoryview derivation paths consistently with bytes to preserve the intended derived key.

Bug Fixes:
- Read bytearray and memoryview derivation paths as packed four-byte indexes, preventing them from being incorrectly interpreted one byte at a time and producing different derived keys.

Enhancements:
- Align DerPath documentation and type definitions with the supported bytes-like derivation path forms.

Documentation:
- Document the changed bytearray and memoryview derivation behavior and its impact in the changelog and release notes.

Tests:
- Add coverage confirming bytes, bytearray, and memoryview produce identical packed derivation indexes.