### PR TITLE
bytes_from_octets promises bytes and returns them (closes #1255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,33 @@ documented at release-notes length in the first place, and are still in
   showing the two fields as one link being cheaper than the field
   tools read for that purpose specifically.
 
+### The public API and the module layout
+
+- **`bytes_from_octets` answers with the `bytes` it is annotated to
+  return** (closes #1255). A `bytearray` or a `memoryview` went back to
+  the caller as its own object, so a `BIP32KeyData` built from a
+  bytearray chain code aliased that bytearray, and the xprv the key
+  serializes to changed when the caller wrote a byte into a buffer that
+  was its own to write to. `bytes(octets)` on the way out is the fix,
+  and the arm every `Octets` parameter of the library runs through
+  allocates nothing for it: `bytes(b)` is `b` itself where `b` is
+  already `bytes`, which is what a hex string decodes to and what nearly
+  every call passes.
+
+  The two `type: ignore[return-value]` that disclosed the gap go with
+  it, and so does the `bytes(...)` each call site needing real `bytes`
+  had put around the result: a concatenation, a reversal that has to
+  stay contiguous, an ordering against a `bytes` digest, a field
+  declared `bytes` that has to hash, a `decode`, and the `BytesIO` a
+  `PsbtView` parses out of. One coercion that answers `bytes` is what
+  each of them was asking for, and the reasons written beside them go
+  with them.
+
+  `assert_valid` is still a read that does not rewrite the field it
+  reads. The copy is `__init__`'s, where a key is built rather than
+  inspected, and `assert_valid`'s own type check runs on a local it
+  never assigns back.
+
 ## v2026.8.27
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,26 @@ full year, short month, short day (YYYY-M-D)
 
 ## v2026.9 (work in progress, not released yet)
 
+### Worth knowing, though nothing raises
+
+- **`bytes_from_octets` returns `bytes`, and not the buffer it was
+  handed** (closes #1255). A `bytearray` or a `memoryview` came back as
+  itself, so what a caller got was the object it had passed in and the
+  `-> bytes` on the signature was not what the function did.
+
+  Act on it if you pass a `bytearray` or a `memoryview` to
+  `btclib.utils.bytes_from_octets` and then use what comes back as a
+  mutable buffer: writing through it raises `TypeError: 'bytes' object
+  does not support item assignment`, and `isinstance(result, bytearray)`
+  is now False. A `bytes` argument and a hex `str` are unaffected, and
+  anything that reads the result as octets reads it unchanged.
+
+  The other direction is what the change is for and asks nothing of
+  you. A `BIP32KeyData` built from a bytearray chain code kept that
+  bytearray as its field, so the xprv the key serialized to moved when
+  the caller wrote a byte into a buffer that was its own to write to;
+  what a field built through this coercion holds is now a copy.
+
 ## v2026.8.27
 
 ### Breaking changes

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -130,7 +130,8 @@ The four aliases:
     ``btclib.utils.bytes_from_octets`` to normalize one yourself. The
     mutable buffers are here because every consumer takes one: a
     ``memoryview`` sliced out of a larger field is octets like any
-    other, and is not copied on its way in.
+    other. That coercion copies it, so writing to a buffer after
+    passing it does not reach what btclib built from it.
 
 ``String = bytes | str | bytearray | memoryview``
     The same types, read the other way round: here a ``str`` is *text*,

--- a/src/btclib/base58.py
+++ b/src/btclib/base58.py
@@ -135,12 +135,10 @@ def encode(v: Octets, in_size: int | None = None) -> bytes:
     """Encode a bytes-like object using Base58Check."""
     v = bytes_from_octets(v, in_size)
     h256 = hash256(v)
-    # bytes(v) rather than v: a memoryview has no __add__, so `v + h256[:4]`
-    # raises TypeError once v is the buffer bytes_from_octets hands back
-    # unchanged. The copy is safe here, unlike in bytes_from_octets itself:
-    # v does not survive past this line, so there is nothing of the
-    # caller's for a copy to lose sync with
-    return _b58encode(bytes(v) + h256[:4])
+    # the concatenation a memoryview has no operator for: what makes it
+    # one is `bytes_from_octets` above, where every buffer becomes the
+    # `bytes` the payload is built from
+    return _b58encode(v + h256[:4])
 
 
 def _b58decode_to_int(v: bytes) -> int:

--- a/src/btclib/block/merkle_proof.py
+++ b/src/btclib/block/merkle_proof.py
@@ -108,17 +108,14 @@ def assert_as_valid(
     assert_type(branch, Sequence, "branch")
 
     root = bytes_from_octets(merkle_root, 32)
-    # bytes(...) rather than the buffer bytes_from_octets hands back: a
-    # memoryview is returned as itself, and reversing one with [::-1]
-    # yields a strided, non-contiguous view that the next
-    # bytes_from_octets call inside merkle_root_from_branch refuses --
-    # a valid proof spelled with memoryviews would then read as False
-    # rather than True (issue #1429). Neither txid nor sibling is
-    # returned to the caller, so the copy costs one allocation each and
-    # loses nothing out of sync
+    # `[::-1]` of a memoryview is a strided, non-contiguous view, which
+    # the `bytes_from_octets` inside `merkle_root_from_branch` refuses --
+    # a valid proof spelled with memoryviews would read as False rather
+    # than True (issue #1429). Reversed here is the `bytes` the coercion
+    # answers with, which reverses into `bytes`
     computed = merkle_root_from_branch(
-        bytes(bytes_from_octets(txid, 32))[::-1],
-        [bytes(bytes_from_octets(sibling, 32))[::-1] for sibling in branch],
+        bytes_from_octets(txid, 32)[::-1],
+        [bytes_from_octets(sibling, 32)[::-1] for sibling in branch],
         index,
         _HF,
         _assert_inner_node_is_not_a_tx,

--- a/src/btclib/ecc/ssa.py
+++ b/src/btclib/ecc/ssa.py
@@ -287,10 +287,10 @@ def _x_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve) -> int:
 
     if is_octets(x_Q):
         # every spelling `Octets` names, which is what
-        # `bytes_from_octets` takes and returns as it came. Accepted at
-        # all three sizes here, where the dispatch this
-        # replaces took them at the SEC two and refused them at the
-        # x-only one, its fallback having asked for `(str, bytes)`
+        # `bytes_from_octets` takes. Accepted at all three sizes here,
+        # where the dispatch this replaces took them at the SEC two and
+        # refused them at the x-only one, its fallback having asked for
+        # `(str, bytes)`
         #
         # the two octet spellings are told apart by length and not by
         # trying one and catching the other: p-size is BIP340's x-only

--- a/src/btclib/hashes.py
+++ b/src/btclib/hashes.py
@@ -89,14 +89,11 @@ def ripemd160(octets: Octets) -> bytes:
     octets = bytes_from_octets(octets)
     if _RIPEMD160_IN_HASHLIB:
         return hashlib.new("ripemd160", octets).digest()
-    # bytes(octets) rather than octets: pure_python_ripemd160 concatenates
-    # its argument on the argument's own left side, which a memoryview has
-    # no __add__ for; hashlib.new above needs no such copy, every digest
-    # constructor taking any buffer directly. octets does not survive
-    # past this call, so the copy costs nothing borrowed from the caller,
-    # and _ripemd160.py itself stays the vendored file it documents
-    # itself as being
-    return pure_python_ripemd160(bytes(octets))
+    # `pure_python_ripemd160` concatenates its argument on the argument's
+    # own left side, which a memoryview has no `__add__` for: what it is
+    # handed is the `bytes` `bytes_from_octets` above made of it, so
+    # `_ripemd160.py` stays the vendored file it documents itself as being
+    return pure_python_ripemd160(octets)
 
 
 def sha1(octets: Octets) -> bytes:
@@ -406,19 +403,13 @@ def merkle_root_from_branch(
     if index < 0:
         raise BTClibValueError(f"negative leaf index: {index}")
 
-    # bytes(...) rather than the buffer bytes_from_octets hands back: root
-    # and sibling are this function's own local values, folded into pair
-    # and rehashed rather than read back to whoever passed leaf or branch
-    # in, so the no-copy rule bytes_from_octets keeps for its own caller's
-    # buffer does not reach here. A memoryview reaching `sibling + root`
-    # or `root + sibling` below fails on whichever side it is the left
-    # operand of, a memoryview having no __add__, and a memoryview leaf
-    # would otherwise be this function's own return value, unbroken by an
-    # empty branch, despite the -> bytes above
-    root = bytes(bytes_from_octets(leaf, 32))
+    # the folds below concatenate these two, which a memoryview has no
+    # `__add__` for, and an empty branch returns the leaf as the `bytes`
+    # above says: `bytes_from_octets` is where each becomes one
+    root = bytes_from_octets(leaf, 32)
     for sibling_ in branch:
         # a branch item that is not a hash cannot be a sibling
-        sibling = bytes(bytes_from_octets(sibling_, 32))
+        sibling = bytes_from_octets(sibling_, 32)
         if index % 2:
             # the running hash is a right child, and a left sibling equal
             # to it is the CVE-2012-2459 duplication: a shorter list has

--- a/src/btclib/key.py
+++ b/src/btclib/key.py
@@ -143,19 +143,14 @@ class PubKeyData:
         *,
         check_validity: bool = True,
     ) -> None:
-        # `bytes()` around it: `bytes_from_octets` returns a bytearray or
-        # a memoryview as it came, deliberately, and `utils` says why --
-        # `assert_valid` is a read and must not rewrite the field it
-        # reads. Here the field is built rather than read, and it is
-        # declared `bytes`: without the coercion a key made from a
-        # bytearray is unhashable, where the docstring above promises that
-        # equality and hashing read the declared fields, and one made from
-        # a memoryview carries octets no concatenation accepts --
-        # `script.taproot` joins a merkle root to the x it reads off
-        # `sec` before hashing the pair under a tag.
-        # `bytes(b)` on bytes is `b` itself, so the spelling every caller
-        # of this library uses copies nothing
-        object.__setattr__(self, "sec", bytes(bytes_from_octets(sec)))
+        # the field is declared `bytes` and `bytes_from_octets` is what
+        # makes it one: a key made from a bytearray would be unhashable,
+        # where the docstring above promises that equality and hashing
+        # read the declared fields, and one made from a memoryview would
+        # carry octets no concatenation accepts -- `script.taproot` joins
+        # a merkle root to the x it reads off `sec` before hashing the
+        # pair under a tag
+        object.__setattr__(self, "sec", bytes_from_octets(sec))
         object.__setattr__(self, "network", _normalized(network))
 
         if check_validity:

--- a/src/btclib/p2p/compact_blocks.py
+++ b/src/btclib/p2p/compact_blocks.py
@@ -270,12 +270,12 @@ def _short_id(key: tuple[int, int], wtxid: Octets) -> int:
     after a caller changed the header it was taken from.
     """
     k0, k1 = key
-    # bytes(...) rather than the buffer bytes_from_octets hands back: a
-    # memoryview is returned as itself, and reversing one with [::-1]
-    # yields a strided, non-contiguous view that siphash's own call to
-    # bytes_from_octets refuses -- a wtxid spelled as a memoryview would
-    # then raise where every other Octets spelling answers (issue #1429)
-    digest = siphash(k0, k1, bytes(bytes_from_octets(wtxid, _HASH_SIZE))[::-1])
+    # `[::-1]` of a memoryview is a strided, non-contiguous view, which
+    # siphash's own call to `bytes_from_octets` refuses -- a wtxid
+    # spelled as a memoryview would raise where every other `Octets`
+    # spelling answers (issue #1429). Reversed here is the `bytes` the
+    # coercion answers with, which reverses into `bytes`
+    digest = siphash(k0, k1, bytes_from_octets(wtxid, _HASH_SIZE)[::-1])
     return digest & _MAX_SHORT_ID
 
 

--- a/src/btclib/psbt/psbt_view.py
+++ b/src/btclib/psbt/psbt_view.py
@@ -218,13 +218,7 @@ class PsbtView:
     sp_dleq_proofs: dict[bytes, bytes]
 
     def __init__(self, data: BinaryIO | Octets) -> None:
-        # `bytes` where `BytesIO` would take the buffer itself: it copies
-        # either way — what it does not do is flatten a non-contiguous
-        # memoryview, which `Octets` admits and which it refuses with
-        # `BufferError: underlying buffer is not C-contiguous`
-        stream: BinaryIO = (
-            BytesIO(bytes(bytes_from_octets(data))) if is_octets(data) else data
-        )
+        stream: BinaryIO = BytesIO(bytes_from_octets(data)) if is_octets(data) else data
         if not stream.seekable():
             err_msg = "a psbt view needs a seekable stream: it reads a map "
             err_msg += "when it is asked for it, not in the order they arrive"

--- a/src/btclib/script/script_pub_key.py
+++ b/src/btclib/script/script_pub_key.py
@@ -833,16 +833,14 @@ def _script_from(script_pub_key: Octets | ScriptPubKey) -> bytes:
     script and go through: no descriptor derives one, and the caller who
     wrote them meant them.
 
-    `bytes_from_octets` alone cannot do this: it returns anything that is
-    not a `str` untouched, so the `ScriptPubKey` that a wallet and a
-    descriptor both answer with would travel through to a comparison
-    against `bytes` that is False at every index, and the caller would
-    read the None it falls off the end with as "not this wallet's".
+    `bytes_from_octets` alone cannot do this: it refuses the
+    `ScriptPubKey` that a wallet and a descriptor both answer with, and
+    it reads a `str` as hex or not at all, where a caller holding an
+    output as text as readily holds an address.
     """
     if isinstance(script_pub_key, ScriptPubKey):
         return script_pub_key.script
     if isinstance(script_pub_key, (bytes, bytearray, memoryview)):
-        # copied, where `bytes_from_octets` deliberately does not copy:
         # this function exists to produce the thing a caller compares and
         # keys a dict by, and a bytearray is unhashable
         return bytes(script_pub_key)

--- a/src/btclib/script/taproot.py
+++ b/src/btclib/script/taproot.py
@@ -545,18 +545,12 @@ def check_output_pubkey(q: Octets, script: Octets, control: Octets) -> bool:
     """
     q = bytes_from_octets(q)
     script = bytes_from_octets(script)
-    # `bytes(...)` because the merkle fold below orders two slices of this
-    # against a `bytes` digest, and a memoryview does not order against
-    # `bytes` where a bytearray does -- the asymmetry is Python's, and it
-    # reaches here because `bytes_from_octets` returns every buffer as it
-    # came, deliberately: `utils` states why, an `assert_valid` being a
-    # read that must not rewrite the field it reads. Nothing is stored
-    # here, `control` being a local, so the copy costs one allocation of
-    # at most 33 + 32 * MAX_TREE_DEPTH octets and buys every line under it
-    # not having to know which spelling arrived. `q` and `script` need no
-    # such copy -- one is read as an integer and the other is hashed --
-    # and are left as they came (issue 1220)
-    control = bytes(bytes_from_octets(control))
+    # the merkle fold below orders two slices of this against a `bytes`
+    # digest, and a memoryview does not order against `bytes` where a
+    # bytearray does -- the asymmetry is Python's. What the fold reads is
+    # the `bytes` `bytes_from_octets` answers with, so no line under it
+    # has to know which spelling arrived (issue 1220)
+    control = bytes_from_octets(control)
     if len(control) > 33 + 32 * MAX_TREE_DEPTH:
         raise BTClibValueError("control block too long")
     m = (len(control) - 33) // 32

--- a/src/btclib/tx_or_psbt.py
+++ b/src/btclib/tx_or_psbt.py
@@ -81,9 +81,9 @@ def _octets_from_any(data: String) -> bytes:
         return _octets_from_text(data)
 
     # the refusal of what is neither text nor bytes is bytes_from_octets's
-    # to give, `split` below being str's and `decode` bytes'; a buffer
-    # that is not `bytes` is made one, for the same reason
-    raw = bytes(bytes_from_octets(data))
+    # to give, `split` below being str's and `decode` bytes': a memoryview
+    # has no `decode`, and the coercion is what makes it bytes
+    raw = bytes_from_octets(data)
     try:
         text = raw.decode("ascii")
     except UnicodeDecodeError:

--- a/src/btclib/utils.py
+++ b/src/btclib/utils.py
@@ -87,22 +87,21 @@ def _assert_byte_shaped(octets: bytes | bytearray | memoryview) -> None:
     """Refuse a memoryview whose layout or format is not plain bytes.
 
     `bytes` and `bytearray` are always C-contiguous and always format
-    "B" (unsigned bytes); a `memoryview` need not be either. A strided
-    slice such as `mv[::2]` is not C-contiguous, and is returned by
-    `bytes_from_octets` untouched unless refused here.
+    "B" (unsigned bytes); a `memoryview` need not be either, and the
+    copy `bytes_from_octets` makes takes both without a word. A strided
+    slice such as `mv[::2]` is not C-contiguous, and `bytes()` of one
+    gathers its strides into a run that no buffer holds.
 
-    Contiguity is not the only property every other consumer of the
-    buffer this returns assumes: a `memoryview` cast to a signed `"b"`,
-    or built over an array of a wider format such as `"I"`, is
-    C-contiguous and still not read the way `hashes.magic_message`'s
-    `for byte in data` or `hashes.siphash`'s `len(msg)` read it --
-    `len()` counts elements rather than octets, and iterating one
-    yields whatever the format decodes to rather than an unsigned byte
-    in `0..255` (issue #1430). Format `"B"` is the one every buffer
-    this function accepts shares, `bytes`, `bytearray` and an
-    unformatted `memoryview` included, so it is the property asked for
-    rather than `itemsize == 1`, which a signed `"b"` view or a `"c"`
-    one (bytes objects, not ints) would still pass.
+    Contiguity is not the only property the octets a caller counts rest
+    on: a `memoryview` cast to a signed `"b"`, or built over an array of
+    a wider format such as `"I"`, is C-contiguous and still not the
+    octets it looks like -- `len()` counts elements where `bytes()`
+    yields `itemsize` of them each, so the caller's count of its own
+    octets and the library's disagree (issue #1430). Format `"B"` is the
+    one every buffer this function accepts shares, `bytes`, `bytearray`
+    and an unformatted `memoryview` included, so it is the property
+    asked for rather than `itemsize == 1`, which a signed `"b"` view or
+    a `"c"` one (bytes objects, not ints) would still pass.
     """
     if not isinstance(octets, memoryview):
         return
@@ -117,21 +116,24 @@ def _assert_byte_shaped(octets: bytes | bytearray | memoryview) -> None:
 def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> bytes:
     """Return bytes from a hex-string, stripping leading/trailing spaces.
 
-    If the input is not a string, then it goes untouched. Optionally, it
-    also ensures required output size: one size, or any iterable of them,
-    and a bool is neither -- `out_size=True` would accept a single octet
-    and say it had checked a size.
+    A `bytearray` or a `memoryview` is copied, which is what makes the
+    `bytes` this promises true: handed back as it came, either is still
+    the caller's own object, so a write to it afterwards reaches into
+    whatever kept the return value -- the chain code of a
+    `BIP32KeyData`, and the xprv that key serializes to. The copy is
+    also what reads as octets everywhere the result goes: a `memoryview`
+    has no `+` to concatenate with, and a `bytearray` keys no dict.
+
+    Optionally, it also ensures required output size: one size, or any
+    iterable of them, and a bool is neither -- `out_size=True` would
+    accept a single octet and say it had checked a size.
 
     A non-contiguous `memoryview` -- what a strided slice such as
-    `mv[::2]` gives -- is refused here rather than handed back: every
-    other consumer of the buffer this returns needs a C-contiguous one,
-    `hash160` failing with a bare `BufferError` being one of them, so the
-    refusal is raised through the exception contract at the one place
-    every `Octets` parameter passes rather than left to whichever
-    consumer trips over it first. A `memoryview` whose format is not
-    unsigned bytes is refused the same way: `len()` of one counts
-    elements rather than octets, and a consumer that reads it byte by
-    byte reads whatever its format decodes to instead (issue #1430).
+    `mv[::2]` gives -- is refused rather than copied, and so is one whose
+    format is not unsigned bytes: `_assert_byte_shaped` says why neither
+    is the octets it looks like. The refusal is raised through the
+    exception contract at the one place every `Octets` parameter passes,
+    rather than left to whichever consumer trips over it first.
     """
     if isinstance(octets, str):  # hex string
         # `bytes.fromhex` raises a bare ValueError -- the same class the
@@ -148,24 +150,21 @@ def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> byte
             raise BTClibValueError(f"invalid hex string: {e}") from e
     elif isinstance(octets, (bytes, bytearray, memoryview)):
         _assert_byte_shaped(octets)
+        # the copy that makes the annotation true (issue #1255).
+        # `bytes(b)` is `b` itself where `b` is already `bytes`, which is
+        # what nearly every call passes, so the arm every `Octets`
+        # parameter of the library runs through allocates nothing
+        octets = bytes(octets)
     else:
         # what is neither went through untouched and reached whatever the
         # caller went on to do with it: `len` of a tuple of 33 ints is 33,
         # so `taproot.assert_valid_control_block` accepted one as a
-        # control block size.
-        # Every buffer and not `bytes` alone, and returned as it came:
-        # `assert_valid` is a read and must not rewrite the field it
-        # reads, which is what `bytes()` here would do to a bytearray a
-        # caller built (`tests/bip32/bip32_test.py` pins it)
+        # control block size
         err_msg = f"invalid octets type: {type(octets).__name__}"  # type: ignore[unreachable]
         raise BTClibTypeError(err_msg)
 
     if out_size is None:
-        # the annotation says `bytes` and this hands back the buffer it
-        # was given, which the widened `Octets` is what makes visible:
-        # disclosed rather than silenced, because making the signature
-        # true is a change across the tree and its own (issue #1255)
-        return octets  # type: ignore[return-value]
+        return octets
 
     # one size or an iterable of them, and nothing else: `tuple()` on
     # whatever is left would refuse a float with a bare TypeError about
@@ -184,13 +183,9 @@ def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> byte
             err_msg = f"invalid output size type: {type(size).__name__}"
             raise BTClibTypeError(err_msg)
 
-    # nbytes rather than len(): the two already agree for bytes,
-    # bytearray and the format-"B" memoryview _assert_byte_shaped just
-    # let through, so this measures the octets rather than repeating a
-    # coincidence that check happens to make true
-    size = memoryview(octets).nbytes
+    size = len(octets)
     if size in sizes:
-        return octets  # type: ignore[return-value]
+        return octets
 
     err_msg = f"invalid size: {size} bytes instead of {out_size}"
     raise BTClibValueError(err_msg)

--- a/tests/base58_test.py
+++ b/tests/base58_test.py
@@ -135,10 +135,10 @@ def test_wif() -> None:
 def test_encode_octets_spellings() -> None:
     """`encode` takes every `Octets` spelling, memoryview included.
 
-    A memoryview has no `__add__`, and `bytes_from_octets` hands one
-    back unchanged: `encode` copies it to `bytes` right at the
-    concatenation `_b58encode`'s payload needs, which is the one place
-    a memoryview payload would otherwise fail (issue #1255).
+    A memoryview has no `__add__`, and the payload `_b58encode` is
+    handed is a concatenation: what carries every spelling to it is
+    `bytes_from_octets`, which answers with the `bytes` its signature
+    promises (issue #1255).
     """
     payload = b"hello world"
     known_answer = b"3vQB7B6MrGQZaxCuFg4oh"

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -1090,7 +1090,12 @@ def test_assert_valid_does_not_rewrite_the_key_data() -> None:
     # function for unreachable and checks none of it -- warn_unreachable
     # being off, in silence. Measured: with the assertion written directly
     # on the attribute, a reveal_type below it prints nothing at all
-    xkey_data = replace_unchecked(xkey_data, chain_code=bytearray(xkey_data.chain_code))
+    #
+    # object.__setattr__ and not replace_unchecked: that one builds the
+    # instance through __init__, where bytes_from_octets copies the
+    # buffer, so what it installs is bytes and there is nothing left for
+    # a rewrite to be visible in
+    object.__setattr__(xkey_data, "chain_code", bytearray(xkey_data.chain_code))
     chain_code: object = xkey_data.chain_code
     assert isinstance(chain_code, bytearray)
 
@@ -1102,7 +1107,7 @@ def test_assert_valid_does_not_rewrite_the_key_data() -> None:
 def test_assert_valid_does_not_rewrite_on_a_read() -> None:
     """Keep b58encode and serialize from coercing fields in place."""
     xkey_data = BIP32KeyData.b58decode(XKEY)
-    xkey_data = replace_unchecked(xkey_data, chain_code=bytearray(xkey_data.chain_code))
+    object.__setattr__(xkey_data, "chain_code", bytearray(xkey_data.chain_code))
 
     xkey_data.b58encode()
     after_b58encode: object = xkey_data.chain_code
@@ -1111,6 +1116,29 @@ def test_assert_valid_does_not_rewrite_on_a_read() -> None:
     xkey_data.serialize()
     after_serialize: object = xkey_data.chain_code
     assert isinstance(after_serialize, bytearray)
+
+
+def test_a_bytearray_chain_code_is_copied_into_the_key_data() -> None:
+    """The caller keeps its buffer, and the key keeps its octets.
+
+    `bytes_from_octets` copies what `__init__` is given, so a caller
+    writing to the bytearray it built a key from does not rewrite the
+    key: without the copy the field aliased that buffer, and the xprv
+    this serializes to changed under a caller who never touched the key
+    (issue #1255).
+    """
+    chain_code = bytearray(b"\x11" * 32)
+    xkey_data = BIP32KeyData(
+        version="0488ade4",
+        depth=0,
+        parent_fingerprint="00000000",
+        index=0,
+        chain_code=chain_code,
+        key="00" + "22" * 32,
+    )
+    xprv = xkey_data.b58encode()
+    chain_code[0] = 0xFF
+    assert xkey_data.b58encode() == xprv
 
 
 def test_assert_valid_reports_a_float_field_instead_of_coercing_it() -> None:

--- a/tests/block/merkle_proof_test.py
+++ b/tests/block/merkle_proof_test.py
@@ -207,14 +207,14 @@ def test_an_honest_block_has_no_inner_node_that_parses_as_a_transaction() -> Non
 
 
 def test_a_memoryview_txid_and_branch_verify_as_any_other_octets() -> None:
-    """Reversing the buffer bytes_from_octets hands back must not strand it.
+    """A memoryview reversed must reach the fold as the octets it spells.
 
-    A memoryview is returned unchanged, and `[::-1]` over one is a
-    strided, non-contiguous view: the second `bytes_from_octets` call
-    inside `merkle_root_from_branch` used to refuse it, which `verify`
-    reports as a proof that does not verify rather than as the shape
-    error it is -- a valid proof spelled with memoryviews answered False
-    (issue #1429).
+    `[::-1]` over a memoryview is a strided, non-contiguous view, which
+    the second `bytes_from_octets` call inside `merkle_root_from_branch`
+    refuses -- and `verify` reports a refusal as a proof that does not
+    verify rather than as the shape error it is, so a valid proof
+    spelled with memoryviews answered False (issue #1429). What is
+    reversed here is the `bytes` the first coercion answers with.
     """
     block = _load("block_200000.bin")
     txids = [tx.id for tx in block.transactions]

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -337,8 +337,8 @@ def test_an_extended_key_is_no_longer_a_bip340_key() -> None:
 def test_a_buffer_is_octets_at_every_size_this_takes() -> None:
     """A bytearray and a memoryview, at all three sizes (issue #1188).
 
-    They are what `bytes_from_octets` accepts beside `Octets` and returns
-    as they came, and what `to_pub_key` names at run time beside the
+    They are what `bytes_from_octets` accepts beside `Octets` and copies
+    into `bytes`, and what `to_pub_key` names at run time beside the
     static union -- the asymmetry `alias` states and this module
     inherits.
 

--- a/tests/key_test.py
+++ b/tests/key_test.py
@@ -47,10 +47,10 @@ def test_pub_key_data() -> None:
 def test_the_sec_field_is_bytes_however_the_octets_were_spelled(sec: Octets) -> None:
     """A buffer is octets here, because the field is declared `bytes`.
 
-    `bytes_from_octets` returns a bytearray and a memoryview as they
-    came, deliberately: it is what `assert_valid` reads with, and a read
-    must not rewrite what it reads. A constructor builds instead, and two
-    of this module's promises rest on its field being what it says.
+    `bytes_from_octets` copies a bytearray and a memoryview into
+    `bytes`, so the field holds what its annotation promises however the
+    octets were spelled, and two of this module's promises rest on its
+    field being what it says.
 
     Equality and hashing read the declared fields, which a bytearray
     would take away: it is unhashable, so a key spelled that way could

--- a/tests/p2p/compact_blocks_test.py
+++ b/tests/p2p/compact_blocks_test.py
@@ -203,13 +203,13 @@ def test_the_short_id_is_taken_over_the_hash_the_wire_carries() -> None:
 
 
 def test_a_memoryview_wtxid_gives_the_same_short_id_as_bytes() -> None:
-    """Reversing the buffer bytes_from_octets hands back must not strand it.
+    """A memoryview reversed must reach siphash as the octets it spells.
 
-    A memoryview is returned unchanged, and `[::-1]` over one is a
-    strided, non-contiguous view: `siphash`'s own call to
-    `bytes_from_octets` used to refuse it, so a wtxid spelled as a
-    memoryview raised where every other `Octets` spelling answers
-    (issue #1429).
+    `[::-1]` over a memoryview is a strided, non-contiguous view, which
+    `siphash`'s own call to `bytes_from_octets` refuses, so a wtxid
+    spelled as a memoryview raised where every other `Octets` spelling
+    answers (issue #1429). What is reversed here is the `bytes` the
+    coercion answers with.
     """
     block = _block_481824()
     compact_block = _compact(block)

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -133,9 +133,9 @@ def test_one_internal_key_however_it_is_spelled(
     wants the octets alone and the Python one the point.
 
     The buffers are here because the key reaches the tweak as octets to be
-    concatenated, and a memoryview is not one: `bytes_from_octets` returns
-    every buffer as it came, so what makes them octets is `PubKeyData`
-    coercing its own field, and nothing else on this path would.
+    concatenated, and a memoryview is not one: `PubKeyData` coerces its
+    own field through `bytes_from_octets`, which is where every spelling
+    becomes the `bytes` the tweak concatenates.
     """
     prv_key = 0xC0FFEE
     point = mult(prv_key)
@@ -549,14 +549,13 @@ def test_check_output_pubkey_takes_every_buffer_the_door_accepts(
     """Every spelling `bytes_from_octets` takes reaches the same answer.
 
     A memoryview used to raise a bare `TypeError` from the merkle fold,
-    on both arms: `bytes_from_octets` returns every buffer as it came,
-    so a slice of the control block stayed a memoryview and would not
-    order against the `bytes` digest it is compared with. A bytearray
-    was unaffected, ordering against `bytes` where a memoryview does
-    not, which is Python's asymmetry rather than this library's --
-    and it is why the census in `bool_parameter_test.py` could not see
-    this: the wrong spelling is accepted at the door and refused
-    halfway (issue 1220).
+    on both arms: a slice of the control block was a memoryview, and one
+    does not order against the `bytes` digest it is compared with. A
+    bytearray was unaffected, ordering against `bytes` where a
+    memoryview does not, which is Python's asymmetry rather than this
+    library's -- and it is why the census in `bool_parameter_test.py`
+    could not see this: the wrong spelling is accepted at the door and
+    refused halfway (issue 1220).
     """
     tree: TaprootScriptTree = [[(0xC0, ["OP_2"])], [(0xC0, ["OP_3"])]]
     q, _ = output_pubkey(0xC0FFEE, tree)
@@ -676,12 +675,10 @@ def test_the_two_output_keys_are_one_tweak() -> None:
         output_pubkey(internal_pubkey, script_tree)
     )
 
-    # a memoryview x, which `bytes_from_octets` passes through as it came:
-    # what makes it octets here is the `02` this function prefixes, `bytes`
-    # on the left of a concatenation taking any buffer on the right where
-    # `memoryview + bytes` is not an operation at all. The internal key of
-    # `output_pubkey` becomes bytes one layer lower, in `PubKeyData`, so
-    # this entry point needs its own assertion rather than that one's
+    # a memoryview x, coerced by this function's own `bytes_from_octets`
+    # before the `02` it prefixes: the internal key of `output_pubkey`
+    # becomes bytes one layer lower, in `PubKeyData`, so this entry point
+    # needs its own assertion rather than that one's
     assert output_pubkey_from_merkle_root(memoryview(x_only), merkle_root) == (
         output_pubkey(internal_pubkey, script_tree)
     )

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -263,9 +263,7 @@ def test_octets_are_bytes_or_the_hex_string_of_bytes_and_nothing_else() -> None:
     `bytes_from_octets` returned anything that was not a `str`
     unchanged, so `len` of a tuple of 33 ints was 33 and
     `taproot.assert_valid_control_block` accepted it as a control block
-    size. Every buffer is still taken, and returned as it came: a read
-    must not rewrite the field it reads, which is what `bytes()` here
-    would do to a bytearray a caller built.
+    size. Every buffer is still taken.
     """
     assert bytes_from_octets(b"\x00\x01") == b"\x00\x01"
     assert bytes_from_octets("0001") == b"\x00\x01"
@@ -273,9 +271,6 @@ def test_octets_are_bytes_or_the_hex_string_of_bytes_and_nothing_else() -> None:
     # field was built from rather than only what a caller writes
     assert bytes_from_octets(bytearray(b"\x00\x01")) == b"\x00\x01"
     assert bytes_from_octets(memoryview(b"\x00\x01")) == b"\x00\x01"
-    # unchanged, and not merely equal
-    buffer: object = bytes_from_octets(bytearray(b"\x00"))
-    assert isinstance(buffer, bytearray)
 
     for not_octets in (tuple(range(33)), [1, 2], None, 1.5):
         with pytest.raises(BTClibTypeError, match="invalid octets type: "):
@@ -298,6 +293,28 @@ def test_octets_are_bytes_or_the_hex_string_of_bytes_and_nothing_else() -> None:
         int_from_integer("0xzz")
 
 
+def test_a_buffer_becomes_the_bytes_the_signature_promises() -> None:
+    """`-> bytes`, and not the caller's own buffer handed back.
+
+    A `bytearray` or a `memoryview` returned as it came stays the
+    caller's, so a write to it afterwards rewrites whatever the library
+    built from it -- a `BIP32KeyData` chain code and the xprv that key
+    serializes to, which `tests/bip32/bip32_test.py` pins. Nor is either
+    the `bytes` the annotation promises: a bytearray keys no dict and a
+    memoryview concatenates with nothing (issue #1255).
+    """
+    for spelling in (b"\x00\x01", bytearray(b"\x00\x01"), memoryview(b"\x00\x01")):
+        assert type(bytes_from_octets(spelling)) is bytes
+        assert bytes_from_octets(spelling) == b"\x00\x01"
+
+    # the size check is on the way out and copies nothing of its own, so
+    # it is asked here too rather than assumed to share the arm above
+    buffer = bytearray(b"\x00\x01")
+    copied = bytes_from_octets(buffer, 2)
+    buffer[0] = 0xFF
+    assert copied == b"\x00\x01"
+
+
 def test_a_non_contiguous_memoryview_is_refused_at_the_coercion() -> None:
     """A strided slice is `Octets` to the annotation, `BufferError` underneath.
 
@@ -316,7 +333,7 @@ def test_a_non_contiguous_memoryview_is_refused_at_the_coercion() -> None:
     with pytest.raises(BTClibValueError, match="invalid octets: non-contiguous"):
         hash160(strided)
 
-    # a contiguous slice is untouched, same as any other buffer
+    # a contiguous slice is taken, same as any other buffer
     contiguous = memoryview(raw)[:32]
     assert bytes_from_octets(contiguous) == raw[:32]
     assert hash160(contiguous) == hash160(raw[:32])
@@ -344,7 +361,7 @@ def test_a_memoryview_of_the_wrong_format_is_refused_at_the_coercion() -> None:
         hash160(wide)
 
     # a plain memoryview, and one cast back to unsigned bytes, are format
-    # "B" and untouched, same as any other buffer
+    # "B" and taken, same as any other buffer
     plain = memoryview(raw)
     assert plain.format == "B"
     assert bytes_from_octets(plain) == raw


### PR DESCRIPTION
`bytes_from_octets` is annotated `-> bytes` and handed a `bytearray` or
a `memoryview` straight back, so the caller's later write into its own
buffer reached whatever the library had already stored — a
`BIP32KeyData`'s chain code, and the xprv that key serializes to. The
buffer arm now copies, and the annotation becomes true.

The issue frames the choice as widening the return annotation (~144
downstream mypy errors) against `@overload` (~142). This takes a road
it did not consider: making the runtime match the annotation instead.
It costs **zero** downstream mypy errors, and it removes the nine
`bytes(bytes_from_octets(...))` sites that were working around the
aliasing rather than annotating over them.

No caller depended on the aliasing. The one construct that read as
though it did — two `assert_valid` tests installing a bytearray field —
did so only through `replace_unchecked`, which rebuilds through
`__init__`; they install it with `object.__setattr__` now and still
pass. The docstring justifying the old behaviour ("it is what
`assert_valid` reads with") was a misattribution: `assert_valid` never
called `bytes_from_octets`.

`RELEASE_NOTES.md` carries an entry: a caller who passed a `bytearray`
and used the result as a buffer now gets `TypeError`, with nothing in
the library raising to say so.

Closes #1255

## Summary by Sourcery

Make bytes_from_octets return independent bytes values for all accepted buffer inputs and update callers, documentation, and tests accordingly.

Bug Fixes:
- Ensure bytearray and memoryview inputs are copied to prevent caller mutations from altering stored key data and serialized extended keys.
- Preserve correct handling of buffer inputs across encoding, hashing, Merkle proofs, Taproot, compact blocks, and PSBT parsing.

Enhancements:
- Make bytes_from_octets consistently return the bytes type promised by its annotation.
- Remove redundant downstream bytes conversions now handled by the centralized octet coercion.
- Validate buffer size after normalization to bytes while retaining rejection of non-contiguous and incorrectly formatted memoryviews.

Documentation:
- Document the corrected bytes_from_octets behavior and the breaking change for callers that mutate returned buffers.

Tests:
- Update buffer-related tests and add coverage confirming returned buffers are independent immutable bytes and key serialization remains stable after input mutation.