### PR TITLE
typos and codespell exclude fuzz/corpus/ from their own text scans (closes #1418, closes #1438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -925,6 +925,33 @@ documented at release-notes length in the first place, and are still in
   payload for `fuzz_address.py`, and the vendored segwit transaction and
   the smallest vendored block for `fuzz_p2p_data.py` (closes #1410).
 
+- **`pyproject.toml`'s `[tool.typos.files]` `extend-exclude` gains
+  `fuzz/corpus/**`, and `[tool.codespell]`'s `skip` gains
+  `fuzz/corpus/*`.** Both hooks detect a binary file the same way, a
+  sniff for a NUL byte rather than a length threshold: several of the
+  checked-in seed files under `fuzz/corpus/` are empty payloads, and
+  the keepalive nonce is an eight-byte field with none in it either,
+  so nothing marks either kind as binary and both hooks read them as
+  text. Each runs with `--write-changes` (`.pre-commit-config.yaml`),
+  so a byte sequence either dictionary offers to "correct" would
+  silently invalidate the round-trip property a seed was checked in
+  to prove, in a rewrite of a `.bin` file no reviewer reads a diff
+  for. `--force-exclude`, already in the typos hook's `args`, is what
+  keeps its own entry reachable: pre-commit names files explicitly on
+  its command line, and typos otherwise overrides an exclude for a
+  path named that way. Neither tool's dialect forces the two globs to
+  differ -- each excludes the whole subtree spelled either way, and
+  each entry keeps its own list's existing single-star or
+  double-star idiom rather than the narrower "one directory deep for
+  typos" difference `[tool.typos.files]`'s own comment argues for the
+  vendored-data entries, which is about a leading `*/` and not a
+  trailing one. `fuzz/corpus/*` is root-anchored on purpose, matching
+  `fuzz/corpus/**` rather than reaching a hypothetical
+  `vendor/fuzz/corpus/` too; the cost for codespell is a leading
+  `./`, which defeats its `fnmatch` match and which pre-commit never
+  supplies, `git ls-files` emitting no path that carries one
+  (closes #1418, closes #1438).
+
 - **`codeql.yml` runs on `pull_request` too, alongside `push` on `main`
   and the weekly `schedule`.** The OpenSSF Scorecard's `SAST` check
   reads a merged pull request's own commits and found CodeQL configured

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -467,7 +467,28 @@ filterwarnings = ["error"]
 # by extension rather than by directory, so that tests/_data/README.md --
 # which records where each of those files came from -- is still spell
 # checked, being prose about the data and not the data
-skip = "*/_data/*.json,*/_data/*.csv,*/_data/*.txt,*/_data/*.bin,*/_generated_files/*,.secrets.baseline,uv.lock"
+
+# fuzz/corpus/'s own seed files, added under btclib-org/btclib#1438: the
+# same content sniff for a NUL byte [tool.typos.files] argues below
+# decides what codespell treats as binary too -- is_text_file reads the
+# first 1024 bytes and looks for one -- so the same seeds read as text
+# here, and codespell runs with --write-changes as well
+# (.pre-commit-config.yaml). "fuzz/corpus/*", a single star, measured to
+# exclude the whole subtree exactly as the "fuzz/corpus/**" below does
+# for typos -- neither tool's dialect forces the difference, and this
+# one is spelled in the single-star idiom the entries above already
+# use. [tool.typos.files]'s own remark below is about a leading "*/",
+# which stops typos at one directory the way it does not stop
+# codespell, not about a trailing one, which stops neither: measured
+# both ways, "*/_data/*.json" alone misses a control two directories
+# deep for typos and "fuzz/corpus/*" here still excludes the whole
+# subtree. Root-anchored on purpose, matching the entry below, rather than
+# "*fuzz/corpus/*", which would also reach a hypothetical
+# vendor/fuzz/corpus/: codespell matches with fnmatch against the path
+# it receives, so the cost of the anchor is a leading "./" defeating
+# this entry. Untested in the hook itself: pre-commit hands codespell
+# the bare paths git ls-files emits, none of them carrying one
+skip = "*/_data/*.json,*/_data/*.csv,*/_data/*.txt,*/_data/*.bin,*/_generated_files/*,.secrets.baseline,uv.lock,fuzz/corpus/*"
 # identifiers, not misspellings: "wit" is a transaction's witness and
 # "nd" is the Neutered Derivation the bip32 docstrings spell out. Both
 # are real words to codespell's dictionary, so neither can be fixed by
@@ -533,6 +554,20 @@ extend-exclude = [
     "**/_generated_files/*",
     ".secrets.baseline",
     "uv.lock",
+    # fuzz/corpus/'s own seed files are wire-format bytes, not prose or
+    # vendored data the entries above cover. typos's binary detection is
+    # a sniff for a NUL byte, not a length threshold: several of these
+    # seeds are empty payloads, and the keepalive nonce is an
+    # eight-byte field with none in it either, so nothing marks either
+    # kind as binary and typos reads them as text.
+    # .pre-commit-config.yaml's typos hook runs with --write-changes, so
+    # a byte sequence its dictionary offers to "correct" would silently
+    # invalidate the round-trip property a seed was checked in to
+    # prove, in a rewrite of a .bin file no reviewer reads a diff for.
+    # --force-exclude is what makes this entry reach that hook at all:
+    # pre-commit names files explicitly on its command line, and typos
+    # otherwise overrides an exclude for a path named that way
+    "fuzz/corpus/**",
 ]
 
 [tool.typos.default]


### PR DESCRIPTION
`typos` and `codespell` both run with `--write-changes`, and both read
`fuzz/corpus/`'s seed files as text. Their binary detection is the same
sniff for a NUL byte in the file's own bytes rather than a length
threshold: several of the checked-in seeds are empty payloads, and the
keepalive nonce is an eight-byte field with none in it either, so
nothing marks either kind as binary. A byte sequence either dictionary
offered to "correct" would silently invalidate the round-trip property
a seed was checked in to prove, in a rewrite of a `.bin` file no
reviewer reads a diff for.

`[tool.typos.files]`'s `extend-exclude` gains `fuzz/corpus/**`, and
`[tool.codespell]`'s `skip` gains `fuzz/corpus/*`. The two spellings
differ only because each keeps its own list's existing idiom — both
exclude the whole subtree in either tool, measured. `--force-exclude`,
already in the typos hook's `args`, is what keeps its entry reachable
under pre-commit's own invocation, which names files explicitly on the
command line.

## Measured

- Both exclusions hold at the landing sha: `typos --files fuzz/corpus`
  and `codespell --builtin clear fuzz/corpus` each exit 0, at the
  pinned `typos==1.49.0` and `codespell==2.4.3`.
- Both are root-anchored: a planted `nested/fuzz/corpus/` is still
  scanned by each, and `fuzz/`'s own harnesses remain scanned.
- The leading `*/` that `[tool.typos.files]`'s own comment argues for
  the vendored-data entries stops typos at one directory and does not
  stop codespell; a trailing star stops neither. Both halves run, each
  against a control with the entry neutered so the harness is known to
  fire.
- The cost of the anchor is a leading `./` defeating codespell's
  `fnmatch` match, which pre-commit never supplies — `git ls-files`
  emits no path carrying one.

## Gates

`pre-commit run --all-files` exit 0, every hook `Passed`.
`pytest` exit 0, `30762 passed, 11 skipped`, coverage `100.00%`.
`sphinx-build -n -W --keep-going` exit 0, anchor grep finding nothing
against a proved positive control.

Reviewed locally at fresh context over four rounds before opening.

Closes #1418

Closes #1438

## Summary by Sourcery

Bug Fixes:
- Prevent typos and codespell from modifying fuzz corpus seed files that may be misidentified as text.