### PR TITLE
Which releases the dependency floors name is pyproject.toml's and nowhere else's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,23 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **Which releases the dependency floors name is `pyproject.toml`'s and
+  nowhere else's.** `CONTRIBUTING.md` stated all three verbatim and had
+  already gone stale on one: it said `typing-extensions>=4.4`, the
+  release adding `override`, where the floor moved to `>=4.10` for
+  `TypeIs` when `utils.is_octets` started narrowing with it. Nothing
+  compared the two, and nothing now has to -- that paragraph keeps the
+  reasoning that does not age (two required and one an extra, no upper
+  bound, and why a ceiling on a sibling would cost a release per minor)
+  and points at `pyproject.toml` for the numbers. A floor moves whenever
+  this tree starts calling something newer, so a second copy of it is
+  the one that goes stale rather than a second guarantee.
+
+  `bitcoin-core-rpc`'s floor gains the reason it never carried, now that
+  it is the only place the number lives: 2026.8.13 for
+  `magic_from_signet_challenge`, absent from 2026.8.12 and present there,
+  measured against both releases rather than read off a changelog.
+
 - **`release.yml`'s `pypi-install` stops being silently skipped by
   `public-api`'s designed failure, one hop past `publish-pypi`'s own
   fix.** `publish-pypi`'s `always()` (issue #1461) opts it back in past

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,14 +220,18 @@ tools, including those needed to build the documentation, is then created with:
 uv sync
 ```
 
-**The declared dependencies are `bitcoin-core-rpc>=2026.8.13`,
-`typing-extensions>=4.4` and, as the `secp256k1` extra,
-`btclib-secp256k1>=0.8.0.4`, with no upper bound**, and the absence of a
-ceiling is a decision. `typing-extensions` backports `typing.override`,
-which 3.12 has and the 3.10 floor does not, and its floor is the release
-that adds it. The other two are btclib-org projects developed by the same
-people, and the bindings' whole purpose is to be the bindings this library
-calls, so a breaking change there is coordinated with the release here —
+**Two dependencies are required and one, the bindings, is the `secp256k1`
+extra; every one of them is a floor with no upper bound**, and the absence
+of a ceiling is a decision. Which releases those floors name is
+`pyproject.toml`, next to the reason each one is where it is: a floor
+moves whenever this tree starts calling something newer, so a copy of the
+number here would be a second place to remember and the first to go
+stale. `typing-extensions` is the backport of what the 3.10 floor does
+not have, and its floor is the release adding the latest name this tree
+imports from it. The other two are btclib-org projects developed by the
+same people, and the bindings' whole purpose is to be the bindings this
+library calls, so a breaking change there is coordinated with the release
+here —
 which is what a version ceiling substitutes for when it cannot be. A
 `<0.9` ceiling would cost a btclib
 release for every bindings minor, the ones that break nothing included, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,16 @@ requires-python = ">=3.10"
 # Required, where the bindings below are an extra, and that asymmetry was
 # weighed rather than inherited: a `fetch` extra was considered and
 # refused (issue #1126). CONTRIBUTING.md's dependency paragraph carries
-# the reasoning, beside the ceiling argument it already makes.
+# the reasoning, beside the ceiling argument it already makes; the
+# releases themselves are named here and nowhere else, a floor moving
+# whenever this tree starts calling something newer and a second copy of
+# the number being the one that goes stale.
 dependencies = [
+    # 2026.8.13 for `magic_from_signet_challenge`, which `p2p.magic`
+    # re-exports and `fetch.bitcoin_core` calls: measured against the two
+    # releases, the name is absent from 2026.8.12 and present here. The
+    # rest of what this tree calls -- `BitcoinCoreRpcClient`, `RpcError`,
+    # `chain_from_network`, `magic_from_chain` -- predates that floor
     "bitcoin-core-rpc>=2026.8.13",
     # `typing.override` is 3.12's, `typing.TypeIs` is 3.13's, and the
     # floor is 3.10, so both come from the backport; 4.4 is the release


### PR DESCRIPTION
`CONTRIBUTING.md` stated all three dependency floors verbatim, and had
already gone stale on one.

## The drift

It said `typing-extensions>=4.4` — the release adding `override` — where
`pyproject.toml` says `>=4.10`, the release adding `TypeIs`, which the
floor moved to when `utils.is_octets` started narrowing with it
([#1445](https://github.com/btclib-org/btclib/pull/1445), yesterday).
Nothing compared the two spellings.

The fix is not a test that keeps two copies in step — that would be a
worse answer than not having the second copy. A floor moves whenever
this tree starts calling something newer, so a duplicate of the number
is the one that goes stale rather than a second guarantee.

## What each file keeps

`CONTRIBUTING.md` keeps the reasoning that does not age, and points at
`pyproject.toml` for the numbers:

- two dependencies required and the bindings an extra, every one a floor
  with no upper bound
- why a ceiling on a sibling would cost a btclib release per bindings
  minor, and why `<1` would constrain nothing pre-1.0
- why a `fetch` extra was considered and refused
- the `INSTALLED = False` argument for why the bindings floor carries
  weight the specifier alone does not show

`pyproject.toml` keeps the releases, each beside the reason it is where
it is.

## A floor that had no reason written down

`bitcoin-core-rpc>=2026.8.13` was the only one of the three with nothing
saying why, and it is now the only place that number lives — so it gains
one: `magic_from_signet_challenge`, which `p2p.magic` re-exports and
`fetch.bitcoin_core` calls.

Measured by installing both releases rather than read off a changelog:

```
2026.8.12: magic_from_signet_challenge False
2026.8.13: magic_from_signet_challenge True
```

The rest of what this tree calls — `BitcoinCoreRpcClient`, `RpcError`,
`chain_from_network`, `magic_from_chain` — predates that floor. So all
three floors are minimal: each is the release carrying the newest name
this tree imports from it, not a higher one.

## Left alone deliberately

`CONTRIBUTING.md`'s "`.python-version` pins 3.14" and the `3.10` in its
documented commands are the same class of copied number, and both are
accurate today (checked). They stay: an interpreter floor moves on the
order of once a year rather than whenever a symbol is called, and
`requires-python` is what ruff infers `py310` from and what
`[tool.mypy]`'s `python_version` matches — so a mismatch there fails
tooling rather than sitting silently in prose.

## Gates

Run in the branch's own worktree, exit code read:

- `uv run pre-commit run --all-files` — 0
- `uv run pytest --cov` — 0, 31047 passed, coverage 100.00%

## Summary by Sourcery

Centralize dependency floor versions in `pyproject.toml` and remove stale duplicates from contributor documentation.

Enhancements:
- Make `pyproject.toml` the single source of truth for dependency floors while retaining their rationale in contributor guidance.
- Document the minimum `bitcoin-core-rpc` release based on the API used by the project.

Documentation:
- Update `CONTRIBUTING.md` to reference dependency versions from `pyproject.toml` instead of duplicating them.

Chores:
- Record the dependency-floor documentation cleanup and rationale in the changelog.