### PR TITLE
A hybrid-prefix internal key is refused on both taproot arms (closes #1227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3387,6 +3387,33 @@ documented at release-notes length in the first place, and are still in
   `_assert_valid_address_index` is unreachable.
   `tests/integer_policy_test.py`'s census gains the case.
 
+- **A hybrid-prefix internal key is refused on both arms, not only on
+  the Python one** (closes #1227). `script.taproot`'s
+  `_output_pubkey_and_internal_key` builds its `PubKeyData` with
+  `check_validity=False`, skipping the length-and-prefix check the type
+  otherwise runs, so a hybrid internal key -- 0x06 or 0x07, both
+  coordinates and a parity byte -- reached whichever arm answered next:
+  `xonly.tweak_add` on the bindings arm, whose `ec_pubkey_parse` takes
+  one, and `PubKeyData.point`'s lift on the Python arm, whose
+  `point_from_octets` defaults `hybrid=False`. Which internal keys
+  `output_pubkey` and `input_script_sig` took was therefore
+  `pip install`'s decision rather than btclib's.
+
+  `key.py` gains `_HYBRID_PREFIXES`, beside `_COMPRESSED_PREFIXES` and
+  `_UNCOMPRESSED_PREFIX`, and `_output_pubkey_and_internal_key` checks
+  it before building `PubKeyData`, above the arm split: a hybrid
+  internal key now raises `"invalid internal public key: hybrid SEC
+  prefix 0x06"` (or `0x07`) on both arms rather than reaching either's
+  own parse. The check is not a second opinion on what the bindings
+  decide -- libsecp256k1 accepts a hybrid key, so refusing it is
+  btclib's own policy above the boundary and not a re-check of the C,
+  for the reason `key.py`'s paragraph already gives: nothing in bitcoin
+  produces one.
+  `tests/script/taproot_test.py` gains a test asserting the one refusal
+  on both arms, the shape
+  `test_the_tweak_names_no_half_of_a_sec_it_cannot_blame` already uses
+  for the sec octets an arm's own parse refuses.
+
 ### Tests
 
 - **The tests exercising the pure-Python arm are named `test_the_py_arm_...`,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -308,6 +308,19 @@ full year, short month, short day (YYYY-M-D)
   `derive_from_account_range`; all four now raise `BTClibTypeError`
   rather than silently narrowing what they accept.
 
+- **`script.taproot`'s internal key refuses a hybrid SEC prefix, on
+  both arms** (closes #1227). `output_pubkey` and `input_script_sig`
+  took a `0x06`/`0x07`-prefixed internal key with `btclib_secp256k1`
+  installed and refused the same octets without it, so which keys they
+  accepted was decided by `pip install` rather than by btclib. Both now
+  raise `BTClibValueError: invalid internal public key: hybrid SEC
+  prefix 0x06` (or `0x07`) regardless of which arm answers.
+
+  Act on it if an internal key you pass to either is ever
+  hybrid-prefixed — nothing in bitcoin produces one, so a signer's own
+  key material is unaffected; a hand-built or fuzzed test vector is
+  where this shows. CHANGELOG.md has where the check runs and why.
+
 ### Worth knowing, though nothing raises
 
 - **A `bytearray` and a `memoryview` are octets, and now the signatures

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -146,7 +146,7 @@ used to teach and to prototype as much as to build:
     straight into a Python `int`: `bip32.derive`
     (`src/btclib/bip32/bip32.py:666`), `commit_nonce.commit_nonce_`
     (`src/btclib/ecc/commit_nonce.py:155`) and `taproot._tweaked_prvkey`
-    (`src/btclib/script/taproot.py:461`). A caller-owned buffer can be
+    (`src/btclib/script/taproot.py:474`). A caller-owned buffer can be
     wiped once the call that filled it returns; the `int` it is read
     into cannot be, and outlives the call regardless —
     `bip32.derive` keeps `prv_key_int` for the life of the key

--- a/src/btclib/key.py
+++ b/src/btclib/key.py
@@ -86,9 +86,15 @@ __all__ = [
 # `hybrid` argument asks for it, the script engine being the caller that
 # has to accept what was mined, and it defaults to `hybrid=False` because
 # nothing in bitcoin produces one. This type takes that default, so a
-# hybrid key is refused here rather than carried as a canonical form
+# hybrid key is refused here rather than carried as a canonical form.
+# `script.taproot`'s internal key reads `_HYBRID_PREFIXES` directly for
+# the same refusal, ahead of the bindings/Python split: `check_validity`
+# is off for that key, so this module's own proof never runs for it, and
+# a hybrid prefix is the one spelling libsecp256k1 parses that btclib's
+# stated policy does not (issue #1227)
 _COMPRESSED_PREFIXES = (0x02, 0x03)
 _UNCOMPRESSED_PREFIX = 0x04
+_HYBRID_PREFIXES = (0x06, 0x07)
 
 
 def _normalized(network: Any) -> Any:

--- a/src/btclib/script/taproot.py
+++ b/src/btclib/script/taproot.py
@@ -31,7 +31,7 @@ from btclib.curves.curve import _libsecp256k1_serves, _y_even_var
 from btclib.curves.curve_group import HEX_THRESHOLD
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import tagged_hash
-from btclib.key import PubKeyData
+from btclib.key import _HYBRID_PREFIXES, PubKeyData
 from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE
 from btclib.script.op_codes_tapscript import (
     OP_CODE_NAMES,
@@ -275,16 +275,29 @@ def _output_pubkey_and_internal_key(
         # are what both arms want, and `PubKeyData` proves them in `point`
         # or not at all. It accepts the 33-byte and the 65-byte form, and
         # `[1:33]` is the x-coordinate of either.
+        sec = _sec_from_key(internal_pubkey)
+        # A hybrid prefix is refused here, above the arm split, rather
+        # than left to whichever arm's own parse runs: it is a third
+        # spelling of a compressed or uncompressed key and not a
+        # malformed one, so libsecp256k1 admits it where the Python
+        # arm's `hybrid=False` default does not, and which internal keys
+        # this function takes would otherwise be `pip install`'s
+        # decision rather than btclib's (issue #1227). key.py's
+        # paragraph on `_HYBRID_PREFIXES` is why the answer is refusal.
+        if sec[0] in _HYBRID_PREFIXES:
+            raise BTClibValueError(
+                f"invalid internal public key: hybrid SEC prefix {sec[0]:#04x}"
+            )
         #
         # check_validity=False, and not because what arrives is known
         # good: `assert_valid` reads a length and a prefix, and
-        # `_sec_from_key` answers any prefix at those two lengths -- the
-        # hybrid 06 and 07 among them -- so some of what reaches here it
-        # would refuse. It is skipped because it is half a proof bought
+        # `_sec_from_key` answers any prefix at those two lengths the
+        # check above does not -- so some of what reaches here it would
+        # still refuse. It is skipped because it is half a proof bought
         # early: whatever these octets are handed to parses them, which is
         # `_sec_from_key`'s own reason for not proving them, and it names
         # what is wrong with the key where a prefix check names the prefix
-        key_data = PubKeyData(_sec_from_key(internal_pubkey), check_validity=False)
+        key_data = PubKeyData(sec, check_validity=False)
     else:
         h_str = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
         # BIP341's unspendable point is published as an x-only key and

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -507,6 +507,41 @@ def test_the_tweak_names_no_half_of_a_sec_it_cannot_blame(
                 output_pubkey(sec)
 
 
+@needs_bindings
+@pytest.mark.parametrize("prefix", [0x06, 0x07], ids=["0x06", "0x07"])
+def test_a_hybrid_internal_key_is_refused_on_both_arms(
+    prefix: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A hybrid internal key is refused, not a spelling one arm alone parses.
+
+    Marked, as the test above is, for the same reason: with no bindings
+    installed there is no delegated arm to compare the second assertion
+    of each pair against.
+
+    libsecp256k1's `ec_pubkey_parse` takes 0x06 and 0x07 as it takes
+    0x04, and `sec_point.point_from_octets`'s own lift defaults
+    `hybrid=False` -- unrefused, that asymmetry is issue #1227: which
+    internal keys `output_pubkey` and `input_script_sig` take would be
+    `pip install`'s decision rather than btclib's. The refusal in
+    `_output_pubkey_and_internal_key` runs above the arm split, so this
+    is one message on both arms rather than a silent accept on one and
+    `point_from_octets`'s own "not a point: prefix 0x0…" on the other.
+
+    Both prefixes, because `hybrid=True` reads them asymmetrically once
+    a caller does ask for them -- 0x06 names an even y and 0x07 an odd
+    one -- and this refusal is meant to run before that reading, on
+    either one.
+    """
+    Q = mult(7)
+    sec = bytes([prefix]) + Q[0].to_bytes(32, "big") + Q[1].to_bytes(32, "big")
+    with pytest.raises(BTClibValueError, match="hybrid SEC prefix"):
+        output_pubkey(sec)
+    with monkeypatch.context() as no_bindings:
+        no_bindings.setattr(taproot, "_libsecp256k1_serves", lambda *_: False)
+        with pytest.raises(BTClibValueError, match="hybrid SEC prefix"):
+            output_pubkey(sec)
+
+
 @pytest.mark.parametrize("spelling", [bytes, bytearray, memoryview])
 def test_check_output_pubkey_takes_every_buffer_the_door_accepts(
     spelling: Callable[[bytes], Octets], monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
`script.taproot` took a `0x06`/`0x07`-prefixed internal key with the
bindings installed and refused the same octets without them, so which
keys the function accepted was decided by `pip install` rather than by
btclib. `_output_pubkey_and_internal_key` builds its `PubKeyData` with
`check_validity=False` — deliberately, since whatever the octets are
handed to parses them — and the two arms then read different fields of
it: the bindings arm passes `sec` whole to `xonly.tweak_add`, which
parses a hybrid key happily, while the Python arm reads `point`, whose
lift defaults `hybrid=False`.

**This branch closes a question the issue reserved**, and says so here
rather than leaving it to be reconstructed. The issue offers three
answers and calls the choice a policy call: refuse hybrid before
delegating, accept it on both arms, or document the divergence and leave
it.

The answer taken is the first, **with a placement the issue does not
consider, and the placement is what makes it admissible**. A prefix check
in front of the bindings call would be duplicate validation at that
boundary — what issue #887 removed and what `_sec_from_key`'s docstring
exists to justify. But libsecp256k1 *accepts* `0x06`/`0x07`: nothing in
the bindings refuses them, so the check is not a second opinion on
something the C already decides. It is btclib's own policy, which today
only one arm applies, by accident of which field it reads. Placed above
the arm split, where both arms pass through, it is a shared precondition
rather than a guard in front of a parse.

The ground for refusing rather than widening: `key.py`'s standing
paragraph says a hybrid key is refused because nothing in bitcoin
produces one, and `point_from_octets` defaults `hybrid=False` for the
same reason. Accepting on both arms would widen what btclib takes on the
strength of what libsecp256k1 happens to allow, which is that paragraph's
opposite. **The cut-back, if the answer is unwanted**: drop the check and
record the divergence in `SECURITY.md` instead, as the third option asks.

The check sits in `_output_pubkey_and_internal_key` and not in
`_sec_from_key`, whose contract is unproven octets however spelled; a
refusal there would reach every future caller rather than this one.
`output_pubkey_from_merkle_root` and `check_output_pubkey` take x-only
keys with the prefix supplied internally, so neither was in scope.

The regression test asserts the refusal on both arms, forcing the Python
one with the seam the suite already uses. `SECURITY.md`'s citation of
`_tweaked_prvkey` shifted by this diff and is repaired in it, verified
against the cited content rather than against which function the line
lands in.

The published release accepts this key: PyPI serves `v2026.8.21`, and the
commit that introduced the unproven-octets shortcut is an ancestor of that
tag, so `RELEASE_NOTES.md` carries a breaking-changes bullet.

Local review took two rounds. The first found that bullet missing — the
omission rested on `v2023.7.12`, which never accepted a hybrid key, a
correct measurement of the wrong baseline. Cleared at `6966c369`.

Collateral filed while working this branch:
[ISS 1419](https://github.com/btclib-org/btclib/issues/1419) — nothing in
the suite compares a *refusal* across the two arms, only agreement where
both answer, which is the general form of this defect.

Closes #1227

## Summary by Sourcery

Reject hybrid-prefixed taproot internal keys consistently across all execution paths.

Bug Fixes:
- Make taproot reject hybrid-prefixed internal public keys consistently on both the Python and libsecp256k1-backed execution paths instead of accepting them only when bindings are installed.

Documentation:
- Document the hybrid-key rejection as a breaking change in the release notes and changelog, and update the security reference affected by the source change.

Tests:
- Add regression coverage confirming both hybrid SEC prefixes are rejected on both taproot execution paths.