### PR TITLE
v2026.8.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Only v2026.8.7 and what follows it are here. The releases before it were
 documented at release-notes length in the first place, and are still in
 [RELEASE_NOTES.md](./RELEASE_NOTES.md) rather than duplicated here.
 
-## v2026.9 (work in progress, not released yet)
+## v2026.8.29
 
 ### Repository
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,7 +19,7 @@ behind this file.
 Release names follow *[calendar versioning](https://calver.org/)*:
 full year, short month, short day (YYYY-M-D)
 
-## v2026.9 (work in progress, not released yet)
+## v2026.8.29
 
 ### Worth knowing, though nothing raises
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ name = "btclib"
 # file. Not a literal in src/btclib/__init__.py for setuptools to import
 # and conf.py to repeat: two declarations are two things a release
 # workflow has to compare before trusting either
-version = "2026.9"
+version = "2026.8.29"
 description = "A library for 'bitcoin cryptography'"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "btclib"
-version = "2026.9"
+version = "2026.8.29"
 source = { editable = "." }
 dependencies = [
     { name = "bitcoin-core-rpc" },


### PR DESCRIPTION
The release that puts btclib on the post-vendorability
`bitcoin-core-rpc`: the floor moves to the sibling's v2026.8.29 —
the split package — and `btclib.fetch` publishes `SessionTransport`
beside `urlopen_transport` as the seam's second implementation. What a
user has to act on is RELEASE_NOTES.md's one entry:
`bytes_from_octets` now returns `bytes` rather than the buffer it was
handed. The rest of the cycle is repository prose and workflow
hygiene.

Release checklist, each a measurement on `312f296f`:

- `griffe check btclib -a v2026.8.27 -s src` — exit 0, no breakage
  (the `-s` flag the documented command lacks is
  [ISS 1502](https://github.com/btclib-org/btclib/issues/1502),
  filed while preparing this)
- `deps-latest` dispatched and read per job — all fourteen green,
  the `bindings at latest` jobs included, so the btclib-secp256k1 pin
  is sound and the lock ships as pinned; `bitcoin-core-rpc` is already
  floored at the newest release, this cycle's own doing
- both btclib-org pins are floors on released versions, no direct
  reference anywhere in the metadata
- `uv run pre-commit run --all-files` exit 0;
  `uv run pytest --cov` exit 0, 31062 passed, coverage 100.00%;
  `sphinx-build -n -W` exit 0
- Read the Docs builds `312f296f` successfully (the builds page, not
  the rendered site)
- the required integration gate ran locally on the floor-bump branch
  before it landed — 3 passed against a live bitcoind v31.1.0

Closes nothing: the cycle's issues are all closed by the changes that
landed them.

## Summary by Sourcery

Release btclib v2026.8.29 with updated dependency floors and the documented `bytes_from_octets` return-value change.

Enhancements:
- Publish the v2026.8.29 release and align the package metadata, changelogs, and lockfile with the new version.

Documentation:
- Document the user-visible change that `bytes_from_octets` now returns a `bytes` value instead of the input buffer.