### PR TITLE
Sequence[Octets]/Iterable[Octets] parameters refuse a bare Octets, and the input-validation walk now drives them (closes #1405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3346,6 +3346,41 @@ documented at release-notes length in the first place, and are still in
   spelling, and a spelling `Octets` gains later is refused the same way
   at both instead of by whichever accident is available.
 
+- **Every public function taking a `Sequence[Octets]` or `Iterable[Octets]`
+  refuses a bare `Octets` in its place, naming the shape rather than
+  leaving the mistake to surface as a complaint about an `int`** (closes
+  #1405). `block.merkle_proof.assert_as_valid` and
+  `hashes.merkle_root_from_branch` on a branch, `block.proof_of_work.chain_work`
+  on a bits sequence, `block.block_filter.BasicBlockFilter.match_any` on
+  its elements, `ecc.musig2.key_sort`, `key_agg`, `key_agg_and_tweak`,
+  `nonce_agg`, `partial_sig_agg`, `partial_sig_agg_adaptor` and
+  `SessionContext` on their pubkeys, tweaks, nonces or partial
+  signatures, `ecc.ssa`'s four batch-verification entry points on their
+  messages, `psbt.psbt_utils.decode_musig2_participant_pub_keys` and
+  `decode_taproot_bip32` on a mapping's values, `script.witness.Witness`
+  on its stack, and `silent_payments.scan_outputs` and
+  `scan_transaction_outputs` on the outputs to check. The guard sits at
+  the public entry point rather than at a private twin only that entry
+  point calls -- `ecc.musig2._pub_keys` and `_tweaks`, `ecc.ssa`'s
+  `assert_batch_as_valid_`, still take the caller's word once the public
+  function in front of them has checked it, which is what
+  `CONTRIBUTING.md`'s validation rule already asks for and what keeps
+  the coverage floor from asking for a branch no valid call can reach.
+  `p2p.inventory._sequence_of` moves from its own hand-listed spellings
+  to `utils.is_octets`, `p2p.block_filters` inheriting the fix through
+  it rather than needing one of its own.
+
+  `tests/input_validation_test.py`'s walk did not drive any of these:
+  its vocabulary answered every `Sequence[Octets]`/`Iterable[Octets]`
+  parameter with no alias at all, which is a function the walk skips
+  outright rather than one it exercises weakly, and is why the gap
+  survived a gate built to catch exactly this class of defect. The
+  vocabulary now names the two shapes beside `Octets` itself, so
+  `chain_work`, `key_agg`, `key_sort`, `nonce_agg`, `scan_outputs` and
+  `descriptors.satisfaction_sizer` are walked automatically, and a
+  function taking either shape written from here on is walked the same
+  way without anybody remembering to add it by hand.
+
 - **`ssa.challenge_` and `dsa.recover_pub_key_` refuse a bool, closing
   the trailing-underscore layer's own gap in issue #1206's policy**
   (closes #1248). Both take a bare `int` rather than an `Integer`, so

--- a/src/btclib/block/block_filter.py
+++ b/src/btclib/block/block_filter.py
@@ -465,6 +465,14 @@ class BasicBlockFilter:
         filter cannot hold -- an empty script, or the script of an
         OP_RETURN output, neither of which is ever put in one.
         """
+        # every Octets is itself iterable, so passing one script instead
+        # of an iterable of them would zip through its bytes and query
+        # each as its own element (issue #1405)
+        if is_octets(elements):
+            err_msg = "invalid elements type: "
+            err_msg += type(elements).__name__
+            raise BTClibTypeError(err_msg)
+
         k0, k1 = _key_from_block_hash(bytes(self.block_hash))
         upper_bound = self.element_count * BASIC_FILTER_M
         targets = sorted(

--- a/src/btclib/block/merkle_proof.py
+++ b/src/btclib/block/merkle_proof.py
@@ -35,7 +35,7 @@ from btclib.exceptions import (
 )
 from btclib.hashes import hash256, merkle_root_from_branch
 from btclib.tx import Tx
-from btclib.utils import assert_type, bytes_from_octets
+from btclib.utils import assert_type, bytes_from_octets, is_octets
 
 __all__ = [
     "assert_as_valid",
@@ -99,7 +99,12 @@ def assert_as_valid(
     """
     # the branch before it is walked: what is not a sequence went to the
     # comprehension below untouched, so a None left it as "not iterable"
-    # -- a complaint about iteration and not about a branch (issue #814)
+    # -- a complaint about iteration and not about a branch (issue #814).
+    # An Octets is itself a Sequence, so assert_type alone lets one
+    # through -- zipped through its bytes and treated as one sibling per
+    # byte -- and is_octets is what refuses that shape (issue #1405)
+    if is_octets(branch):
+        raise BTClibTypeError(f"invalid branch type: {type(branch).__name__}")
     assert_type(branch, Sequence, "branch")
 
     root = bytes_from_octets(merkle_root, 32)

--- a/src/btclib/block/proof_of_work.py
+++ b/src/btclib/block/proof_of_work.py
@@ -32,7 +32,7 @@ from datetime import datetime
 
 from btclib.alias import Octets
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.utils import assert_type, bytes_from_octets, is_integer
+from btclib.utils import assert_type, bytes_from_octets, is_integer, is_octets
 
 __all__ = [
     "DIFFICULTY_ADJUSTMENT_INTERVAL",
@@ -328,6 +328,13 @@ def chain_work(bits_sequence: Sequence[Octets]) -> int:
     with the most work behind it, and only the second is expensive to
     replace. Bitcoin Core accumulates the same sum as `nChainWork`.
     """
+    # every Octets is a Sequence too: passing one instead of a list of
+    # them would zip through its bytes and sum the work of each as if it
+    # were its own `bits` (issue #1405)
+    if is_octets(bits_sequence) or not isinstance(bits_sequence, Sequence):
+        raise BTClibTypeError(
+            f"invalid bits sequence type: {type(bits_sequence).__name__}"
+        )
     return sum(block_work(bits) for bits in bits_sequence)
 
 

--- a/src/btclib/ecc/musig2.py
+++ b/src/btclib/ecc/musig2.py
@@ -128,11 +128,12 @@ from btclib.curves.sec_point import (
 from btclib.ecc import ssa
 from btclib.exceptions import (
     BTClibRuntimeError,
+    BTClibTypeError,
     BTClibValueError,
     InvalidContributionError,
 )
 from btclib.hashes import tagged_hash
-from btclib.utils import assert_type, bytes_from_octets
+from btclib.utils import assert_type, bytes_from_octets, is_octets
 
 __all__ = [
     "KeyAggContext",
@@ -239,6 +240,19 @@ def _bytes_xor(a: bytes, b: bytes) -> bytes:
     return bytes(x ^ y for x, y in zip(a, b, strict=True))
 
 
+def _assert_octets_sequence(value: object, what: str) -> None:
+    """Refuse anything but a Sequence of Octets, naming which.
+
+    Every Octets is itself a Sequence, so passing one where the list of
+    pubkeys, tweaks, nonces or partial signatures was meant would zip
+    through its bytes and treat each as its own element (issue #1405);
+    `not isinstance(value, Sequence)` is what refuses everything else the
+    comprehensions below would otherwise raise a bare TypeError on.
+    """
+    if is_octets(value) or not isinstance(value, Sequence):
+        raise BTClibTypeError(f"invalid {what} type: {type(value).__name__}")
+
+
 def _pub_keys(pub_keys: Sequence[Octets]) -> tuple[bytes, ...]:
     return tuple(bytes_from_octets(pk, _PK_SIZE) for pk in pub_keys)
 
@@ -290,6 +304,7 @@ def key_sort(pub_keys: Sequence[Octets]) -> list[bytes]:
     reorders its argument makes the key of whoever kept a reference to
     that list change under them.
     """
+    _assert_octets_sequence(pub_keys, "pub_keys")
     return sorted(_pub_keys(pub_keys))
 
 
@@ -347,6 +362,7 @@ def key_agg(pub_keys: Sequence[Octets]) -> KeyAggContext:
     another order and the group is another group. `key_sort` is the
     usual way to agree on one.
     """
+    _assert_octets_sequence(pub_keys, "pub_keys")
     pks = _pub_keys(pub_keys)
     L = _hash_pub_keys(pks)
     second = _second_pub_key(pks)
@@ -418,6 +434,9 @@ def key_agg_and_tweak(
     is_xonly: Sequence[bool],
 ) -> KeyAggContext:
     """Aggregate the keys, then apply the tweaks in order."""
+    # pub_keys is key_agg's own to guard, below; tweaks is only this
+    # function's, `_tweaks` having no other caller that already checked it
+    _assert_octets_sequence(tweaks, "tweaks")
     tweaks_ = _tweaks(tweaks)
     is_xonly = _flags(is_xonly)
     _require_same_length(tweaks_, is_xonly)
@@ -548,6 +567,7 @@ def nonce_agg(pub_nonces: Sequence[Octets]) -> bytes:
     signer, by publishing the negation of what the others published,
     stop the session at will.
     """
+    _assert_octets_sequence(pub_nonces, "pub_nonces")
     nonces = [bytes_from_octets(nonce, _NONCE_SIZE) for nonce in pub_nonces]
     agg_nonce = b""
     for j in (0, 1):
@@ -626,6 +646,11 @@ class SessionContext:
         msg: Octets,
         adaptor: Octets | None = None,
     ) -> None:
+        # this constructor is a direct entry point of its own, not only
+        # reached through key_agg_and_tweak, so pub_keys and tweaks are
+        # both its own to guard
+        _assert_octets_sequence(pub_keys, "pub_keys")
+        _assert_octets_sequence(tweaks, "tweaks")
         object.__setattr__(self, "agg_nonce", bytes_from_octets(agg_nonce, _NONCE_SIZE))
         object.__setattr__(self, "pub_keys", _pub_keys(pub_keys))
         object.__setattr__(self, "tweaks", _tweaks(tweaks))
@@ -1065,8 +1090,11 @@ def _agg_s(psigs: Sequence[Octets], session_ctx: SessionContext) -> tuple[int, i
     caller below knows or needs to know whether the session carries an
     adaptor: `session_values` already folded T into R before either is
     called, so the sum is the same sum either way, and it is only the
-    two callers that decide what the sum is allowed to mean.
+    two callers that decide what the sum is allowed to mean. Both are
+    public and neither else validates `psigs`, so this is where it is
+    checked, once, for both.
     """
+    _assert_octets_sequence(psigs, "psigs")
     values = session_values(session_ctx)
     s = 0
     for i, psig in enumerate(psigs):

--- a/src/btclib/ecc/ssa.py
+++ b/src/btclib/ecc/ssa.py
@@ -94,6 +94,7 @@ from btclib.utils import (
     int_from_bits,
     int_from_integer,
     is_integer,
+    is_octets,
 )
 
 __all__ = [
@@ -1155,8 +1156,14 @@ def _assert_batch_sequences(
 
     A `str` is a Sequence and stays one: run time cannot tell
     Sequence[Octets] from Sequence[str], so the elements are what answer
-    for their own values.
+    for their own values -- that is about telling one Sequence[Octets]
+    from another, though, and no Sequence at all is `msgs`'s own mistake
+    to refuse: every Octets is itself a Sequence, so one message passed
+    where the batch was meant would zip through its bytes and challenge
+    each as its own message (issue #1405).
     """
+    if is_octets(msgs):
+        raise BTClibTypeError(f"invalid msgs type: {type(msgs).__name__}")
     for value, what in ((msgs, "msgs"), (Qs, "Qs"), (sigs, "sigs")):
         assert_type(value, Sequence, what)
 

--- a/src/btclib/hashes.py
+++ b/src/btclib/hashes.py
@@ -18,7 +18,7 @@ from btclib import var_int
 from btclib._ripemd160 import ripemd160 as pure_python_ripemd160
 from btclib.alias import HashDigestF, HashF, Octets
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.utils import bytes_from_octets, is_integer
+from btclib.utils import bytes_from_octets, is_integer, is_octets
 
 __all__ = [
     "hash160",
@@ -385,6 +385,12 @@ def merkle_root_from_branch(
     means knowing what a transaction looks like -- a layer this module
     sits below, and must not import.
     """
+    # every Octets is itself a Sequence, so passing one instead of a list
+    # of siblings would zip through its bytes and hash each as its own
+    # sibling (issue #1405)
+    if is_octets(branch):
+        raise BTClibTypeError(f"invalid branch type: {type(branch).__name__}")
+
     # the type before the sign, `"0" < 0` being a bare TypeError about
     # the operands: an index is a position and a bool is not one, `True`
     # naming the second leaf of every tree it is passed to

--- a/src/btclib/p2p/inventory.py
+++ b/src/btclib/p2p/inventory.py
@@ -115,6 +115,7 @@ from btclib.utils import (
     bytes_from_octets,
     bytesio_from_binarydata,
     is_integer,
+    is_octets,
     read_exactly,
 )
 
@@ -239,14 +240,15 @@ def _assert_valid_hash(hash_: bytes, what: str) -> None:
 def _sequence_of(values: Sequence[_Element], what: str) -> tuple[_Element, ...]:
     """Return the tuple of a sequence that is not text or octets.
 
-    A str and a bytes are Sequences whose elements are a character and an
-    integer, which is what none of the fields below holds: asked whole
-    here, so that a caller who passed one is told about the argument
-    rather than about its first character.
+    An Octets -- str, bytes, bytearray or memoryview -- is a Sequence
+    whose elements are a character or an integer, which is what none of
+    the fields below holds: asked whole here, so that a caller who passed
+    one is told about the argument rather than about its first element.
+    `is_octets` is the four spellings named once, so a spelling `Octets`
+    gains later is refused here too (issue #1405, as issue #1261 for
+    `utils.is_octets` itself).
     """
-    if isinstance(values, (str, bytes, bytearray, memoryview)) or not isinstance(
-        values, Sequence
-    ):
+    if is_octets(values) or not isinstance(values, Sequence):
         raise BTClibTypeError(f"invalid {what} type: {type(values).__name__}")
     return tuple(values)
 

--- a/src/btclib/psbt/psbt_utils.py
+++ b/src/btclib/psbt/psbt_utils.py
@@ -28,6 +28,7 @@ from btclib.utils import (
     bytesio_from_binarydata,
     fields_from_json_object,
     is_integer,
+    is_octets,
     list_from_json_array,
     read_exactly,
 )
@@ -451,6 +452,15 @@ def decode_taproot_bip32(
     """Parse correctly the tap_bip32_derivation init arguments."""
     if dict_ is None:
         return {}
+    # each value's first element is itself a Sequence[Octets], the leaf
+    # hashes of one key, and every Octets is itself a Sequence: passing
+    # one where the list of hashes was meant would zip through its bytes
+    # and treat each as its own leaf hash (issue #1405)
+    for leaf_hashes, _origin in dict_.values():
+        if is_octets(leaf_hashes):
+            err_msg = "invalid taproot bip32 leaf hashes type: "
+            err_msg += type(leaf_hashes).__name__
+            raise BTClibTypeError(err_msg)
     taproot_bip32 = {
         bytes_from_octets(k): ([bytes_from_octets(x) for x in v[0]], v[1])
         for k, v in dict_.items()
@@ -536,6 +546,15 @@ def decode_musig2_participant_pub_keys(
     """Parse correctly the musig2_participant_pub_keys init argument."""
     if dict_ is None:
         return {}
+    # each value is itself a Sequence[Octets], the participants of one
+    # aggregate key, and every Octets is itself a Sequence: passing one
+    # where the list of participants was meant would zip through its
+    # bytes and treat each as its own participant (issue #1405)
+    for participants_ in dict_.values():
+        if is_octets(participants_):
+            err_msg = "invalid musig2 participant pub keys type: "
+            err_msg += type(participants_).__name__
+            raise BTClibTypeError(err_msg)
     participants = {
         bytes_from_octets(k): [bytes_from_octets(x) for x in v]
         for k, v in dict_.items()

--- a/src/btclib/script/witness.py
+++ b/src/btclib/script/witness.py
@@ -12,11 +12,13 @@ from dataclasses import dataclass
 from btclib import var_bytes, var_int
 from btclib.alias import BinaryData, Octets
 from btclib.consensus import MAX_WITNESS_STACK_ITEMS
+from btclib.exceptions import BTClibTypeError
 from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
     bytesio_from_binarydata,
     fields_from_json_object,
+    is_octets,
     list_from_json_array,
 )
 
@@ -49,6 +51,11 @@ class Witness:
     def __init__(
         self, stack: Sequence[Octets] | None = None, *, check_validity: bool = True
     ) -> None:
+        # every Octets is itself a Sequence, so passing one instead of a
+        # list of stack elements would zip through its bytes and treat
+        # each as its own element (issue #1405)
+        if is_octets(stack):
+            raise BTClibTypeError(f"invalid stack type: {type(stack).__name__}")
         # https://docs.python.org/3/tutorial/controlflow.html#default-argument-values
         object.__setattr__(
             self,

--- a/src/btclib/silent_payments.py
+++ b/src/btclib/silent_payments.py
@@ -89,7 +89,7 @@ from btclib.script.witness import Witness
 from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.to_pub_key import PubKey, point_from_pub_key, pub_keyinfo_from_pub_key
 from btclib.tx.out_point import OutPoint
-from btclib.utils import bytes_from_octets, is_integer, str_from_string
+from btclib.utils import bytes_from_octets, is_integer, is_octets, str_from_string
 
 __all__ = [
     "K_MAX",
@@ -790,6 +790,13 @@ def scan_outputs(
     say -- still has to advance k, or every later output of the same
     sender is missed.
     """
+    # every Octets is itself a Sequence, so passing one instead of a list
+    # of outputs would zip through its bytes and check each as its own
+    # output (issue #1405)
+    if is_octets(outputs_to_check) or not isinstance(outputs_to_check, Sequence):
+        raise BTClibTypeError(
+            f"invalid outputs_to_check type: {type(outputs_to_check).__name__}"
+        )
     secret = shared_secret(b_scan, tweak)
     # every k tweaks the one spend key, and `_tweak_add_var` would cross
     # the boundary with it at each of them: the chain crosses with it once
@@ -932,6 +939,14 @@ def scan_transaction_outputs(
     unconverted; the Python arm, `scan_outputs`, reads the same bytes
     through `int_from_prv_key`.
     """
+    # `scan_outputs`'s own guard, checked again here rather than relying
+    # on the delegation below: the bindings arm never reaches that
+    # function, so `outputs_to_check` is this function's own to refuse
+    # (issue #1405)
+    if is_octets(outputs_to_check) or not isinstance(outputs_to_check, Sequence):
+        raise BTClibTypeError(
+            f"invalid outputs_to_check type: {type(outputs_to_check).__name__}"
+        )
     A_sum = pub_key_sum([pub_key for pub_key, _script_pub_key in pub_keys])
     h = input_hash(outpoints, A_sum)
 

--- a/tests/block/blockfilters_test.py
+++ b/tests/block/blockfilters_test.py
@@ -32,12 +32,12 @@ filter is the BIP141 witness commitment.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from btclib.block import BasicBlockFilter, Block, BlockContext
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from tests import load, vector_id
 
 _HEADER_ROW = 1  # "Block Height,Block Hash,Block,[Prev Output Scripts ..."
@@ -301,6 +301,10 @@ def test_blockfilters_match(
     assert not block_filter.match(_ABSENT_SCRIPT)
     assert not block_filter.match_any([_ABSENT_SCRIPT, _ABSENT_SCRIPT[::-1]])
     assert not block_filter.match_any([])
+
+    if included:
+        with pytest.raises(BTClibTypeError, match="invalid elements type"):
+            block_filter.match_any(cast("Any", included[0]))
 
 
 def test_a_coinbase_input_has_no_previous_output_script() -> None:

--- a/tests/block/merkle_proof_test.py
+++ b/tests/block/merkle_proof_test.py
@@ -14,11 +14,12 @@ the block carries the transactions and the root that commits to them.
 """
 
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
 from btclib.block import Block, merkle_proof
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash256, merkle_root_from_branch
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 
@@ -241,3 +242,25 @@ def test_a_malformed_branch_is_refused() -> None:
 
     # and the right branch for the wrong root
     assert not merkle_proof.verify(txids[index], branch, index, bytes(32))
+
+
+def test_one_sibling_is_not_a_branch_of_them() -> None:
+    """Octets are a Sequence too, and iterating one yields its octets.
+
+    A caller passing the one sibling it has, rather than a branch holding
+    it, would otherwise have `assert_type`'s own `Sequence` check let it
+    through -- an `Octets` is one -- and be zipped through its bytes,
+    each treated as its own sibling (issue #1405).
+    """
+    block = _load("block_200000.bin")
+    txids = [tx.id for tx in block.transactions]
+    hashes = [txid[::-1] for txid in txids]
+    root = block.header.merkle_root
+    index = 3
+    branch = [sibling[::-1] for sibling in _branch(hashes, index)]
+    sibling = branch[0]
+
+    with pytest.raises(BTClibTypeError, match="invalid branch type"):
+        merkle_proof.assert_as_valid(txids[index], cast("Any", sibling), index, root)
+    with pytest.raises(BTClibTypeError, match="invalid branch type"):
+        merkle_root_from_branch(sibling, cast("Any", sibling), index, hash256)

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from hashlib import sha256 as hf
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -647,6 +647,29 @@ def test_batch_validation() -> None:
     with pytest.raises(BTClibRuntimeError, match=err_msg):
         ssa.assert_batch_as_valid_(ms, Qs, sigs)
     assert not ssa.batch_verify_(ms, Qs, sigs)
+
+
+def test_one_message_is_not_a_batch_of_them() -> None:
+    """Octets are a Sequence too, and iterating one yields its octets.
+
+    A caller passing the one message it has, rather than a batch holding
+    it, would otherwise zip through its bytes and challenge each as its
+    own message (issue #1405). Only `msgs` is `Sequence[Octets]`; `Qs`
+    and `sigs` are refused the way `_assert_batch_sequences`'s own
+    `Sequence` check already refused a `None` (issue #814), untouched
+    here.
+    """
+    aux = b"\x00" * 32
+    m = b"\x00" * 16
+    q, Q = ssa.gen_keys(1)
+    sig = ssa.sign(m, q, aux)
+
+    for batch_call in (ssa.assert_batch_as_valid, ssa.assert_batch_as_valid_):
+        with pytest.raises(BTClibTypeError, match="invalid msgs type"):
+            batch_call(cast("Any", m), [Q], [sig])
+    for verify_call in (ssa.batch_verify, ssa.batch_verify_):
+        with pytest.raises(BTClibTypeError, match="invalid msgs type"):
+            verify_call(cast("Any", m), [Q], [sig])
 
 
 def test_a_batch_of_one_takes_the_single_signature_shortcut(

--- a/tests/input_validation_test.py
+++ b/tests/input_validation_test.py
@@ -112,12 +112,18 @@ _WRONG_TYPE: dict[str, tuple[Any, ...]] = {
     "BinaryData": (None, 1.5),
     "DerPath": (None, 1.5),
     "Integer": (None, 1.5),
+    # an Octets, beside None and 1.5: every Octets is itself iterable, so
+    # a signature reading Sequence[Octets] or Iterable[Octets] accepts
+    # one as far as mypy goes, and a function that does not refuse it by
+    # name zips through its bytes instead (issue #1405)
+    "Iterable[Octets]": (None, 1.5, b"\xaa\xbb\xcc\xdd"),
     "Key": (None, 1.5),
     "Octets": (None, 1.5, tuple(range(4))),
     "Point": (None, 1.5, "not a point"),
     "PrvKey": (None, 1.5),
     "PubKey": (None, 1.5),
     "ScriptList": (None, 1.5, "not a list"),
+    "Sequence[Octets]": (None, 1.5, b"\xaa\xbb\xcc\xdd"),
     "String": (None, 1.5, 1),
 }
 
@@ -139,10 +145,12 @@ _WRONG_VALUE: dict[str, tuple[Any, ...]] = {
     # a tuple of the wrong arity, and a pair of ints that is no point:
     # run time cannot tell tuple[int] from tuple[int, int], so the arity
     # is a value here and not a type
+    "Iterable[Octets]": (["not hex at all"],),
     "Point": ((1,), (1, 2)),
     "PrvKey": ("not a key",),
     "PubKey": ("not a key",),
     "ScriptList": (["OP_NOT_AN_OP_CODE"],),
+    "Sequence[Octets]": (["not hex at all"],),
     "String": ("not an address",),
 }
 
@@ -316,8 +324,17 @@ def test_the_vocabulary_is_the_libraries_input_types() -> None:
                 if a.annotation is not None
             }
 
+    # `Sequence[Octets]` and `Iterable[Octets]` are not declarations of
+    # their own -- `Octets` is -- so a renamed `Octets` is still caught
+    # by unwrapping one level before checking
+    def _is_declared(alias: str) -> bool:
+        for wrapper in ("Sequence[", "Iterable["):
+            if alias.startswith(wrapper) and alias.endswith("]"):
+                return alias[len(wrapper) : -1] in declared
+        return alias in declared
+
     assert set(_WRONG_TYPE) == set(_WRONG_VALUE)
-    assert set(_WRONG_TYPE) <= declared
+    assert all(_is_declared(alias) for alias in _WRONG_TYPE)
 
     without_a_wrong_value = {
         # three Literals: a value outside them is what mypy refuses, and a

--- a/tests/psbt/psbt_utils_test.py
+++ b/tests/psbt/psbt_utils_test.py
@@ -11,6 +11,8 @@ import pytest
 from btclib.bip32 import BIP32KeyOrigin
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.psbt.psbt_utils import (
+    decode_musig2_participant_pub_keys,
+    decode_taproot_bip32,
     deserialize_map,
     deserialize_tx,
     parse_taproot_bip32,
@@ -57,6 +59,42 @@ def test_parse_taproot_bip32_hostile_count() -> None:
     # one leaf hash announced, one byte short of it
     with pytest.raises(BTClibValueError, match="invalid number of leaf hashes: "):
         parse_taproot_bip32(b"\x01" + b"\x00" * 31 + b"\xde\xad\xbe\xef")
+
+
+def test_one_leaf_hash_is_not_a_list_of_them() -> None:
+    """Octets are a Sequence too, and iterating one yields its octets.
+
+    A caller filing the one leaf hash it has under a key, rather than a
+    list holding it, would otherwise have `decode_taproot_bip32` zip
+    through its bytes and treat each as its own hash (issue #1405).
+    """
+    key_origin = BIP32KeyOrigin(b"\xde\xad\xbe\xef", "m/86h/1h/0h/0/0")
+    leaf_hash = bytes(range(32))
+    pub_key = b"\x02" * 32
+
+    assert decode_taproot_bip32({pub_key: ([leaf_hash], key_origin)}) == {
+        pub_key: ([leaf_hash], key_origin)
+    }
+    with pytest.raises(BTClibTypeError, match="invalid taproot bip32 leaf hashes"):
+        decode_taproot_bip32({pub_key: (leaf_hash, key_origin)})  # type: ignore[dict-item]
+
+
+def test_one_participant_pub_key_is_not_a_list_of_them() -> None:
+    """Octets are a Sequence too, and iterating one yields its octets.
+
+    A caller filing the one participant it has under an aggregate key,
+    rather than a list holding it, would otherwise have
+    `decode_musig2_participant_pub_keys` zip through its bytes and treat
+    each as its own participant (issue #1405).
+    """
+    aggregate = b"\x03" * 33
+    participant = b"\x02" * 33
+
+    assert decode_musig2_participant_pub_keys({aggregate: [participant]}) == {
+        aggregate: [participant]
+    }
+    with pytest.raises(BTClibTypeError, match="invalid musig2 participant pub keys"):
+        decode_musig2_participant_pub_keys({aggregate: participant})  # type: ignore[dict-item]
 
 
 def test_deserialize_map_short_read() -> None:

--- a/tests/script/witness_test.py
+++ b/tests/script/witness_test.py
@@ -10,7 +10,7 @@ import pytest
 
 from btclib import var_int
 from btclib.consensus import MAX_WITNESS_STACK_ITEMS
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.script import Witness
 from tests.conftest import JsonGolden
 
@@ -37,6 +37,18 @@ def test_witness() -> None:
     witness.assert_valid()
     assert witness == Witness.parse(witness.serialize())
     assert witness == Witness.from_dict(witness.to_dict())
+
+
+def test_one_element_is_not_a_stack_of_them() -> None:
+    """Octets are a Sequence too, and iterating one yields its octets.
+
+    A caller passing the one element it has, rather than a stack holding
+    it, would otherwise zip through its bytes and treat each as its own
+    element (issue #1405).
+    """
+    element = b"\x01\x02"
+    with pytest.raises(BTClibTypeError, match="invalid stack type"):
+        Witness(element)  # type: ignore[arg-type]
 
 
 def test_frozen() -> None:

--- a/tests/silent_payments_test.py
+++ b/tests/silent_payments_test.py
@@ -24,7 +24,7 @@ that says the output is *spendable* rather than merely predicted.
 from __future__ import annotations
 
 from hashlib import sha256
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -775,6 +775,33 @@ def test_scan_transaction_outputs_wraps_a_delegated_refusal(
     with pytest.raises(BTClibValueError, match="silent payment scan failed"):
         silent_payments.scan_transaction_outputs(
             _B_SCAN_PRV, mult(_B_SPEND_PRV), outpoints, pub_keys, [_NOT_AN_X]
+        )
+
+
+def test_one_output_is_not_a_list_of_them() -> None:
+    """Octets are a Sequence too, and iterating one yields its octets.
+
+    A caller passing the one output it has, rather than a list holding
+    it, would otherwise zip through its bytes and check each as its own
+    output (issue #1405). The bindings arm never reaches `scan_outputs`,
+    so `scan_transaction_outputs` guards its own `outputs_to_check`
+    rather than inheriting the check through delegation.
+    """
+    script_pub_key = "0014" + hash160(bytes_from_point(mult(_B_SCAN_PRV))).hex()
+    pub_keys = [(mult(_B_SCAN_PRV), script_pub_key)]
+    outpoints = [OutPoint("00" * 31 + "01", 0)]
+
+    with pytest.raises(BTClibTypeError, match="invalid outputs_to_check type"):
+        silent_payments.scan_transaction_outputs(
+            _B_SCAN_PRV,
+            mult(_B_SPEND_PRV),
+            outpoints,
+            pub_keys,
+            cast("Any", _NOT_AN_X),
+        )
+    with pytest.raises(BTClibTypeError, match="invalid outputs_to_check type"):
+        silent_payments.scan_transaction_outputs(
+            _B_SCAN_PRV, mult(_B_SPEND_PRV), outpoints, pub_keys, cast("Any", None)
         )
 
 


### PR DESCRIPTION
Every `Octets` is itself iterable, so a caller passing one where a
sequence of them was meant zips through its bytes: never a silent
miscount, since `bytes_from_octets` refuses the `int` each octet becomes,
but the complaint names an `int` rather than the parameter's own shape.
`utils.is_octets`, added by
[ISS 1261](https://github.com/btclib-org/btclib/issues/1261) for two call
sites, is what makes the guard one line per site rather than a new
question each time.

**This branch answers a question the issue left open**: whether every
such parameter is worth guarding, or only the ones a caller is likely to
reach with a single `Octets` by mistake. The answer taken is **neither —
publicity decides it**, on `CONTRIBUTING.md`'s standing rule that a name
a caller can reach checks its inputs while the private twin it defers to
does not, because the library composes that twin where the checks have
already run. `__all__` is what decides publicity, not the leading
underscore. **The cut-back, if the answer is unwanted**: guard only the
entry points a caller plausibly reaches by mistake and drop the rest;
nothing else in the branch depends on the choice.

## The walk was not covering these at all

`tests/input_validation_test.py` drives the input-validation rules over
every public function whose required parameters are all library input
types, and it mapped an annotation to its vocabulary entry by exact
match. Neither `Sequence[Octets]` nor `Iterable[Octets]` was an entry, so
`_drivable()` excluded every function carrying one — not weak coverage
but none, and a gate that skips a file prints what a clean file prints.

Teaching the vocabulary those two shapes is what catches the next such
parameter as well as this census. It costs one adjustment to
`test_the_vocabulary_is_the_libraries_input_types`, whose check compares
each entry against the tree's own top-level declarations: `Sequence[Octets]`
is not itself a declaration where `Octets` is, so the check now unwraps one
level first. The property it exists for survives — a renamed `Octets` still
fails it, and a wrapper the unwrapping does not anticipate falls through to
the plain membership test and fails rather than passing.

Local review took two rounds and verified that claim by execution rather
than by reading, running `_drivable()` directly and confirming the newly
driven functions match the census. Its one finding was that three sites
wrote the guard as two adjacent `if` blocks raising the identical
exception, where the same diff's own `musig2` helper and the pre-existing
`p2p.inventory._sequence_of` write the two conditions as one. The
combined form is the tree's landed precedent, so the three were
collapsed; the review then proved each operand still refuses on its own,
by calling every guard with a value that satisfies only one of them,
which a branch-coverage figure over an `or` cannot show.

`p2p.inventory._sequence_of` hand-rolled the four `Octets` spellings
instead of calling `is_octets`, which is the staleness ISS 1261 exists to
prevent; it is fixed here, in a file the census already touches.

Cleared at `b27c8fc4`.

Collateral filed while working this branch:
[ISS 1420](https://github.com/btclib-org/btclib/issues/1420) — the same
hand-rolled spelling list survives in three other modules and in
`utils.list_from_json_array`, none of which match this census's pattern.

Closes #1405

## Summary by Sourcery

Strengthen public input validation so bare Octets are rejected wherever collections of Octets are required, and expand automated validation coverage for these parameter shapes.

New Features:
- Reject bare Octets values passed where sequences or iterables of Octets are expected across public APIs, with errors identifying the invalid parameter shape.

Bug Fixes:
- Prevent byte-wise misinterpretation of individual Octets in block, hashing, MuSig2, signature, PSBT, witness, and silent-payment operations.
- Replace hand-maintained Octets checks in peer-to-peer inventory validation with the shared utility.

Enhancements:
- Extend input-validation discovery to cover Sequence[Octets] and Iterable[Octets] annotations and automatically exercise matching public functions.

Tests:
- Add regression coverage for bare Octets supplied to sequence-oriented APIs and for both operands of the relevant validation guards.