### PR TITLE
RELEASING.md says what a red public-api means, and asks that every job be checked for having run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,19 @@ documented at release-notes length in the first place, and are still in
   the same shape `attest` and `github-release` already carried and the
   same reason (issue #1470).
 
+- **RELEASING.md says what a red `public-api` means and asks that every
+  job be checked for having *run*.** The griffe step described the
+  command a maintainer types and never said `release.yml` runs the same
+  comparison as a job, so a release run that is overall red while every
+  job that matters is green had nothing explaining it; that paragraph
+  now says so, names the `always()` wiring that keeps it costing the
+  release nothing, and records both sites where that wiring was wrong
+  (issues #1461 and #1470). A step after the publish asks the question
+  those two failures turn on: a failed job is loud and a skipped one is
+  silent, so a run can look finished with a sentinel missing from it,
+  and the `gh api .../jobs` line beside it says which conclusions are
+  expected on a tag and which on a rehearsal.
+
 ## v2026.8.27
 
 ### Repository

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -254,6 +254,29 @@ to `deps-latest`'s own result.
    moving tree, so the tag is the only target it has and a cycle's worth
    of output is the only shape its answer takes.
 
+   **`release.yml` runs this too, as its `public-api` job, and a red one
+   there is the expected shape of a cycle with breaking changes in it.**
+   The job exists so the answer arrives while RELEASE_NOTES.md is being
+   written; it is not a gate, and its own comment says so. Which means a
+   release run is *overall red* on a cycle like that while every job that
+   matters is green — read the job list and not the run's own badge, the
+   same way `deps-latest` above is read per job. Nothing downstream waits
+   on it: `publish-testpypi`, `publish-pypi` and `pypi-install` each open
+   their `if:` with `always()` and name the dependencies they do require,
+   so a red `public-api` costs the release nothing.
+
+   That wiring is younger than the job and was wrong twice. On
+   v2026.8.26's rehearsal `publish-testpypi` listed `public-api` in
+   `needs:` with no `always()`, so a red `public-api` meant the job never
+   started and the `testpypi` environment review never fired at all
+   (issue #1461); on the v2026.8.27 tag itself `pypi-install` was skipped
+   the same way, one hop further down, `publish-pypi`'s own fix not
+   reaching it (issue #1470). Both are fixed. What the pair is worth
+   remembering for is the failure mode rather than the two sites: a job
+   that is skipped and not failed leaves the run *green where it is
+   absent*, so the thing to check after a release is that every job you
+   expected actually ran, not merely that nothing you can see is red.
+
 1. Retitle the "work in progress" section of **both** RELEASE_NOTES.md
    and CHANGELOG.md as `## v<version>`. The workflow lifts the GitHub
    release notes from RELEASE_NOTES.md's section alone, so that one has
@@ -416,6 +439,23 @@ to `deps-latest`'s own result.
    merged pull requests instead — the fallback `version-check` exists to
    make unreachable, not a second way to write release notes — and they
    are worth replacing by hand if it ever fires.
+
+1. Check that every job you expected actually *ran*. A failed job is
+   loud and a skipped one is silent, so the run can look finished with a
+   sentinel missing from it — which is how v2026.8.27 published with
+   `pypi-install` never having run (issue #1470, the paragraph under the
+   griffe step above). `conclusion` tells the two apart, and a skipped
+   job's `started_at` and `completed_at` are the same second with no
+   steps in it:
+
+   ```shell
+   gh api "repos/btclib-org/btclib/actions/runs/<run id>/jobs?per_page=100" \
+     --jq '.jobs[] | [.conclusion, .name] | @tsv'
+   ```
+
+   `publish-testpypi` is `skipped` on a tag and `publish-pypi` on a
+   rehearsal — each is the other's trigger — and `public-api` is red on
+   any cycle with breaking changes. Everything else should be `success`.
 
 1. Read the `documented` job rather than the site: read the docs activates
    and builds a new release tag from the automation rule REPOSITORY.md


### PR DESCRIPTION
Follow-up to [#1471](https://github.com/btclib-org/btclib/pull/1471),
which fixed the wiring but left RELEASING.md silent about it.

## Why

The griffe step described the command a maintainer types and never said
`release.yml` runs the same comparison as its own `public-api` job. So a
release run that is **overall red while every job that matters is
green** — the expected shape of any cycle with breaking changes — had
nothing in this file explaining it. That is exactly what v2026.8.26's
rehearsal and the v2026.8.27 tag both looked like.

## What changed

- **The griffe step** now says `release.yml` runs it as `public-api`,
  that a red one is expected on a breaking-changes cycle, and that the
  run's own badge is the wrong thing to read — the job list is, the same
  way `deps-latest` is already read per job. It names the `always()`
  wiring that keeps a red `public-api` costing the release nothing, and
  records both sites where that wiring was wrong
  ([#1461](https://github.com/btclib-org/btclib/issues/1461),
  [#1470](https://github.com/btclib-org/btclib/issues/1470)).

- **A new step after the publish** asks the question those two turn on:
  a failed job is loud and a skipped one is silent, so a run can look
  finished with a sentinel missing from it — which is how v2026.8.27
  published with `pypi-install` never having run. The `gh api
  .../jobs?per_page=100` line lists every job's conclusion, and the
  sentence beside it says which skips are expected (`publish-testpypi`
  on a tag, `publish-pypi` on a rehearsal, each being the other's
  trigger).

## Gates

Run in the branch's own worktree, exit code read:

- `uv run pre-commit run --all-files` — 0
- `uv run pytest --cov` — 0, coverage 100.00%

## Summary by Sourcery

Clarify release verification by documenting expected `public-api` failures and requiring maintainers to confirm that every expected workflow job actually ran.

Enhancements:
- Clarify how maintainers should interpret the release workflow’s `public-api` result, including expected red runs during breaking-change cycles and the non-blocking behavior of downstream jobs.
- Add release verification guidance to confirm every expected workflow job ran, distinguish skipped jobs from failures, and account for expected tag-versus-rehearsal skips.

Documentation:
- Expand RELEASING.md with guidance for interpreting `public-api` and checking workflow job conclusions after publishing.

Chores:
- Record the release-workflow wiring incidents addressed by the guidance in the changelog.