### PR TITLE
docs/proposals/cli.md links the current bitcoin-core-rpc slug, and RELEASING.md's griffe command carries the src search path (closes #1500) (closes #1502)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,15 @@ documented at release-notes length in the first place, and are still in
   along with the number. `ecc/ssa.py:837` keeps the two percentages that
   already carry its argument and drops the two absolute figures beside
   them.
+- **`docs/proposals/cli.md` links the `bitcoin-core-rpc` sibling by its
+  current slug** (closes #1500), rather than `btclib-bitcoin-core-rpc`,
+  which resolves only through GitHub's redirect and disagreed with the
+  same line's own link text.
+- **RELEASING.md's griffe command carries the search paths
+  `release.yml`'s `public-api` job passes** (closes #1502): run by hand,
+  `uv run --with griffe griffe check btclib -a <tag> -s . -s src` finds
+  `btclib` under the `src/` layout, where the command the file documented
+  exited on `ModuleNotFoundError` before comparing anything.
 
 ### Packaging, linting and CI
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -221,7 +221,7 @@ to `deps-latest`'s own result.
    automates on a commit:
 
    ```shell
-   uv run --with griffe griffe check btclib -a <previous release tag>
+   uv run --with griffe griffe check btclib -a <previous release tag> -s . -s src
    ```
 
    `tests/release_notes_test.py` keeps both release-note files count-free:

--- a/docs/proposals/cli.md
+++ b/docs/proposals/cli.md
@@ -653,7 +653,7 @@ needed a recorded exclusion, by name, because no predicate separated it from
 `alias` and `exceptions` mechanically.
 
 It is now the
-[bitcoin-core-rpc](https://github.com/btclib-org/btclib-bitcoin-core-rpc)
+[bitcoin-core-rpc](https://github.com/btclib-org/bitcoin-core-rpc)
 package, which btclib depends on and does not publish, so the walker never
 reaches it and there is nothing to exclude. **The exclusion table is empty
 today**, and the traversal contract above is the whole of the rule: the


### PR DESCRIPTION
Two documented things that were wrong as written: a link that resolved
only through a redirect, and a command that exited 1 as printed.

**`docs/proposals/cli.md`** linked the sibling as
`btclib-org/btclib-bitcoin-core-rpc`, a slug GitHub keeps pointed at
`btclib-org/bitcoin-core-rpc` — so the link worked only for as long as
its owner keeps the redirect, and it disagreed with the same line's own
link text. A whole-tree sweep found one other occurrence, in a landed
`CHANGELOG.md` entry under `## v2026.8.7`; that one stays, the file being
append-only and the entry being a record of what was true then.

**`RELEASING.md`'s griffe step** told the reader to run

    uv run --with griffe griffe check btclib -a <previous release tag>

which exits 1 with `ModuleNotFoundError: btclib` under the `src/` layout,
before comparing any API at all. `release.yml`'s own `public-api` job
already knew this and passes `-s . -s src`; the documented command and
the job disagreed, and the documented one was the broken half.

## The reserved decision

ISS 1502 allowed either carrying the job's search paths in `RELEASING.md`
or pointing at the job as the authority. **The paths are carried**, and
the reason is that the job cannot answer at the moment this step runs:
`release.yml` triggers on a `v*` tag push or `workflow_dispatch`, while
`RELEASING.md`'s griffe step is an ordered checklist item that runs
*before* the tag exists and feeds `RELEASE_NOTES.md` while it is being
written. Pointing at the job would have removed the by-hand, pre-tag
check the paragraph exists for. What that costs is a second place to keep
in sync with the workflow, which is the price of the option taken.

The command was run rather than reasoned about: bare it exits 1, with
`-s . -s src` it exits 0, against `v2026.8.29`.

## A correction made during review

The `CHANGELOG.md` entry first quoted the *bare* command and claimed it
finds `btclib` — true of the sentence, false of the command it quoted.
The entry now quotes the working command, and names "the command the file
documented" as the thing that used to fail, so the two invocations in one
sentence cannot be confused.

## Verification

Rebased twice as `main` moved under it, ending on `8d8fd0f3`.
`RELEASING.md` and `docs/proposals/cli.md` are byte-identical blobs at the
cleared sha and the final one, so only the base moved.

`CHANGELOG.md` needed care: `git merge-tree --write-tree` reports this
branch clean because it applies the `merge=union` driver, while
`git -c merge.union.driver=false merge-tree` — the merge GitHub actually
performs — reported a conflict until the rebase. The file was then
reconstructed against the new base and compared byte for byte. The first
reconstruction failed, and it was the reconstruction that was wrong: it
anchored the block where the old base ended, while the tree's convention
appends at the end of the open group, so the entry correctly sits below
the one that landed while this branch waited. The second reconstruction
matches, the block occurs once, and the tampered control was rebuilt
after the first one turned out to change nothing — a control aimed at a
line that did not contain the word it replaced.

Gates on this sha: `mypy` exit 0 (314 files), `pytest` exit 0 (31086
passed, 11 skipped, coverage 100.00%), `pre-commit run --all-files` exit
0, `sphinx-build -n -W --keep-going` exit 0.

Closes #1500
Closes #1502

## Summary by Sourcery

Fix the documented release API check and CLI proposal repository link so both instructions work as written.

Bug Fixes:
- Correct the documented Griffe release-check command so it resolves the src-layout package before comparing APIs.
- Update the CLI proposal link to use the current bitcoin-core-rpc repository slug.

Documentation:
- Clarify the changelog record for the corrected Griffe command and repository link.