### PR TITLE
hashes.ripemd160's pure-Python fallback and merkle_root_from_branch take a memoryview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3491,6 +3491,35 @@ documented at release-notes length in the first place, and are still in
   `test_the_tweak_names_no_half_of_a_sec_it_cannot_blame` already uses
   for the sec octets an arm's own parse refuses.
 
+- **`hashes.ripemd160`'s pure-Python fallback and `merkle_root_from_branch`
+  take a `memoryview`, as every other `Octets` spelling** (issue #1255).
+  Both concatenate a buffer `bytes_from_octets` hands back unchanged, on
+  the buffer's own left side: `_ripemd160.ripemd160` pads its argument
+  before hashing, and `merkle_root_from_branch` folds a running `root`
+  and each level's `sibling` into the pair that level hashes, one of the
+  two landing on the left depending on the corresponding bit of `index`.
+  A memoryview has no `__add__` on either side of `+`, so
+  `ripemd160(memoryview(...))` on an interpreter whose hashlib has no
+  RIPEMD-160 raised a bare `TypeError` unconditionally, and
+  `merkle_root_from_branch(memoryview(...), ...)` raised the same error
+  at whichever positions put a memoryview `sibling` or the memoryview
+  `leaf` on that left side. An empty `branch` also returned `leaf`
+  untouched, so a memoryview leaf came back as one despite the
+  function's own `-> bytes`.
+
+  Both copy the buffer to `bytes` at the point of concatenation, entirely
+  inside `hashes.py`: `_ripemd160.py` stays the vendored file its own
+  docstring says it is, and `hashes.ripemd160` converts before the call
+  rather than the vendored function after it. Neither `root` nor
+  `sibling` is returned to whoever passed `leaf` or `branch` in -- each
+  is folded into a new value and rehashed -- so the no-copy rule
+  `bytes_from_octets` keeps for a caller's own buffer does not reach
+  either site. `sha1`, `sha256`, `hash160`, `hash256`, `reduce_to_hlen`,
+  `siphash` and `magic_message` already take every spelling:
+  `hashlib`'s digest constructors and `update` accept any buffer, and
+  `magic_message`'s own concatenation puts its buffer on the right of a
+  `bytes` value, where `bytes + memoryview` works.
+
 ### Tests
 
 - **The tests exercising the pure-Python arm are named `test_the_py_arm_...`,

--- a/src/btclib/hashes.py
+++ b/src/btclib/hashes.py
@@ -89,7 +89,14 @@ def ripemd160(octets: Octets) -> bytes:
     octets = bytes_from_octets(octets)
     if _RIPEMD160_IN_HASHLIB:
         return hashlib.new("ripemd160", octets).digest()
-    return pure_python_ripemd160(octets)
+    # bytes(octets) rather than octets: pure_python_ripemd160 concatenates
+    # its argument on the argument's own left side, which a memoryview has
+    # no __add__ for; hashlib.new above needs no such copy, every digest
+    # constructor taking any buffer directly. octets does not survive
+    # past this call, so the copy costs nothing borrowed from the caller,
+    # and _ripemd160.py itself stays the vendored file it documents
+    # itself as being
+    return pure_python_ripemd160(bytes(octets))
 
 
 def sha1(octets: Octets) -> bytes:
@@ -399,10 +406,19 @@ def merkle_root_from_branch(
     if index < 0:
         raise BTClibValueError(f"negative leaf index: {index}")
 
-    root = bytes_from_octets(leaf, 32)
+    # bytes(...) rather than the buffer bytes_from_octets hands back: root
+    # and sibling are this function's own local values, folded into pair
+    # and rehashed rather than read back to whoever passed leaf or branch
+    # in, so the no-copy rule bytes_from_octets keeps for its own caller's
+    # buffer does not reach here. A memoryview reaching `sibling + root`
+    # or `root + sibling` below fails on whichever side it is the left
+    # operand of, a memoryview having no __add__, and a memoryview leaf
+    # would otherwise be this function's own return value, unbroken by an
+    # empty branch, despite the -> bytes above
+    root = bytes(bytes_from_octets(leaf, 32))
     for sibling_ in branch:
         # a branch item that is not a hash cannot be a sibling
-        sibling = bytes_from_octets(sibling_, 32)
+        sibling = bytes(bytes_from_octets(sibling_, 32))
         if index % 2:
             # the running hash is a right child, and a left sibling equal
             # to it is the CVE-2012-2459 duplication: a shorter list has

--- a/tests/hashes_test.py
+++ b/tests/hashes_test.py
@@ -19,6 +19,7 @@ from btclib.hashes import (
     merkle_root,
     merkle_root_and_mutated,
     merkle_root_and_mutated_from_hashes,
+    merkle_root_from_branch,
     ripemd160,
 )
 from tests.to_key_test import (
@@ -47,6 +48,12 @@ def test_ripemd160_wherever_hashlib_has_none(monkeypatch: pytest.MonkeyPatch) ->
     assert ripemd160(octets) == expected
     # and through the caller that every address goes through
     assert hash160(octets) == ripemd160(sha256(octets).digest())
+
+    # pure_python_ripemd160 concatenates its argument on the argument's
+    # own left side, which a memoryview has no __add__ for; a bytearray
+    # already works, bytearray + bytes being an operation
+    assert ripemd160(memoryview(octets)) == expected
+    assert ripemd160(bytearray(octets)) == expected
 
 
 def test_hashlib_ripemd160_probe(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -151,6 +158,37 @@ def test_merkle_root_from_hashes() -> None:
         b"\x00" * 32,
         False,
     )
+
+
+@pytest.mark.parametrize("index", [0, 1, 2, 3])
+def test_merkle_root_from_branch_octets_spellings(index: int) -> None:
+    """Every `Octets` spelling of leaf and branch reaches the same root.
+
+    `root` and `sibling` land on either side of `+` depending on which
+    bit of `index` is set at each step, and a memoryview has no
+    `__add__` on either side of it. Which side a branch element lands
+    on is not known until `index` has been halved down to it, so the
+    implementation copies every element to `bytes` unconditionally
+    rather than only the ones a memoryview would otherwise fail on.
+    """
+    leaf = bytes([0x11]) * 32
+    siblings = [bytes([0x22]) * 32, bytes([0x33]) * 32]
+    expected = merkle_root_from_branch(leaf, siblings, index, hash256)
+
+    for spell in (bytes, lambda b: b.hex(), bytearray, memoryview):
+        root = merkle_root_from_branch(
+            spell(leaf), [spell(s) for s in siblings], index, hash256
+        )
+        assert root == expected
+        assert isinstance(root, bytes)
+
+
+def test_merkle_root_from_branch_empty_branch_is_bytes() -> None:
+    """An empty branch answers the leaf, in this function's own bytes."""
+    leaf = bytes([0x11]) * 32
+    root = merkle_root_from_branch(memoryview(leaf), [], 0, hash256)
+    assert root == leaf
+    assert isinstance(root, bytes)
 
 
 def test_merkle_root_empty() -> None:


### PR DESCRIPTION
One slice of [ISS 1255](https://github.com/btclib-org/btclib/issues/1255),
which stays open: `bytes_from_octets` is annotated `-> bytes` and returns
the buffer it was handed, so a `memoryview` argument survives into code
that assumes real `bytes`. The previous slice was
[PR 1426](https://github.com/btclib-org/btclib/pull/1426), `base58.encode`.

Two reachable defects in `hashes.py`, both `TypeError` today:

- **`ripemd160`'s pure-Python arm.** `pure_python_ripemd160` concatenates
  its argument on the argument's own left side, which a `memoryview` has
  no `__add__` for. The fix converts in `hashes.py` rather than in
  `_ripemd160.py`: that file is vendored from `bitcoin/bitcoin` and its
  own docstring enumerates the deltas it carries from upstream, every one
  of them a gate of this repository and none of them arithmetic. A fix
  inside it would be one more, and not a gate.
- **`merkle_root_from_branch`.** A `memoryview` element landing on the
  left of the fold raises; which side a given element lands on is not
  known until `index` has been halved down to it, so the implementation
  copies unconditionally. Separately, on an empty branch the function
  returned a `memoryview` from a signature promising `bytes`.

## Measured, not asserted

The pre-fix behaviour was reproduced by checking the committed test file
out against a `git archive` of the pre-fix tree: **6 failed, 12 passed**
there, **18 passed** here. The four `Octets` spellings were driven cell
by cell at every index —

| | 0 | 1 | 2 | 3 |
|---|---|---|---|---|
| `bytes` | ok | ok | ok | ok |
| `str` (`.hex()`) | ok | ok | ok | ok |
| `bytearray` | ok | ok | ok | ok |
| `memoryview` | **TypeError** | **TypeError** | **TypeError** | **TypeError** |

— pre-fix; every cell passes here, and every return is `bytes`.

**The slice is complete for this file, by the issue's own instrument.**
Giving `bytes_from_octets` the honest `-> bytes | bytearray | memoryview`
and removing both disclosed ignores, over `src/btclib tests`:
`src/btclib/hashes.py` reports five errors at the parent — lines 92, 417,
419, 421, 432 — and none here, with the parent's five as the positive
control for the filter.

`magic_message` was measured and needs nothing: its buffer sits on the
*right* of a `bytes` value, where `bytes + memoryview` works. The
`Sequence[bytes]` merkle family is outside the blast radius, every caller
building from `.serialize()` or a `.digest()`.

## Scope

`bytes_from_octets`' signature and its two disclosed
`# type: ignore[return-value]` are untouched; they close only when the
whole campaign does. `_ripemd160.py` is untouched. `block/merkle_proof.py`
has its own separate defect, which this fix does **not** resolve, filed as
[ISS 1429](https://github.com/btclib-org/btclib/issues/1429); a second
finding is [ISS 1430](https://github.com/btclib-org/btclib/issues/1430).

## Gates

All three at exit 0: `pre-commit run --all-files`; `pytest` at
`30754 passed, 11 skipped`, coverage `100.00%`; `sphinx-build -n -W
--keep-going`, with the `href="#\./"` grep finding nothing against a
6626-hit positive control.

Reviewed locally at fresh context over two rounds before opening.

## Summary by Sourcery

Support memoryview inputs consistently in RIPEMD-160 fallback hashing and merkle root branch calculations.

Bug Fixes:
- Make the pure-Python RIPEMD-160 fallback accept memoryview inputs.
- Ensure merkle root calculation accepts all Octets forms, including memoryview, and returns bytes for empty branches.

Tests:
- Add coverage for memoryview and other Octets spellings in RIPEMD-160 and merkle branch calculations, including empty-branch return types.