### PR TITLE
Buffer guards ask a memoryview's byte shape, is_octets narrows as TypeIs, and every guard is driven with all four Octets spellings (closes #1429, #1430, #1433, #1434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3448,8 +3448,11 @@ documented at release-notes length in the first place, and are still in
   another order, which is what let these four survive both sweeps; the
   `ssa` one reads the shape positively (dispatching into it) rather than
   refusing it, the same tuple asking the opposite question. `is_octets`
-  now returns `TypeIs[Octets]` rather than `bool`, so a caller that
-  dispatches on it keeps the narrowing an `isinstance` tuple gave mypy:
+  now returns `TypeIs[Octets]` rather than `bool` — the
+  `typing-extensions` floor rises to 4.10, the release that adds
+  `TypeIs`, with the reason beside it in `pyproject.toml` — so a caller
+  that dispatches on it keeps the narrowing an `isinstance` tuple gave
+  mypy:
   `psbt_view`'s `data: BinaryIO | Octets` narrows to `BinaryIO` on the
   untaken branch, and `fetch.fetcher`'s `raw: Octets` narrows to nothing
   on it, which is what the disclosed `# type: ignore[unreachable]` beside
@@ -3774,6 +3777,20 @@ documented at release-notes length in the first place, and are still in
   calls need no coverage sweep, so it runs in the ordinary suite rather
   than beside `py-arm-authority.yml`'s weekly re-derivation, which pays
   for one.
+
+- **The guards refusing a bare `Octets` where a sequence of something
+  else was meant are now driven with a `bytearray` and a `memoryview`
+  too, beside the `str` and `bytes` each already had** (closes #1434).
+  `tests/input_validation_test.py`'s `_WRONG_TYPE` table drives
+  `Iterable[Octets]` and `Sequence[Octets]` with all four spellings
+  instead of one, and the hand-written guard tests in
+  `tests/p2p/address_test.py`, `tests/p2p/addrv2_test.py` and
+  `tests/serialization_boundary_test.py` gain the two missing spellings
+  beside the ones they already drove. A guard naming three of the four
+  passed every one of these before this change, the coverage floor
+  answering nothing about it: the branch each guard's refusal sits in
+  was already reached by the spellings the walk did drive, a case
+  exercised being a different thing from a branch reached.
 
 ### Curves, signatures and keys
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3439,6 +3439,31 @@ documented at release-notes length in the first place, and are still in
   `is_octets`'s answer, a `Mapping` being wrong for a reason of its own
   and not part of what `is_octets` asks.
 
+- **`fetch.fetcher.tx_from_raw`, `psbt.psbt_view.PsbtView` twice and
+  `ecc.ssa`'s x-only dispatch move to `utils.is_octets`, the pattern the
+  last four entries moved every other guard off of** (closes #1433). An
+  AST census keyed on the hand-listed tuple's own element order -- `str,
+  bytes, bytearray, memoryview`, the shape `issue #1261` and
+  `issue #1420` were both found with -- cannot see a tuple written in
+  another order, which is what let these four survive both sweeps; the
+  `ssa` one reads the shape positively (dispatching into it) rather than
+  refusing it, the same tuple asking the opposite question. `is_octets`
+  now returns `TypeIs[Octets]` rather than `bool`, so a caller that
+  dispatches on it keeps the narrowing an `isinstance` tuple gave mypy:
+  `psbt_view`'s `data: BinaryIO | Octets` narrows to `BinaryIO` on the
+  untaken branch, and `fetch.fetcher`'s `raw: Octets` narrows to nothing
+  on it, which is what the disclosed `# type: ignore[unreachable]` beside
+  its own message already said before this change and says again now for
+  the same reason. `p2p.address.Addr` and `p2p.addrv2.AddrV2` already
+  called `is_octets` on a declared `Sequence[...]` parameter; the same
+  narrowing now applies there too, disclosed the same way.
+  `bip32.bip32.BIP32KeyData.b58decode` keeps its own hand-listed tuple:
+  its parameter is a `String`, the same union as `Octets` under a
+  different name for a different reason, and `is_octets` would ask the
+  wrong question of it -- `to_prv_key` and `to_pub_key`'s key-type tuples
+  are a different question again, naming types beside the four this issue
+  is about.
+
 - **`ssa.challenge_` and `dsa.recover_pub_key_` refuse a bool, closing
   the trailing-underscore layer's own gap in issue #1206's policy**
   (closes #1248). Both take a bare `int` rather than an `Integer`, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3566,6 +3566,39 @@ documented at release-notes length in the first place, and are still in
   `magic_message`'s own concatenation puts its buffer on the right of a
   `bytes` value, where `bytes + memoryview` works.
 
+- **`block.merkle_proof.verify` and `p2p.compact_blocks`'s short-id
+  derivation take a `memoryview` txid, sibling or wtxid, as every other
+  `Octets` spelling** (closes #1429). `bytes_from_octets` hands a
+  memoryview back unchanged, and both then reversed it with `[::-1]`: a
+  strided, non-contiguous view, which the `bytes_from_octets` call
+  downstream of the reversal refused. `merkle_proof.assert_as_valid`
+  raised on it, and `verify` catches that as a proof that does not
+  verify, so a valid proof spelled with memoryviews answered False
+  rather than True, with nothing raised to notice; `CmpctBlock.short_id`
+  had no such boundary in front of it and raised outright. Both copy the
+  buffer to `bytes` at the point of reversal, entirely at the call site:
+  neither the txid, the sibling nor the wtxid is returned to whoever
+  passed it in.
+
+- **`bytes_from_octets` refuses a `memoryview` whose format is not
+  unsigned bytes, closing the gap the contiguity check alone left**
+  (closes #1430). A `memoryview` cast to a signed `"b"`, or built over an
+  array of a wider format such as `"I"`, is C-contiguous and was
+  returned unchanged; `hashes.magic_message`'s
+  `var_int.serialize(len(msg))` and `hashes.siphash`'s `for byte in
+  data` then read it in elements rather than in octets, `len()` counting
+  elements and each iterated value being whatever the format decodes to
+  rather than an unsigned byte in `0..255` -- silently disagreeing with
+  the same octets spelled as `bytes`. `_assert_contiguous` is renamed
+  `_assert_byte_shaped` and asks `mv.format == "B"` beside the
+  contiguity it already asked, the property `bytes`, `bytearray` and
+  every unformatted `memoryview` share; `itemsize == 1` was considered
+  and rejected, a signed `"b"` view and a `"c"`-cast one (bytes objects,
+  not ints) both being itemsize one and still not what the consumers
+  above assume. `bytes_from_octets`'s own output-size check now measures
+  `nbytes` rather than `len()`, the two no longer able to silently
+  disagree once every buffer reaching that check is format `"B"`.
+
 ### Tests
 
 - **`uv run pytest tests` is gated at the 100% ratchet, the path it names

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,11 @@ requires-python = ">=3.10"
 # the reasoning, beside the ceiling argument it already makes.
 dependencies = [
     "bitcoin-core-rpc>=2026.8.13",
-    # `typing.override` is 3.12's and the floor is 3.10, so the decorator
-    # explicit-override asks for comes from the backport; 4.4 is the
-    # release that adds it
-    "typing-extensions>=4.4",
+    # `typing.override` is 3.12's, `typing.TypeIs` is 3.13's, and the
+    # floor is 3.10, so both come from the backport; 4.4 is the release
+    # that adds `override`, 4.10 the one that adds `TypeIs`, and the
+    # later of the two is the floor
+    "typing-extensions>=4.10",
 ]
 keywords = [
     # The GitHub repository topics, in the same order, and the order is by

--- a/src/btclib/block/merkle_proof.py
+++ b/src/btclib/block/merkle_proof.py
@@ -108,9 +108,17 @@ def assert_as_valid(
     assert_type(branch, Sequence, "branch")
 
     root = bytes_from_octets(merkle_root, 32)
+    # bytes(...) rather than the buffer bytes_from_octets hands back: a
+    # memoryview is returned as itself, and reversing one with [::-1]
+    # yields a strided, non-contiguous view that the next
+    # bytes_from_octets call inside merkle_root_from_branch refuses --
+    # a valid proof spelled with memoryviews would then read as False
+    # rather than True (issue #1429). Neither txid nor sibling is
+    # returned to the caller, so the copy costs one allocation each and
+    # loses nothing out of sync
     computed = merkle_root_from_branch(
-        bytes_from_octets(txid, 32)[::-1],
-        [bytes_from_octets(sibling, 32)[::-1] for sibling in branch],
+        bytes(bytes_from_octets(txid, 32))[::-1],
+        [bytes(bytes_from_octets(sibling, 32))[::-1] for sibling in branch],
         index,
         _HF,
         _assert_inner_node_is_not_a_tx,

--- a/src/btclib/ecc/ssa.py
+++ b/src/btclib/ecc/ssa.py
@@ -285,7 +285,7 @@ def _x_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve) -> int:
             return x_Q[0]
         raise BTClibValueError(f"not a valid public key: {x_Q}")
 
-    if isinstance(x_Q, (str, bytes, bytearray, memoryview)):
+    if is_octets(x_Q):
         # every spelling `Octets` names, which is what
         # `bytes_from_octets` takes and returns as it came. Accepted at
         # all three sizes here, where the dispatch this

--- a/src/btclib/fetch/fetcher.py
+++ b/src/btclib/fetch/fetcher.py
@@ -35,7 +35,7 @@ from btclib.exceptions import (
 from btclib.network import NETWORKS, network_from_name
 from btclib.script import ScriptPubKey
 from btclib.tx import OutPoint, Tx, TxOut
-from btclib.utils import bytes_from_octets
+from btclib.utils import bytes_from_octets, is_octets
 
 __all__ = [
     "Fetcher",
@@ -230,7 +230,7 @@ def tx_from_raw(raw: Octets, tx_id: str, network: str) -> Tx:
     all show up here, as the wrong id rather than as a wrong amount
     somewhere later.
     """
-    if not isinstance(raw, (bytes, str, bytearray, memoryview)):
+    if not is_octets(raw):
         # `Tx.parse` reads a stream and lets anything that is not Octets
         # through untouched, so a json number where the hex belongs
         # surfaces as AttributeError on `.read` -- a traceback into the

--- a/src/btclib/p2p/address.py
+++ b/src/btclib/p2p/address.py
@@ -433,9 +433,15 @@ class Addr(Payload):
         # that a caller who passed one gets a complaint about the
         # argument rather than about its first character. `is_octets` is
         # the four spellings named once, so a spelling `Octets` gains
-        # later is refused here too (issue #1420)
-        if is_octets(addresses) or not isinstance(addresses, Sequence):
-            err_msg = f"invalid addresses type: {type(addresses).__name__}"
+        # later is refused here too (issue #1420). The declared parameter
+        # is already a Sequence[TimestampedNetworkAddress], which mypy
+        # reads as never overlapping Octets now that is_octets narrows --
+        # true only of a caller obeying the annotation, which the check
+        # exists for the one that does not (issue #1433)
+        if is_octets(addresses) or not isinstance(  # type: ignore[redundant-expr]
+            addresses, Sequence
+        ):
+            err_msg = f"invalid addresses type: {type(addresses).__name__}"  # type: ignore[unreachable]
             raise BTClibTypeError(err_msg)
         object.__setattr__(self, "addresses", tuple(addresses))
 

--- a/src/btclib/p2p/addrv2.py
+++ b/src/btclib/p2p/addrv2.py
@@ -430,9 +430,15 @@ class AddrV2(Payload):
         # caller who passed one gets a complaint about the argument
         # rather than about its first character. `is_octets` is the four
         # spellings named once, so a spelling `Octets` gains later is
-        # refused here too (issue #1420)
-        if is_octets(addresses) or not isinstance(addresses, Sequence):
-            err_msg = f"invalid addresses type: {type(addresses).__name__}"
+        # refused here too (issue #1420). The declared parameter is
+        # already a Sequence[NetworkAddressV2], which mypy reads as never
+        # overlapping Octets now that is_octets narrows -- true only of a
+        # caller obeying the annotation, which the check exists for the
+        # one that does not (issue #1433)
+        if is_octets(addresses) or not isinstance(  # type: ignore[redundant-expr]
+            addresses, Sequence
+        ):
+            err_msg = f"invalid addresses type: {type(addresses).__name__}"  # type: ignore[unreachable]
             raise BTClibTypeError(err_msg)
         object.__setattr__(self, "addresses", tuple(addresses))
 

--- a/src/btclib/p2p/compact_blocks.py
+++ b/src/btclib/p2p/compact_blocks.py
@@ -270,7 +270,12 @@ def _short_id(key: tuple[int, int], wtxid: Octets) -> int:
     after a caller changed the header it was taken from.
     """
     k0, k1 = key
-    digest = siphash(k0, k1, bytes_from_octets(wtxid, _HASH_SIZE)[::-1])
+    # bytes(...) rather than the buffer bytes_from_octets hands back: a
+    # memoryview is returned as itself, and reversing one with [::-1]
+    # yields a strided, non-contiguous view that siphash's own call to
+    # bytes_from_octets refuses -- a wtxid spelled as a memoryview would
+    # then raise where every other Octets spelling answers (issue #1429)
+    digest = siphash(k0, k1, bytes(bytes_from_octets(wtxid, _HASH_SIZE))[::-1])
     return digest & _MAX_SHORT_ID
 
 

--- a/src/btclib/psbt/psbt_view.py
+++ b/src/btclib/psbt/psbt_view.py
@@ -117,7 +117,7 @@ from btclib.psbt.psbt_utils import (
 from btclib.script.sig_hash import PrecomputedTxData
 from btclib.tx import Tx, TxOut
 from btclib.tx.limits import MAX_TX_IN_COUNT, MAX_TX_OUT_COUNT
-from btclib.utils import assert_no_trailing, bytes_from_octets, read_exactly
+from btclib.utils import assert_no_trailing, bytes_from_octets, is_octets, read_exactly
 
 __all__ = [
     "PsbtView",
@@ -223,9 +223,7 @@ class PsbtView:
         # memoryview, which `Octets` admits and which it refuses with
         # `BufferError: underlying buffer is not C-contiguous`
         stream: BinaryIO = (
-            BytesIO(bytes(bytes_from_octets(data)))
-            if isinstance(data, (bytes, str, bytearray, memoryview))
-            else data
+            BytesIO(bytes(bytes_from_octets(data))) if is_octets(data) else data
         )
         if not stream.seekable():
             err_msg = "a psbt view needs a seekable stream: it reads a map "
@@ -309,7 +307,7 @@ class PsbtView:
         )
         self._offsets = offsets
 
-        if isinstance(data, (bytes, str, bytearray, memoryview)):
+        if is_octets(data):
             # octets are one whole psbt and a stream is the caller's:
             # btclib/utils.py states the rule both halves read. The cast is
             # this branch's own premise -- octets are what the stream above

--- a/src/btclib/utils.py
+++ b/src/btclib/utils.py
@@ -81,15 +81,34 @@ __all__ = [
 NoneOneOrMoreInt = int | Iterable[int] | None
 
 
-def _assert_contiguous(octets: bytes | bytearray | memoryview) -> None:
-    """Refuse a non-contiguous memoryview, the one buffer that can be one.
+def _assert_byte_shaped(octets: bytes | bytearray | memoryview) -> None:
+    """Refuse a memoryview whose layout or format is not plain bytes.
 
-    `bytes` and `bytearray` are always C-contiguous; a `memoryview` need
-    not be -- a strided slice such as `mv[::2]` is not, and is returned
-    by `bytes_from_octets` untouched unless refused here.
+    `bytes` and `bytearray` are always C-contiguous and always format
+    "B" (unsigned bytes); a `memoryview` need not be either. A strided
+    slice such as `mv[::2]` is not C-contiguous, and is returned by
+    `bytes_from_octets` untouched unless refused here.
+
+    Contiguity is not the only property every other consumer of the
+    buffer this returns assumes: a `memoryview` cast to a signed `"b"`,
+    or built over an array of a wider format such as `"I"`, is
+    C-contiguous and still not read the way `hashes.magic_message`'s
+    `for byte in data` or `hashes.siphash`'s `len(msg)` read it --
+    `len()` counts elements rather than octets, and iterating one
+    yields whatever the format decodes to rather than an unsigned byte
+    in `0..255` (issue #1430). Format `"B"` is the one every buffer
+    this function accepts shares, `bytes`, `bytearray` and an
+    unformatted `memoryview` included, so it is the property asked for
+    rather than `itemsize == 1`, which a signed `"b"` view or a `"c"`
+    one (bytes objects, not ints) would still pass.
     """
-    if isinstance(octets, memoryview) and not octets.c_contiguous:
+    if not isinstance(octets, memoryview):
+        return
+    if not octets.c_contiguous:
         err_msg = "invalid octets: non-contiguous memoryview"
+        raise BTClibValueError(err_msg)
+    if octets.format != "B":
+        err_msg = f"invalid octets: memoryview format {octets.format!r} instead of 'B'"
         raise BTClibValueError(err_msg)
 
 
@@ -107,7 +126,10 @@ def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> byte
     `hash160` failing with a bare `BufferError` being one of them, so the
     refusal is raised through the exception contract at the one place
     every `Octets` parameter passes rather than left to whichever
-    consumer trips over it first.
+    consumer trips over it first. A `memoryview` whose format is not
+    unsigned bytes is refused the same way: `len()` of one counts
+    elements rather than octets, and a consumer that reads it byte by
+    byte reads whatever its format decodes to instead (issue #1430).
     """
     if isinstance(octets, str):  # hex string
         # `bytes.fromhex` raises a bare ValueError -- the same class the
@@ -123,7 +145,7 @@ def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> byte
         except ValueError as e:
             raise BTClibValueError(f"invalid hex string: {e}") from e
     elif isinstance(octets, (bytes, bytearray, memoryview)):
-        _assert_contiguous(octets)
+        _assert_byte_shaped(octets)
     else:
         # what is neither went through untouched and reached whatever the
         # caller went on to do with it: `len` of a tuple of 33 ints is 33,
@@ -160,10 +182,15 @@ def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> byte
             err_msg = f"invalid output size type: {type(size).__name__}"
             raise BTClibTypeError(err_msg)
 
-    if len(octets) in sizes:
+    # nbytes rather than len(): the two already agree for bytes,
+    # bytearray and the format-"B" memoryview _assert_byte_shaped just
+    # let through, so this measures the octets rather than repeating a
+    # coincidence that check happens to make true
+    size = memoryview(octets).nbytes
+    if size in sizes:
         return octets  # type: ignore[return-value]
 
-    err_msg = f"invalid size: {len(octets)} bytes instead of {out_size}"
+    err_msg = f"invalid size: {size} bytes instead of {out_size}"
     raise BTClibValueError(err_msg)
 
 

--- a/src/btclib/utils.py
+++ b/src/btclib/utils.py
@@ -55,6 +55,8 @@ from collections.abc import Iterable, Mapping
 from io import BytesIO
 from typing import Any, BinaryIO
 
+from typing_extensions import TypeIs
+
 from btclib.alias import BinaryData, Integer, Octets, String
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 
@@ -323,7 +325,7 @@ def is_integer(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
 
 
-def is_octets(value: Any) -> bool:
+def is_octets(value: Any) -> TypeIs[Octets]:
     """Return whether the value is one Octets, rather than a sequence of them.
 
     An `Octets` -- `str`, `bytes`, `bytearray` or `memoryview` -- is
@@ -333,6 +335,14 @@ def is_octets(value: Any) -> bool:
     question instead, once, so a spelling `Octets` gains later is refused
     at every caller of this rather than at whichever remembered to list
     it (issue #1261).
+
+    `TypeIs` rather than `bool`: a caller dispatching on this narrows on
+    both branches, `str | bytes | bytearray | memoryview` where it is
+    true and whatever is left of the wider type where it is false, which
+    is what lets a site written as a hand-listed `isinstance` tuple --
+    invisible to a census keyed on that tuple's own element order -- call
+    this instead without losing the narrowing mypy strict mode otherwise
+    needs the tuple for (issue #1433).
     """
     return isinstance(value, Octets)
 

--- a/tests/block/merkle_proof_test.py
+++ b/tests/block/merkle_proof_test.py
@@ -206,6 +206,34 @@ def test_an_honest_block_has_no_inner_node_that_parses_as_a_transaction() -> Non
         merkle_proof.assert_as_valid(block.transactions[index].id, branch, index, root)
 
 
+def test_a_memoryview_txid_and_branch_verify_as_any_other_octets() -> None:
+    """Reversing the buffer bytes_from_octets hands back must not strand it.
+
+    A memoryview is returned unchanged, and `[::-1]` over one is a
+    strided, non-contiguous view: the second `bytes_from_octets` call
+    inside `merkle_root_from_branch` used to refuse it, which `verify`
+    reports as a proof that does not verify rather than as the shape
+    error it is -- a valid proof spelled with memoryviews answered False
+    (issue #1429).
+    """
+    block = _load("block_200000.bin")
+    txids = [tx.id for tx in block.transactions]
+    hashes = [txid[::-1] for txid in txids]
+    root = block.header.merkle_root
+    index = 3
+    branch = [sibling[::-1] for sibling in _branch(hashes, index)]
+
+    txid_mv = memoryview(txids[index])
+    branch_mv = [memoryview(sibling) for sibling in branch]
+    root_mv = memoryview(root)
+
+    merkle_proof.assert_as_valid(txid_mv, branch_mv, index, root_mv)
+    assert merkle_proof.verify(txid_mv, branch_mv, index, root_mv)
+    assert merkle_proof.verify(txid_mv, branch_mv, index, root_mv) == (
+        merkle_proof.verify(txids[index], branch, index, root)
+    )
+
+
 def test_a_malformed_branch_is_refused() -> None:
     """Refuse a branch malformed in sibling size, index or length."""
     block = _load("block_200000.bin")

--- a/tests/input_validation_test.py
+++ b/tests/input_validation_test.py
@@ -115,15 +115,29 @@ _WRONG_TYPE: dict[str, tuple[Any, ...]] = {
     # an Octets, beside None and 1.5: every Octets is itself iterable, so
     # a signature reading Sequence[Octets] or Iterable[Octets] accepts
     # one as far as mypy goes, and a function that does not refuse it by
-    # name zips through its bytes instead (issue #1405)
-    "Iterable[Octets]": (None, 1.5, b"\xaa\xbb\xcc\xdd"),
+    # name zips through its bytes instead (issue #1405). All four Octets
+    # spellings, a guard naming three of the four otherwise passing this
+    # walk (issue #1434)
+    "Iterable[Octets]": (
+        None,
+        1.5,
+        b"\xaa\xbb\xcc\xdd",
+        bytearray(b"\xaa\xbb\xcc\xdd"),
+        memoryview(b"\xaa\xbb\xcc\xdd"),
+    ),
     "Key": (None, 1.5),
     "Octets": (None, 1.5, tuple(range(4))),
     "Point": (None, 1.5, "not a point"),
     "PrvKey": (None, 1.5),
     "PubKey": (None, 1.5),
     "ScriptList": (None, 1.5, "not a list"),
-    "Sequence[Octets]": (None, 1.5, b"\xaa\xbb\xcc\xdd"),
+    "Sequence[Octets]": (
+        None,
+        1.5,
+        b"\xaa\xbb\xcc\xdd",
+        bytearray(b"\xaa\xbb\xcc\xdd"),
+        memoryview(b"\xaa\xbb\xcc\xdd"),
+    ),
     "String": (None, 1.5, 1),
 }
 

--- a/tests/name_contract_test.py
+++ b/tests/name_contract_test.py
@@ -125,6 +125,24 @@ def _promised_by(name: str) -> str | None:
     return None
 
 
+def _return_type(returns: ast.expr) -> str:
+    """Return what a function's annotation promises its caller, TypeIs as bool.
+
+    `TypeIs[Octets]` narrows a caller's type checker and answers exactly
+    `True` or `False` at runtime (PEP 742), the same as the `bool` it
+    replaced on `utils.is_octets` -- so a name promising `bool` is kept
+    to that promise by one, and this is the one place the annotation is
+    read for both censuses below. The caller's own `node.returns is not
+    None` already established what this takes, `ast.expr` rather than
+    `ast.FunctionDef` so mypy narrows it there instead of losing the
+    check across the call.
+    """
+    unparsed = ast.unparse(returns)
+    if unparsed.startswith("TypeIs["):
+        return "bool"
+    return unparsed
+
+
 def _named() -> dict[str, str]:
     """Return every public function whose name promises a return type.
 
@@ -148,7 +166,7 @@ def _named() -> dict[str, str]:
             # strict over it, so an unannotated one is a state the tree
             # does not reach
             assert node.returns is not None
-            found[f"{module}.{node.name}"] = ast.unparse(node.returns)
+            found[f"{module}.{node.name}"] = _return_type(node.returns)
     return found
 
 
@@ -287,7 +305,7 @@ def _public_bools() -> list[str]:
         for node in ast.walk(tree):
             if not isinstance(node, ast.FunctionDef) or node.name.startswith("_"):
                 continue
-            if node.returns is not None and ast.unparse(node.returns) == "bool":
+            if node.returns is not None and _return_type(node.returns) == "bool":
                 found.append(f"{module}.{node.name}")
     return sorted(found)
 

--- a/tests/p2p/address_test.py
+++ b/tests/p2p/address_test.py
@@ -400,6 +400,11 @@ def test_a_wrong_type_is_a_type_error() -> None:
         Addr("10.0.0.1")  # type: ignore[arg-type]
     with pytest.raises(BTClibTypeError, match="invalid addresses type"):
         Addr(b"\x00" * 30)  # type: ignore[arg-type]
+    # every Octets spelling, not only str and bytes (issue #1434)
+    with pytest.raises(BTClibTypeError, match="invalid addresses type"):
+        Addr(bytearray(b"\x00" * 30))  # type: ignore[arg-type]
+    with pytest.raises(BTClibTypeError, match="invalid addresses type"):
+        Addr(memoryview(b"\x00" * 30))
     with pytest.raises(BTClibTypeError, match="invalid address type"):
         Addr([NetworkAddress()])  # type: ignore[list-item]
 

--- a/tests/p2p/addrv2_test.py
+++ b/tests/p2p/addrv2_test.py
@@ -643,6 +643,13 @@ def test_an_addrv2_refuses_what_is_not_a_sequence_of_entries() -> None:
         AddrV2("not a sequence")  # type: ignore[arg-type]
     with pytest.raises(BTClibTypeError, match="invalid addresses type"):
         AddrV2(1)  # type: ignore[arg-type]
+    # every Octets spelling, not str alone (issue #1434)
+    with pytest.raises(BTClibTypeError, match="invalid addresses type"):
+        AddrV2(b"not a sequence")  # type: ignore[arg-type]
+    with pytest.raises(BTClibTypeError, match="invalid addresses type"):
+        AddrV2(bytearray(b"not a sequence"))  # type: ignore[arg-type]
+    with pytest.raises(BTClibTypeError, match="invalid addresses type"):
+        AddrV2(memoryview(b"not a sequence"))
     with pytest.raises(BTClibTypeError, match="invalid address type"):
         AddrV2([1])  # type: ignore[list-item]
 

--- a/tests/p2p/compact_blocks_test.py
+++ b/tests/p2p/compact_blocks_test.py
@@ -202,6 +202,22 @@ def test_the_short_id_is_taken_over_the_hash_the_wire_carries() -> None:
         compact_block.short_id(wtxid[:31])
 
 
+def test_a_memoryview_wtxid_gives_the_same_short_id_as_bytes() -> None:
+    """Reversing the buffer bytes_from_octets hands back must not strand it.
+
+    A memoryview is returned unchanged, and `[::-1]` over one is a
+    strided, non-contiguous view: `siphash`'s own call to
+    `bytes_from_octets` used to refuse it, so a wtxid spelled as a
+    memoryview raised where every other `Octets` spelling answers
+    (issue #1429).
+    """
+    block = _block_481824()
+    compact_block = _compact(block)
+    wtxid = block.transactions[_SEGWIT_INDEXES[0]].hash
+
+    assert compact_block.short_id(memoryview(wtxid)) == compact_block.short_id(wtxid)
+
+
 def test_a_mainnet_block_survives_the_compact_round_trip() -> None:
     """Encode a real block, reconstruct it from a full pool, compare bytes.
 

--- a/tests/serialization_boundary_test.py
+++ b/tests/serialization_boundary_test.py
@@ -354,12 +354,17 @@ _MODULE_READER_IDS = tuple(label for label, _, _ in _MODULE_READERS)
 _MODULE_WRITERS = (
     ("var_int.serialize", var_int.serialize, 1, (None, 1.5, "1", b"\x01")),
     ("var_bytes.serialize", var_bytes.serialize, b"\x01", (None, 1.5, [1, 2])),
-    ("script.serialize", script.serialize, ["OP_DUP"], (None, 1.5, "OP_DUP", b"\x76")),
+    (
+        "script.serialize",
+        script.serialize,
+        ["OP_DUP"],
+        (None, 1.5, "OP_DUP", b"\x76", bytearray(b"\x76"), memoryview(b"\x76")),
+    ),
     (
         "taproot.serialize",
         taproot.serialize,
         ["OP_DUP"],
-        (None, 1.5, "OP_DUP", b"\x76"),
+        (None, 1.5, "OP_DUP", b"\x76", bytearray(b"\x76"), memoryview(b"\x76")),
     ),
 )
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -4,13 +4,14 @@
 
 """Tests for the `btclib.utils` module."""
 
+import array
 import random
 from io import BytesIO
 
 import pytest
 
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.hashes import hash160
+from btclib.hashes import hash160, magic_message, siphash
 from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
@@ -319,6 +320,60 @@ def test_a_non_contiguous_memoryview_is_refused_at_the_coercion() -> None:
     contiguous = memoryview(raw)[:32]
     assert bytes_from_octets(contiguous) == raw[:32]
     assert hash160(contiguous) == hash160(raw[:32])
+
+
+def test_a_memoryview_of_the_wrong_format_is_refused_at_the_coercion() -> None:
+    """A memoryview cast to a non-byte format reads as elements, not octets.
+
+    `array.array("I", [1, 2])` is 8 octets read as two 4-byte unsigned
+    ints; a memoryview over it is C-contiguous, so the contiguity check
+    alone let it through, and `len()` of it answers 2 where a consumer
+    reading octets means 8 (issue #1430). Refused here, once, at the
+    same coercion every `Octets` parameter passes.
+    """
+    raw = bytes(range(8))
+    wide = memoryview(array.array("I", [1, 2]))
+    assert wide.c_contiguous
+    assert wide.format != "B"
+    assert len(wide) == 2
+    assert wide.nbytes == 8
+
+    with pytest.raises(BTClibValueError, match="invalid octets: memoryview format"):
+        bytes_from_octets(wide)
+    with pytest.raises(BTClibValueError, match="invalid octets: memoryview format"):
+        hash160(wide)
+
+    # a plain memoryview, and one cast back to unsigned bytes, are format
+    # "B" and untouched, same as any other buffer
+    plain = memoryview(raw)
+    assert plain.format == "B"
+    assert bytes_from_octets(plain) == raw
+    cast_back = wide.cast("B")
+    assert cast_back.format == "B"
+    assert bytes_from_octets(cast_back) == wide.tobytes()
+
+
+def test_magic_message_and_siphash_answer_the_same_for_every_octets_spelling() -> None:
+    """The two functions issue #1430 named read a buffer element by element.
+
+    `magic_message`'s `var_int.serialize(len(msg))` and `siphash`'s
+    `for byte in data` both used to read a wide-format memoryview's
+    elements where every other `Octets` spelling reads octets, so the
+    two disagreed with `bytes(mv)` silently. `bytes_from_octets` now
+    refuses the buffer before either reads it.
+    """
+    payload = bytes(range(8))
+    wide = memoryview(array.array("I", [1, 2]))
+
+    assert magic_message(payload) == magic_message(bytearray(payload))
+    assert magic_message(payload) == magic_message(memoryview(payload))
+    assert siphash(1, 2, payload) == siphash(1, 2, bytearray(payload))
+    assert siphash(1, 2, payload) == siphash(1, 2, memoryview(payload))
+
+    with pytest.raises(BTClibValueError, match="invalid octets: memoryview format"):
+        magic_message(wide)
+    with pytest.raises(BTClibValueError, match="invalid octets: memoryview format"):
+        siphash(1, 2, wide)
 
 
 def test_is_octets_answers_one_octets_not_a_sequence_of_them() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -420,7 +420,7 @@ test = [
 requires-dist = [
     { name = "bitcoin-core-rpc", specifier = ">=2026.8.13" },
     { name = "btclib-secp256k1", marker = "extra == 'secp256k1'", specifier = ">=0.8.0.4" },
-    { name = "typing-extensions", specifier = ">=4.4" },
+    { name = "typing-extensions", specifier = ">=4.10" },
 ]
 provides-extras = ["secp256k1"]
 


### PR DESCRIPTION
`bytes_from_octets` hands a memoryview back unchanged, and reversing one with `[::-1]` yields a strided, non-contiguous view that a second `bytes_from_octets` call downstream refuses: `merkle_proof.verify` read that refusal as a proof that does not verify, and `CmpctBlock.short_id` raised outright with no such boundary in front of it. Both now copy the buffer to bytes at the point of reversal. `_assert_contiguous`, renamed `_assert_byte_shaped`, asks that a memoryview's format is `"B"` beside the contiguity it already asked — a view cast to a signed `"b"` or built over a wider format is C-contiguous and was read in elements rather than in octets — and `bytes_from_octets`' own output-size check measures `nbytes`.

`utils.is_octets` returns `TypeIs[Octets]`, and the guards an element-order census could not see — `fetch.fetcher.tx_from_raw`, `psbt.psbt_view.PsbtView` twice, `ecc.ssa`'s x-only dispatch — now call it, keeping at every caller the narrowing an `isinstance` tuple gave mypy. The `typing-extensions` floor rises to 4.10, the release that adds `TypeIs`, with the reason beside it in `pyproject.toml`.

The bare-Octets guards are driven with a bytearray and a memoryview beside the str and bytes they already drove, pinning the refactor.

Closes #1429
Closes #1430
Closes #1433
Closes #1434

## Summary by Sourcery

Harden Octets and memoryview handling while standardizing type-narrowing guards across the library.

Bug Fixes:
- Handle memoryview inputs consistently when reversing transaction identifiers and hashes.
- Reject non-contiguous or non-byte-shaped memoryviews at the octet conversion boundary.
- Apply octet validation consistently across remaining input guards.

Enhancements:
- Make is_octets provide TypeIs-based type narrowing for callers.

Build:
- Raise the minimum typing-extensions version to 4.10 to support TypeIs.

Documentation:
- Document the expanded memoryview validation and octet guard behavior in the changelog.

Tests:
- Cover bytearray and memoryview inputs across octet guards and serialization boundaries.
- Add regression coverage for memoryview-based Merkle proofs, compact-block short IDs, and invalid memoryview formats.