### PR TITLE
REPOSITORY.md's Publishing section stops reading back github-pages (closes #1533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,15 @@ documented at release-notes length in the first place, and are still in
   `environment:` key — and the sample output under *Publishing waits
   for an approval* now shows only `github-pages`, `pypi` and `testpypi`,
   which is what `gh api repos/btclib-org/btclib/environments` answers.
+- **`REPOSITORY.md`'s Publishing section stops reading back
+  `github-pages`** (closes #1533). Section 11 of the organization
+  standard places it outside this file — it is GitHub's own
+  environment, created by enabling Pages rather than by the repository
+  — so the sample readback under *Publishing waits for an approval*
+  now selects `pypi` and `testpypi` only, and the sentence recording
+  `github-pages`'s branch restriction is gone; the branch Pages serves
+  is what *Pages, which is btclib.org*'s own `source.branch` already
+  answers.
 
 ### Documentation and the website
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -555,8 +555,8 @@ stays allowed.
 
 ```shell
 gh api repos/btclib-org/btclib/environments \
-  --jq '.environments[] | {name, protection_rules: [.protection_rules[]?.type]}'
-# {"name":"github-pages","protection_rules":["branch_policy"]}
+  --jq '.environments[] | select(.name == "pypi" or .name == "testpypi") |
+        {name, protection_rules: [.protection_rules[]?.type]}'
 # {"name":"pypi","protection_rules":["required_reviewers","branch_policy"]}
 # {"name":"testpypi","protection_rules":["required_reviewers"]}
 ```
@@ -573,8 +573,7 @@ gh api repos/btclib-org/btclib/environments/pypi/deployment-branch-policies \
 it — the same call against `testpypi` 404s, where it answers for `pypi`
 — so a publish to TestPyPI accepts any branch or tag once approved;
 `release.yml`'s own `workflow_dispatch` trigger is what narrows it
-further. `github-pages` restricts to `main`, the branch Pages already
-serves.
+further.
 
 ## Pages, which is btclib.org
 


### PR DESCRIPTION
Section 11 of the organization standard places `github-pages` outside
`REPOSITORY.md` — it is GitHub's own environment, created by enabling
Pages rather than by the repository, and its protection rule is GitHub's
too, so reading it back records a value nobody here can set. The
sentence landed on 2026-08-29, closing btclib-org/.github#575, the day
before this file's *Publishing* section was last touched. Two sites here
still put it back in.

Filed by the local reviewer of [PR 1534](https://github.com/btclib-org/btclib/pull/1534)
while reading the section that pull request edited, and worked by that
same pull request's coder, which is why neither had to re-derive the
section.

## The two sites, and why one of them is not a deletion

The pasted readback under *Publishing waits for an approval* had
`github-pages` in its output. Deleting that line and leaving the command
unfiltered would have left a paste that is not what the command answers
— a readback that cannot be re-derived, which is the one failure this
file cannot afford. The `jq` filter is scoped instead, to the standard's
own two names, and the pasted block is that command's real output: the
reviewer ran it verbatim, newline inside the quoted argument included,
and `cmp`'d the result against the paste byte for byte, with a one-byte
tamper as the control that `cmp` discriminates.

The second site is the closing sentence of a paragraph, so it was read
whole before being cut rather than deleted on a grep hit. What remains
ends on "`release.yml`'s own `workflow_dispatch` trigger is what narrows
it further." — a complete sentence. And the *fact* that sentence carried
is not lost: `## Pages, which is btclib.org` already pastes
`gh api repos/btclib-org/btclib/pages`, whose `source.branch` answers
`main`. That is a different setting from the `github-pages` environment's
`branch_policy` — both were checked live and both answer `main`, which
is a coincidence of value and not the same thing — so what goes is the
value GitHub owns, and what stays is the one this repository set.

## The alternative the review weighed and did not require

`select(.name == "pypi" or .name == "testpypi")` names two literals, so
it cannot surface a *third* environment appearing — and
[ISS 1516](https://github.com/btclib-org/btclib/issues/1516) is the
proof that a stray does appear here. The reviewer measured that against
a synthetic payload carrying one: the pre-diff unfiltered form surfaces
it, this diff's form does not, and `select(.name != "github-pages")`
does while answering the two pasted lines byte-identically against the
live endpoint.

Both are defensible, so the author's stands. The unfiltered readback is
not the answer either way: the standard rejects it in as many words —
"recording whatever a repository holds writes a stray environment down
rather than finding it, which is what legitimises it" — and puts the
detection command in the standard, for whoever audits, rather than in
each `REPOSITORY.md`.

## A stale clause that ships on purpose

PR 1534's own bullet, in this same unreleased `## v2026.9` section, says
the readback "now shows only `github-pages`, `pypi` and `testpypi`".
After this commit it shows two. That clause is not edited, and the
reason is not the append-only rule — editing was measured to be
available, permitted and precedented. It is that rewriting it would
replace a stale clause with a false one: PR 1534 genuinely produced a
three-name readback, and saying otherwise would make the record assert
something untrue of the change it is the record of. A changelog bullet's
tense is relative to its own change. The correction is the bullet
immediately below it.

## Gates

`pre-commit run --all-files` exit 0, zero `Failed` lines; `pytest` exit
0, 31096 passed, coverage 100.00%; `mypy` exit 0, no issues in 315
source files; `sphinx-build -n -W --keep-going` exit 0;
`git status --porcelain` empty after the last. Local review cleared
`85e4e5d29fbf2362df3b0067884bfb419c37285a`, and states that it ran no
gate itself and read no CI.

Closes #1533

## Summary by Sourcery

Stop `REPOSITORY.md` from recording GitHub-managed `github-pages` settings in its Publishing documentation.

Enhancements:
- Align `REPOSITORY.md`'s Publishing readback with the organization standard by excluding GitHub-managed `github-pages` environment data and retaining only repository-managed deployment environments.
- Remove the redundant `github-pages` branch restriction statement while preserving the Pages source branch documentation.

Documentation:
- Update the changelog to document the Publishing section's corrected environment readback.