### PR TITLE
ruff's own file discovery, not CONTRIBUTING.md's prose, is where the bare ruff format and pre-commit's hook are made to agree (closes #1517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,20 @@ documented at release-notes length in the first place, and are still in
   `tests/build_system_test.py`'s own detector, from #1509, is widened to
   recognize a test that reaches outside the sdist through `git` and not
   only through a `.github` or `fuzz` path segment.
+- **`[tool.ruff.format] exclude` now names `CHANGELOG.md` and
+  `RELEASE_NOTES.md`** (closes #1517). The bare `ruff format` in
+  CONTRIBUTING.md's gate block has no path argument, so it discovers a
+  `.md` file's fenced Python blocks the same as any other source --
+  `ruff check` does not, only the formatter does -- and for these two
+  append-only files that meant reformatting a historical snippet's own
+  spacing on every run, where the `ruff-format` pre-commit hook never
+  reached either file, `ruff-pre-commit`'s own `types_or` being
+  `[python, pyi, jupyter]`. Excluding both makes the bare command agree
+  with the hook instead of outrunning it. This supersedes issue #1293's
+  answer to the same divergence, which was to document it in
+  CONTRIBUTING.md: that paragraph goes, a setting being checkable where
+  a warning has to be read and remembered. Wanting the warning back
+  instead costs reverting this entry's two files.
 
 ### The public API and the module layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -384,16 +384,6 @@ or, in one go, with [pre-commit](https://pre-commit.com/):
 uv run pre-commit run --all-files
 ```
 
-**The two are not the same for `ruff format`.** The bare command above
-has no path argument, so it walks the whole tree and reformats a
-fenced-code Python block it finds inside a `.md` file, `CHANGELOG.md`
-and `RELEASE_NOTES.md` included; the `ruff-format` hook in
-`.pre-commit-config.yaml` restricts itself to `ruff-pre-commit`'s own
-`types_or: [python, pyi, jupyter]`, so `pre-commit run --all-files`
-never hands it a `.md` file and leaves those fences untouched. `git
-status` after running the bare command shows the difference; the gate
-CI runs is the pre-commit one.
-
 The suite writes nothing: it runs against a read-only checkout, and from an
 installed sdist. The one exception is deliberate and has to be asked for.
 Several modules compare a dataclass's `to_dict()` against a json file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -841,6 +841,29 @@ exclude = [
 [tool.ruff]
 # target-version is inferred from project.requires-python
 
+[tool.ruff.format]
+# ruff format reads the fenced ```python blocks a .md file carries and
+# reformats them like any other source, which for these two append-only
+# files meant rewriting a historical snippet's own spacing every time
+# the bare command walked the whole tree with no path argument -- a
+# comment's leading spaces tightened and a blank line inserted after an
+# import, in blocks nothing here asks to be current (issue #1517). The
+# `ruff-format` pre-commit hook never reached either file --
+# ruff-pre-commit's own types_or is [python, pyi, jupyter] -- so the
+# bare command now agrees with the hook instead of outrunning it.
+#
+# The formatter's own `exclude` and not [tool.ruff]'s `extend-exclude`,
+# which resolves to the file discovery `check` and `format` share: the
+# divergence being repaired is the formatter's alone, and `ruff check`
+# never read these fences to begin with -- it resolves a .md file out by
+# type before an exclude is consulted at all. Withdrawing the two from
+# the shared discovery would cost nothing today and would silently widen
+# the day a subcommand does read markdown.
+#
+# Named one by one, so a .md file that gains a python fence later is not
+# covered until it is added here.
+exclude = ["CHANGELOG.md", "RELEASE_NOTES.md"]
+
 [tool.ruff.lint]
 # preview and explicit-preview-rules only make sense as a pair. Naming a
 # rule in `ignore` below, instead of coding it, is itself a preview


### PR DESCRIPTION
Closes #1517

`uv run ruff format`, the command `CONTRIBUTING.md` documents as a gate,
carries no path argument, so it walks the whole tree and reformats the
fenced `python` blocks in `CHANGELOG.md` and `RELEASE_NOTES.md` like any
other source — tightening a comment's leading spaces, inserting a blank
line after an import, inside snippets that record what a command looked
like when it was written and are not meant to be current. The
`ruff-format` pre-commit hook never touches either file:
`ruff-pre-commit` restricts the hook to `types_or: [python, pyi,
jupyter]`. So the documented command and the hook that gates the same
tree disagreed, and the bare one won.

`[tool.ruff.format] exclude = ["CHANGELOG.md", "RELEASE_NOTES.md"]`
settles it at the configuration rather than at the invocation, so any
bare `ruff format` leaves them alone and not only the documented one.
The two files are the only ones in the tree carrying a fenced `python`
block, so naming them is the whole of the class.

The formatter's own `exclude` and not `[tool.ruff]`'s `extend-exclude`,
which resolves to the file discovery `check` and `format` share. The two
answer identically today — `ruff check` resolves a `.md` file out by type
before any exclude is consulted, and answers `No Python files found under
the given path(s)` when handed these two explicitly, so there was never
lint coverage here to withdraw. The narrower form is what the divergence
actually is, and the one that does not widen by itself the day some
subcommand does read markdown.

**This reverses issue #1293's answer to the same divergence**, which was
to describe it in `CONTRIBUTING.md` and ask the reader to remember it.
That paragraph now describes something that no longer happens, so it is
removed rather than left standing. Wanting the warning back instead of
the setting costs reverting this branch's two files. The removed
paragraph sits at line 387, past `## This repository in particular` at
line 193, so nothing diverges from the portion `CONTRIBUTING.md` shares
with the other repositories of the organization.

Scoping the documented command instead — `ruff format src/btclib tests` —
was considered and rejected: `.github/scripts`, `docs/` and `fuzz/` all
carry python files the bare command reaches today and a scoped one would
silently stop reformatting, and the gate block is meant to check the
whole tree.

## Measured

With the exclude, and with `exclude = []` substituted in the same tree,
on the pinned `ruff 0.16.4`:

```
ruff format --diff                  → exit 0, "360 files already formatted"
ruff format --diff  (exclude = [])  → exit 1, "2 files would be reformatted"
ruff check --show-settings          → formatter.exclude populated,
                                      file_resolver.extend_exclude empty
```

The control names the two files and exits non-zero, so it is not blind.
`--diff` throughout: the command that writes is the one this branch
exists to stop.

## Gates

`mypy src/btclib tests .github/scripts` 0 on 315 files; `pytest` 0 with
31094 passed, 29 skipped, 3 xfailed, coverage 100.00%; `pre-commit run
--all-files` 0 with no `Failed` line; `sphinx-build -n -W --keep-going`
0; `ruff format --diff` bare, after the rebase, 0. The three `xfail`s
belong to issue #1524 and are untouched here.

## Summary by Sourcery

Configure Ruff to exclude historical Markdown files from formatting so the bare formatter command and pre-commit hook apply consistently.

Bug Fixes:
- Prevent bare `ruff format` from rewriting fenced Python snippets in the historical `CHANGELOG.md` and `RELEASE_NOTES.md` files.
- Align the documented formatter gate with the `ruff-format` pre-commit hook’s file coverage.

Enhancements:
- Move the formatter/file-discovery behavior into Ruff configuration by excluding the two historical Markdown files.
- Remove the outdated contributor guidance describing the formatter and pre-commit hook mismatch.

Chores:
- Record the Ruff exclusion and resolution of issue #1517 in the changelog.