### PR TITLE
REPOSITORY.md reads back default_branch, environments and allow_auto_merge (closes #1496) (closes #1513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,19 @@ documented at release-notes length in the first place, and are still in
   reads `uv version --short` at tag time, so a bump moved earlier would
   offer it the next cycle's number instead of the one being released.
   The window this closes is the changelog's, not the version's.
+- **`REPOSITORY.md` reads `default_branch`, the environments behind
+  *Publishing*, and `allow_auto_merge` back from GitHub, instead of
+  asserting them in prose with no command beside them** (closes #1496,
+  closes #1513). A renamed default branch, a changed environment set or
+  auto-merge turned off would each have left the file's claim standing
+  with nothing red to say otherwise. The *Publishing* readback also
+  covers `pypi`'s `branch_policy` and names a fourth environment, `CI`,
+  which holds no secret, no variable and no protection rule and which no
+  workflow reads — recorded here as a leftover, deleting it or keeping
+  it for a reason being the maintainer's decision (issue #1516). The
+  `allow_auto_merge` readback is btclib's share of issue
+  btclib-org/.github#566, which the same gap in `portanode` and
+  `bitcoin-core-rpc` keeps open.
 
 ### Documentation and the website
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -270,11 +270,18 @@ waiting for slots is what would change it.
 
 ## Branch protection
 
-`main` is the only branch, and everything reaches it through a pull
-request: the four checks above with `strict`, one approving review,
-`dismiss_stale_reviews`, **required signatures**, linear history, no force
-pushes, no deletions, `required_conversation_resolution`, and
-`enforce_admins` *off* — an administrator can bypass all of it.
+`main` is the repository's default branch and its only one:
+
+```shell
+gh api repos/btclib-org/btclib --jq '.default_branch'
+# main
+```
+
+Everything reaches it through a pull request: the four checks above with
+`strict`, one approving review, `dismiss_stale_reviews`, **required
+signatures**, linear history, no force pushes, no deletions,
+`required_conversation_resolution`, and `enforce_admins` *off* — an
+administrator can bypass all of it.
 
 That last one is what carries the review. CONTRIBUTING.md states why a
 review cannot be satisfied by its author; the consequence here is that on
@@ -382,10 +389,16 @@ a particular signer.
 
 ```shell
 gh api repos/btclib-org/btclib \
-  --jq '{allow_squash_merge, allow_merge_commit, allow_rebase_merge}'
+  --jq '{allow_squash_merge, allow_merge_commit, allow_rebase_merge,
+         allow_auto_merge}'
 ```
 
-answers `true` for the first and `false` for the other two.
+answers `true` for the first and the last, `false` for the middle two.
+`allow_auto_merge` is what makes "auto-merge presses it" above a setting
+this file reads back rather than a fact about a workflow: turned off,
+every landing here would wait for somebody to press *Squash and merge* by
+hand at the moment the last check goes green, and nothing would turn red
+to say so.
 
 **There is no second path**, the section above having the bypass mode
 that closes it and the ruleset entry that names `squash` as the only
@@ -521,6 +534,50 @@ gh api -X PUT repos/btclib-org/btclib/actions/permissions/workflow \
 environments both require a review, and `pypi` is restricted to `v*`
 tags. `RELEASING.md` records the reasoning, including why self-review
 stays allowed.
+
+```shell
+gh api repos/btclib-org/btclib/environments \
+  --jq '.environments[] | {name, protection_rules: [.protection_rules[]?.type]}'
+# {"name":"CI","protection_rules":[]}
+# {"name":"github-pages","protection_rules":["branch_policy"]}
+# {"name":"pypi","protection_rules":["required_reviewers","branch_policy"]}
+# {"name":"testpypi","protection_rules":["required_reviewers"]}
+```
+
+`pypi`'s `branch_policy` is the `v*` tag restriction stated above:
+
+```shell
+gh api repos/btclib-org/btclib/environments/pypi/deployment-branch-policies \
+  --jq '.branch_policies[] | {name, type}'
+# {"name":"v*","type":"tag"}
+```
+
+`testpypi` carries `required_reviewers` with no `branch_policy` beside
+it — the same call against `testpypi` 404s, where it answers for `pypi`
+— so a publish to TestPyPI accepts any branch or tag once approved;
+`release.yml`'s own `workflow_dispatch` trigger is what narrows it
+further. `github-pages` restricts to `main`, the branch Pages already
+serves.
+
+**`CI` is a fourth environment the call above lists, and nothing in this
+repository uses it:**
+
+```shell
+gh api repos/btclib-org/btclib/environments/CI/secrets --jq '.total_count'
+# 0
+gh api repos/btclib-org/btclib/environments/CI/variables --jq '.total_count'
+# 0
+git grep -n 'environment:$' -- .github/workflows/
+# .github/workflows/release.yml:458
+# .github/workflows/release.yml:505
+```
+
+Both matches name `testpypi` and `pypi`, on `publish-testpypi` and
+`publish-pypi` respectively — no workflow declares `environment: CI`. It
+holds no secret and no variable either, so nothing depends on it. That
+makes `CI` a leftover rather than a recorded setting, and whether it is
+deleted or kept for a reason is the maintainer's decision to make
+(issue #1516); this paragraph is the record of what it is until then.
 
 ## Pages, which is btclib.org
 


### PR DESCRIPTION
`REPOSITORY.md` opens by claiming to be the whole of the settings that live
outside the tree. Three of them were asserted in prose with no command
beside them, which section 11 of the organization standard asks for and
which every other section of this file already has.

- `default_branch`, never read back from GitHub, though the file asserts
  several times that `main` is the only branch
- the environments behind *Publishing*, recorded in prose; the endpoint
  answers four names where the prose names two, and `pypi`'s `v*` tag
  `branch_policy` was read back by nothing
- `allow_auto_merge`, which the *Merge methods* section rests on and never
  reads

Each is now a `gh api ... --jq` readback beside the claim it supports, so a
renamed default branch, a changed environment set or auto-merge turned off
is something a reader can catch rather than something that leaves the file
quietly wrong.

## The reserved decision

The fourth environment, `CI`, holds no secret, no variable and no
protection rule, and no workflow names it. This branch **records** it and
does not delete it: removing a GitHub environment is an outward-facing
change and the maintainer's, not a branch's. That is the half of
btclib-org/btclib#1516 a tree edit can answer, so this carries no closing
keyword for it — its *Done when* also wants an affirmative reason for `CI`
to stay, which nothing here supplies.

`allow_auto_merge` is btclib's share of btclib-org/.github#566, which the
same gap in the sibling trees keeps open; cited without a verb so it does
not fire across trackers.

## Verification

Local review re-ran every `gh api` and `git grep` command the diff adds and
compared each answer against the sentence beside it — the point of the
branch being that its claims are re-derivable, that is the check that
matters, and all of them matched. Gates on this sha, run by the author:
`pre-commit run --all-files`, `mypy src/btclib tests .github/scripts`,
`pytest` (31074 passed, 100.00% coverage) and
`sphinx-build -n -W --keep-going`, each exit 0.

Closes #1496
Closes #1513

## Summary by Sourcery

Make REPOSITORY.md verify its repository settings directly against GitHub and record the complete environment configuration.

Enhancements:
- Add GitHub API readbacks to REPOSITORY.md for the default branch, merge methods including auto-merge, and repository environments and their deployment policies.
- Document the unused CI environment and defer its removal or retention to maintainer decision.

Documentation:
- Make repository settings claims re-derivable by readers through commands and document the complete environment configuration, including pypi tag restrictions and TestPyPI behavior.