### PR TITLE
The `typos` hook is `repo: local`, and `docs/_build/` leaves `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,9 +74,6 @@ instance/
 # Scrapy stuff:
 .scrapy
 
-# Sphinx documentation
-docs/_build/
-
 # PyBuilder
 target/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -263,26 +263,26 @@ repos:
   # camelCase. Between them they found six typos in shipped surfaces, the
   # README's `bitcon` included. pyproject.toml ([tool.typos]) has the whole
   # of the reasoning and the configuration, as for codespell
-  - repo: https://github.com/crate-ci/typos
-    # a release tag, not the `v1` beside it: that one is a major-version
-    # alias upstream moves onto each release, so `pre-commit autoupdate`
-    # picks it as the newest tag and the pin stops being one -- the hook
-    # would then follow every future 1.x, which is the whole of what a rev
-    # is here to prevent. A dictionary that grows under a fixing hook is
-    # not a detail: this one rewrites what it reads
-    rev: v1.49.0
+  # crate-ci/typos re-tags a moving `v1` alias onto the same commit
+  # as each release, and `git describe --tags` breaks the tie between
+  # two tags on one commit by creation date, which names the alias.
+  # `autoupdate` proposes that alias on every run and `pinned-rev` above
+  # refuses it on every run, so the pin stays stuck rather than moving.
+  # `autoupdate` walks every `repo:` entry except `local` and `meta`, so
+  # a local hook is the one shape it cannot reach; `additional_dependencies`
+  # below carries the version pin in its place, and `language`, `entry`,
+  # `args` and `types` are upstream's own typos hook definition, copied
+  # in rather than fetched
+  - repo: local
     hooks:
       - id: typos
-        name: typos (identifiers and hyphenated words, in place fixes)
-        # what the hook declares, restated rather than inherited: both
-        # flags are choices this repository has to keep making. Dropping
-        # --write-changes would make it a report where every other fixing
-        # hook here corrects; dropping --force-exclude would make
-        # [tool.typos.files] silent, because pre-commit passes filenames
-        # and typos honours its own exclude list only under that flag --
-        # measured, without it the normative BIP39 italian wordlist takes
-        # 18 corrections into English
+        name: typos
+        language: python
+        additional_dependencies: [typos==1.49.0]
+        entry: typos
         args: [--write-changes, --force-exclude]
+        types: [text]
+        stages: [pre-commit, pre-merge-commit, pre-push, manual]
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.23.2
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -793,6 +793,24 @@ documented at release-notes length in the first place, and are still in
   `failure`. btclib-org/.github#364 is open: the review step's
   `is_error:true` failure has no explanation this change supplies.
 
+- **`.pre-commit-config.yaml`'s `typos` entry is `repo: local`, pinned
+  through `additional_dependencies` rather than through `rev:`.**
+  `pre-commit autoupdate` walks every `repo:` entry except `local` and
+  `meta`, so a `local` hook is the one shape it cannot reach with the
+  moving `v1` alias crate-ci/typos re-tags onto each release's commit;
+  `language`, `entry`, `args` and `types` restate upstream's own hook
+  definition, and `stages: [pre-commit, pre-merge-commit, pre-push,
+  manual]` is what a `repo: local` hook does not inherit from a
+  manifest and needs stated to stay out of `commit-msg` (issue
+  btclib-org/.github#399).
+
+- **`.gitignore` no longer carries `docs/_build/`.** `build/`, a few
+  lines above it, already ignores `docs/build/html`: `docs/Makefile` and
+  `docs/make.bat` both set `BUILDDIR = build`, and the documented
+  `sphinx-build -n -W --keep-going -b html docs/source docs/build/html`
+  writes there too, so `docs/_build/` matched neither (issue
+  btclib-org/.github#411).
+
 ### Packaging, linting and CI
 
 - **`pyproject.toml`'s ruff configuration selects `["ALL"]`,** matching


### PR DESCRIPTION
`.pre-commit-config.yaml`'s `typos` entry converges on `btclib-org/.github`'s own ([ISS 399](https://github.com/btclib-org/.github/issues/399)), and `.gitignore` drops a `docs/_build/` that decides nothing ([ISS 411](https://github.com/btclib-org/.github/issues/411)).

`pre-commit autoupdate` walks every `repo:` entry except `local` and `meta`, and `crate-ci/typos` re-tags a moving `v1` alias onto the same commit as each release — so `git describe --tags` names the alias, `autoupdate` proposes it every run, and `pinned-rev` refuses it every run. A `repo: local` hook is the shape `autoupdate` cannot reach; `additional_dependencies: [typos==1.49.0]` carries the pin instead. The twenty lines are taken byte for byte, which is the issue's *Done when*.

**This closes neither issue.** Both are owed by one more tree — `btclib-node` — and each takes its keyword there. Tracking issues: btclib-org/.github#399 and btclib-org/.github#411

**A decision ISS 411 reserved is closed here, and this is the notice it asked for.** That issue's *Not measured* names the one reading under which the line is not inert: a hand-run `sphinx-build` with Sphinx's own default output directory. The ground for deciding it does not apply is that nothing in this tree reaches `_build` by any documented route — `docs/Makefile:9` and `docs/make.bat:11` both set `BUILDDIR = build`, `CONTRIBUTING.md:1030` documents `sphinx-build … docs/source docs/build/html`, and after the removal `git grep 'docs/_build'` matches only this branch's own changelog entry. The only remaining route is typing `docs/_build` explicitly. **The cut-back, if that answer is unwanted, is restoring the two `.gitignore` lines**; nothing else in the branch depends on them.

Local review established one thing worth recording, because it is what makes the change safe rather than merely green. The hook is provably the *same hook* before and after: upstream's manifest at the pinned tag declares `language: python`, `entry: typos`, `args: [--write-changes, --force-exclude]`, `types: [text]` and the four `stages:` — every field the new local block states, at the same version. Same file set, same flags, same stage eligibility, and `pyproject.toml` untouched. So the only genuinely new input to `typos` is the prose this diff adds, which the reviewer ran the pinned binary over itself: exit 0, with two controls, one of them proving that `[tool.typos.type.verbatim]` is what suppresses the deliberate misspellings under their real filenames.

`stages:` is the key that could have been lost and was not. A `repo: local` hook inherits no stage restriction from a manifest, and this config sets no `default_stages` — so omitting it would make the hook eligible at `commit-msg`, where its own `--write-changes` rewrites the message being typed. That failure was measured in a sibling tree during this campaign, where a hand-copied conversion did drop it.

**A pre-existing exposure was found and filed rather than fixed here: [ISS 1418](https://github.com/btclib-org/btclib/issues/1418).** `typos` reads eight of the 32 seed files under `fuzz/corpus/` as text — they carry no NUL byte and the hook passes no `--binary` — and `[tool.typos.files]` excludes none of them, so a `--write-changes` run could rewrite a fuzzing corpus and invalidate the round-trip property each seed was proved against. It is **not** this branch's defect: the mirror form carried the identical `args` and inherited the identical `types`, so the exposure predates the port and is unchanged by it. Verified clean today — `typos --force-exclude fuzz/corpus` reports 0, against a 3-error positive control.

`.github/dependabot.yml`'s census is deliberately not touched. ISS 422's test is whether the census was exhaustive before the port; here it was not — four `additional_dependencies` version pins already sat outside `rev:` at the base, and the tree already carries the rule the new pin follows, three lines above one of them: *"Pinned, because nothing bumps an additional dependency: pre-commit.ci moves rev, dependabot has no pre-commit ecosystem."*

Gates: `pytest` exit 0, 30727 passed, 100% coverage; `sphinx-build -n -W --keep-going` exit 0; the docs anchor grep exit 1, which the gate wants; `pre-commit run --all-files` exit 0 with `typos` included.

## Summary by Sourcery

Align pre-commit configuration and documentation build ignores with the repository’s actual tooling and maintenance requirements.

Enhancements:
- Convert the typos pre-commit hook to a locally defined hook with an explicitly pinned dependency while preserving its behavior and supported stages.
- Remove the unused `docs/_build/` ignore pattern.

Documentation:
- Document the typos hook pinning change and removal of the obsolete documentation build path from the changelog.