### PR TITLE
REPOSITORY.md reads back the topics and the security settings (issue btclib-org/.github#468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ documented at release-notes length in the first place, and are still in
   the wrong question and "did every step I expected actually run" is the
   right one.
 
+- **`REPOSITORY.md` reads back the settings it never had a section
+  for.** (issue btclib-org/.github#468) It claimed to be the whole of
+  what is set outside the tree, and held no readback of the topics, of
+  private vulnerability reporting or of the rest of
+  `security_and_analysis` — a *Security settings* table and a *Topics*
+  section now carry them, each command run against this repository
+  rather than assumed from a sibling's copy. The table has a row for
+  every key the command answers with, the two that read `disabled`
+  included, and says where the reason they are off is written down: a
+  table shorter than its own command is the defect that issue names, not
+  a tidier one.
+
 ### Packaging, linting and CI
 
 - **The sentinel schedule and the badge row follow section 10's calendar,

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -637,13 +637,55 @@ organization answers `0`; the last per-repository webhook left anywhere
 was bitcoin-core-rpc's, dead since the App arrived and deleted on
 2026-08-28 (bitcoin-core-rpc#291).
 
+## Security settings
+
+All of these are repository settings and none of them is in the tree, so
+this list is the whole of them:
+
+```shell
+gh api repos/btclib-org/btclib --jq '.security_and_analysis'
+# the alerts themselves are not in that object: the endpoint that
+# answers for them has no body, and says so with its status -- 204 for
+# enabled, 404 for not
+gh api -i repos/btclib-org/btclib/vulnerability-alerts | head -1
+gh api repos/btclib-org/btclib/private-vulnerability-reporting
+```
+
+| Setting | State |
+| --- | --- |
+| Dependabot alerts | enabled |
+| Dependabot security updates | enabled |
+| Secret scanning | enabled |
+| Secret scanning push protection | enabled |
+| Secret scanning non-provider patterns | disabled |
+| Secret scanning validity checks | disabled |
+| Private vulnerability reporting | enabled |
+
+The two that read `disabled` are not settings this repository declined:
+[Plan-gated settings](#plan-gated-settings) below is where that belongs,
+and reading their state as something to go and fix is the mistake that
+section exists to prevent.
+
+Code scanning default setup (CodeQL) is answered above, in [Code
+scanning](#code-scanning), which is where the reason it is off belongs
+rather than repeated here.
+
+Private vulnerability reporting is what `SECURITY.md` sends a reporter
+to, and the link in `.github/ISSUE_TEMPLATE/config.yml`'s "Security
+vulnerability" form is the same door:
+[GitHub's own documentation](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository)
+is what says that form appears only where the setting above reads
+`enabled`, so the setting and the two files go together. Whether the
+form 404s where it is off was not checked here, and doing so means
+turning it off.
+
 ## Plan-gated settings
 
 Some settings cannot be enabled and fail silently: secret scanning's
 non-provider patterns and validity checks need paid Secret Protection,
-and the API answers a PATCH with 200 while leaving them disabled. Do not
-read that 200 as success. The `detect-secrets` hook is the compensating
-control.
+which is why they read `disabled` in the table above, and the API answers
+a PATCH with 200 while leaving them so. Do not read that 200 as success.
+The `detect-secrets` hook is the compensating control.
 
 The other plan-gated number is not a setting at all, and it is the one
 this repository's workflows are arranged around: how many jobs may run
@@ -678,3 +720,31 @@ contention with every other repository of the organization, which spends
 against this same ceiling. Whether that is worth paying for is a
 question for whoever would pay, and it is recorded here so that it is
 asked with the second column in view.
+
+## Topics
+
+```shell
+gh api repos/btclib-org/btclib --jq '.topics'
+```
+
+```json
+["base58","bech32","bip32","bip340","bip39","bitcoin","cryptography",
+ "ecdsa","electrum","elliptic-curves","hardware-wallet",
+ "message-signing","musig2","output-descriptors","psbt","schnorr",
+ "secp256k1","segwit","slip39","taproot"]
+```
+
+Twenty, GitHub's own ceiling on the field. `pyproject.toml`'s `keywords`
+carries the same twenty plus five more past that ceiling — `rfc-6979`,
+`mnemonic`, `merkle-proof`, `bip44`, `bitcoin-script` — which are
+keywords for PyPI and not topics, a comment beside the list saying so.
+Nothing in the tree holds the two lists together, so this is the command
+that does: it prints the difference and exits nonzero on one, GitHub
+returning its own alphabetical order rather than the relevance order
+`pyproject.toml` declares:
+
+```shell
+diff <(gh api repos/btclib-org/btclib --jq '.topics[]' | sort) \
+     <(awk '/^keywords = \[/,/Past the twenty topics/' pyproject.toml \
+       | grep -oE '"[a-z0-9-]+"' | tr -d '"' | sort)
+```


### PR DESCRIPTION
`REPOSITORY.md` claims to be the whole of the settings outside the tree, and this
copy held no readback of the topics, of private vulnerability reporting, or of
`security_and_analysis` at all — no section for them existed.

A *Security settings* table and a *Topics* section now carry them, every value
read back from the endpoint with the command beside it. The table has a row for
every key `gh api repos/btclib-org/btclib --jq '.security_and_analysis'` answers
with, the two that read `disabled` included, and says where the reason they are
off is written down; *Plan-gated settings* points back the same way both sibling
copies do.

No closing keyword: btclib-org/.github#468 is owed by several sibling copies and
stays open until the last of them lands. Both references are qualified on
purpose — a bare `#468` in this repository resolves to its own merged pull
request of that number.

Issue btclib-org/.github#468

## Summary by Sourcery

Document the repository’s previously unrepresented GitHub security settings and topics so `REPOSITORY.md` reflects its complete external configuration.

New Features:
- Document repository security settings, private vulnerability reporting, and GitHub topics in `REPOSITORY.md` using endpoint readbacks.
- Add a documented comparison between GitHub topics and the project’s package keywords.

Enhancements:
- Clarify which security settings are plan-gated and where CodeQL configuration is documented.
- Keep the repository configuration documentation aligned with the values returned by GitHub APIs.

Documentation:
- Expand `REPOSITORY.md` with complete security settings and topics sections, including commands and supporting explanations.

Chores:
- Record the repository documentation update in the changelog.