### PR TITLE
_b58decode's comment stops recording a wall clock (closes #1449)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,15 @@ documented at release-notes length in the first place, and are still in
   inspected, and `assert_valid`'s own type check runs on a local it
   never assigns back.
 
+### Documentation and the website
+
+- **`_b58decode`'s comment stops recording a wall clock** (closes
+  #1449). `bytes(b) is b` for an exact `bytes` object is the fact that
+  makes the coercion free, and it is what `utils.bytes_from_octets`
+  already names for the same reason; the nanosecond figure the comment
+  carried instead was a number nothing re-measures, and it is gone
+  rather than kept current.
+
 ## v2026.8.27
 
 ### Repository

--- a/src/btclib/base58.py
+++ b/src/btclib/base58.py
@@ -160,7 +160,8 @@ def _b58decode(v: bytes | bytearray | memoryview) -> bytes:
     # bytes for the buffers that are a String and are not bytes: a
     # memoryview has neither translate nor lstrip, and a bytearray
     # answers both in its own type. Free on the path that matters:
-    # bytes(b) is b for a bytes object, 29 ns
+    # `bytes(b)` is `b` itself where `b` is already `bytes`, the same
+    # identity `bytes_from_octets` uses for the same reason.
     v = bytes(v)
     # every alphabet byte deleted, so what is left is what is not one:
     # the same question as `any(x not in _ALPHABET for x in v)` asked in


### PR DESCRIPTION
`_b58decode`'s comment recorded `bytes(b) is b for a bytes object, 29
ns`, and `CLAUDE.md` says a comment does not record a wall clock: the
number decays and nothing re-measures it.

The figure goes and the fact under it stays, because the fact is a
checkable language-level identity rather than a benchmark: `bytes(b)` is
`b` itself where `b` is already `bytes`, and it is not for a `bytearray`
or a `memoryview`. The comment points at `utils.bytes_from_octets`,
which already states the same identity for the same reason, rather than
restating it — *one fact in one place*.

Worth recording for whoever closes the issue: **its own acceptance check
is vacuous**. `git grep -nE '[0-9]+ ns\b'` answers nothing on this git
build whether or not the defect is present, because `git grep -E` does
not honour `\b` here — `git grep -nP` or a plain `grep -rnE` is what
sees it. The fix was verified with a pattern proved against the tree,
not with that command.

Closes #1449

## Summary by Sourcery

Remove the obsolete `_b58decode` timing claim and retain a timeless explanation of its zero-copy bytes conversion.

Enhancements:
- Replace the stale nanosecond benchmark in `_b58decode` with a durable explanation of the `bytes` identity behavior and its relationship to `bytes_from_octets`.

Documentation:
- Document the removal of the outdated wall-clock measurement from the `_b58decode` comment in the changelog.