### PR TITLE
README.md's downloads badge links to the plural pepy URL (closes #1478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,12 @@ documented at release-notes length in the first place, and are still in
   showing the two fields as one link being cheaper than the field
   tools read for that purpose specifically.
 
+- **`README.md`'s downloads badge links to `pepy.tech/projects/btclib`,
+  plural.** The singular form answers `308` and redirects to the plural,
+  which section 2 of the organization standard now fixes as the link
+  target for the same reason it already gives for the Read the Docs
+  host: a redirect is something its owner can retire (closes #1478).
+
 ### The public API and the module layout
 
 - **`bytes_from_octets` answers with the `bytes` it is annotated to

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ says how the choice is enforced.
 [![GitHub release](https://img.shields.io/github/v/release/btclib-org/btclib.svg)](https://github.com/btclib-org/btclib/releases)
 [![development status](https://img.shields.io/pypi/status/btclib.svg)](https://pypi.python.org/pypi/btclib/)
 [![license](https://img.shields.io/github/license/btclib-org/btclib.svg)](https://github.com/btclib-org/btclib/blob/main/LICENSE)
-[![downloads](https://static.pepy.tech/badge/btclib)](https://pepy.tech/project/btclib)
+[![downloads](https://static.pepy.tech/badge/btclib)](https://pepy.tech/projects/btclib)
 [![supported Python versions](https://img.shields.io/pypi/pyversions/btclib.svg?logo=python)](https://pypi.python.org/pypi/btclib/)
 [![implementation](https://img.shields.io/pypi/implementation/btclib.svg)](https://pypi.python.org/pypi/btclib/)
 [![wheel](https://img.shields.io/pypi/wheel/btclib.svg)](https://pypi.python.org/pypi/btclib/)


### PR DESCRIPTION
The downloads badge linked to `pepy.tech/project/btclib`, singular,
which answers `308` and redirects to `pepy.tech/projects/btclib`.
Section 2 of the organization standard now fixes the plural as the link
target, for the same reason it already gives for the Read the Docs
host: a redirect is something its owner can retire.

Measured: the singular answers `308` with `location:
https://pepy.tech/projects/btclib`; the plural answers `200`; a
fabricated project name under the plural answers `404`, which is the
control saying the `200` reports a page rather than a catch-all.

`#1467`, the fuzz badge, is **not** in this branch and stays open. It
needs a `workflow_dispatch` run of `fuzz.yml` on `main` to give the
badge a state to report — the same move that seeded `mutation.yml`'s
badge — and that command was refused by the writing session's
permission classifier. The reasoning and the exact command are recorded
in a comment on the issue.

Closes #1478

## Summary by Sourcery

Point the downloads badge at Pepy’s canonical project URL to avoid relying on a redirect.

Bug Fixes:
- Update the README downloads badge to link directly to the canonical plural Pepy project URL instead of a redirecting URL.

Chores:
- Document the downloads badge URL correction in the changelog.