### PR TITLE
CONTRIBUTING.md names the checks that gate a merge, and the sync that makes the no-bindings job one (closes #1453, closes #1450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,30 @@ documented at release-notes length in the first place, and are still in
   target for the same reason it already gives for the Read the Docs
   host: a redirect is something its owner can retire (closes #1478).
 
+- **`CONTRIBUTING.md`'s last section named a check that does not gate a
+  merge and omitted the step that makes a reproduction of another one
+  work.** *What runs when* named `website` among the rows a merge waits
+  for; branch protection's required contexts are `Lint and type-check`,
+  `Build the documentation`, `test: every job passed` and `Regtest
+  against Bitcoin Core` — the `lint`, `docs`, `test` and
+  `integration-bitcoind` rows — and none of them is `website.yml`'s
+  `Build the website`, which the workflow's own header already calls
+  not required, carrying a `paths` filter a required check cannot have.
+  The sentence now names the rows that produce those contexts and says
+  why `website` is not among them.
+
+  *Reproducing what CI runs*'s `no-bindings` reproduction ran its assert
+  step against whatever `.venv` an earlier command in the file left
+  behind, `uv run` syncing additively rather than pruning: after the
+  plain `uv sync` two paragraphs above it, `INSTALLED` still reads
+  `True` and `assert not INSTALLED` fails before pytest ever runs. The
+  reproduction now opens with the `uv sync --exact --no-default-groups
+  --group harness` that prunes the bindings back out and closes with the
+  `uv sync` that restores the environment afterwards, and says what
+  `--group test` in place of `harness` does instead — installs the
+  bindings back and reports the whole suite passing as a no-bindings run
+  (closes #1453, closes #1450).
+
 ### The public API and the module layout
 
 - **`bytes_from_octets` answers with the `bytes` it is annotated to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -488,10 +488,15 @@ stale the next time one is added or dropped.
 grep -n 'uses: \./\.github/workflows/' .github/workflows/release.yml
 ```
 
-The `test`, `lint`/`docs`, `integration-bitcoind` and `website` rows are what a
+The `test`, `lint`/`docs` and `integration-bitcoind` rows are what a
 merge waits for, and between them they report the required checks: `lint`
 and `docs` share a row and report one each. They run one image on one
 interpreter: `ubuntu-latest`, and the version `.python-version` names.
+`website` is not among them: it carries a `paths` filter, and a required
+check that a filtered trigger can skip would block a merge the filter
+was meant to let through, which is the workflow's own reason for staying
+optional.
+
 Which day each of the rest runs is section 10 of the organization
 standard, in `btclib-org/.github`, and not this file's to restate — one
 calendar in one place is one thing to keep true, where a copy of it in
@@ -602,10 +607,15 @@ then uploads the data file this command wrote as an artifact, for
 `coverage-union` to read; that step has no command of its own to
 reproduce, being a plain `actions/upload-artifact`.
 
-The `no-bindings` job, which runs the suite against a btclib that has no
-`btclib_secp256k1` to delegate to:
+The `no-bindings` job runs the suite against a btclib that has no
+`btclib_secp256k1` to delegate to. CI starts it from an empty
+environment; locally `uv run` syncs additively, so a `.venv` any other
+command in this section left behind — `uv sync` above included — still
+holds the bindings, and the assert below fires on it. `--exact` is what
+prunes them back to the one group this job runs with:
 
 ```shell
+uv sync --exact --no-default-groups --group harness
 uv run --locked --no-default-groups --group harness \
     python -c "from btclib._libsecp256k1 import INSTALLED; \
       assert not INSTALLED, 'btclib_secp256k1 is installed'; \
@@ -614,11 +624,19 @@ uv run --locked --no-default-groups --group harness \
 COVERAGE_FILE=coverage-data-no-bindings \
     uv run --locked --no-default-groups --group harness \
     pytest --cov --cov-fail-under=0
+uv sync
 ```
+
+The closing `uv sync` restores the environment `--exact` just pruned to
+`harness` alone, the same restoration the note above makes for any
+group-restricted command in this section.
 
 `harness` and not `test`: `test` is `harness` plus `bindings`, and uv's
 `--no-group` suppresses a group that was selected rather than one another
 group includes, so the split in pyproject.toml is what this job is.
+`--group test` in place of `harness` installs the bindings back and runs
+the whole suite with them present, reporting it as a passing no-bindings
+run with nothing to say it was not one.
 `--cov --cov-fail-under=0`, not `--no-cov` (issue #1002): the delegated
 arms are still unreachable in this configuration by construction, so a
 report of this run *alone* would still fail the 100% gate for the one


### PR DESCRIPTION
Two defects in `CONTRIBUTING.md`'s last section, both about what the
file says a gate is.

*What runs when* named `website` among the rows a merge waits for. It is
not one: the required contexts are `Lint and type-check`, `Build the
documentation`, `test: every job passed` and `Regtest against Bitcoin
Core` — four contexts from three rows, `lint` and `docs` sharing a row.
`website.yml` carries a `paths` filter, and a required check a filtered
trigger can skip would block a merge the filter was meant to let
through, which is the workflow's own reason for staying optional.

The `no-bindings` reproduction omitted the `uv sync --exact` that makes
it one. Measured, in a worktree whose `.venv` any earlier command in
that section had left with the bindings present:

- as documented today: `AssertionError: btclib_secp256k1 is installed`
  — the reproduction dies on its own guard and reproduces nothing;
- with `uv sync --exact --no-default-groups --group harness` first:
  exit 0, no bindings, the job actually reproduced;
- with the closing `uv sync`: the environment is back, bindings present.

`uv run` syncs additively, which is why the guard fires: CI starts from
an empty environment and a local run does not.

Closes #1453
Closes #1450

## Summary by Sourcery

Correct contributor documentation for merge gates and make the no-bindings CI reproduction reliable in locally reused environments.

Bug Fixes:
- Correct the merge-gating documentation to identify the required checks and explain why the website workflow remains optional.
- Fix the documented no-bindings reproduction so it removes existing bindings before testing and restores the environment afterward.

Enhancements:
- Clarify the effects of the harness and test dependency groups when reproducing CI jobs locally.

Documentation:
- Update CONTRIBUTING.md and the changelog with accurate merge requirements and reliable no-bindings reproduction instructions.