### PR TITLE
README.md's badge row drops the link to the repository (closes btclib-org/.github#381)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -811,6 +811,18 @@ documented at release-notes length in the first place, and are still in
   writes there too, so `docs/_build/` matched neither (issue
   btclib-org/.github#411).
 
+- **`README.md`'s badge row no longer carries the link to the
+  repository.** Section 2 of the organization standard refuses it: the
+  badge renders `btclib-org/btclib` because its own URL spells that
+  string, and the row is an audit, so an item that measures nothing does
+  not belong in it. What that gives up is the reader who meets this file
+  as the long description an index renders or as the `README.md` an
+  unpacked sdist carries, where the repository is not one click away;
+  `pyproject.toml`'s `[project.urls]` `repository` reaches that reader
+  instead, served under `project_urls` by the index and written into the
+  sdist's own `PKG-INFO` as a `Project-URL` line
+  (closes btclib-org/.github#381).
+
 ### Packaging, linting and CI
 
 - **`pyproject.toml`'s ruff configuration selects `["ALL"]`,** matching

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # A Python library for 'bitcoin cryptography'
 
 <!-- The badges are what the reader decides with: the first line says what
-this is and whether it can be used, the second whether it works, the third
-where the code is and where to ask about it. A badge that reports no state
--- "we use ruff", "we use uv" -- reports a choice instead, and those are in
-CONTRIBUTING.md, beside the prose that says how the choice is enforced. One
-badge per line keeps a change to one line and every line inside MD013,
-whose 80 columns bind only where a space follows them.
+this is and whether it can be used, and the second whether it works. A
+badge that reports no state -- "we use ruff", "we use uv" -- reports a
+choice instead, and those are in CONTRIBUTING.md, beside the prose that
+says how the choice is enforced. One badge per line keeps a change to one
+line and every line inside MD013, whose 80 columns bind only where a space
+follows them.
 Scorecard is placed last among the sentinel badges rather than in the
 calendar order the rest follow: section 10 names it the one sentinel whose
 triggers are the action's own rather than the standard's, and it has no
@@ -40,8 +40,6 @@ the stated rule rather than this tree's own reading of a silent one. -->
 [![integration-bitcoind workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/btclib-org/btclib/badge)](https://scorecard.dev/viewer/?uri=github.com/btclib-org/btclib)
 [![documentation build](https://app.readthedocs.org/projects/btclib/badge/?version=latest)](https://btclib.readthedocs.io)
-
-[![GitHub repository: btclib-org/btclib](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib-181717?logo=github)](https://github.com/btclib-org/btclib/)
 
 ---
 


### PR DESCRIPTION
Closes btclib-org/.github#381

The last of the five trees carrying the badge. `btclib-secp256k1`,
`bitcoin-core-rpc`, `btclib-benchmarks` and `portanode` have landed
theirs, so this is the landing that closes the issue.

Section 2 of the organization standard refuses the badge: it renders the
repository's name because the URL says so, and the row is an audit, so
the one item that measures nothing is the one that does not belong in
it. The order of what remains is untouched.

What the badge gave up is a pointer for a reader meeting this
`README.md` away from the forge, and `[project.urls]`'s `repository` is
where it already lives. Checked in the artefact rather than in the
manifest: `Project-URL: repository, https://github.com/btclib-org/btclib`
is on line 11 of `PKG-INFO` in the published 2026.8.21 sdist, and the
same key answers from the PyPI JSON.

**The head comment is corrected in the same diff**, because the deletion
falsifies it: it read "the third where the code is and where to ask
about it", and the third line is the badge.

**It deliberately gains no claim about the sibling trees.**
`btclib-secp256k1` and `bitcoin-core-rpc` each wrote "btclib and X carry
the same two lines" into their own copies. Repeating that here would keep
one cross-tree fact true in three places, against section 9's *One fact
in one place*, and section 2 is the one place that says what a row
carries. Nothing here now depends on another repository's current state.

## What closing this does not settle

ISS 381's *Done when* is a conjunction, and only one half of it is
answered here. "The link removed and the order otherwise unchanged" is
done in all five trees. "Each tree's row is the one section 2 states" is
**not**, and stopped being true after the issue was written: the
`scorecard` calendar row landed on 2026-08-25, which moves where section
2's order puts that badge — between `integration-hwi` and `os-macos`,
where this tree still has it after `integration-bitcoind`.

Correcting that is a row-order change, which this issue's *Done when*
excludes in as many words, so it is filed rather than folded: #1424,
which names this tree and `portanode` as carrying the same paragraph. A
reader of the closed issue should not take it as saying the five rows are
section 2's rows.

#1423 is the other filing, and stays a filing: `CONTRIBUTING.md:209`
carries the same badge in its toolchain block. That block is the
opposite rubric —
its badges "report no state", where "the README keeps the ones that can
turn red" — so section 2's reason does not reach it, and the three trees
disagree three ways.

## Gates

| gate | exit |
| --- | --- |
| `uv run pre-commit run --all-files` | 0 |
| `uv run pytest` | 0 — 30748 passed, 11 skipped, coverage 100.00% |
| `uv run --locked --no-default-groups --group docs sphinx-build -n -W --keep-going -b html docs/source docs/build/html` | 0 |
| `grep -rn 'href="#\./' docs/build/html` | 1 — nothing found, which is the pass |
| `uv run pre-commit run --all-files`, re-run with `docs/build/html` present | 0, `check sdist` passed |

All re-run after a rebase onto `9b230493`, which `strict: true` on this
branch required: `main` moved during review, and a run on the previous
sha is not a run on this one. The branch's own patch survived the replay
unchanged — the two patches differ in one `index` blob-hash line, for a
file the base moved, and `README.md`'s blob is the same object at both
shas.
