### PR TITLE
The Best Practices badge, the ceiling's one home, an index wait with no guard, and a copied script's scope

### DIFF
--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -11,10 +11,18 @@ procedure and reports drift, rather than fixing it: refreshing a vector
 file is a decision this script does not get to make, so what it opens
 is an issue, never a commit.
 
+btclib-secp256k1 carries a copy under this same name, and the two are
+not interchangeable: that one parses its own tests/README.md, and it
+passes over an entry with no `commit` in silence where this one reports
+the heading as skipped. The two checks differ there because the pin
+files do -- that README has no such entry, this one does. The rest is
+common to both, so a fix to the parsing, to the `gh` call or to a
+field's spelling is owed to the other copy in the same campaign.
+
 Scope is narrower than the README: only entries whose `behind` already
 reads 0 -- the ones a human last confirmed were exactly at upstream's
 tip. An entry documented as behind is a decision already made, and
-re-reporting the same gap every month would just be noise; if a *new*
+re-reporting the same gap every week would just be noise; if a *new*
 commit moves it further, `behind`'s own count in the README goes stale
 in a way this script cannot see either, which is the reason it never
 tries to judge relevance, only tip-vs-pinned identity.

--- a/.github/workflows/os-windows.yml
+++ b/.github/workflows/os-windows.yml
@@ -34,9 +34,10 @@ name: os-windows
 #
 # A workflow of its own rather than a row in os-macos.yml, which is the same
 # design that file argues for itself: one variable each, so a red cell
-# names a platform. On its own hour too, an hour after os-macos.yml: fourteen
-# more jobs against twenty slots would rebuild in one morning the queue
-# this file exists to take out of a pull request.
+# names a platform. On its own hour too, an hour after os-macos.yml: this
+# matrix landing on top of that one, against the ceiling REPOSITORY.md's
+# Plan-gated settings carries, would rebuild in one morning the queue this
+# file exists to take out of a pull request.
 #
 # It gates no commit and no merge -- a Windows regression sits on main for
 # at most a week -- but release.yml calls it, so one cannot be published

--- a/.github/workflows/pypi-install.yml
+++ b/.github/workflows/pypi-install.yml
@@ -148,38 +148,52 @@ jobs:
       # none of this. The wait step went in without the line (issue #1141)
       # and took every Windows cell of v2026.8.21's release run with it --
       # "Missing opening '(' after keyword 'for'" -- having never run
-      # before that tag, the release path being the only one that reaches
-      # it. A step whose script happens to be a couple of plain commands
-      # survives PowerShell unchanged, which is what makes an omission
-      # invisible on review; declaring it on every step is what makes the
-      # absence of one visible instead. Both siblings' copies of this file
-      # already do
+      # before that tag, a release being then the only trigger that
+      # reached it. A step whose script happens to be a couple of plain
+      # commands survives PowerShell unchanged, which is what makes an
+      # omission invisible on review; declaring it on every step is what
+      # makes the absence of one visible instead. Both siblings' copies of
+      # this file already do
       #
       # the index does not serve a new file the instant the upload returns,
       # and this workflow installs whatever the resolver picks: a run that
       # starts too early tests the *previous* version and reports a pass for
-      # it, which is worse than reporting nothing. So the release path waits
-      # for the version its tag names, and fails if it never arrives rather
-      # than measuring the wrong thing. Only there: the input is empty on
-      # every other trigger
+      # it, which is worse than reporting nothing. So a run with a release
+      # behind it waits for the version its tag names, and fails if it never
+      # arrives rather than measuring the wrong thing.
+      #
+      # The step itself runs on every trigger and does nothing on most of
+      # them, the input being empty wherever no release is calling. An
+      # `if:` here would make a tag the only thing that ever runs it, and
+      # a step a release is the first to run is a step whose defect ships
+      # with that release -- which has already happened to this script, in
+      # more than one of these repositories. Unguarded, every weekly run
+      # parses it on every cell of the matrix. The empty case is a
+      # condition around the loop rather than an early `exit 0` for that
+      # same reason: bash parses a script as it runs, so an exit at the
+      # top leaves what follows unparsed, where an `if` is parsed whole
+      # before its condition is tested
       - name: Wait for the index to serve the released version
-        if: inputs.version != ''
         shell: bash
         env:
           TAG: ${{ inputs.version }}
         run: |
           version="${TAG#v}"
-          for attempt in $(seq 20); do
-            if curl -sf --max-time 10 -o /dev/null \
-                "https://pypi.org/pypi/btclib/${version}/json"; then
-              echo "the index serves ${version}"
-              exit 0
-            fi
-            echo "attempt ${attempt}: ${version} is not served yet"
-            sleep 15
-          done
-          echo "::error::${version} never appeared on the index"
-          exit 1
+          if [ -z "$version" ]; then
+            echo "no release behind this run: nothing to wait for"
+          else
+            for attempt in $(seq 20); do
+              if curl -sf --max-time 10 -o /dev/null \
+                  "https://pypi.org/pypi/btclib/${version}/json"; then
+                echo "the index serves ${version}"
+                exit 0
+              fi
+              echo "attempt ${attempt}: ${version} is not served yet"
+              sleep 15
+            done
+            echo "::error::${version} never appeared on the index"
+            exit 1
+          fi
       # uv rather than actions/setup-python, which is what every other
       # workflow here already uses and what this one has to use for a
       # reason of its own: setup-python installs from the runner tool
@@ -319,27 +333,32 @@ jobs:
         python: ["3.14"]
     timeout-minutes: 20
     steps:
-      # the same wait, for the same reason install-published's copy
-      # states: a run started by release.yml's call must not measure the
-      # version the tag is replacing
+      # the same wait, unguarded the same way and for the reasons
+      # install-published's copy states: a run started by release.yml's
+      # call must not measure the version the tag is replacing, and a
+      # step only a release ever runs is a step only a release finds
+      # broken
       - name: Wait for the index to serve the released version
-        if: inputs.version != ''
         shell: bash
         env:
           TAG: ${{ inputs.version }}
         run: |
           version="${TAG#v}"
-          for attempt in $(seq 20); do
-            if curl -sf --max-time 10 -o /dev/null \
-                "https://pypi.org/pypi/btclib/${version}/json"; then
-              echo "the index serves ${version}"
-              exit 0
-            fi
-            echo "attempt ${attempt}: ${version} is not served yet"
-            sleep 15
-          done
-          echo "::error::${version} never appeared on the index"
-          exit 1
+          if [ -z "$version" ]; then
+            echo "no release behind this run: nothing to wait for"
+          else
+            for attempt in $(seq 20); do
+              if curl -sf --max-time 10 -o /dev/null \
+                  "https://pypi.org/pypi/btclib/${version}/json"; then
+                echo "the index serves ${version}"
+                exit 0
+              fi
+              echo "attempt ${attempt}: ${version} is not served yet"
+              sleep 15
+            done
+            echo "::error::${version} never appeared on the index"
+            exit 1
+          fi
       - name: Setup uv with Python ${{ matrix.python }}
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,24 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **`README.md`'s badge row ends with the OpenSSF Best Practices badge.**
+  Section 2 of the organization standard keys it on the property
+  *registered at bestpractices.dev* and fixes its place last in the row,
+  after Read the Docs. What it renders is the questionnaire's live state,
+  which is the line between it and the REUSE badge that same section
+  refuses: a state that moves when an answer stops being true, rather
+  than a registration with a service (issue btclib-org/.github#350).
+
+- **The concurrency ceiling's figure lives in `REPOSITORY.md`'s
+  *Plan-gated settings* alone**, beside
+  `gh api orgs/btclib-org --jq .plan.name` and GitHub's own table of what
+  each plan gives, section 10 of the organization standard giving the
+  number one home per tree. *Required checks on main* now states the
+  ceiling unnumbered and points there, as does `os-windows.yml`'s header,
+  which stated the figure outright. A date beside a number says when it
+  was true and not that it still is, where the command answers for the
+  day it is run (issue btclib-org/.github#412).
+
 - **`CLAUDE.md`'s *Non-obvious facts* section gains three bullets,**
   learned running this campaign: `btclib-org/.github`'s weekly calendar
   is two tables and either can move mid-campaign, so a row's day/hour or
@@ -844,6 +862,31 @@ documented at release-notes length in the first place, and are still in
   declaration is that the bullet stays untested (closes #1431).
 
 ### Packaging, linting and CI
+
+- **`pypi-install.yml`'s index-wait step runs on every trigger**, doing
+  nothing where no release is calling, in place of the
+  `if: inputs.version != ''` that made a tag the only thing which ever ran
+  it. A step a release is the first to run is a step whose defect ships
+  with that release, which this step's has done in more than one
+  publishing repository; unguarded, every weekly run parses it on every
+  cell of the matrix. The empty case is a condition around the wait loop
+  rather than an early `exit 0`, bash parsing a script as it runs: an
+  exit at the top would leave the loop below unparsed, and that parse is
+  what the shape buys. Both jobs of the workflow carry the step, and the
+  comment explaining the shape is written to be taken verbatim by the two
+  sibling publishing repositories (issue btclib-org/.github#49).
+
+- **`.github/scripts/check_vendored_vectors.py` says what it parses and
+  where it departs from `btclib-secp256k1`'s copy of the same name.**
+  Section 14 of the organization standard keeps these copies per
+  repository by subject and outside the compared list, asking each for
+  that sentence instead: this one reads `tests/_data/README.md` and
+  reports a pin with no `commit` as a skipped heading, where the sibling
+  reads its own `tests/README.md` and passes such an entry over in
+  silence, its pin file having none. The rest is common to both, so a fix
+  to the parsing, to the `gh` call or to a field's spelling is owed to
+  the other copy. Its scope paragraph also says *every week*, which is
+  what `vendored-vectors.yml` schedules (issue btclib-org/.github#446).
 
 - **`pyproject.toml`'s ruff configuration selects `["ALL"]`,** matching
   section 5 of the organization standard, in place of the hand-picked

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ own -- is to the trigger rule rather than to the calendar. -->
 [![mutation workflow status](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml)
 [![integration-bitcoind workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml)
 [![documentation build](https://app.readthedocs.org/projects/btclib/badge/?version=latest)](https://btclib.readthedocs.io)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14253/badge)](https://www.bestpractices.dev/projects/14253)
 
 ---
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -77,12 +77,13 @@ the one claim the recorded vectors cannot make. `integration-bitcoind.yml`
 therefore carries no `paths` filter: a required check that never runs blocks a
 merge, where a skipped one satisfies it.
 
-GitHub Free gives an organization twenty concurrent jobs (as of
-2026-08-21). Measured over a working afternoon while a commit here asked
-for thirty-nine, this repository sat at nineteen or twenty running jobs
-for 1375 of 2100 seconds — so a pull request's wall clock was the wait
-for a slot and not the work. That is the measurement the gate and the
-weekly sweeps are arranged around.
+The plan puts a ceiling on how many jobs the organization runs at once,
+and *Plan-gated settings* below is where that figure lives, beside the
+command that re-derives it. Measured over a working afternoon while a
+commit here asked for thirty-nine jobs, this repository sat at the
+ceiling or one job below it for 1375 of 2100 seconds — so a pull
+request's wall clock was the wait for a slot and not the work. That is
+the measurement the gate and the weekly sweeps are arranged around.
 
 `codeql.yml` carries no required check at all. It runs on `main`, on its
 schedule and on every pull request now — the OpenSSF Scorecard's `SAST`
@@ -619,3 +620,37 @@ non-provider patterns and validity checks need paid Secret Protection,
 and the API answers a PATCH with 200 while leaving them disabled. Do not
 read that 200 as success. The `detect-secrets` hook is the compensating
 control.
+
+The other plan-gated number is not a setting at all, and it is the one
+this repository's workflows are arranged around: how many jobs may run
+at once. It is an attribute of the organization, shared by every
+repository in it, and the plan is what sets it.
+
+```shell
+gh api orgs/btclib-org --jq .plan.name        # free
+```
+
+[GitHub's own table](https://docs.github.com/en/actions/reference/limits)
+is the authority, and two of its columns matter here — the standard
+runner rows, larger runners being a thing nothing here asks for (read on
+2026-08-26, GitHub free to move the numbers without notice):
+
+| plan | concurrent jobs | of which macOS |
+| --- | --- | --- |
+| Free | 20 | 5 |
+| Pro | 40 | 5 |
+| Team | 60 | 5 |
+| Enterprise | 500 | 50 |
+
+**Read the second column before spending anything on the first.** The
+first is what *Required checks on main* above measures a wider gate
+against, and Team would triple it; the second is the ceiling behind the
+macOS queueing `os-macos.yml`'s header records, and Team does not move it
+at all. So taking the platform cells out of the merge gate is not a
+workaround for a plan — below Enterprise no plan changes that
+arithmetic, and Enterprise is not what is being asked about. What a paid
+plan would buy is the rest: the Linux and Windows crowding, and the
+contention with every other repository of the organization, which spends
+against this same ceiling. Whether that is worth paying for is a
+question for whoever would pay, and it is recorded here so that it is
+asked with the second column in view.


### PR DESCRIPTION
The Best Practices badge, the ceiling's one home, an index wait with no guard, and a copied script's scope

README.md's badge row ends with the OpenSSF Best Practices badge, which
section 2 of the organization standard keys on the property registered
at bestpractices.dev and places last in the fixed order, after Read the
Docs. The project is 14253: its badge answers 200 and its page names
this repository.

Section 10 gives the concurrency ceiling's figure one home per tree,
REPOSITORY.md's Plan-gated settings, beside the command that re-derives
it. That section gains the plan command, GitHub's own table read today
and what its macOS column means for the platform sweeps. Required checks
on main and os-windows.yml's header, which stated the figure, now state
the ceiling unnumbered and point there; os-ubuntu.yml, claude-review.yml,
codeql.yml and CONTRIBUTING.md's own half already did. CONTRIBUTING.md's
shared half names the ceiling without a figure and is left alone, an
edit there being a divergence from every other repository rather than
this tree's to make.

pypi-install.yml's index-wait step loses its `if: inputs.version != ''`
in both jobs, which is option 3 of the decision recorded on
btclib-org/.github#49: a step a release is the first to run is a step
whose defect ships with that release, and this one's has. The empty case
is a condition around the wait loop rather than an early `exit 0`, and
that is measured rather than assumed: with the loop inside a condition
that is false, a syntax error injected into it still fails an empty-TAG
run with exit 2, where an early exit leaves the loop unparsed and
answers 0. An empty TAG exits 0 and a served version still passes, both
run against the step body parsed out of the file. The step's comment is
written to be copied unchanged into bitcoin-core-rpc and
btclib-secp256k1.

Section 14 asks every copy of check_vendored_vectors.py for a header
sentence naming what it parses and where it departs from the sibling of
the same name, the copies being per repository by subject and outside
the compared list. This one reads tests/_data/README.md and reports a
pin with no `commit` as a skipped heading, where btclib-secp256k1's
reads its own tests/README.md and passes such an entry over in silence,
its pin file having none. Its scope paragraph said every month where
vendored-vectors.yml schedules a week.

No issue closes here: each of the four is owed by more than one tree.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


---

**No closing keyword, deliberately.** All four are decisions owed by
several trees: `#350`'s registration is the maintainer's, `#412` and
`#49` span four and three repositories, and `#446` wants every copy.

The measurement at the heart of the `#49` port, reproduced independently
by the reviewer with controls in both directions and a `bash -n` control
besides: **bash parses a script as it runs**, so an early `exit 0` leaves
everything below it unparsed and exits 0 on a file `bash -n` reports as
malformed. The guarded-condition shape is the only one of the two that
buys what dropping the `if:` was chosen for. Measured on GNU bash 3.2.57;
the runners' bash 5.x is untested, and the mechanism is bash's documented
execution model rather than something verified at that version.

Gates, all exit 0: `uv sync`; lint `pre-commit run --all-files`; `mypy`;
bindings arm `pytest --cov` (31047 passed, 100.00%); harness sync;
bindings-absent assert; no-bindings arm (25102 passed); `coverage
combine`; `coverage report --fail-under=100` (100.00%); `uv sync`;
docs `sphinx-build -n -W --keep-going`.

## Summary by Sourcery

Align repository metadata, concurrency documentation, release workflow validation, and vendored-vector script guidance with the organization’s shared standards.

New Features:
- Add an OpenSSF Best Practices badge to the README badge row.
- Document the organization’s concurrency limits, plan lookup, and macOS-specific capacity in REPOSITORY.md.

Bug Fixes:
- Ensure PyPI index-wait scripts are parsed and validated on every workflow trigger while remaining a no-op when no release version is supplied.

Enhancements:
- Clarify the scope and repository-specific differences of the vendored-vector checking script.
- Consolidate the concurrency ceiling as a single documented value rather than duplicating it across workflow and repository documentation.

CI:
- Update both PyPI publishing jobs to use guarded waiting logic without a workflow-level input condition.
- Clarify workflow comments around concurrency limits and platform scheduling.

Documentation:
- Record the badge, concurrency-limit, publishing-workflow, and vendored-vector-check changes in the changelog.