### PR TITLE
Open v2026.9, and release.yml: pypi-install stops being silently skipped by public-api's transitive failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -528,6 +528,14 @@ jobs:
   pypi-install:
     name: Run the pypi-install workflow
     needs: publish-pypi
+    # publish-pypi's own always() opts it back in past public-api's
+    # designed failure, but does not carry this job with it: a bare
+    # needs: here still reads back through publish-pypi's own needs:,
+    # public-api two hops away skipping this job even though its one
+    # listed dependency succeeded. Measured on the v2026.8.26 tag: this
+    # sentinel never ran on v2026.8.27, and #1461's fix to publish-pypi
+    # itself was not enough (issue #1470)
+    if: always() && needs.publish-pypi.result == 'success'
     uses: ./.github/workflows/pypi-install.yml
     with:
       version: ${{ github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Only v2026.8.7 and what follows it are here. The releases before it were
 documented at release-notes length in the first place, and are still in
 [RELEASE_NOTES.md](./RELEASE_NOTES.md) rather than duplicated here.
 
+## v2026.9 (work in progress, not released yet)
+
 ## v2026.8.27
 
 ### Repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,25 @@ documented at release-notes length in the first place, and are still in
 
 ## v2026.9 (work in progress, not released yet)
 
+### Packaging, linting and CI
+
+- **`release.yml`'s `pypi-install` stops being silently skipped by
+  `public-api`'s designed failure, one hop past `publish-pypi`'s own
+  fix.** `publish-pypi`'s `always()` (issue #1461) opts it back in past
+  `public-api`, but does not carry `pypi-install` with it: a bare
+  `needs: publish-pypi` still reads back through `publish-pypi`'s own
+  `needs:`, `public-api` two hops away skipping this job even though
+  its one listed dependency succeeded. Measured on the v2026.8.27 tag:
+  `Publish to PyPI` completed `success`, and `Run the pypi-install
+  workflow`'s check run started and completed the same second, zero
+  steps run. RELEASING.md calls the workflow this job calls "the
+  sentinel on what the index serves"; it did not run for that release,
+  and both checks it would have made were done by hand instead and
+  passed, so the release itself is sound. `if: always() &&
+  needs.publish-pypi.result == 'success'` now sits beside its `needs:`,
+  the same shape `attest` and `github-release` already carried and the
+  same reason (issue #1470).
+
 ## v2026.8.27
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,8 @@ behind this file.
 Release names follow *[calendar versioning](https://calver.org/)*:
 full year, short month, short day (YYYY-M-D)
 
+## v2026.9 (work in progress, not released yet)
+
 ## v2026.8.27
 
 ### Breaking changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ name = "btclib"
 # file. Not a literal in src/btclib/__init__.py for setuptools to import
 # and conf.py to repeat: two declarations are two things a release
 # workflow has to compare before trusting either
-version = "2026.8.27"
+version = "2026.9"
 description = "A library for 'bitcoin cryptography'"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "btclib"
-version = "2026.8.27"
+version = "2026.9"
 source = { editable = "." }
 dependencies = [
     { name = "bitcoin-core-rpc" },


### PR DESCRIPTION
Two commits, squashing to one: opens the v2026.9 development cycle
(RELEASING.md's last release step), then fixes a second instance of
[#1461](https://github.com/btclib-org/btclib/issues/1461)'s pattern
found while verifying v2026.8.27 — filed as
[#1470](https://github.com/btclib-org/btclib/issues/1470).

## Open v2026.9

`pyproject.toml` to the two-component placeholder, `CHANGELOG.md` and
`RELEASE_NOTES.md` open a new "work in progress" section above
v2026.8.27's, `uv.lock` re-locked. Same shape as every prior cycle-open
commit.

## pypi-install stops being silently skipped

`publish-pypi`'s own `always()` fix (#1461,
[#1462](https://github.com/btclib-org/btclib/pull/1462)) opts it back
in past `public-api`'s designed failure — but `pypi-install`, whose
only `needs:` is `publish-pypi`, does not inherit that opt-in. A bare
`needs:` still reads back through the listed job's own `needs:` chain,
and `public-api` two hops away skipped `pypi-install` even though
`publish-pypi` itself succeeded.

Measured on [run 33048874272](https://github.com/btclib-org/btclib/actions/runs/33048874272),
the actual v2026.8.27 release: `Publish to PyPI` completed `success`;
`Run the pypi-install workflow`'s check run started and completed the
same second, zero steps run. `attest` and `github-release`, the other
two jobs downstream of `publish-pypi`, already carried the explicit
`always() && needs.<job>.result == 'success'` shape from #1461's own
PR and both ran fine — `pypi-install` was the one job that didn't get
it.

RELEASING.md calls the workflow this job calls "the sentinel on what
the index serves." It never ran for v2026.8.27; both checks it would
have made were done by hand instead and passed (a fresh install with
`[secp256k1]`, the signature round trip, the BIP39 vector against the
shipped wordlist), so the release itself is sound — the fix is only for
the sentinel's own future runs.

## Gates

Run in the branch's own worktree, exit code read, once per commit:

- `uv run pre-commit run --all-files` — 0
- `uv run pytest --cov` — 0, coverage 100.00%

## Summary by Sourcery

Open the v2026.9 development cycle and ensure the PyPI installation sentinel runs after successful package publication.

Bug Fixes:
- Ensure the release workflow's PyPI installation sentinel runs when publishing succeeds, even if the public API job intentionally fails.

Enhancements:
- Open the v2026.9 development cycle with updated version and release tracking metadata.

CI:
- Correct downstream release-job conditions so successful PyPI publishing is not silently blocked by an upstream failure in the dependency chain.

Documentation:
- Add the v2026.9 work-in-progress entries to the changelog and release notes.