### PR TITLE
fuzz is a sentinel and nothing else (issue btclib-org/.github#460)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -27,22 +27,39 @@ name: fuzz
 # discovering each target by its own glob rather than by a list this
 # file would have to keep in step with `fuzz/`'s own contents.
 #
-# Two jobs, ClusterFuzzLite's own two fuzzing modes
-# (google/clusterfuzzlite's docs/running_clusterfuzzlite.md, "ClusterFuzz
-# Lite Modes"): `pr_fuzzing` runs the short "code-change" mode on a pull
-# request, which is what the OpenSSF Scorecard's `Fuzzing` check credits
-# on the branch itself rather than only after it lands; `batch_fuzzing`
-# runs the longer "batch" mode, which is what builds a corpus over time
-# and is meant for a schedule rather than for a pull request's own wait.
+# One job, ClusterFuzzLite's "batch" mode (google/clusterfuzzlite's
+# docs/running_clusterfuzzlite.md, "ClusterFuzz Lite Modes"), which is
+# what builds a corpus over time and is meant for a schedule. No pull
+# request trigger and no "code-change" job beside it: section 10 of the
+# organization standard makes the clock the discriminator rather than
+# the trigger, and says why *not required* is not the free half of that
+# -- what a pull request charges is the wait, and a reader waits on the
+# list rather than on the subset of it that gates. An hour of fuzzing on
+# every push is not work the clock is deciding.
 #
-# `batch_fuzzing` runs on the schedule below, which section 10 of the
-# organization standard, in btclib-org/.github, names for `fuzz`. Not
+# The half a pull request does owe is the regression, and it is an
+# ordinary test of the suite: it names the input this fuzzer crashed on
+# and what `parse` is expected to do with it now, which is usually to
+# refuse it in this library's own exception.
+#
+# Not `fuzz/corpus/`, which is a seed corpus and answers the opposite
+# question. `tests/fuzz_corpus_test.py` asserts that every seed there is
+# still a valid serialization of what it parses, so a crash input added
+# to it is refused by the very hardening that fixed the crash, and the
+# only way back to green would be to delete the regression. What that
+# gate is for is keeping this fuzzer's own starting point honest as the
+# parsers move under it, in milliseconds and with no container to
+# build -- which is a different service, and a real one.
+#
+# The schedule below is section 10's own grid for `fuzz`. Not
 # `push: branches: [main]` either, unlike `scorecard.yml`: `fuzz-seconds:
 # 3600` below is an hour of fuzzing, and ClusterFuzzLite's own docs call
 # a push-triggered batch job "not recommended" for exactly the reason
 # that becomes -- one on every push queues faster than an hour-long job
 # drains. `workflow_dispatch` is required by this section regardless of
-# the above, and is what runs a batch by hand between scheduled runs.
+# the above, and is what runs the batch by hand -- before a release
+# rather than waiting for Monday, which is what section 10 names it
+# for.
 on:
   schedule:
     # Day and hour are section 10's own workflow table; minute is this
@@ -51,83 +68,45 @@ on:
     # file's to restate.
     - cron: "4 3 * * 1"
   workflow_dispatch:
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, closed]
 
-# least privilege for the GITHUB_TOKEN: neither job writes to the
-# repository or to code scanning -- `output-sarif: true` below only
+# least privilege for the GITHUB_TOKEN: the job below writes neither to
+# the repository nor to code scanning -- `output-sarif: true` only
 # writes the SARIF as a run artifact, uploading nothing on its own -- so
-# no job elevates past the workflow default
+# nothing elevates past the workflow default
 permissions:
   contents: read
 
 # named literally rather than through github.workflow, which in a called
 # workflow is the caller's name (section 10's "What every workflow
-# does"); a pull request run never collides with either of the other
-# two, `github.event.pull_request.number` being unset on both, so the
-# fallback to `github.ref` groups a schedule run and a workflow_dispatch
-# run together instead -- wanted, not merely tolerated:
+# does"). The group is `github.ref`, so a scheduled run and a dispatch
+# on the same ref share one -- wanted, not merely tolerated:
 # cancel-in-progress below means a manual run does not wait behind the
-# scheduled batch's own hour for the numbers it was asked for, the same
-# design and the same reason `mutation.yml` already carries
+# scheduled batch's own hour for the numbers it was asked for, which is
+# the whole of why the dispatch is there before a release. Same design
+# and same reason `mutation.yml` already carries
 concurrency:
-  group: fuzz-${{ github.event.pull_request.number || github.ref }}
+  group: fuzz-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  pr_fuzzing:
-    name: PR fuzzing
-    # a draft pull request is work in progress, and a closed one is taken
-    # only to supersede a run its own concurrency group is still holding
-    # -- the same guard codeql.yml and test.yml carry, for the same
-    # reason
-    if: >-
-      github.event_name == 'pull_request' &&
-      !github.event.pull_request.draft &&
-      github.event.action != 'closed'
-    runs-on: ubuntu-latest
-    # the docker build plus 600 seconds of fuzzing, far above what either
-    # takes: what this bounds is a hung job holding a runner
-    timeout-minutes: 20
-    steps:
-      # every action pinned to a commit SHA. The tag is a comment above
-      # rather than the usual trailing one: `google/clusterfuzzlite/
-      # actions/build_fuzzers` and its sha already fill the 100-column
-      # budget .yamllint.yaml sets for a pin, and appending " # v1"
-      # would cross it -- the disable-line escape hatch that comment
-      # describes cannot carry the tag text too, its own regex admitting
-      # nothing else on the line.
-      # No `actions/checkout` step: the two actions below run as docker
-      # actions against the workspace GitHub Actions already checked out
-      # for a `pull_request` trigger, which is what
-      # google/clusterfuzzlite's own referenced example
-      # (oliverchang/curl's cflite_pr.yml) does too
-      - name: Build fuzzers
-        # v1
-        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
-        with:
-          language: python
-          sanitizer: address
-      - name: Run fuzzers
-        # v1
-        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          fuzz-seconds: 600
-          mode: code-change
-          sanitizer: address
-          output-sarif: true
-
   batch_fuzzing:
     name: Batch fuzzing
+    # the guard stays although both triggers above satisfy it: an hour of
+    # fuzzing then stays off any trigger added later until this line is
+    # widened on purpose
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     # the docker build plus one hour of fuzzing (fuzz-seconds below), far
     # above what either takes
     timeout-minutes: 90
     steps:
-      # the tag is a comment above rather than trailing, for the reason
-      # given in `pr_fuzzing`'s own copy of this comment
+      # every action pinned to a commit SHA. The tag is a comment above
+      # rather than the usual trailing one: `google/clusterfuzzlite/
+      # actions/build_fuzzers` and its sha already fill the 100-column
+      # budget .yamllint.yaml sets for a pin, and appending " # v1" would
+      # cross it -- the disable-line escape hatch that comment describes
+      # cannot carry the tag text too, its own regex admitting nothing
+      # else on the line
       - name: Build fuzzers
         # v1
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
@@ -144,7 +123,7 @@ jobs:
           sanitizer: address
           output-sarif: true
 
-  # no aggregate job: neither job above is a required check. A branch
+  # no aggregate job: the job above is not a required check. A branch
   # rule naming one would be naming a context a fuzzing finding is meant
   # to open an issue against (section 10's "What fills the workflow is
   # the tree's"), not to block a merge on -- the reviewer already reads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,36 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **`fuzz.yml` ran on every pull request and gated nothing** (issue
+  btclib-org/.github#460): the `pull_request` trigger and the
+  `pr_fuzzing` job that hung on it are gone, and `fuzz` is what section
+  10 of the organization standard calls it, a sentinel — `schedule` and
+  `workflow_dispatch`, nothing else. That job put ten minutes of fuzzing
+  on every push to an open pull request, and
+  `gh run list --workflow fuzz.yml --json event,conclusion` says what
+  became of those runs. No merge was waiting on the answer: `main`'s
+  `required_status_checks` names `Lint and type-check`, `Build the
+  documentation`, `test: every job passed` and `Regtest against Bitcoin
+  Core`, and `fuzz` produces none of those contexts, so what the job
+  charged was the reader's wait. That rule lives in the classic
+  branch-protection object rather than in a ruleset, which is why
+  `gh api repos/btclib-org/btclib/branches/main/protection` answers for
+  it and a rulesets-only read answers nothing. The pull request that cut
+  v2026.8.26 merged three minutes into its `PR fuzzing` job and
+  cancelled it, run `33008079111`, which is the case section 10 quotes.
+  `CONTRIBUTING.md`'s *What runs when* row moves with the triggers.
+
+- **A crash this sentinel finds becomes an ordinary test, not a seed**:
+  the regression names the input and what `parse` is expected to do with
+  it now, which is usually to refuse it in `BTClibException`.
+  `fuzz/corpus/` answers the opposite question —
+  `tests/fuzz_corpus_test.py` asserts that every seed there is still a
+  valid serialization of what it parses, so a crash input added to it is
+  refused by the very hardening that fixed the crash, and the only way
+  back to green would be to delete the regression. What that gate is for
+  is keeping this fuzzer's own starting point honest as the parsers move
+  under it.
+
 - **`README.md`'s badge row ends with the OpenSSF Best Practices badge.**
   Section 2 of the organization standard keys it on the property
   *registered at bestpractices.dev* and fixes its place last in the row,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -464,7 +464,7 @@ read by every checkout of this repository.
 | `website` | pull request, push, on website files | — |
 | `claude-review` | pull request, and `@claude` in a comment | — |
 | `codeql` | pull request, push to main, and weekly | 2 languages |
-| `fuzz` | pull request, weekly | — |
+| `fuzz` | weekly, and by hand before a release | — |
 | `scorecard` | weekly, push to main | — |
 | `os-ubuntu` | weekly, a release | ubuntu images and interpreters |
 | `os-macos` | weekly, a release | macOS images and interpreters |


### PR DESCRIPTION
Issue btclib-org/.github#460 — the standard's half is
btclib-org/.github#461, which lands first.

`fuzz.yml` loses the `pull_request` trigger and the `pr_fuzzing` job that
hung on it. `schedule` and `workflow_dispatch` are what is left, which is
what section 10 calls a sentinel.

**What the pull request arm cost**, over this file's first day (landed
`bf42c89d`, 2026-08-25):

- 93 runs, every one `pull_request`. The scheduled arm has never fired,
  which is not a defect: the cron is `4 3 * * 1` and the first Monday
  after landing had not arrived. Control that this tree's crons do fire —
  `mutation.yml` 3 scheduled runs, `deps-latest.yml` 1.
- Of the last 60: **30 `skipped`, 29 `cancelled`, 0 completed.** The
  concurrency group takes each at the next push, after it has held a
  runner for as much as its 20-minute `timeout-minutes`.
- **16 minutes on #1452**, the pull request cut for the v2026.9 release,
  with every other check already green.

This repository carries no `required_status_checks` rule, so none of that
was a merge waiting on an answer — it was the wait a reader pays.

**The regression half is not lost.** `tests/fuzz_corpus_test.py` replays
every seed under `fuzz/corpus/` against the entry points each harness
declares, on every ordinary `pytest` run, in milliseconds and with no
container to build. A crash the sentinel finds becomes a seed there.

**Two details worth a reviewer's eye.** The concurrency group drops
`github.event.pull_request.number ||`, a fallback nothing can take now.
`batch_fuzzing`'s `if:` **stays** although both remaining triggers
satisfy it, with a comment saying why: it keeps an hour of fuzzing off a
trigger somebody adds later without reading the header, which is how the
pull request one arrived.

**Gates**, run on this sha:

- `uv run --locked --only-group lint pre-commit run --all-files
  --show-diff-on-failure` → exit **0**, 41 Passed / **0 Failed**
  (`actionlint`, `zizmor`, `yamllint`, `markdownlint-cli2` among them);
  the commit hook ran the same set again at commit time.
- `uv run --locked --no-default-groups --group test pytest --cov` → exit
  **0**, `31047 passed, 11 skipped`.
- `uv run --locked --no-default-groups --group docs sphinx-build -n -W
  --keep-going` → exit **0**, `build succeeded` — owed because
  `docs/source/changelog_link.md` pulls `CHANGELOG.md` under `-W`.

**Not run, and why**: the no-bindings arm and the `coverage combine
--fail-under=100`. The diff touches no `.py` — `git status --porcelain`
lists `fuzz.yml`, `CHANGELOG.md`, `CONTRIBUTING.md` and nothing else — so
no line of measured source moved. Stated rather than assumed.

## Summary by Sourcery

Make fuzzing a scheduled and manually dispatched sentinel instead of running it on pull requests.

Bug Fixes:
- Stop running fuzzing on every pull request, eliminating unnecessary runner usage and pull-request wait time from a non-required check.

Enhancements:
- Retain fuzzing as a scheduled or manually dispatched sentinel job for periodic and pre-release corpus exploration.
- Document the updated fuzzing trigger behavior and clarify that discovered crashes should become ordinary regression tests rather than corpus seeds.

Documentation:
- Update contributor documentation to describe weekly and pre-release manual fuzzing instead of pull-request fuzzing.
- Record the fuzzing workflow and regression-testing policy in the changelog.