### PR TITLE
docs: alias.py's Octets and TaprootScriptTree, bip32.py's BIP32Key, der_path.py's DerPath and descriptors.py's DescriptorTree gain a #: attribute-doc comment (closes #1357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2379,6 +2379,24 @@ documented at release-notes length in the first place, and are still in
   assignment its own paragraph describes rather than the quoted
   expression inside it, at `:1347` (closes #1329).
 
+- **`Octets`, `TaprootScriptTree`, `BIP32Key`, `DerPath` and
+  `DescriptorTree` each gain a `#:` attribute-doc comment** (closes
+  #1357). `nitpick_ignore` no longer carries any of them, `:members:`
+  now rendering a page for each that a signature naming it can link to.
+  A `#:` comment before the assignment, not a docstring after it: autodoc
+  reads that spelling too, but it is a STRING token at column 0, and
+  `check-docstring-first` reads a second one of those as a second module
+  docstring and fails on it. `der_path.py`'s module docstring points at
+  `DerPath` for the representations it accepts, rather than listing
+  them itself, since that is now the name stating the fact; `alias.py`'s
+  own module docstring keeps its paragraph on `Octets`, which is about
+  the distinction from `String` rather than a definition of `Octets`
+  itself, so it needed no change. The pre-existing `#` comment above
+  `Octets`, `TaprootScriptTree` and `DescriptorTree` opened with the
+  same definition the new comment now states; each loses that opening
+  sentence and keeps the reasoning that followed it, which the new
+  comment does not carry.
+
 ### The public API and the module layout
 
 - **`HwiSigner.register_descriptor` wraps HWI's `registerdescriptor`**

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,13 +89,10 @@ intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 #   fragment as the unresolved class, rather than resolving the pieces on
 #   either side of it. No mapping answers a target that is not a name to
 #   begin with
-# - a name this tree documents nowhere. alias.py's Octets and
-#   TaprootScriptTree, bip32.py's BIP32Key, der_path.py's DerPath and
-#   descriptors.py's DescriptorTree are bare module-level assignments
-#   with no docstring of their own, so `:members:` renders no page for a
-#   signature naming them to link to; the p2p payload classes below are
-#   private, and automodule does not document a name beginning with an
-#   underscore at all
+# - a private name: the p2p payload classes below begin with an
+#   underscore, and automodule does not document a name spelled that way
+#   at all, so `:members:` renders no page for a signature naming one to
+#   link to
 nitpick_ignore = [
     ("py:class", "collections.abc.Callable[[]"),
     ("py:class", "tuple[int"),
@@ -108,11 +105,6 @@ nitpick_ignore = [
         ),
     ),
     ("py:class", "int | bytes | str | bytearray | memoryview | tuple[int"),
-    ("py:class", "Octets"),
-    ("py:class", "DerPath"),
-    ("py:class", "BIP32Key"),
-    ("py:class", "TaprootScriptTree"),
-    ("py:class", "DescriptorTree"),
     ("py:class", "btclib.p2p.inventory._InventoryPayload"),
     ("py:class", "btclib.p2p.inventory._LocatorPayload"),
     ("py:class", "btclib.p2p.keepalive._NoncePayload"),

--- a/src/btclib/alias.py
+++ b/src/btclib/alias.py
@@ -55,8 +55,6 @@ __all__ = [
     "ValidSigHashType",
 ]
 
-# Octets are a sequence of eight-bit bytes or a hex-string (not text string)
-#
 # hex-strings are strings that can be converted to bytes using bytes.fromhex,
 # e.g.:
 # "deadbeef"
@@ -81,6 +79,8 @@ __all__ = [
 # caller who wrote a buffer down a `type: ignore` -- and cost more than
 # that, mypy not being able to see the buffer paths, so a place that
 # breaks on one was found a caller at a time (issue #1238)
+#: Bytes, or the hex-string that decodes to them, wherever raw bytes are
+#: asked for.
 Octets = bytes | str | bytearray | memoryview
 
 # bytes or text string (not hex-string)
@@ -471,9 +471,8 @@ INFJ = 7, 0, 0
 Command = int | str | bytes | bytearray | memoryview
 ScriptList = list[Command]
 
-# A BIP341 taproot script tree: a leaf is a one-element list holding a
-# (leaf_version, script) pair, a branch a two-element list of subtrees;
-# the nesting is what makes the alias recursive.
+# A BIP341 taproot script tree, recursive: a branch nests two more of
+# the same alias.
 #
 # list, and not the Sequence mypy's variance note suggests when a caller's
 # list[tuple[int, list[str]]] does not fit: str is itself a Sequence[str],
@@ -485,6 +484,8 @@ ScriptList = list[Command]
 # It is paid wherever a tree is built into a variable instead of passed as
 # a literal, by annotating that variable with this alias
 TaprootLeaf = tuple[int, ScriptList]
+#: A leaf, a one-element list holding a `TaprootLeaf`, or a branch, a
+#: two-element list of subtrees.
 TaprootScriptTree = list[Union[TaprootLeaf, "TaprootScriptTree"]]
 
 # what tree_helper returns beside the merkle root: every leaf of the tree

--- a/src/btclib/bip32/bip32.py
+++ b/src/btclib/bip32/bip32.py
@@ -454,6 +454,7 @@ def rootxprv_from_seed(
     return rootxprv_from_seed_(seed, version).b58encode()
 
 
+#: A `BIP32KeyData`, or the base58 text -- xprv or xpub -- it encodes.
 BIP32Key = BIP32KeyData | String
 
 

--- a/src/btclib/bip32/der_path.py
+++ b/src/btclib/bip32/der_path.py
@@ -4,11 +4,7 @@
 
 """BIP32 derivation path and key origin.
 
-A BIP32 derivation path can be represented as:
-
-- "m/44h/0'/1H/0/10" or "44h/0'/1H/0/10" string
-- sequence of integer indexes (even a single int)
-- bytes, bytearray or memoryview (multiples of 4-bytes index)
+`DerPath` names the representations a derivation path is accepted in.
 
 Three hardening symbols are read and two are written, which is not an
 oversight: BIP32 spells its own test vectors "m/0H/1/2H", while BIP380
@@ -179,6 +175,9 @@ def _indexes_from_der_path_str(der_path: str, skip_m: bool) -> list[int]:
 # `alias.Octets` spells for every other packed-octets consumer -- not
 # `Octets` itself, which also admits `str`, a spelling this alias already
 # gives a different meaning (the path string, not packed octets)
+#: An "m/44h/0'/1H/0/10" string, a sequence of int indexes (a single int
+#: included), or bytes, bytearray or memoryview, each a multiple of a
+#: 4-byte index.
 DerPath = str | Sequence[int] | int | bytes | bytearray | memoryview
 
 

--- a/src/btclib/descriptors/descriptors.py
+++ b/src/btclib/descriptors/descriptors.py
@@ -477,12 +477,13 @@ def _tree_expression(tree: DescriptorTree) -> str:
     return _expression("pk", str(tree))
 
 
-# a tr() script tree: a leaf, or a branch of two subtrees. A leaf is the
-# KEY expression a `pk()` leaf is, the `MultiA` of BIP387's two
-# functions; a branch is a tuple, which is what tells a branch from a
-# leaf. The leaves hold KEY expressions and not scripts because a ranged
-# descriptor has no script until an index is given
+# A tr() script tree. A leaf is the KEY expression a `pk()` leaf is, the
+# `MultiA` of BIP387's two functions; a branch is a tuple, which is what
+# tells a branch from a leaf. The leaves hold KEY expressions and not
+# scripts because a ranged descriptor has no script until an index is
+# given
 DescriptorLeaf = KeyExpression | MultiA | Miniscript
+#: A `DescriptorLeaf`, or a branch, a tuple of two subtrees.
 DescriptorTree = DescriptorLeaf | tuple["DescriptorTree", "DescriptorTree"]
 
 


### PR DESCRIPTION
**This branch closes a question the issue reserved**, and says so here
rather than leaving it to be reconstructed from a changelog bullet.
[ISS 1357](https://github.com/btclib-org/btclib/issues/1357) states two
ways forward and declines to choose: document the five bare module-level
assignments so `nitpick_ignore` no longer has to carry their names, or
keep the module-docstring convention and the entries with it.

**The ground for documenting them**: `Octets` is the most pervasive type
in this library's public API, so every signature naming it renders a name
the reader cannot follow, and an ignore list is a set of exceptions worth
shrinking rather than keeping. **The cut-back, if the answer is
unwanted**: restore the five `nitpick_ignore` entries and the
module-docstring-only convention for `Octets` and `DerPath`. Nothing else
in the branch depends on the choice.

The done-when is measurable and was measured rather than asserted: the
build runs `-n -W`, so a name that still does not resolve after its entry
is removed turns the documentation gate red. Each of the five renders
exactly one anchor in the built HTML.

## A `#:` comment, not a docstring after the assignment

Autodoc reads two spellings for an attribute doc, and the one its own
documentation shows — a string literal after the assignment — fails this
tree's `check-docstring-first` hook, which reads any `STRING` token at
column 0 as a module docstring and a second one as a second module
docstring. A `#:` comment is a `COMMENT` token, which that hook exempts.
The hook goes on enforcing its real job over these four files rather than
being configured around them.

Napoleon reads a first line containing a colon as a type declaration for
the member, on either spelling; none of the five carries one.

## What else moved

`conf.py`'s comment above `nitpick_ignore` named the five as documented
nowhere, which this branch makes false, so it now names only the
remaining reason: the private `p2p` payload classes, which `automodule`
never documents whatever their docstring. `der_path.py`'s module
docstring pointed at the representations `DerPath` accepts by listing
them; the list moves onto `DerPath` itself and the docstring points at
it, so the fact is stated on the name that owns it.

Local review took two rounds. The first found the new comments restating
an adjacent, pre-existing comment for three of the five, and for `Octets`
restating it *less* precisely — the doc-facing sentence being the one
that would have glossed away the buffers. Each of the three lost the
duplicated sentence and kept the reasoning that followed it. Cleared at
`2a7551a5`, with the rendered page checked rather than the prose reasoned
about: the signature line carries the full union directly above the
sentence.

Closes #1357

## Summary by Sourcery

Expose documentation for five public type aliases and remove their obsolete Sphinx reference suppressions.

Enhancements:
- Add autodoc attribute documentation for the public type aliases `Octets`, `TaprootScriptTree`, `BIP32Key`, `DerPath`, and `DescriptorTree`.
- Remove the corresponding Sphinx nitpick exceptions and keep documentation linting compatible with the attribute documentation format.
- Move derivation-path representation details onto `DerPath` and retain only the remaining private-name documentation exception.

Documentation:
- Document the five public type aliases so generated API pages can resolve links from signatures.