### PR TITLE
v2026.8.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Only v2026.8.7 and what follows it are here. The releases before it were
 documented at release-notes length in the first place, and are still in
 [RELEASE_NOTES.md](./RELEASE_NOTES.md) rather than duplicated here.
 
-## v2026.8.26
+## v2026.8.27
 
 ### Repository
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,7 +19,7 @@ behind this file.
 Release names follow *[calendar versioning](https://calver.org/)*:
 full year, short month, short day (YYYY-M-D)
 
-## v2026.8.26
+## v2026.8.27
 
 ### Breaking changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ name = "btclib"
 # file. Not a literal in src/btclib/__init__.py for setuptools to import
 # and conf.py to repeat: two declarations are two things a release
 # workflow has to compare before trusting either
-version = "2026.8.26"
+version = "2026.8.27"
 description = "A library for 'bitcoin cryptography'"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "btclib"
-version = "2026.8.26"
+version = "2026.8.27"
 source = { editable = "." }
 dependencies = [
     { name = "bitcoin-core-rpc" },


### PR DESCRIPTION
Corrects v2026.8.26's date after landing it: the `v2026.8.26` tag was
pushed on 2026-08-27, past a tip that had already moved four commits
into the day, so the version it declared no longer named the day it
was cut. That tag is deleted — nothing was uploaded to either index
under it, the tag-triggered run cancelled before any publish job
started — and `v2026.8.27` is this branch's own tag once it lands.

Same content [#1456](https://github.com/btclib-org/btclib/pull/1456)
carried, retitled a day later:

- `pyproject.toml`'s version, `2026.8.26` → `2026.8.27`, re-locked.
- `CHANGELOG.md`'s and `RELEASE_NOTES.md`'s headings, together.

No new library or packaging change: the four commits the tip gained
since #1456 (#1464, #1465, #1466, #1468) are README badge edits with
nothing that reads as a bullet.

## Gates

Run in the branch's own worktree, exit code read:

- `uv run pre-commit run --all-files` — 0
- `uv run pytest --cov` — 0, 31047 passed, coverage 100.00%

## Summary by Sourcery

Retarget the release from v2026.8.26 to v2026.8.27 across project metadata and release documentation.

Enhancements:
- Update the project release metadata and documentation from v2026.8.26 to v2026.8.27.

Build:
- Re-lock dependencies for the updated project version.

Documentation:
- Rename the changelog and release notes headings to v2026.8.27.