### PR TITLE
`pytest tests` meets the coverage ratchet, the path being the whole suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3541,6 +3541,27 @@ documented at release-notes length in the first place, and are still in
 
 ### Tests
 
+- **`uv run pytest tests` is gated at the 100% ratchet, the path it names
+  being the whole suite rather than a selection out of it** (issue
+  btclib-org/.github#430). `tests/conftest.py`'s `coverage_fail_under`
+  relaxes the floor for a run that asked for a subset, and any path at
+  all counted as one: with `testpaths = ["tests"]`, the command that
+  spells out what a bare `uv run pytest` collects reported its coverage
+  without gating on it, so the gate was off for the spelling that reads
+  as more careful than the bare one rather than less. What decides now is
+  containment — `asks_for_everything`, ported from `btclib-node`'s own
+  conftest, asks whether the paths given cover every `testpaths` entry,
+  so `tests`, `./tests`, `.` and the rootdir are whole runs while
+  `tests/bip32` is still a subset. `-k` and `-m` are untouched, so this
+  hook reads a selection off three things where section 8 of the
+  organization standard now counts seven, `--deselect`, `--ignore`,
+  `--ignore-glob` and `--lf` beside them: agreeing with the wider set is
+  btclib-org/.github#424 and not this change. No CI job answers
+  differently: the `coverage` job of `test.yml`, where the ratchet is
+  enforced, runs pytest with no path at all, and the runs that do name
+  one name a file or a directory under `tests`, which is a subset on
+  either side of this change.
+
 - **The tests exercising the pure-Python arm are named `test_the_py_arm_...`,
   matching the spelling `tests/py_arm_authority_test.py` and its census
   already carry** (closes #1270). Every test under `tests/bip32/`,

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,14 +31,21 @@ have it there: the suite takes the same time either way on the 3.14
 
 **A run that selects a subset is not gated.** `fail_under` applies to
 every report coverage writes, so `uv run pytest tests/bip32` would fail
-on the tree's coverage rather than on anything about that run. Naming
-paths, `-k` or `-m` therefore drops the threshold to zero:
-`coverage_fail_under` in `tests/conftest.py` is where that happens, and
-its docstring is why. The report still prints, which is what makes it
-worth reading while iterating on one module. Ways of shortening a run
-that are not a selection — `--lf`, `--deselect`, an `-x` that stops
-early — keep the full threshold and will report a shortfall the tree
-does not have.
+on the tree's coverage rather than on anything about that run. A path
+that leaves part of the suite behind, `-k` or `-m` therefore drops the
+threshold to zero: `coverage_fail_under` in `tests/conftest.py` is where
+that happens, and its docstring is why. The report still prints, which is
+what makes it worth reading while iterating on one module. Ways of
+shortening a run that are not a selection — `--lf`, `--deselect`, an `-x`
+that stops early — keep the full threshold and will report a shortfall
+the tree does not have. Section 8 of the organization standard counts
+the first two of those as selections, which this tree does not yet do;
+btclib-org/.github#424 is that gap.
+
+`uv run pytest tests` is not a selection either. What decides is whether
+the paths named contain every `testpaths` entry, so the directory that
+*is* the suite — and anything above it — is gated at the ratchet exactly
+like the bare command.
 
 Passing `--cov-fail-under` names the threshold yourself, and outranks
 both of those.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,12 +44,60 @@ settings.register_profile("thorough", deadline=None, max_examples=2_000)
 settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "btclib"))
 
 
+def asks_for_everything(
+    file_or_dir: list[str] | None, testpaths: list[str], rootpath: Path
+) -> bool:
+    """Whether the paths named on the command line take the suite in.
+
+    No path at all narrows nothing and is the whole run. A path above one
+    of them -- `pytest .`, or the rootdir spelled out -- collects it too,
+    so what decides is containment and not equality. `tests` alone would
+    match either way; `./tests` and `tests/` are the same directory under
+    another name and need the paths resolved before they compare equal;
+    and a path above `testpaths` is never equal to it, so only
+    containment reads all four as the whole run they collect.
+
+    `file_or_dir` is `None` rather than `[]` on the `--help` path, the
+    parse having been abandoned rather than left unfinished: `--help` is
+    bound to pytest's `HelpAction`, which raises `PrintHelp` to skip the
+    rest of argument parsing, so the positional still carries argparse's
+    default when `pytest_configure` fires. That is no path either, and
+    folding it is what keeps `--help` from ending in a traceback whose
+    last frame is this file.
+
+    The two sides are relative to different directories: a path on the
+    command line to where pytest was run from, a `testpaths` entry to the
+    rootdir, which is what `testpaths` means. Both are then resolved, and
+    the second needs it as much as the first -- pytest builds `rootpath`
+    with `os.path.abspath`, which leaves a symlink in the path alone,
+    while `Path.resolve` follows one, so a tree reached through `/tmp` on
+    macOS would compare `/tmp/...` against `/private/tmp/...` and find no
+    containment anywhere.
+    """
+    given = [Path(path).resolve() for path in file_or_dir or []]
+    if not given:
+        return True
+    wanted = [(rootpath / path).resolve() for path in testpaths]
+    if not wanted:
+        # `all` over nothing is true, which would make every path named
+        # here the whole suite. With `testpaths` unset there is nothing
+        # to measure containment against, so this errs toward dropping
+        # the floor rather than gating a run it cannot call whole
+        return False
+    return all(
+        any(target == path or path in target.parents for path in given)
+        for target in wanted
+    )
+
+
 def coverage_fail_under(
     asked: float | None,
     configured: float | None,
-    file_or_dir: list[str],
+    file_or_dir: list[str] | None,
     keyword: str,
     markexpr: str,
+    testpaths: list[str],
+    rootpath: Path,
 ) -> float | None:
     """Return the coverage threshold this run's selection has to meet.
 
@@ -81,17 +129,29 @@ def coverage_fail_under(
     untouched whichever kind of run it is -- the caller naming the
     threshold is the one thing this must not overrule.
 
-    A subset is what pytest was *asked* for: paths, `-k` or `-m`. Not
-    every way a run can be short -- `--lf`, `--deselect` and an `-x` that
-    stops early are not read -- so those still meet the full threshold
-    and report a shortfall the tree does not have. They are the flags of
-    an iteration whose next run is the whole suite, and reading intent
-    off all of them would make this a second definition of what a real
-    run is.
+    A subset is what pytest was *asked* for: a path that leaves part of
+    the suite behind, `-k` or `-m`. Not every way a run can be short --
+    `--lf`, `--deselect` and an `-x` that stops early are not read -- so
+    those still meet the full threshold and report a shortfall the tree
+    does not have. They are the flags of an iteration whose next run is
+    the whole suite, and reading intent off all of them would make this a
+    second definition of what a real run is.
+
+    Section 8 of the organization standard has since taken the other
+    side -- it counts `--deselect`, `--ignore`, `--ignore-glob` and
+    `--lf` as selections too, and records the paragraph above as the
+    reading it rejects. This tree agreeing with the wider set is
+    btclib-org/.github#424, and is not what the containment rule here
+    was about.
+
+    Which paths leave nothing behind is `asks_for_everything` above, and
+    it is the reason `testpaths` and the rootdir are arguments here.
     """
     if asked is not None:
         return asked
-    if file_or_dir or keyword or markexpr:
+    if keyword or markexpr:
+        return 0
+    if not asks_for_everything(file_or_dir, testpaths, rootpath):
         return 0
     return configured
 
@@ -113,6 +173,8 @@ def pytest_configure(config: pytest.Config) -> None:
         config.option.file_or_dir,
         config.option.keyword,
         config.option.markexpr,
+        config.getini("testpaths"),
+        config.rootpath,
     )
 
 

--- a/tests/conftest_test.py
+++ b/tests/conftest_test.py
@@ -27,6 +27,11 @@ from tests.conftest import REGENERATE, check_golden, coverage_fail_under
 
 MODULE = "something_test.py"
 _ROOT = Path(__file__).parents[1]
+# what pyproject.toml's `testpaths` holds, passed in rather than read:
+# the cases below are about what a command line means against a given
+# `testpaths`, and reading the real one would make them a test of the
+# configuration as well
+_TESTPATHS = ["tests"]
 
 
 @pytest.fixture(autouse=True)
@@ -123,8 +128,45 @@ def test_a_whole_run_is_gated_at_what_pyproject_configured() -> None:
     worth pinning: pyproject.toml is where 100 is decided, and a copy of
     it in this file would be a second place to change it.
     """
-    assert coverage_fail_under(None, 100.0, [], "", "") == 100.0
-    assert coverage_fail_under(None, 42.0, [], "", "") == 42.0
+    assert coverage_fail_under(None, 100.0, [], "", "", _TESTPATHS, _ROOT) == 100.0
+    assert coverage_fail_under(None, 42.0, [], "", "", _TESTPATHS, _ROOT) == 42.0
+
+
+@pytest.mark.parametrize(
+    "file_or_dir",
+    [["tests"], ["./tests"], ["tests/"], ["."], [str(_ROOT)], None],
+    ids=[
+        "the suite",
+        "./ before it",
+        "trailing slash",
+        "the cwd",
+        "absolute",
+        "--help",
+    ],
+)
+def test_a_path_that_collects_the_suite_is_a_whole_run(
+    file_or_dir: list[str] | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A path at or above `testpaths` is gated like the bare command.
+
+    `pytest tests` is what somebody types who means the whole suite and
+    says so, and every path here collects exactly what a bare run
+    collects. Equality against `testpaths` would take in `tests` alone:
+    `./tests` and `tests/` are that same directory spelled otherwise, and
+    `.` and the rootdir are above it, which is why containment and not
+    equality is what decides.
+
+    `None` is the `--help` path, where the parse is abandoned before the
+    positional is filled in; it reaches this function like any other run,
+    and answering it wrongly would be a traceback rather than a threshold.
+
+    The relative spellings are read against the working directory, which
+    is what pytest does with them, so the run has to be standing in the
+    rootdir for them to mean the suite.
+    """
+    monkeypatch.chdir(_ROOT)
+    gate = coverage_fail_under(None, 100.0, file_or_dir, "", "", _TESTPATHS, _ROOT)
+    assert gate == 100.0
 
 
 @pytest.mark.parametrize(
@@ -135,18 +177,38 @@ def test_a_whole_run_is_gated_at_what_pyproject_configured() -> None:
         ([], "derive", ""),
         ([], "", "integration"),
         (["tests/bip32"], "derive", "integration"),
+        (["tests"], "derive", ""),
     ],
-    ids=["one file", "one directory", "-k", "-m", "all three"],
+    ids=["one file", "one directory", "-k", "-m", "all three", "the suite, -k"],
 )
 def test_a_selected_subset_is_gated_at_nothing(
-    file_or_dir: list[str], keyword: str, markexpr: str
+    file_or_dir: list[str], keyword: str, markexpr: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Any of the three selections drops the threshold to zero.
 
     Zero and not None: None is what pytest-cov reads the configured
     threshold into, so it would restore the very gate this removes.
+
+    The last case is the whole suite named beside a `-k`: the path takes
+    everything in and the expression then selects out of it, so what
+    decides is the selection and not the path.
     """
-    assert coverage_fail_under(None, 100.0, file_or_dir, keyword, markexpr) == 0
+    monkeypatch.chdir(_ROOT)
+    gate = coverage_fail_under(
+        None, 100.0, file_or_dir, keyword, markexpr, _TESTPATHS, _ROOT
+    )
+    assert gate == 0
+
+
+def test_without_testpaths_a_named_path_is_a_subset() -> None:
+    """With nothing naming the suite, no path can be all of it.
+
+    A bare run then collects the rootdir, so a path on the command line
+    asks for less whatever it is. `all` over an empty `testpaths` would
+    answer the opposite -- every run a whole one, and the floor never
+    relaxed for the one-file run it exists for.
+    """
+    assert coverage_fail_under(None, 100.0, ["tests"], "", "", [], _ROOT) == 0
 
 
 def test_cov_is_not_the_last_token_of_addopts() -> None:
@@ -180,8 +242,9 @@ def test_cov_is_not_the_last_token_of_addopts() -> None:
 
 def test_an_explicit_threshold_survives_either_kind_of_run() -> None:
     """`--cov-fail-under` is the caller's, and outranks both branches."""
-    assert coverage_fail_under(90.0, 100.0, ["tests/bip32"], "", "") == 90.0
-    assert coverage_fail_under(90.0, 100.0, [], "", "") == 90.0
+    subset = ["tests/bip32"]
+    assert coverage_fail_under(90.0, 100.0, subset, "", "", _TESTPATHS, _ROOT) == 90.0
+    assert coverage_fail_under(90.0, 100.0, [], "", "", _TESTPATHS, _ROOT) == 90.0
     # zero is a threshold somebody asked for, not a missing answer: it
     # has to survive the `is not None` test rather than be falsy
-    assert coverage_fail_under(0, 100.0, [], "", "") == 0
+    assert coverage_fail_under(0, 100.0, [], "", "", _TESTPATHS, _ROOT) == 0


### PR DESCRIPTION
`tests/conftest.py`'s coverage hook read any path on the command line as a
selection from the suite, so `uv run pytest tests` — the spelling that says
out loud which suite is meant — switched the 100% floor off. What decides now
is containment against `testpaths`, not whether a path was named.

Tracking issue: btclib-org/.github#430. This is one of its boxes and closes
nothing here; the issue stays open until `bitcoin-core-rpc`'s branch lands,
and that branch carries the closing citation.

## The defect, measured before the fix

At `54ff0356`, the same 21 094 tests and the same 89.60% either way —
`--ignore` chosen because the hook does not read it, so the only difference
between the two commands is the word `tests`:

```shell
uv run --locked --no-default-groups --group test pytest -q --ignore=tests/ecc
# FAIL Required test coverage of 100.0% not reached. Total coverage: 89.60%
# exit 1
uv run --locked --no-default-groups --group test pytest -q tests --ignore=tests/ecc
# 21094 passed, 9 skipped
# exit 0
```

The gate was off for the more careful spelling, not the less careful one.

## What the branch does

**`asks_for_everything`, ported from `btclib-node`'s `tests/conftest.py` at
`5f87b16`.** Each `testpaths` entry has to be contained in some path named on
the command line, so `tests`, `./tests`, `tests/`, `.` and the rootdir spelled
out are all the whole run they collect, and only a path that leaves an entry
out drops the threshold.

**Three things the port had to get right, each with its reason in the
docstring:**

- `file_or_dir` is `None` and not `[]` under `--help`. `--help` is bound to
  pytest's `HelpAction`, which raises `PrintHelp` to abandon the rest of the
  parse, and `pytest_configure` fires anyway — so a containment test that
  iterates the positional ends `--help` in a traceback whose last frame is
  this file.
- The two sides are relative to different directories: a command-line path to
  where pytest was run from, a `testpaths` entry to the rootdir.
- **Both sides are resolved, which is one line more than the reference does.**
  pytest builds `rootpath` with `os.path.abspath` (`_pytest/pathlib.py`'s
  `absolutepath`, whose docstring says to prefer it over `Path.resolve`), so it
  keeps a symlink that the given side follows: a tree reached through `/tmp` on
  macOS would compare `/tmp/…` against `/private/tmp/…` and find containment
  nowhere. `btclib-node` resolves only one side, which is btclib-org/btclib-node#496.

**Six cases in `tests/conftest_test.py`**, one of them parametrized over the
six spellings that must all read as a whole run — `["tests"]`, `["./tests"]`,
`["tests/"]`, `["."]`, the absolute rootdir, and `--help`'s `None` — beside a
real subset as the positive control and a tree that configures no `testpaths`
at all.

**`tests/README.md`** now says what decides, and keeps its existing sentence
about `--lf`, `--deselect` and an early `-x` intact.

**The divergence from section 8 is stated where it lives.** While this branch
was in review, `btclib-org/.github@334eb17` widened §8's trigger set to seven —
paths, `-k`, `-m`, `--deselect`, `--ignore`, `--ignore-glob`, `--lf` — and
recorded the narrower reading as rejected, quoting this tree's own docstring in
order to reject it. This hook reads the first three. That gap is
btclib-org/.github#424 and not this change, and the `CHANGELOG.md` entry, the
docstring and `tests/README.md` each say so rather than leaving a reader to
find it.

## No CI job answers differently

Every run in the workflows that names a path names a strict subset — 21
`.github/mutation/*.toml` profiles, `tests/integration`, and one file under it
— and `test.yml`'s `coverage` job passes no path at all, the `no-bindings` one
passing `--cov-fail-under=0`. `git grep -F 'pytest tests'` over the tree finds
no documented or scripted command that runs the bare directory, so nothing that
was green goes red.

## Gates

Re-run on the rebased sha, per `CONTRIBUTING.md`'s last section:

| command | exit |
| --- | --- |
| `COVERAGE_FILE=coverage-data-bindings uv run --locked --no-default-groups --group test pytest --cov` | **0** — 100.00%, 30 762 passed, 11 skipped |
| `uv run --locked --only-group lint pre-commit run --all-files --show-diff-on-failure` | **0** — Failed 0, Passed 41 |
| `uv run --locked --no-default-groups --group docs sphinx-build -n -W --keep-going -b html docs/source docs/build/html` | **0** |
| `grep -rn 'href="#\./' docs/build/html` | **1**, which is the pass |

The docs gate is genuinely owed: `docs/source/changelog_link.md` pulls
`../../CHANGELOG.md` through a MyST `include` and this diff moves that file.

## Review

Three rounds of local review at fresh context. The first cleared the pre-rebase
sha conditionally — `origin/main` moved twice underneath it. The second read
the rebase and the three prose corrections it asked for, and blocked on one
`CHANGELOG.md` sentence that said §8 had not yet decided which flags count,
nine minutes after §8 decided; `CHANGELOG.md` is append-only, so that was the
last moment it could be made true. The third read the correction. That is not the
ack of record: `claude-review.yml` is switched off across the organization,
`CLAUDE_REVIEW_ENABLED` existing on no repository, so section 11's *a tree
whose gate is off carries no ack of record* is the state here.

## Summary by Sourcery

Apply the coverage ratchet to commands that collect the complete configured test suite while continuing to relax it for partial selections.

Bug Fixes:
- Ensure commands naming the complete configured test suite, such as `pytest tests`, retain the 100% coverage threshold instead of being treated as subset runs.

Enhancements:
- Determine whether a run is complete by checking command-line path containment against configured `testpaths`, including normalized path spellings and help invocation.
- Preserve relaxed coverage behavior for genuine path, keyword, and marker selections while keeping explicit coverage thresholds authoritative.

Documentation:
- Document the updated coverage selection behavior and its divergence from the organization-wide standard.

Tests:
- Add coverage-hook tests for complete-suite path spellings, help handling, subset selection, absent `testpaths`, and explicit thresholds.