### PR TITLE
pypi-install.yml waits for the index through a script with a test (issue btclib-org/.github#509)

### DIFF
--- a/.github/scripts/wait_for_pypi_release.py
+++ b/.github/scripts/wait_for_pypi_release.py
@@ -1,0 +1,128 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Wait until the index serves the version a release just published.
+
+`pypi-install.yml` installs whatever the resolver picks, and the index
+does not serve a new file the instant the upload returns: a run that
+starts too early installs the version the release replaces and reports a
+pass for it, which is worse than reporting nothing. So a run with a
+release behind it waits for the version its tag names, and fails rather
+than let the matrix measure the wrong thing.
+
+The budget is a deadline and not a count of attempts. A wait stated as
+attempts times an interval is a product to be multiplied out before it
+can be compared with the job's own `timeout-minutes`, and a wait that
+outlasts that is killed inside itself: the run then carries the runner's
+message about a cancelled job where this was written to name the page to
+go and read (issue #1165). Every request is bounded by what is left of
+the deadline as well as by its own timeout, so the whole wait ends
+within `--timeout` of its first request for anything the index does
+between answers. What is not bounded here is a single answer arriving a
+byte at a time: `urlopen`'s timeout is a socket timeout and applies per
+blocking read, so that case is the job's `timeout-minutes` to end.
+
+No trigger reaches the verdict this exists for. What is waited on is
+somebody else's upload, so neither a release nor a rehearsal can arrange
+for it to be late, and a trigger added to reach the loop reaches its
+first attempt instead. `tests/wait_for_pypi_release_test.py` is
+therefore the only thing that drives the retry, the deadline and the
+error path: it substitutes the transport and the clock, and advances the
+clock past the deadline itself.
+
+The tag is empty on every trigger but a release call, and an empty tag is
+nothing to wait for rather than an error -- which is what makes this
+runnable on a schedule and a dispatch, where a step only a release runs
+is a step whose defect ships with a release.
+
+    uv run --no-project --python 3.14 \
+        .github/scripts/wait_for_pypi_release.py btclib "$TAG"
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from http import HTTPStatus
+from http.client import HTTPException
+from urllib.request import Request, urlopen
+
+# the JSON API of the index, which answers one document per version and
+# 404 until the version is there. `pip index` and a resolver run would
+# answer the same question through a cache this cannot see
+INDEX = "https://pypi.org/pypi"
+
+# what a release has to arrive within, in seconds, and the one number the
+# job's `timeout-minutes` is compared against
+DEFAULT_TIMEOUT = 300.0
+# between two questions to the index: long enough not to hammer it, short
+# enough that the wait ends near the upload rather than near the deadline
+DEFAULT_INTERVAL = 15.0
+# one question's own bound, so that a connection that hangs spends part of
+# the deadline rather than all of it
+DEFAULT_REQUEST_TIMEOUT = 10.0
+
+
+def served(url: str, timeout: float) -> bool:
+    """Return whether the index answers this version's document."""
+    request = Request(url, method="GET")  # noqa: S310
+    try:
+        with urlopen(request, timeout=timeout) as answer:  # noqa: S310
+            status: int = answer.status
+    # every way the index can fail to answer is one more reason to wait:
+    # a 404 while the upload is still landing is an HTTPError, a
+    # connection refused or timed out is an OSError, and a truncated
+    # answer is an HTTPException. None of them is this script's verdict,
+    # which the deadline alone decides
+    except (OSError, HTTPException):
+        return False
+    return status == HTTPStatus.OK
+
+
+def wait(
+    package: str,
+    version: str,
+    timeout: float,
+    interval: float,
+    request_timeout: float,
+) -> int:
+    """Poll the index for one version, and say what the deadline decided."""
+    url = f"{INDEX}/{package}/{version}/json"
+    started = time.monotonic()
+    deadline = started + timeout
+    while (left := deadline - time.monotonic()) > 0:
+        if served(url, min(request_timeout, left)):
+            waited = time.monotonic() - started
+            print(f"the index serves {version} after {waited:.0f} s")
+            return 0
+        print(f"{version} is not served yet")
+        time.sleep(min(interval, max(deadline - time.monotonic(), 0.0)))
+    print(f"::error::{version} is not on the index {timeout:.0f} s later")
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Read the tag from the command line and wait for what it names."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("package", help="the name the index serves it under")
+    parser.add_argument("tag", help="the release tag, empty on every other run")
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    parser.add_argument("--interval", type=float, default=DEFAULT_INTERVAL)
+    parser.add_argument(
+        "--request-timeout", type=float, default=DEFAULT_REQUEST_TIMEOUT
+    )
+    args = parser.parse_args(argv)
+
+    version = args.tag.removeprefix("v")
+    if not version:
+        print("no release behind this run: nothing to wait for")
+        return 0
+    return wait(
+        args.package, version, args.timeout, args.interval, args.request_timeout
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/pypi-install.yml
+++ b/.github/workflows/pypi-install.yml
@@ -3,10 +3,14 @@ name: pypi-install
 
 # checks whether what is already on PyPI actually works, not merely
 # installs -- which no pull request asks, checking out the tree it is
-# testing being the whole point of one. No checkout here either, on
-# purpose: nothing from this repository takes part, which is what
-# guarantees the checks below resolve to what was installed from the
-# index and not to a source tree.
+# testing being the whole point of one. No checkout in the jobs that
+# install, on purpose: nothing from this repository takes part in them,
+# which is what guarantees the checks below resolve to what was installed
+# from the index and not to a source tree. wait-for-index is the one job
+# that checks anything out and it installs nothing: its sparse checkout
+# reaches .github/scripts, and the repository root that cone mode always
+# adds with it, so there is no src/btclib on the runner that answers it
+# either.
 #
 # `import btclib` runs __init__.py alone, and the data files under
 # btclib/ -- `git ls-files | grep '^src/btclib/.*_data/'` is which, the
@@ -97,11 +101,65 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # one question about the index, asked once, ahead of every cell that
+  # would otherwise ask it. What the wait decides when it runs out is a
+  # verdict no trigger can produce -- what is waited on is somebody
+  # else's upload, so neither a release nor a rehearsal can arrange for
+  # it to be late -- so it is a script with a test rather than a loop in
+  # a run: block, which is what section 10 of btclib-org/.github's
+  # README.md asks of a wait (btclib-org/.github#509). The budget is the
+  # script's own default deadline; timeout-minutes here is well above it,
+  # and bounds the job rather than the wait.
+  #
+  # It runs on every trigger and waits on almost none of them: the input
+  # is empty wherever no release is calling, and an empty tag is nothing
+  # to wait for. An `if:` here would make a tag the only thing that ever
+  # runs it, and a job a release is the first to run is a job whose
+  # defect ships with that release -- which has already happened to this
+  # wait, in more than one of these repositories
+  wait-for-index:
+    name: Wait for the index to serve the released version
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # sparse, and this is the whole reason the checkout is admissible
+      # in a workflow whose point is that nothing of this repository is
+      # on the runner: what lands is .github/scripts plus the repository
+      # root, cone mode being the default and root files always being in
+      # the cone, so there is no src/btclib for an import to resolve to.
+      # The root's pyproject.toml is inert here for a second reason,
+      # --no-project ignoring it. This job imports nothing of the project
+      # in any case, and the jobs that do check out nothing at all
+      - name: Check out the wait script
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      # --no-project, so it runs on the interpreter uv fetches and
+      # installs nothing: the script takes the standard library alone,
+      # which is what lets it run before anything of this project exists
+      # on the runner
+      - name: Wait for the index to serve the released version
+        shell: bash
+        env:
+          TAG: ${{ inputs.version }}
+        run: |
+          uv run --no-project --python 3.14 \
+            .github/scripts/wait_for_pypi_release.py btclib "$TAG"
+
   install-published:
     name: >-
       ${{ matrix.no-binary && 'Build' || 'Install' }}
       ${{ matrix.python }} from PyPI on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    # nothing here installs until the index serves what a release just
+    # published: a cell that starts too early resolves to the version the
+    # tag is replacing and reports a pass for it, which is worse than
+    # reporting nothing. On every other trigger the wait job returns at
+    # once, having had no version to wait for
+    needs: wait-for-index
     strategy:
       fail-fast: false
       matrix:
@@ -145,7 +203,7 @@ jobs:
     steps:
       # every run step below declares `shell: bash`, and the matrix is why:
       # the default shell on a Windows runner is PowerShell, which parses
-      # none of this. The wait step went in without the line (issue #1141)
+      # none of this. A run step went in without the line (issue #1141)
       # and took every Windows cell of v2026.8.21's release run with it --
       # "Missing opening '(' after keyword 'for'" -- having never run
       # before that tag, a release being then the only trigger that
@@ -154,46 +212,6 @@ jobs:
       # omission invisible on review; declaring it on every step is what
       # makes the absence of one visible instead. Both siblings' copies of
       # this file already do
-      #
-      # the index does not serve a new file the instant the upload returns,
-      # and this workflow installs whatever the resolver picks: a run that
-      # starts too early tests the *previous* version and reports a pass for
-      # it, which is worse than reporting nothing. So a run with a release
-      # behind it waits for the version its tag names, and fails if it never
-      # arrives rather than measuring the wrong thing.
-      #
-      # The step itself runs on every trigger and does nothing on most of
-      # them, the input being empty wherever no release is calling. An
-      # `if:` here would make a tag the only thing that ever runs it, and
-      # a step a release is the first to run is a step whose defect ships
-      # with that release -- which has already happened to this script, in
-      # more than one of these repositories. Unguarded, every weekly run
-      # parses it on every cell of the matrix. The empty case is a
-      # condition around the loop rather than an early `exit 0` for that
-      # same reason: bash parses a script as it runs, so an exit at the
-      # top leaves what follows unparsed, where an `if` is parsed whole
-      # before its condition is tested
-      - name: Wait for the index to serve the released version
-        shell: bash
-        env:
-          TAG: ${{ inputs.version }}
-        run: |
-          version="${TAG#v}"
-          if [ -z "$version" ]; then
-            echo "no release behind this run: nothing to wait for"
-          else
-            for attempt in $(seq 20); do
-              if curl -sf --max-time 10 -o /dev/null \
-                  "https://pypi.org/pypi/btclib/${version}/json"; then
-                echo "the index serves ${version}"
-                exit 0
-              fi
-              echo "attempt ${attempt}: ${version} is not served yet"
-              sleep 15
-            done
-            echo "::error::${version} never appeared on the index"
-            exit 1
-          fi
       # uv rather than actions/setup-python, which is what every other
       # workflow here already uses and what this one has to use for a
       # reason of its own: setup-python installs from the runner tool
@@ -297,6 +315,12 @@ jobs:
       Install ${{ matrix.python }}[secp256k1] from PyPI on
       ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    # nothing here installs until the index serves what a release just
+    # published: a cell that starts too early resolves to the version the
+    # tag is replacing and reports a pass for it, which is worse than
+    # reporting nothing. On every other trigger the wait job returns at
+    # once, having had no version to wait for
+    needs: wait-for-index
     strategy:
       fail-fast: false
       matrix:
@@ -333,32 +357,6 @@ jobs:
         python: ["3.14"]
     timeout-minutes: 20
     steps:
-      # the same wait, unguarded the same way and for the reasons
-      # install-published's copy states: a run started by release.yml's
-      # call must not measure the version the tag is replacing, and a
-      # step only a release ever runs is a step only a release finds
-      # broken
-      - name: Wait for the index to serve the released version
-        shell: bash
-        env:
-          TAG: ${{ inputs.version }}
-        run: |
-          version="${TAG#v}"
-          if [ -z "$version" ]; then
-            echo "no release behind this run: nothing to wait for"
-          else
-            for attempt in $(seq 20); do
-              if curl -sf --max-time 10 -o /dev/null \
-                  "https://pypi.org/pypi/btclib/${version}/json"; then
-                echo "the index serves ${version}"
-                exit 0
-              fi
-              echo "attempt ${attempt}: ${version} is not served yet"
-              sleep 15
-            done
-            echo "::error::${version} never appeared on the index"
-            exit 1
-          fi
       - name: Setup uv with Python ${{ matrix.python }}
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,36 @@ documented at release-notes length in the first place, and are still in
   whose unit is spelled out — which escape all three patterns, that
   command's included — are issue #1508.
 
+### Packaging, linting and CI
+
+- **`pypi-install.yml` waits for the index through a script with a
+  test.** (issue btclib-org/.github#509) The wait is
+  `.github/scripts/wait_for_pypi_release.py`, run by a `wait-for-index`
+  job that both matrix jobs need, and it counts against a deadline rather
+  than against attempts — one number to compare with the job's own
+  `timeout-minutes`, where attempts times an interval is a product to
+  multiply out first. What decides the wait is unreachable from every
+  trigger this workflow has, the thing waited on being somebody else's
+  upload, so `tests/wait_for_pypi_release_test.py` substitutes the
+  transport and the clock and is what drives the retry, the deadline and
+  the `::error::` the run would otherwise meet for the first time during
+  a release. Which of those a test actually pins was settled by mutating
+  the script rather than by reading it: what that found unpinned was the
+  status comparison, the clamp that keeps a request outlasting the
+  deadline from handing `time.sleep` a negative number, and
+  `DEFAULT_TIMEOUT` itself, no other case's outcome turning on the
+  shipped deadline. The wait job is also the only one here that checks
+  anything out, and what lands is `.github/scripts` and the repository
+  root that cone mode always adds with it — no `src/btclib`, so no
+  source tree of this project sits on the runner of a job that installs,
+  and the root's `pyproject.toml` is inert besides, `--no-project`
+  ignoring it.
+- **`RELEASING.md` sent a releaser to a `published` job and a
+  `published` workflow, and neither has existed since `6acfd4f0`
+  renamed the file to `pypi-install.yml`.** Both now name what the
+  Actions tab lists. The sentence was already open in this diff, which
+  is why it is repaired here rather than filed.
+
 ## v2026.8.29
 
 ### Repository

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -550,11 +550,12 @@ to `deps-latest`'s own result.
    btclib-secp256k1 adopts this and what its own `RELEASING.md` then says
    is that repository's decision, tracked at issue #1159.
 
-1. Read the release run's `published` job, which is this workflow called
-   with the tag rather than a dispatch to remember: it has no checkout, so
-   it resolves to what PyPI actually serves rather than to a source tree,
-   and it waits for the version the tag names before installing anything,
-   so it cannot pass by testing the release before it. It checks a BIP39
+1. Read the release run's `pypi-install` job, which is this workflow called
+   with the tag rather than a dispatch to remember: the jobs that install
+   have no checkout, so they resolve to what PyPI actually serves rather
+   than to a source tree, and none of them starts until `wait-for-index`
+   has seen the index serve the version the tag names, so the run cannot
+   pass by testing the release before it. It checks a BIP39
    vector against the `_data/` files a wheel missing one would still
    install and import cleanly, and a BIP340 vector besides — both fixed
    forever, so neither needs an edit after a release the way a
@@ -562,7 +563,7 @@ to `deps-latest`'s own result.
    own, and a failure means the outside world moved, not this repository —
    a new interpreter release, PyPI serving a file that does not match its
    own hash — which is why it is a workflow of its own rather than a job
-   of this one. Actions → published → Run workflow is for asking between
+   of this one. Actions → pypi-install → Run workflow is for asking between
    those runs, with no particular version in mind.
 
 1. Open the next cycle's version: set a generic next version without

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,6 +278,7 @@ source-exclude = [
     "/tests/generate_sbom_test.py",
     "/tests/mutation_counts_test.py",
     "/tests/verify_dist_contents_test.py",
+    "/tests/wait_for_pypi_release_test.py",
     # the same reasoning, for fuzz/ rather than .github/scripts: git-only
     # below is why it is not in the sdist, and this test reads
     # fuzz/fuzz_*.py and fuzz/corpus/ off the tree, both absent from an
@@ -1124,6 +1125,11 @@ ignore = [
 # job that started an emulator: what it saw and how long it took, or the
 # ::error:: annotation naming what it saw instead
 ".github/scripts/wait_for_hwi_device.py" = ["T201"]
+# and the release wait, whose output is the log of a job with nothing
+# else in it: one line per question the index has not answered yet, the
+# answer when it comes, or the ::error:: annotation naming the version
+# that never arrived
+".github/scripts/wait_for_pypi_release.py" = ["T201"]
 # and the py-arm authority re-derivation: which module it is
 # measuring, one line per disagreement found, and the all-clear or count
 # at the end are what a weekly run's log says happened

--- a/tests/wait_for_pypi_release_test.py
+++ b/tests/wait_for_pypi_release_test.py
@@ -1,0 +1,312 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the release wait of `.github/scripts`.
+
+What a run of `pypi-install.yml` shows is the wait that does not wait: on
+a schedule and on a dispatch the tag is empty, and the matrix installing
+anything at all is the check that the script returned. What no run can
+show is any other outcome -- what is waited on is somebody else's upload,
+so neither a release nor a rehearsal can arrange for the index to be
+late -- so the retry, the deadline and the `::error::` are reached here
+or nowhere.
+
+Both of the wait's inputs are substituted for that. `_Transport` is the
+index: a scripted sequence of answers that also records what it was
+asked, timeout included. `_Clock` is the clock, and it moves only when
+the script sleeps on it, which is what makes the deadline arrive in no
+time at all and the attempts before it exact rather than approximate.
+
+The script is loaded by path, `.github/scripts` being no package, as the
+other scripts under it are tested.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from contextlib import contextmanager
+from email.message import Message
+from http import HTTPStatus
+from pathlib import Path
+from types import ModuleType
+from typing import TYPE_CHECKING, NamedTuple
+from urllib.error import HTTPError
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from contextlib import AbstractContextManager
+
+_SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "wait_for_pypi_release.py"
+_URL = "https://pypi.org/pypi/btclib/2026.9.1/json"
+
+
+class _Clock:
+    """A monotonic clock that stands still until the script sleeps on it."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.slept: list[float] = []
+
+    def monotonic(self) -> float:
+        """Return the reading, which only `sleep` below moves."""
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        """Spend the seconds a wait on a real clock would have spent."""
+        self.slept.append(seconds)
+        self.now += seconds
+
+
+class _Transport:
+    """The answers the index gives, in order, and the questions it got."""
+
+    def __init__(self, answers: list[bool]) -> None:
+        self.answers = answers
+        self.asked: list[tuple[str, float]] = []
+
+    def __call__(self, url: str, timeout: float) -> bool:
+        """Answer the next verdict in the script, and record the question."""
+        self.asked.append((url, timeout))
+        return self.answers.pop(0) if self.answers else False
+
+
+class _Answer(NamedTuple):
+    """What `served` reads of a response, which is its status alone."""
+
+    status: int
+
+
+@contextmanager
+def _answering(status: int) -> Iterator[_Answer]:
+    """Hand out a response the way `urlopen` hands one to a `with`."""
+    yield _Answer(status)
+
+
+@pytest.fixture
+def script(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Return the script, imported by path, registered before it runs."""
+    spec = importlib.util.spec_from_file_location("wait_for_pypi_release", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "wait_for_pypi_release", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def clock(script: ModuleType, monkeypatch: pytest.MonkeyPatch) -> _Clock:
+    """Put a clock this test moves where the script reads a real one."""
+    fake = _Clock()
+    monkeypatch.setattr(script, "time", fake)
+    return fake
+
+
+def _index(
+    script: ModuleType, monkeypatch: pytest.MonkeyPatch, answers: list[bool]
+) -> _Transport:
+    """Put a scripted sequence of answers where the index would be."""
+    transport = _Transport(answers)
+    monkeypatch.setattr(script, "served", transport)
+    return transport
+
+
+def test_an_empty_tag_is_nothing_to_wait_for(
+    script: ModuleType,
+    clock: _Clock,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A run with no release behind it asks the index nothing at all.
+
+    `clock` is asked for although nothing here should sleep, and that is
+    the point: without it a regressed guard falls through to the real
+    `time.sleep` and the suite sits for the whole default budget before
+    reporting anything, where the fake turns the same regression into an
+    immediate failure.
+    """
+    index = _index(script, monkeypatch, [])
+
+    assert script.main(["btclib", ""]) == 0
+
+    assert index.asked == []
+    assert "nothing to wait for" in capsys.readouterr().out
+
+
+def test_the_version_asked_for_is_the_one_the_tag_names(
+    script: ModuleType,
+    clock: _Clock,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The `v` of a tag is no part of the version the index serves."""
+    index = _index(script, monkeypatch, [True])
+
+    assert script.main(["btclib", "v2026.9.1"]) == 0
+
+    assert index.asked == [(_URL, 10.0)]
+    assert clock.slept == []
+    assert "the index serves 2026.9.1" in capsys.readouterr().out
+
+
+def test_a_version_not_served_yet_is_waited_for(
+    script: ModuleType,
+    clock: _Clock,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An index that has not caught up yet costs an interval, not the run."""
+    index = _index(script, monkeypatch, [False, False, True])
+
+    assert script.main(["btclib", "2026.9.1", "--interval", "15"]) == 0
+
+    assert [url for url, _ in index.asked] == [_URL, _URL, _URL]
+    assert clock.slept == [15.0, 15.0]
+    assert "the index serves 2026.9.1 after 30 s" in capsys.readouterr().out
+
+
+def test_a_version_that_never_arrives_is_the_deadline_speaking(
+    script: ModuleType,
+    clock: _Clock,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The wait ends where its deadline is, and names what never came."""
+    index = _index(script, monkeypatch, [])
+
+    assert script.main(["btclib", "2026.9.1", "--timeout", "300"]) == 1
+
+    assert clock.now == pytest.approx(300.0)
+    assert len(index.asked) == 20
+    reported = capsys.readouterr().out
+    assert "::error::2026.9.1 is not on the index 300 s later" in reported
+
+
+def test_the_last_wait_is_cut_to_what_is_left_of_the_deadline(
+    script: ModuleType, clock: _Clock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A deadline that is no multiple of the interval is still the deadline."""
+    index = _index(script, monkeypatch, [])
+
+    assert (
+        script.main(["btclib", "2026.9.1", "--timeout", "20", "--interval", "15"]) == 1
+    )
+
+    assert clock.slept == [15.0, 5.0]
+    assert clock.now == pytest.approx(20.0)
+    assert [timeout for _, timeout in index.asked] == [10.0, 5.0]
+
+
+def test_a_request_outlasting_the_deadline_leaves_no_negative_sleep(
+    script: ModuleType,
+    clock: _Clock,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A request that overruns its share still ends in the annotation.
+
+    `served` is bounded by a socket timeout, which applies per blocking
+    read, so an index answering a byte at a time can return after the
+    deadline has already passed. What is left is then negative, and the
+    clamp is what keeps `time.sleep` from being handed it -- a real one
+    raises on a negative number, which would replace the `::error::`
+    this exists to print with a traceback.
+    """
+    asked: list[tuple[str, float]] = []
+
+    def slow(url: str, timeout: float) -> bool:
+        """Answer no, having spent longer than the whole budget."""
+        asked.append((url, timeout))
+        clock.now += 40.0
+        return False
+
+    monkeypatch.setattr(script, "served", slow)
+
+    assert script.main(["btclib", "2026.9.1", "--timeout", "30"]) == 1
+
+    assert asked == [(_URL, 10.0)]
+    assert clock.slept == [0.0]
+    assert "::error::2026.9.1 is not on the index 30 s later" in capsys.readouterr().out
+
+
+def test_the_defaults_are_the_budget_a_release_actually_gets(
+    script: ModuleType, clock: _Clock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The workflow passes no budget, so the shipped one is what bounds it.
+
+    `DEFAULT_TIMEOUT` is the figure the job's `timeout-minutes` is set
+    above, and no other case's outcome turns on it: three state a
+    deadline of their own, and of the three that do not, one returns at
+    the empty-tag guard before the wait is entered and the other two are
+    answered well inside any deadline they could have been given. So the
+    shipped number could be changed without a red run. This is the run
+    the workflow makes.
+    """
+    index = _index(script, monkeypatch, [])
+
+    assert script.main(["btclib", "2026.9.1"]) == 1
+
+    assert clock.now == pytest.approx(300.0)
+    assert clock.slept == [15.0] * 20
+    assert [timeout for _, timeout in index.asked] == [10.0] * 20
+
+
+def test_the_index_answering_the_document_is_it_serving_the_version(
+    script: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The transport reads the status, not merely that something answered."""
+    asked: list[tuple[str, float]] = []
+
+    def urlopen(request: object, *, timeout: float) -> AbstractContextManager[_Answer]:
+        """Answer as the index does once the file it names is there."""
+        asked.append((request.full_url, timeout))  # type: ignore[attr-defined]
+        return _answering(HTTPStatus.OK)
+
+    monkeypatch.setattr(script, "urlopen", urlopen)
+
+    assert script.served(_URL, 10.0)
+    assert asked == [(_URL, 10.0)]
+
+
+def test_a_2xx_that_is_not_ok_is_not_the_index_serving_it(
+    script: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`served` compares the status rather than that a status arrived.
+
+    The test above hands it `OK` alone, so it holds just as well against
+    a `served` that returns `True` for whatever answers -- which is a
+    mutation that survived it. This is the case that kills that one.
+    """
+    monkeypatch.setattr(
+        script,
+        "urlopen",
+        lambda request, *, timeout: _answering(HTTPStatus.NO_CONTENT),
+    )
+
+    assert not script.served(_URL, 10.0)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        HTTPError(_URL, HTTPStatus.NOT_FOUND, "Not Found", Message(), None),
+        TimeoutError("timed out"),
+        ConnectionResetError("reset by peer"),
+    ],
+)
+def test_an_index_that_does_not_answer_is_not_serving_the_version(
+    script: ModuleType, monkeypatch: pytest.MonkeyPatch, failure: Exception
+) -> None:
+    """Every way the exchange can fail is one more reason to keep waiting."""
+
+    def urlopen(*_args: object, **_kwargs: object) -> AbstractContextManager[_Answer]:
+        """Fail the way the index fails while the upload is still landing."""
+        raise failure
+
+    monkeypatch.setattr(script, "urlopen", urlopen)
+
+    assert not script.served(_URL, 10.0)


### PR DESCRIPTION
`pypi-install.yml`'s wait for the index is now
`.github/scripts/wait_for_pypi_release.py`, run by a `wait-for-index`
job both matrix jobs need, with `tests/wait_for_pypi_release_test.py`
driving it.

This is the first of ISS 509's three boxes; `btclib-secp256k1` and
`bitcoin-core-rpc` still owe theirs, so the changelog cites
`(issue btclib-org/.github#509)` rather than closing it.

**Why the test is the substance rather than an accompaniment.** The loop
this replaces has never executed. Only `release.yml`'s `workflow_call`
supplies `version`, so on `schedule` and `workflow_dispatch` the guard
takes the "nothing to wait for" branch, and the retry, the deadline and
the `::error::` have no production evidence behind them at all. The
first real execution of `wait-for-index` will be a release —
`pypi-install.yml` has no `pull_request` trigger, so this pull request
will not run it, and `actionlint` and `zizmor` are the whole of the
static check.

A local reviewer re-implemented the tests as a stdlib harness and ran
them against seven mutants of the script. Six died: the deadline, the
retry, the truncation of the last sleep, the per-request bound, the
annotation text and the `v`-stripping are each pinned by a named test.
The seventh — `served` returning `True` instead of comparing the status
— survived, and `test_a_2xx_that_is_not_ok_is_not_the_index_serving_it`
is the case that kills it. Verified: with `return status ==
HTTPStatus.OK` mutated to `return True`, that test and only that test
goes red.

Two other findings from the same review are fixed:

- the script's docstring was `r"""`-prefixed with `\\` at the end of its
  example, so `--help` printed a command that pastes into a shell as a
  stray backslash argument and a second line executed on its own. It is
  the only one of eight scripts here opening with `r"""`, and the only
  one whose rendered example did not work.
- `test_an_empty_tag_is_nothing_to_wait_for` took `script` and not
  `clock`, so a regressed guard would have slept on the real clock for
  the default budget rather than failing. With the fake clock the same
  regression now fails in 0.6 s — measured by deleting the guard.

Two claims that were true of the mechanism's load-bearing half and
absolute as written are narrowed: the sparse checkout reaches
`.github/scripts` **and the repository root**, cone mode always
including root files, and `--timeout` bounds the wait between answers
rather than a single answer arriving a byte at a time, `urlopen`'s
timeout being a socket timeout. Both appear in the workflow, the script
and the changelog entry, which is append-only.

`RELEASING.md` also sent a releaser to a `published` job and a
`published` workflow; neither has existed since `6acfd4f0` renamed the
file. The sentence was already open in this diff, so it is repaired
here rather than filed.

Gates, run by me on this sha: `uv run --locked pre-commit run
--all-files` exit 0; `uv run --locked pytest` exit 0, 31072 passed, 11
skipped, coverage 100.00%; `uv run --locked --no-default-groups --group
docs sphinx-build -n -W --keep-going` exit 0.

## Summary by Sourcery

Ensure PyPI installation checks wait for the tagged release to become available before validating the published packages.

New Features:
- Add a reusable PyPI release wait script that verifies a tagged version is available before package installation jobs run.

Bug Fixes:
- Prevent release checks from passing by testing an older package version before the newly published version is available.
- Correct releasing documentation to reference the current pypi-install workflow and job names.

Enhancements:
- Centralize the index wait for both installation matrix jobs with deadline-based polling and explicit failure reporting.
- Document the workflow’s sparse-checkout behavior, wait semantics, and current release process.

CI:
- Add comprehensive clock- and transport-controlled tests covering successful polling, retries, deadlines, request bounds, HTTP statuses, failures, and empty tags.
- Update workflow dependencies so both PyPI installation matrices wait for the shared index-check job.

Documentation:
- Update the changelog with the PyPI wait implementation and related workflow behavior.
- Correct RELEASING.md references from the obsolete published workflow and job to pypi-install.

Tests:
- Add tests for the PyPI release wait script and exclude the test from source distributions.

Chores:
- Configure the new script’s logging output for the project’s security lint rules.