### PR TITLE
check_vendored_vectors.py names a heading with no fenced block, and names each heading once per reason (closes #1447, #1451)

### DIFF
--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -11,13 +11,12 @@ procedure and reports drift, rather than fixing it: refreshing a vector
 file is a decision this script does not get to make, so what it opens
 is an issue, never a commit.
 
-btclib-secp256k1 carries a copy under this same name, and the two are
-not interchangeable: that one parses its own tests/README.md, and it
-passes over an entry with no `commit` in silence where this one reports
-the heading as skipped. The two checks differ there because the pin
-files do -- that README has no such entry, this one does. The rest is
-common to both, so a fix to the parsing, to the `gh` call or to a
-field's spelling is owed to the other copy in the same campaign.
+btclib-secp256k1 carries a copy under this same name, over its own
+tests/README.md, whose entries are each pinned to a commit under a
+heading owning one fenced block. A fix to the parsing, to the `gh` call
+or to a field's spelling is owed to the other copy in the same
+campaign; the collapsing of identical skip lines below is not, a
+heading owning several blocks being a shape that README does not carry.
 
 Scope is narrower than the README: only entries whose `behind` already
 reads 0 -- the ones a human last confirmed were exactly at upstream's
@@ -31,20 +30,21 @@ A path upstream has renamed or deleted is reported rather than raising:
 it has no commit to name as a tip, and a pin standing on a file that is
 not there any more is the one drift nobody would otherwise notice.
 
-Two shapes in the README this script does not attempt: an entry with no
-`commit` at all (chain data self-identified by hash, files this project
-composed itself, a section heading with no pin of its own), and a path
-carrying a `<name>` placeholder -- one pin standing in for several real
-paths under a directory, which the "commits touching a path" call above
-cannot be asked about in one request. No current entry uses that shape:
-BIP327's eight files and BIP324's two were themselves written that way
-once, each pin citing one commit as the tip of every path it stood in
-for. Splitting them into one pin per real path is what brought them
-into this script's scope, and also corrected BIP327's, whose shared
-commit was the tip of only one of the eight. Every heading the README
-carries but this script did not check is listed in its own report, so
-nothing silently reads as "checked and clean" that was not checked at
-all.
+Three shapes in the README this script does not attempt: an entry with
+no `commit` at all (chain data self-identified by hash, files this
+project composed itself), a path carrying a `<name>` placeholder -- one
+pin standing in for several real paths under a directory, which the
+"commits touching a path" call above cannot be asked about in one
+request -- and a heading with no fenced block under it at all, which is
+either a group heading the pins below it supersede or a pin whose block
+an edit broke. No current entry uses the placeholder shape: BIP327's
+eight files and BIP324's two were themselves written that way once,
+each pin citing one commit as the tip of every path it stood in for.
+Splitting them into one pin per real path is what brought them into
+this script's scope, and also corrected BIP327's, whose shared commit
+was the tip of only one of the eight. Every heading the README carries
+but this script did not check is listed in its own report, so nothing
+silently reads as "checked and clean" that was not checked at all.
 
     python .github/scripts/check_vendored_vectors.py tests/_data/README.md
 """
@@ -110,12 +110,26 @@ class Drift:
 def _entries_at_tip(readme: str) -> tuple[list[Entry], list[str]]:
     """Return the checkable entries, and the headings this skips.
 
-    A heading is skippable for any of three reasons: no repo/path/commit
-    triple at all, a path carrying a `<name>` placeholder, or a `behind`
-    already other than 0 -- a gap a human already decided not to close.
+    A heading is skippable for any of four reasons: no fenced block of
+    its own, no repo/path/commit triple, a path carrying a `<name>`
+    placeholder, or a `behind` already other than 0 -- a gap a human
+    already decided not to close.
+
+    The first is the one the loop below cannot see, walking blocks as it
+    does: a heading owning none never enters it. A group heading a finer
+    one supersedes has that shape, and so does a pin whose block an edit
+    broke -- a fence indented into the prose, a `text` marker cut to a
+    bare one. Telling those two apart is not this script's to do; naming
+    the heading is.
+
+    One heading contributes one line per reason rather than one per
+    block: blocks skipped for the same reason under one heading repeat a
+    line carrying nothing to tell them apart, so a reader gets the same
+    sentence several times where one line carries all of it.
     """
     entries: list[Entry] = []
     skipped: list[str] = []
+    owned: set[str] = set()
     heading = ""
     pos = 0
     for match in re.finditer(r"```text\n(.*?)\n```", readme, re.DOTALL):
@@ -123,6 +137,7 @@ def _entries_at_tip(readme: str) -> tuple[list[Entry], list[str]]:
         if headings_before:
             heading = headings_before[-1]
         pos = match.end()
+        owned.add(heading)
 
         fields = dict(_FIELD.findall(match.group(1)))
         repo, path, commit = (
@@ -140,7 +155,14 @@ def _entries_at_tip(readme: str) -> tuple[list[Entry], list[str]]:
             skipped.append(f"{heading} (already documented as behind)")
             continue
         entries.append(Entry(heading, repo, path.strip(), commit.split()[0]))
-    return entries, skipped
+    skipped.extend(
+        f"{unowned} (no fenced block)"
+        for unowned in _HEADING.findall(readme)
+        if unowned not in owned
+    )
+    # dict.fromkeys keeps the first of each identical line, in the
+    # order the walk and the pass after it appended them
+    return entries, list(dict.fromkeys(skipped))
 
 
 def _latest_commit(repo: str, path: str) -> tuple[str, str] | None:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,29 @@ documented at release-notes length in the first place, and are still in
   and the `gh api .../jobs` line beside it says which conclusions are
   expected on a tag and which on a rehearsal.
 
+- **`check_vendored_vectors.py` names a heading owning no fenced block.**
+  `_entries_at_tip` walks the fenced blocks of `tests/_data/README.md`,
+  so a heading owning none entered neither the checked list nor the
+  skipped one and the report passed over it in silence, against the
+  module docstring's own promise that every heading the README carries
+  but the script did not check is listed. A pass over the headings after
+  that walk names each of them `(no fenced block)`, which is what a
+  group heading the pins below it supersede and a pin whose block an
+  edit broke both look like from there — telling those two apart is a
+  reader's to do, and being told of either at all is the point.
+  `tests/check_vendored_vectors_test.py` asks that promise of the pin
+  file the weekly run parses rather than of a fixture alone, a fixture
+  answering only for the shapes it was written to carry (closes #1447).
+
+- **A heading owning several fenced blocks is reported once per reason
+  rather than once per block.** `tests/fetch/_data/*` owns a block
+  listing the files and two more carrying the chain data that verifies
+  them, all skipped for the same reason, and the repeated line carries
+  nothing to tell them apart. Identical lines are collapsed, and a
+  heading whose blocks were passed over for different reasons still
+  reports each of those reasons, the reason being what a reader acts on
+  (closes #1451).
+
 ## v2026.8.27
 
 ### Repository

--- a/tests/check_vendored_vectors_test.py
+++ b/tests/check_vendored_vectors_test.py
@@ -205,6 +205,142 @@ def test_the_heading_is_the_nearest_one_before_the_block(checker: ModuleType) ->
     assert [e.heading for e in entries] == ["`f.json`"]
 
 
+_PIN_README = Path(__file__).parent / "_data" / "README.md"
+
+# the two shapes `tests/_data/README.md` carries that no fenced block
+# describes: a group heading whose files are pinned one by one below it,
+# and a file this project composed itself, whose section is prose and a
+# pulled date. Written out here rather than assembled by `entry()`,
+# which gives every heading a block by construction and so cannot pose
+# the question
+_UNPINNED = """\
+## bitcoin/bips
+
+### BIP327 (MuSig2): one file under `tests/ecc/_data/`
+
+Eight files, pinned one by one below: the group heading is where the
+prose common to them goes.
+
+### `tests/ecc/_data/key_agg_vectors.json`
+
+```text
+repo    bitcoin/bips
+path    bip-0327/vectors/key_agg_vectors.json
+commit  deadbeef  2026-01-01
+blob    cafe1234
+pulled  2026-01-02
+behind  0 revisions; that commit is the tip of the path
+```
+
+## Not vendored from anywhere
+
+### `tests/_data/ours.json`
+
+btclib's own, composed rather than copied: there is no upstream URL to
+give, because there is no upstream.
+
+Pulled 2020-01-01.
+"""
+
+
+def test_a_heading_with_no_fenced_block_of_its_own_is_named_as_skipped(
+    checker: ModuleType,
+) -> None:
+    """The shape the block-by-block walk cannot see, and reports anyway.
+
+    `_entries_at_tip` iterates fenced blocks, so a heading owning none
+    never enters the loop: without a second pass it is neither checked
+    nor listed, which is what a pin whose block an edit broke looks
+    like, and what the module docstring promises cannot happen
+    (issue #1447).
+    """
+    entries, skipped = checker._entries_at_tip(_UNPINNED)
+
+    assert [e.heading for e in entries] == ["`tests/ecc/_data/key_agg_vectors.json`"]
+    assert skipped == [
+        "BIP327 (MuSig2): one file under `tests/ecc/_data/` (no fenced block)",
+        "`tests/_data/ours.json` (no fenced block)",
+    ]
+
+
+def test_a_heading_owning_several_blocks_is_skipped_once(checker: ModuleType) -> None:
+    """One line per reason, not one per block (issue #1451).
+
+    `tests/fetch/_data/*` has this shape: a block listing the files, and
+    two more carrying the chain data that verifies them. All three are
+    skipped for the same reason, and the line naming the heading says
+    nothing that tells them apart.
+    """
+    text = (
+        "### `tests/fetch/_data/*` — seven response bodies\n\n"
+        "```text\ngetblockcount.json  48 bytes\npulled  2026-08-02\n```\n\n"
+        "What they carry is chain data, and it verifies itself.\n\n"
+        "```text\ntxid  f4184fc596403b9d638783cf57adfe4c75c605f6"
+        "356fbc91338530e9831e9e16\n```\n\n"
+        "which is `tests/block/_data/block_481824_complete.bin`.\n\n"
+        "```text\n0000000000000000001c8018d9cb3b742ef25114f27563e3fc4a1902167f9893\n```"
+    )
+
+    entries, skipped = checker._entries_at_tip(text)
+
+    assert entries == []
+    assert skipped == [
+        "`tests/fetch/_data/*` — seven response bodies (no commit to check against)"
+    ]
+
+
+def test_one_heading_keeps_one_line_per_reason(checker: ModuleType) -> None:
+    """Two blocks skipped for different reasons are two lines, not one.
+
+    What is collapsed is the identical line, so a heading whose blocks
+    were passed over for two reasons still reports both: the reason is
+    what a reader acts on, and dropping one would trade the repetition
+    of issue #1451 for a silence.
+    """
+    text = (
+        "### group\n\n"
+        "```text\npulled  2020-01-01\n```\n\n"
+        "```text\nrepo  r\npath  vectors/<name>.json\ncommit  deadbeef\n"
+        "behind  0 revisions\n```"
+    )
+
+    _entries, skipped = checker._entries_at_tip(text)
+
+    assert skipped == [
+        "group (no commit to check against)",
+        "group (one pin serves several files)",
+    ]
+
+
+def test_every_heading_of_the_pin_file_is_checked_or_named_once(
+    checker: ModuleType,
+) -> None:
+    """The promise, over the README the weekly run actually parses.
+
+    A fixture answers for the shapes it was written to carry, and this
+    parser's failure mode is a shape nobody thought to write down: what
+    it does not match, it drops. `tests/_data/README.md` is what the
+    workflow passes, so it is what settles whether a heading can go
+    missing from the report -- and the first assertion is what says the
+    parse still sees the file at all, a parser that matched nothing
+    passing every other line here.
+    """
+    readme = _PIN_README.read_text(encoding="utf-8")
+
+    entries, skipped = checker._entries_at_tip(readme)
+
+    assert entries
+    assert sorted(skipped) == sorted(set(skipped))
+    checked = {e.heading for e in entries}
+    unreported = [
+        heading
+        for heading in checker._HEADING.findall(readme)
+        if heading not in checked
+        and not any(line.startswith(f"{heading} (") for line in skipped)
+    ]
+    assert unreported == []
+
+
 def test_a_block_with_no_heading_before_it_has_an_empty_one(
     checker: ModuleType,
 ) -> None:


### PR DESCRIPTION
`_entries_at_tip` walks the fenced blocks of `tests/_data/README.md`, so
a heading owning none entered neither the list of checked entries nor
the list of skipped ones: the module docstring promises that every
heading the README carries but the script did not check is listed, and
that shape was the one it did not keep. A pass over the headings after
the walk names each of them `(no fenced block)`, which is both what a
group heading the pins below it supersede and what a pin whose block an
edit broke look like from inside the parser.

The same walk named a heading once per block it owns, so
`tests/fetch/_data/*` -- a block listing the files, and two carrying the
chain data that verifies them -- produced the same sentence three times
with nothing to tell the three apart. Identical lines are collapsed;
lines differing in their reason are not, the reason being what a reader
acts on.

`tests/check_vendored_vectors_test.py` drives both shapes, and asks the
docstring's promise of `tests/_data/README.md` itself: a fixture answers
only for the shapes it was written to carry, and what this parser drops
is the shape nobody wrote down.


Closes #1447
Closes #1451

## Summary by Sourcery

Make vendored-vector checks report every unchecked heading once per distinct reason.

Bug Fixes:
- Ensure every README heading without an owned fenced block is reported as skipped instead of being silently ignored.
- Collapse duplicate skip messages for headings with multiple blocks while retaining distinct messages for distinct skip reasons.

Documentation:
- Update the checker documentation and changelog to describe reporting unowned headings and deduplicating skip messages.

Tests:
- Add coverage for unowned headings, repeated blocks, multiple skip reasons, and complete reporting of headings in the production pin README.