### PR TITLE
REPOSITORY.md says what it covers, and what it passes over (issue btclib-org/.github#551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,41 @@ documented at release-notes length in the first place, and are still in
   `allow_auto_merge` readback is btclib's share of issue
   btclib-org/.github#566, which the same gap in `portanode` and
   `bitcoin-core-rpc` keeps open.
+- **`REPOSITORY.md` no longer claims to be the whole of what is set
+  outside the tree.** (issue btclib-org/.github#551) Section 11 of the
+  standard bounds a `REPOSITORY.md` at the settings the standard asks
+  about — the ones section 16's checklist sets on a new repository, and
+  the ones a section of it states a rule for — and rejects the blanket
+  claim, which no command checks. The opening states that perimeter and
+  names *Code quality* as sitting past it, the standard stating no rule
+  about that setting and the code scanning default setup it does ask for
+  being what leaves the quality analysis running. It also names the
+  answers that do have a copy in the tree — `CNAME` carries the Pages
+  custom domain, and `pyproject.toml` the topics as `keywords` and the
+  documentation site as `[project.urls] homepage` — where it used to say
+  nothing here can be recovered by reading the tree at all. Dropping
+  that clause answers for this repository the question issue
+  btclib-org/.github#571 holds open for the standard and for the copies
+  in the other trees: *Pages*, *Topics* and *Read the Docs* each state an
+  identity between a setting and a tracked file, so the file that would
+  carry the clause is what refutes it.
+- **A *What this file passes over* section says where that scope ends.**
+  (issue btclib-org/.github#551) The repository document's fields no
+  section quotes, the facilities that answer empty, and `allow_forking`,
+  `allow_update_branch`, `has_discussions`, `has_downloads`,
+  `is_template` and `web_commit_signoff_required`, which the standard
+  states no rule about — with the grep that says so and the control that
+  keeps its zeros absences. Read the Docs' other project settings and
+  PyPI's side of the trusted publisher are there too, those being the
+  services' own rather than this repository's. The empty Actions and
+  Dependabot secret stores get a paragraph of their own rather than a
+  place among the facilities: section 11 holds the review credential at
+  the organization, so the zero is where that decision shows (issue
+  btclib-org/.github#572). `has_wiki` and `has_projects` are left to
+  issue btclib-org/.github#550 rather than recorded as outside the
+  scope, and `has_issues` is passed over as a premise of the process
+  rather than as a field on no rule. What the scope costs is that a
+  change to any of them shows up here in nothing.
 
 ### Documentation and the website
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -6,8 +6,26 @@ than carrying it, so that a session fixing a bug in `ecc/` does not hold
 it in context.
 
 The branch rules and the repository settings live *outside* the
-repository, so this file is the whole of them: nothing here can be
-recovered by reading the tree.
+repository, and this file is where those answers are written down. What
+is recorded is the settings
+[the standard](https://github.com/btclib-org/.github/blob/main/README.md)
+asks about — the ones
+[section 16's checklist](https://github.com/btclib-org/.github/blob/main/README.md#16-checklists)
+sets on a new repository, and the ones a section of the standard states
+a rule for — together with whatever a call quoted for one of those answers
+alongside it. That is this file's scope, and *What this file passes
+over*, at the foot, says what falls outside it.
+
+*Code quality* is recorded past that edge: no section of the standard
+states a rule about that setting, and it is here because turning off the
+code scanning default setup — which section 11 does ask for — leaves the
+quality analysis running, so stopping it is a decision of this
+repository's.
+
+Where an answer has a copy in the tree, the section recording it says so:
+`CNAME` carries the Pages custom domain, and `pyproject.toml` carries the
+topics as `keywords` and the documentation site as `[project.urls]
+homepage`.
 
 ## Required checks on main
 
@@ -805,3 +823,104 @@ diff <(gh api repos/btclib-org/btclib --jq '.topics[]' | sort) \
      <(awk '/^keywords = \[/,/Past the twenty topics/' pyproject.toml \
        | grep -oE '"[a-z0-9-]+"' | tr -d '"' | sort)
 ```
+
+## What this file passes over
+
+The scope at the top is a perimeter, and this is its other edge: what an
+endpoint answers for and no section above reaches. What follows says of
+each which it is — outside that scope, or a question the standard has
+not answered.
+
+**What no call sets.** `gh api repos/btclib-org/btclib` answers with the
+repository document, most of which is URLs, counts and state GitHub
+derives from the tree; the switches among them this file records are the
+ones a section above reads back with a call of its own, and the
+paragraphs below are about switches it does not. `gh api
+repos/btclib-org/btclib/pages` has the same shape: `custom_404` follows a
+`404.html` in the root, and `status` and `https_certificate` report the
+last build and the certificate issued for the domain.
+
+**A field the standard states no rule about, and no call above answers
+alongside one it does.** `allow_forking`, `allow_update_branch`,
+`has_discussions`, `has_downloads`, `is_template` and
+`web_commit_signoff_required` are in the repository document, in no
+`--jq` object above, and in no rule of the standard:
+
+```shell
+std=$(gh api repos/btclib-org/.github/contents/README.md --jq .content \
+  | base64 -d)
+for f in allow_forking allow_update_branch has_discussions has_downloads \
+         is_template web_commit_signoff_required; do
+  printf '%s %s\n' "$f" "$(printf '%s' "$std" | grep -c "$f")"  # 0 each
+done
+printf '%s' "$std" | grep -c delete_branch_on_merge  # not 0, which is
+                                                     # what makes those
+                                                     # zeros absences
+```
+
+Recording a field on no rule grows this file with GitHub's API rather
+than with the standard.
+
+**The wiki and the projects board are where that reasoning stops.**
+`has_wiki` and `has_projects` are in the same document and in no rule of
+the standard either, and what a `REPOSITORY.md` owes a reader about them
+is the open question of issue btclib-org/.github#550. Nothing here
+answers it.
+
+**The tracker is a premise rather than a setting.** `has_issues` is on,
+and the standard's own maintenance runs on the issue tracker —
+`CONTRIBUTING.md`'s *The issue tracker* is what a session reads before
+filing — so no section states it as a setting to read back. It is here as
+a premise of the process rather than as a field on no rule.
+
+**A credential this repository does not hold.** `claude-review.yml`
+spends `secrets.CLAUDE_CODE_OAUTH_TOKEN`, and section 11 of the standard
+holds that token at the organization, in both stores, rather than in each
+repository:
+
+```shell
+gh api repos/btclib-org/btclib/actions/secrets --jq '.total_count'     # 0
+gh api repos/btclib-org/btclib/dependabot/secrets --jq '.total_count'  # 0
+gh api orgs/btclib-org/actions/secrets \
+  --jq '.secrets[] | "\(.name) \(.visibility)"'
+# CLAUDE_CODE_OAUTH_TOKEN all
+gh api orgs/btclib-org/dependabot/secrets \
+  --jq '.secrets[] | "\(.name) \(.visibility)"'
+# CLAUDE_CODE_OAUTH_TOKEN all
+```
+
+The organization's stores answering with a name are what make the two
+zeros absences rather than an endpoint that answers empty for everyone,
+and an empty store here is where the standard's decision shows rather
+than a facility nobody reached for. The `CI` environment's own secrets
+and variables are a different endpoint again, `environments/CI/secrets`,
+which *Publishing* above reads back.
+
+**A facility nobody reached for.** The repository's Actions variables,
+self-hosted runners, deploy keys, autolinks and custom property values
+each answer empty here, and an empty answer records no decision.
+Webhooks are not among them: *Read the Docs* above reads those back,
+with the control that makes the `0` an absence rather than a permission
+ceiling. Whichever of the rest is reached for one day arrives with the
+section that uses it.
+
+**A service's own settings, past the ones the standard states a rule
+for.** [Section 11's *Pages and Read the
+Docs*](https://github.com/btclib-org/.github/blob/main/README.md#pages-and-read-the-docs)
+asks for the source, the build type and the CNAME, and for what `latest`
+and `stable` follow; those are above. The Read the Docs project answers
+for more than the `default_branch` and `default_version` read back there,
+`privacy_level`, `single_version` and `versioning_scheme` among them, and
+its redirects and its environment variables are not in that document at
+all: `curl -s -o /dev/null -w '%{http_code}'` against
+`https://app.readthedocs.org/api/v3/projects/btclib/redirects/` and
+against `.../environmentvariables/` answers `401`, where the project call
+above answers unauthenticated. PyPI's side of the trusted publisher is
+not here either — the owner, repository, workflow and environment the
+index matches an OIDC token against are set on the index, and
+[RELEASING.md](./RELEASING.md)'s *One-time setup* is where they are
+written down.
+
+What the scope costs is a silent flip. A change to any of the above
+shows up here in nothing, and finding one means reading each document
+against this file rather than running a command.


### PR DESCRIPTION
Advances btclib-org/.github#551 — this repository's copy. It does not close it: two trees still carry the blanket sentence.

**This branch closes a question btclib-org/.github#571 reserved, and says so here first because that is what is owed.** 571 asks whether `REPOSITORY.md`'s opening keeps the standard's clause *"nothing here can be recovered by reading the tree"*; its *Done when* box 1 — section 11 says which it is — is unticked. This branch drops the clause for btclib and names the answers that do have a copy in the tree instead.

**The ground.** This file's own sections refute the clause three times: *Pages* says `CNAME` in the root is the `cname` setting's value, *Topics* says `pyproject.toml`'s `keywords` carries the same topics, and *Read the Docs* says `[project.urls] homepage` carries the string `gh api repos/btclib-org/btclib --jq '.homepage'` answers with — `https://btclib.readthedocs.io/`, identical to `pyproject.toml:159`.

The landed copies are not a precedent against it. `.github` declares no `keywords` and an empty `.homepage`, so the clause is *true* there — and a copy where the clause is true is no precedent for one where it is false. Every other landed copy that keeps the clause also states an identity below it, which is the contradiction 571 names rather than a decision it settles: each is another instance of the question, not an answer to it.

**The cut-back, if the answer is unwanted**: the opening's last paragraph goes and the clause returns to its first. Nothing else in the diff leans on either.

The standard's own sentence and the copies in the other trees stay 571's.

---

Reviewed locally at fresh context over two rounds. Round 1 found three blocking findings — two of them sentences the previous round's author and its orchestrator had both missed, including that this branch was closing 571 silently. Round 2 cleared the content and blocked on one thing: the commit message's census of the landed copies said *two* where four had landed, two of them six hours old. The conclusion survived the reviewer's own re-derivation; the account did not, and a landing decision is taken on the account. It is corrected here by stating the criterion instead of a count, which is what section 9 asks for.

The reviewer also found and corrected a defect in **btclib-org/.github#571 itself** while re-deriving: 571 says `bitcoin-core-rpc`'s branch drops the clause, and `git diff --stat 8f58690 6441381` is empty with `8f58690:REPOSITORY.md:8-9` carrying it. That is evidence this branch leans on, so it is the branch's to own; it is corrected on the record.

Gates on the landing sha, after a rebase onto today's `main`: `pre-commit run --all-files` exit 0, 41 Passed, 0 Failed; `sphinx-build -n -W --keep-going` exit 0, with the built `changelog_link.html` confirmed to contain the new entry — the control that says the build read what changed rather than a cached doctree. The changelog entry was rebuilt by reconstruction and verified with four controls run unchained, each proved to differ first: blank line dropped, block duplicated, block at the group's top, one word tampered. `cmp` against the reconstruction exits 0; all four controls exit 1.

## Summary by Sourcery

Clarify the scope of `REPOSITORY.md` by identifying tracked configuration it reflects and settings it deliberately leaves undocumented.

New Features:
- Document the repository settings and tracked-file values covered by `REPOSITORY.md`, including Pages, topics, and Read the Docs configuration.
- Add a section defining settings, services, credentials, and facilities that the repository documentation intentionally passes over.

Bug Fixes:
- Remove the inaccurate claim that repository settings cannot be recovered by reading the tree.

Enhancements:
- Clarify the scope and limitations of repository settings documentation, including that changes outside the documented perimeter may remain silent.

Documentation:
- Update the changelog with the revised repository-documentation scope and exclusions.