### PR TITLE
src/btclib's docstrings carry the relation and not the microseconds (closes #1494)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,31 @@ documented at release-notes length in the first place, and are still in
   offer it the next cycle's number instead of the one being released.
   The window this closes is the changelog's, not the version's.
 
+### Documentation and the website
+
+- **A docstring in `src/btclib` carries the relation and not the
+  microseconds** (closes #1494). CLAUDE.md's *Conventions to match*
+  counts a wall clock among the numbers nothing gates, and
+  CONTRIBUTING.md's *Prose in this tree* divides one in two: the
+  relation a reader needs to follow the decision — half of what a
+  signature costs, an order of magnitude under the Python arithmetic —
+  stays where the decision is written, and the matrix per size or per
+  caller goes in the entry that took it. Each figure of the package now
+  reads as the relation it stood for, and
+  `grep -rnE '[0-9]+ (ns|us)\b' src/btclib` answers nothing. That is the
+  spelling to run it with: `git grep -nE` and the same pattern answer
+  nothing whatever the tree holds, this git's `-E` not applying `\b` as
+  `grep -E` does, and `git grep -nP` is the other one that measures it.
+
+  The arguments are unchanged: which of two paths wins, by how much, and
+  why. What is gone is the figure that made each of them a claim about a
+  machine, which is the class #1449 and #1489 name.
+
+  The same figures written in milliseconds are issue #1505, the copies
+  of them in `tests/` and `SECURITY.md` are issue #1506, and the ones
+  whose unit is spelled out — which escape all three patterns, that
+  command's included — are issue #1508.
+
 ## v2026.8.29
 
 ### Repository

--- a/src/btclib/bip32/bip32.py
+++ b/src/btclib/bip32/bip32.py
@@ -438,8 +438,8 @@ def rootxprv_from_seed_(
     caller deriving a child public key from a seed had btclib build
     Base58Check text and read it back at every hop, three encodings and
     three decodings of a spelling that never left the module: seed to
-    `m/0h/1` and neutered is 69.41 us over distinct seeds against 32.42 for
-    the same three calls over `BIP32KeyData`, and 57.14 against 32.59 where
+    `m/0h/1` and neutered costs about twice what the same three calls
+    over `BIP32KeyData` do over distinct seeds, and not much less where
     one seed repeats and `_cached_base58_decode` answers (issue 886). The
     text is what `rootxprv_from_seed` is for, and nothing here stops
     answering it.
@@ -517,7 +517,7 @@ def xpub_from_xprv_(xprv: BIP32Key) -> BIP32KeyData:
     # what `serialize` inside it does: `_xpub_from_xprv` builds with
     # `check_validity=False`, so this is the one validation of the key
     # answered here -- and it is the whole of what the encoding was
-    # validating, 0.64 us of its 6.73
+    # validating, a tenth of what that encoding costs
     xkey.assert_valid()
     return xkey
 
@@ -648,8 +648,9 @@ def __prv_key_derivation(xkey: _BIP32KeyData, index: int, pub_key: bytes) -> Non
     # and leaves an unzeroized copy of each intermediate behind. The key
     # goes in as the 32 bytes it is stored as rather than as
     # xkey.prv_key_int, so that no arithmetic on the secret happens
-    # here; it costs 0.55 us against 0.03, on a derivation whose hmac
-    # and public key are some 15 us of their own.
+    # here; the foreign call costs more than the Python sum does, and
+    # both are lost in the hmac and public key of the derivation around
+    # them.
     #
     # The dispatch is not on the curve, BIP32 being defined for secp256k1
     # alone: it is on whether the bindings are there to serve it, which is
@@ -712,8 +713,8 @@ class _PythonPubKeyTweakChain:
     step to the next rather than parsed again out of the octets the step
     before it has just written -- which is what the bindings' class holds
     it for, and is worth more here: `point_from_octets` on a compressed
-    key is a modular square root, 84.7 us where their own parse is 2.9,
-    so a path of any length pays one instead of one per level.
+    key is a modular square root, far dearer than their own parse, so a
+    path of any length pays one instead of one per level.
 
     `curves.curve` has the same arithmetic twice over -- `_tweak_add_var`
     ends in `ec.add_var(P, mult(t, ec.G, ec))`, and `_TweakChain` is a
@@ -881,13 +882,13 @@ def __pub_key_derivation(
     offset, chain_code = _pub_key_offset(xkey.chain_code, xkey.key, index)
 
     # the parent point plus the generator times the offset: one step is
-    # 11.6 us where secp256k1_ec_pubkey_tweak_add computes it and 175.2
-    # where `add_var(P, mult(t))` does, which is what a caller without
-    # the bindings pays here -- the dispatch being off altogether on that
-    # arm, so the multiplication is Python as well. xkey holds the key
-    # serialized throughout on the delegated one: no point of btclib's
-    # own is ever built, ffi.new's raw C struct staying inside the
-    # bindings.
+    # an order of magnitude cheaper where secp256k1_ec_pubkey_tweak_add
+    # computes it than where `add_var(P, mult(t))` does, which is what a
+    # caller without the bindings pays here -- the dispatch being off
+    # altogether on that arm, so the multiplication is Python as well.
+    # xkey holds the key serialized throughout on the delegated one: no
+    # point of btclib's own is ever built, ffi.new's raw C struct staying
+    # inside the bindings.
     # Compressed on the way out, which is the spelling an extended key
     # holds: asking for the uncompressed form to read a y out of it costs
     # a second serialize and the parity arithmetic that follows, for a
@@ -1027,7 +1028,7 @@ def derive_(
     # the output check the wrapper is entitled to, and the only validation
     # of the derived key: `derive` calls `b58encode(check_validity=False)`,
     # skipping the check `serialize` would otherwise run, so this is where
-    # it happens -- 0.64 us of the 6.73 the encoding costs
+    # it happens, at a tenth of what the encoding costs
     derived.assert_valid()
     return derived
 
@@ -1150,21 +1151,20 @@ def derive_from_account_range_(
     Asked one at a time, each of those walks `m/branch/index` from the
     account key, so the branch level -- which every sibling shares -- is
     derived again for every one of them, hmac and tweak and all. Here it
-    is derived once and each index is one level on top of it: 20.17 us an
-    address against 37.08, measured over a thousand.
+    is derived once and each index is one level on top of it, at a
+    little over half the cost per address, measured over a thousand.
 
     Which is the larger half of what issue 918 asked about, and not the
     half it named. The parse of the account key is one per *path* and not
     one per level -- `_PubKeyTweakChain` holds the point across the levels
     of a walk, so the branch key is never parsed from octets -- so what a
-    range saves there is 2.34 us of an address that is 37, six percent
-    and not worth an entry point. The level is worth one.
+    range saves there is six percent of an address, which is not worth
+    an entry point. The level is worth one.
 
     A sequence rather than a first and a count, so that a scan resuming
     at a gap, or a descriptor's own list, is the argument itself. One
-    address is a loss -- 42.1 us against 37.2, the branch walked and
-    nothing to amortize it over -- and two already pay, 62.3 against
-    73.8, so a caller with exactly one still wants
+    address is a loss -- the branch walked and nothing to amortize it
+    over -- and two already pay, so a caller with exactly one still wants
     `derive_from_account_`.
 
     Every index is refused by the rules `derive_from_account_` refuses

--- a/src/btclib/curves/__init__.py
+++ b/src/btclib/curves/__init__.py
@@ -53,17 +53,18 @@ what its absence does not promise: nothing here is constant-time.
 (issue #849). On the generator the regular form is also the faster one,
 by a factor of four: _mult_fixed_base makes no doubling at all, where a
 wNAF makes one per bit however wide its table is and however thoroughly
-it is cached -- 571 us against 130 over the memoized odd multiples of G,
-at w=8, w=10 and w=12 alike. So the arm every key derivation, every BIP32
+it is cached, the factor holding over the memoized odd multiples of G at
+w=8, w=10 and w=12 alike. So the arm every key derivation, every BIP32
 child and every signing nonce runs has no variable-time alternative to
 offer. What is left is a variable-base mult with a secret scalar, which
 in this package is ecc.dh: 1.13x on secp256k1 and 1.03x on nistp256, the
 second being that measurement's own noise. Beside it, the blinded nonce
-inverse is 1.5 us of a 414 us signature, the projective blinding of
-curve_group._blinded_jac is 1%, and every verification is already _var.
-The 1.13x was measured with the bindings switched off. btclib_secp256k1
-is the secp256k1 extra rather than a required dependency, so a caller who
-skips it is already in that state, with nothing to switch.
+inverse is a fraction of a percent of a signature, the projective
+blinding of curve_group._blinded_jac is 1%, and every verification is
+already _var. The 1.13x was measured with the bindings switched off.
+btclib_secp256k1 is the secp256k1 extra rather than a required
+dependency, so a caller who skips it is already in that state, with
+nothing to switch.
 
 They are implementations of one operation, kept side by side to be measured
 against each other, and a menu of them is not an API: a caller reading them

--- a/src/btclib/curves/curve.py
+++ b/src/btclib/curves/curve.py
@@ -552,10 +552,10 @@ def _is_x_coordinate_var(x: int, ec: Curve) -> bool:
 
     Existence and nothing else, which is what a caller with no use for
     the y has to ask, and it is a question the Legendre symbol answers
-    without ever forming a root: 14 us on secp256k1 against the 75 of
-    ec.y, and `xonly.pubkey_verify` answers the same of the x alone in
-    2.4, being secp256k1_xonly_pubkey_parse and a verdict -- the same
-    answer three ways, all three refusing the same x. It is
+    without ever forming a root, several times cheaper on secp256k1 than
+    ec.y is, and `xonly.pubkey_verify` answers the same of the x alone
+    cheaper still, being secp256k1_xonly_pubkey_parse and a verdict --
+    the same answer three ways, all three refusing the same x. It is
     libsecp256k1's own shape, `secp256k1_ge_x_on_curve_var` being
     `secp256k1_fe_is_square_var` of x^3 + ax + b and nothing else.
 
@@ -583,9 +583,9 @@ def _y_even_var(x: int, ec: Curve) -> int:
 
     ec.y_even_var, delegated for secp256k1: the even y is the one an
     x-only key names, so `xonly.to_pubkey` asked for the uncompressed
-    form hands back the y that was lifted -- 3.6 us against 73. That is
-    1.2 more than _is_x_coordinate_var above, which is why both exist:
-    finding the root is what the verdict does not do.
+    form hands back the y that was lifted, a fraction of the Python
+    root. It costs more than _is_x_coordinate_var above, which is why
+    both exist: finding the root is what the verdict does not do.
 
     An x the bindings refuse falls through to ec.y_even_var instead of
     raising here, so that the message stays in the one place that has the
@@ -615,13 +615,13 @@ def _sec_from_point(Q: Point) -> bytes:
 
     Uncompressed, 0x04 || x || y, which is what makes the round trip
     worth taking, in both directions. It is the form ec_pubkey_parse
-    reads without lifting an x coordinate back to a point, 2.1 us of the
-    13 a whole multiplication costs; and, asked of ec_pubkey_serialize on
-    the way out, the form that does not drop a y this side would have to
-    lift again -- 3.2 us of point_from_octets against 1.2, a lift
-    delegated to the bindings against two int.from_bytes, the lesson
-    bip32.py records for public derivation. The 32 octets more cost
-    0.09 us to write here.
+    reads without lifting an x coordinate back to a point, a sixth of
+    what a whole multiplication costs; and, asked of ec_pubkey_serialize
+    on the way out, the form that does not drop a y this side would have
+    to lift again -- point_from_octets on the compressed form costs
+    better than twice what it does on this one, a lift delegated to the
+    bindings against two int.from_bytes, the lesson bip32.py records for
+    public derivation. The 32 octets more are all but free to write here.
     """
     p_size = secp256k1.p_size
     return b"\x04" + Q[0].to_bytes(p_size, "big") + Q[1].to_bytes(p_size, "big")
@@ -701,9 +701,9 @@ def _multi_mult_x_only_var(
     `_libsecp256k1_multi_mult_` and not the public `multi_mult_var`, that
     one taking points -- which is the form the lift would have to build
     and the multiplication would then write straight back out. The
-    thirty-two terms of sixteen signatures: 301.9 us against 387.5 with
-    both terms lifted by the caller, of the 553.9 that batch costs end to
-    end.
+    thirty-two terms of sixteen signatures cost a fifth less than they do
+    with both terms lifted by the caller, on a batch that is not quite
+    twice the multiplication end to end.
 
     Every scalar is required to be in 1..n-1 and every x to be an
     x-coordinate. The caller is what holds to that -- ssa's rand is drawn
@@ -800,7 +800,7 @@ def _mult_checked(m: int, Q: Point | None, ec: Curve, *, prepared: bool) -> Poin
     ladder the generator runs, whose tables are memoized per point,
     instead of to the GLV endomorphism, which builds nothing and keeps
     nothing. On the bindings path it changes nothing at all: libsecp256k1
-    is 22.8 us against the ladder's warm 142.3, so a prepared point is
+    is several times faster than the ladder warm, so a prepared point is
     still faster delegated, and the tables are only reached where the
     bindings decline.
     """
@@ -883,8 +883,8 @@ class PreparedPoint:
     Two tables answer to it, one per operation:
 
     - `mult` takes the fixed-base ladder of the generator instead of the
-      GLV endomorphism: 142.3 us a call against 551.0, once 9.50 ms has
-      built the per-position tables -- 43 positions of 64 points on
+      GLV endomorphism, near four times cheaper a call once the
+      per-position tables are built -- 43 positions of 64 points on
       secp256k1, some 366 KiB. Break-even is 23 multiplications of the
       one point -- `dh.diffie_hellman` against a counterparty, a taproot
       internal key tweaked repeatedly, `pedersen` against a fixed second
@@ -893,17 +893,17 @@ class PreparedPoint:
       take a public key -- memoizes the wNAF tables of the key's two
       endomorphism halves at `_FIXED_POINT_W` instead of rebuilding them
       at `_DOUBLE_MULT_W` per signature: 2 tables built per verification
-      become 0, and the verification 609.1 us against 471.0 for ECDSA,
-      664.5 against 531.2 for BIP340. Break-even is 22 signatures under
-      the one key, the first verification costing 3599 us where a bare
-      key's costs 630.
+      become 0, and the verification a fifth cheaper for ECDSA and for
+      BIP340 alike. Break-even is 22 signatures under the one key, the
+      first verification costing several times what a bare key's does.
 
     Both are the Python arithmetic. On secp256k1 with the bindings
-    available neither is reached -- libsecp256k1 verifies in 22.8 us and
-    holds its own tables in its own context -- so what this is for is the
-    Python path: another curve, another hash function, or a deployment
-    without the compiled bindings. Handing one in on the delegated path
-    is not an error and costs nothing; it simply buys nothing.
+    available neither is reached -- libsecp256k1 verifies in a fraction
+    of either and holds its own tables in its own context -- so what this
+    is for is the Python path: another curve, another hash function, or
+    a deployment without the compiled bindings. Handing one in on the
+    delegated path is not an error and costs nothing; it simply buys
+    nothing.
 
     Preparing is a caller's word and never inferred, and the memory is
     why: the tables are per distinct point, so a library that memoized
@@ -914,9 +914,9 @@ class PreparedPoint:
     maxsize the tables live under.
 
     Nothing is built by the constructor. It parses and validates the
-    point, which is the other half of what a verifier repeats -- 75.2 us
-    of decompression per signature, on the Python path where a
-    compressed key is a field square root -- and leaves the tables to the
+    point, which is the other half of what a verifier repeats -- a
+    decompression per signature, on the Python path where a compressed
+    key is a field square root -- and leaves the tables to the
     first multiplication that wants them, because which of the two
     families above is wanted is a question only that call answers.
 
@@ -1008,15 +1008,16 @@ def _double_mult_python(
     own fastest path.
 
     Which makes this the second curve comparison of the call, the guard
-    above having asked `_libsecp256k1_serves` the first: 0.394 us on a
-    curve that is not secp256k1, the frame and `Curve.__eq__`'s two
-    _eq_key tuples together, where the identical object short-circuits on
-    identity. That is 8% of a low-cardinality double multiplication and
-    two tenths of a second of the suite, spent for the same reason
-    _double_mult_w_NAF_var spends about 3 us a call there: what the saving
-    would buy is a fraction of a second, and what it would cost is a
-    second copy of the dispatch, one per caller, free to drift. `mult`
-    makes the same two comparisons for the same reason.
+    above having asked `_libsecp256k1_serves` the first, on a curve that
+    is not secp256k1: the frame and `Curve.__eq__`'s two _eq_key tuples
+    together, where the identical object short-circuits on identity. That
+    is 8% of a low-cardinality double multiplication and two tenths of a
+    second of the suite, spent for the same reason
+    _double_mult_w_NAF_var spends a constant of its own a call there:
+    what the saving would buy is a fraction of a second, and what it
+    would cost is a second copy of the dispatch, one per caller, free to
+    drift.
+    `mult` makes the same two comparisons for the same reason.
 
     `fixed` is the points whose tables are memoized, passed down rather
     than read off `ec` at the bottom: a verification under a
@@ -1066,10 +1067,11 @@ def _sum_var(points: Sequence[Point], ec: Curve) -> Point:
     reason to hand it over was not obvious: a delegated addition is two
     serializations and a parse around one C addition, where the Python is
     an extended Euclid. Measured, the Euclid is what dominates: one
-    addition 4.41 us delegated against 11.03, and the gap widens with
-    every term -- an addition of the Python chain costs 11 us where a
-    term added to a delegated sum costs 0.46. The crossing is cheap
-    because it is the uncompressed serialization `_sec_from_point`
+    addition delegated costs less than half what it does in Python, and
+    the gap widens with every term -- an addition of the Python chain
+    costs the same at every term, where a term added to a delegated sum
+    costs a small fraction of one. The crossing is cheap because it is
+    the uncompressed serialization `_sec_from_point`
     writes, which ec_pubkey_parse reads without lifting an x; a
     compressed one would be a field square root a term.
 
@@ -1102,9 +1104,9 @@ def _sum_var(points: Sequence[Point], ec: Curve) -> Point:
         # tests the same y and says why in its own comment
         secs = [_sec_from_point(Q) for Q in points if Q[1]]
         # and a run with no addition left in it is answered without
-        # crossing: one term is that term, and none is infinity. 7.11 us
-        # against 10.31 for BIP352's one-input sum, which is a crossing
-        # to be told what was handed over
+        # crossing: one term is that term, and none is infinity, which
+        # spares BIP352's one-input sum a crossing made to be told what
+        # was handed over
         if len(secs) < 2:
             return _point_from_sec(secs[0]) if secs else INF
         total = libsecp256k1_pubkey_sum(secs, False)
@@ -1126,8 +1128,8 @@ def _tweak_add_var(P: Point, t: int, ec: Curve) -> Point:
     `add_var(P, mult(t, ec.G, ec))` it is a delegated multiplication, the
     product read back into a Point, P written out again for the addition,
     and that addition made here; `secp256k1_ec_pubkey_tweak_add` is the
-    shape itself, one call on the serialized point -- 10.89 us against
-    19.62 on secp256k1.
+    shape itself, one call on the serialized point, near half the cost on
+    secp256k1.
 
     Not `double_mult_var(1, P, t, ec.G, ec)`, which is the same sum and
     delegates too: that one multiplies P by one, and a scalar
@@ -1147,9 +1149,9 @@ def _tweak_add_var(P: Point, t: int, ec: Curve) -> Point:
     A zero tweak is not in that list: libsecp256k1 takes a tweak "valid
     according to secp256k1_ec_seckey_verify *or 32 zero bytes*", which
     its own header says of `secp256k1_ec_pubkey_tweak_add`, and answers
-    P directly, at 5.01 us against the 131.40 that routing it to the
-    Python pair instead would cost -- there `mult` has the scalar
-    libsecp256k1 declines and takes the fixed-base ladder for an answer
+    P directly, at a fraction of what routing it to the Python pair
+    instead would cost -- there `mult` has the scalar libsecp256k1
+    declines and takes the fixed-base ladder for an answer
     that is the point already in hand.
     """
     ec.require_on_curve(P)
@@ -1185,9 +1187,10 @@ class _TweakChain:
     object that holds the parsed point across such a chain. So this
     needs no fan-out entry point of its own, and the bindings have none:
     the fan-out is a chain read the other way round. Sixteen tweaks of
-    one point 112.7 us against 133.8, the difference being the fifteen
-    parses that do not happen; what that is worth at the one caller, per
-    number of outputs found, is in the CHANGELOG entry that took it.
+    one point cost less than sixteen separate ones, the difference being
+    the fifteen parses that do not happen; what that is worth at the one
+    caller, per number of outputs found, is in the CHANGELOG entry that
+    took it.
 
     Nothing is required of the order the tweaks arrive in. The
     difference is taken modulo n, so the same tweak may be asked for
@@ -1259,8 +1262,8 @@ def _jac_double_mult(
     verifications the bindings' own decline -- a hash function that is not
     sha256, a BIP340 message that is not 32 bytes (issue 169), a
     caller-imposed nonce, another curve -- and which paid a Python
-    double_mult_var underneath whatever the reason. 1.02 ms against 28 us on
-    secp256k1.
+    double_mult_var underneath whatever the reason, some thirty-five
+    times the delegated one on secp256k1.
 
     Jacobian in and Jacobian out, rather than those two rewritten in
     affine coordinates, because it is not only their arithmetic that is
@@ -1274,9 +1277,9 @@ def _jac_double_mult(
     The two conversions in are one modular inversion each on the z == 1
     that a parsed key and a lifted r arrive as, and a shortcut for that
     case -- the affine point being the same pair of coordinates, no
-    inversion at all -- saves both of them, 3% of the 28 us the call
-    costs. Not worth a branch, and neither is the caller's own
-    mod_inv_var(1) on the way back out, the same inversion again on the
+    inversion at all -- saves both of them, 3% of what the call costs.
+    Not worth a branch, and neither is the caller's own mod_inv_var(1)
+    on the way back out, the same inversion again on the
     cheapest operand it has.
     """
     if not _libsecp256k1_serves(ec, None):

--- a/src/btclib/curves/curve_group.py
+++ b/src/btclib/curves/curve_group.py
@@ -401,9 +401,10 @@ class CurveGroup:
         # on average and only 23 of them not at all, and the count *is*
         # the secret: exactly the number of zero base-16 digits of the
         # scalar, or for _mult_jac_var the number of its low zero bits. An
-        # early return there put that on the clock, 0.03 us against the
-        # 3.7 us of a generic addition, and _mult measured 0.93 ms with no
-        # zero digit against 0.55 ms with 63.
+        # early return there puts that on the clock: skipping the
+        # addition costs a fraction of making it, so a scalar with no
+        # zero digit takes measurably longer through _mult than one with
+        # 63 of them.
         #
         # So no branch on infinity, and no arithmetic on it either: a
         # Python integer costs what its size costs, and the zero
@@ -415,9 +416,9 @@ class CurveGroup:
         # adds the infinity of a zero digit pair a quarter of the time --
         # the additions an early return answers for free, at the price of
         # putting their count on the clock. Dropping the early return
-        # without the stand-ins is not enough: P + INFJ still costs
-        # 1.8 us against 5.4, and _mult_jac_var is still 25% faster on a
-        # scalar with 128 low zero bits
+        # without the stand-ins is not enough: P + INFJ still costs a
+        # third of a generic addition, and _mult_jac_var is still 25%
+        # faster on a scalar with 128 low zero bits
         QS = (Q, self._stand_in_q)[Q[2] == 0]
         RS = (R, self._stand_in_r)[R[2] == 0]
 
@@ -1139,16 +1140,16 @@ def _mult_fixed_base(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoint:
 
     w=6 by measurement, over 30 random 256-bit scalars on secp256k1, best
     of seven alternating rounds. The window buys time and is paid in
-    memory, and the time does not turn: 193 us at w=4, 157 at w=5, 127 at
-    w=6, 110 at w=7, 96 at w=8, against tables of 136, 221, 366, 629 and
-    1088 KiB. Where to stop is therefore where the memory stops being
-    worth it, and past w=6 a doubled table buys under 15% each time.
+    memory, and the time does not turn: it falls at every step from w=4
+    to w=8, against tables of 136, 221, 366, 629 and 1088 KiB. Where to
+    stop is therefore where the memory stops being worth it, and past
+    w=6 a doubled table buys under 15% each time.
 
     Against what `curve.mult` ran before, at w=6: 2.77x, 3.42x and 4.13x
-    at w=4, 5 and 6 over the GLV endomorphism's 537 us on secp256k1, and
-    5.98x over the regular window's 785 us on secp256r1, which has no
-    endomorphism to be measured against and gains the more for it. The
-    two curves hold tables of the same size.
+    at w=4, 5 and 6 over the GLV endomorphism on secp256k1, and 5.98x
+    over the regular window on secp256r1, which has no endomorphism to
+    be measured against and gains the more for it. The two curves hold
+    tables of the same size.
 
     It is libsecp256k1's `secp256k1_ecmult_gen`, which sums one
     precomputed entry per digit position and doubles nothing, and it
@@ -1159,11 +1160,11 @@ def _mult_fixed_base(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoint:
     The reason is the point repeating and not the point being the
     generator, so `curve.PreparedPoint` reaches here as well, for a
     caller who has said its own point will come back. Break-even is 23
-    multiplications of that point: 9.50 ms and 366 KiB to build against
-    142.3 us a call warm, where the GLV endomorphism `curves.mult`
-    otherwise runs costs 551.0 with nothing to build. Which is why
+    multiplications of that point: a table of 366 KiB and a build to pay
+    for, against a warm call cheaper than what the GLV endomorphism
+    `curves.mult` otherwise runs costs, which builds nothing. Which is why
     nothing infers it -- the same measurement, read the other way, is
-    9.5 ms and 366 KiB of pure loss for a point multiplied once.
+    that build and 366 KiB of pure loss for a point multiplied once.
 
     The accumulator is rescaled where `curves.mult` rescales the point on
     its other arm: the table here is memoized and canonical, so it is the
@@ -1786,8 +1787,8 @@ def _multi_mult_var(
     len(), because a zero scalar is dropped downstream and the batch that
     reaches either implementation is the nonzero one: 56 scalars of which
     2 are nonzero is a batch of two, and sending it to Bos-Coster on its
-    length costs 1.81 ms against the wNAF's 1.02. The pass that counts
-    them is 0.8 us at that size, under a thousandth of either.
+    length costs nearly twice what the wNAF does. The pass that counts
+    them is under a thousandth of either at that size.
 
     The input points are assumed to be on curve, the scalar coefficients
     are assumed to have been reduced mod n if appropriate (e.g. cyclic

--- a/src/btclib/curves/curve_group_2.py
+++ b/src/btclib/curves/curve_group_2.py
@@ -55,22 +55,23 @@ follow-ups; what is here is the rest:
       per-point table of odd multiples
 
 Measured against libsecp256k1 and not taken. Each of these is an algorithm
-that library carries and this one does not, with the number that decided
-it, so that what the next reader has is the result and not the
+that library carries and this one does not, with the result that decided
+it, so that what the next reader has is the verdict and not the
 measurement to make again. Best of five on secp256k1's p, Python 3.14.6,
 macOS arm64:
 
     - the field inverse by an addition chain, Peter Dettman's and Brian
       Smith's, and libsecp256k1's own safegcd beside them:
-      `pow(a, -1, p)` is 8.3 us, being CPython's extended Euclid in C,
-      where 255 modular squarings in bytecode -- fewer than any chain
-      needs -- are 61 us. `pow(a, p - 2, p)` is 74.7 us, which is why
-      `mod_inv_var` does not spell Fermat either:
+      `pow(a, -1, p)` is CPython's extended Euclid in C, where 255
+      modular squarings in bytecode -- fewer than any chain needs --
+      cost several times what it does. `pow(a, p - 2, p)` costs about
+      what those squarings do, which is why `mod_inv_var` does not
+      spell Fermat either:
 
         - https://briansmith.org/ecc-inversion-addition-chains-01
-    - fast reduction for a pseudo-Mersenne p: `x % p` is 0.162 us and the
-      Solinas form for `2^256 - 2^32 - 977`, two products by a 33-bit
-      constant and a conditional subtraction, is 0.193. CPython's
+    - fast reduction for a pseudo-Mersenne p: the Solinas form for
+      `2^256 - 2^32 - 977`, two products by a 33-bit constant and a
+      conditional subtraction, costs more than `x % p` does. CPython's
       division is C, and 512 bits by 256 is small
     - limbs with delayed reduction, libsecp256k1's 5 by 52 bits and its
       magnitude tracking: the Python analogue is letting intermediates
@@ -78,32 +79,32 @@ macOS arm64:
       wrong way -- an integer costs what its size costs
     - a separate squaring routine: CPython's long_mul already takes the
       squaring path when both operands are the same object, `a*a % p`
-      being 0.226 us against the 0.247 of `a*b % p`
+      costing measurably less than `a*b % p`
     - the masked table lookup of `secp256k1_ecmult_table_get_ge`, which
       reads every entry of a table under a cmov: a list index is a list
       index
     - the lambda split's division by a multiply and a shift,
       `secp256k1_scalar_mul_shift_var`: `_multiplier_decomposer` rounds
       with `(_B2 * m + n // 2) // n`, 384 bits by 256, where libsecp256k1
-      multiplies by a precomputed reciprocal instead. 0.24 us against
-      0.15, once per multiplication of some 700
+      multiplies by a precomputed reciprocal instead. The rounding is
+      the dearer of the two and is paid once per multiplication, which
+      is three orders of magnitude above either
     - the table built with no inversion at all,
       `secp256k1_ecmult_odd_multiples_table` with
       `secp256k1_ge_table_set_globalz`: the odd multiples are formed on an
       isomorphic curve where the doubled point is affine, the z-ratios are
       kept as they go, and the entries reach one common Z by products
       alone. What it would remove is the single inversion a call now
-      spends, 7.4 us of a 700 us `_mult` and of the 3667 us a 16-point
+      spends, which is 1% of a `_mult` and 0.2% of what a 16-point
       `_multi_mult_var` takes; the rest of that conversion is the three
-      products an entry costs -- 21.9 us of the first, 253 of the second
-      -- and the isomorphic construction pays those in its own coin. An
-      accumulator that has to live in that frame and be rescaled out of it
-      at the end, for a ceiling of 1% and of 0.2%
+      products an entry costs, and the isomorphic construction pays
+      those in its own coin. An accumulator that has to live in that
+      frame and be rescaled out of it at the end, for those two ceilings
     - the square root by an addition chain is the one of these that
       measures positive and is still not here: `pow(a, (p + 1) // 4, p)`
-      is 73.6 us against the 63.6 of libsecp256k1's chain, which is 1.16x
-      for some twenty lines holding for secp256k1's p alone, on a
-      function a point decompression away from these loops
+      is 1.16x libsecp256k1's chain, for some twenty lines holding for
+      secp256k1's p alone, on a function a point decompression away from
+      these loops
 
 """
 
@@ -304,10 +305,9 @@ def _double_mult_w_NAF_var(
     0.81, 64 bits 0.72, 128 bits 0.68, 256 bits 0.67. The crossover is
     around 16 bits, so every curve with a real order is on the winning
     side and the toy curves of the test suite -- n = 11, n = 31 -- are
-    the ones paying, about 3 us a call. Taken as it is rather than
-    guarded by a size test: the guard would buy back a fraction of a
-    second of the suite and put a branch in the middle of signature
-    verification.
+    the ones paying. Taken as it is rather than guarded by a size test:
+    the guard would buy back a fraction of a second of the suite and put
+    a branch in the middle of signature verification.
 
     `fixed` is the points whose tables are memoized rather than built
     here, `_multi_mult_w_NAF_var` says what that buys, and it is the

--- a/src/btclib/curves/sec_point.py
+++ b/src/btclib/curves/sec_point.py
@@ -147,9 +147,10 @@ def point_from_octets(
 
     The compressed prefixes are the only branch libsecp256k1 serves, and
     the whole cost of the function is there: lifting x to a point is a
-    modular square root, 75 us of the 76 in Python against 2.9 of the 3.2
-    delegated, while the 65-byte forms carry the y and take 1.2 either
-    way (issue 284).
+    modular square root, nearly all of that cost on either arm, and
+    delegated it costs a small fraction of what the Python one does,
+    while the 65-byte forms carry the y and cost the same either way
+    (issue 284).
 
     hybrid admits the 0x06 and 0x07 prefixes of that same section, which
     carry both coordinates like 0x04 does and repeat the parity of y in
@@ -242,10 +243,10 @@ def _sec_from_octets(pub_key: bytes, ec: Curve) -> bytes:
     to_pub_key.pub_keyinfo_from_pub_key wants of it.
 
     For a compressed key on secp256k1 that proof is `keys.pubkey_verify`,
-    which is ec_pubkey_parse and a verdict: 2.4 us against the 4.4 of a
-    round trip that lifts x, re-proves the point it lifted on the curve
-    and serializes it again -- and against the 2.7 of `keys.reserialize`,
-    which answers the octets this already has. The parse is also the very
+    which is ec_pubkey_parse and a verdict, cheaper than a round trip
+    that lifts x, re-proves the point it lifted on the curve and
+    serializes it again, and cheaper than `keys.reserialize`, which
+    answers the octets this already has. The parse is also the very
     call libsecp256k1 will make on these bytes if they are on their way to
     its dsa.verify -- which is why a caller that is about to make it does
     not come through here at all, but through

--- a/src/btclib/descriptors/key_expression.py
+++ b/src/btclib/descriptors/key_expression.py
@@ -197,9 +197,10 @@ class KeyExpression:
         xkey = prv_keys.get(self.xkey, self.xkey) if prv_keys else self.xkey
         # `derive_` and not `derive`: the Base58Check text would be decoded
         # straight back by `pub_keyinfo_from_key` on this same line, a
-        # `BIP32KeyData` being in the `PubKey` union already -- 53.56 us
-        # against 36.69 per key at an index (issue 886). The union `derive_`
-        # takes is `derive`'s, so the xkey a descriptor holds as a string
+        # `BIP32KeyData` being in the `PubKey` union already, the text
+        # spelling being the dearer of the two per key at an index (issue
+        # 886). The union `derive_` takes is `derive`'s, so the xkey a
+        # descriptor holds as a string
         # still goes in as it is
         return pub_keyinfo_from_key(derive_(xkey, der_path), network)[0]
 

--- a/src/btclib/ecc/bms.py
+++ b/src/btclib/ecc/bms.py
@@ -392,9 +392,10 @@ def assert_as_valid(msg: Octets, addr: String, sig: Sig | String) -> None:
     # signature is valid only if the provided address is matched, and an
     # address is a hash of the sec octets: no point is built here, the
     # bindings answering the octets themselves -- which is the mod_inv_var of
-    # an affine conversion not paid either. `verify` is 25 us against 739,
-    # the mean over 40 random keys, of which some 16 are the recovery
-    # itself and 2.4 the r-congruence check of the Sig validation above
+    # an affine conversion not paid either. Delegated, `verify` costs a
+    # small fraction of what the Python path does, the mean over 40
+    # random keys, of which the recovery itself is most and the
+    # r-congruence check of the Sig validation above a little
     if _libsecp256k1_serves(secp256k1, None):
         pub_key = _libsecp256k1_recover_sec_(
             key_id, reduce_to_hlen(magic_msg), sig.dsa_sig, compressed, lower_s=False

--- a/src/btclib/ecc/dh.py
+++ b/src/btclib/ecc/dh.py
@@ -74,7 +74,7 @@ def diffie_hellman(
     The shared point is the multiplication of a point that is not the
     generator, which is the one case `mult` does not delegate: on
     secp256k1 it is `secp256k1_ec_pubkey_tweak_mul` that computes it
-    here, 15.2 us against the 549 of the Python endomorphism path and,
+    here, at a fraction of what the Python endomorphism path costs and,
     dU being a secret, in constant time -- which that path is not.
 
     `ecdh.shared_secret` of the bindings is a different function and not
@@ -92,8 +92,8 @@ def diffie_hellman(
     if d and _libsecp256k1_serves(ec, None):
         # uncompressed, which is the cheap form to hand over: parsing 65
         # octets reads both coordinates where 33 are a field square root,
-        # and the point is here to be written either way -- 12.6 us
-        # against 14.7 for the multiplication that follows
+        # and the point is here to be written either way, so the
+        # multiplication that follows is spared the lift
         sec = libsecp256k1_keys.pubkey_tweak_mul(
             bytes_from_point(QV, ec, compressed=False), d
         )

--- a/src/btclib/ecc/dsa.py
+++ b/src/btclib/ecc/dsa.py
@@ -217,11 +217,11 @@ class Sig:
       the bindings answer for secp256k1 alone. A delegation is a second
       path gated like the others, for a computation with no arithmetic
       in it;
-    - there is nothing to win. Serializing is 0.697 us here against
-      `to_der`'s 1.057; parsing is 1.253 against `to_compact`'s 0.971,
-      and what `to_compact` answers is r || s, which this side would
-      still have to split and build a `Sig` from. `lower_s` is one
-      comparison against n // 2, 0.037 us against `is_low_s`'s 0.840;
+    - there is nothing to win. Serializing here is cheaper than
+      `to_der`; parsing is dearer than `to_compact`, and what
+      `to_compact` answers is r || s, which this side would still have
+      to split and build a `Sig` from. `lower_s` is one comparison
+      against n // 2, an order of magnitude under `is_low_s`;
     - the exception messages are a public contract. `Sig.parse` names
       which rule the encoding broke, one message each; libsecp256k1
       returns a single 0, and the bindings' `parse_der` says "invalid
@@ -282,8 +282,8 @@ class Sig:
         # candidate, and trying them is btclib's arithmetic either way.
         # What is delegated is the question asked of each -- whether some
         # point of the curve has that x -- which for secp256k1 is
-        # ec_pubkey_parse of the compressed key 0x02 || x, 2.4 us against
-        # the 75 of a modular square root whose y is of no use here
+        # ec_pubkey_parse of the compressed key 0x02 || x, a fraction of
+        # the modular square root whose y is of no use here
         r = self.r
         congruence_not_found = True
         while congruence_not_found and r < self.ec.p:
@@ -397,9 +397,9 @@ def _compact(sig: Sig) -> bytes:
     """Return r || s, the 64 octets libsecp256k1 takes a signature in.
 
     A signature is two scalars, and this is them: `Sig.serialize` writes
-    the DER the wire carries, which the bindings would take apart again --
-    0.71 us to write and 1.25 to read back, against 0.08 and 0.32 here
-    (issue 922). Nothing is validated, the caller having a `Sig` whose
+    the DER the wire carries, which the bindings would take apart again,
+    dearer than this form both to write and to read back (issue 922).
+    Nothing is validated, the caller having a `Sig` whose
     `assert_valid` has run or whose values libsecp256k1 has just computed.
     """
     n_size = sig.ec.n_size
@@ -437,7 +437,8 @@ def gen_keys(
 
     # mult, not the _mult under it: the scalar is the private key and the
     # point is the generator, which is the one multiplication libsecp256k1
-    # is dispatched to -- constant time there, and 8.1 us against 862.
+    # is dispatched to -- constant time there, and two orders of
+    # magnitude under the Python arithmetic.
     # ssa.gen_keys computes this very point the same way
     return q, mult(q, ec=ec)
 
@@ -511,9 +512,9 @@ def _sign_recoverable_(
     #
     # It is the more expensive of the two paths to leave it on. With the
     # dispatch off that congruence is `_is_x_coordinate_var`'s Legendre
-    # symbol in Python, 13.30 us of the 177.8 a signature costs, and
-    # `_grind_low_r` pays it once per attempt -- 110 us of a 1440 us
-    # grinding signature over eight of them
+    # symbol in Python, some seven percent of what a signature costs,
+    # and `_grind_low_r` pays it once per attempt -- the same fraction
+    # of a grinding signature over eight of them
     return Sig(r, s, ec, check_validity=False), key_id
 
 
@@ -736,8 +737,8 @@ def _libsecp256k1_sign_(
     #
     # The compact form, r || s, and not the DER `sign` answers by
     # default: a signature is two scalars, and the DER would be written
-    # by libsecp256k1 and taken apart again here -- 1.25 us to read
-    # against the 0.32 of `_sig_from_compact` (issue 922).
+    # by libsecp256k1 and taken apart again here, several times what
+    # `_sig_from_compact` costs to read (issue 922).
     #
     # A key the caller supplied crosses as they hold it, compressed or
     # not, rather than being brought to the cheaper encoding first: what
@@ -1166,9 +1167,10 @@ def sign_recoverable_(
         # reads the recovery id, and the id is a value this call is made
         # for and that nothing downstream re-derives -- a faulted r or s
         # fails the first verification anybody makes, a wrong id does not.
-        # 22.4 us (btclib-secp256k1#224), once per signature, this path
-        # not grinding. Written out, it survives the day the wrapper's
-        # default is asked again in btclib-secp256k1#224
+        # A verification's worth (btclib-secp256k1#224), once per
+        # signature, this path not grinding. Written out, it survives
+        # the day the wrapper's default is asked again in
+        # btclib-secp256k1#224
         sig_bytes, key_id = libsecp256k1_recovery.sign(msg_hash, q, verify=True)
         # `_sig_from_compact` for `sign_`'s reason, stated there: these
         # are the values secp256k1_ecdsa_sign_recoverable has just
@@ -1498,9 +1500,9 @@ def _assert_as_valid_(
     # arithmetic under it: what reaches here is the verification the
     # bindings' own ecdsa_verify declined -- another hash function, a
     # commitment to check, a caller-imposed nonce, a curve of its own --
-    # and on secp256k1 the multiplication is theirs all the same, 28 us
-    # against 1.02 ms, which is this whole verification 61 us against
-    # 1.10 ms of it
+    # and on secp256k1 the multiplication is theirs all the same, some
+    # thirty-five times under the Python arithmetic, which is the whole
+    # of the gap between the two verifications
     KJ = _jac_double_mult(v, QJ, u, ec.GJ, ec, fixed)  # 5
 
     # Fail if infinite(K).
@@ -1522,8 +1524,8 @@ def _assert_as_valid_(
     # field elements that reduce to r -- one candidate where n is above
     # p/2 and more where the cofactor makes room. It measures 1.00x here:
     # the bindings hand back a point whose Z is 1, so the inversion this
-    # path pays is of one, and where the multiplication is Python's it is
-    # 8.8 us of a verification that is 1148
+    # path pays is of one, and where the multiplication is Python's it
+    # is under a percent of the verification
     x_K = (KJ[0] * mod_inv_var(KJ[2] * KJ[2], ec.p)) % ec.p
     # Fail if r ≠ x_K %n.
     if r != x_K % ec.n:  # 6, 7, 8
@@ -1619,17 +1621,17 @@ def assert_as_valid_(
         # the octets unproven, because the verification below proves them:
         # validating a public key is parsing it, for a compressed one a
         # field square root, and doing it here as well lifts the same x
-        # twice -- 2.35 us of a 22.78 us verification (issue 887). So a
+        # twice -- a tenth of a verification for nothing (issue 887). So a
         # key that is no point leaves through the ValueError caught below
         sec = _sec_from_pub_key(key)
         # the compact form, which is the signature: `Sig.serialize` would
         # write the DER the wire carries for a call whose first act is to
-        # take it apart again, 0.71 us against 0.08 (issue 922). It also
-        # validated, and assert_valid has just run above -- on the Sig
-        # handed in, or inside the Sig.parse that made one -- so what that
+        # take it apart again, an order of magnitude over what the
+        # compact form costs (issue 922). It also validated, and
+        # assert_valid has just run above -- on the Sig handed in, or
+        # inside the Sig.parse that made one -- so what that
         # would run again is the congruence check of r, not free even
-        # delegated: 0.54 us against 3.1, of a verification that is 22 in
-        # total
+        # delegated and many times more where it is not
         sig_bytes = _compact(sig)
         # normalize=True, because libsecp256k1 rejects what is not in the
         # lower-s form and which form a signature is in was the signer's
@@ -1661,8 +1663,8 @@ def assert_as_valid_(
     Q = point_from_pub_key(key, sig.ec)
     QJ = Q[0], Q[1], 1
     # the key's own memoized tables where the caller prepared it, the
-    # curve's alone where it did not: 471.0 us against 609.1 under one
-    # key, and `curves.PreparedPoint` is where the trade is written
+    # curve's alone where it did not, a fifth off a verification under
+    # one key, and `curves.PreparedPoint` is where the trade is written
     fixed = key.fixed if isinstance(key, PreparedPoint) else sig.ec._fixed_points
     # second part delegated to helper function
     _assert_as_valid_(c, QJ, sig.r, sig.s, sig.ec, fixed, lower_s=False)
@@ -1954,9 +1956,10 @@ def recover_pub_keys_(
 
     # the enumeration is btclib's loop and not a function libsecp256k1
     # has, but each candidate in it is a recid the bindings answer for, so
-    # what runs here is a `recover` call per candidate: 42 us against 1381
-    # (issue 286). A recid is two bits, i.e. every candidate a curve of
-    # cofactor 1 has, and _libsecp256k1_serves admits no other curve --
+    # what runs here is a `recover` call per candidate, some thirty times
+    # under the Python enumeration (issue 286). A recid is two
+    # bits, i.e. every candidate a curve of cofactor 1 has, and
+    # _libsecp256k1_serves admits no other curve --
     # secp256k1's cofactor is 1, so the range below is the
     # `range(2 * (ec.cofactor + 1))` of the Python enumeration above, in
     # the same order, key_id by key_id
@@ -2086,9 +2089,9 @@ def _recover_pub_key_(
     # delegated as the lift above is: this is the Python path of recovery
     # -- the named candidate goes to secp256k1_ecdsa_recover instead, and
     # the enumeration has no counterpart to go to at all -- but the
-    # arithmetic under it is libsecp256k1's for secp256k1 all the same:
-    # 708 us against 49 for the whole of this function, and 1347 against
-    # 107 for the enumeration that runs it once per candidate.
+    # arithmetic under it is libsecp256k1's for secp256k1 all the same,
+    # an order of magnitude off the whole of this function and off the
+    # enumeration that runs it once per candidate.
     # The mean over 40 random keys, and a recovery needs the population
     # stated where a signature does not: what the enumeration costs
     # depends on how many of its candidates lift, which is a property of
@@ -2147,8 +2150,8 @@ def _libsecp256k1_recover_sec_(
     # already, and hands in a 32-byte msg_hash and a key_id in [0, 3].
     #
     # secp256k1_ecdsa_recover is step 1.6 of SEC 1 v.2 section 4.1.6 for
-    # the one named candidate: 16 us here against the 708 of the Python
-    # path, which is `recover_pub_key` 22 us against 694 once the Sig
+    # the one named candidate, some forty times under the Python
+    # path, and much the same gap in `recover_pub_key` once the Sig
     # validation both of them pay is counted in, the mean over 40 random
     # keys. It answers sec octets rather than a point, which is what an
     # address wants, so bms hashes these very bytes and never builds a

--- a/src/btclib/ecc/ellswift.py
+++ b/src/btclib/ecc/ellswift.py
@@ -309,8 +309,8 @@ def encode_var(pub_key: PubKey, ec: Curve = secp256k1) -> bytes:
 
     if _libsecp256k1_serves(ec, None):
         # uncompressed, as in `dh.diffie_hellman`: the encoding parses
-        # what it is handed, and 65 octets are read where 33 are lifted --
-        # 13.1 us against 15.1
+        # what it is handed, and 65 octets are read where 33 are lifted,
+        # which is the field square root not paid
         return libsecp256k1_ellswift.encode(bytes_from_point(Q, ec, compressed=False))
 
     _constants(ec)

--- a/src/btclib/ecc/ssa.py
+++ b/src/btclib/ecc/ssa.py
@@ -169,12 +169,12 @@ class Sig:
         # The question is existence: BIP340 fixes the y even, and
         # verification recomputes the point from the scalars rather than
         # lifting this r, so _is_x_coordinate_var and not the _y_even_var that
-        # was here (issue 622). The delegated lift was already 2.9 us
-        # against 75 on the accepting path, and 0.65 of that is not the
-        # reason: _y_even_var falls back to ec.y_even_var for an x the bindings
+        # was here (issue 622). The delegated lift was already cheap on
+        # the accepting path, and what it saves there is not the reason:
+        # _y_even_var falls back to ec.y_even_var for an x the bindings
         # refuse -- that being where the message naming the value comes
-        # from -- so refusing cost the whole Python square root, 78.7 us
-        # against the 22.4 of verifying a good signature. The expensive
+        # from -- so refusing cost the whole Python square root, several
+        # times what verifying a good signature costs. The expensive
         # answer was the one an attacker picks, half of the field
         # elements being no x-coordinate and costing nothing to produce.
         #
@@ -328,8 +328,8 @@ def point_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve = secp256k1) -> Point:
     # the lift is what validates the x, and the same one for every
     # spelling: an x-only key is an x and the even y that goes with it.
     # _y_even_var is ec.y_even_var answered by libsecp256k1 for secp256k1,
-    # 2.9 us against the 75 of a modular square root, and the Python one
-    # for every other curve
+    # a fraction of the modular square root it replaces, and the Python
+    # one for every other curve
     x = _x_from_bip340pub_key(x_Q, ec)
     return x, _y_even_var(x, ec)
 
@@ -515,9 +515,9 @@ def sign_(
     #
     # One call rather than a branch on the length: for a 32-byte message
     # the two answer the same signature octet for octet, and the
-    # extraparams struct sign_custom fills costs 15.66 us against 15.43
-    # (best of nine, 3000 calls each) -- not a second code path's worth of
-    # a signature that is 15.
+    # extraparams struct sign_custom fills costs a shade more (best of
+    # nine, 3000 calls each) -- not a second code path's worth of a
+    # signature.
     #
     # A commitment stays with the Python path: it tweaks the nonce, and
     # the nonce is the bindings' own to derive
@@ -696,10 +696,10 @@ class Signer:
     so a second signature under the same key builds it again -- and that
     keypair is a multiplication of the generator, about half of what a
     BIP340 signature costs. This holds one across calls instead, which is
-    worth some 14 us a signature of a signature that is 22. The
-    measurement per batch size is in the CHANGELOG entry that introduced
-    this class, an entry being read as the history of a release where
-    this is read as a statement about the code as it stands.
+    worth better than half a signature each time. The measurement per
+    batch size is in the CHANGELOG entry that introduced this class, an
+    entry being read as the history of a release where this is read as a
+    statement about the code as it stands.
 
     The same signatures come out, `sign` here being `sign_` over the
     keypair the signer holds, with the same default aux -- 32 octets
@@ -869,9 +869,10 @@ def _assert_as_valid_(
     # reaches here is the verification the bindings' own declined, which
     # is another curve or another hash function -- the size of the message
     # was the third of those and is not any more -- and on secp256k1 the
-    # multiplication is still theirs, 28 us against 1.02 ms. This whole
-    # verification is then 38 us against 1.17 ms, the two lifts around it
-    # -- the r of the signature and the x-only key -- being theirs as well
+    # multiplication is still theirs, some thirty-five times under the
+    # Python arithmetic. The whole verification follows it, the two lifts
+    # around it -- the r of the signature and the x-only key -- being
+    # theirs as well
     KJ = _jac_double_mult(ec.n - c, QJ, s, ec.GJ, ec, fixed)
 
     # The following check is prescribed by BIP340 but it is useless:
@@ -996,8 +997,7 @@ def assert_as_valid_(
         # check_validity=False, because assert_valid has just run above --
         # on the Sig handed in, or inside the Sig.parse that made one. What
         # it would run again is the lift of r, which is not free even
-        # delegated: 0.14 us against 3.1, of a verification that is 21 in
-        # total
+        # delegated and costs many times more where it is not
         sig_bytes = sig.serialize(check_validity=False)
         try:
             verified = libsecp256k1_ssa.verify(msg, x_bytes, sig_bytes)
@@ -1020,10 +1020,10 @@ def assert_as_valid_(
     # with it: `_x_from_bip340pub_key` reads the key and proves nothing
     y_Q = _y_even_var(x_Q, sig.ec)
     # the key's own memoized tables where the caller prepared it, as in
-    # `dsa.assert_as_valid_`: 531.2 us against 664.5 under one key. The
-    # negation is in that set too, which is what makes it answer here --
-    # a prepared point of odd y is this same key, and the lift above is
-    # the one of the two BIP340 names
+    # `dsa.assert_as_valid_`, which is a fifth off a verification under
+    # one key. The negation is in that set too, which is what makes it
+    # answer here -- a prepared point of odd y is this same key, and the
+    # lift above is the one of the two BIP340 names
     fixed = Q.fixed if isinstance(Q, PreparedPoint) else sig.ec._fixed_points
     # Let c = int(hf(bytes(r) || bytes(Q) || msg)) mod n.
     c = challenge_(msg, x_Q, sig.r, sig.ec, hf)
@@ -1123,9 +1123,10 @@ def _recover_pub_key_(c: int, r: int, s: int, ec: Curve) -> int:
     # libsecp256k1 recovers no x-only key -- its recovery module is ECDSA
     # ("recover(msg, signature, recid)") and its xonly module has no
     # recovery in it -- so the delegated double_mult_var is the whole of what
-    # there is to gain here, and it is all of the cost: 3540 us against
-    # 109 for this function. Which is also why this stays private, with no
-    # public spelling above it: BIP340 has no recovery flag to carry the
+    # there is to gain here, and it is all of the cost, the Python
+    # arithmetic costing some thirty times more. Which is also why
+    # this stays private, with no public spelling above it: BIP340 has
+    # no recovery flag to carry the
     # candidate, x-only keys leaving nothing for one to disambiguate
     QJ = _jac_double_mult(ec.n - e1, KJ, e1 * s, ec.GJ, ec, ec._fixed_points)
     # QJ = e1*(s*G - K) is INF whenever r is the x of s*G, y even, and
@@ -1182,8 +1183,8 @@ def assert_batch_as_valid_(
     signature must share one curve.
 
     **It is not the fast way to verify n signatures of secp256k1.**
-    Measured against n delegated `verify_` calls, the batch is about 37 us
-    a signature and a `verify_` about 18, both flat in n, so there is no
+    Measured against n delegated `verify_` calls, the batch costs about
+    twice a `verify_` a signature, both flat in n, so there is no
     crossover at any batch size. libsecp256k1 has no batch verification to
     delegate to, checked at 687155df upstream and at the tip of
     secp256k1-zkp, whose half-aggregation is a different construction; so

--- a/src/btclib/hashes.py
+++ b/src/btclib/hashes.py
@@ -70,9 +70,9 @@ def _hashlib_has_ripemd160() -> bool:
     the interpreter included, as an import side effect, which under FIPS
     is not even permitted.
 
-    The fallback below costs about 130x an OpenSSL digest (60 us against
-    0.45 us here, on 32 bytes), and is paid only where the alternative is
-    that `import btclib.hashes` raises.
+    The fallback below costs about 130x an OpenSSL digest on 32 bytes,
+    and is paid only where the alternative is that `import btclib.hashes`
+    raises.
     """
     try:
         hashlib.new("ripemd160")
@@ -232,7 +232,7 @@ def _assert_valid_hf(hf: HashF) -> None:
     `callable` and not a trial call: a digest object is not callable, so
     the check is a slot lookup rather than the hash it would otherwise
     have to build, which matters where it sits in front of a verification
-    the bindings answer in 22 us.
+    the bindings answer fast enough for that hash to show.
 
     So it is not exhaustive, and does not need to be: a callable of the
     wrong shape -- `hashes.hash256`, which takes the message rather than
@@ -446,13 +446,11 @@ def tagged_hash(tag: bytes, m: bytes, hf: HashF = hashlib.sha256) -> bytes:
     under every other.
     """
     # libsecp256k1 computes exactly this in hashes.tagged_sha256, and the
-    # binding is not called because it is slower at every size: 0.53 us
-    # against 0.44 on an empty message, 0.63 against 0.44 on 64 bytes,
-    # 2.27 against 0.70 on 1 kB, and 111 against 20 on 64 kB. hashlib's
-    # SHA256 is OpenSSL's, hardware-accelerated, where libsecp256k1
-    # compiles its own portable C. This path also has to stay for
-    # hf != sha256, so delegating would buy neither speed nor one
-    # implementation less.
+    # binding is not called because it is slower at every size, and by
+    # more the larger the message: hashlib's SHA256 is OpenSSL's,
+    # hardware-accelerated, where libsecp256k1 compiles its own portable
+    # C. This path also has to stay for hf != sha256, so delegating would
+    # buy neither speed nor one implementation less.
     h1 = hf()
     h1.update(tag)
     tag_hash = h1.digest()

--- a/src/btclib/kdf.py
+++ b/src/btclib/kdf.py
@@ -92,11 +92,10 @@ def ansi_x9_63_kdf(z: bytes, size: int, hf: HashF, shared_info: bytes | None) ->
     # it. A list of digests joined and then sliced holds the keying data
     # three times over -- the digests, the join's copy, the slice's --
     # where this holds it twice: deriving 64 MiB peaks at 2.00x the
-    # output against 5.79x. It costs about 0.03 us a block, so a fifth of
-    # a microsecond at the one or two blocks `diffie_hellman` asks for,
-    # which is around one percent of the 15.2 us multiplication it
-    # arrives through -- and a tenth of the derivation at sizes far
-    # beyond that
+    # output against 5.79x. What the writing costs at the one or two
+    # blocks `diffie_hellman` asks for is around one percent of the
+    # multiplication it arrives through -- and a tenth of the derivation
+    # at sizes far beyond that
     #
     # the `memoryview` is what makes each write exact: a bytearray slice
     # assignment of the wrong length resizes the buffer and shifts every

--- a/src/btclib/number_theory.py
+++ b/src/btclib/number_theory.py
@@ -128,9 +128,9 @@ def mod_inv(a: int, m: int) -> int:
     that is secret. The extended Euclid under that one takes the
     iterations its input asks for, and for an operand drawn uniformly
     below m what its duration carries is the operand's bit-length: on
-    secp256k1's order, 8.8 us for a 256-bit scalar against 4.3 for a
-    128-bit one, falling at every step between them. That
-    correlation is what the Minerva attack collects -- an ECDSA nonce is
+    secp256k1's order a 256-bit scalar takes about twice what a 128-bit
+    one does, falling at every step between them. That correlation is
+    what the Minerva attack collects -- an ECDSA nonce is
     such a scalar, and a few thousand signing times sorted by it are a
     lattice away from the private key.
 
@@ -194,16 +194,15 @@ def mod_inv_batch(a: Sequence[int], m: int) -> list[int]:
 
     So it costs `n` draws from `secrets` and 2n multiplications on top of
     the trick, and the draws are the whole of it: measured on secp256k1's
-    `p` over 16 random elements, best of nine alternating rounds, 43.7 us
-    against the 20.9 of `mod_inv_batch_var` -- 2.1x, and 22.8 us of
-    difference for 16 draws of 1.6.
+    `p` over 16 random elements, best of nine alternating rounds, 2.1x
+    `mod_inv_batch_var`, and the difference is what those draws cost.
 
     It is still the trick, which is the point of it being a batch at all:
-    16 separate `mod_inv` calls are 155.9 us over the same elements, so
-    blinding the batch is 3.6x cheaper than blinding one at a time, where
-    the unblinded batch is 6.3x cheaper than the unblinded singles' 131.3.
-    The saving shrinks as the draws grow with n and the one Euclid does
-    not; the trick still wins at every size worth batching.
+    over the same 16 elements, blinding the batch is 3.6x cheaper than
+    blinding one at a time, where the unblinded batch is 6.3x cheaper
+    than the unblinded singles. The saving shrinks as the draws grow
+    with n and the one Euclid does not; the trick still wins at every
+    size worth batching.
 
     Not constant-time, for the reasons `mod_inv` gives at length. The
     empty sequence is not an error here either.
@@ -290,8 +289,8 @@ def legendre_symbol_var(a: int, p: int) -> int:
 
     By the reciprocity recursion rather than by Euler's criterion, which
     is `pow(a, (p - 1) // 2, p)` -- an exponentiation the size of the
-    square root the caller is asking about, where this is a gcd: 13.3 us
-    against 74.7 on secp256k1's p, over 3000 calls, best of seven. The
+    square root the caller is asking about, where this is a gcd, several
+    times cheaper on secp256k1's p over 3000 calls, best of seven. The
     factors of two come out all at once, `a & -a` being the lowest set
     bit, which is libsecp256k1's `secp256k1_ctz64_var`; asking a gcd
     rather than an exponent is what its `secp256k1_fe_is_square_var`

--- a/src/btclib/psbt_signer.py
+++ b/src/btclib/psbt_signer.py
@@ -828,15 +828,15 @@ class SoftwareSigner:
 
         `ssa.Signer` and not `ssa.sign_`, for one leaf as for many: what
         it saves is the `Sig` that `sign_` builds and `serialize` takes
-        apart again, 90.5 us a leaf against 97.3, and a psbt wants the
-        octets. The keypair it holds is built and wiped inside the call.
+        apart again, and a psbt wants the octets. The keypair it holds
+        is built and wiped inside the call.
 
         Holding one *across* calls was measured and is not done. Those
         leaves are the one place this library signs BIP340 more than once
-        under one key, and a keypair kept between them is 82.1 us a leaf
-        against 90.5 -- but only from the second leaf of a key onward,
-        and a key in a single leaf is the ordinary shape. The saving is
-        the smaller half of what `Signer` buys and the only half that
+        under one key, and a keypair kept between them is cheaper per
+        leaf -- but only from the second leaf of a key onward, and a key
+        in a single leaf is the ordinary shape. The saving is the smaller
+        half of what `Signer` buys and the only half that
         makes a secret outlive the call that needed it, which is not a
         trade to make for a case that may not arise.
         """

--- a/src/btclib/script/script.py
+++ b/src/btclib/script/script.py
@@ -709,13 +709,13 @@ class Script:
     def asm(self) -> ScriptList:
         """The parsed script, parsed once.
 
-        A plain property would parse self.script again on every read:
-        57.9 us for a 16.5 kB script, for a value that cannot change.
-        Cached, a second read is 0.02 us.
+        A plain property would parse self.script again on every read,
+        for a value that cannot change; cached, a second read is an
+        attribute lookup.
 
         Nothing warms the cache: construction does not parse, and
         __init__ filling the cache in would be the wrong trade --
-        measured on that 16.5 kB script, an instance holding the parse
+        measured on a 16.5 kB script, an instance holding the parse
         costs 55.4 kB against 0.2 kB without it, 277 times the script's
         own bytes, and nothing inside the library reads .asm.
         """

--- a/src/btclib/script/script_pub_key.py
+++ b/src/btclib/script/script_pub_key.py
@@ -704,9 +704,9 @@ class ScriptPubKey(Script):
         if lexicographic_sorting:
             # btclib_secp256k1's keys.pubkey_sort is not called here:
             # on compressed keys it gives the identical order, byte for
-            # byte, at 11.0 us against sorted()'s 0.062 on three keys --
-            # 180 times the cost for the same answer -- and it re-
-            # serializes an uncompressed key to a compressed one, which
+            # byte, at some 180 times sorted()'s cost on three keys for
+            # the same answer -- and it re-serializes an uncompressed
+            # key to a compressed one, which
             # a drop-in delegation cannot do without rewriting the
             # script. sorted() is also what Bitcoin Core's own
             # sortedmulti() computes, CPubKey::operator< (src/pubkey.h)

--- a/src/btclib/script/taproot.py
+++ b/src/btclib/script/taproot.py
@@ -252,8 +252,8 @@ def _output_pubkey_and_internal_key(
     first answers the pair and drops the third, the second needs the
     internal key beside the parity. Read twice, that key was lifted twice
     on the Python path -- the same square root of the same x, which is the
-    redundancy issue 896 is about, one function further out -- and 3.74 us
-    of ec_pubkey_parse twice with the bindings.
+    redundancy issue 896 is about, one function further out -- and two
+    ec_pubkey_parse calls with the bindings.
 
     Sharing it is also what keeps the two answering for the same spellings
     of an internal key: a form accepted for the output key and refused for
@@ -336,20 +336,20 @@ def _tweaked_pubkey(pub_key: PubKeyData, h: bytes) -> tuple[bytes, int]:
 
     One `PubKeyData` for both arms, each reading off it the field it
     uses (issue #1188). `sec` is what `xonly.tweak_add` prefers whole,
-    `04 || x || y` carrying the y it would otherwise lift -- 4.11 us
-    against 5.92 -- and `02 || x`, `03 || x` and `04 || x || y` all name
-    the same x-only key to it. `point` is the square root, taken once
+    `04 || x || y` carrying the y it would otherwise lift, and `02 || x`,
+    `03 || x` and `04 || x || y` all name the same x-only key to it.
+    `point` is the square root, taken once
     however many readers ask, which is issue 896.
     """
     t = _tap_tweak(pub_key.sec[1:33], h)
 
     # secp256k1_xonly_pubkey_tweak_add is this very operation, parity
-    # included, and it answers the pair this function returns. 12.0 us
-    # against 109.3 for the three lines below, over 2000 tweaks: the
-    # Python path lifts the x-only key to a point with secp256k1.y_even_var,
-    # i.e. a modular square root, which is 74 us of that on its own --
-    # while libsecp256k1 needs no such lift, having the y coordinate as
-    # it goes.
+    # included, and it answers the pair this function returns, at a
+    # fraction of what the three lines below cost over 2000 tweaks: the
+    # Python path lifts the x-only key to a point with
+    # secp256k1.y_even_var, i.e. a modular square root, which is most of
+    # that on its own -- while libsecp256k1 needs no such lift, having
+    # the y coordinate as it goes.
     #
     # The predicate is a constant now that the curve is, and the guards
     # in this module keep it rather than saying so: it is the seam the
@@ -464,9 +464,10 @@ def _tweaked_prvkey(internal_prvkey: int, h: bytes) -> int:
     # time, which the Python `%` on a secret scalar is not. The x-only
     # public key the tweak commits to comes from the bindings too, and
     # the parity byte dropped from it is the one they will decide again
-    # for themselves: 32.0 us against 82.3 over 2000 tweaks, the
-    # difference being the point this path never materializes and
-    # the square root it never takes to check that point's parity
+    # for themselves, at well under half the Python path's cost over
+    # 2000 tweaks, the difference being the point this path never
+    # materializes and the square root it never takes to check that
+    # point's parity
     if _libsecp256k1_serves(secp256k1, None):
         pub_key = bytes_from_prv_key_int(internal_prvkey, secp256k1)[1:]
         t = _tap_tweak(pub_key, h)
@@ -475,9 +476,9 @@ def _tweaked_prvkey(internal_prvkey: int, h: bytes) -> int:
 
     P = mult(internal_prvkey)
     # the parity of a y already in hand: secp256k1.y_even_var(P[0]) lifted
-    # the x back to the point P is -- 74.6 us of modular square root
-    # against 0.03 -- to compare its y with the one beside it (issue
-    # 619). Not a delegation but a deletion, which is what this path
+    # the x back to the point P is -- a modular square root for nothing
+    # -- to compare its y with the one beside it (issue 619). Not a
+    # delegation but a deletion, which is what this path
     # needed: it runs where the bindings do not, so there was nothing
     # here to dispatch to. The two spellings differ on the infinity
     # btclib writes as y == 0, and mult of a key int_from_prv_key has

--- a/src/btclib/silent_payments.py
+++ b/src/btclib/silent_payments.py
@@ -738,9 +738,9 @@ def _labelled(
 
     This is the inner loop of a scan -- once per output that did not
     match directly, and again at every k -- so the additions are
-    `_sum_var`'s rather than the Python arithmetic under it: a hundred
-    outputs 2202.4 us against 3166.5. The negation of P_k is the same
-    point for both parities and is taken once.
+    `_sum_var`'s rather than the Python arithmetic under it, the latter
+    being the dearer of the two over a hundred outputs. The negation of
+    P_k is the same point for both parities and is taken once.
     """
     try:
         candidate = point_from_bip340pub_key(output, secp256k1)
@@ -818,9 +818,10 @@ def scan_outputs(
                 break
             # a wallet that published no labelled address has nothing for
             # the subtraction below to find, and `_labelled` is a lift
-            # and two additions per output before it can say so: a
-            # hundred outputs 45.8 us against 3167.2. BIP352 asks for the
-            # change label m = 0 whatever else was used, so the map is
+            # and two additions per output before it can say so, which
+            # over a hundred outputs is most of what the scan spends.
+            # BIP352 asks for the change label m = 0 whatever else was
+            # used, so the map is
             # normally not empty -- what this spares is the caller who
             # passed none, and the answer is `_labelled`'s own for an
             # empty map, which is None every time

--- a/src/btclib/to_prv_key.py
+++ b/src/btclib/to_prv_key.py
@@ -131,9 +131,10 @@ def int_from_prv_key(prv_key: PrvKey, ec: Curve = secp256k1) -> int:
 
     # libsecp256k1's keys.prvkey_verify is the C answer to this check,
     # here and at the two other sites in this module, and it is not called
-    # for want of anything to gain: 0.11 us against the 0.024 of the
-    # comparison, on a value that is already a Python int, and no
-    # constant-time argument to pay it with, since whether a key is in
+    # for want of anything to gain: the foreign call costs more than the
+    # comparison it would replace, on a value that is already a Python
+    # int, and no constant-time argument to pay it with, since whether a
+    # key is in
     # range is precisely what the caller is being told. The comparison
     # also serves every curve, where the binding is secp256k1 alone.
     if not 0 < q < ec.n:

--- a/src/btclib/to_pub_key.py
+++ b/src/btclib/to_pub_key.py
@@ -325,9 +325,10 @@ def _sec_from_pub_key(pub_key: PubKey) -> bytes:
     the caller that turns the `ValueError` into btclib's own.
 
     A `Point` comes back uncompressed, which is the cheap form to parse --
-    0.26 us against the 2.34 of a compressed key, both coordinates being
-    there to read -- where `pub_keyinfo_from_pub_key` answers the
-    compressed one, `compressed=None` meaning "whatever the key says" and
+    both coordinates are there to read, where a compressed key pays the
+    field square root that lifts x -- while `pub_keyinfo_from_pub_key`
+    answers the compressed one, `compressed=None` meaning "whatever the
+    key says" and
     a point saying nothing. No network and no compressed filter either,
     which is what the callers ask for: a verification takes the key as the
     key says it is, and the curve it is asked about is the signature's.

--- a/src/btclib/wallet/script_wallet.py
+++ b/src/btclib/wallet/script_wallet.py
@@ -515,9 +515,10 @@ class ScriptWallet(RangedWallet):
         The object spelling of that walk, `derive_from_account_`: the
         Base58Check text `derive_from_account` answers would be decoded
         straight back by `pub_keyinfo_from_key` on this same line, a
-        `BIP32KeyData` being in the `PubKey` union already. 57.31 us against
-        34.23 per derived key, a fresh index each call so that no decode
-        cache answers (issue 886)
+        `BIP32KeyData` being in the `PubKey` union already, and decoding
+        the text straight back is the dearer of the two per derived key,
+        a fresh index each call so that no decode cache answers (issue
+        886)
         """
         return pub_keyinfo_from_key(
             derive_from_account_(key, branch, index), self.network


### PR DESCRIPTION
Every wall-clock figure in `src/btclib` outside the two sites already
done now reads as the relation it stood for.

Closes #1494

`grep -rnE '[0-9]+ (ns|us)\b' src/btclib` answered 116 at `7aa4e906` and
answers nothing here. That command's spelling matters: `git grep -nE`
with the same pattern answers 0 whatever the tree holds, this git's `-E`
not applying `\b`, and `git grep -nP` is the other one that measures it.

**The rule has two halves in two documents and they reconcile as *keep
the relation, lose the absolute figure*.** `CLAUDE.md` counts a wall
clock among the numbers nothing gates; `CONTRIBUTING.md` says a
docstring keeps the number that carries the reason and sends the matrix
per size or per caller to the changelog entry that took it. The two
precedents both deleted rather than transplanted — `af469a35` replaced
`29 ns` with the identity that makes the coercion free, `e4e10e06`
replaced six figures with "costs about what an empty function of the
same arity costs" — so they are done-sites, not exemptions.

**What a reader cannot check by reading, stated plainly:** no timing was
re-run. Every relation is arithmetic over the two figures the prose
already stated, so the diff is the only place both halves are visible,
and a deleted figure that was itself wrong is not caught here.

A local reviewer recomputed all ~70 relations from the `-` lines against
the `+` lines and found three wrong, all now fixed:

- `sec_point.py` read "all but the whole of that cost in Python and a
  small fraction of it delegated", whose parallel construction binds
  both halves to one denominator. It was 75 of 76 in Python and **2.9 of
  3.2 delegated** — nearly all of the cost on either arm. The relation
  meant was the cross-path one, and the sentence now says both.
- six sites rendered 32–44x as a bare "orders of magnitude", where this
  diff elsewhere calibrates the phrase correctly — two orders for 106x,
  three for 2900x, an order for 9x to 23x. They now say some thirty,
  some thirty-five and some forty times. It is the one relation family
  the branch overstated, consistently, by about 3x. Six and not the four
  a first pass found: `grep -rn 'orders of magnitude'` is line-oriented
  and the phrase wraps across a comment's line break at two of them, so
  the zero it answered there was the pattern's rather than the tree's.
- `kdf.py` attached "around one percent" to a block where it belonged to
  the one or two blocks the caller asks for; per block it is 0.20%.

**The judgment call, which the coder named rather than hid**, is
`curve_group_2.py`'s table of algorithms measured and *not* taken: its
matrix was deleted rather than moved to a changelog entry, because
`CONTRIBUTING.md`'s rule presupposes an entry that took the measurement
and no such entry exists for algorithms nobody adopted. The reviewer
agreed, on the two precedents rather than on the argument.

Two collateral issues were filed and a third came out of the review:
#1505 (the same rule in milliseconds), #1506 (copies in `tests/` and
`SECURITY.md`, three of them the very figures this branch removes) and
#1508 (figures whose unit is spelled out, which escape all three
patterns). The changelog's closing accounting names all three; it named
two before the review. #1505's file:line list was read at the branch tip
rather than at the base it cites, which is corrected in a comment there
and self-heals when this lands.

Gates, run on this sha: `uv run --locked pre-commit run --all-files`
exit 0; `uv run --locked pytest` exit 0, 31062 passed, 11 skipped,
coverage 100.00%; `uv run --locked --no-default-groups --group docs
sphinx-build -n -W --keep-going` exit 0.

## Summary by Sourcery

Express performance rationale in `src/btclib` through durable relative relationships instead of absolute timing measurements.

Enhancements:
- Replace absolute wall-clock measurements in `src/btclib` documentation with qualitative performance relationships while preserving the rationale behind each design decision.
- Remove measured-but-unadopted algorithm timing tables from the curve documentation and clarify that the relevant measurements are retained in changelog history.

Documentation:
- Document the migration of package docstrings from machine-specific timing figures to durable relative comparisons and track related timing-documentation follow-up issues.