### PR TITLE
The verbatim files are the standard's copies, byte for byte (issue btclib-org/.github#423) (issue btclib-org/.github#316) (issue btclib-org/.github#281) (issue btclib-org/.github#412)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,12 +6,18 @@
 # anything for it to apply.
 #
 # It applies to rebases too, which is where it earns its keep, and it has
-# a price worth knowing: these two files then never conflict at all, so
-# the same existing entry edited on two branches merges in silence rather
-# than being flagged. That is why neither states how many entries it has —
-# a count is exactly such an edit, and union would have kept both numbers.
-# Section 9 of the organization standard, btclib-org/.github's README.md,
-# is where this rule is recorded.
+# a price worth knowing: on a checkout these two files never conflict at
+# all, so the same existing entry edited on two branches merges in
+# silence rather than being flagged. That is why neither states how many
+# entries it has — a count is exactly such an edit, and union would have
+# kept both numbers.
+#
+# The driver is a checkout's, and the forge does not apply it: a pull
+# request whose changelog or release notes overlap its base is reported
+# CONFLICTING however cleanly the same pair merges under the driver, and
+# a rebase on a checkout is what clears it. Section 9 of the organization
+# standard, btclib-org/.github's README.md, is where this rule is
+# recorded.
 #
 # Both lines are in every repository's copy, a tree carrying no
 # RELEASE_NOTES.md included: section 2 of that README.md gives the

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -9,13 +9,15 @@
   // and after the offending block
   // <!-- markdownlint-enable MD013 -->
 
-  // This file is the same in btclib, btclib-secp256k1 and
-  // bitcoin-core-rpc, deliberately: prose moves between the three, and a
-  // paragraph that lints in one has to lint in the others. No rule is
-  // disabled here -- what follows only names a style where markdownlint's
-  // default is "consistent", which asks each file to agree with itself and
-  // therefore lets two files disagree. That is what let an indented block
-  // pass in one repository and fail in another.
+  // This file is the same in every repository of the organization,
+  // deliberately: prose moves between the trees, and a paragraph that
+  // lints in one has to lint in the others. Section 14 of the
+  // organization standard, btclib-org/.github's README.md, is what says
+  // so, and tests/verbatim_test.py there is what compares the copies. No
+  // rule is disabled here -- what follows only names a style where
+  // markdownlint's default is "consistent", which asks each file to agree
+  // with itself and therefore lets two files disagree. That is what let
+  // an indented block pass in one repository and fail in another.
   //
   // A rule that only one file needs is not here: bitcoin-core-rpc's
   // CHANGELOG.md repeats "### Added" under every release, which is what

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -428,6 +428,24 @@ documented at release-notes length in the first place, and are still in
   file `LICENSE`/`__copyright__`'s own drift (issue #389) already
   earned a test.
 
+### The verbatim files are the standard's copies, byte for byte
+
+- **`.gitattributes` states the union price as section 9 of the
+  standard does** (issue btclib-org/.github#423): the driver is a
+  checkout's and the forge does not apply it, so a pull request whose
+  `CHANGELOG.md` or `RELEASE_NOTES.md` overlaps its base is reported
+  `CONFLICTING` however cleanly the pair merges locally, and a rebase on
+  a checkout is what clears it.
+- **`.markdownlint.jsonc` points at section 14 of the standard for who
+  carries it** (issue btclib-org/.github#316), in place of an
+  enumeration of trees.
+- **`CONTRIBUTING.md`'s shared half is btclib-org/.github's** (issue
+  btclib-org/.github#281): the half is replaced whole rather than each
+  change applied by hand, a hand-written list of them being what comes
+  up short. Among them, *The landing queue* points at `REPOSITORY.md`'s
+  *Plan-gated settings* for the ceiling's figure (issue
+  btclib-org/.github#412).
+
 ## v2026.8.29
 
 ### Repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,24 @@ neither of them shows, is [the standard's *What a pull request says it
 is*][s-title]. Read it before opening one; it is the rule most often
 found broken after the fact.
 
+**Before it is opened, the branch's own commit subjects and bodies are
+read against that same rule.** The description does not exist yet to
+disagree with them, and [the standard][s-title] has the command that
+scans the branch's own commit text for a verb in front of a reference.
+
+**The two spellings are named here as well as there, against [section 9's
+*One fact in one place*][s9]**, the paragraph above naming the section
+and not the forms, which are the half a citation is got wrong in:
+`(closes #N)` cites an issue the change closes, wherever the citation
+sits — the title, the commit subject where [*Merge method*][s11] makes
+that the thing that lands, and a `CHANGELOG.md` entry — and `(issue #N)`
+cites, in those same places, an issue the change advances and does *not*
+close. One token holds one meaning whichever file it sits in, so the
+pair is chosen by what is true of the change rather than by which file
+is being written, and a tree's own landed subjects are not what to copy
+it from: nothing already landed is rewritten, so what a repository wrote
+before the rule stays where it is.
+
 `REVIEWING.md` is the standard a review is written against, and is this
 file's other half. Read before opening a pull request, it is what the
 pull request will be answered against.
@@ -104,7 +122,8 @@ on concurrent jobs, so rebasing every waiting pull request after each
 landing spends that capacity on runs the next landing invalidates
 anyway, and delays the one pull request that is actually next: work
 spent on a pull request that is not next is work that delays the one
-that is.
+that is. The ceiling's figure is `REPOSITORY.md`'s, under *Plan-gated
+settings*, beside the command that re-derives it.
 
 Order is cheapest and least contended first, most invasive last, so that
 a large change does not sit at the head blocking everything behind it.
@@ -164,8 +183,18 @@ the merge button asks:
 
 ```shell
 gh api -X PUT repos/{owner}/{repo}/pulls/<n>/merge \
-  -f merge_method=squash
+  -f merge_method=squash -f sha=<the head the checks ran on>
 ```
+
+**The `sha` is not optional.** Reading the ack and merging are two
+calls, and the head is free to move between them — the push that would
+move it comes out of the same round the verdict does. Unpinned, the
+command takes whatever sits at the head when it runs; pinned, [the
+endpoint answers `409` where the head has moved][gh-merge], and a round
+lost that way is cheaper than a tree nobody has read reaching `main`.
+*The review* above anchors the exchange to a sha and [section 11][s11]
+has an ack name one: the pin is that rule reaching the call that
+performs the landing.
 
 **Verify what landed rather than trusting the answer**, the signature
 [the standard asks for][s-sigs] being a valid one rather than a
@@ -175,6 +204,11 @@ particular signer's:
 gh api repos/{owner}/{repo}/commits/main \
   --jq '.commit.verification | {verified, reason}'
 ```
+
+**What it closed is read again here too, from the landed sha rather
+than from the pull request**: [the standard's *What a pull request says
+it is*][s-title] has the second read, and why the first alone does not
+reach a squash subject composed after it runs.
 
 The forge deletes the head branch itself, per the setting section 11
 names. What is still yours is bringing every checkout sitting on `main`
@@ -189,6 +223,7 @@ settings and why they are what they are.
 [s-title]: https://github.com/btclib-org/.github#what-a-pull-request-says-it-is
 [s-rev]: https://github.com/btclib-org/.github#review
 [s-sigs]: https://github.com/btclib-org/.github#signatures
+[gh-merge]: https://docs.github.com/en/rest/pulls/pulls#merge-a-pull-request
 
 ## This repository in particular
 


### PR DESCRIPTION
The verbatim files are the standard's copies, byte for byte (issue btclib-org/.github#423) (issue btclib-org/.github#316) (issue btclib-org/.github#281) (issue btclib-org/.github#412)

Section 14 of the standard names `.gitattributes`, `.markdownlint.jsonc`
and the shared half of `CONTRIBUTING.md` as the same file in every
repository, and btclib-org/.github's copies moved ahead of this tree's.
Each is replaced whole by the content of btclib-org/.github at 4b7d5c4:
`.markdownlint.jsonc` as a file, and `.gitattributes` and
`CONTRIBUTING.md` above `## This repository in particular`, this tree's
own half of each untouched. The diff is what the replacement carries;
nothing was applied by hand.

The changelog entry sits at the end of the open section in a heading of
its own, which is where section 9 of the standard sends a new entry;
this section is grouped by theme, and btclib-org/.github#567 is open on
the two rules meeting.

Measured with `tests/verbatim_test.py`'s own cut: the shared half of
each file hashes the same here as at btclib-org/.github 4b7d5c4.

None of the four issues closes here: btclib-org/.github's
`EXPECTED_DRIFT` entries are deleted once every tree converges.

btclib-org/.github#423
btclib-org/.github#316
btclib-org/.github#281
btclib-org/.github#412


Local review: CLEARED 91ed708 (this sha carries the identical tree, re-parented onto main after the landing below it). Gates on that tree, as this repository's `CONTRIBUTING.md` writes them: exit 0.

## Summary by Sourcery

Align the repository’s shared policy files and contribution guidance byte-for-byte with the organization standard.

Enhancements:
- Synchronize the shared portions of `.gitattributes`, `.markdownlint.jsonc`, and `CONTRIBUTING.md` with the organization standard, including updated pull request validation and merge guidance.

Documentation:
- Document the standard’s issue-reference conventions, commit validation expectations, SHA-pinned merges, and post-merge verification procedures.

Chores:
- Add a changelog entry describing the verbatim-file standardization.
