### PR TITLE
REPOSITORY.md records the App that connects read the docs, and release.yml sources its throttle (closes #1482, closes #1460)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -728,11 +728,23 @@ jobs:
   # that succeeded, for as long as that takes somebody to notice. Two
   # releases went out undocumented that way, which is issue #574.
   # The rendered URL and not the v3 API, which is the reverse of what
-  # `pypi-install` above does with PyPI's: read the docs throttles an
-  # unauthenticated caller to five requests a minute and warns that
-  # requests from a cloud provider are blocked outright without a token, so
-  # asking the API from a runner would mean storing a credential for a
-  # check that gates nothing. /en/<tag>/ is CDN-served, answers 404 for a
+  # `pypi-install` above does with PyPI's. Read the docs documents
+  # network-level blocks on automated scripts calling it from a cloud
+  # provider or CI -- which a GitHub-hosted runner is -- and says a token
+  # bypasses them, so asking the API from here would mean storing a
+  # credential for a check that gates nothing, and that credential is what
+  # carries the choice. Sourced, not observed: nothing in this tree has
+  # called the API from a runner.
+  #   https://docs.readthedocs.com/platform/stable/api/v3.html
+  # The same page limits an unauthenticated caller to 5 requests a minute.
+  # That figure is read the docs' and is cited here rather than
+  # re-derived: bursts run against both the project and the versions
+  # endpoint landed their first 429 at a different call each time --
+  # sometimes within a handful, sometimes not inside a fifteen-call burst
+  # at all -- the window being shared across paths and callers. So nothing
+  # here measures where the limit bites, and no count of it is stated
+  # (issue #1460).
+  # /en/<tag>/ is CDN-served, answers 404 for a
   # version that is inactive or has no successful build, and is the URL a
   # reader follows anyway.
   # Release-only, a rehearsal never being tagged; after version-check, so a
@@ -758,18 +770,16 @@ jobs:
   # last attempt no longer sleeps either, which used to buy nothing.
   #
   # What the loop cannot do is tell "still building" from "will never
-  # build": RTD's own webhook accepts a push that matches no version with
-  # a 200 and `{"build_triggered": false, "versions": []}` -- a green
-  # delivery with nothing behind it -- and /en/<tag>/ answers 404 in both
+  # build": a push that matches no version is accepted and triggers
+  # nothing -- a green delivery with nothing behind it, whatever carries
+  # it -- and /en/<tag>/ answers 404 in both
   # that case and the ordinary "build not finished yet" one, so the
   # rendered URL alone cannot separate them. The v3 API can (a build's
   # `state.code` and `success`, queried straight, matched this tag's
   # `v2026.8.21` build seconds after it finished) but the comment above
-  # already rules the API out for this job, for a reason that still
-  # holds and that testing here confirmed rather than assumed: RTD
-  # throttles an unauthenticated caller to 5 requests a minute and blocks
-  # a cloud-provider caller -- which a GitHub-hosted runner is -- outright
-  # without a token. Querying it from this loop would mean storing an RTD
+  # already rules the API out for this job, and states the reason once
+  # rather than twice: what rules it out is the credential a runner would
+  # have to carry. Querying it from this loop would mean storing an RTD
   # credential in a job that gates nothing, to buy a distinction the job
   # already gestures at by naming the builds page. Scraping the builds
   # *page* instead of the API was considered and dropped too: same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,40 @@ documented at release-notes length in the first place, and are still in
   branch, and `REPOSITORY.md`'s required-checks table names only
   `Regtest against Bitcoin Core` (closes #1463).
 
+- **`REPOSITORY.md` records how the Read the Docs project is connected
+  today.** It recorded one webhook, with a secret and a
+  `last_response.code` of 200, and instructed the next maintainer to
+  replace an integration this repository does not have: `gh api
+  repos/btclib-org/btclib/hooks` answers `0`. What connects the project
+  is the organization-wide `read-the-docs-community` GitHub App. The
+  control is the same call against a repository this token has no admin
+  on, which refuses out loud and exits non-zero rather than answering an
+  empty list: that is what makes the zero a repository with no hook and
+  not a permission ceiling reading like one. Two present-tense sentences
+  that still named a webhook -- one here, one in `release.yml` -- name
+  the delivery instead (closes #1482).
+- **`release.yml` states read the docs' throttle once, and sources it.**
+  Two comments gave the same fact in two strengths, one as a warning
+  about a block and one as an observed one that "testing here confirmed
+  rather than assumed". Both figures are read the docs' own, and the
+  comment now cites the page that carries them rather than presenting
+  either as a finding of this tree's: five requests a minute
+  unauthenticated, and network-level blocks on automated scripts calling
+  from a cloud provider or CI, which a token bypasses. That second clause
+  is what the choice rests on -- a runner would have to carry an RTD
+  credential for a check that gates nothing -- and it is sourced rather
+  than observed, nothing here having called the API from a runner. The
+  per-minute figure is cited and not re-derived, which is the part the
+  issue got wrong and this entry records rather than repeats: bursts
+  against both the project and the versions endpoint landed their first
+  429 at a different call each time -- sometimes within a handful,
+  sometimes not inside a fifteen-call burst at all -- so a run reaching
+  fifteen clean does not refute five a minute; it measures a window shared
+  across paths and callers. The issue was
+  filed on one such run. What survives it is the defect that needed no
+  burst: the file stated the same fact twice, in two strengths, one of
+  them claiming testing here had confirmed it (closes #1460).
+
 ### The public API and the module layout
 
 - **`bytes_from_octets` answers with the `bytes` it is annotated to

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -571,9 +571,11 @@ curl -s https://app.readthedocs.org/api/v3/projects/btclib/ \
 - **`latest` follows the default branch, which is `main`.** That setting is
   Read the Docs' own and not GitHub's, so renaming the branch here leaves
   it pointing at one that no longer exists — and a push to a branch no
-  version follows is *accepted*, answered with `{"build_triggered": false,
-  "versions": []}`, which is a green delivery and a site frozen at its last
-  build (issue #574).
+  version follows is *accepted* and builds nothing, which is a green
+  delivery and a site frozen at its last build (issue #574). The
+  `{"build_triggered": false, "versions": []}` body that used to be
+  quoted here is the webhook era's; what carries a delivery now is the
+  App below, and no call in this file reads what it answers.
 - **`stable` is the highest semantic-version tag**, chosen by Read the Docs
   and moved by it on each release, pre-releases excluded. It takes no
   setting and no rule, and it is what `/en/stable/` serves.
@@ -610,20 +612,30 @@ could have been — included, so `/en/v<version>/` starts at the first tag
 pushed after the rule and there is nothing behind it. `/en/stable/` is the
 last release either way, which is what makes the backfill skippable.
 
-**The webhook has to carry a secret.** A delivery from one that does not is
-refused with 400 and the reason in the body, which GitHub records in the
-hook's delivery log and reports nowhere else:
+**What connects the project is the `read-the-docs-community` GitHub App**,
+installed on the organization for every repository, so this repository
+carries no webhook of its own and none to give a secret to:
 
 ```shell
-gh api repos/btclib-org/btclib/hooks \
-  --jq '.[] | [.config.url, (.config.secret != null), .last_response.code]'
-# ["https://app.readthedocs.org/api/v2/webhook/btclib/331149/",true,200]
+gh api orgs/btclib-org/installations \
+  --jq '.installations[] | select(.app_slug == "read-the-docs-community")
+        | [.app_slug, .repository_selection]'
+# ["read-the-docs-community","all"]
+gh api repos/btclib-org/btclib/hooks --jq 'length'
+# 0
+gh api repos/octocat/Hello-World/hooks --jq 'length'
+# gh: Not Found (HTTP 404)
+# gh: This API operation needs the "admin:repo_hook" scope.
 ```
 
-A hook added here by hand has no secret and cannot be given one that Read
-the Docs knows. The one that works was issued by the project's integration
-page, and that is also how it is replaced: delete the integration there
-and add it again, rather than editing the hook on this side.
+The third command is the control, and it is what makes the second an
+answer about this repository rather than about the token: a call this
+token may not make refuses out loud and exits non-zero rather than
+answering an empty list, so the `0` above is a repository with no hook
+and not a permission ceiling that reads like one. Every repository of the
+organization answers `0`; the last per-repository webhook left anywhere
+was bitcoin-core-rpc's, dead since the App arrived and deleted on
+2026-08-28 (bitcoin-core-rpc#291).
 
 ## Plan-gated settings
 


### PR DESCRIPTION
Two issues, one subject: what this tree says about Read the Docs.

`REPOSITORY.md` ended on a webhook this repository does not have. It
recorded one hook with a secret and a `200`, and told the next
maintainer to replace an integration that is not there. What connects
the project is the organization-wide `read-the-docs-community` GitHub
App, installed for every repository on 2026-08-22.

The zero is measured with a control, because an absence and a permission
ceiling read alike: the same call against a repository this token has no
admin on refuses out loud and exits non-zero rather than answering an
empty list. An earlier draft used bitcoin-core-rpc's own surviving hook
as that control, which was true when written and stopped being true the
same evening — that hook was deleted (bitcoin-core-rpc#291). A control
another session can delete is not one; a permission boundary is.

`release.yml` gave read the docs' throttle twice, in two strengths, one
claiming testing here had confirmed it. Both figures are read the docs'
own and the comment now cites the page that carries them rather than
presenting either as this tree's finding. What the choice rests on — a
runner would have to carry an RTD credential for a check that gates
nothing — is what it leads with, marked sourced rather than observed.

No burst is quoted, and the reason is the issue's own premise failing.
ISS 1460 was filed on fifteen unauthenticated calls that all answered
200, read as refuting the documented five a minute. It does not
reproduce: across several bursts against both endpoints the first 429
landed at a different call each time, sometimes within a handful,
sometimes not inside a fifteen-call burst at all. A clean run of fifteen
refutes nothing. What survives is the defect that never needed a burst —
one fact stated twice, one of them claiming a test.

Closes #1482
Closes #1460

## Summary by Sourcery

Correct the repository’s Read the Docs integration and throttling documentation to reflect current, sourced behavior.

Bug Fixes:
- Update repository documentation to accurately identify the organization-wide Read the Docs GitHub App as the project’s current integration instead of a nonexistent webhook.
- Correct Read the Docs API throttling documentation by sourcing the limits, removing unsupported observations, and clarifying why the release workflow does not query the API.

Enhancements:
- Align repository and release workflow comments with the current Read the Docs delivery mechanism and documented behavior.
- Document verification that the repository has no individual webhooks while distinguishing an empty result from insufficient permissions.

Documentation:
- Add changelog entries covering the Read the Docs integration and throttling documentation corrections.