### PR TITLE
base58.encode takes a memoryview payload, matching bytes and bytearray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3421,6 +3421,18 @@ documented at release-notes length in the first place, and are still in
   before any of them is walked. `tests/integer_policy_test.py`'s census
   gains `derive_from_account_`'s own `branch` and `address_index`.
 
+- **`base58.encode` takes a `memoryview`, as every other `Octets`
+  spelling** (issue #1255). `bytes_from_octets` hands a memoryview back
+  unchanged, and `encode` concatenated it with the checksum on its own
+  left side -- `memoryview + bytes` is not an operation, where `bytes +
+  memoryview` is, the same asymmetry issue #1220 names elsewhere in the
+  library -- so `encode(memoryview(b"..."))` raised a bare `TypeError`
+  rather than returning the same answer a `bytes` or `bytearray` payload
+  gets. The payload is copied to `bytes` at that one concatenation,
+  after it has already been hashed, rather than up front: nothing here
+  is returned to the caller, so the copy costs one allocation and keeps
+  nothing out of sync with anything the caller still holds.
+
 - **`max_index` refuses a bool too, closing the same two helpers'
   remaining gap** (closes #1413). Unlike `branch` and `address_index`
   above, a bool `max_index` was not refused at all: it is a bound the

--- a/src/btclib/base58.py
+++ b/src/btclib/base58.py
@@ -135,7 +135,12 @@ def encode(v: Octets, in_size: int | None = None) -> bytes:
     """Encode a bytes-like object using Base58Check."""
     v = bytes_from_octets(v, in_size)
     h256 = hash256(v)
-    return _b58encode(v + h256[:4])
+    # bytes(v) rather than v: a memoryview has no __add__, so `v + h256[:4]`
+    # raises TypeError once v is the buffer bytes_from_octets hands back
+    # unchanged. The copy is safe here, unlike in bytes_from_octets itself:
+    # v does not survive past this line, so there is nothing of the
+    # caller's for a copy to lose sync with
+    return _b58encode(bytes(v) + h256[:4])
 
 
 def _b58decode_to_int(v: bytes) -> int:

--- a/tests/base58_test.py
+++ b/tests/base58_test.py
@@ -132,6 +132,20 @@ def test_wif() -> None:
     assert key == compressed_key
 
 
+def test_encode_octets_spellings() -> None:
+    """`encode` takes every `Octets` spelling, memoryview included.
+
+    A memoryview has no `__add__`, and `bytes_from_octets` hands one
+    back unchanged: `encode` copies it to `bytes` right at the
+    concatenation `_b58encode`'s payload needs, which is the one place
+    a memoryview payload would otherwise fail (issue #1255).
+    """
+    payload = b"hello world"
+    known_answer = b"3vQB7B6MrGQZaxCuFg4oh"
+    for spelling in (payload, bytearray(payload), memoryview(payload)):
+        assert encode(spelling) == known_answer
+
+
 def test_integers() -> None:
     """Verify the integer codec over each digit and the full alphabet."""
     digits = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"


### PR DESCRIPTION
`base58.encode(memoryview(b"hello world"))` raises `TypeError:
unsupported operand type(s) for +: 'memoryview' and 'bytes'` on the
published release. `bytes_from_octets` hands a buffer back unchanged —
deliberately, since `assert_valid` is a read and must not rewrite the
field it reads — and `encode` then puts that buffer on the left of the
`+` its payload concatenation needs. A `memoryview` has no `__add__` at
all, so the defect is precise to that one spelling: `bytearray + bytes`
answers a `bytearray` and passes.

`encode` copies to `bytes` at the concatenation. The copy is not in
tension with `bytes_from_octets`' no-copy rule: nothing of the caller's
is handed back from here, the value being consumed into the payload and
read once by `hash256` before that.

Every caller one layer up already puts real `bytes` on the *left* of the
`+` — `b58`'s address and WIF builders, `bip32`'s `b58encode` through
`b"".join`, which answers `bytes` whatever its elements are — so the
defect lives in one place and nothing above it needed touching.
`_b58decode` already copies, which is why the decode side was never
affected.

## Scope

This is **one slice** of a campaign, and it deliberately carries no
closing keyword. [The tracking
issue](https://github.com/btclib-org/btclib/issues/1255) proposes giving
`bytes_from_octets` an honest return annotation and reports that doing so
surfaces errors across dozens of files; it asks for the work in slices by
layer, `hashes` and `base58` first, since that is where the `+` operators
are and one of them is public. `base58` is the public one.

`hashes` was held by another branch while this was written and is free
now, so it is the next slice. `bytes_from_octets`' signature and its two
disclosed `type: ignore[return-value]` comments are untouched here: those
go when the campaign ends, not before.

Local review took two rounds. Its finding was that the new test docstring
narrated what the code did before, which the sweep that closed
[ISS 1382](https://github.com/btclib-org/btclib/issues/1382) had just
swept out of this tree — including from a test docstring of exactly this
shape. Restated in the present tense. Cleared at `e806a303`.

## Summary by Sourcery

Fix Base58 encoding of memoryview payloads while preserving existing behavior for other octet representations.

Bug Fixes:
- Allow `base58.encode` to accept `memoryview` payloads consistently with other supported octet types.

Tests:
- Add coverage for `bytes`, `bytearray`, and `memoryview` payloads producing the same Base58Check encoding.