### PR TITLE
CLAUDE.md names two more traps a release found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ documented at release-notes length in the first place, and are still in
 
 ## v2026.9 (work in progress, not released yet)
 
+### Repository
+
+- **`CLAUDE.md` names two more traps a release found.** Asking what an
+  index serves has to be asked from outside every checkout of this
+  project, and `--isolated --no-project` is not what makes it so: one
+  command answered `2026.9` from the primary checkout and `2026.8.27`,
+  which is what PyPI served, from a directory belonging to nothing,
+  while that checkout's own `pyproject.toml` declared `2026.8.26` — so
+  it is not reading the tree either, and a cached build of some earlier
+  state of it is enough to shadow the index with a version plausible
+  enough to be written into a release verification. And *Verifying*
+  gains the asymmetry the whole of this release turned on: a failed
+  thing is loud and an absent thing is silent, so "nothing is red" is
+  the wrong question and "did every step I expected actually run" is the
+  right one.
+
 ### Packaging, linting and CI
 
 - **The sentinel schedule and the badge row follow section 10's calendar,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,19 @@ Do not use Fable unless explicitly instructed.
   answers zero on a file that has real matches; `--perl-regexp` is what
   actually honors `\b`. Prove a sweep's zero against a known positive
   before trusting it.
+- **Asking what an index serves has to be asked from outside every
+  checkout of this project**, and `--isolated --no-project` is not what
+  makes it so. Measured on release day, one command
+  (`uv run --isolated --no-project --with btclib python -c "import
+  btclib; print(btclib.__version__)"`) three ways: `2026.9` run from the
+  primary checkout, `2026.8.27` — what PyPI actually served — run from a
+  directory belonging to nothing, and the checkout it answered from
+  declaring `2026.8.26` in its own `pyproject.toml`. So it is not
+  reading the tree either, and "the tree is current" is not the guard: a
+  cached build of some earlier state of it is enough to shadow the
+  index, and the version it hands back is plausible enough to be written
+  into a release verification. `cd` to the scratchpad first, and print
+  `btclib.__file__` beside the version when the answer decides anything.
 
 ## Conventions to match
 
@@ -251,6 +264,18 @@ exit code rather than its filtered output: `pre-commit run ... | grep -v
 Passed` hides a failure, and a `grep` that finds nothing exits 1, which
 is not the gate's answer to anything. `REVIEWING.md`'s *The gates are the
 evidence* is where that rule is written for a reader who is not this
-one. Prefer
+one.
+
+**A failed thing is loud and an absent thing is silent**, so "nothing is
+red" is not the question — "did every step I expected actually run" is.
+A CI job skipped rather than failed leaves the run green where it is
+missing: v2026.8.27 published with its post-publish sentinel never
+having run, and nothing anywhere said so, because `needs:` without
+`always()` gates on the whole transitive chain and not on the jobs it
+lists (issues #1461 and #1470; `RELEASING.md` carries the check).
+The same asymmetry is what makes a zero from a sweep worth distrusting,
+above, and an empty `grep` worth reading twice.
+
+Prefer
 measuring to asserting: every claim in this file was checked against the
 tree, and the tree changes.


### PR DESCRIPTION
Two facts this release cost a session to find, written where the next
one will read them.

## `--isolated --no-project` does not ask the index

The one that nearly went into a release verification. Verifying what
PyPI serves has to be done from outside every checkout of this project.
Measured three ways with one command
(`uv run --isolated --no-project --with btclib python -c "import btclib;
print(btclib.__version__)"`):

| run from | answer |
| --- | --- |
| the primary checkout | `2026.9` |
| a directory belonging to nothing | `2026.8.27` — what PyPI served |
| that checkout's own `pyproject.toml` declared | `2026.8.26` |

So it is not reading the tree either, which is why "the tree is current"
is not the guard: a cached build of some earlier state of it is enough
to shadow the index, and the version it hands back is plausible enough
to be believed and written down. `btclib.__file__` beside the version is
what tells them apart.

I hit this verifying v2026.8.27 and reported the wrong version for about
a minute before the contrast showed up.

## A failed thing is loud, an absent thing is silent

*Verifying* warned about filtered output and exit codes — both of them
about a **wrong** answer. It said nothing about a **missing** one, and
that is what the whole of this release turned on: v2026.8.27 published
with its post-publish sentinel never having run, and the run looked
finished, because `needs:` without `always()` gates on the whole
transitive chain rather than on the jobs it lists
([#1461](https://github.com/btclib-org/btclib/issues/1461),
[#1470](https://github.com/btclib-org/btclib/issues/1470); `RELEASING.md`
carries the check itself).

It also ties together two things the file already said separately: the
same asymmetry is why a sweep's zero wants a known positive, two
sections earlier, and the two are one idea.

Both bullets are this tree's rather than general — the first is about a
checkout of *this* project shadowing *this* package on the index, the
second cites the two issues in this repository that measured it.

## Also, unrelated to the diff

[#1455](https://github.com/btclib-org/btclib/issues/1455) is closed as
obsolete: [#1457](https://github.com/btclib-org/btclib/pull/1457)
(btclib-org/.github#460) removed `pr_fuzzing` entirely hours after I
filed it. The measurement is kept in a closing comment, because the
ratchet still applies to `batch_fuzzing` with about eleven minutes of
margin (19m build + 60m fuzzing against `timeout-minutes: 90`), and
nothing counts the harnesses.

## Gates

- `uv run pre-commit run --all-files` — 0

Prose only, so no suite run: no Python changed.

## Summary by Sourcery

Document release verification safeguards for distinguishing index-served packages from local artifacts and detecting skipped checks in otherwise successful runs.

Enhancements:
- Document two release-verification pitfalls: isolated package checks can be shadowed by local or cached builds, and green runs can conceal skipped verification steps.
- Align the changelog and contributor guidance with the new release-verification lessons and reinforce checking package provenance and expected job execution.

Documentation:
- Add release-specific guidance to CLAUDE.md and the changelog covering package-source verification and silent CI omissions.