### PR TITLE
Open the v2026.9 cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Only v2026.8.7 and what follows it are here. The releases before it were
 documented at release-notes length in the first place, and are still in
 [RELEASE_NOTES.md](./RELEASE_NOTES.md) rather than duplicated here.
 
+## v2026.9 (work in progress, not released yet)
+
 ## v2026.8.29
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,8 @@ behind this file.
 Release names follow *[calendar versioning](https://calver.org/)*:
 full year, short month, short day (YYYY-M-D)
 
+## v2026.9 (work in progress, not released yet)
+
 ## v2026.8.29
 
 ### Worth knowing, though nothing raises

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ name = "btclib"
 # file. Not a literal in src/btclib/__init__.py for setuptools to import
 # and conf.py to repeat: two declarations are two things a release
 # workflow has to compare before trusting either
-version = "2026.8.29"
+version = "2026.9"
 description = "A library for 'bitcoin cryptography'"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "btclib"
-version = "2026.8.29"
+version = "2026.9"
 source = { editable = "." }
 dependencies = [
     { name = "bitcoin-core-rpc" },


### PR DESCRIPTION
The pull request RELEASING.md asks for right after a release: a new work-in-progress section in RELEASE_NOTES.md and CHANGELOG.md, and the generic placeholder version in pyproject.toml, re-locked — the shape nothing tagged can have, so a checkout of main between releases reports itself as work in progress and version-check refuses it should it ever reach a tag.

## Summary by Sourcery

Open the v2026.9 work-in-progress cycle after the v2026.8 release.

Enhancements:
- Open the v2026.9 development cycle with unreleased work-in-progress sections in the changelog and release notes.
- Set the project version to the generic v2026.9 development version and refresh the lockfile accordingly.