### PR TITLE
CLAUDE.md names the divergence between a config-level exclude and a path named on the command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,18 @@ documented at release-notes length in the first place, and are still in
   back to green would be to delete the regression. What that gate is for
   is keeping this fuzzer's own starting point honest as the parsers move
   under it (shipped in v2026.8.29).
+- **`CLAUDE.md`'s *Non-obvious facts* names the divergence between a
+  config-level `exclude` and a path named on the command line.** The
+  bare command a gate runs and the natural gesture of formatting the
+  file just touched answer differently, and nothing says which was
+  asked; enforcing the exclude against an explicit path is a switch of
+  its own, which `typos` carries in its hook args and `[tool.ruff]` in
+  `force-exclude`. The bullet names what it costs where the switch is
+  absent — a fenced python block rewritten inside a tag-sealed section,
+  and `tests/changelog_immutability_test.py` red on the result — why
+  the divergence does not reach `[tool.mypy]`'s `exclude` at all, for an
+  unrelated reason, and the command that answers from the tool rather
+  than from the file, in the two key groups it splits the answer across.
 
 ### Documentation and the website
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,24 @@ Do not use Fable unless explicitly instructed.
   each entry with `os.path.isdir`: `"btclib"` fails that test and is
   matched against import names instead, which is why the `src/` layout
   move left the line unchanged.
+- **A config-level `exclude` does not reach a path named on the command
+  line**, so the bare command a gate runs and the natural gesture —
+  formatting the file just touched — answer differently, with nothing
+  saying which one you asked. Enforcing an exclude against an explicit
+  path is its own switch, and the tools here that need it say so:
+  `typos` passes `--force-exclude` in its hook args, and
+  `[tool.ruff] force-exclude` covers `[tool.ruff.format]`'s `exclude`.
+  Lacking it, `ruff format CHANGELOG.md` rewrites a fenced python block
+  inside a tag-sealed section, which
+  `tests/changelog_immutability_test.py` then fails on. The divergence
+  does not reach `[tool.mypy]`'s `exclude`, for an unrelated reason —
+  its hook sets `pass_filenames: false` and names directories, so the
+  exclude applies by recursion. Ask the tool and not the file, and read
+  two key groups rather than one: `ruff check --show-settings` prints
+  the switch as `file_resolver.force_exclude` and the file names it
+  enforces as `formatter.exclude`, so `file_resolver.exclude`, which
+  holds ruff's built-in defaults, answers no for a file the formatter
+  does skip.
 - **`SECURITY.md`'s file:line citations are unchecked by any gate and
   drift silently.** An unrelated edit to a cited file shifts the line
   with nothing red; verify with `awk 'NR==N' <file>` against the


### PR DESCRIPTION
A bullet in `CLAUDE.md`'s *Non-obvious facts that will otherwise waste a
session*, and its `CHANGELOG.md` entry. No issue: this is the wrap-up
report of the 2026-08-29 campaign, written into the file the maintainer
asked for it in.

## What it says

A config-level `exclude` does not reach a path named on the command
line. So the bare command a gate runs and the natural gesture — running
the same tool on the file just touched — answer differently, and nothing
in either output says which question was asked. Enforcing the exclude
against an explicit path is a separate switch, and this tree carries it
in two different places: `typos` in its hook args, ruff in
`[tool.ruff] force-exclude`.

The bullet names what it costs where the switch is absent, which is not
hypothetical here: `ruff format CHANGELOG.md` rewrites a line inside a
fenced `python` block in the `v2026.8.27` section, and
`tests/changelog_immutability_test.py` seals that section against its
tag.

## What the review changed

Two rounds, both blocking, both applied and both re-measured before
applying.

The first is the one worth reading. The bullet's closing sentence
originally pointed a reader at `ruff check --show-settings` and said it
"prints the resolved `file_resolver` keys". Measured, that is the one
key group which does *not* hold the exclude the bullet is about:
`file_resolver.exclude` opens ruff's built-in defaults, and
`CHANGELOG.md` appears exactly once in the whole 1700-line dump, at line
1676 under `formatter.exclude`. A session obeying that sentence to
answer the bullet's own worked example would have read `file_resolver`,
not found the file, and concluded it was not excluded — the wasted
session the bullet exists to prevent, arrived at by following it. The
fix makes the split itself the fact rather than appending a key to a
list, because it is the same shape as the bullet's subject: a name
promising a scope it does not have.

The second is wording. `[tool.mypy]`'s `exclude` was said to be "out of
reach", where this tree spells the complement whenever it means
*protected from* (`CONTRIBUTING.md`, `SECURITY.md`) and uses the bare
form for *unavailable* (`src/btclib/_libsecp256k1.py`). The sentence
read as the opposite of the clause following it. Raised as
non-blocking on the ground that the `CHANGELOG.md` copy is append-only;
treated as blocking instead, because the `CLAUDE.md` copy has the larger
and more repeated readership.

The commit message carried the same wording defect and is corrected
there too. The review is scoped to the tree and the message is not in
the tree, so it was named as in scope explicitly; the branch being one
commit, that body is what lands.

## Gates

`pre-commit run --all-files` exit 0, zero `Failed` lines; `mypy` exit 0,
no issues in 315 source files; `sphinx-build -n -W --keep-going` exit 0;
`pytest` exit 0, coverage 100.00%. `git status --porcelain` empty after
the fixer hooks and again after the suite. Local review cleared
`aceebd8a30d87f08f1f0a63ffcdd8be326c61e52`.

## Summary by Sourcery

Document command-line exclusion behavior across the repository's formatting, linting, and type-checking tools.

Enhancements:
- Document the divergence between configuration-level excludes and explicitly named command-line paths, including the tool-specific settings needed to enforce exclusions and the distinct behavior of mypy.

Documentation:
- Add guidance to CLAUDE.md and the changelog explaining how to inspect Ruff's effective exclusion settings and avoid unintended formatting of protected changelog content.