### PR TITLE
tests/wait_for_hwi_device_test.py drives the deadline path, and source-exclude gains it and normalize_sdist_test.py (closes #1477) (closes #1509)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,23 @@ documented at release-notes length in the first place, and are still in
   renamed the file to `pypi-install.yml`.** Both now name what the
   Actions tab lists. The sentence was already open in this diff, which
   is why it is repaired here rather than filed.
+- **`.github/scripts/wait_for_hwi_device.py` has a test** (closes #1477),
+  `tests/wait_for_hwi_device_test.py`, substituting `enumerate_devices`
+  and `time` the way `tests/wait_for_pypi_release_test.py` does for its
+  own deadline. The path it drives is the one `integration-hwi.yml`'s
+  weekly run exercises only when an emulator genuinely fails to come up:
+  a `SignerError` from HWI, an enumerate answering a device that is not
+  usable, and the `::error::` line naming what was last seen once the
+  deadline passes.
+- **`[tool.uv.build-backend] source-exclude` now excludes
+  `/tests/normalize_sdist_test.py` and the new
+  `/tests/wait_for_hwi_device_test.py`** (closes #1509), both loading a
+  path under `.github/scripts` that an unpacked sdist does not carry, the
+  same shape the array already excludes other tests for.
+  `tests/build_system_test.py` gained a test that walks every
+  `tests/*.py` for that shape and asserts it is in the list, so a future
+  test built the same way is caught rather than only named after the
+  fact.
 
 ### The public API and the module layout
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,12 +272,16 @@ source-exclude = [
     # .github/scripts holds is not shipped, so each of these loads a
     # path that is not there -- a fixture error rather than a test.
     # Anchored, because a name this specific matching at some other
-    # depth would be an accident rather than a decision
+    # depth would be an accident rather than a decision.
+    # tests/build_system_test.py checks that every test reaching
+    # .github/scripts or fuzz/ this way is named here
     "/tests/check_py_arm_authority_test.py",
     "/tests/check_vendored_vectors_test.py",
     "/tests/generate_sbom_test.py",
     "/tests/mutation_counts_test.py",
+    "/tests/normalize_sdist_test.py",
     "/tests/verify_dist_contents_test.py",
+    "/tests/wait_for_hwi_device_test.py",
     "/tests/wait_for_pypi_release_test.py",
     # the same reasoning, for fuzz/ rather than .github/scripts: git-only
     # below is why it is not in the sdist, and this test reads

--- a/tests/build_system_test.py
+++ b/tests/build_system_test.py
@@ -39,6 +39,7 @@ key, and a second build requirement is what has to be seen.
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -132,3 +133,60 @@ def test_the_bindings_extra_and_group_ask_for_the_same_thing() -> None:
     assert extra == group, f"the extra asks {extra}, the group asks {group}"
     assert len(extra) == 1, f"the extra names more than the bindings: {extra}"
     assert extra[0].startswith("btclib-secp256k1"), extra[0]
+
+
+# `[tool.uv.build-backend] source-exclude` carries its own reasoning in
+# pyproject.toml for why a test loading `.github/scripts` or `fuzz/` off
+# disk belongs in it: each such test is unrunnable from an unpacked
+# sdist, neither directory being shipped. What no comment there can show
+# is that the list still names every test with that shape -- ISS 1509
+# found one it did not, and nothing failed
+_SOURCE_EXCLUDE = re.compile(
+    r"^source-exclude\s*=\s*\[(.*?)^\]", re.MULTILINE | re.DOTALL
+)
+_TESTS = Path(__file__).parent
+
+
+def _source_exclude() -> list[str]:
+    """Return `[tool.uv.build-backend] source-exclude`'s own entries."""
+    text = _PYPROJECT.read_text(encoding="utf-8")
+    match = _SOURCE_EXCLUDE.search(text)
+    assert match, "no source-exclude array in pyproject.toml"
+    return _QUOTED.findall(match.group(1))
+
+
+def _reaches_outside_the_sdist(tree: ast.Module) -> bool:
+    """Whether a module builds a path through a `.github` or a `fuzz` segment.
+
+    The convention this looks for is `Path(__file__).parents[1] /
+    ".github" / "scripts" / "<name>.py"` and `Path(__file__).parent.parent
+    / "fuzz"` -- a `/` join with one side the literal directory name --
+    walked rather than matched on the formatted text, so a reflow of the
+    expression across lines is still seen.
+    """
+    return any(
+        isinstance(node, ast.BinOp)
+        and isinstance(node.op, ast.Div)
+        and isinstance(node.right, ast.Constant)
+        and node.right.value in (".github", "fuzz")
+        for node in ast.walk(tree)
+    )
+
+
+def test_every_test_reaching_outside_the_sdist_is_source_excluded() -> None:
+    """A `tests/*.py` built on `.github/scripts` or `fuzz/` is in the list.
+
+    Not the other direction: `source-exclude` also names entries no test
+    file could match -- `docs/build`, the linter caches -- so only this
+    direction closes what ISS 1509 found open.
+    """
+    excluded = set(_source_exclude())
+    missing = [
+        f"/tests/{path.name}"
+        for path in sorted(_TESTS.glob("*.py"))
+        if _reaches_outside_the_sdist(
+            ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        )
+        and f"/tests/{path.name}" not in excluded
+    ]
+    assert not missing, f"reaches outside the sdist, not in source-exclude: {missing}"

--- a/tests/wait_for_hwi_device_test.py
+++ b/tests/wait_for_hwi_device_test.py
@@ -1,0 +1,263 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the device wait of `.github/scripts`.
+
+What `integration-hwi.yml` shows every Wednesday is the branch that finds
+a device: the emulator comes up, `enumerate_devices` answers one usable
+entry, and the wait returns before its deadline is ever read. What that
+run cannot show is the other branch, because arranging for the emulator
+never to come up is not a rehearsal anybody schedules -- so the deadline,
+the `::error::` it prints and everything that only a failure reaches are
+tested here or nowhere, the run that would exercise them being the one
+that also means the workflow failed.
+
+`enumerate_devices` is substituted by a scripted sequence of answers,
+each either a list of devices or a `SignerError` to raise, and `time` by
+a clock that only moves when the script sleeps on it -- the same shape
+`wait_for_pypi_release_test.py` uses for its own deadline, and for the
+same reason: a regression that falls through to a real `time.sleep`
+turns into an immediate failure here instead of a suite that sits for
+whichever timeout was passed.
+
+The script is loaded by path, `.github/scripts` being no package, as the
+other scripts under it are tested. It defines no dataclass of its own --
+`HwiDevice` is `btclib.hwi`'s -- so registering the module in
+`sys.modules` before `exec_module` is not needed here, as
+`verify_dist_contents_test.py` says for the same reason.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from btclib.exceptions import SignerError
+from btclib.hwi import HwiDevice
+
+_SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "wait_for_hwi_device.py"
+
+
+class _Clock:
+    """A monotonic clock that stands still until the script sleeps on it."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.slept: list[float] = []
+
+    def monotonic(self) -> float:
+        """Return the reading, which only `sleep` below moves."""
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        """Spend the seconds a wait on a real clock would have spent."""
+        self.slept.append(seconds)
+        self.now += seconds
+
+
+class _Enumerator:
+    """The answers `enumerate_devices` gives, in order, and what it saw."""
+
+    def __init__(self, answers: list[list[HwiDevice] | SignerError]) -> None:
+        self.answers = answers
+        self.asked: list[tuple[list[str], str]] = []
+
+    def __call__(self, *, executable: list[str], network: str) -> list[HwiDevice]:
+        """Answer the next scripted verdict, and record the question."""
+        self.asked.append((executable, network))
+        answer = self.answers.pop(0) if self.answers else []
+        if isinstance(answer, SignerError):
+            raise answer
+        return answer
+
+
+@pytest.fixture
+def script() -> ModuleType:
+    """Return the script, imported by path."""
+    spec = importlib.util.spec_from_file_location("wait_for_hwi_device", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def clock(script: ModuleType, monkeypatch: pytest.MonkeyPatch) -> _Clock:
+    """Put a clock this test moves where the script reads a real one."""
+    fake = _Clock()
+    monkeypatch.setattr(script, "time", fake)
+    return fake
+
+
+def _enumerate(
+    script: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    answers: list[list[HwiDevice] | SignerError],
+) -> _Enumerator:
+    """Put a scripted sequence of answers where `enumerate_devices` would be."""
+    enumerator = _Enumerator(answers)
+    monkeypatch.setattr(script, "enumerate_devices", enumerator)
+    return enumerator
+
+
+def test_describe_names_no_devices_for_an_empty_answer(script: ModuleType) -> None:
+    """An enumerate that saw nothing is reported as exactly that."""
+    assert script.describe([]) == "no devices"
+
+
+def test_describe_names_the_fingerprint_of_a_usable_device(
+    script: ModuleType,
+) -> None:
+    """A device with no error and a fingerprint is named by the fingerprint."""
+    device = HwiDevice(
+        type="trezor", model="1", path="0001:0002", fingerprint=b"\x01\x02\x03\x04"
+    )
+
+    assert script.describe([device]) == "trezor (01020304)"
+
+
+def test_describe_names_the_error_of_a_device_that_answered_one(
+    script: ModuleType,
+) -> None:
+    """A device HWI could not talk to is named by its error, not `_named`."""
+    device = HwiDevice(type="ledger", model="nano", path="0001:0002", error="locked")
+
+    assert script.describe([device]) == "ledger (locked)"
+
+
+def test_describe_names_a_device_with_neither_error_nor_fingerprint(
+    script: ModuleType,
+) -> None:
+    """`_named` falls back to saying so, for a device asked for one too soon."""
+    device = HwiDevice(type="trezor", model="1", path="0001:0002")
+
+    assert script.describe([device]) == "trezor (no fingerprint)"
+
+
+def test_wait_returns_as_soon_as_one_usable_device_is_seen(
+    script: ModuleType, clock: _Clock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The success path: one usable device ends the wait before the deadline."""
+    usable = HwiDevice(
+        type="trezor", model="1", path="0001:0002", fingerprint=b"\x01\x02\x03\x04"
+    )
+    enumerator = _enumerate(script, monkeypatch, [[usable]])
+
+    assert script.wait(["hwi"], "mainnet", 90.0) == 0
+
+    assert enumerator.asked == [(["hwi"], "mainnet")]
+    assert clock.slept == []
+
+
+def test_wait_past_its_deadline_names_the_last_thing_seen(
+    script: ModuleType,
+    clock: _Clock,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A device that never becomes usable is what the `::error::` line names.
+
+    Every scripted answer here is a device that answered no fingerprint and
+    no error -- neither usable nor a `SignerError` -- so the loop sleeps on
+    the fake clock until it, rather than an unrelated `StopIteration`, is
+    what ends the test.
+    """
+    unusable = HwiDevice(type="trezor", model="1", path="0001:0002")
+    enumerator = _enumerate(script, monkeypatch, [[unusable]] * 400)
+
+    assert script.wait(["hwi"], "mainnet", 5.0) == 1
+
+    assert clock.now >= 5.0
+    assert enumerator.asked
+    reported = capsys.readouterr().out
+    assert "::error::no usable device within 5 s: trezor (no fingerprint)" in reported
+
+
+def test_wait_treats_a_signer_error_as_nothing_seen_yet(
+    script: ModuleType,
+    clock: _Clock,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """HWI failing to run or to answer json is retried, not raised.
+
+    The scripted answers raise `SignerError` throughout, so the deadline is
+    what ends the wait, and the message the `::error::` line names is the
+    exception's own text -- not `describe`'s, which never runs because no
+    answer reaches the `else` branch.
+    """
+    enumerator = _enumerate(
+        script, monkeypatch, [SignerError("hwi: command not found")] * 400
+    )
+
+    assert script.wait(["hwi"], "mainnet", 5.0) == 1
+
+    assert clock.now >= 5.0
+    assert enumerator.asked
+    reported = capsys.readouterr().out
+    assert "::error::no usable device within 5 s: hwi: command not found" in reported
+
+
+def test_wait_keeps_going_past_two_or_more_usable_devices(
+    script: ModuleType, clock: _Clock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two usable devices at once is not the one this waits for.
+
+    `HwiSigner`'s own `_select` is what refuses an ambiguous enumerate;
+    this loop is not that check, and correctly is not -- it only asks
+    whether the run has *something* to hand to it, so it keeps polling
+    past two exactly as it does past zero, until one of the two is
+    unplugged or the deadline is reached.
+    """
+    both_usable = [
+        HwiDevice(
+            type="trezor", model="1", path="0001:0002", fingerprint=b"\x01\x02\x03\x04"
+        ),
+        HwiDevice(
+            type="trezor", model="1", path="0001:0003", fingerprint=b"\x05\x06\x07\x08"
+        ),
+    ]
+    _enumerate(script, monkeypatch, [both_usable] * 400)
+
+    assert script.wait(["hwi"], "mainnet", 5.0) == 1
+
+    assert clock.now >= 5.0
+
+
+def test_main_refuses_to_run_with_no_hwi_named(
+    script: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`BTCLIB_HWI` unset is a failure named before any enumerate is tried."""
+    monkeypatch.delenv("BTCLIB_HWI", raising=False)
+    monkeypatch.setattr("sys.argv", ["prog"])
+
+    assert script.main() == 1
+    assert (
+        "::error::BTCLIB_HWI names the hwi to run, and is unset"
+        in capsys.readouterr().out
+    )
+
+
+def test_main_splits_btclib_hwi_on_spaces_and_waits(
+    script: ModuleType,
+    clock: _Clock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`--emulators` and the rest of `BTCLIB_HWI` reach `wait` as one argv."""
+    usable = HwiDevice(
+        type="trezor", model="1", path="0001:0002", fingerprint=b"\x01\x02\x03\x04"
+    )
+    enumerator = _enumerate(script, monkeypatch, [[usable]])
+    monkeypatch.setenv("BTCLIB_HWI", "hwi --emulators")
+    monkeypatch.setattr("sys.argv", ["prog", "--network", "testnet"])
+
+    assert script.main() == 0
+
+    assert enumerator.asked == [(["hwi", "--emulators"], "testnet")]


### PR DESCRIPTION
`.github/scripts/wait_for_hwi_device.py` was the one script under that
directory with no test beside it, and the path it exists for is the one
nothing runs: `wait()` returns 0 as soon as a usable device answers, so
`integration-hwi.yml`'s weekly run exercises the success branch every
Wednesday and the deadline branch never — the branch whose `::error::`
line is the only thing anybody reads when an emulator genuinely fails to
come up, executed for the first time on the run that matters.

`tests/wait_for_hwi_device_test.py` loads the script by path as the
sibling script tests do, and substitutes `enumerate_devices` and `time`
the way `tests/wait_for_pypi_release_test.py` does for its own deadline.
It drives the deadline path and asserts the `::error::` line names what
was last seen, the `SignerError` branch, an enumerate answering a device
that is not usable, and `main()` with `BTCLIB_HWI` unset.

## Why the two issues are one branch

Writing that test creates a third instance of exactly the defect ISS 1509
names: a test loading a path under `.github/scripts`, which an unpacked
sdist does not carry, absent from `[tool.uv.build-backend]
source-exclude` — so it would be a fixture error rather than a test for
anybody running the suite from an sdist. Both `/tests/normalize_sdist_test.py`
(ISS 1509's own finding) and the new `/tests/wait_for_hwi_device_test.py`
join the array.

`tests/build_system_test.py` gains the gate that would have caught both.
It walks every `tests/*.py` for the AST shape that reaches outside the
sdist and asserts the file is named in `source-exclude`, so the next test
built that way is caught rather than named after the fact. Its scope is
the idiom this tree actually uses, and its docstring says so: a test
spelling the path with `os.path.join` or a literal would still slip past,
which local review measured and judged acceptable rather than left
implied.

## A claim this branch does not make

The coverage floor did not ask for these tests. `[tool.coverage.run]
source` names `btclib` and `tests`, so `.github/scripts` is outside what
the ratchet measures at all — deleting the new file and running the whole
suite leaves `Miss` at 0 and coverage at 100.00%, with only the statement
count moving. The tests exist because the deadline path is untested, not
because a gate demanded them.

## Verification

Rebased onto `a8fc8ee3`. `git range-diff` reports `!` for the single
commit, and that difference is the union driver's own: the branch's added
and removed lines with `CHANGELOG.md` excluded hash equal at both shas
(256 lines each side, neither empty), so no content moved and the local
review's clearance stands. `CHANGELOG.md` was reconstructed against the
new base with the block spliced at its own anchor and compared byte for
byte — identical, with a tampered control proving the comparison is not
blind.

Gates re-run on the rebased sha, from inside the worktree with
`btclib.__file__` asserted to resolve there: `mypy` exit 0 (314 source
files), `pytest` exit 0 — 31086 passed, 11 skipped, coverage 100.00% —
`pre-commit run --all-files` exit 0, `sphinx-build -n -W --keep-going`
exit 0.

Closes #1477
Closes #1509

## Summary by Sourcery

Test the HWI wait failure paths and enforce source-distribution exclusions for tests that depend on repository-only files.

Enhancements:
- Add comprehensive tests for the HWI device wait script, including deadline handling, signer failures, unusable or ambiguous devices, error reporting, and environment-driven command execution.
- Add an AST-based build-system check ensuring tests that load files outside the source distribution are listed in `source-exclude`.

Build:
- Exclude the new HWI wait test and normalize-sdist test from source distributions because they depend on files not included in the sdist.

Tests:
- Cover the HWI wait script's success, timeout, retry, device-description, and `main()` behavior.