### PR TITLE
p2p.address, p2p.addrv2, script.script and utils.list_from_json_array refuse a bare Octets through is_octets rather than a hand-listed tuple (closes #1420)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3393,6 +3393,17 @@ documented at release-notes length in the first place, and are still in
   function taking either shape written from here on is walked the same
   way without anybody remembering to add it by hand.
 
+- **`p2p.address.Addr`, `p2p.addrv2.AddrV2`, `script.script.serialize`
+  and `utils.list_from_json_array` refuse a bare `Octets` the same way,
+  through `utils.is_octets` rather than each naming the four spellings
+  by hand** (closes #1420). Each guard was correct at every spelling
+  `Octets` held when it was written -- unlike `issue #1261`'s two, none
+  of the four had gone stale yet -- but the tuple is the same staleness
+  the other guards already moved off of, `p2p.inventory._sequence_of`
+  among them. `list_from_json_array` keeps `Mapping` refused beside
+  `is_octets`'s answer, a `Mapping` being wrong for a reason of its own
+  and not part of what `is_octets` asks.
+
 - **`ssa.challenge_` and `dsa.recover_pub_key_` refuse a bool, closing
   the trailing-underscore layer's own gap in issue #1206's policy**
   (closes #1248). Both take a bare `int` rather than an `Integer`, so

--- a/src/btclib/p2p/address.py
+++ b/src/btclib/p2p/address.py
@@ -67,6 +67,7 @@ from btclib.utils import (
     assert_no_trailing,
     bytesio_from_binarydata,
     is_integer,
+    is_octets,
     read_exactly,
 )
 
@@ -430,10 +431,10 @@ class Addr(Payload):
         # a str and a bytes are Sequences, and each of their elements is
         # what a `TimestampedNetworkAddress` is not: asked whole here, so
         # that a caller who passed one gets a complaint about the
-        # argument rather than about its first character
-        if isinstance(addresses, (str, bytes, bytearray, memoryview)) or not isinstance(
-            addresses, Sequence
-        ):
+        # argument rather than about its first character. `is_octets` is
+        # the four spellings named once, so a spelling `Octets` gains
+        # later is refused here too (issue #1420)
+        if is_octets(addresses) or not isinstance(addresses, Sequence):
             err_msg = f"invalid addresses type: {type(addresses).__name__}"
             raise BTClibTypeError(err_msg)
         object.__setattr__(self, "addresses", tuple(addresses))

--- a/src/btclib/p2p/addrv2.py
+++ b/src/btclib/p2p/addrv2.py
@@ -127,6 +127,7 @@ from btclib.utils import (
     bytes_from_octets,
     bytesio_from_binarydata,
     is_integer,
+    is_octets,
     read_exactly,
 )
 
@@ -427,10 +428,10 @@ class AddrV2(Payload):
         # a str and a bytes are Sequences, and each of their elements is
         # what a `NetworkAddressV2` is not: asked whole here, so that a
         # caller who passed one gets a complaint about the argument
-        # rather than about its first character
-        if isinstance(addresses, (str, bytes, bytearray, memoryview)) or not isinstance(
-            addresses, Sequence
-        ):
+        # rather than about its first character. `is_octets` is the four
+        # spellings named once, so a spelling `Octets` gains later is
+        # refused here too (issue #1420)
+        if is_octets(addresses) or not isinstance(addresses, Sequence):
             err_msg = f"invalid addresses type: {type(addresses).__name__}"
             raise BTClibTypeError(err_msg)
         object.__setattr__(self, "addresses", tuple(addresses))

--- a/src/btclib/script/script.py
+++ b/src/btclib/script/script.py
@@ -40,6 +40,7 @@ from btclib.utils import (
     bytesio_from_binarydata,
     encode_num,
     fields_from_json_object,
+    is_octets,
 )
 
 __all__ = [
@@ -471,9 +472,9 @@ def serialize(script: Sequence[Command]) -> bytes:
     is not a sequence at all was "not iterable" from underneath the
     library.
     """
-    if isinstance(script, (str, bytes, bytearray, memoryview)) or not isinstance(
-        script, Sequence
-    ):
+    # `is_octets` is the four spellings named once, so a spelling
+    # `Octets` gains later is refused here too (issue #1420)
+    if is_octets(script) or not isinstance(script, Sequence):
         err_msg = f"invalid script commands type: {type(script).__name__}"
         raise BTClibTypeError(err_msg)
 

--- a/src/btclib/utils.py
+++ b/src/btclib/utils.py
@@ -418,11 +418,17 @@ def list_from_json_array(value: Any, what: str) -> list[Any]:
     iterable" from underneath the library, and the two iterables that are
     not arrays are worse than that -- a `str` is a list of its characters
     and a `Mapping` a list of its keys, so each element is refused for
-    what it is not rather than the whole for what it is.
+    what it is not rather than the whole for what it is. `is_octets` is
+    the four `Octets` spellings named once rather than listed here, so a
+    spelling `Octets` gains later is refused the same way (issue #1420);
+    `Mapping` is refused beside it for a reason of its own and stays a
+    named check.
     """
-    if isinstance(
-        value, (str, bytes, bytearray, memoryview, Mapping)
-    ) or not isinstance(value, Iterable):
+    if (
+        is_octets(value)
+        or isinstance(value, Mapping)
+        or not isinstance(value, Iterable)
+    ):
         err_msg = f"invalid {what} type: {type(value).__name__}"
         raise BTClibTypeError(err_msg)
     return list(value)


### PR DESCRIPTION
Closes #1420

Three `Sequence[X]` shape guards and one `Iterable` guard hand-listed the
four `Octets` spellings instead of sharing `utils.is_octets`, the same
pattern [ISS 1405](https://github.com/btclib-org/btclib/issues/1405)
fixed for `p2p.inventory._sequence_of` (landed `464edb08`).

**The defect is staleness, not today's correctness.** `Octets` is exactly
`str | bytes | bytearray | memoryview`, so all four sites were right as
written. A spelling `Octets` gains later is refused at `is_octets`' one
definition and not at whichever site remembered to list it.

| site | guard |
|---|---|
| `p2p/address.py` — `Addr.__init__` | `is_octets(addresses) or not isinstance(addresses, Sequence)` |
| `p2p/addrv2.py` — `AddrV2.__init__` | same shape |
| `script/script.py` — `serialize` | same shape |
| `utils.py` — `list_from_json_array` | `is_octets(value) or isinstance(value, Mapping) or not isinstance(value, Iterable)` |

The fourth is deliberately narrower. `Mapping` is in that guard for its
own reason — a `str` and a `Mapping` are both wrong there for a
different reason than a bare `Octets` is — so it stays a named check of
its own, and the outer test is `Iterable`, not `Sequence`.

## Equivalence, run rather than read

Reviewed locally at fresh context before opening. The review compared the
old expression against the new over a matrix of values — the four
spellings, subclasses of `str`/`bytes`/`bytearray`, a `str`-based
`IntEnum`, `True`, `False`, `0`, `1`, `1.5`, `None`, list, tuple, dict,
set, iterator, `range`, a `Sequence` subclass, a bare `__iter__` object,
a `memoryview`, `object()` — and found no difference at any site. The
control (`bytes | str` against the same tuple) reported four differences,
so the comparison can see one.

Substituting `Sequence` for `Iterable` at the fourth site changes the
answer for three of those values, which is what makes it a separate
guard rather than the same one written longer.

## Scope

`bip32/bip32.py` and `ecc/ssa.py` carry the lookalike shape and are
untouched: both are the *positive* "is this one `Octets`" dispatch rather
than a `Sequence[X]` refusal, and `bip32.py`'s argument is annotated
`String` rather than `Octets` — the same union under a different name, so
`is_octets` would be the wrong name there.

## Gates

All three at exit 0 on `34ee848b`:

- `uv run pre-commit run --all-files`, standalone and again as the commit
  hook, mypy strict included
- `uv run pytest` — `30749 passed, 11 skipped`, coverage `100.00%`, no
  `pragma` or `noqa` anywhere in the diff
- `uv run --locked --no-default-groups --group docs sphinx-build -n -W
  --keep-going -b html`, with the `href="#\./"` grep at exit 1 proved
  live against a planted-and-removed control

## Summary by Sourcery

Use the shared `is_octets` predicate to keep sequence and iterable input validation consistent and maintainable.

Enhancements:
- Centralize bare `Octets` detection across address, script, and JSON-array validation guards by using `utils.is_octets`.
- Preserve the distinct `Mapping` rejection in JSON-array validation while retaining the existing input behavior.

Chores:
- Document the input-validation consistency improvement in the changelog.