### PR TITLE
__init__.py drops __author__, __author_email__ and __license__ (closes #1507)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,22 @@ documented at release-notes length in the first place, and are still in
   Actions tab lists. The sentence was already open in this diff, which
   is why it is repaired here rather than filed.
 
+### The public API and the module layout
+
+- **`btclib.__author__`, `__author_email__` and `__license__` are gone**
+  (closes #1507). Each duplicated a fact `pyproject.toml` already
+  states — its `authors` table's `name` and `email`, and its `license`
+  SPDX expression — and nothing in the tree read the copy kept here;
+  `__license__`'s own copy, `"MIT License"`, was not even a valid SPDX
+  expression, `pyproject.toml`'s `"MIT"` being the identifier and
+  `"MIT License"` the full name PEP 639 reserves for a different field.
+  `__version__` and `__copyright__` stay: other files in this tree
+  already read the first, and the second carries a year range with no
+  second copy anywhere to read instead.
+  `tests/copyright_test.py` now asserts the three stay absent, the same
+  file `LICENSE`/`__copyright__`'s own drift (issue #389) already
+  earned a test.
+
 ## v2026.8.29
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,21 @@ full year, short month, short day (YYYY-M-D)
 
 ## v2026.9 (work in progress, not released yet)
 
+### Breaking changes
+
+- **`btclib.__author__`, `btclib.__author_email__` and `btclib.__license__`
+  no longer exist** (closes #1507). Each duplicated a fact
+  `pyproject.toml` already states.
+
+  Act on it if you read any of the three: `btclib.__author__` and
+  `btclib.__author_email__`'s replacement is
+  `importlib.metadata.metadata("btclib")["Author-email"]`, which carries
+  both as one `"name <email>"` string; `btclib.__license__`'s is
+  `importlib.metadata.metadata("btclib")["License-Expression"]`, which
+  answers `"MIT"` rather than `btclib.__license__`'s former
+  `"MIT License"`. `btclib.__version__` and `btclib.__copyright__` are
+  unaffected.
+
 ## v2026.8.29
 
 ### Worth knowing, though nothing raises

--- a/src/btclib/__init__.py
+++ b/src/btclib/__init__.py
@@ -62,8 +62,6 @@ except PackageNotFoundError:
     # this package supports 3.10, and the file is not in the wheel anyway.
     # Importing has to keep working, so the version says it does not know
     __version__ = "unknown"
-__author__ = "The btclib developers"
-__author_email__ = "devs@btclib.org"
 # the one place the years are written. The notice at the head of every
 # source file carries none, by design: it comes from the COPYRIGHT file,
 # which ruff's CPY001 (flake8-copyright) enforces, so it never needs
@@ -71,7 +69,14 @@ __author_email__ = "devs@btclib.org"
 # docs/source/conf.py reads this line rather than importing it, read the
 # docs not installing this package into the environment it builds in
 __copyright__ = "Copyright (c) 2017-2026 The btclib developers"
-__license__ = "MIT License"
+# no __author__, __author_email__ or __license__: pyproject.toml's
+# `authors` table and `license` field already state each of the three,
+# and nothing in this tree ever read the copy kept here (issue #1507).
+# A caller after any of them reads the installed distribution's own
+# metadata, which is the standard way and does not drift from
+# pyproject.toml the way a second hand-typed literal can:
+# `importlib.metadata.metadata("btclib")["Author-email"]` and
+# `["License-Expression"]`.
 
 __all__ = [
     "alias",

--- a/tests/copyright_test.py
+++ b/tests/copyright_test.py
@@ -26,6 +26,18 @@ reason `release.yml` gives for reaching for it only from a `python -` a
 workflow can pin to a newer interpreter, which a module in this package
 cannot. Once 3.10 is dropped, `_pyproject_author` can read the file the
 way `release.yml` already does.
+
+Issue #1507: `btclib.__author__`, `__author_email__` and `__license__`
+each duplicated `pyproject.toml`'s `authors` table or `license` field
+with nothing reading either copy, `__license__`'s own copy
+("MIT License") not even a valid spelling of the SPDX expression
+("MIT") it was a copy of. Unlike the holder above, each of the three has
+exactly one other place stating the same fact, so there is nothing here
+for a package-level literal to add: a caller after any of them reads the
+installed distribution's own metadata instead, which cannot drift from
+`pyproject.toml` the way a second literal can. So the three are gone
+rather than added to the triangle, and the test below is what keeps
+them from being silently redeclared.
 """
 
 import re
@@ -82,3 +94,20 @@ def test_license_holder_matches_the_declared_author() -> None:
         f"{author!r}. A wheel built from one and read from the other "
         "would disagree about who holds the copyright"
     )
+
+
+def test_no_duplicate_author_or_license_dunders() -> None:
+    """`__author__`, `__author_email__` and `__license__` stay gone.
+
+    Each duplicated a fact `pyproject.toml` already states -- its
+    `authors` table or its `license` field -- and nothing read the copy
+    kept here (issue #1507). Re-adding one reopens exactly the drift this
+    file exists to catch for the copyright holder, this time with no test
+    watching it.
+    """
+    for dunder in ("__author__", "__author_email__", "__license__"):
+        assert not hasattr(btclib, dunder), (
+            f"btclib.{dunder} exists again; pyproject.toml already states "
+            "the fact it would duplicate, and nothing in the tree reads it "
+            "(issue #1507)"
+        )


### PR DESCRIPTION
`src/btclib/__init__.py` declared five dunders. Two are read back and
compared by tests; three were read by nothing, and each restated a fact
`pyproject.toml` already fixes.

`__author__` and `__author_email__` duplicated the `authors` table's
`name` and `email`. `__license__` duplicated `license`, and did so in a
spelling PEP 639 does not accept: `MIT` is the SPDX identifier, `MIT
License` the full name reserved for a different field — so the copy was
the one that would have failed the grammar the original is written in.

## Delete rather than compare

ISS 1507 allowed either, "whichever `pyproject.toml` being the authority
makes true". Deletion was chosen because nothing read the three, and
because `importlib.metadata` already answers both facts at runtime —
verified, not assumed: `metadata("btclib")["Author-email"]` returns
`The btclib developers <devs@btclib.org>` and `["License-Expression"]`
returns `MIT`. The deletion is therefore lossless rather than merely
tidy, which is what makes it preferable to keeping three uncompared
copies forever.

Comparing instead would have cost a test extending
`tests/copyright_test.py`'s triangle, a regex for `authors[].email`, and
fixing `__license__`'s literal before it could be compared at all — no
breaking change, but three duplicate declarations kept for values
nothing reads.

`__version__` and `__copyright__` stay: other files read the first, and
the second carries a year range with no other copy to read instead.
`tests/copyright_test.py` now asserts the three stay absent.

## Source-breaking

`btclib.__author__`, `btclib.__author_email__` and `btclib.__license__`
are gone. `RELEASE_NOTES.md` carries the bullet under *Breaking
changes*, naming the `importlib.metadata` calls that replace them; the
"before" spellings are checked against the `v2023.7.12` tag, where the
package still sat outside `src/`.

## Verification

Rebased onto `1b53f83e`; `git range-diff` reports the patch identical
(`=`), and the branch's own added and removed lines hash equal at both
shas, so only the base moved and the local review's clearance stands.
`CHANGELOG.md` was reconstructed and compared byte for byte against the
new base with the block spliced at its own anchor — identical, with a
tampered control proving the comparison is not blind.

Gates re-run on the rebased sha: `mypy` exit 0, `pytest` exit 0 (31075
passed, 11 skipped, coverage 100.00%), `pre-commit run --all-files` exit
0, `sphinx-build -n -W --keep-going` exit 0. Load average 7.64 at the
suite run.

Closes #1507

## Summary by Sourcery

Remove duplicate author and license metadata from the public module namespace and rely on the package metadata as the single source of truth.

Enhancements:
- Remove the redundant `btclib.__author__`, `__author_email__`, and `__license__` module attributes, using installed package metadata as the source for this information.

Documentation:
- Document the removal of the three public module attributes and provide `importlib.metadata` replacements.

Tests:
- Add regression coverage ensuring the removed author and license attributes are not reintroduced.