### PR TITLE
Relocate every misplaced CHANGELOG bullet to the open cycle and tag each with its shipping release (closes #1524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,91 @@ documented at release-notes length in the first place, and are still in
   rather than as a field on no rule. What the scope costs is that a
   change to any of them shows up here in nothing.
 
+- **A pull request no longer waits for macOS.** One run of the full matrix is
+  45 jobs, 93 minutes of compute and 399 minutes of queueing, and the two
+  macOS images account for most of the second number: 29.4 and 23.2 minutes
+  of mean wait for a runner, one of them 42.2, against 0.5 to 1.6 for ubuntu
+  and windows. So `test.yml` keeps all seven interpreters and drops to four
+  platforms, and the new `macos.yml` runs the two macOS images against the
+  same lock weekly, on demand, and from a release -- which is what keeps a
+  macOS regression from being published while nobody waits for one. It is
+  scheduled the same morning as `latest.yml`, half an hour before, so the two
+  read as a difference: red in both is the platform, red in `latest` alone is
+  the upgrade (shipped in v2026.8.21)
+- **The documentation build is a workflow of its own**, `docs.yml`, where it
+  was the second job of `lint.yml`: a failed sphinx build and a failed hook
+  are different verdicts, and a workflow each is what gives them a badge each
+  and a line each in the checks list. The job keeps its name, `Build the
+  documentation`, so the required check did not have to move -- a context is
+  matched by name and not by the workflow that reported it (shipped in
+  v2026.8.21)
+- **`integration.yml` gates a merge**, where it gated only a release: 36
+  seconds of work for a disposable regtest node, less than the matrix it runs
+  beside, and it answers the one claim the recorded vectors cannot make. Its
+  `paths` filter goes with the promotion, a required check that never runs
+  blocking a merge where a skipped one satisfies it (shipped in v2026.8.21)
+- **Every CI job has a name, and the names say what the job answers**, the
+  same vocabulary bitcoin-core-rpc uses: `suite`, `coverage`, `dist` and the
+  aggregate `test: every job passed` where the ids carried a `-py` suffix
+  that distinguished nothing, `suite-latest` and `install-published` where a
+  suffix does name a variant, and a sentence on each of the eleven jobs of
+  `release.yml`, which showed their ids in the checks list (shipped in
+  v2026.8.21)
+- **`published.yml` is called by `release.yml`** with the tag's version, and
+  waits for the index to serve it before installing -- so it can no longer
+  pass by testing the release before this one, which the dispatch
+  RELEASING.md asked for by hand could do. Its schedule goes from weekly to
+  monthly, the release path now answering the question the weekly stood in
+  for. Not a `workflow_run` trigger, which zizmor rates dangerous: that runs
+  the default branch's copy on a push nobody reviewed (shipped in
+  v2026.8.21)
+- **`release.yml` has a concurrency group**, the last workflow without one
+  and the only one whose runs have side effects, and it calls the docs and
+  macOS workflows beside the ones it already called (shipped in
+  v2026.8.21)
+- **A pre-commit rev that is not a released version fails the gate.** A local
+  pygrep hook rejects a rev naming only a major version, which follows every
+  future release of it, and a prerelease, which is not a release: the two
+  moves `autoupdate` offered in bitcoin-core-rpc, one of which was merged
+  before anyone read the diff. pre-commit warns about the first and exits
+  zero, which is the difference the hook makes (shipped in v2026.8.21)
+- The dead `github.base_ref == 'master'` exception is gone from every job
+  that carried it, along with the prose describing a two-branch release flow:
+  `master` is not a branch here any more, so the clause could never be true
+  and `push` was aimed at a ref that does not exist -- which meant nothing
+  ran on the trunk, and no cache was written where a pull request could read
+  it (shipped in v2026.8.21)
+- **`fuzz.yml` ran on every pull request and gated nothing** (issue
+  btclib-org/.github#460): the `pull_request` trigger and the
+  `pr_fuzzing` job that hung on it are gone, and `fuzz` is what section
+  10 of the organization standard calls it, a sentinel — `schedule` and
+  `workflow_dispatch`, nothing else. That job put ten minutes of fuzzing
+  on every push to an open pull request, and
+  `gh run list --workflow fuzz.yml --json event,conclusion` says what
+  became of those runs. No merge was waiting on the answer: `main`'s
+  `required_status_checks` names `Lint and type-check`, `Build the
+  documentation`, `test: every job passed` and `Regtest against Bitcoin
+  Core`, and `fuzz` produces none of those contexts, so what the job
+  charged was the reader's wait. That rule lives in the classic
+  branch-protection object rather than in a ruleset, which is why
+  `gh api repos/btclib-org/btclib/branches/main/protection` answers for
+  it and a rulesets-only read answers nothing. The pull request that cut
+  v2026.8.26 merged three minutes into its `PR fuzzing` job and
+  cancelled it, run `33008079111`, which is the case section 10 quotes.
+  `CONTRIBUTING.md`'s *What runs when* row moves with the triggers (shipped
+  in v2026.8.29).
+
+- **A crash this sentinel finds becomes an ordinary test, not a seed**:
+  the regression names the input and what `parse` is expected to do with
+  it now, which is usually to refuse it in `BTClibException`.
+  `fuzz/corpus/` answers the opposite question —
+  `tests/fuzz_corpus_test.py` asserts that every seed there is still a
+  valid serialization of what it parses, so a crash input added to it is
+  refused by the very hardening that fixed the crash, and the only way
+  back to green would be to delete the regression. What that gate is for
+  is keeping this fuzzer's own starting point honest as the parsers move
+  under it (shipped in v2026.8.29).
+
 ### Documentation and the website
 
 - **A docstring in `src/btclib` carries the relation and not the
@@ -161,6 +246,29 @@ documented at release-notes length in the first place, and are still in
   literal, and cannot drift from it the way the dropped one could --
   `tests/copyright_test.py` now loads `conf.py` by path and checks the
   read.
+- **Prose no longer states counts nothing checks, and two that had
+  already drifted are fixed** (issue #1144). CONTRIBUTING.md's own
+  "measure, don't assert" rule was not honored in 36 places across
+  CLAUDE.md, RELEASING.md, REPOSITORY.md, CONTRIBUTING.md, README.md
+  and SECURITY.md — a count of something that can grow or shrink,
+  asserted as present-tense fact with nothing guarding it from
+  drifting silently false. Most had the number dropped where the named
+  things already carried the count, or a live command pointed at
+  instead (`gh api ... --jq '.required_status_checks.checks'`,
+  `cosmic-ray baseline`); GitHub's own platform limits (twenty
+  concurrent jobs on the Free plan) kept their number, with a dated
+  qualifier, since that is their policy and not this repository's
+  history.
+
+  Two were already wrong, not just unguarded. README.md said Electrum's
+  mnemonic standard reads "the five wordlists Electrum reads" where
+  `electrum.py`'s own `ELECTRUM_WORDLISTS` reuses `BIP39_LANGUAGE_FILES`
+  entire — twelve languages, only Portuguese overridden. RELEASING.md
+  said "the two `publish-*` jobs are the only holders of `id-token:
+  write`" in `release.yml`, where `attest` holds it too, for its
+  Sigstore OIDC exchange; the review gate the sentence was arguing for
+  still holds, `attest` only running via `needs:` after a publish job
+  succeeds, but the sentence itself was false (shipped in v2026.8.27).
 
 ### Packaging, linting and CI
 
@@ -247,6 +355,26 @@ documented at release-notes length in the first place, and are still in
   CONTRIBUTING.md: that paragraph goes, a setting being checkable where
   a warning has to be read and remembered. Wanting the warning back
   instead costs reverting this entry's two files.
+
+- **Every genuinely misplaced bullet is out of `_KNOWN_DRIFT`, moved to the
+  open cycle and tagged with the release that actually shipped it** (closes
+  #1524). Moving each to the release `git merge-base --is-ancestor` names as
+  the earliest containing its own commit does not work: that tag's own section
+  for the same heading was checked directly and never carried the bullet
+  either. Each commit wrote its bullet under whichever heading, searched for
+  downward from the top of the file, was the first still carrying a subsection
+  of the matching name -- never under a fresh subsection the still-open cycle
+  would have opened for it, because none was -- so any already-tagged
+  destination gains text its own sealed tag never had, the same failure this
+  module exists to catch. The one heading with no tag to violate is the
+  currently open one, which is where every relocatable bullet moved, each back
+  into the subsection it already belonged to and each carrying its own trailing
+  "(shipped in vX.Y.Z)" naming that release, so a reader can still tell it
+  apart from what this cycle actually added; once this cycle is tagged, every
+  one of them is part of that release's own history from the start. `v2026.8.7`
+  keeps its exemption, now to `13941fd1`'s and `0744d3f4`'s own text alone:
+  both rewrote a bullet already in that section in place rather than adding
+  one, so there is nothing left in it to relocate.
 
 ### The public API and the module layout
 
@@ -589,36 +717,6 @@ documented at release-notes length in the first place, and are still in
 ## v2026.8.27
 
 ### Repository
-
-- **`fuzz.yml` ran on every pull request and gated nothing** (issue
-  btclib-org/.github#460): the `pull_request` trigger and the
-  `pr_fuzzing` job that hung on it are gone, and `fuzz` is what section
-  10 of the organization standard calls it, a sentinel — `schedule` and
-  `workflow_dispatch`, nothing else. That job put ten minutes of fuzzing
-  on every push to an open pull request, and
-  `gh run list --workflow fuzz.yml --json event,conclusion` says what
-  became of those runs. No merge was waiting on the answer: `main`'s
-  `required_status_checks` names `Lint and type-check`, `Build the
-  documentation`, `test: every job passed` and `Regtest against Bitcoin
-  Core`, and `fuzz` produces none of those contexts, so what the job
-  charged was the reader's wait. That rule lives in the classic
-  branch-protection object rather than in a ruleset, which is why
-  `gh api repos/btclib-org/btclib/branches/main/protection` answers for
-  it and a rulesets-only read answers nothing. The pull request that cut
-  v2026.8.26 merged three minutes into its `PR fuzzing` job and
-  cancelled it, run `33008079111`, which is the case section 10 quotes.
-  `CONTRIBUTING.md`'s *What runs when* row moves with the triggers.
-
-- **A crash this sentinel finds becomes an ordinary test, not a seed**:
-  the regression names the input and what `parse` is expected to do with
-  it now, which is usually to refuse it in `BTClibException`.
-  `fuzz/corpus/` answers the opposite question —
-  `tests/fuzz_corpus_test.py` asserts that every seed there is still a
-  valid serialization of what it parses, so a crash input added to it is
-  refused by the very hardening that fixed the crash, and the only way
-  back to green would be to delete the regression. What that gate is for
-  is keeping this fuzzer's own starting point honest as the parsers move
-  under it.
 
 - **`README.md`'s badge row ends with the OpenSSF Best Practices badge.**
   Section 2 of the organization standard keys it on the property
@@ -11599,30 +11697,6 @@ documented at release-notes length in the first place, and are still in
 
 ### Documentation and the website
 
-- **Prose no longer states counts nothing checks, and two that had
-  already drifted are fixed** (issue #1144). CONTRIBUTING.md's own
-  "measure, don't assert" rule was not honored in 36 places across
-  CLAUDE.md, RELEASING.md, REPOSITORY.md, CONTRIBUTING.md, README.md
-  and SECURITY.md — a count of something that can grow or shrink,
-  asserted as present-tense fact with nothing guarding it from
-  drifting silently false. Most had the number dropped where the named
-  things already carried the count, or a live command pointed at
-  instead (`gh api ... --jq '.required_status_checks.checks'`,
-  `cosmic-ray baseline`); GitHub's own platform limits (twenty
-  concurrent jobs on the Free plan) kept their number, with a dated
-  qualifier, since that is their policy and not this repository's
-  history.
-
-  Two were already wrong, not just unguarded. README.md said Electrum's
-  mnemonic standard reads "the five wordlists Electrum reads" where
-  `electrum.py`'s own `ELECTRUM_WORDLISTS` reuses `BIP39_LANGUAGE_FILES`
-  entire — twelve languages, only Portuguese overridden. RELEASING.md
-  said "the two `publish-*` jobs are the only holders of `id-token:
-  write`" in `release.yml`, where `attest` holds it too, for its
-  Sigstore OIDC exchange; the review gate the sentence was arguing for
-  still holds, `attest` only running via `needs:` after a publish job
-  succeeds, but the sentence itself was false.
-
 - **`_libsecp256k1`'s docstring names the two states the module
   publishes** (issue #1137). It said the question "are the bindings
   installed" is answered by `AVAILABLE`, and there is no `AVAILABLE` in
@@ -14295,57 +14369,6 @@ by issue #1011. Neither file counts its entries: `grep -c '^- '` does
 that, whereas a stated number is a line every open branch has to edit.
 
 ### Repository
-
-- **A pull request no longer waits for macOS.** One run of the full matrix is
-  45 jobs, 93 minutes of compute and 399 minutes of queueing, and the two
-  macOS images account for most of the second number: 29.4 and 23.2 minutes
-  of mean wait for a runner, one of them 42.2, against 0.5 to 1.6 for ubuntu
-  and windows. So `test.yml` keeps all seven interpreters and drops to four
-  platforms, and the new `macos.yml` runs the two macOS images against the
-  same lock weekly, on demand, and from a release -- which is what keeps a
-  macOS regression from being published while nobody waits for one. It is
-  scheduled the same morning as `latest.yml`, half an hour before, so the two
-  read as a difference: red in both is the platform, red in `latest` alone is
-  the upgrade
-- **The documentation build is a workflow of its own**, `docs.yml`, where it
-  was the second job of `lint.yml`: a failed sphinx build and a failed hook
-  are different verdicts, and a workflow each is what gives them a badge each
-  and a line each in the checks list. The job keeps its name, `Build the
-  documentation`, so the required check did not have to move -- a context is
-  matched by name and not by the workflow that reported it
-- **`integration.yml` gates a merge**, where it gated only a release: 36
-  seconds of work for a disposable regtest node, less than the matrix it runs
-  beside, and it answers the one claim the recorded vectors cannot make. Its
-  `paths` filter goes with the promotion, a required check that never runs
-  blocking a merge where a skipped one satisfies it
-- **Every CI job has a name, and the names say what the job answers**, the
-  same vocabulary bitcoin-core-rpc uses: `suite`, `coverage`, `dist` and the
-  aggregate `test: every job passed` where the ids carried a `-py` suffix
-  that distinguished nothing, `suite-latest` and `install-published` where a
-  suffix does name a variant, and a sentence on each of the eleven jobs of
-  `release.yml`, which showed their ids in the checks list
-- **`published.yml` is called by `release.yml`** with the tag's version, and
-  waits for the index to serve it before installing -- so it can no longer
-  pass by testing the release before this one, which the dispatch
-  RELEASING.md asked for by hand could do. Its schedule goes from weekly to
-  monthly, the release path now answering the question the weekly stood in
-  for. Not a `workflow_run` trigger, which zizmor rates dangerous: that runs
-  the default branch's copy on a push nobody reviewed
-- **`release.yml` has a concurrency group**, the last workflow without one
-  and the only one whose runs have side effects, and it calls the docs and
-  macOS workflows beside the ones it already called
-- **A pre-commit rev that is not a released version fails the gate.** A local
-  pygrep hook rejects a rev naming only a major version, which follows every
-  future release of it, and a prerelease, which is not a release: the two
-  moves `autoupdate` offered in bitcoin-core-rpc, one of which was merged
-  before anyone read the diff. pre-commit warns about the first and exits
-  zero, which is the difference the hook makes
-- The dead `github.base_ref == 'master'` exception is gone from every job
-  that carried it, along with the prose describing a two-branch release flow:
-  `master` is not a branch here any more, so the clause could never be true
-  and `push` was aimed at a ref that does not exist -- which meant nothing
-  ran on the trunk, and no cache was written where a pull request could read
-  it
 
 - **`uv.lock` is at every dependency's newest release**, which closed the
   seven advisories the default branch was carrying: six on GitPython,

--- a/tests/changelog_immutability_test.py
+++ b/tests/changelog_immutability_test.py
@@ -49,33 +49,74 @@ and both are read as a name rather than as a verdict:**
   the file under this name is skipped rather than treated as a match or
   a mismatch it was never able to compute.
 
-**One exception, closed rather than open-ended.** Running this exact
-comparison against `origin/main` before this module existed found
-CHANGELOG.md's `v2026.8.7`, `v2026.8.21` and `v2026.8.27` already
-disagreeing with their own tag, so the defect above is real here and not
-only argued.
-
-`v2026.8.21` and `v2026.8.27` gained lines and lost none, which is the
-rebase's *misplacement* outcome rather than the *stacked-duplicate* one
-`.gitattributes`' own reasoning names, and finding which release those
-bullets belong to is issue #1524.
-
-`v2026.8.7` is not that, or not only: it lost lines as well, and the
+**One exception, and its own repair narrowed it rather than closing
+it.** Running this comparison against `origin/main` before this module
+existed found CHANGELOG.md's `v2026.8.7`, `v2026.8.21` and `v2026.8.27`
+already disagreeing with their own tag (issue #1512). `v2026.8.21` and
+`v2026.8.27` had gained lines and lost none, misplaced bullets from
+`afc1ca36` and `cbedc3b7` respectively, landed after that release's own
+tag was already cut. `v2026.8.7` had both gained and lost lines: the
 union driver only ever keeps both sides' *added* lines, so it cannot
-rewrite or delete what a tag already holds. Two landed commits did,
+rewrite or delete what a tag already holds, and two landed commits did,
 deliberately and in review -- `13941fd1` de-linked `[HISTORY.md](...)`
 inside that section, the file having been renamed and the link now
-404ing, and `0744d3f4` rewrote a bullet's quoted misspellings. Both are
-post-release edits to a released section, and neither is the mechanism
-this module exists for; only the bullets `237c86d4` added under that
-section's own heading are. Anyone repairing #1524 has to separate the
-two before moving anything.
+404ing, and `0744d3f4` rewrote a bullet's quoted misspellings in place.
+The bullets `237c86d4` added under that section's own heading, with no
+deletions, shared `afc1ca36`'s and `cbedc3b7`'s *misplacement* shape
+instead.
 
-`_KNOWN_DRIFT` below names the sections so the gate does not open red on
-a defect this branch did not write, and marks them `xfail(strict=True)`:
-a hand fix that makes one match its tag again turns that case into an
-*unexpected* pass, which is a failure too, so the exemption cannot
-quietly outlive the drift it names.
+None of the three landed under a subsection the open cycle would have
+opened for it. Each was written under whichever heading, searching down
+from the top of the file, was the first still carrying a subsection of
+the matching name -- not "there was nowhere to put it", but that no
+fresh subsection was opened under the still-open cycle for it.
+`git show <commit>:CHANGELOG.md | grep -nE '^## |^### '` is what shows
+this at each of the three: `237c86d4` wrote under `### Repository`,
+which neither the open cycle nor `v2026.8.9`, immediately below it,
+carried that day -- `v2026.8.7`, the next heading down, being the
+first that did; `afc1ca36` wrote under `### Documentation and the
+website`, which the open cycle's own subsections did not include that
+day, `v2026.8.21` immediately below it being the first that did; and
+`cbedc3b7` wrote under `### Repository`, again absent from the open
+cycle's own subsections that day, `v2026.8.27` immediately below it
+being the first that did. Issue #1458 points the right way without
+being the whole story: it is the subsection, not only the cycle
+heading, that a release now has to open for the next one.
+
+issue #1524 is that repair, and its own measurement corrected the
+obvious plan for the misplaced bullets: "move each to the release that
+actually shipped it" reads as though some already-tagged release's own
+snapshot shows it correctly filed, and none does. `git
+merge-base --is-ancestor <commit> <tag>` says `237c86d4` first reaches
+`v2026.8.21`, `afc1ca36` first reaches `v2026.8.27`, `cbedc3b7` first
+reaches `v2026.8.29` -- but every one of those tags' *own* section for
+that heading was checked directly and lacks the bullet too, because each
+commit wrote it under an already-released heading as measured above,
+and nothing has touched it since: the mistake was never a rebase
+disturbing a settled tag, it is what that one commit itself wrote, and
+every tag cut afterwards simply inherited it unchanged. So no already-
+tagged heading can receive a bullet without gaining text its own sealed
+tag never had, which is the identical failure this module exists to
+catch, moved rather than fixed. The one heading with no tag to violate
+is the currently open one, `## v2026.9 (work in progress, not released
+yet)`, in the subsection each bullet already belonged to -- and once
+that cycle is itself tagged, the bullet is part of its tag from day one,
+unlike every prior placement. Each relocated bullet carries its own
+trailing "(shipped in v<version>)", the tag `merge-base --is-ancestor`
+found, so a reader can still tell it apart from what this cycle actually
+added.
+
+`v2026.8.7` keeps its exemption, now to `13941fd1` and `0744d3f4` alone:
+`237c86d4`'s bullets, the section's only relocatable content, are gone
+from it, and the two deliberate, already-reviewed edits that remain
+rewrote their own text in place rather than adding a bullet, so there is
+nothing left to relocate -- matching the tag again would mean undoing
+two already-reviewed corrections instead.
+
+`_KNOWN_DRIFT` below names the one remaining section and marks it
+`xfail(strict=True)`: a further hand fix that makes it match its tag
+again turns that case into an *unexpected* pass, which is a failure too,
+so the exemption cannot quietly outlive the drift it names.
 """
 
 from __future__ import annotations
@@ -97,11 +138,15 @@ _HEADING = re.compile(r"^## (\S+)(.*)$", re.MULTILINE)
 # "git" in a subprocess list is a partial executable path
 _GIT = shutil.which("git") or "git"
 
+# what emptied v2026.8.7 of relocatable content is issue #1524 moving
+# out 237c86d4's own bullets, not the separate move of v2026.8.21's
+# and v2026.8.27's. What remains, 13941fd1's and 0744d3f4's own
+# deliberate edits, rewrote text already in that section rather than
+# adding a bullet, so there is nothing to relocate -- matching the tag
+# again would mean undoing two already-reviewed corrections
 _KNOWN_DRIFT = frozenset(
     {
         ("CHANGELOG.md", "v2026.8.7"),
-        ("CHANGELOG.md", "v2026.8.21"),
-        ("CHANGELOG.md", "v2026.8.27"),
     }
 )
 
@@ -151,12 +196,13 @@ def _cases() -> list[Any]:
         if (path, version) in _KNOWN_DRIFT:
             marks = pytest.mark.xfail(
                 reason=(
-                    f"known pre-existing drift: {path}'s {version!r} section"
-                    " already disagreed with its own tag before this module"
-                    " existed (issue #1524); a fix moving the misplaced"
-                    " bullet to its true release should turn this case into"
-                    " an unexpected pass, which is what removes it from"
-                    " _KNOWN_DRIFT"
+                    f"deliberate, reviewed post-release edit: {path}'s"
+                    f" {version!r} section carries 13941fd1's and"
+                    " 0744d3f4's own text, rewritten in place rather than"
+                    " added as a bullet, so there is nothing to relocate"
+                    " (issue #1524); a further fix making this match its"
+                    " tag again should turn this case into an unexpected"
+                    " pass, which is what removes it from _KNOWN_DRIFT"
                 ),
                 strict=True,
             )


### PR DESCRIPTION
Closes #1524

The gate landed by issue #1512 found three `CHANGELOG.md` sections
already carrying bullets their own release tag does not. This repairs
them and narrows the exemption they were parked behind.

## The repair this issue asked for does not work

The *Done when* asked that each misplaced bullet move to the release
`git merge-base --is-ancestor` names as the earliest containing its
commit. Measured, that destination is already wrong in its own snapshot:

| bullet | earliest containing tag | section it sits in *at that tag* |
| --- | --- | --- |
| `237c86d4` | `v2026.8.21` | `v2026.8.7` |
| `afc1ca36` | `v2026.8.27` | `v2026.8.21` |
| `cbedc3b7` | `v2026.8.29` | `v2026.8.27` |

Each commit wrote its bullet under an already-released heading as its own
first act, so every tag cut afterwards inherited the identical
misplacement. Moving the text to the destination tag's section makes
*that* section stop matching *its own* tag. Measured on `cbedc3b7`,
whose destination `v2026.8.29` carried no exemption to hide behind:

```
Failed: CHANGELOG.md's 'v2026.8.29' section no longer matches its own v2026.8.29 tag
[XPASS(strict)] ... CHANGELOG.md's 'v2026.8.27' ...
2 failed, 6 passed, 18 skipped, 2 xfailed        exit 1
```

So the plan does not trade one exemption for another, which would at
least have been neutral. It adds a fourth. Recorded on the issue.

## Why the bullets landed where they did

Not because no open cycle existed above them — one did, and was the
first heading in the file at all three commits. Each commit needed a
subsection the open cycle had not opened yet, so the downward search
skipped past it to the first already-released heading that carried one:

| commit | subsection needed | first heading carrying it |
| --- | --- | --- |
| `237c86d4` | `### Repository` | `v2026.8.7` (`v2026.9` and `v2026.8.9` had none) |
| `afc1ca36` | `### Documentation and the website` | `v2026.8.21` |
| `cbedc3b7` | `### Repository` | `v2026.8.27` |

Issue #1458 is what opens those subsections at release time now, so the
mechanism is closed going forward.

## Where they go instead

The open cycle is the one heading with no tag to violate, so every
relocatable bullet moves there, each back into the subsection it already
belonged to. That placement asserts a release the bullets did not ship
in — false in the same way their old placement was false, with one
difference that decides it: under `v2026.8.7` they sat in a section this
gate already exempts and stayed freely correctable, while the open cycle
seals them into its tag from day one. So each carries a trailing
`(shipped in v<version>)`, re-derivable with `merge-base
--is-ancestor`, and a reader can tell the eleven apart from what this
cycle actually added.

`v2026.8.7` keeps its exemption, narrowed to `13941fd1` (de-linked
`[HISTORY.md](./HISTORY.md)` after issue #1011 renamed the file) and
`0744d3f4` (rewrote a bullet's quoted misspellings). Both rewrote text
already in that section in place rather than adding a bullet, so nothing
is left in it to relocate: matching the tag again would mean reverting
two reviewed changes. `xfail(strict=True)` removes the exemption by
itself if that ever becomes true.

## Measured

The gate converts two sections from exemption to real assertion —
`7 passed, 18 skipped, 3 xfailed` before, `9 passed, 18 skipped, 1
xfailed` after. Positive controls run on this base, not carried
forward: a synthetic bullet spliced into each repaired section goes
red, and restoring `v2026.8.7` to its own tag's text gives
`XPASS(strict)`, so neither the assertions nor the surviving exemption
is passing blind.

The migration is a pure move: a multiset line diff over `CHANGELOG.md`
removes twelve line-variants — one blank, plus the eleven bullets'
final lines, each returning with its parenthetical appended — and adds
those tails plus this entry. `merge=union` keeps both sides' *added*
lines and this branch removes some, so the released sections were
re-measured against their tags after the rebase: `v2026.8.9`,
`v2026.8.21`, `v2026.8.27`, `v2026.8.29` all 0 added and 0 removed, and
`v2026.8.7` unchanged at its two known edits.

## Gates

`ruff check` 0; `ruff format --diff` 0; `mypy src/btclib tests
.github/scripts` 0 on 315 files; `pytest` 0 with 31096 passed, 29
skipped, 1 xfailed, coverage 100.00%; `pre-commit run --all-files` 0;
`sphinx-build -n -W --keep-going` 0.

## Summary by Sourcery

Repair changelog release placement and tighten immutability checks so misplaced entries are tracked in the open cycle without masking genuine drift.

Bug Fixes:
- Relocate all misplaced changelog bullets into the open release cycle and annotate each with the release in which it actually shipped.
- Narrow the changelog immutability exemption to the two deliberate post-release edits that remain in v2026.8.7.

Enhancements:
- Document the rationale for the relocation strategy and preserve changelog integrity assertions for released sections.

Tests:
- Update changelog immutability tests to recognize the repaired sections and retain a strict exemption only for v2026.8.7.