### PR TITLE
btclib takes the post-vendorability sibling: floor, prose, SessionTransport (closes #1497) (closes #1498) (closes #1484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,6 +281,42 @@ documented at release-notes length in the first place, and are still in
   inspected, and `assert_valid`'s own type check runs on a local it
   never assigns back.
 
+- **The docstrings crediting `bitcoin-core-rpc`'s separate exceptions and
+  transport to its being vendorable as one file now credit the reason
+  that survives the split** (closes #1497). v2026.8.29 splits the
+  package into an `errors`, `chains`, `transport` and `client` module
+  behind its facade, so there is no longer one file to vendor; each
+  keeps the reason that decided it regardless -- the package declares
+  zero dependencies and imports nothing of btclib's. `pyproject.toml`'s
+  floor moves with the prose: `bitcoin-core-rpc>=2026.8.29` is the first
+  release the rewritten docstrings are true of, and the first the
+  `chains` module exists in. `uv.lock` is re-locked to it.
+
+- **`btclib.fetch` and `btclib.fetch.transport` publish `SessionTransport`,
+  the sibling's second `HttpTransport`** (closes #1498). It keeps one
+  connection per `(scheme, host, port)` open across calls instead of one
+  per call, which is worth choosing over many calls against one node --
+  a walker fetching many transactions, a client polling one -- and it
+  has a `close()` and works as a context manager; `urlopen_transport`
+  stays the default. `BitcoinCoreFetcher` and `EsploraFetcher` already
+  take it, through the client's own `transport=` and their own
+  `transport=` respectively, so the change is the export and the tests
+  proving it -- `tests/all_test.py`'s aliasing checks and
+  `tests/keyword_only_test.py`'s table, both of which now name it.
+
+- **`btclib.p2p`'s lazy import of `bitcoin_core_rpc` keeps a reason that
+  is still true, not the one that stopped being** (closes #1484).
+  Reaching `magic_from_chain` and its neighbours used to cost
+  `urllib.request`, `ssl` and `socket`, because the sibling was one
+  file; now they live in `chains.py` alone, which costs nothing beyond
+  the standard library, so the `__getattr__` below buys what this
+  package's other lazy submodules buy -- `import btclib.p2p` free of a
+  name nobody asked for -- and nothing about `urllib.request` any more.
+  README.md, this package's own docstring and `tests/imports_test.py`'s
+  `test_the_codec_does_not_pay_for_the_rpc_package` are corrected to it,
+  the test now proving `bitcoin_core_rpc` reaches `sys.modules` on the
+  second half and `urllib.request` never does.
+
 ### Documentation and the website
 
 - **`_b58decode`'s comment stops recording a wall clock** (closes

--- a/README.md
+++ b/README.md
@@ -334,24 +334,26 @@ back.
 
 The rpc client `fetch` speaks through is not in that stack: it is
 [bitcoin-core-rpc](https://github.com/btclib-org/bitcoin-core-rpc), a
-package of its own that btclib depends on — one file, standard library
-only, installable or copyable, and usable by anyone who wants a node
+package of its own that btclib depends on — zero dependencies of its
+own, standard library only, and usable by anyone who wants a node
 client and no bitcoin library. `btclib.fetch` turns its answers into `Tx`
 and `TxOut`, and checks the chain the node reports against the network
 those are labelled for.
 
 The dependency stops at `src/btclib/fetch/` and at `src/btclib/p2p/magic.py`,
 which is where the p2p message start is — that package's table, not a
-second copy of it. bitcoin-core-rpc declares its own `FetchError`,
-importing nothing of btclib's being what lets its file be vendored, and
+second copy of it. bitcoin-core-rpc declares its own `FetchError`, and
+declares zero dependencies of its own, importing nothing of btclib's;
 `btclib.fetch.fetcher.client_errors` re-raises it as `btclib.exceptions`'
 own, with the `status` and the `code` carried across: an `except
 FetchError` written against btclib catches what a fetcher raises. No
 module loads `urllib.request` on its way to anything else: importing it
-is what reaching that package costs, so `btclib.p2p` publishes the
-message start without importing it and a caller who parses messages pays
-nothing for a client it never uses. Constructing a client opens no
-socket; the first call does.
+is what reaching the client or its transport costs, and `src/btclib/fetch/`
+is the only place that does. `btclib.p2p`'s message start reaches this
+same package's chain vocabulary instead, which depends on nothing beyond
+the standard library, so a caller who parses messages pays nothing for a
+client it never uses. Constructing a client opens no socket; the first
+call does.
 
 ---
 

--- a/docs/source/btclib.fetch.rst
+++ b/docs/source/btclib.fetch.rst
@@ -36,9 +36,17 @@ btclib.fetch.fetcher module
 btclib.fetch.transport module
 -----------------------------
 
+.. `SessionTransport` is re-exported by this module and by the package
+   below, and belongs to neither: it is `bitcoin-core-rpc`'s, and autodoc
+   resolves both names to that one class. Documented once, under the
+   package, which is where a caller reaches it -- without this it is
+   rendered twice, at two cross-reference targets, and -W fails the build
+   on the duplicate.
+
 .. automodule:: btclib.fetch.transport
    :members:
    :show-inheritance:
+   :exclude-members: SessionTransport
 
 Module contents
 ---------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,13 @@ requires-python = ">=3.10"
 # whenever this tree starts calling something newer and a second copy of
 # the number being the one that goes stale.
 dependencies = [
-    # 2026.8.13 for `magic_from_signet_challenge`, which `p2p.magic`
-    # re-exports and `fetch.bitcoin_core` calls: measured against the two
-    # releases, the name is absent from 2026.8.12 and present here. The
-    # rest of what this tree calls -- `BitcoinCoreRpcClient`, `RpcError`,
-    # `chain_from_network`, `magic_from_chain` -- predates that floor
-    "bitcoin-core-rpc>=2026.8.13",
+    # 2026.8.29 is the split of the package into errors, chains,
+    # transport and client modules behind its facade, and the first
+    # release the `chains` module exists in. The rest of what this tree
+    # calls -- `BitcoinCoreRpcClient`, `RpcError`, `chain_from_network`,
+    # `magic_from_chain`, `magic_from_signet_challenge` -- predates that
+    # floor
+    "bitcoin-core-rpc>=2026.8.29",
     # `typing.override` is 3.12's, `typing.TypeIs` is 3.13's, and the
     # floor is 3.10, so both come from the backport; 4.4 is the release
     # that adds `override`, 4.10 the one that adds `TypeIs`, and the

--- a/src/btclib/exceptions.py
+++ b/src/btclib/exceptions.py
@@ -117,10 +117,10 @@ class FetchError(BTClibRuntimeError):
     than the host that has to be fixed.
 
     Declared here rather than taken from `bitcoin_core_rpc`, which raises
-    a class of the same name: that package imports nothing of btclib's --
-    which is what lets its one file be vendored -- so its `FetchError`
-    derives from a `BTClibRuntimeError` of its own, and an `except
-    BTClibRuntimeError` written against this module would not catch it.
+    a class of the same name: that package declares zero dependencies and
+    imports nothing of btclib's, so its `FetchError` derives from a
+    `BTClibRuntimeError` of its own, and an `except BTClibRuntimeError`
+    written against this module would not catch it.
     `btclib.fetch.fetcher.client_errors` is the one place the two meet.
     """
 

--- a/src/btclib/fetch/__init__.py
+++ b/src/btclib/fetch/__init__.py
@@ -21,8 +21,8 @@ while opening no socket.
 
 **The exceptions a `Fetcher` raises are btclib's**, and that costs one
 translation. The package declares a `FetchError`, an `HttpError` and an
-`RpcError` of its own -- it imports nothing of btclib's, which is what
-lets its one file be vendored -- so those are not the classes
+`RpcError` of its own -- it declares zero dependencies and imports
+nothing of btclib's -- so those are not the classes
 `btclib.exceptions` declares, and `fetcher.client_errors` re-raises them
 as the ones a caller catches, `status` and `code` carried across. What
 that buys back is the import cost: `btclib.exceptions` no longer reaches
@@ -41,9 +41,10 @@ what raises if there is nothing to connect to.
 **What is exported, and what is not.** The two fetchers, the interface
 they implement, the rpc client a Bitcoin Core one is reached through, and
 the transport seam: the timeout, the protocol a substitute has to satisfy
-and the one implementation of it that opens a socket. That last group is
-here because the seam is the supported way to test calling code without a
-node, which is not a detail of the two implementations.
+and the two implementations of it that open a socket -- one connection
+per call, and one kept open across calls. That last group is here
+because the seam is the supported way to test calling code without a
+node, which is not a detail of the two fetcher implementations.
 
 `bitcoin_core.cookie_auth` is deliberately not here:
 `BitcoinCoreRpcClient` takes a `cookie_path` and reads that file at every
@@ -67,7 +68,12 @@ from bitcoin_core_rpc import BitcoinCoreRpcClient
 from btclib.fetch.bitcoin_core import BitcoinCoreFetcher
 from btclib.fetch.esplora import BLOCKSTREAM_INFO, EsploraFetcher
 from btclib.fetch.fetcher import Fetcher
-from btclib.fetch.transport import DEFAULT_TIMEOUT, HttpTransport, urlopen_transport
+from btclib.fetch.transport import (
+    DEFAULT_TIMEOUT,
+    HttpTransport,
+    SessionTransport,
+    urlopen_transport,
+)
 
 __all__ = [
     "BLOCKSTREAM_INFO",
@@ -77,5 +83,6 @@ __all__ = [
     "EsploraFetcher",
     "Fetcher",
     "HttpTransport",
+    "SessionTransport",
     "urlopen_transport",
 ]

--- a/src/btclib/fetch/bitcoin_core.py
+++ b/src/btclib/fetch/bitcoin_core.py
@@ -4,9 +4,9 @@
 
 """The btclib fetcher backed by a `BitcoinCoreRpcClient`.
 
-The client itself is the `bitcoin-core-rpc` package: one file with nothing
-but the standard library behind it, installable or vendorable, and no part
-of btclib. What this module adds is the integration -- the answers turned
+The client itself is the `bitcoin-core-rpc` package: zero dependencies of
+its own, nothing but the standard library behind it, and no part of
+btclib. What this module adds is the integration -- the answers turned
 into btclib transactions, and the chain the node serves compared with the
 network those transactions are labelled for.
 

--- a/src/btclib/fetch/fetcher.py
+++ b/src/btclib/fetch/fetcher.py
@@ -52,10 +52,10 @@ def client_errors() -> Iterator[None]:
     """Re-raise what the rpc client raises as btclib's own exception.
 
     `bitcoin_core_rpc` declares a `FetchError`, an `HttpError` and an
-    `RpcError` of its own -- it imports nothing of btclib's, that being
-    what lets its one file be vendored -- so those three are not the
-    classes `btclib.exceptions` declares, and an `except FetchError`
-    written against btclib does not catch them. This is the one place the
+    `RpcError` of its own -- it declares zero dependencies and imports
+    nothing of btclib's -- so those three are not the classes
+    `btclib.exceptions` declares, and an `except FetchError` written
+    against btclib does not catch them. This is the one place the
     two meet, and every call that crosses into the package goes through
     it: `EsploraFetcher.text` and `BitcoinCoreFetcher._call` are the two
     lines that do.

--- a/src/btclib/fetch/transport.py
+++ b/src/btclib/fetch/transport.py
@@ -5,8 +5,8 @@
 """The standard-library HTTP transport, re-exported under btclib's name.
 
 The implementation is `bitcoin_core_rpc`'s: a bounded read, no redirect
-followed and no proxy taken from the environment, in a package that is one
-file with nothing but the standard library behind it. btclib depends on it
+followed and no proxy taken from the environment, in a package that
+depends on nothing beyond the standard library. btclib depends on it
 for the rpc client and reaches the same transport through it, rather than
 keeping a second copy of that bounded-read and redirect policy in step
 with the first.
@@ -15,6 +15,15 @@ Aliases and not wrappers: `EsploraFetcher` passes `transport=` straight
 through to `http_request`, and a caller substituting one for a test needs
 the object those two agree on. `HttpTransport` is that seam, and this is
 btclib's name for it.
+
+Two implementations satisfy it. `urlopen_transport` is the default: one
+connection per call, opened and handed to the node to close.
+`SessionTransport` keeps one connection per `(scheme, host, port)` open
+across calls instead, which is worth choosing over many calls against one
+node -- a walker fetching many transactions, a client polling one --
+where the reused connection, and on `https` the reused TLS handshake, is
+what the default pays for on every call. It has a `close()` and works as
+a context manager; nothing here calls either on a caller's behalf.
 
 What does *not* come through unchanged is the exceptions. `http_request`
 raises the package's `FetchError` and `HttpError`, which are not the
@@ -28,6 +37,7 @@ from bitcoin_core_rpc import (
     DEFAULT_TIMEOUT,
     MAX_ERROR_BODY_SIZE,
     HttpTransport,
+    SessionTransport,
     http_request,
     urlopen_transport,
 )
@@ -37,6 +47,7 @@ __all__ = [
     "DEFAULT_TIMEOUT",
     "MAX_ERROR_BODY_SIZE",
     "HttpTransport",
+    "SessionTransport",
     "http_request",
     "urlopen_transport",
 ]

--- a/src/btclib/p2p/__init__.py
+++ b/src/btclib/p2p/__init__.py
@@ -28,17 +28,18 @@ mapping a command to a type -- reading a message back into a typed
 payload is `Version.parse(message.payload)` under the caller's own
 `if`, which is the shape `net_processing.cpp` has too.
 
-**The message start is published without being imported**, which is the
-asymmetry to know about here. `magic_from_chain`, `magic_from_network`
-and `magic_from_signet_challenge` are `btclib.p2p.magic`'s, and that
-module reaches the `bitcoin-core-rpc` package -- which imports
-`urllib.request`, and `ssl` and `socket` under it, none of which a codec
-has any use for. README.md states the property that would cost: "No
-module loads `urllib.request` on its way to anything else." So
-`__getattr__` below publishes the three the way
-`btclib/script/__init__.py` publishes `sig_hash` and `engine`, and
-`import btclib.p2p` stays what a parser needs and nothing else. Asking
-for a message start is what pays for one.
+**The message start is published without being imported.**
+`magic_from_chain`, `magic_from_network` and `magic_from_signet_challenge`
+are `btclib.p2p.magic`'s, and that module reaches the `bitcoin-core-rpc`
+package's `chains` vocabulary, which depends on nothing beyond the
+standard library -- `urllib.request`, and `ssl` and `socket` under it,
+live in that package's `client` and `transport` instead, which a
+message-start lookup never reaches. README.md states the property this
+keeps: "No module loads `urllib.request` on its way to anything else."
+`__getattr__` below still answers the three lazily, the same pattern
+`btclib/script/__init__.py` uses for `sig_hash` and `engine`: `import
+btclib.p2p` stays what a parser needs and nothing else, whether or not
+the module behind a lazy name would itself have been free.
 
 `btclib.p2p.limits` is not published at all, as `btclib.block.limits` is
 not published from `btclib.block`: a caller reading a protocol constant

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -117,6 +117,7 @@ REEXPORTED = {
             "DEFAULT_TIMEOUT",
             "MAX_ERROR_BODY_SIZE",
             "HttpTransport",
+            "SessionTransport",
             "http_request",
             "urlopen_transport",
         ],

--- a/tests/fetch/bitcoin_core_test.py
+++ b/tests/fetch/bitcoin_core_test.py
@@ -31,6 +31,7 @@ import pytest
 from bitcoin_core_rpc import (
     DEFAULT_SIGNET_CHALLENGE,
     BitcoinCoreRpcClient,
+    SessionTransport,
     chain_from_network,
     network_from_chain,
 )
@@ -168,6 +169,24 @@ def test_get_tx_asks_for_the_id_it_was_given() -> None:
     body = sent(endpoint)
     assert body["method"] == "getrawtransaction"
     assert body["params"] == [TX_ID]
+
+
+def test_a_session_transport_can_drive_the_fetcher() -> None:
+    """`BitcoinCoreFetcher` takes a client, so its transport is the client's.
+
+    Nothing here is the fetcher's to wire: `SessionTransport`'s
+    constructor opens no connection, so building one and handing it to
+    the client this fetcher is built over is the whole of driving one
+    fetcher through it -- no round trip, and no code of this class's own
+    to reach.
+    """
+    session = SessionTransport()
+    endpoint = BitcoinCoreRpcClient(
+        URL, user=RPC_USER, password=RPC_PASSWORD, transport=session
+    )
+    assert (
+        BitcoinCoreFetcher(endpoint, verify_network=False).client.transport is session
+    )
 
 
 def test_get_tx_labels_the_outputs_for_the_fetchers_network() -> None:

--- a/tests/fetch/esplora_test.py
+++ b/tests/fetch/esplora_test.py
@@ -15,6 +15,7 @@ import pytest
 
 from btclib.exceptions import BTClibValueError, FetchError, HttpError
 from btclib.fetch.esplora import BLOCKSTREAM_INFO, EsploraFetcher
+from btclib.fetch.transport import SessionTransport
 from btclib.tx import OutPoint
 from tests.fetch import TIP_HEIGHT, TIP_ID, TX_ID, Recorded, recorded_body
 
@@ -49,6 +50,17 @@ def test_the_reference_deployment_is_a_value_to_pass_not_a_default() -> None:
         assert url.startswith("https://")
         assert url.endswith("/api")
         assert (network == "mainnet") != (network in url)
+
+
+def test_a_session_transport_can_drive_the_fetcher() -> None:
+    """`transport=` takes `SessionTransport` exactly as it takes `Recorded`.
+
+    Construction opens no connection -- `SessionTransport`'s own docstring
+    says so -- so this is the wiring and not a round trip: the object
+    passed in is the one the fetcher keeps and would call.
+    """
+    session = SessionTransport()
+    assert EsploraFetcher(BASE, transport=session).transport is session
 
 
 def test_an_unknown_network_is_refused() -> None:

--- a/tests/imports_test.py
+++ b/tests/imports_test.py
@@ -117,27 +117,28 @@ def test_the_codec_does_not_pay_for_the_rpc_package() -> None:
     """`btclib.p2p` publishes the message start without importing it.
 
     The package's whole claim is that it opens no socket, and the module
-    holding the message start reaches `bitcoin_core_rpc`, which brings
-    `urllib.request` in with it -- and `ssl` and `socket` under that --
-    none of which a codec has any use for. README.md states the property
-    this keeps: "No module loads `urllib.request` on its way to anything
-    else".
+    holding the message start reaches `bitcoin_core_rpc` -- but only its
+    `chains` module, which depends on nothing beyond the standard
+    library; `urllib.request`, and `ssl` and `socket` under it, live in
+    `client.py` and `transport.py`, which a message-start lookup never
+    reaches. README.md states the property this keeps: "No module loads
+    `urllib.request` on its way to anything else".
 
     So `src/btclib/p2p/__init__.py` answers the three names through PEP 562,
     as `src/btclib/script/__init__.py` answers `sig_hash` and `engine`, and
     what is pinned here is both halves: importing the package costs
-    nothing, and asking for a message start is what pays.
+    nothing, and asking for a message start costs only
+    `bitcoin_core_rpc` itself -- never `urllib.request`.
 
-    The two names asserted are the two the test above asserts, and
-    `socket` is deliberately not a third. `src/btclib/__init__.py` reads the
-    version with `importlib.metadata`, which imports `email.utils` on
-    every interpreter before 3.13, and that module imports `socket` for
-    `make_msgid` -- so `socket` is in `sys.modules` after importing
-    anything of btclib's, says nothing about this package, and asserting
-    its absence passes here and fails on most of the matrix. What
-    re-measures it, on any interpreter: `UV_PROJECT_ENVIRONMENT=.venv-3.11
-    uv run --python 3.11 python -c "import btclib.p2p, sys;
-    print('socket' in sys.modules)"`.
+    `socket` is deliberately not asserted absent anywhere here.
+    `src/btclib/__init__.py` reads the version with `importlib.metadata`,
+    which imports `email.utils` on every interpreter before 3.13, and
+    that module imports `socket` for `make_msgid` -- so `socket` is in
+    `sys.modules` after importing anything of btclib's, says nothing
+    about this package, and asserting its absence passes here and fails
+    on most of the matrix. What re-measures it, on any interpreter:
+    `UV_PROJECT_ENVIRONMENT=.venv-3.11 uv run --python 3.11 python -c
+    "import btclib.p2p, sys; print('socket' in sys.modules)"`.
 
     A subprocess for the reason the test above gives: `unimported_btclib`
     takes btclib out of `sys.modules` and leaves `bitcoin_core_rpc` where
@@ -152,23 +153,27 @@ def test_the_codec_does_not_pay_for_the_rpc_package() -> None:
     btclib_node uses `socket.inet_pton`, and it is a package that does
     open connections.
     """
-    reached_only_by_asking = ("'urllib.request'", "'bitcoin_core_rpc'")
+    package_name = "'bitcoin_core_rpc'"
+    transport_cost = "'urllib.request'"
 
     probe = "import btclib.p2p, sys; print(sorted(sys.modules))"
     loaded = subprocess.run(  # noqa: S603
         [sys.executable, "-c", probe], check=True, capture_output=True, encoding="utf-8"
     ).stdout
-    for name in reached_only_by_asking:
-        assert name not in loaded, name
+    assert package_name not in loaded
+    assert transport_cost not in loaded
 
     # and the other half, so that the first is a property of the codec
-    # and not of a dependency that stopped importing what it imports
+    # and not of a dependency that stopped importing what it imports --
+    # the package is reached the moment a message start is asked for, and
+    # `urllib.request` still is not: `chains.py` is the whole of what
+    # that lookup runs
     probe = "import btclib.p2p as p; p.magic_from_chain; import sys; print(sorted(sys.modules))"
     loaded = subprocess.run(  # noqa: S603
         [sys.executable, "-c", probe], check=True, capture_output=True, encoding="utf-8"
     ).stdout
-    for name in reached_only_by_asking:
-        assert name in loaded, name
+    assert package_name in loaded
+    assert transport_cost not in loaded
 
 
 def test_address_encodings_stay_below_script(unimported_btclib: None) -> None:

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -184,6 +184,15 @@ KEYWORD_ONLY: dict[str, list[str]] = {
     ],
     "btclib.fetch:BitcoinCoreRpcClient.assert_chain": ["signet_challenge"],
     "btclib.fetch:BitcoinCoreRpcClient.call": ["request_timeout", "max_body_size"],
+    "btclib.fetch:BitcoinCoreRpcClient.call_batch": [
+        "request_timeout",
+        "max_body_size",
+    ],
+    "btclib.fetch:BitcoinCoreRpcClient.call_raw": [
+        "jsonrpc",
+        "request_timeout",
+        "max_body_size",
+    ],
     "btclib.fetch:BitcoinCoreRpcClient.from_chain": [
         "user",
         "password",
@@ -194,6 +203,7 @@ KEYWORD_ONLY: dict[str, list[str]] = {
         "signet_challenge",
     ],
     "btclib.fetch:EsploraFetcher.__init__": ["network", "timeout", "transport"],
+    "btclib.fetch:SessionTransport.__init__": ["max_body_size", "connection_factory"],
     "btclib.fetch:urlopen_transport": ["max_body_size"],
     "btclib.hwi:HwiSigner.__init__": [
         "executable",

--- a/uv.lock
+++ b/uv.lock
@@ -326,11 +326,11 @@ wheels = [
 
 [[package]]
 name = "bitcoin-core-rpc"
-version = "2026.8.20"
+version = "2026.8.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/80/7a/02580ed845cc0daa380f76e3b19be84e2d6de0a58d46fe5f71d2c5588798/bitcoin_core_rpc-2026.8.20.tar.gz", hash = "sha256:9e47e906ffeb09dc2c9a5fc5ce2f893794a069193f65af271621a04cd733d79a", size = 382663, upload-time = "2026-08-20T13:42:00.63Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/b2/06b9d205d78f0ceccff52894504092adfee7f8bb06aa0dfa9c1796a6dda9/bitcoin_core_rpc-2026.8.29.tar.gz", hash = "sha256:ffef4bb09408fa2a7917824ad4b09b073fcf98fa6d2fd6c59610c40d51671b59", size = 484678, upload-time = "2026-08-29T06:17:00.542Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/3b/3ad6ebf51dcd6387b801f0a66da7451f25064c95b9718be659fa31aaf0c9/bitcoin_core_rpc-2026.8.20-py3-none-any.whl", hash = "sha256:34a7c1f406409872792d46155e8f3cc5e9f2671da0136120a181bced810a9b6b", size = 44521, upload-time = "2026-08-20T13:41:59.346Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8c/6aa9fa848f0de6d44065926dcf1c7c1c388d095ca595004349a4f029a7ff/bitcoin_core_rpc-2026.8.29-py3-none-any.whl", hash = "sha256:ea8f8ce4276e1e66ce954026f0a4d71131cd95923fd39e5e2210e850694f7271", size = 59722, upload-time = "2026-08-29T06:16:59.233Z" },
 ]
 
 [[package]]
@@ -418,7 +418,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bitcoin-core-rpc", specifier = ">=2026.8.13" },
+    { name = "bitcoin-core-rpc", specifier = ">=2026.8.29" },
     { name = "btclib-secp256k1", marker = "extra == 'secp256k1'", specifier = ">=0.8.0.4" },
     { name = "typing-extensions", specifier = ">=4.10" },
 ]


### PR DESCRIPTION
Three issues, one subject — btclib's account of `bitcoin-core-rpc`
after the sibling retired vendorability.
[ISS 1497](https://github.com/btclib-org/btclib/issues/1497): the floor
moves to `>=2026.8.29`, the split's first release, and six passages —
the five the issue names plus `README.md`'s — stop reasoning from "one
file … vendored" and keep the reason that survives, zero dependencies
and nothing of btclib's imported, verified against the released tag.
[ISS 1498](https://github.com/btclib-org/btclib/issues/1498):
`btclib.fetch` publishes `SessionTransport` beside `urlopen_transport`
as the seam's second implementation, with a wiring test per fetcher
proving the transport object reaches the client construction-only, and
the keyword-only guard extended to the sibling's new surface.
[ISS 1484](https://github.com/btclib-org/btclib/issues/1484) closes on
the arm its own Done-when names: the floor bump itself falsified the
test asserting that reaching `magic_from_chain` costs `urllib.request`
— the split's `chains` is eager and light — so the lazy plumbing stays
with its comment and tests updated to the reason that is true now, a
pin the review re-measured live on the installed release.

Evidence: the coder's gates on this head — `uv run pytest` exit 0,
31062 passed, coverage 100.00%; `pre-commit run --all-files` exit 0;
`sphinx-build -n -W` exit 0; and the required integration gate
reproduced locally per CONTRIBUTING.md against a live bitcoind
v31.1.0 regtest node — exit 0, 3 passed, the workflow's own junit
check re-run verbatim. Local review at fresh context verified every
rewritten passage, the lock, the keyword-only rows and the #1484
closure against `v2026.8.29` as released:
`CLEARED 9718b8c3685f0de063bceadebb51e888eeea745d`, no findings.

Collateral, filed and not worked here:
[ISS 1500](https://github.com/btclib-org/btclib/issues/1500) — a
proposal document links the sibling's retired repository slug.

Closes #1497
Closes #1498
Closes #1484

## Summary by Sourcery

Align btclib with the split `bitcoin-core-rpc` release by updating its dependency floor and documentation while adding reusable session-based transport support.

New Features:
- Expose `SessionTransport` as an additional reusable HTTP transport for fetchers, supporting persistent connections across requests.

Bug Fixes:
- Update lazy-import behavior and dependency assumptions after the `bitcoin-core-rpc` package split so message-start lookups avoid importing HTTP transport modules.

Enhancements:
- Refresh documentation and docstrings to describe `bitcoin-core-rpc` as a zero-dependency package and update the supported dependency floor to v2026.8.29.

Build:
- Re-lock dependencies against `bitcoin-core-rpc>=2026.8.29`.

Documentation:
- Revise README, API documentation, changelog, and package documentation to reflect the sibling package split, transport options, and current lazy-import guarantees.

Tests:
- Add export, fetcher wiring, keyword-only API, and import-isolation coverage for `SessionTransport` and the updated dependency behavior.