### PR TITLE
docs/source/conf.py derives the author from pyproject.toml (closes #1519)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,18 @@ documented at release-notes length in the first place, and are still in
   `btclib` under the `src/` layout, where the command the file documented
   exited on `ModuleNotFoundError` before comparing anything.
 
+- **`docs/source/conf.py`'s Sphinx `author` reads `pyproject.toml`'s
+  `authors` table instead of repeating it** (closes #1519). It was a
+  fourth hand-typed copy of the holder `tests/copyright_test.py`'s
+  triangle already checks LICENSE and the wheel's declared author
+  against, outside that triangle and outside `src/btclib/__init__.py`'s
+  own three, dropped by issue #1507. `conf.py` already parses
+  `pyproject.toml` into `PYPROJECT` for `release` and the github `BLOB`
+  url, so `author` is a second read of that dict rather than a second
+  literal, and cannot drift from it the way the dropped one could --
+  `tests/copyright_test.py` now loads `conf.py` by path and checks the
+  read.
+
 ### Packaging, linting and CI
 
 - **`pypi-install.yml` waits for the index through a script with a

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ from sphinx.transforms.post_transforms import SphinxPostTransform
 # the repository root, two levels up from this file, and the one place
 # below that is allowed to name it
 ROOT = Path(__file__).parents[2].resolve()
-# read once and read twice from: the version below and the github url the
+# read once, for the author and version below and the github url the
 # transform at the bottom builds its links on
 PYPROJECT = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
@@ -39,7 +39,10 @@ project_copyright = re.search(
     (ROOT / "src" / "btclib" / "__init__.py").read_text(encoding="utf-8"),
     re.MULTILINE,
 ).group(1)
-author = "The btclib developers"
+# pyproject.toml's `authors` table, the one place the holder is
+# declared: PYPROJECT is already parsed above, so this is a second
+# read of it rather than a second literal (issue #1519)
+author = PYPROJECT["project"]["authors"][0]["name"]
 # read from pyproject.toml, the one place the version is declared, and not
 # from importlib.metadata: that would need btclib installed in the
 # environment building the documentation, which read the docs does not do

--- a/tests/copyright_test.py
+++ b/tests/copyright_test.py
@@ -38,10 +38,25 @@ installed distribution's own metadata instead, which cannot drift from
 `pyproject.toml` the way a second literal can. So the three are gone
 rather than added to the triangle, and the test below is what keeps
 them from being silently redeclared.
+
+Issue #1519: `docs/source/conf.py` declared its own Sphinx `author`
+as a fourth literal naming the same holder, sitting beside
+`project_copyright` two lines above it, which already reads
+`__copyright__` back rather than repeating its years. `author` now
+reads `pyproject.toml`'s `authors` table the same way, through the
+`PYPROJECT` dict that file already parses for its own `release` and
+`BLOB` -- a derivation rather than a fourth vertex to compare, since
+unlike LICENSE and pyproject.toml above, `conf.py`'s copy has
+nowhere it needs to diverge from the source it names. The test below
+loads `conf.py` by path, the way it is not a package to import, and
+checks the read rather than a value that can no longer drift on its
+own.
 """
 
+import importlib.util
 import re
 from pathlib import Path
+from types import ModuleType
 
 import btclib
 
@@ -71,6 +86,17 @@ def _pyproject_author() -> str:
     match = re.search(_AUTHOR_RE, text)
     assert match, "pyproject.toml has no 'authors = [{ name = ... }]' line"
     return match.group(1)
+
+
+def _conf_module() -> ModuleType:
+    """Load docs/source/conf.py by path: no package, so no import."""
+    path = _ROOT / "docs" / "source" / "conf.py"
+    spec = importlib.util.spec_from_file_location("conf", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_license_and_copyright_name_the_same_holder() -> None:
@@ -111,3 +137,15 @@ def test_no_duplicate_author_or_license_dunders() -> None:
             "the fact it would duplicate, and nothing in the tree reads it "
             "(issue #1507)"
         )
+
+
+def test_conf_py_author_reads_pyproject_rather_than_repeating_it() -> None:
+    """Sphinx's `author` is `pyproject.toml`'s, read back, not retyped."""
+    conf_author = _conf_module().author
+    pyproject_author = _pyproject_author()
+    assert conf_author == pyproject_author, (
+        f"docs/source/conf.py's author is {conf_author!r}, pyproject.toml's "
+        f"is {pyproject_author!r}. conf.py reads pyproject.toml's `authors` "
+        "table for this value (issue #1519); if the two differ here the "
+        "read itself, not a stale literal, is what to look at"
+    )


### PR DESCRIPTION
`tests/copyright_test.py` closes a triangle on who holds the copyright —
`LICENSE`'s notice, `src/btclib/__init__.py`'s `__copyright__`, and
`pyproject.toml`'s `authors` table — and its own docstring says why:
`LICENSE` and `__copyright__` had already drifted apart once.
`docs/source/conf.py`'s Sphinx `author` was a fourth copy of the same
holder, outside that triangle, compared by nothing.

## Derive rather than compare

`conf.py`'s `author` now reads `PYPROJECT["project"]["authors"][0]["name"]`
instead of repeating the string. That removes the copy rather than
watching it, and it costs no new dependency: `PYPROJECT` is already
parsed with `tomllib` at module scope for `release` and for the GitHub
blob URL, so this is a second read of a dict that exists, not a second
parse and not an `importlib.metadata` call. The distinction matters
because `conf.py` is deliberately written to build the documentation
*without* btclib installed — the comment on the neighbouring `release`
line states exactly that, and Read the Docs is why.

Comparing instead was weighed and refused: it leaves the duplicate
literal standing, and one line above, `project_copyright` already reads
`__copyright__` back rather than repeating it — so watching this one
would have left the file treating two adjacent facts inconsistently for
no measured reason.

Closing the issue on a measurement was also considered and did not
apply: the two strings were byte-identical, so a naive comparison would
have been green rather than red, and nothing made the two facts
independently necessary.

## The test

`tests/copyright_test.py` gains a case asserting `conf.py`'s `author`
equals what the file's own `_pyproject_author()` reads. It is not the
tautology it looks like: `conf.py` derives through `tomllib`, while
`_pyproject_author()` parses the same raw text with a regex, so the two
paths are independent and a wrong key or index in the derivation would
be caught. Local review measured that rather than taking it on trust,
and measured too that `tests/init_test.py::test_version` — the precedent
cited for it — is in fact the *weaker* of the two, comparing two calls
to one API.

## Verification

The derivation is value-preserving, not merely non-erroring: the built
`index.html` still renders the holder, and review confirmed the same
fact independently by loading `conf.py` by path and evaluating `author`.
A `conf.py` that derives the wrong value builds without a warning, which
is why neither check was left to `-W` alone.

The `CHANGELOG.md` entry lands in the open `## v2026.9` section; no
released section is touched, which
`tests/changelog_immutability_test.py` now enforces.

Gates on this sha: `ruff check` exit 0, `mypy` exit 0 (315 files),
`pytest` exit 0 (31094 passed, 29 skipped, 3 xfailed, coverage 100.00%),
`pre-commit run --all-files` exit 0, `sphinx-build -n -W --keep-going`
exit 0 with no warnings.

Closes #1519

## Summary by Sourcery

Keep the documentation author synchronized with pyproject.toml by deriving it from the existing project metadata and testing the linkage.

Enhancements:
- Derive the Sphinx documentation author from the canonical author entry in pyproject.toml to prevent duplicated metadata from drifting.
- Add coverage verifying that docs/source/conf.py reads the same author declared in pyproject.toml.

Documentation:
- Document the author metadata deduplication in the changelog.

Tests:
- Load the Sphinx configuration by path and verify its author matches the pyproject.toml author.