### PR TITLE
The sentinel schedule and the badge row follow section 10's calendar, reordered by family

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -90,7 +90,7 @@ on:
     # file's to restate.
     # Cron runs from the default branch only, so this asks nothing until
     # it reaches main; elsewhere the dispatch below is the way in
-    - cron: "4 4 * * 2"
+    - cron: "4 4 * * 0"
   # the escape hatch: a run on demand for a branch whose pull request is
   # not open yet
   workflow_dispatch:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -58,15 +58,15 @@ name: fuzz
 # that becomes -- one on every push queues faster than an hour-long job
 # drains. `workflow_dispatch` is required by this section regardless of
 # the above, and is what runs the batch by hand -- before a release
-# rather than waiting for Monday, which is what section 10 names it
-# for.
+# rather than waiting for the scheduled run, which is what section 10
+# names it for.
 on:
   schedule:
     # Day and hour are section 10's own workflow table; minute is this
     # repository's own row in section 10's repository table.
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
-    - cron: "4 3 * * 1"
+    - cron: "4 4 * * 2"
   workflow_dispatch:
 
 # least privilege for the GITHUB_TOKEN: the job below writes neither to

--- a/.github/workflows/integration-bitcoind.yml
+++ b/.github/workflows/integration-bitcoind.yml
@@ -49,14 +49,14 @@ name: integration-bitcoind
 
 on:
   schedule:
-    # Sunday, the hour after mutation.yml: what this run watches is the
-    # download rather than the tree, so it wants the emptiest day rather
-    # than a particular one, and Sunday holds one other job.
+    # An integration sentinel, the other being integration-hwi.yml: what
+    # this run watches is the download rather than the tree, so it wants
+    # no particular day.
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "4 5 * * 0"
+    - cron: "4 5 * * 2"
   # the same trigger set as the other gates: main so that the commit a
   # merge creates is asked the question too -- and so that a cache is
   # written where every pull request can read it -- the pull request so

--- a/.github/workflows/integration-hwi.yml
+++ b/.github/workflows/integration-hwi.yml
@@ -29,13 +29,14 @@ name: integration-hwi
 
 on:
   schedule:
-    # Friday, the hour after os-ubuntu.yml: an emulator is a service to keep
-    # working, and a week is as often as anybody acts on the answer.
+    # An integration sentinel, the other being integration-bitcoind.yml:
+    # an emulator is a service to keep working, and a week is as often as
+    # anybody acts on the answer.
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "4 5 * * 5"
+    - cron: "4 3 * * 3"
   push:
     branches: [main]
   workflow_call:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -18,14 +18,14 @@ name: links
 
 on:
   schedule:
-    # Monday, with vendored-vectors.yml an hour later: both ask whether
-    # what this tree points at is still where it says, one over the
-    # internet and one over a pinned blob.
+    # Project health: this asks whether what the tree points at over the
+    # internet still resolves, where vendored-vectors.yml asks the same of
+    # a pinned blob -- one question over two distances.
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "4 4 * * 1"
+    - cron: "4 4 * * 6"
   # the escape hatch, and the way to check a branch before merging a
   # documentation change that adds links
   workflow_dispatch:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -30,18 +30,17 @@ on:
   # every commit, and `cosmic-ray baseline` below fails the run before any
   # mutant if the test command has gone stale
   schedule:
-    # Sunday, an hour before integration-bitcoind.yml and nothing else:
-    # a session measured in hours gets the emptiest day the grid has. It
-    # also asks something on a different axis from every other sentinel
-    # here -- the suite's own quality, not a dependency's or a
-    # platform's.
+    # Test depth, the other of that family being fuzz.yml: a session
+    # measured in hours, asking something on a different axis from every
+    # other sentinel here -- the suite's own quality, not a dependency's
+    # or a platform's.
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Cron runs from the default branch only, so this file gates nothing
     # until it reaches the default branch -- elsewhere it is reachable
     # through the
     # dispatch button below and nowhere else
-    - cron: "4 4 * * 0"
+    - cron: "4 5 * * 1"
   # the escape hatch, and the way to spend a whole afternoon on the engine
   # session that the weekly budget only samples
   workflow_dispatch:
@@ -469,7 +468,7 @@ jobs:
           done <<< "$SESSIONS"
       # always(), because the reports are the whole product: a session cut
       # short, or one whose exec died, still holds every verdict reached
-      # before that, and those are what somebody reads on Monday
+      # before that, and those are what somebody reads afterwards
       - name: Write the reports
         if: always() && env.SELECTED == 'true'
         env:

--- a/.github/workflows/os-macos.yml
+++ b/.github/workflows/os-macos.yml
@@ -35,15 +35,16 @@ name: os-macos
 
 on:
   schedule:
-    # Saturday, with os-windows.yml an hour later: the two platforms whose
-    # runners are the slowest to come, on the day the grid gives to
-    # platforms. Red in both is the tree; red in one is that platform,
-    # which is the whole of what running them apart buys.
+    # A platform sentinel, with os-ubuntu.yml and os-windows.yml: macOS
+    # and Windows are the platforms whose runners are the slowest to come,
+    # which is why no two of the three share an hour. Red in both is the
+    # tree; red in one is that platform, which is the whole of what
+    # running them apart buys.
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "4 4 * * 6"
+    - cron: "4 5 * * 4"
   # lets release.yml gate a publication on this platform too, which is what
   # keeps a weekly sentinel from being the only thing that ever asks
   workflow_call:

--- a/.github/workflows/os-ubuntu.yml
+++ b/.github/workflows/os-ubuntu.yml
@@ -35,10 +35,9 @@ name: os-ubuntu
 
 on:
   schedule:
-    # Friday, with integration-hwi.yml an hour later: a platform sentinel
-    # is two images times every interpreter, and three of them in one
-    # morning is the queue this arrangement exists to avoid, so the three
-    # take separate mornings. What shares this one is two emulator jobs.
+    # A platform sentinel is two images times every interpreter, and three
+    # of them in one morning is the queue this arrangement exists to
+    # avoid, so the three take separate slots.
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Only the default branch schedules workflows, so on any other branch

--- a/.github/workflows/os-windows.yml
+++ b/.github/workflows/os-windows.yml
@@ -44,13 +44,13 @@ name: os-windows
 
 on:
   schedule:
-    # Saturday, the hour after os-macos.yml: see that file for why the two
-    # platforms share a day and not an hour.
+    # A platform sentinel: see os-macos.yml for why the three do not share
+    # an hour.
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "4 5 * * 6"
+    - cron: "4 5 * * 5"
   # lets release.yml gate a publication on this platform too, which is what
   # keeps a weekly sentinel from being the only thing that ever asks
   workflow_call:

--- a/.github/workflows/py-arm-authority.yml
+++ b/.github/workflows/py-arm-authority.yml
@@ -57,13 +57,13 @@ on:
   push:
     branches: [main]
   schedule:
-    # Tuesday, the hour after codeql.yml: both are censuses of the tree
-    # rather than questions about a dependency, and neither gates.
+    # A census of the tree rather than a question about a dependency, and
+    # it gates nothing; codeql.yml is the other sentinel of that shape.
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "4 5 * * 2"
+    - cron: "4 4 * * 4"
   workflow_dispatch:
   pull_request:
     # ready_for_review, so a pull request marked ready gets the run the

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,15 +23,15 @@ on:
     # the action's, not section 10's general rule
     branches: [main]
   schedule:
-    # Saturday, hour 03: section 10's calendar, decided by
-    # btclib-org/.github#363 and landed via btclib-org/.github#382. The
-    # minute is this repository's own row in the same table.
+    # Section 10's calendar, decided by btclib-org/.github#363 and landed
+    # via btclib-org/.github#382; the minute is this repository's own row
+    # in the same table.
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # The push trigger above already runs the analysis on every push to
     # main, which is what feeds the badge and the published score between
     # scheduled runs; this covers what push cannot -- a week with none.
-    - cron: "4 3 * * 6"
+    - cron: "4 5 * * 0"
 
 # least privilege for the GITHUB_TOKEN at the workflow level, with one
 # elevation on the job below: the analysis reads the tree, requests a

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -19,15 +19,14 @@ name: vendored vectors
 
 on:
   schedule:
-    # Monday, the hour after links.yml: that one asks whether a page this
-    # tree points at still resolves, this one whether a file it pinned is
-    # still the file, and the two are the same question over different
-    # distances.
+    # Test data: links.yml asks whether a page this tree points at still
+    # resolves, this one whether a file it pinned is still the file --
+    # one question over two distances.
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "4 5 * * 1"
+    - cron: "4 3 * * 1"
   workflow_dispatch:
   pull_request:
     # ready_for_review, so a pull request marked ready gets the run the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,35 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **The sentinel schedule and the badge row follow section 10's calendar,
+  reordered by family**, which is the port btclib-org/.github#480 owes
+  each tree. Eleven of this repository's fourteen `cron:` lines move to
+  the day and hour that calendar now gives their workflow, at this
+  repository's own minute; `deps-latest`, `pypi-install` and `os-ubuntu`
+  keep their exact slots, and no `dependabot.yml` is touched --
+  `deps-latest` stays where it is precisely so that it still reports the
+  day before Dependabot opens its pull requests. `README.md`'s badges are
+  the same decision seen from the other side, the badge order *being* the
+  calendar order over the sentinel subset: three groups now, with the
+  gates ahead of the sentinels in the order a commit meets them, Read the
+  Docs beside `docs` rather than after the sentinels, and the `wheel`
+  badge restored -- it is not a duplicate of `pypi/v`, being read off the
+  files a release uploaded rather than off anything the project declares.
+
+- **A workflow's schedule comment states which family it belongs to and
+  stops restating its day and hour.** Every one of them already carried
+  the line *the time is section 10's grid in btclib-org/.github and not
+  this file's to restate*, and every one restated it anyway on the line
+  above -- so the reorder above turned eleven true comments false in one
+  commit, adjacency claims included, `os-ubuntu.yml`'s among them though
+  its own `cron:` did not move. What each says now is the reason that
+  outlives a calendar: which family it sits in and what it asks that the
+  others do not. Two copies stay, having earned themselves --
+  `deps-latest.yml`'s Wednesday is the Dependabot relationship the
+  schedule exists to keep, and `pypi-install.yml` names the hour it
+  follows, both still true and both load-bearing
+  (btclib-org/.github#485).
+
 - **Which releases the dependency floors name is `pyproject.toml`'s and
   nowhere else's.** `CONTRIBUTING.md` stated all three verbatim and had
   already gone stale on one: it said `typing-extensions>=4.4`, the

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # A Python library for 'bitcoin cryptography'
 
-<!-- The badges are what the reader decides with: the first block says what
-this is and whether it can be used, and the second whether it works. At the
-end, the OpenSSF Scorecard badges.
+<!-- The badges are what the reader decides with, in three groups: what the
+software is and whether it can be used, whether it works, and how it is
+run as a project. At the end, the OpenSSF badges.
+
+Inside the second group the gates come first, in the order a commit meets
+them, and the sentinels follow in the order section 10 of the
+organization standard schedules them -- the badge order *is* the calendar
+order over that subset, which is why the two move together or not at all.
+The day and hour each sentinel owns live in that section and are not
+copied here: a reader wanting the schedule reads it there, where it is
+still true.
 
 One badge per line keeps a change to one line and every line inside MD013,
 whose 80 columns bind only where a space follows them.
@@ -11,32 +19,33 @@ A badge that reports no state -- "we use ruff", "we use uv" -- reports a
 choice instead, and those are in CONTRIBUTING.md, beside the prose that
 says how the choice is enforced.
 -->
-[![GitHub release](https://img.shields.io/github/v/release/btclib-org/btclib.svg)](https://github.com/btclib-org/btclib/releases)
 [![PyPI version](https://img.shields.io/pypi/v/btclib.svg?logo=pypi)](https://pypi.python.org/pypi/btclib/)
+[![GitHub release](https://img.shields.io/github/v/release/btclib-org/btclib.svg)](https://github.com/btclib-org/btclib/releases)
+[![development status](https://img.shields.io/pypi/status/btclib.svg)](https://pypi.python.org/pypi/btclib/)
+[![license](https://img.shields.io/github/license/btclib-org/btclib.svg)](https://github.com/btclib-org/btclib/blob/main/LICENSE)
 [![downloads](https://static.pepy.tech/badge/btclib)](https://pepy.tech/project/btclib)
 [![supported Python versions](https://img.shields.io/pypi/pyversions/btclib.svg?logo=python)](https://pypi.python.org/pypi/btclib/)
 [![implementation](https://img.shields.io/pypi/implementation/btclib.svg)](https://pypi.python.org/pypi/btclib/)
-[![development status](https://img.shields.io/pypi/status/btclib.svg)](https://pypi.python.org/pypi/btclib/)
-[![license](https://img.shields.io/github/license/btclib-org/btclib.svg)](https://github.com/btclib-org/btclib/blob/main/LICENSE)
+[![wheel](https://img.shields.io/pypi/wheel/btclib.svg)](https://pypi.python.org/pypi/btclib/)
 
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib/main.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib/main)
-[![test workflow status](https://github.com/btclib-org/btclib/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/test.yml)
-[![vendored-vectors workflow status](https://github.com/btclib-org/btclib/actions/workflows/vendored-vectors.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/vendored-vectors.yml)
-[![py-arm-authority workflow status](https://github.com/btclib-org/btclib/actions/workflows/py-arm-authority.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/py-arm-authority.yml)
-[![fuzz workflow status](https://github.com/btclib-org/btclib/actions/workflows/fuzz.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/fuzz.yml)
-[![mutation workflow status](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml)
 [![lint workflow status](https://github.com/btclib-org/btclib/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/lint.yml)
-[![links workflow status](https://github.com/btclib-org/btclib/actions/workflows/links.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/links.yml)
+[![test workflow status](https://github.com/btclib-org/btclib/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/test.yml)
 [![docs workflow status](https://github.com/btclib-org/btclib/actions/workflows/docs.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/docs.yml)
 [![documentation build](https://app.readthedocs.org/projects/btclib/badge/?version=latest)](https://btclib.readthedocs.io)
-[![codeql workflow status](https://github.com/btclib-org/btclib/actions/workflows/codeql.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/codeql.yml)
+[![vendored-vectors workflow status](https://github.com/btclib-org/btclib/actions/workflows/vendored-vectors.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/vendored-vectors.yml)
+[![mutation workflow status](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml)
+[![fuzz workflow status](https://github.com/btclib-org/btclib/actions/workflows/fuzz.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/fuzz.yml)
+[![integration-bitcoind workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml)
+[![integration-hwi workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-hwi.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/integration-hwi.yml)
 [![deps-latest workflow status](https://github.com/btclib-org/btclib/actions/workflows/deps-latest.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/deps-latest.yml)
 [![pypi-install workflow status](https://github.com/btclib-org/btclib/actions/workflows/pypi-install.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/pypi-install.yml)
+[![py-arm-authority workflow status](https://github.com/btclib-org/btclib/actions/workflows/py-arm-authority.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/py-arm-authority.yml)
 [![os-macos workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-macos.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/os-macos.yml)
 [![os-ubuntu workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-ubuntu.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/os-ubuntu.yml)
 [![os-windows workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-windows.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/os-windows.yml)
-[![integration-hwi workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-hwi.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/integration-hwi.yml)
-[![integration-bitcoind workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml)
+[![links workflow status](https://github.com/btclib-org/btclib/actions/workflows/links.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/links.yml)
+[![codeql workflow status](https://github.com/btclib-org/btclib/actions/workflows/codeql.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/codeql.yml)
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/btclib-org/btclib/badge)](https://scorecard.dev/viewer/?uri=github.com/btclib-org/btclib)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14253/badge)](https://www.bestpractices.dev/projects/14253)


### PR DESCRIPTION
btclib's port of [btclib-org/.github#480](https://github.com/btclib-org/.github/issues/480)
— the sentinel calendar reordered by family, and section 2's badge order
rewritten to follow it. Both halves in one pull request, because they are
one decision: the badge order *is* the calendar order over the sentinel
subset, and splitting them leaves a tree whose badges and whose schedule
disagree.

## The crons

Eleven of fourteen move. `deps-latest`, `pypi-install` and `os-ubuntu`
keep their exact slots, and **no `dependabot.yml` is touched** —
`deps-latest` stays where it is precisely so it still reports the day
before Dependabot opens its pull requests.

Re-derived rather than applied from the issue's block: both tables were
fetched from `.github`'s README today, every `cron:` in this tree
recomputed from them at this repository's own minute, and the result
compared line for line against the eleven the issue lists. They agree,
the three that stand still included.

```
vendored-vectors      4 5 * * 1  ->  4 3 * * 1
mutation              4 4 * * 0  ->  4 5 * * 1
fuzz                  4 3 * * 1  ->  4 4 * * 2
integration-bitcoind  4 5 * * 0  ->  4 5 * * 2
integration-hwi       4 5 * * 5  ->  4 3 * * 3
py-arm-authority      4 5 * * 2  ->  4 4 * * 4
os-macos              4 4 * * 6  ->  4 5 * * 4
os-windows            4 5 * * 6  ->  4 5 * * 5
links                 4 4 * * 1  ->  4 4 * * 6
codeql                4 4 * * 2  ->  4 4 * * 0
scorecard             4 3 * * 6  ->  4 5 * * 0
unchanged: deps-latest, pypi-install, os-ubuntu
```

## The badges

Three groups. Inside the CI group the gates come first in the order a
commit meets them (pre-commit.ci, `lint`, `test`, `docs`, Read the Docs),
then the sentinels in the calendar's own order. Read the Docs **moves
beside `docs`** rather than sitting after the sentinels. The `wheel`
badge is **restored** — it is not a duplicate of `pypi/v`, being read off
the files a release uploaded rather than off anything the project
declares.

## Collateral, and why it belongs here

Every schedule comment already carried the line *"the time is section
10's grid in btclib-org/.github and not this file's to restate"* — and
every one restated it anyway on the line above. So moving the crons
turned **eleven true comments false in one commit**, the adjacency claims
included (`os-ubuntu.yml`'s among them, though its own `cron:` did not
move — its neighbour did).

Each now states the reason that outlives a calendar: which family it sits
in, and what it asks that the others do not. This is
[btclib-org/.github#485](https://github.com/btclib-org/.github/issues/485)'s
lesson applied at the point where it was cheapest — a comment that names
the family ages into truth, where one that copies a day does not.

Two copies stay, having earned themselves: `deps-latest.yml`'s day is
the Dependabot relationship the schedule exists to preserve, and
`pypi-install.yml` names the hour it follows. Both checked against
`dependabot.yml` and against the crons; both still true.

## Gates

Run in the branch's own worktree, exit code read:

- `uv run pre-commit run --all-files` — 0 (actionlint, zizmor, yamllint
  and markdownlint all see this diff)
- `uv run pytest --cov` — 0, 31047 passed, coverage 100.00%
- a re-sweep for absolute day names in `.github/workflows/` returns only
  the two copies named above, with the pattern proved against a known
  positive first

## Summary by Sourcery

Reorder sentinel schedules and badges to match the organization calendar while making workflow comments resilient to future schedule changes.

Enhancements:
- Align sentinel workflow schedules and README badge ordering with the organization’s section 10 calendar and family grouping.
- Update workflow schedule comments to describe durable sentinel roles rather than duplicating calendar day and hour details.
- Restore the PyPI wheel badge and organize badges into project, CI, and OpenSSF groups.

Documentation:
- Document the new badge grouping and the relationship between sentinel badge order and the organization calendar.