### PR TITLE
The aggregate refuses an empty needs result instead of walking past it (closes #1454)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -860,13 +860,43 @@ jobs:
       # pull request means every one of them reports `skipped` on
       # purpose. `changes` itself is not conditional, and a job that
       # fails outright still reports `failure`, never `skipped` -- an
-      # allowlist rather than a denylist of the two, since an
-      # unanticipated result (empty string included, issue #1001's own
-      # failure mode) is exactly what this step exists to catch
+      # allowlist rather than a denylist of the two, so a result this
+      # file does not anticipate fails the gate instead of passing it
+      # for not being named.
+      #
+      # The allowlist decides one field at a time, and word splitting
+      # does not hand it every field: a trailing empty one is dropped
+      # and an empty join gives no iteration at all, so the loop by
+      # itself decides the gate on the results beside the empty one, or
+      # on nothing (issue #1454). The `case` before it is what refuses
+      # those, and the comma separator is what lets it: `join` writes
+      # one separator between every pair of elements whatever they
+      # convert to -- `Join.cs` in actions/runner -- so an empty result
+      # is an empty field, and the commas wrapped around `$results` make
+      # an empty first field, an empty last one, an empty one between
+      # two others and an empty join a single pattern.
+      #
+      # What no reading of this string reaches is a `needs` entry whose
+      # `result` key is missing rather than empty: `needs.*.result` is a
+      # filtered array and collects only the keys it finds, so such an
+      # entry is gone before the join runs (`Index.cs`, same
+      # repository). Section 10 of the organization standard has an
+      # aggregate read its own run's job listing from the API rather
+      # than `needs` at all. This workflow is one `release.yml` calls,
+      # where that listing is the caller's run and holds the publishing
+      # jobs waiting on this very job, so that shape does not fit here
+      # until btclib-org/.github#474 answers a reused gate
       - name: Fail unless every job above succeeded or was legitimately skipped
         run: |
-          results='${{ join(needs.*.result, ' ') }}'
+          results='${{ join(needs.*.result, ',') }}'
           echo "results: $results"
+          case ",$results," in
+            *,,*)
+              echo "::error::a job this gate depends on reported no result"
+              exit 1
+              ;;
+          esac
+          IFS=,
           for result in $results; do
             case "$result" in
               success | skipped) ;;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,25 @@ documented at release-notes length in the first place, and are still in
   reports each of those reasons, the reason being what a reader acts on
   (closes #1451).
 
+- **`test: every job passed` fails on a `needs` result that is empty**,
+  which is the one shape its allowlist could not see. An empty result
+  contributed no word to `for` under the space the join used as its
+  separator, so the loop decided the gate on the results beside it, and
+  on a join empty throughout it compared nothing and exited 0 -- a
+  required check reporting on a run it never read. The separator is a
+  comma, which makes an empty result an empty field rather than
+  nothing, and a `case` over the string wrapped in commas decides
+  before the loop: an empty first field, an empty last one, an empty
+  one between two others and an empty join are a single pattern to it,
+  where the loop cannot see a trailing empty field even under a comma.
+  The comment above the step says what neither reading catches -- a
+  `needs` entry whose `result` key is missing rather than empty is
+  dropped by the `needs.*.result` filter before the join runs -- and
+  why the run's own job listing, which section 10 of the organization
+  standard has an aggregate read instead of `needs`, is not open to
+  this workflow while `release.yml` calls it and that listing is the
+  caller's run (btclib-org/.github#474) (closes #1454).
+
 ## v2026.8.27
 
 ### Repository


### PR DESCRIPTION
The aggregate's guard joined `needs.*.result` on a space and walked the
result with an unquoted `for`, so an empty element vanished into the
field splitting and an empty join gave no iteration at all: the step
passed with nothing checked, while the comment beside it claimed the
allowlist was what caught exactly that case.

The join now uses a comma and `IFS=,`, and a `case` decides the two
shapes the loop still cannot see — a trailing empty field, which
splitting drops, and an empty join, which yields no fields. Measured
against the runner's own semantics: `join` appends the separator between
every pair whatever the elements convert to, and `needs.*.result` drops
an entry with no `result` key before the join ever runs.

The guard is strictly stronger on every shape tested and weaker on none;
the two controls — an ordinary pass and an ordinary failure — behave as
before. The job's name is untouched: it is one of the contexts `main`
requires.

Closes #1454

## Summary by Sourcery

Reject aggregate checks when dependency results are empty instead of allowing them to pass unchecked.

Bug Fixes:
- Make the aggregate workflow check fail when any dependency reports an empty result, including when all results are empty.

Enhancements:
- Preserve the existing allowlist behavior for successful and legitimately skipped jobs while rejecting unanticipated result values.

Documentation:
- Document the empty-result guard behavior and the limitation around missing result keys in the changelog.