### PR TITLE
v2026.8.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Only v2026.8.7 and what follows it are here. The releases before it were
 documented at release-notes length in the first place, and are still in
 [RELEASE_NOTES.md](./RELEASE_NOTES.md) rather than duplicated here.
 
-## v2026.9 (work in progress, not released yet)
+## v2026.8.26
 
 ### Repository
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,7 +19,7 @@ behind this file.
 Release names follow *[calendar versioning](https://calver.org/)*:
 full year, short month, short day (YYYY-M-D)
 
-## v2026.9 (work in progress, not released yet)
+## v2026.8.26
 
 ### Breaking changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ name = "btclib"
 # file. Not a literal in src/btclib/__init__.py for setuptools to import
 # and conf.py to repeat: two declarations are two things a release
 # workflow has to compare before trusting either
-version = "2026.9"
+version = "2026.8.26"
 description = "A library for 'bitcoin cryptography'"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "btclib"
-version = "2026.9"
+version = "2026.8.26"
 source = { editable = "." }
 dependencies = [
     { name = "bitcoin-core-rpc" },


### PR DESCRIPTION
Cuts **v2026.8.26**: `pyproject.toml`'s version, the re-lock that follows
it, and the two "work in progress" headings retitled. Nothing else is in
the diff, which is what makes the commit under the tag readable.

## What the release is

The largest source-breaking cycle since v2023.7.12, and a new protocol
layer beside it. The full record is
[CHANGELOG.md](./CHANGELOG.md#v2026826); what a user has to *act* on is
[RELEASE_NOTES.md](./RELEASE_NOTES.md#v2026826), and this is the shape of
it.

**A user has to act on** a run of refusals that used to be silent
answers. A `bool` is no longer an integer anywhere — as a key, a
multiplier, a curve parameter or a `Point` coordinate — where
`wif_from_prv_key(True)` used to hand back a WIF of the key 1.
`borromean.sign` and `pedersen.commit` refuse a scalar outside 1..n-1
rather than reducing it into range. `ecc` no longer takes a WIF or an
extended key where a private key belongs, `ecc.ssa` no longer takes a
BIP32 extended key as a BIP340 public key, and `fingerprint` is
`btclib.bip32`'s now rather than `to_pub_key`'s. `deserialize_tx` stops
declaring an `include_witness` that meant nothing.
`NETWORKS["regtest"].genesis_block` was stored byte-reversed and is
corrected, so an equality against the old value stops holding.
`script.taproot`'s internal key refuses a hybrid SEC prefix on both
arms. And the importable package moved from the repository root to
`src/btclib/`, which changes nothing for an install and everything for a
checkout used in place.

**New in the library**: `btclib.p2p`, the peer-to-peer message layer —
the handshake and address payloads, the inventory payloads, BIP152's
compact blocks, BIP155's `addrv2`, BIP157's block filters, and the `tx`
and `block` payloads, each parsed through one `Message` envelope.
`btclib.key` holds the canonical form of a key, `PubKeyData` and
`PrvKeyData`, so a key parsed once is carried rather than spelled back
to be parsed again. `btclib.kdf` is the key derivation functions.
`btclib.bip85` derives a Nostr key. `ecc.dsa.Signer` and `ecc.ssa.Signer`
sign several messages under one key. The HWI wrapper gains
`register_descriptor`.

**Worth knowing, and nothing raises**: a `bytearray` and a `memoryview`
are octets everywhere `bytes` and a hex `str` already were —
`Octets`, `String`, `Integer`, `Command`, `DerPath`, `PrvKey`, `PubKey`
and `Key` all widened, and the guards behind them were driven with all
four spellings to prove it.

**Repository**: the bindings are an extra and not a dependency, so
`import btclib` answers with no C toolchain in reach and CI runs the
suite with none installed; ClusterFuzzLite fuzzes the parsers a peer's
bytes reach first; the OpenSSF Scorecard and CodeQL run against this
tree; ruff selects `ALL`, with every declined rule carrying its own
argument.

## The steps nothing enforces

- **`deps-latest`**, dispatched before the tag rather than waited for:
  [run 33005739198](https://github.com/btclib-org/btclib/actions/runs/33005739198)
  — **green, every job**: `bindings at latest` and `dependencies at
  latest` alike, on ubuntu, macOS and Windows across 3.10 and 3.14.
  Nothing to read past — the bindings pin is sound and no stranger has
  drifted, which is the reading that lets a tag go out.
- **`griffe check btclib -a v2026.8.21`** exits 1 with ten differences.
  Eight are the alias widening above, reported as
  `Attribute value was changed` and breaking nobody. The two real ones —
  `to_pub_key.fingerprint` removed, and `BIP340PubKey` losing
  `BIP32Key` — are both already in RELEASE_NOTES.md's breaking-changes
  list. Nothing it names is missing.
- **Dependencies were brought to their newest release first**, in
  [#1452](https://github.com/btclib-org/btclib/pull/1452), rather than
  left for Dependabot: the choice is stated there floor by floor,
  including the two btclib-org floors that deliberately did not move.

## Gates

Run in the branch's own worktree, exit code read:

- `uv run pre-commit run --all-files` — 0
- `uv run pytest --cov` — 0, coverage 100.00%
- `uv run --locked --no-default-groups --group docs sphinx-build -n -W
  --keep-going -b html docs/source docs/build/html` — 0

## Summary by Sourcery

Prepare the v2026.8.26 release by updating its version metadata and release documentation.

Build:
- Update the project version and lockfile for the v2026.8.26 release.

Documentation:
- Retitle the changelog and release notes sections from work in progress to v2026.8.26.