### PR TITLE
README.md's Scorecard badge sits in the sentinels' calendar order (closes #1424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -823,6 +823,14 @@ documented at release-notes length in the first place, and are still in
   sdist's own `PKG-INFO` as a `Project-URL` line
   (closes btclib-org/.github#381).
 
+- **`README.md`'s OpenSSF Scorecard badge is in the sentinel badges'
+  calendar order with the rest.** Section 2 of the organization standard
+  takes that order from section 10's day/hour table, and the table gives
+  `scorecard` a row like every other sentinel. The exception section 10
+  states for this sentinel reaches its triggers, which are
+  `ossf/scorecard-action`'s own rather than the standard's, and not its
+  place in the calendar (closes #1424).
+
 ### Packaging, linting and CI
 
 - **`pyproject.toml`'s ruff configuration selects `["ALL"]`,** matching

--- a/README.md
+++ b/README.md
@@ -7,12 +7,10 @@ choice instead, and those are in CONTRIBUTING.md, beside the prose that
 says how the choice is enforced. One badge per line keeps a change to one
 line and every line inside MD013, whose 80 columns bind only where a space
 follows them.
-Scorecard is placed last among the sentinel badges rather than in the
-calendar order the rest follow: section 10 names it the one sentinel whose
-triggers are the action's own rather than the standard's, and it has no
-row in section 10's day/hour table yet -- btclib-org/.github#363 proposes
-one, and btclib-org/.github#358 is where this placement is asked to become
-the stated rule rather than this tree's own reading of a silent one. -->
+The OpenSSF Scorecard badge sits in the sentinels' calendar order like
+every other: section 10 gives scorecard a day/hour row, and the
+exception that section states for it -- its triggers are the action's
+own -- is to the trigger rule rather than to the calendar. -->
 [![PyPI version](https://img.shields.io/pypi/v/btclib.svg?logo=pypi)](https://pypi.python.org/pypi/btclib/)
 [![downloads](https://static.pepy.tech/badge/btclib)](https://pepy.tech/project/btclib)
 [![development status](https://img.shields.io/pypi/status/btclib.svg)](https://pypi.python.org/pypi/btclib/)
@@ -34,11 +32,11 @@ the stated rule rather than this tree's own reading of a silent one. -->
 [![pypi-install workflow status](https://github.com/btclib-org/btclib/actions/workflows/pypi-install.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/pypi-install.yml)
 [![os-ubuntu workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-ubuntu.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/os-ubuntu.yml)
 [![integration-hwi workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-hwi.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/integration-hwi.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/btclib-org/btclib/badge)](https://scorecard.dev/viewer/?uri=github.com/btclib-org/btclib)
 [![os-macos workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-macos.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/os-macos.yml)
 [![os-windows workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-windows.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/os-windows.yml)
 [![mutation workflow status](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml)
 [![integration-bitcoind workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/btclib-org/btclib/badge)](https://scorecard.dev/viewer/?uri=github.com/btclib-org/btclib)
 [![documentation build](https://app.readthedocs.org/projects/btclib/badge/?version=latest)](https://btclib.readthedocs.io)
 
 ---


### PR DESCRIPTION
Closes #1424

`README.md`'s badge-row comment justified putting the OpenSSF Scorecard
badge out of calendar order from three claims that no longer hold:
that section 10 has no day/hour row for `scorecard`, that
`btclib-org/.github#363` proposes one, and that `btclib-org/.github#358`
is where the placement is asked to become a stated rule. Section 10 now
carries `| scorecard | Saturday | 03 |`, and both issues are closed.

Section 2 orders the sentinels by that calendar, so the badge moves to
where the calendar puts it — between `integration-hwi` (Friday 05) and
`os-macos` (Saturday 04).

## The ordering is derived, not asserted

The day/hour table was parsed into `(weekday, hour)` with Monday first
and every sentinel badge in the row sorted by it. **The check
discriminates**: it answers `False` on the old order and `True` on the
new, so it is not a check that passes on anything. The other workflow
badges were already in order; only Scorecard moved. Read the Docs stays
last, per section 2.

`.github/workflows/scorecard.yml` carries `cron: "4 3 * * 6"` — Saturday,
hour 03, minute 04 — so the tree already answers the row it is being
ordered by.

The standard moved three times while this was in flight. That is
immaterial and was measured rather than assumed: the digest of the
table rows is identical at each sha, taken by two parties.

## The comment is rewritten rather than deleted

With the row present there is no deviation left to justify, so deleting
the paragraph was on the table. It stays because a real negative result
survives: `scorecard.yml`'s own header and section 10 both say
Scorecard's triggers are the action's rather than the standard's, and
neither bounds that to triggers — so a reader can reasonably generalise
it to exemption from section 10 entirely, which is the inference the old
paragraph institutionalised. The new comment says the exception reaches
the trigger rule and not the calendar.

## Left filed rather than fixed

- [ISS 1432](https://github.com/btclib-org/btclib/issues/1432) — the row
  carries no `fuzz` badge although this tree runs `fuzz.yml` as a
  sentinel and section 2's rule is unconditional. That is the row's
  *membership* where this is its *order*, and `btclib-org/.github#342`
  still holds open what fuzzing's shape is here, so it is a decision
  rather than a mechanical fix.
- [portanode ISS 227](https://github.com/btclib-org/portanode/issues/227)
  — the same superseded premise in another tree. Its badge order is
  already what the calendar gives, so only its prose is stale there.

`RELEASE_NOTES.md` does not move: a badge row's order is nothing a caller
has to act on.

## Gates

All three at exit 0 on `5ea096c4`: `pre-commit run --all-files` with
`markdownlint-cli2` and `zizmor` green; `pytest` at `30754 passed, 11
skipped`, coverage `100.00%`; `sphinx-build -n -W --keep-going`, with the
`href="#\./"` grep at exit 1 against two controls — a planted anchor that
matches, and a file count proving the recursion read every built page.

Reviewed locally at fresh context over two rounds before opening.

## Summary by Sourcery

Align the README sentinel badges with the organization calendar while clarifying Scorecard's trigger-specific exception.

Bug Fixes:
- Move the OpenSSF Scorecard badge into the sentinel badge order defined by the calendar in section 10.

Enhancements:
- Clarify that Scorecard's exception applies to its workflow triggers rather than its calendar placement.

Chores:
- Document the README badge-order correction in the changelog.