### PR TITLE
The release pull request opens the next cycle's changelog sections (closes #1458)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,34 @@ documented at release-notes length in the first place, and are still in
 
 ## v2026.9 (work in progress, not released yet)
 
+### Repository
+
+- **The release pull request now opens the next cycle's changelog
+  sections itself, instead of leaving them to a later one** (closes
+  #1458). Between the two, `main` carried a `CHANGELOG.md` whose topmost
+  section was a released version, and any branch in flight filed its
+  entries under a release they were not in. The failure was silent:
+  the release commit touches only the heading, so a rebase reports no
+  conflict, and `CHANGELOG.md` being append-only the entry cannot be
+  moved afterwards — worse in `RELEASE_NOTES.md`, whose section the
+  `github-release` step lifts, so an entry landing there before the tag
+  publishes a change the tag does not contain. What this closes is the
+  window, not the whole class: a branch cut *before* the release commit
+  and rebased across it still files under the released heading, the
+  union driver keeping an added line at the anchor it was written at,
+  and that half is issue #1512.
+- **`version-check` does not object to the new section above the
+  retitled one**, which is what makes closing the window free rather
+  than a trade: its awk matches `## v<version>` exactly and never
+  reaches a heading preceding the tag's, and the two forms cannot
+  collide, a tag being refused without a day where the placeholder is
+  prescribed without one.
+- **The `pyproject.toml` version stays where it was**, after the
+  publish, and *Open the next cycle* is now that alone: `version-check`
+  reads `uv version --short` at tag time, so a bump moved earlier would
+  offer it the next cycle's number instead of the one being released.
+  The window this closes is the changelog's, not the version's.
+
 ## v2026.8.29
 
 ### Repository

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -289,6 +289,18 @@ to `deps-latest`'s own result.
    progress, not released yet" as the release notes. A rehearsal is
    exempt, being what runs before this step.
 
+   In the same pull request, start the next cycle's "work in progress"
+   section in both files, above the one just retitled. What that closes
+   is the window between this pull request landing and *Open the next
+   cycle* below: without it `main` carries a CHANGELOG.md whose topmost
+   section is a released version, and any branch in flight files its
+   entries under a release they are not in — silently, the release
+   commit touching only the heading, so a rebase reports no conflict
+   (issue #1458). `version-check` is unbothered by the section above:
+   its awk matches `## v<version>` exactly and never reaches a heading
+   that precedes the tag's, and the tag always carries a day where the
+   placeholder never does, so the two forms cannot collide.
+
 1. Run `uv run pre-commit run --all-files` and `uv run pytest --cov`,
    follow docs/README.rst to check that the documentation builds, and get
    the above onto `main` through the usual pull request. The local gates
@@ -329,8 +341,8 @@ to `deps-latest`'s own result.
    stay, but what the diff cannot say has to be written, and what a
    reader should not have to discover at the button belongs there too.
 
-   Write it from RELEASE_NOTES.md's "work in progress" section, which the
-   cycle has been filling one landed change at a time, and check that
+   Write it from the section the retitle above renamed, which the cycle
+   has been filling one landed change at a time, and check that
    against `git log v<previous version>..main --oneline` regardless of
    how current it looks, rather than trust that every line landed when it
    should have. Griffe's result and `deps-latest`'s run belong here too,
@@ -553,10 +565,15 @@ to `deps-latest`'s own result.
    of this one. Actions → published → Run workflow is for asking between
    those runs, with no particular version in mind.
 
-1. Open the next cycle: set a generic next version without the day
-   (e.g. after 2026.8.4, use 2026.9) in pyproject.toml, and start a new
-   "work in progress" section in RELEASE_NOTES.md and CHANGELOG.md,
-   through a pull request like any other.
+1. Open the next cycle's version: set a generic next version without
+   the day (e.g. after 2026.8.4, use 2026.9) in pyproject.toml, through
+   a pull request like any other. The two "work in progress" sections
+   this step used to create are already there, the retitle step above
+   having made them in the release's own pull request. What stays here
+   is the version, which cannot move earlier with them: `version-check`
+   reads `uv version --short` at tag time, and a pyproject.toml already
+   bumped would offer it the next cycle's number instead of the one
+   being released.
 
    Those two sections are where the next release's notes accumulate, one
    landed change at a time, and the merge step above is what reads them


### PR DESCRIPTION
`RELEASING.md`'s *Retitle* step now starts the next cycle's "work in
progress" sections in the same pull request, so `main` never carries a
`CHANGELOG.md` whose topmost section is a released version.

Closes #1458

Between the release pull request landing and *Open the next cycle*
landing, any other branch in flight had nowhere correct to file an
entry, and the failure is silent: the release commit touches only the
heading, so a rebase reports no conflict. `CHANGELOG.md` being
append-only, an entry landed under the wrong release cannot be moved
afterwards; `RELEASE_NOTES.md` is worse, the `github-release` step
lifting that file's section, so an entry landing there before the tag
publishes a change the tag does not contain.

**Of the three ways out the issue names, this is the one that leaves
nothing to remember.** Forbidding other merges until the cycle is open
is a rule enforced by nothing, on the one day several branches are in
flight. Documenting where an entry goes in the meantime asks a reader to
recall a rule at the moment the tree gives them no signal, which is the
one instrument a silent trap defeats.

**What made it free rather than a trade was measurable, and a reviewer
re-derived it by running the guard rather than reading it.** `release.yml`'s
retitle awk was extracted from the workflow and driven against a
constructed post-fold `CHANGELOG.md` and `RELEASE_NOTES.md`: it finds the
tag's section and exits 0, with a patch tag, with a day-less placeholder,
and with a day-bearing placeholder naming a different version. The one
case that can be constructed to collide — a placeholder written with the
tag's own day — **fails closed at exit 1 before the publish**, and the
`github-release` extraction produced only the tag's own body.

The shape is also already landed and gated: `origin/main` today carries
an empty `## v2026.9 (work in progress, not released yet)` above
`## v2026.8.29` in `RELEASE_NOTES.md`, green under `lint`, `test` and
`docs`. The fold's only novelty is that the same shape exists at a tag.

**The `pyproject.toml` version deliberately does not move with it**, and
*Open the next cycle* is now that bump alone: `version-check` reads
`uv version --short` at tag time, so a bump moved earlier would offer it
the next cycle's number instead of the one being released.

**What this closes is the window, not the whole class.** A branch cut
*before* the release commit and rebased across it still files under the
released heading — the union driver keeps an added line at the anchor it
was written at, which the reviewer reproduced with `git merge-file
--union`. That half is #1512, filed in the same round. Both the
changelog entry and the commit body say so, the entry being append-only.

Gates on this sha: `uv run --locked pre-commit run --all-files` exit 0;
`uv run --locked pytest` exit 0, 31062 passed, 11 skipped, coverage
100.00%; `uv run --locked --no-default-groups --group docs sphinx-build
-n -W --keep-going` exit 0.

## Summary by Sourcery

Have the release pull request open the next changelog cycle while reserving the later follow-up for the project version bump.

Bug Fixes:
- Update the release process so the release pull request creates the next cycle’s work-in-progress sections in both changelog files, eliminating the window where entries could be recorded under the released version.

Enhancements:
- Keep the project version bump separate from changelog section creation so tag-time version validation continues to identify the version being released.
- Adjust release instructions to source release notes from the section renamed during the release pull request and leave only the version bump for opening the next cycle.

Documentation:
- Document the revised release workflow and its handling of changelog sections, version bumps, and the remaining rebasing limitation.