### PR TITLE
`ruff` honors an exclude for a path named explicitly, not only for the bare command (closes #1530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,15 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **`ruff format` honors `[tool.ruff.format]`'s `exclude` for a path named
+  explicitly on its own command line, not only for the bare command
+  CONTRIBUTING.md documents** (closes #1530). Without `[tool.ruff]
+  force-exclude = true`, `ruff format CHANGELOG.md` rewrites a comment's
+  spacing inside a tag-sealed `## v2026.8.27` section, which
+  `tests/changelog_immutability_test.py` then reads as drift. The key reaches
+  every subcommand and adds nothing else to what an explicit path can miss:
+  `[tool.ruff]` itself names no `exclude` or `extend-exclude`, so `ruff check`
+  resolves the same files before and after.
 - **`pypi-install.yml` waits for the index through a script with a
   test.** (issue btclib-org/.github#509) The wait is
   `.github/scripts/wait_for_pypi_release.py`, run by a `wait-for-index`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -841,6 +841,24 @@ exclude = [
 [tool.ruff]
 # target-version is inferred from project.requires-python
 
+# this key is what makes the formatter's own `exclude` below hold for a path
+# named explicitly on the command line, e.g. `ruff format CHANGELOG.md`, and
+# not only for the bare, path-less command CONTRIBUTING.md documents --
+# `[tool.typos.files]`'s own `extend-exclude` comment states the same
+# `--force-exclude` semantics for that hook. Without it, the named form
+# rewrites a comment's spacing inside a tag-sealed `## v2026.8.27` section,
+# which `tests/changelog_immutability_test.py` then reads as drift (issue
+# #1530). Measured on the pinned ruff 0.16.4: `ruff format --diff --no-cache
+# CHANGELOG.md` exits 1 without this key and 0 with it, a control with nothing
+# excluded also exiting 1 so the difference is the exclusion and not a file
+# needing no reformatting. The key lives here rather than under
+# `[tool.ruff.format]` because ruff reads it for every subcommand;
+# `[tool.ruff]` carries no `exclude` or `extend-exclude` of its own, so the
+# only patterns it enforces against an explicit path are the formatter's own
+# file names below and ruff's built-in defaults (`.git`, `__pypackages__`,
+# and the rest), checked with `ruff check --show-settings`.
+force-exclude = true
+
 [tool.ruff.format]
 # ruff format reads the fenced ```python blocks a .md file carries and
 # reformats them like any other source, which for these two append-only


### PR DESCRIPTION
Closes #1530

`[tool.ruff.format]`'s `exclude`, landed by issue #1517 so that `ruff
format` stops rewriting the fenced `python` blocks in `CHANGELOG.md` and
`RELEASE_NOTES.md`, holds for the bare command `CONTRIBUTING.md`
documents. It does not hold for a path named on the command line: ruff
enforces an exclude against an explicit path only when `force-exclude`
is set, and this tree set it nowhere.

## Why it matters, and did not before

On `origin/main`, `ruff 0.16.4`:

```
uv run ruff format --diff --no-cache               → exit 0, "360 files already formatted"
uv run ruff format --diff --no-cache CHANGELOG.md  → exit 1, "1 file would be reformatted"
```

The line it rewrites is `CHANGELOG.md:4055`, inside the section opened by
`## v2026.8.27` at 717 and closed by `## v2026.8.21` at 4663 — checked
from both boundaries, since one alone does not establish membership.
That section is sealed against its tag by
`tests/changelog_immutability_test.py`, landed by issue #1512, and issue
#1524 has just spent a pull request repairing three sections that drifted
this way. So the rewrite that was cosmetic before those two landed is now
the defect the tree gates against, reachable in one command someone might
type without thinking about the file's history.

The `ruff-format` pre-commit hook never fires it — `ruff-pre-commit`
restricts itself to `types_or: [python, pyi, jupyter]`. What reaches it
is a person or an agent naming the file they just touched.

## The measurement

Three configurations, the same `CHANGELOG.md`, the pinned `ruff`:

```
[tool.ruff.format] exclude = [...]            → exit 1
  + [tool.ruff] force-exclude = true          → exit 0
[tool.ruff] alone, nothing excluded           → exit 1   (control)
```

The control is what says the middle row is an exclusion being enforced
rather than a file that needed no reformatting.

## What the key costs

`force-exclude` belongs to `[tool.ruff]` rather than to the formatter, so
it reaches `ruff check` — which pre-commit invokes with filenames named
explicitly, exactly the case the key changes. Measured over all 340
tracked `*.py`, `*.pyi` and `*.ipynb` files, passed explicitly, before
and after:

```
ruff check --show-files   BEFORE 340 lines   AFTER 340 lines   IDENTICAL
control (drop one input)  1 line differs → the comparison is not blind
ruff format --diff        identical output on both sides
```

Nothing leaves lint's reach. `[tool.ruff]` names no `exclude` or
`extend-exclude` of its own, so the only patterns the key begins
enforcing are the formatter's own named files and ruff's built-in
defaults; the sole tracked paths matching any default are
`.vscode/*.json`, which the hooks never pass and which `include` drops
anyway.

## The tree already carried this reasoning for the other tool

`[tool.typos.files]`'s comment states the identical `--force-exclude`
semantics — pre-commit names files explicitly, and typos otherwise
overrides an exclude for a path named that way. The new comment points
at it rather than restating it.

The census behind "the other tool" is closed rather than assumed: of the
five config-level excludes in `pyproject.toml`, `[tool.uv.build-backend]`
and `[tool.coverage.run]` have no hook naming paths for them, `[tool.mypy]`
is invoked with `pass_filenames: false` and fixed directory arguments so
its `exclude` applies by recursion, and `[tool.typos.files]` already
carries the switch. Ruff was the only one exposed.

## Gates

`ruff format --diff` named, bare and scoped all 0; `ruff check` 0; `mypy
src/btclib tests .github/scripts` 0; `pytest` 0 with 31096 passed, 29
skipped, 1 xfailed, coverage 100.00%; `pre-commit run --all-files` 0;
`sphinx-build -n -W --keep-going` 0.

## Summary by Sourcery

Enable Ruff's force-exclude behavior so formatter exclusions remain effective for explicitly named files without changing lint coverage.

Bug Fixes:
- Ensure Ruff formatting exclusions are enforced when excluded files are passed explicitly on the command line.

Chores:
- Document the Ruff exclusion behavior and its interaction with explicit paths in the changelog and project configuration.