### PR TITLE
A refusal comparator joins no_bindings_test.py's child (closes #1419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3591,6 +3591,24 @@ documented at release-notes length in the first place, and are still in
   reporting the combination at `--fail-under=100` with the pragma
   removed, which still fails on this line.
 
+- **`tests/no_bindings_test.py` gains a second child, comparing what
+  each arm refuses rather than only what both compute** (closes #1419).
+  `tests/py_arm_authority_test.py` counts which third-party vectors
+  reach each arm and never compares them, and the file's existing
+  child compares only what both arms answer successfully, so neither
+  would have caught issue #1227's hybrid taproot internal key --
+  accepted on one arm and refused on the other, decided by whether the
+  bindings are installed. `test_the_two_arms_refuse_the_same_inputs`
+  runs `_REFUSALS`, a table of inputs the tree already knows once
+  diverged this way, through a dedicated child, and holds the two arms
+  to one exception class always and to one message where a shared
+  precondition raises before either arm has answered -- `dsa.py`'s own
+  rule, that the discrimination is the bindings' but the hierarchy is
+  btclib's, is what decides which. A subprocess launch and a handful of
+  calls need no coverage sweep, so it runs in the ordinary suite rather
+  than beside `py-arm-authority.yml`'s weekly re-derivation, which pays
+  for one.
+
 ### Curves, signatures and keys
 
 - **`indexes_from_der_path` reads a `bytearray` or a `memoryview` as

--- a/tests/no_bindings_test.py
+++ b/tests/no_bindings_test.py
@@ -26,6 +26,16 @@ platform the matrix runs, rather than only where a second install exists.
 What the child returns is compared with what this process computes with
 the bindings in reach: agreement between the two implementations is the
 property, and a child that merely fails to crash proves nothing about it.
+
+`test_the_two_arms_refuse_the_same_inputs` asks the same question of a
+refusal: `tests/py_arm_authority_test.py` counts which vectors reach
+each arm and never compares them, and the test above compares only what
+both arms compute successfully, so neither would have caught issue
+#1227 -- a hybrid taproot internal key answered on one arm and raised
+on the other, one input and two answers decided by `pip install`
+rather than by btclib. A second child, built the same way, runs a
+table of inputs the tree already knows once diverged this way and
+compares what each arm refuses them with.
 """
 
 from __future__ import annotations
@@ -34,6 +44,7 @@ import json
 import os
 import subprocess
 import sys
+from collections.abc import Callable
 from typing import Any
 
 import pytest
@@ -48,7 +59,8 @@ from btclib.curves import (
     set_libsecp256k1_serving,
 )
 from btclib.ecc import dsa, ssa
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibException, BTClibValueError
+from btclib.script.taproot import output_pubkey
 from tests import needs_bindings
 
 # the seed, key and message the child works from: constants, because the
@@ -257,3 +269,159 @@ def test_the_switch_is_read_back_by_the_reader() -> None:
         assert is_libsecp256k1_serving() is True
     finally:
         set_libsecp256k1_serving(serving=ENABLED)
+
+
+# the point taproot's own tests already build from -- (0xC0FFEE)`mult`
+# would do as well, and this is any point, not a fixture the taproot
+# suite shares
+_Q = mult(_PRV_KEY)
+_X = _Q[0].to_bytes(32, "big")
+_Y = _Q[1].to_bytes(32, "big")
+
+# name -> (the call, whether the two arms are held to its wording too).
+# Both taproot entries carry `PubKeyData(..., check_validity=False)`'s
+# unproven octets to whichever arm answers next -- issue #887 -- so a
+# refusal one arm makes and the other does not is this table's reason
+# to exist, not an edge case of it.
+#
+# "bool private key" and "hybrid internal key" are held to the message
+# as well as the class: both refusals run in a shared precondition
+# above the arm split -- `int_from_integer` for the first (issue
+# #1206), `_output_pubkey_and_internal_key`'s own hybrid check for the
+# second (issue #1227) -- so the two arms never see the input until
+# after the one btclib sentence has already fired.
+#
+# "bad-prefix internal key" is held to the class alone. `0x05 || x` is a
+# SEC length with no SEC prefix, the fault of neither coordinate, and
+# `_sec_from_key` leaves it unproven for `_tweaked_pubkey`'s own parse
+# to refuse (issue #887): the bindings arm learns of it from
+# `tweak_add`'s bare `ValueError`, the Python one from `PubKeyData.
+# point`'s lift, and neither call can say what the other would have
+# said. `tests/script/taproot_test.py`'s own
+# `test_the_tweak_names_no_half_of_a_sec_it_cannot_blame` holds this
+# input to the class alone for the same reason (issues #1214, #1218);
+# `dsa.py`'s own rule is that the discrimination is the bindings' but
+# the hierarchy has to be btclib's, and this is the general form of
+# that rule applied here rather than an exception to it.
+_REFUSALS: dict[str, tuple[Callable[[], object], bool]] = {
+    "bool private key": (lambda: dsa.sign(_MSG_HASH, True), True),
+    "hybrid internal key": (
+        lambda: output_pubkey(bytes([0x06]) + _X + _Y),
+        True,
+    ),
+    "bad-prefix internal key": (lambda: output_pubkey(bytes([0x05]) + _X), False),
+}
+
+# a second child, built the same way as `_CHILD` above: the finder
+# first, then a table of the same inputs `_REFUSALS` names, run against
+# whatever each raises rather than what each returns. `installed` and
+# `dispatch` are asked again here rather than trusted from the first
+# child's own answer, a separate `-c` invocation being a separate
+# process this test has not otherwise looked at
+_REFUSAL_CHILD = """
+import json, sys
+
+
+class RefuseTheBindings:
+    def find_spec(self, name, path=None, target=None):
+        if name == "btclib_secp256k1" or name.startswith("btclib_secp256k1."):
+            raise ImportError("btclib_secp256k1 is out of reach")
+        return None
+
+
+sys.meta_path.insert(0, RefuseTheBindings())
+
+import btclib
+from btclib._libsecp256k1 import INSTALLED
+from btclib.curves import curve
+from btclib.ecc import dsa
+from btclib.exceptions import BTClibException
+from btclib.script.taproot import output_pubkey
+
+assert "btclib_secp256k1" not in sys.modules, "the finder let the bindings in"
+
+
+def refused(call):
+    try:
+        call()
+    except BTClibException as e:
+        return [type(e).__name__, str(e)]
+    return None  # a call this table names but does not refuse is the finding
+
+
+print(json.dumps({{
+    "installed": INSTALLED,
+    "dispatch": curve._libsecp256k1_available,
+    "bool private key": refused(lambda: dsa.sign({msg_hash!r}, True)),
+    "hybrid internal key": refused(
+        lambda: output_pubkey(bytes.fromhex({hybrid_sec!r}))
+    ),
+    "bad-prefix internal key": refused(
+        lambda: output_pubkey(bytes.fromhex({bad_prefix_sec!r}))
+    ),
+}}))
+"""
+
+
+def _refusal_child_answers() -> dict[str, Any]:
+    """Run the refusal child and return what it printed, or fail on stderr."""
+    source = _REFUSAL_CHILD.format(
+        msg_hash=_MSG_HASH,
+        hybrid_sec=(bytes([0x06]) + _X + _Y).hex(),
+        bad_prefix_sec=(bytes([0x05]) + _X).hex(),
+    )
+    completed = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", source],
+        capture_output=True,
+        encoding="utf-8",
+        check=False,
+        # the same ceiling as `_child_answers`, and the same reason: a
+        # hung child fails as this test rather than as a slow suite
+        timeout=120,
+    )
+    assert completed.returncode == 0, completed.stderr
+    answers: dict[str, Any] = json.loads(completed.stdout)
+    return answers
+
+
+def _locally_refused(call: Callable[[], object]) -> tuple[str, str]:
+    """Run call with the bindings in reach and return what it raised."""
+    with pytest.raises(BTClibException) as excinfo:
+        call()
+    return type(excinfo.value).__name__, str(excinfo.value)
+
+
+@needs_bindings
+def test_the_two_arms_refuse_the_same_inputs() -> None:
+    """A refusal is held to one class everywhere, one wording where it can be.
+
+    `tests/py_arm_authority_test.py` counts which vectors of somebody
+    else's making reach each arm and never compares them, and
+    `test_btclib_answers_with_the_bindings_out_of_reach` above compares
+    only what both arms compute successfully -- so neither would have
+    caught issue #1227: a hybrid taproot internal key answered on the
+    bindings arm and raised on the Python one, one input and two
+    answers decided by `pip install` rather than by btclib. This asks
+    the question those two do not: given an input, do the two arms
+    refuse it the same way.
+
+    `_REFUSALS` names the inputs and, per input, whether the two arms
+    are held to its wording -- the comment above the table says which
+    and why. Every entry is refused here, with the bindings in reach,
+    before the child runs, so a table entry that stopped refusing would
+    fail this half rather than silently comparing two successes.
+    """
+    local = {name: _locally_refused(call) for name, (call, _) in _REFUSALS.items()}
+
+    answers = _refusal_child_answers()
+    assert answers["installed"] is False
+    assert answers["dispatch"] is False
+
+    for name, (_, compare_message) in _REFUSALS.items():
+        got = answers[name]
+        assert got is not None, f"{name}: the no-bindings arm did not refuse"
+        child_cls, child_msg = got
+        local_cls, local_msg = local[name]
+        assert child_cls == local_cls, name
+        if compare_message:
+            assert child_msg == local_msg, name


### PR DESCRIPTION
Closes #1419

`tests/py_arm_authority_test.py` counts which third-party vectors reach
each arm and never compares them, and `no_bindings_test.py`'s existing
child compares only what both arms compute *successfully*. So neither
would have caught the hybrid taproot internal key of
[ISS 1227](https://github.com/btclib-org/btclib/issues/1227): accepted
on one arm and refused on the other, with which answer a caller gets
decided by whether the bindings are installed rather than by btclib.

`test_the_two_arms_refuse_the_same_inputs` runs `_REFUSALS` — a table of
inputs the tree already knows once diverged this way — through a second,
dedicated child.

| entry | held to | why |
|---|---|---|
| bool private key ([ISS 1206](https://github.com/btclib-org/btclib/issues/1206)) | class **and** message | the refusal fires in a shared precondition above the arm split |
| hybrid internal key ([ISS 1227](https://github.com/btclib-org/btclib/issues/1227)) | class **and** message | same shape, landed as `54ff0356` |
| bad-prefix internal key ([ISS 1214](https://github.com/btclib-org/btclib/issues/1214) / [ISS 1218](https://github.com/btclib-org/btclib/issues/1218)) | class alone | the refusing call cannot attribute the fault, so comparing the message would assert something the test cannot know |

The third row follows `tests/script/taproot_test.py`'s own
`test_the_tweak_names_no_half_of_a_sec_it_cannot_blame` and the `dsa.py`
rule beside it: the discrimination is the bindings', the hierarchy is
btclib's.

## Where it runs, and why not beside the weekly job

Measured before deciding rather than assumed: a subprocess launch and a
handful of calls is nothing like `py_arm_authority_test.py`'s coverage
sweep. `test_the_two_arms_refuse_the_same_inputs` costs `0.19s`, the same
order as its sibling child, so it belongs in the ordinary suite rather
than beside the weekly re-derivation.

## Gates

All three at exit 0 on `938c3403`:

- `uv run pre-commit run --all-files`
- `uv run pytest` — `30749 passed, 11 skipped`, coverage `100.00%`
- `uv run --locked --no-default-groups --group docs sphinx-build -n -W --keep-going -b html`, with `grep -rn 'href="#\./'` finding nothing

Reviewed locally at fresh context before opening, over two rounds. Round
one found the `CHANGELOG.md` entry sitting under
`### Curves, signatures and keys` rather than `### Tests` — a `merge=union`
join places lines where the driver puts them, and neither `git diff` nor
`git range-diff` shows it. Placement is now read from the object at each
sha rather than from a diff, and verified again against the predicted
merge with the new `main`.

## Summary by Sourcery

Ensure both cryptographic implementation arms reject known invalid inputs consistently, regardless of whether optional bindings are installed.

Bug Fixes:
- Add coverage ensuring the Python and bindings-backed implementations refuse the same invalid inputs, preventing environment-dependent acceptance or rejection.

Enhancements:
- Extend the no-bindings test with a dedicated subprocess comparison for exception classes and, where attributable to shared validation, messages across both implementation arms.

Tests:
- Add refusal consistency checks for invalid private keys and malformed Taproot internal keys.