### PR TITLE
Prose corrects a stated coverage count, adds the missing fuzz badge, and declares section 7's ninth convention (closes #1436, #1432, #1431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -831,6 +831,18 @@ documented at release-notes length in the first place, and are still in
   `ossf/scorecard-action`'s own rather than the standard's, and not its
   place in the calendar (closes #1424).
 
+- **`README.md`'s badge row carries a badge for `fuzz.yml` too, in the
+  sentinel badges' calendar order.** Section 10 gives `fuzz` a Monday 03
+  row, the earliest slot in the week, so its badge sits first among the
+  sentinels, ahead of `links` (closes #1432).
+
+- **`tests/README.md` and `conventions_test.py`'s `_CONVENTIONS` account
+  for section 7's "the suite opens no socket" bullet, declaring it not
+  tested here.** `imports_test.py`'s import-hygiene walk answers whether
+  `socket` reaches `sys.modules` on import, which is a different question
+  from a walk over the call sites that construct one, so the honest
+  declaration is that the bullet stays untested (closes #1431).
+
 ### Packaging, linting and CI
 
 - **`pyproject.toml`'s ruff configuration selects `["ALL"]`,** matching
@@ -3540,6 +3552,14 @@ documented at release-notes length in the first place, and are still in
   `bytes` value, where `bytes + memoryview` works.
 
 ### Tests
+
+- **`tests/conftest.py`'s `coverage_fail_under` docstring stops quoting
+  the percentage one file's run happened to report** (closes #1436). The
+  `6.33%` in its example failure message was true of that run and of
+  nothing else: a number nothing re-derives, and one every test added
+  anywhere in the tree moves. The sentence makes its point without it,
+  and now matches `bitcoin-core-rpc`'s port of the same docstring word
+  for word.
 
 - **`uv run pytest tests` is gated at the 100% ratchet, the path it names
   being the whole suite rather than a selection out of it** (issue

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ own -- is to the trigger rule rather than to the calendar. -->
 [![lint workflow status](https://github.com/btclib-org/btclib/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/lint.yml)
 [![docs workflow status](https://github.com/btclib-org/btclib/actions/workflows/docs.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/docs.yml)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib/main.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib/main)
+[![fuzz workflow status](https://github.com/btclib-org/btclib/actions/workflows/fuzz.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/fuzz.yml)
 [![links workflow status](https://github.com/btclib-org/btclib/actions/workflows/links.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/links.yml)
 [![vendored-vectors workflow status](https://github.com/btclib-org/btclib/actions/workflows/vendored-vectors.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/vendored-vectors.yml)
 [![codeql workflow status](https://github.com/btclib-org/btclib/actions/workflows/codeql.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/codeql.yml)

--- a/tests/README.md
+++ b/tests/README.md
@@ -260,21 +260,22 @@ What to know before reading one:
 
 ## Convention tests
 
-Section 7 of the [organization standard][std] lists eight conventions a
-suite can turn into a red test, and says a repository needs the ones its
-own prose states rather than all of them. That escape clause is right and
-it costs something: an absent convention test reads exactly like a
+Section 7 of the [organization standard][std] lists conventions a suite
+can turn into a red test, and says a repository needs the ones its own
+prose states rather than all of them. That escape clause is right and it
+costs something: an absent convention test reads exactly like a
 convention this repository does not have, and a `grep` over `tests/`
 cannot tell the two apart — the suites of the organization name the same
 idea three different ways, and one of them folds several checks into the
 file that is about its single module.
 
-So which of the eight this repository tests is **declared here**, and
-`conventions_test.py` asserts the declaration is true: every convention
-named below is one of section 7's, every module named exists and holds at
-least one test, and the two halves together account for all eight. One
-row per module, so a convention answered by more than one file is named
-once per file rather than in a row too wide for eighty columns.
+So which of section 7's conventions this repository tests is **declared
+here**, and `conventions_test.py` asserts the declaration is true: every
+convention named below is one of section 7's, every module named exists
+and holds at least one test, and the two halves together account for
+every one of them. One row per module, so a convention answered by more
+than one file is named once per file rather than in a row too wide for
+eighty columns.
 
 | convention | tested in |
 | --- | --- |
@@ -289,7 +290,7 @@ once per file rather than in a row too wide for eighty columns.
 | the calling convention | `private_defaults_test.py` |
 | input validation | `input_validation_test.py` |
 
-Not tested here: none.
+Not tested here: the suite opens no socket.
 
 The calling convention takes three modules because it is three rules —
 a keyword-only parameter stays keyword-only, a private signature carries

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,10 +107,9 @@ def coverage_fail_under(
     What that costs is this function. `fail_under` applies to every
     report coverage writes, a partial one included, so `pytest
     tests/bip32/bip32_test.py` would end in `Required test coverage of
-    100.0% not reached. Total coverage: 6.33%` -- true of that run and
-    saying nothing about the tree. Running one file and one test are
-    documented commands, and a gate that fails them is a gate read as
-    noise.
+    100.0% not reached` -- true of that run and saying nothing about the
+    tree. Running one file and one test are documented commands, and a
+    gate that fails them is a gate read as noise.
 
     So a run that asked for a subset is gated at zero rather than having
     coverage switched off: the report still prints, which is what makes

--- a/tests/conventions_test.py
+++ b/tests/conventions_test.py
@@ -4,8 +4,8 @@
 
 """The convention-test declaration in tests/README.md is true.
 
-Section 7 of the organization standard lists eight conventions a suite
-can turn into a red test, and closes with the clause that makes the list
+Section 7 of the organization standard lists conventions a suite can
+turn into a red test, and closes with the clause that makes the list
 usable: a repository needs the ones its own prose states rather than all
 of them. That clause is right, and its price is that an *absent*
 convention test is indistinguishable from a convention this repository
@@ -38,11 +38,12 @@ import pytest
 _TESTS = Path(__file__).parent
 _README = _TESTS / "README.md"
 
-# section 7's eight, in its order and its words: the lead of each bullet,
-# which is what the first column of the table repeats. This tuple is the
-# standard's rather than this repository's, so a bullet added there is a
-# failure here until both this and the table have caught up -- which is
-# the point of naming them rather than accepting whatever the table says.
+# section 7's conventions, in its order and its words: the lead of each
+# bullet, which is what the first column of the table repeats. This
+# tuple is the standard's rather than this repository's, so a bullet
+# added there is a failure here until both this and the table have
+# caught up -- which is the point of naming them rather than accepting
+# whatever the table says.
 _CONVENTIONS = (
     "the public surface",
     "the copyright header",
@@ -52,6 +53,7 @@ _CONVENTIONS = (
     "the build system",
     "the calling convention",
     "input validation",
+    "the suite opens no socket",
 )
 
 _HEADING = "## Convention tests"
@@ -144,13 +146,13 @@ def test_every_module_named_holds_a_test(convention: str, module: str) -> None:
 
 
 def test_the_two_halves_account_for_every_convention() -> None:
-    """The table and the "Not tested here" line partition section 7's eight.
+    """The table and the "Not tested here" line partition section 7's set.
 
     This is the assertion the declaration exists for. Either half alone
     is satisfiable by saying less: a table naming three conventions is
-    true about those three and silent about the other five, and silence
-    is exactly what section 7's escape clause makes unreadable. Together
-    they have to name each of the eight once.
+    true about those three and silent about the rest, and silence is
+    exactly what section 7's escape clause makes unreadable. Together
+    they have to name each convention once.
     """
     match = _NOT_TESTED.search(_SECTION)
     assert match, (
@@ -177,5 +179,6 @@ def test_the_two_halves_account_for_every_convention() -> None:
     ]
     assert not unaccounted, (
         f"{', '.join(unaccounted)} is neither declared tested nor listed as"
-        " not tested; section 7's eight are what the two halves must cover"
+        " not tested; section 7's conventions are what the two halves"
+        " must cover"
     )


### PR DESCRIPTION
`tests/conftest.py`'s `coverage_fail_under` docstring quoted a percentage one file's run happened to report, which nothing re-derives and which moves with every test added anywhere in the tree; the sentence makes its point without the number, matching `bitcoin-core-rpc`'s own port of the same docstring.

`README.md`'s badge row named every sentinel this tree runs except `fuzz.yml`, which is a scheduled sentinel with its own Monday 03 row in the organization standard's calendar — the earliest slot in the week, so its badge sits first among the sentinels.

`tests/conventions_test.py`'s `_CONVENTIONS` held eight of section 7's bullets; the standard now lists nine, "the suite opens no socket" among them. `tests/README.md` declares it not tested here, since `imports_test.py`'s import-hygiene walk answers a different question from the call-site walk that bullet asks for. Both files also drop their own stated counts of the bullets, which is what made the docstring's own repetition of "eight" wrong the moment the standard grew a ninth.

Closes #1436
Closes #1432
Closes #1431

## Summary by Sourcery

Align coverage guidance, workflow badges, and convention declarations with the current project standards.

New Features:
- Add the missing fuzz workflow status badge to the README.
- Declare the section 7 convention that the test suite opens no socket as intentionally untested.

Bug Fixes:
- Remove the unstable, misleading coverage percentage from the partial-test coverage documentation.
- Update convention documentation and validation to account for the organization standard’s expanded convention list.

Documentation:
- Clarify that the convention documentation covers all standard conventions without relying on a fixed count.

Tests:
- Extend convention declaration validation to include the newly listed socket convention.