### PR TITLE
derive_from_account_'s branch and address_index refuse a bool by is_integer (closes #1403) (closes #1398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -746,6 +746,7 @@ documented at release-notes length in the first place, and are still in
   `claude-review` as the table's exception to the `workflow_dispatch`
   sentence below it: `ossf/scorecard-action`'s own triggers are push
   and schedule, not section 10's general rule (closes #1391).
+
 - **`scorecard.yml` gains a `schedule:` trigger, `cron: '4 3 * * 6'`.**
   Saturday, hour 03, is section 10's calendar row for `scorecard`,
   decided by btclib-org/.github#363 and landed via
@@ -929,6 +930,18 @@ documented at release-notes length in the first place, and are still in
   of failing a gate with nothing behind it — measured by reproducing
   the drop and letting the hook restore the line. Both rules apply to
   this file again.
+
+- **A blank line the union driver ate between two ordinary bullets is
+  restored by hand, MD022 and MD032 not reaching a tight-list boundary
+  the way they reach a heading one** (closes #1398). Two `merge=union`
+  branches each appending under the same `### Repository` group left
+  one bullet flush against the next, with no blank line between them:
+  valid CommonMark for a tight list, so neither rule — MD022 for
+  headings, MD032 for a list against its surrounding paragraphs — has
+  anything to say about it, and `markdownlint-cli2 --fix` leaves it
+  exactly as the union join produced it. The gap the directive removed
+  in the entry above is a different one, at a `###` boundary the fixer
+  does reach.
 
 - **`codespell` now corrects in place, with `--write-changes`,** joining
   `markdownlint-cli2`'s `--fix` and `typos`'s inherited
@@ -3292,6 +3305,27 @@ documented at release-notes length in the first place, and are still in
   layer as a whole: prepared is not unchecked, and a bare `int` still
   refuses a `bool` the way `int_from_integer` does for every coerced
   one. `tests/integer_policy_test.py`'s census carries both functions.
+
+- **`derive_from_account_`'s `branch` and `address_index` refuse a bool
+  by `is_integer`, not by accident** (closes #1403). Neither
+  `_assert_valid_branch` nor `_assert_valid_address_index` called
+  `is_integer`: both compared their argument with `<`, `>=` and
+  `in {0, 1}`, none of which a bool fails, so
+  `derive_from_account_(xpub, True, 0)` was refused only because
+  `_derive_from_account` formats the value into a path string and
+  re-parses it with `int()` inside `_index_and_hardening_from_str` --
+  a round trip that happens to reject anything that is not a plain
+  decimal integer, and answers `BTClibValueError` rather than the
+  `BTClibTypeError` every other integer field of the trailing-underscore
+  layer raises.
+
+  Both helpers now call `is_integer` before their own value checks,
+  raising `BTClibTypeError` -- `"non-integer branch: True"` and
+  `"non-integer address index: True"` -- ahead of the string round trip
+  rather than depending on it. `derive_from_account_range_` shares both
+  helpers and needs nothing beyond them, one call per address index
+  before any of them is walked. `tests/integer_policy_test.py`'s census
+  gains `derive_from_account_`'s own `branch` and `address_index`.
 
 ### Tests
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -281,6 +281,20 @@ full year, short month, short day (YYYY-M-D)
   `x_K`, or as `recover_pub_key_`'s `key_id`; both now raise
   `BTClibTypeError`. CHANGELOG.md has the three wordings.
 
+- **`branch` and `address_index` now raise `BTClibTypeError` for a bool
+  or any other non-integer, where they raised `BTClibValueError`**
+  (issue #1403) -- `derive_from_account_` and `derive_from_account_range_`,
+  and `derive_from_account`/`derive_from_account_range` through them.
+  Both parameters were already refused, incidentally, by the string
+  round trip `_derive_from_account` and `derive_from_account_range_`
+  build a der path with; `is_integer` now refuses them directly, before
+  that round trip runs.
+
+  Act on it if your code catches `BTClibValueError`, rather than the
+  common base `BTClibException`, around a call passing one of these
+  four functions a `branch` or `address_index` that is not a plain
+  `int`.
+
 ### Worth knowing, though nothing raises
 
 - **A `bytearray` and a `memoryview` are octets, and now the signatures

--- a/src/btclib/bip32/bip32.py
+++ b/src/btclib/bip32/bip32.py
@@ -1057,6 +1057,12 @@ def _assert_valid_branch(
     if not mxkey.is_hardened:
         raise BTClibValueError("unhardened account/master key")
 
+    # prepared is not unchecked: `branch` is a bare int rather than an
+    # Integer, so `is_integer`'s policy has to be asked of it directly
+    # instead of arriving through `int_from_integer` (issue #1403,
+    # CONTRIBUTING.md's "This repository in particular")
+    if not is_integer(branch):
+        raise BTClibTypeError(f"non-integer branch: {branch}")
     if branch >= _HARDENED_OFFSET:
         raise BTClibValueError("invalid private derivation at branch level")
     if branch > max_index:
@@ -1067,6 +1073,9 @@ def _assert_valid_branch(
 
 
 def _assert_valid_address_index(address_index: int, max_index: int) -> None:
+    # same reasoning as `_assert_valid_branch`'s own `is_integer` check
+    if not is_integer(address_index):
+        raise BTClibTypeError(f"non-integer address index: {address_index}")
     if address_index >= _HARDENED_OFFSET:
         raise BTClibValueError("invalid private derivation at address index level")
     if address_index > max_index:

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -28,7 +28,12 @@ from btclib.amount import valid_sats_amount
 from btclib.b32 import p2wpkh
 from btclib.b58 import p2pkh, wif_from_prv_key
 from btclib.bip32 import BIP32KeyData
-from btclib.bip32.bip32 import rootxprv_from_seed, xpub_from_xprv
+from btclib.bip32.bip32 import (
+    derive,
+    derive_from_account_,
+    rootxprv_from_seed,
+    xpub_from_xprv,
+)
 from btclib.bip32.der_path import (
     bytes_from_der_path,
     indexes_from_der_path,
@@ -87,6 +92,9 @@ _NOW = datetime(2026, 8, 4, tzinfo=timezone.utc)
 _SCRIPT_TREE: TaprootScriptTree = [(0xC0, ["OP_1"])]
 _PREVOUTS = [TxOut(1, b"")]
 _XPUB = xpub_from_xprv(rootxprv_from_seed("00" * 32))
+# account depth, hardened: what derive_from_account_'s own is_hardened
+# check wants
+_ACCOUNT_XPRV = derive(rootxprv_from_seed("00" * 32), "m/44h/0h/0h")
 
 
 def _tx(version: Any = 1, lock_time: Any = 0) -> Tx:
@@ -242,6 +250,20 @@ _CASES: list[tuple[str, Callable[[Any], object]]] = [
         "dsa recovery key_id",
         lambda v: recover_pub_key_(v, _DSA_MSG_HASH, _DSA_SIG),
     ),
+    # `_assert_valid_branch` and `_assert_valid_address_index` compared
+    # with `<`, `>=` and `in {0, 1}` alone, none of which a bool fails,
+    # so the refusal used to come from the string round trip
+    # `_derive_from_account` builds and re-parses -- an incidental
+    # `BTClibValueError` rather than this layer's own `is_integer`
+    # (issue #1403)
+    (
+        "bip32 account branch",
+        lambda v: derive_from_account_(_ACCOUNT_XPRV, v, 0),
+    ),
+    (
+        "bip32 account address index",
+        lambda v: derive_from_account_(_ACCOUNT_XPRV, 0, v),
+    ),
     # `CurveGroup.is_on_curve` is the one funnel behind a `Point` tuple,
     # `point_from_pub_key`, `_x_from_bip340pub_key`, `PreparedPoint` and
     # `bytes_from_point` included, and it read a bool coordinate as an
@@ -322,6 +344,19 @@ _WORDINGS = [
         "dsa recovery key_id",
         lambda v: recover_pub_key_(v, _DSA_MSG_HASH, _DSA_SIG),
         "non-integer key_id: True",
+    ),
+    # `_assert_valid_branch`/`_assert_valid_address_index`'s own
+    # `is_integer` check (issue #1403), ahead of the incidental refusal
+    # the string round trip used to answer for the same mistake
+    (
+        "bip32 account branch",
+        lambda v: derive_from_account_(_ACCOUNT_XPRV, v, 0),
+        "non-integer branch: True",
+    ),
+    (
+        "bip32 account address index",
+        lambda v: derive_from_account_(_ACCOUNT_XPRV, 0, v),
+        "non-integer address index: True",
     ),
     # separate from the three families above: `is_on_curve`'s own
     # refusal of a bool coordinate (issue #1249), one sentence per
@@ -404,6 +439,7 @@ def test_the_integers_a_bool_refusal_must_not_take_with_it() -> None:
     assert ssa_verify(b"msg", secp256k1.G[0], _SSA_SIG)
     assert ssa_challenge_(b"msg", 1, 1, secp256k1, hashlib.sha256)
     assert recover_pub_key_(1, _DSA_MSG_HASH, _DSA_SIG) == secp256k1.G
+    assert derive_from_account_(_ACCOUNT_XPRV, 1, 1).depth == 5
     assert secp256k1.is_on_curve(secp256k1.G) is True
     assert point_from_pub_key(secp256k1.G) == secp256k1.G
     assert PreparedPoint(secp256k1.G).point == secp256k1.G


### PR DESCRIPTION
`_assert_valid_branch` and `_assert_valid_address_index` compare their
argument with `<`, `>=` and `in {0, 1}` alone, none of which a bool
fails, so the refusal `derive_from_account_` gives a bool `branch` or
`address_index` comes from `_derive_from_account`'s string round trip
through `der_path` rather than from this library's own `is_integer`
policy, and answers `BTClibValueError` rather than the
`BTClibTypeError` every other integer field of the trailing-underscore
layer raises. Both helpers now call `is_integer` first, matching what
[ISS 1248](https://github.com/btclib-org/btclib/issues/1248) landed for
`ssa.challenge_` and `dsa.recover_pub_key_`.

`derive_from_account_range_` shares the same two helpers, so all four
entry points are covered by the two edits.

`BTClibTypeError` and `BTClibValueError` are siblings under
`BTClibException`, neither a subclass of the other, so a caller
catching the narrower class sees a different one: that is a breaking
change and `RELEASE_NOTES.md` carries the bullet.

The second issue is one line: the blank line a `merge=union` join
dropped between two ordinary `CHANGELOG.md` bullets, a list-adjacency
boundary `MD022`/`MD032` do not reach, so the fixer cannot see it.

Local review cleared `29fd96f3`.

Collateral filed while working this branch:
[ISS 1413](https://github.com/btclib-org/btclib/issues/1413) and
[.github#421](https://github.com/btclib-org/.github/issues/421).

Closes #1403
Closes #1398

## Summary by Sourcery

Align account derivation integer validation with the library-wide policy and document the resulting exception-type change.

Bug Fixes:
- Ensure account derivation branch and address index parameters reject booleans and other non-integers with the consistent BTClibTypeError.
- Restore the missing blank line between CHANGELOG list entries.

Tests:
- Extend integer-policy coverage for account derivation branch and address index validation, including valid integer inputs.