### PR TITLE
integration-hwi.yml drops the workflow_call nothing calls (closes #1463)

### DIFF
--- a/.github/workflows/integration-hwi.yml
+++ b/.github/workflows/integration-hwi.yml
@@ -39,7 +39,6 @@ on:
     - cron: "4 3 * * 3"
   push:
     branches: [main]
-  workflow_call:
   # the escape hatch, and how a branch is checked against a device before
   # it lands
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,17 @@ documented at release-notes length in the first place, and are still in
   bindings back and reports the whole suite passing as a no-bindings run
   (closes #1453, closes #1450).
 
+- **`integration-hwi.yml` no longer declares `workflow_call`.** Nothing
+  called it — `release.yml` reuses eight workflows and this is not one
+  of them, unlike `integration-bitcoind.yml`, whose own `workflow_call`
+  carries the comment naming `release.yml` as the caller. This file's
+  own header already narrates every way it runs — the weekly schedule,
+  the push to `main`, the dispatch button for a branch touching
+  `src/btclib/hwi.py` — and none of them was ever the release: an
+  emulator is a service to keep working rather than a claim about the
+  branch, and `REPOSITORY.md`'s required-checks table names only
+  `Regtest against Bitcoin Core` (closes #1463).
+
 ### The public API and the module layout
 
 - **`bytes_from_octets` answers with the `bytes` it is annotated to


### PR DESCRIPTION
`integration-hwi.yml` declared `workflow_call` and nothing calls it, so
the trigger stated a fact about the release that is not true.

The trigger goes, rather than a comment being added or a call wired.
`release.yml` names eight callees and this is not among them; the
workflow's own header already narrates every way it runs — weekly
schedule, push to `main`, `workflow_dispatch` — and never names release;
and `integration-bitcoind.yml`'s own `workflow_call` carries the comment
"release.yml calls this workflow" where this one carried none. Removing
the trigger is one of the three outcomes the issue itself names.

The review measured the completeness of that eight-callee list beyond
the grep: the workflow's run history is 122 runs, none of them with
`event=workflow_call`. It has never had a ninth caller.

Closes #1463

## Summary by Sourcery

Remove the unused workflow-call trigger from the HWI integration workflow.

Enhancements:
- Remove the unused `workflow_call` trigger from the HWI integration workflow so its declared triggers accurately reflect how it runs.

CI:
- Update the changelog to document the workflow trigger correction.