### PR TITLE
_assert_valid_ec's docstring stops recording wall clocks (closes #1489)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,6 +285,15 @@ documented at release-notes length in the first place, and are still in
   would not notice. `myst_parser`, the line below it, is what already
   reads the markdown `m2r2` would have converted.
 
+- **`_assert_valid_ec`'s docstring stops recording wall clocks** (closes
+  #1489). The guard costs about what an empty function of the same
+  arity costs, negligible next to any public function that reaches it,
+  and that is the reason the docstring keeps for asking it once per
+  parameter rather than once per function; the wall-clock figures it
+  also carried were numbers nothing re-measures, and they are gone
+  rather than kept current. The `timeit` commands that re-derive the
+  decision stay beside it.
+
 ## v2026.8.27
 
 ### Repository

--- a/src/btclib/curves/curve.py
+++ b/src/btclib/curves/curve.py
@@ -350,17 +350,17 @@ def _assert_valid_ec(ec: Curve) -> None:
     is what makes it `utils.assert_type`'s, which is the one spelling of
     the refusal for the whole library.
 
-    34 ns through that call, 16 of them the empty function of the same
-    arity timed beside it as the floor, and it is asked where each public
-    function first reads the parameter: two guards in the 17.8 us of a
-    signature, two in the 21.3 of a verification, two in the 39.6 of a
-    five-level BIP32 derivation, one in the 8.3 of a multiplication. A
-    wall clock is a number that drifts, so `timeit` over the guard and
-    over `dsa.sign` is what says whether these still hold -- and a harness
-    drifts too, a closure around the guard having measured 42 where the
-    plain call measures 34, so the two go in one process or neither is
-    comparable. What they are here for is the decision to ask once per
-    parameter rather than once per function.
+    `assert_type` costs about what an empty function of the same arity
+    costs, negligible next to any public function that reaches it -- a
+    signature, a verification, a multi-level BIP32 derivation, a
+    multiplication -- so asking it where each public function first
+    reads the parameter, once per parameter rather than once per
+    function, adds nothing worth avoiding. A wall clock is a number
+    that drifts, so `timeit` over the guard, over an empty function of
+    the same arity, and over `dsa.sign` is what says whether that still
+    holds -- and a harness drifts too, a closure around the guard
+    measuring higher than the plain call does, so the guard and what it
+    is measured against go in one process or neither is comparable.
     """
     assert_type(ec, Curve, "ec")
 


### PR DESCRIPTION
`_assert_valid_ec`'s docstring recorded six wall-clock figures — `34 ns`,
`17.8 us`, `21.3`, `39.6`, `8.3` and a `42`/`34` harness-drift pair — which
CLAUDE.md says a comment does not: a number measured once on one machine is not
re-derivable by the next reader, and drifts silently.

The decision is kept (ask once per parameter rather than once per function), the
reason is kept and now states the comparison a reader can check — the guard's
cost against an empty function of the same arity, negligible next to any of its
callers — and the `timeit` commands that re-derive it are still there. Same shape
as the `_b58decode`/`bytes_from_octets` precedent.

The issue's *Done when* asks that `grep -rnE '[0-9]+ (ns|us)\b' src/btclib`
answer nothing. Measured against `origin/main` before this branch existed, it
answers 118, and after this branch 116: the acceptance line as written was
already false and one docstring cannot make it true. The narrower
`[0-9]+ ns\b`, which is what the issue argues, goes 1 to 0. The remaining 116
are the same defect class and are filed as #1494.

Closes #1489

## Summary by Sourcery

Remove stale timing measurements from `_assert_valid_ec` documentation while preserving the rationale and commands for re-evaluating its validation cost.

Enhancements:
- Replace non-reproducible wall-clock measurements in `_assert_valid_ec` documentation with a stable rationale for validating parameters once at their first use while retaining reproducible benchmarking guidance.

Documentation:
- Update the changelog to document the removal of stale timing figures from `_assert_valid_ec`'s docstring.