### PR TITLE
The homepage names this tree's own documentation (issue btclib-org/.github#533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,15 @@ documented at release-notes length in the first place, and are still in
   this workflow while `release.yml` calls it and that listing is the
   caller's run (btclib-org/.github#474) (closes #1454).
 
+- **`[project.urls] homepage` names this tree's own documentation site**
+  (issue btclib-org/.github#533). A releasing tree provides
+  documentation, and its home is that documentation rather than a
+  sibling's project page: the field read `https://btclib.org`, which
+  `documentation` already pointed past, and now carries the identical
+  `https://btclib.readthedocs.io/`. `documentation` stays, an index
+  showing the two fields as one link being cheaper than the field
+  tools read for that purpose specifically.
+
 ## v2026.8.27
 
 ### Repository

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -589,6 +589,18 @@ curl -s https://app.readthedocs.org/api/v3/projects/btclib/ \
   carries between releases. `stable` is the alternative, and what the
   choice decides is which of the two a reader arriving with no version in
   mind is given.
+- **The repository's `.homepage` names this same site**, read back from
+  the endpoint rather than from `pyproject.toml`'s own copy of it:
+
+  ```shell
+  gh api repos/btclib-org/btclib --jq '.homepage'
+  # https://btclib.readthedocs.io/
+  ```
+
+  `[project.urls] homepage` in `pyproject.toml` carries the identical
+  string (issue btclib-org/.github#533): a releasing tree's home is its
+  own documentation, not `btclib.org`, which the *Pages* section above
+  still serves and which the two fields no longer name.
 
 Tags older than the rule are mostly not activatable rather than merely not
 activated: a build needs `.readthedocs.yaml`, which reaches back to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ secp256k1 = [
 ]
 
 [project.urls]
-homepage = "https://btclib.org"
+homepage = "https://btclib.readthedocs.io/"
 documentation = "https://btclib.readthedocs.io/"
 download = "https://github.com/btclib-org/btclib/releases"
 changelog = "https://github.com/btclib-org/btclib/blob/main/RELEASE_NOTES.md"


### PR DESCRIPTION
`[project.urls] homepage` names this tree's own documentation site
rather than `https://btclib.org`, which is a sibling's project page,
and `REPOSITORY.md` records the repository's `.homepage` as read back
from the endpoint. Both are btclib-org/.github#533's third and fourth
boxes for this tree.

`documentation` stays: the issue records that decision, an index and
tools reading that field for that purpose specifically. The
trailing-slash divergence between trees is left exactly as it is —
btclib-org/.github#535 is where it is settled, and normalizing it here
would decide it by inertia.

btclib-node is the fourth releasing tree and its port is still owed, so
this cites the issue rather than closing it.

## Summary by Sourcery

Set this tree's homepage to its own documentation site and align the recorded repository metadata with that destination.

Bug Fixes:
- Point the project homepage to this repository's documentation site instead of the sibling btclib.org project page.

Enhancements:
- Document the repository homepage alignment and preserve the existing documentation URL.

Documentation:
- Update the changelog and repository metadata documentation to reflect the documentation site as the homepage.