### PR TITLE
derive_from_account_'s max_index refuses a bool, not just its narrowed range (closes #1413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3350,6 +3350,25 @@ documented at release-notes length in the first place, and are still in
   before any of them is walked. `tests/integer_policy_test.py`'s census
   gains `derive_from_account_`'s own `branch` and `address_index`.
 
+- **`max_index` refuses a bool too, closing the same two helpers'
+  remaining gap** (closes #1413). Unlike `branch` and `address_index`
+  above, a bool `max_index` was not refused at all: it is a bound the
+  two value checks compare against rather than a value they carry, so
+  `derive_from_account_(xpub, 0, 0, max_index=True)` silently answered
+  the depth-5 key -- `0 <= True` holding arithmetically -- narrowing the
+  accepted range to `{0, 1}` instead of raising anything, a caller who
+  meant no such narrowing getting a wrong answer rather than an error.
+  `var_int.parse`'s own `max_size` already asks `is_integer` of a bound
+  the same way, for the same reason: a json boolean is what turns a
+  schema mistake into a narrowed range rather than a caught one.
+
+  `_assert_valid_branch` now calls `is_integer` on `max_index`, raising
+  `BTClibTypeError("non-integer max_index: True")` before either value
+  check runs -- once, there, rather than in both helpers: it runs first
+  at both call sites, on the same `max_index`, so a second check in
+  `_assert_valid_address_index` is unreachable.
+  `tests/integer_policy_test.py`'s census gains the case.
+
 ### Tests
 
 - **The tests exercising the pure-Python arm are named `test_the_py_arm_...`,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -295,6 +295,19 @@ full year, short month, short day (YYYY-M-D)
   four functions a `branch` or `address_index` that is not a plain
   `int`.
 
+- **The same four functions' `max_index` now raises `BTClibTypeError`
+  for a bool, where it silently narrowed the accepted range instead of
+  raising anything at all** (closes #1413). `max_index=True` made
+  `derive_from_account_(xpub, 0, 0, max_index=True)` answer the depth-5
+  key rather than fail, `0 <= True` holding arithmetically; a caller
+  relying on `0xFFFF`'s default and passing a bool by mistake got a
+  narrowed range rather than a caught one.
+
+  Act on it if you pass a bool as `max_index` to `derive_from_account_`,
+  `derive_from_account_range_`, `derive_from_account` or
+  `derive_from_account_range`; all four now raise `BTClibTypeError`
+  rather than silently narrowing what they accept.
+
 ### Worth knowing, though nothing raises
 
 - **A `bytearray` and a `memoryview` are octets, and now the signatures

--- a/src/btclib/bip32/bip32.py
+++ b/src/btclib/bip32/bip32.py
@@ -1063,6 +1063,14 @@ def _assert_valid_branch(
     # CONTRIBUTING.md's "This repository in particular")
     if not is_integer(branch):
         raise BTClibTypeError(f"non-integer branch: {branch}")
+    # the bound both `branch` and, at every call site below,
+    # `_assert_valid_address_index`'s own `address_index` compare
+    # against -- no less a bare int than either: `max_index=True` is a
+    # bound of one, silently narrowing what is accepted rather than
+    # raising (issue #1413). Checked once, here, since this function
+    # runs first at every call site and on the same `max_index`
+    if not is_integer(max_index):
+        raise BTClibTypeError(f"non-integer max_index: {max_index}")
     if branch >= _HARDENED_OFFSET:
         raise BTClibValueError("invalid private derivation at branch level")
     if branch > max_index:
@@ -1073,7 +1081,11 @@ def _assert_valid_branch(
 
 
 def _assert_valid_address_index(address_index: int, max_index: int) -> None:
-    # same reasoning as `_assert_valid_branch`'s own `is_integer` check
+    # same reasoning as `_assert_valid_branch`'s own `is_integer` check.
+    # `max_index` is not re-checked here: both call sites below run
+    # `_assert_valid_branch` first, on the same `max_index`, which is
+    # where that check lives (issue #1413) -- a second one here could
+    # never be reached and the coverage floor is what catches that
     if not is_integer(address_index):
         raise BTClibTypeError(f"non-integer address index: {address_index}")
     if address_index >= _HARDENED_OFFSET:

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -264,6 +264,16 @@ _CASES: list[tuple[str, Callable[[Any], object]]] = [
         "bip32 account address index",
         lambda v: derive_from_account_(_ACCOUNT_XPRV, 0, v),
     ),
+    # `max_index` reaches the same two helpers as a bound rather than a
+    # derivation value, and was not refused at all: `branch > max_index`
+    # and `address_index > max_index` both hold for `max_index=True`
+    # against a branch/address_index of `0`, so the call answered the
+    # depth-5 key silently narrowed to a range of `{0, 1}` rather than
+    # raising anything (issue #1413)
+    (
+        "bip32 account max_index",
+        lambda v: derive_from_account_(_ACCOUNT_XPRV, 0, 0, max_index=v),
+    ),
     # `CurveGroup.is_on_curve` is the one funnel behind a `Point` tuple,
     # `point_from_pub_key`, `_x_from_bip340pub_key`, `PreparedPoint` and
     # `bytes_from_point` included, and it read a bool coordinate as an
@@ -358,6 +368,13 @@ _WORDINGS = [
         lambda v: derive_from_account_(_ACCOUNT_XPRV, 0, v),
         "non-integer address index: True",
     ),
+    # `max_index`'s own `is_integer` check, the bound rather than the
+    # value (issue #1413)
+    (
+        "bip32 account max_index",
+        lambda v: derive_from_account_(_ACCOUNT_XPRV, 0, 0, max_index=v),
+        "non-integer max_index: True",
+    ),
     # separate from the three families above: `is_on_curve`'s own
     # refusal of a bool coordinate (issue #1249), one sentence per
     # coordinate and shared by every funnel behind it
@@ -440,6 +457,7 @@ def test_the_integers_a_bool_refusal_must_not_take_with_it() -> None:
     assert ssa_challenge_(b"msg", 1, 1, secp256k1, hashlib.sha256)
     assert recover_pub_key_(1, _DSA_MSG_HASH, _DSA_SIG) == secp256k1.G
     assert derive_from_account_(_ACCOUNT_XPRV, 1, 1).depth == 5
+    assert derive_from_account_(_ACCOUNT_XPRV, 1, 1, max_index=1).depth == 5
     assert secp256k1.is_on_curve(secp256k1.G) is True
     assert point_from_pub_key(secp256k1.G) == secp256k1.G
     assert PreparedPoint(secp256k1.G).point == secp256k1.G


### PR DESCRIPTION
`max_index` is the third bare `int` of `derive_from_account_` and its
three siblings, and it is the one that answered rather than refused:
`derive_from_account_(xpub, 0, 0, max_index=True)` derived the depth-5
key, `0 <= True` holding arithmetically, silently narrowing the accepted
range to `{0, 1}`. That is a different defect from the one
[ISS 1403](https://github.com/btclib-org/btclib/issues/1403) closed,
where a bool was always refused and only the mechanism and the exception
class were wrong. `_assert_valid_branch` now calls `is_integer` on it,
raising `BTClibTypeError`.

**This branch answers a design question the issue left open**, and says
so here rather than leaving it to be reconstructed. The question was
whether `max_index`, being a caller-supplied bound rather than a
derivation index, is exempt from the integer policy every other integer
field of this layer follows. The ground for deciding it is not: the tree
already applies that policy to another bound. `var_int.parse`'s
`max_size` carries its own `is_integer` check, and its comment gives the
same reasoning — a cap of one where the caller meant no cap, and `true`
being what a json configuration decodes to. `tests/integer_policy_test.py`
already pins that one, which is why the new case joins the same census.
The cut-back, if the exemption is wanted after all, is to drop the check
and pin the narrowing behaviour in the census instead.

The check sits in `_assert_valid_branch` alone, not in both helpers.
Every call site calls the two in order on the same `max_index`, so a
second copy in `_assert_valid_address_index` is unreachable through the
public API: the coverage floor is what caught it, and it was removed
rather than given a test that forces it.

Local review cleared `d6b10758`, verifying the unreachability argument
by reading the call sites rather than the report of them, and the
`var_int` precedent at its own lines.

The landed `RELEASE_NOTES.md` bullet for ISS 1403 beside this one cites
`(issue #N)`; nothing landed is rewritten, and the divergence is
[.github#421](https://github.com/btclib-org/.github/issues/421). This
branch's own bullet cites `(closes #N)`.

Closes #1413

## Summary by Sourcery

Reject boolean max_index values across account derivation functions to prevent unintended range narrowing.

Bug Fixes:
- Reject boolean `max_index` values in account derivation APIs with `BTClibTypeError` instead of silently narrowing the accepted derivation range.

Documentation:
- Document the corrected `max_index` boolean handling in the changelog and release notes.

Tests:
- Extend the integer-policy census and regression coverage to verify boolean `max_index` rejection while preserving valid integer behavior.