### PR TITLE
release.yml: publish-testpypi and publish-pypi stop gating on public-api's result

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -422,6 +422,17 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI
+    # public-api stays a need for ordering -- reading a broken surface
+    # before spending the platform sweeps' wall clock is the point,
+    # public-api's own comment says so -- but not for its result: that
+    # job's own comment calls it deliberately not a merge gate, and
+    # `needs` without `always()` gates on every listed job regardless,
+    # a skipped job counting as failed the same as this run's own
+    # comment on the line below already says of publish-pypi. Measured
+    # on run 33008687408: public-api exited 1 on the widening every
+    # Octets-taking alias got this cycle, and publish-testpypi never
+    # started, so the testpypi environment review never fired
+    # (issue #1461)
     needs:
       [
         public-api,
@@ -433,7 +444,15 @@ jobs:
         os-windows,
         integration-bitcoind,
       ]
-    if: github.event_name == 'workflow_dispatch' && github.repository == 'btclib-org/btclib'
+    if: >-
+      always() && github.event_name == 'workflow_dispatch' &&
+      github.repository == 'btclib-org/btclib' &&
+      needs.test.result == 'success' && needs.lint.result == 'success' &&
+      needs.docs.result == 'success' &&
+      needs.os-ubuntu.result == 'success' &&
+      needs.os-macos.result == 'success' &&
+      needs.os-windows.result == 'success' &&
+      needs.integration-bitcoind.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -456,6 +475,9 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
+    # See publish-testpypi's own comment: public-api stays a need for
+    # ordering, not for its result, the same issue applying to a tag
+    # push as to a rehearsal
     needs:
       [
         public-api,
@@ -467,7 +489,15 @@ jobs:
         os-windows,
         integration-bitcoind,
       ]
-    if: github.event_name == 'push' && github.repository == 'btclib-org/btclib'
+    if: >-
+      always() && github.event_name == 'push' &&
+      github.repository == 'btclib-org/btclib' &&
+      needs.test.result == 'success' && needs.lint.result == 'success' &&
+      needs.docs.result == 'success' &&
+      needs.os-ubuntu.result == 'success' &&
+      needs.os-macos.result == 'success' &&
+      needs.os-windows.result == 'success' &&
+      needs.integration-bitcoind.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # deployment gate: configure required reviewers on the "pypi"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -863,6 +863,20 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **`release.yml`'s `publish-testpypi` and `publish-pypi` stop gating on
+  `public-api`'s result.** That job's own comment calls it deliberately
+  not a merge gate -- before 1.0 the surface breaks often, and it exists
+  to answer while RELEASE_NOTES.md is already being written, not to
+  block anything -- but both publish jobs still listed it in `needs:`
+  with no `always()`, so its own designed failure on a real
+  breaking-changes cycle silently kept either from ever starting. Never
+  exercised before this cycle: the job landed after v2026.8.21, so the
+  v2026.8.26 rehearsal was the first to run it against one. `needs:`
+  keeps `public-api` for ordering, its own comment wanting the answer
+  ahead of the platform sweeps' wall clock; each `if:` now opens with
+  `always()` and reads every other dependency's `.result` explicitly,
+  the shape `github-release` already used two jobs down (issue #1461).
+
 - **Every dependency is at the newest version this tree resolves to**,
   `uv.lock` re-resolved with `uv lock --upgrade` and
   `.pre-commit-config.yaml` walked by `pre-commit autoupdate`. The


### PR DESCRIPTION
Blocks v2026.8.26 from ever reaching a `testpypi`/`pypi` environment
review. Filed as [#1461](https://github.com/btclib-org/btclib/issues/1461);
this is the fix.

## What broke

`publish-testpypi` and `publish-pypi` both list `public-api` in
`needs:` with no `always()` beside it, so GitHub Actions gates on its
result the same as on `test`, `lint` and the rest — even though
`public-api`'s own comment says it is deliberately not a merge gate,
existing to answer while RELEASE_NOTES.md is already being written,
not to block anything. RELEASING.md agrees: the step's output is
something a maintainer reads by hand and discounts against
RELEASE_NOTES.md's own breaking-changes list.

Never exercised: `public-api` landed in
[#1358](https://github.com/btclib-org/btclib/pull/1358) after
v2026.8.21, so the v2026.8.26 rehearsal — [run
33008687408](https://github.com/btclib-org/btclib/actions/runs/33008687408),
dispatched from `main` — is the first tag or dispatch to run it against
a cycle with real breaking changes. It failed there exactly as
designed, on the alias-widening findings and the two breaks already in
RELEASE_NOTES.md, and `publish-testpypi` never appeared among the run's
jobs at all — no `testpypi` environment review ever fired.

## The fix

`needs:` keeps `public-api` for ordering — its own comment wants the
answer ahead of the platform sweeps' wall clock — but each job's `if:`
now opens with `always()` and reads every other dependency's `.result`
explicitly, the shape `github-release` already uses two jobs down
(`needs: [publish-pypi, attest]`, `if: always() &&
needs.publish-pypi.result == 'success' && ...`) for the identical
reason: "a skipped job is one `needs` treats as failed".

## Gates

Run in the branch's own worktree, exit code read:

- `uv run pre-commit run --all-files` — 0
- `uv run pytest --cov` — 0, coverage 100.00%

## Summary by Sourcery

Ensure release publishing jobs are not blocked by the intentionally non-gating public API check.

Bug Fixes:
- Allow TestPyPI and PyPI publishing jobs to proceed when the non-gating public API check fails, while preserving all other release validation gates.

Enhancements:
- Retain public API analysis as an ordering dependency so its results are available before platform checks complete.

CI:
- Update release workflow conditions to explicitly evaluate required dependency results while ignoring public API's outcome.

Documentation:
- Document the release workflow fix in the changelog.