### PR TITLE
docs/source/conf.py drops the commented-out m2r2 (closes #1479)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,13 @@ documented at release-notes length in the first place, and are still in
   carried instead was a number nothing re-measures, and it is gone
   rather than kept current.
 
+- **`docs/source/conf.py`'s `extensions` list drops its commented-out
+  `m2r2`** (closes #1479). `m2r2` is in neither the dependency groups nor
+  the lock, so uncommenting it would fail the docs build's own import --
+  `uv sync` reads `pyproject.toml` and the lock, never `conf.py`, and
+  would not notice. `myst_parser`, the line below it, is what already
+  reads the markdown `m2r2` would have converted.
+
 ## v2026.8.27
 
 ### Repository

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,7 +49,6 @@ release = PYPROJECT["project"]["version"]
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-    # "m2r2",
     "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",


### PR DESCRIPTION
`docs/source/conf.py`'s `extensions` list opened with a commented-out
`m2r2` that is in neither the dependency groups nor the lock, so it was
not a switch anyone could flip.

Deleted rather than restored. `git log -S m2r2` over the whole tree
dates it to 2022 and shows it moved to the pip-based
`docs/requirements.txt` in 2022, which was itself dropped in 2026 when
the docs build moved to `uv`; `myst_parser` arrived in 2023 and is what
already reads the markdown `m2r2` would have converted. Nothing else in
the tree names it.

The changelog entry says the failure would be the docs build's own
import, not `uv sync`'s: `uv sync` reads `pyproject.toml` and the lock
and never looks at `conf.py`. An earlier draft claimed both would fail
alike, which the review caught.

Closes #1479

## Summary by Sourcery

Remove the obsolete `m2r2` reference from the documentation configuration and record the cleanup in the changelog.

Enhancements:
- Remove the obsolete commented-out `m2r2` Sphinx extension reference now that `myst_parser` handles Markdown documentation.

Documentation:
- Document the removal of the unused `m2r2` configuration and clarify its impact on documentation builds versus dependency synchronization.