### PR TITLE
The wall-clock figures ISS 1494's pattern does not reach carry the relation too (closes #1505) (closes #1506) (closes #1508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,24 @@ documented at release-notes length in the first place, and are still in
   whose unit is spelled out — which escape all three patterns, that
   command's included — are issue #1508.
 
+- **The wall-clock figures #1494's own pattern does not reach now carry
+  the relation too** (closes #1505) (closes #1506) (closes #1508).
+  `grep -rnE '[0-9]+ (ns|us)\b' src/btclib` is silent on a millisecond, a
+  second, a copy of a `src/btclib` figure restated in `tests/` or
+  `SECURITY.md`, and a figure whose unit is written as a word — three
+  more shapes the same rule reaches. `git grep -nP` (not `-E`, whose
+  `\b` this git drops without an error) answers nothing for all three
+  patterns now, over `src/btclib`, `tests` and `SECURITY.md`.
+
+  `base58.py`'s `MAX_LENGTH` comment loses every one of its numbers: the
+  same paragraph already states the quadratic's shape and the chunking's
+  benefit in words, so the figures were the redundant half rather than
+  the reason. `ecc/ssa.py:532` argued for dropping a figure of
+  libsecp256k1's own and then kept it anyway; the contradiction is gone
+  along with the number. `ecc/ssa.py:837` keeps the two percentages that
+  already carry its argument and drops the two absolute figures beside
+  them.
+
 ### Packaging, linting and CI
 
 - **`pypi-install.yml` waits for the index through a script with a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -231,8 +231,8 @@ used to teach and to prototype as much as to build:
     the library where a secret is inverted at all: `mod_inv`
     draws a random factor, so that the extended Euclid's iteration count
     follows the factor rather than the nonce. Unblinded it followed the
-    nonce's bit-length — 8.8 us for a 256-bit scalar against 4.3 for a
-    128-bit one on secp256k1's order — which is the correlation the
+    nonce's bit-length — roughly twice the cost for a 256-bit scalar as
+    for a 128-bit one on secp256k1's order — which is the correlation the
     Minerva attack turns into the private key.
     `bms.sign` is delegated outright, `recovery.sign` signing and naming
     the recovery flag in one call: message signing is defined for

--- a/src/btclib/base58.py
+++ b/src/btclib/base58.py
@@ -80,13 +80,11 @@ _CHUNK_BASE = __BASE**_CHUNK
 # key: 78 bytes of payload plus 4 of checksum, which base58 writes in at
 # most 112 characters (an address takes 35, a WIF 52). The cap is what
 # keeps the quadratic accumulation of _b58decode_to_int away from
-# attacker-supplied text: measured 2.2 ms at 10k characters, 32 ms at
-# 40k and 510 ms at 160k, four times the cost per doubling of the input,
-# and the checksum that would reject it is verified only once the
-# decoding has been paid for. A sixth of what those three cost before
-# the chunking below -- 12.8 ms, 197 ms and 3193 ms -- which is a
-# smaller coefficient and the same curve, so the cap answers the same
-# argument it always did.
+# attacker-supplied text: doubling the input's length quadruples the
+# decode cost, and the checksum that would reject it is verified only
+# once the decoding has been paid for. Chunking below cuts that cost to
+# a sixth, a smaller coefficient on the same curve, so the cap answers
+# the same argument it always did.
 # The encoder is deliberately left uncapped, being quadratic too: what
 # it is handed is data the caller already holds, not a string that
 # arrived from the network.

--- a/src/btclib/curves/curve.py
+++ b/src/btclib/curves/curve.py
@@ -118,7 +118,7 @@ def _assert_mov_resistant(p: int, n: int) -> None:
     extension field where it is easy, and nothing downstream would notice.
 
     Its 99 modular exponentiations are the second cost of building a
-    curve, once nG is gated: 5.2 ms of the 9.7 ms the catalogue would
+    curve, once nG is gated: more than half of what the catalogue would
     spend at import time, which is why the catalogue passes
     weakness_check=False and test_catalogued_curves runs it instead.
 
@@ -243,7 +243,7 @@ class Curve(CurveGroup):
         # n*G is by far the most expensive check here -- a Python
         # double-and-add over nlen bits -- and it dominates the cost of
         # building a curve: at import time the 27 catalogued curves would
-        # spend ~118 ms of ~168 ms on it, against ~2 ms for the
+        # spend most of it on n*G alone, and next to none of it on the
         # primality of n. The catalogue therefore passes
         # order_check=False, as it does weakness_check=False below: its
         # parameters are constants, and test_catalogued_curves rebuilds
@@ -375,8 +375,9 @@ def _catalogued_curve(params: list[Any], name: str) -> Curve:
     apart. Both expensive checks are off: these parameters are the
     standardized constants of SEC 2, FIPS 186-4 and RFC 5639, and
     re-deriving from them at every interpreter start that n is the order
-    of G, and that the curve is not MOV-weak, would cost 118 ms and 5 ms
-    of a ~168 ms module import. What is verified once, by
+    of G, and that the curve is not MOV-weak, would cost most of a
+    module import, order_check the large majority of that and
+    weakness_check a small remainder. What is verified once, by
     test_catalogued_curves rebuilding each curve from the same json data
     with both checks on, does not have to be verified again on the way to
     every signature.
@@ -842,12 +843,13 @@ def _mult_checked(m: int, Q: Point | None, ec: Curve, *, prepared: bool) -> Poin
     # -- a zero scalar, or infinity -- and, with the dispatch
     # above switched off, every multiplication of the curve: that is the
     # reference implementation the test suite holds the bindings against,
-    # and the GLV endomorphism is its fastest form, 0.59 ms against the
-    # 0.82 of _mult, the decomposition being secp256k1's own lambda and
-    # beta. Both are regular: the number of point additions either makes
-    # is the same for every scalar, which is what a private key or a nonce
-    # arriving here needs and what issue 254 is about -- the endomorphism
-    # over interleaved wNAFs would be 0.51 ms and 51 to 64 additions.
+    # and the GLV endomorphism is its fastest form, a little over a
+    # quarter cheaper than _mult's plain double-and-add, the decomposition
+    # being secp256k1's own lambda and beta. Both are regular: the number
+    # of point additions either makes is the same for every scalar, which
+    # is what a private key or a nonce arriving here needs and what issue
+    # 254 is about -- the endomorphism over interleaved wNAFs would cost
+    # a little less again, with 51 to 64 additions.
     # Not spelled as _libsecp256k1_serves, though it is the same
     # test today: what decides here is whether the curve has that
     # endomorphism, so switching the bindings off must leave this arm --

--- a/src/btclib/curves/curve_group.py
+++ b/src/btclib/curves/curve_group.py
@@ -1115,8 +1115,8 @@ def _cached_fixed_base_multiples(
     `curve.PreparedPoint` that the point will come back. What it costs
     to keep is
     2^w points a position -- on secp256k1 at the w=6 `curve.py` passes,
-    43 positions of 64 points, some 366 KiB and 9.3 ms to build, which is
-    the trade `_mult_fixed_base` measures.
+    43 positions of 64 points, some 366 KiB and a build to pay for, which
+    is the trade `_mult_fixed_base` measures.
     """
     tables: list[list[Point]] = []
     K = Q
@@ -1348,16 +1348,17 @@ def _mult_regular_window(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoin
     doublings for the fixed window, and 71 and 253 for this one on every
     one of them.
 
-    Uniformity for free, in other words -- 0.815 ms against 0.812 over 30
-    random 256-bit scalars, best of five -- which is what makes this the
-    `_mult` the package reaches for rather than an option beside it. The
-    fixed window stays as what it is didactically, the plain one, and the
-    wNAF multiplications stay the fast irregular ones for coefficients
-    that are public: `_double_mult_w_NAF_var` is what verification runs.
+    Uniformity for free, in other words -- indistinguishable in cost from
+    the fixed window over 30 random 256-bit scalars, best of five -- which
+    is what makes this the `_mult` the package reaches for rather than an
+    option beside it. The fixed window stays as what it is didactically,
+    the plain one, and the wNAF multiplications stay the fast irregular
+    ones for coefficients that are public: `_double_mult_w_NAF_var` is
+    what verification runs.
 
-    w=4 by measurement, as for the fixed window: 0.803 ms at w=5 and 0.831
-    at w=6, the window paying for a table twice the size of the NAF's at
-    the same width.
+    w=4 by measurement, as for the fixed window: w=5 and w=6 land within
+    a couple of percent either side of it, which buys nothing against a
+    table twice the size of the NAF's at the same width.
 
     Two things follow for the group law underneath. The accumulator starts
     at a table entry instead of at infinity and no digit names infinity, so
@@ -1699,9 +1700,10 @@ def _multi_mult_bos_coster_var(
     Bos-Coster is usually written with the q == 1 case of that identity,
     n1*P1 + n2*P2 = (n1-n2)*P1 + n2*(P1+P2), which is Euclid by repeated
     subtraction: n1/n2 steps to do what one divmod does (issue 175) --
-    multi_mult_var([10**6, 1], [G, H]) would take 10.6 s, and both
-    multi_mult_var([n-1, 1], [G, H]) and multi_mult_var([-1, 1], [G, H]) would
-    never finish, on scalars a caller has every right to pass. The whole
+    multi_mult_var([10**6, 1], [G, H]) would take on the order of a
+    million steps of Euclid, and both multi_mult_var([n-1, 1], [G, H])
+    and multi_mult_var([-1, 1], [G, H]) would never finish, on scalars a
+    caller has every right to pass. The whole
     of Euclid is what makes this a live path rather than a reading
     exercise: _multi_mult_var calls it above its threshold.
 

--- a/src/btclib/curves/curve_group_2.py
+++ b/src/btclib/curves/curve_group_2.py
@@ -286,12 +286,13 @@ def _double_mult_w_NAF_var(
     public key recovery all reach it through `curve`'s
     _double_mult_python, which sends secp256k1 to
     _double_mult_endomorphism_secp256k1_var instead -- four half-length
-    coefficients where this takes two full-length ones, and 0.81 ms where
-    this is 1.02. Measured over random 256-bit coefficients, best of
-    seven: 1.03 ms against the 1.53 ms of curve_group's _double_mult_var,
+    coefficients where this takes two full-length ones, and costs a fifth
+    less doing it. Measured over random 256-bit coefficients, best of
+    seven, this costs a third less than curve_group's _double_mult_var,
     which stays as the reference the tests compare this against. w=5
-    measures 0.99 ms and w=3 1.10, so the w=4 `curve.py` passes is within
-    4% of the best window and its table is half the size of w=5's.
+    costs a little less again and w=3 a little more, so the w=4
+    `curve.py` passes is within 4% of the best window and its table is
+    half the size of w=5's.
 
     The gap over _double_mult_var is the wider since add_jac stopped
     shortcutting infinity: fewer additions is worth the more when an
@@ -355,7 +356,7 @@ def _double_mult_regular_window(
     scalar_len -- 143 additions and 254 doublings on secp256k1, over 200
     random pairs -- where _double_mult_w_NAF_var's is the recoded weight of the
     two coefficients and is 101 to 116 additions over the same pairs, and
-    0.996 ms against 1.11.
+    this function costs about a tenth less overall.
 
     Which is _mult_regular_window's trade, twice: a table of 2^(w-1) points
     per coefficient, and their opposites, to make one addition per window
@@ -518,8 +519,8 @@ def _mult_endomorphism_secp256k1(
     below is algorithm 3.77 as it is written, and what it costs to be
     regular is measured there.
 
-    w=4 by measurement: the regular windows give 0.589 ms at w=4 and
-    0.610 at w=5, over 30 random 256-bit scalars, best of five.
+    w=4 by measurement: the regular windows cost a little less at w=4
+    than at w=5, over 30 random 256-bit scalars, best of five.
     """
     if m < 0:
         raise BTClibValueError(f"negative m: {hex(m)}")
@@ -535,20 +536,20 @@ def _mult_endomorphism_secp256k1_var(
 
     The same decomposition as `_mult_endomorphism_secp256k1`, over
     `_double_mult_w_NAF_var` rather than the regular windows, and the
-    faster of the two: 0.509 ms against 0.589, over 30 random 256-bit
-    scalars, best of five, at w=4. What the 16% buys is 51 to 64 additions
-    and 124 to 131 doublings over 200 random scalars, where the regular
-    windows make 79 and 126 for every one of them -- a quarter more work
-    for the worst scalar than for the best, and which it is is a property
-    of the scalar.
+    faster of the two, by 16%, over 30 random 256-bit scalars, best of
+    five, at w=4. What that 16% buys is 51 to 64 additions and 124 to 131
+    doublings over 200 random scalars, where the regular windows make 79
+    and 126 for every one of them -- a quarter more work for the worst
+    scalar than for the best, and which it is is a property of the
+    scalar.
 
     So nothing signs with this one, and it is here to be measured against
     the other. A verification's coefficients are public and go to
     `_double_mult_endomorphism_secp256k1_var` below, which splits two of
     them rather than one and interleaves the four halves.
 
-    w=4 by measurement here too: 0.527 ms at w=3 and 0.510 at w=5, which
-    is w=4's own noise.
+    w=4 by measurement here too: w=3 and w=5 measure close enough to
+    call it w=4's own noise.
     """
     if m < 0:
         raise BTClibValueError(f"negative m: {hex(m)}")
@@ -577,11 +578,11 @@ def _double_mult_endomorphism_secp256k1_var(
     multiplications the images cost.
 
     That trade is the whole of the gain, and it is the same one
-    `_mult_endomorphism_secp256k1` makes for a single coefficient: 0.81 ms
-    against `_double_mult_w_NAF_var`'s 1.02, measured over 30 random pairs of
-    256-bit coefficients, best of three, alternating the two so that
-    neither is always warm. Both answer the same point on every pair the
-    tests compare, boundary coefficients and infinities included.
+    `_mult_endomorphism_secp256k1` makes for a single coefficient: about a
+    fifth less than `_double_mult_w_NAF_var`'s, measured over 30 random
+    pairs of 256-bit coefficients, best of three, alternating the two so
+    that neither is always warm. Both answer the same point on every pair
+    the tests compare, boundary coefficients and infinities included.
 
     The interleaved wNAF rather than the regular windows: the coefficients
     of a double multiplication are public, being a verification's, which is
@@ -590,8 +591,8 @@ def _double_mult_endomorphism_secp256k1_var(
     `_mult_endomorphism_secp256k1`. A scalar that is a secret goes
     through `mult`.
 
-    w=4 by measurement over the same pairs: 0.88 ms at w=3, 0.81 at w=4,
-    0.82 at w=5, 0.91 at w=6 -- so w=4 and w=5 measure the same and the
+    w=4 by measurement over the same pairs: cost is highest at the
+    extremes, w=3 and w=6, and w=4 and w=5 measure the same, so the
     smaller table decides, as it does for `_double_mult_w_NAF_var`.
 
     `fixed` is `_double_mult_w_NAF_var`'s, and this is the function that

--- a/src/btclib/ecc/ssa.py
+++ b/src/btclib/ecc/ssa.py
@@ -529,7 +529,7 @@ def sign_(
         # perform the check and there is nothing for this arm to add,
         # BIP340's step being a bare verification under a point the
         # keypair already holds. What it costs is measured where it is
-        # performed -- 12.7 microseconds against ECDSA's 19.5,
+        # performed -- cheaper than ECDSA's own analogous step,
         # btclib-secp256k1#224 -- and is not re-measured here, a figure
         # of theirs kept in this file being one that ages when they
         # change and says nothing when it does
@@ -834,9 +834,9 @@ class Signer:
         #
         # the caller's `verify`, and this is where the check is the
         # largest share of what it is added to: the keypair was built
-        # when this signer was, so the signature is 8.18 microseconds
-        # where a fresh one is 15.87, and the same check on it is 61% of
-        # the call against 44% there (btclib-secp256k1#224). It is the
+        # when this signer was, so signing here is markedly cheaper than
+        # a fresh signature, and the same check on it is 61% of the call
+        # against 44% there (btclib-secp256k1#224). It is the
         # one of btclib's signing calls a caller would most plausibly
         # want to decline, which is why the keyword reaching here is the
         # point of exposing it at all

--- a/tests/ecc/der_test.py
+++ b/tests/ecc/der_test.py
@@ -262,8 +262,9 @@ def test_der_low_s_agrees_with_libsecp256k1() -> None:
 
     `lower_s` is one comparison against n // 2 here, and libsecp256k1 has
     the same two answers as `is_low_s` and `normalize`. Nothing delegates
-    to them -- 0.037 us against 0.840, a comparison against a parse and a
-    call -- so this is where the two are held together instead.
+    to them -- an order of magnitude under `is_low_s`, a comparison
+    against a parse and a call -- so this is where the two are held
+    together instead.
     """
     for s in (1, ec.n // 2, ec.n // 2 + 1, ec.n - 1):
         sig = Sig(2**255 - 4, s)

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -1559,7 +1559,7 @@ def test_verify_with_another_hash_function_on_both_arithmetics(
     `libsecp256k1_dsa.verify` is not asked -- a commitment to check, a
     caller-imposed nonce and another curve are the others -- and what
     answers instead is `_assert_as_valid_`, whose multiplication is the
-    bindings' all the same: 128 us against the 1.10 ms of the Python
+    bindings' all the same, some eight times cheaper than the Python
     arithmetic, which is the whole of this verification either way.
 
     The two must not disagree, about a valid signature or an invalid one,
@@ -1942,10 +1942,10 @@ def test_a_key_that_is_no_point_is_refused_before_anything_is_signed(
     this package's own `not a public key`, which is what
     `assert_as_valid_` and `point_from_pub_key` say. Unifying it by
     proving the key here instead would be a field square root the
-    bindings then repeat, some 2.2 of the 5.8 microseconds handing a key
-    in saves. Pinning the message is what makes the translation safe: a
-    wording that moves upstream fails here rather than quietly ceasing
-    to match.
+    bindings then repeat, giving back over a third of what handing a
+    key in currently saves. Pinning the message is what makes the
+    translation safe: a wording that moves upstream fails here rather
+    than quietly ceasing to match.
     """
     if not bindings:
         no_bindings(monkeypatch)

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -221,10 +221,10 @@ def test_refusing_an_r_takes_no_square_root(
     Refusing used to cost more than verifying: `_y_even_var` falls back to
     `ec.y_even_var` for an x the bindings reject, that being where the
     message naming the value came from, so a bad r paid the whole Python
-    square root -- 78.7 us against the 22.4 of verifying a good
-    signature (issue 622). Half of the field elements are no
-    x-coordinate and cost nothing to produce, so that was the expensive
-    answer for the cheap input.
+    square root, several times what verifying a good signature costs
+    (issue 622). Half of the field elements are no x-coordinate and cost
+    nothing to produce, so that was the expensive answer for the cheap
+    input.
 
     mod_sqrt_var is patched to raise rather than timed: what the change has
     to be is a refusal that reaches no square root, on this machine and
@@ -556,8 +556,8 @@ def test_verify_with_a_message_that_is_not_32_bytes_on_both_arithmetics(
     `no_bindings`, because the two must not disagree about a signature
     and only one of them is now reached by default. The Python one is
     reached in earnest by another curve or another hash function; its
-    multiplication is still the bindings' on secp256k1, 183 us against
-    the 1.17 ms of the arithmetic under it.
+    multiplication is still the bindings' on secp256k1, several times
+    cheaper than the arithmetic under it.
     """
     msg = b"a message that is not 32 bytes"
     assert len(msg) != 32

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -206,10 +206,10 @@ def test_the_python_output_key_lifts_the_internal_x_once(
 
     Two things want the internal key's point: proving the octets are one,
     and adding tG to it. Taken separately those are two modular square
-    roots of the same x -- issue 896, which is 74 of the 311 us an output
-    key cost on this arm. `PubKeyData` is what makes them one: `point` is
-    a `cached_property`, so the lift is the proof and the proof is the
-    lift (issue #1188).
+    roots of the same x -- issue 896, which was roughly a quarter of what
+    an output key cost on this arm. `PubKeyData` is what makes them one:
+    `point` is a `cached_property`, so the lift is the proof and the
+    proof is the lift (issue #1188).
 
     Counting `mod_sqrt_var` rather than forbidding it, which is what
     `test_the_python_prvkey_tweak_lifts_nothing` does below: here the


### PR DESCRIPTION
[ISS 1494](https://github.com/btclib-org/btclib/issues/1494) drove
`grep -rnE '[0-9]+ (ns|us)\b' src/btclib` to zero. Three shapes escape
that pattern and carry the same defect: a millisecond or second figure
(ISS 1505), a copy of a `src/btclib` figure restated in `tests/` or
`SECURITY.md` (ISS 1506), and a figure whose unit is written as a word
rather than abbreviated (ISS 1508). Each is now the relation its argument
needs instead of a number that ages while staying plausible.

Note for anyone re-deriving this: **`git grep -E` silently drops `\b` in
this environment**, so the ms/s pattern answers a false zero under `-E`
and 22 lines under `-P`. Every measurement here used `--perl-regexp`,
with a non-zero control on the base.

## The two decisions the issues reserved, taken here

**`base58.py`'s `MAX_LENGTH` comment loses every figure**, rather than
keeping some with a reason beside them, which ISS 1505's *Done when* also
allowed. The same paragraph already states both relations in words — the
quadratic's shape ("four times the cost per doubling of the input") and
the chunking's benefit — so the numbers were the redundant half rather
than the reason. Nothing was kept, so the carve-out does not apply.

**`ecc/ssa.py:532` had refuted itself** and is repaired rather than
merely stripped: the paragraph argued for *not* keeping a figure of
libsecp256k1's own — "one that ages when they change and says nothing
when it does" — and then stated 12.7 and 19.5 anyway. The contradiction
goes with the numbers. `ssa.py:837` keeps the two percentages that
already carry its argument and drops the two absolute figures beside
them, which is ISS 1508's own diagnosis.

## A correction made during review

Local review caught a substituted relation that misstated the figures it
replaced: `curve_group.py`'s w-selection paragraph said cost "climbs at
w=5 and again at w=6", where the originals are 0.815 ms at w=4, **0.803**
at w=5 and 0.831 at w=6 — w=5 is lower, not higher. The sentence now says
w=5 and w=6 land within a couple of percent either side of w=4, which is
literal: -1.5% and +2.0%.

That is the failure mode this whole class of change invites, and no gate
sees it — the branch was green at a 100% floor with the false sentence in
it.

## Verification

`git grep -nP` answers nothing for all three patterns over `src/btclib`,
`tests` and `SECURITY.md` at the tip, with the base answering non-zero as
the control. Every substituted relation was checked against the absolutes
it replaces, recovered with `git show a5932604:<path>`.

Rebased onto `8f6fad07`; review re-derived the rebase's fidelity with
`git hash-object` per blob rather than a diff, and `CHANGELOG.md` was
reconstructed at its own anchor and compared byte for byte with a
tampered control.

Gates on this sha: `mypy` exit 0 (314 files), `pytest` exit 0 (31086
passed, 11 skipped, coverage 100.00%), `pre-commit run --all-files` exit
0, `sphinx-build -n -W --keep-going` exit 0.

Closes #1505
Closes #1506
Closes #1508

## Summary by Sourcery

Replace aging benchmark figures with stable performance relationships across code comments, tests, and security documentation.

Enhancements:
- Replace volatile wall-clock measurements in source, tests, and security documentation with durable qualitative relationships while preserving the relevant performance and security reasoning.

Documentation:
- Update the changelog and security guidance to describe performance relationships without aging benchmark figures.