### PR TITLE
release.yml's needs: public-api orders the upload, and every workflow badge is main's (closes #1467, closes #1536) (issue btclib-org/.github#579)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,9 +242,10 @@ jobs:
   # btclib-org/btclib#651 has not settled yet. Here the answer arrives
   # while RELEASE_NOTES.md is already being written, so a break with no
   # entry is refused at the moment somebody is already writing entries.
-  # Ahead of the build/test matrix below: a broken surface is worth
-  # knowing before the platform sweeps and the smoke tests spend the
-  # wall clock they take
+  # No `needs:` of its own, so it starts when the run does, beside the
+  # platform sweeps rather than ahead of them. What the graph orders
+  # after it is the upload: publish-testpypi and publish-pypi list it,
+  # so the surface has been read before anything reaches an index
   public-api:
     name: Check the public API against the last release
     runs-on: ubuntu-latest
@@ -422,17 +423,16 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI
-    # public-api stays a need for ordering -- reading a broken surface
-    # before spending the platform sweeps' wall clock is the point,
-    # public-api's own comment says so -- but not for its result: that
-    # job's own comment calls it deliberately not a merge gate, and
-    # `needs` without `always()` gates on every listed job regardless,
-    # a skipped job counting as failed the same as this run's own
-    # comment on the line below already says of publish-pypi. Measured
-    # on run 33008687408: public-api exited 1 on the widening every
-    # Octets-taking alias got this cycle, and publish-testpypi never
-    # started, so the testpypi environment review never fired
-    # (issue #1461)
+    # public-api stays a need for ordering -- what it orders is this
+    # job, which does not start until the surface has been read -- but
+    # not for its result: that job's own comment calls it deliberately
+    # not a merge gate, and `needs` without `always()` gates on every
+    # listed job regardless, a skipped job counting as failed the same
+    # as this run's own comment on the line below already says of
+    # publish-pypi. Measured on run 33008687408: public-api exited 1 on
+    # the widening every Octets-taking alias got this cycle, and
+    # publish-testpypi never started, so the testpypi environment
+    # review never fired (issue #1461)
     needs:
       [
         public-api,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -466,6 +466,23 @@ documented at release-notes length in the first place, and are still in
   both rewrote a bullet already in that section in place rather than adding
   one, so there is nothing left in it to relocate.
 
+- **`release.yml`'s comments on `needs: public-api` name the ordering the
+  graph produces** (closes #1536). The entry does not put the surface check
+  ahead of the platform sweeps: `public-api` carries no `needs:` of its own
+  and starts when the run does, beside them. What it orders is the publish,
+  `publish-testpypi` and `publish-pypi` each listing it, so a release reaches
+  an index only after the surface has been read.
+
+- **Every workflow-status badge in `README.md` carries `?branch=main`**
+  (closes #1467) (issue btclib-org/.github#579). Section 2 of the
+  organization standard is where that is decided and why. The issue was
+  filed on the `fuzz` badge alone and this is the whole row, a half
+  qualified one leaving a reader no way to tell which badges answer for
+  `main`. Every one of them answers with a state under the qualifier
+  rather than `no status`, so none needed a `workflow_dispatch` run on
+  `main` to seed the first one, which section 2 asks of a tree that lands
+  the badge.
+
 ### The public API and the module layout
 
 - **`btclib.__author__`, `__author_email__` and `__license__` are gone**

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ whose 80 columns bind only where a space follows them.
 A badge that reports no state -- "we use ruff", "we use uv" -- reports a
 choice instead, and those are in CONTRIBUTING.md, beside the prose that
 says how the choice is enforced.
+
+Every workflow-status badge carries `?branch=main`: section 2 of the
+organization standard is where that is decided and why. The pre-commit.ci
+badge is outside it, being the service's own with its branch already in
+its path.
 -->
 [![PyPI version](https://img.shields.io/pypi/v/btclib.svg?logo=pypi)](https://pypi.python.org/pypi/btclib/)
 [![GitHub release](https://img.shields.io/github/v/release/btclib-org/btclib.svg)](https://github.com/btclib-org/btclib/releases)
@@ -29,23 +34,23 @@ says how the choice is enforced.
 [![wheel](https://img.shields.io/pypi/wheel/btclib.svg)](https://pypi.python.org/pypi/btclib/)
 
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib/main.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib/main)
-[![lint workflow status](https://github.com/btclib-org/btclib/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/lint.yml)
-[![test workflow status](https://github.com/btclib-org/btclib/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/test.yml)
-[![docs workflow status](https://github.com/btclib-org/btclib/actions/workflows/docs.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/docs.yml)
+[![lint workflow status](https://github.com/btclib-org/btclib/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/lint.yml)
+[![test workflow status](https://github.com/btclib-org/btclib/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/test.yml)
+[![docs workflow status](https://github.com/btclib-org/btclib/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/docs.yml)
 [![documentation build](https://app.readthedocs.org/projects/btclib/badge/?version=latest)](https://btclib.readthedocs.io)
-[![vendored-vectors workflow status](https://github.com/btclib-org/btclib/actions/workflows/vendored-vectors.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/vendored-vectors.yml)
-[![mutation workflow status](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml)
-[![fuzz workflow status](https://github.com/btclib-org/btclib/actions/workflows/fuzz.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/fuzz.yml)
-[![integration-bitcoind workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml)
-[![integration-hwi workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-hwi.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/integration-hwi.yml)
-[![deps-latest workflow status](https://github.com/btclib-org/btclib/actions/workflows/deps-latest.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/deps-latest.yml)
-[![pypi-install workflow status](https://github.com/btclib-org/btclib/actions/workflows/pypi-install.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/pypi-install.yml)
-[![py-arm-authority workflow status](https://github.com/btclib-org/btclib/actions/workflows/py-arm-authority.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/py-arm-authority.yml)
-[![os-macos workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-macos.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/os-macos.yml)
-[![os-ubuntu workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-ubuntu.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/os-ubuntu.yml)
-[![os-windows workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-windows.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/os-windows.yml)
-[![links workflow status](https://github.com/btclib-org/btclib/actions/workflows/links.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/links.yml)
-[![codeql workflow status](https://github.com/btclib-org/btclib/actions/workflows/codeql.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/codeql.yml)
+[![vendored-vectors workflow status](https://github.com/btclib-org/btclib/actions/workflows/vendored-vectors.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/vendored-vectors.yml)
+[![mutation workflow status](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml)
+[![fuzz workflow status](https://github.com/btclib-org/btclib/actions/workflows/fuzz.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/fuzz.yml)
+[![integration-bitcoind workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml)
+[![integration-hwi workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-hwi.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/integration-hwi.yml)
+[![deps-latest workflow status](https://github.com/btclib-org/btclib/actions/workflows/deps-latest.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/deps-latest.yml)
+[![pypi-install workflow status](https://github.com/btclib-org/btclib/actions/workflows/pypi-install.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/pypi-install.yml)
+[![py-arm-authority workflow status](https://github.com/btclib-org/btclib/actions/workflows/py-arm-authority.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/py-arm-authority.yml)
+[![os-macos workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-macos.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/os-macos.yml)
+[![os-ubuntu workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-ubuntu.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/os-ubuntu.yml)
+[![os-windows workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-windows.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/os-windows.yml)
+[![links workflow status](https://github.com/btclib-org/btclib/actions/workflows/links.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/links.yml)
+[![codeql workflow status](https://github.com/btclib-org/btclib/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/codeql.yml)
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/btclib-org/btclib/badge)](https://scorecard.dev/viewer/?uri=github.com/btclib-org/btclib)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14253/badge)](https://www.bestpractices.dev/projects/14253)


### PR DESCRIPTION
Two claims this tree makes about its own CI, both false, both about what
`.github/workflows/` actually holds.

### ISS 1536 — `release.yml`'s comments describe a graph it does not have

`public-api` carries no `needs:`, so it starts *with* the sweeps rather than
ahead of them; the only jobs that list it are `publish-testpypi` and
`publish-pypi`. What the entry orders is therefore the **upload** after the
reading, not the reading before the tests, and the two comments now say that.

The change is comment-only, which is measurable rather than a matter of
reading:

```shell
diff <(git show <base>:.github/workflows/release.yml | grep -v '^\s*#') \
     <(git show <head>:.github/workflows/release.yml | grep -v '^\s*#')
```

is empty. No job is renamed, so no required check is renamed out of existence.

### ISS 1467 — the fuzz badge, and then the whole row

The issue was filed on the fuzz badge reporting a deleted branch's failure.
Its own body raised the wider question as item 1, and
`btclib-org/.github` section 2 has since answered it: **every workflow-status
badge carries `?branch=main`**, because an unqualified badge falls back to
another branch's run — a deleted branch's included — and nothing in the render
says so.

So all sixteen workflow-status badges are qualified, not just fuzz. Counted
with the parent as the positive control, because a count that only ever ran
after the change has measured nothing:

| | before | after |
| --- | --- | --- |
| `badge.svg)` unqualified | 16 | 0 |
| `badge.svg?branch=main)` | 0 | 16 |
| `badge.svg` (control) | 16 | 16 |

Untouched, and deliberately: pre-commit.ci, which section 2 exempts by name
since its branch is already in its path; Read the Docs, OpenSSF Scorecard and
OpenSSF Best Practices, which are not workflow-status badges at all. Badge
**hrefs** are left bare — the standard's own row does the same, and
`?branch=main` is not the Actions UI's filter parameter anyway.

All sixteen qualified URLs were rendered: none answers `no status`. Fourteen
read `passing`; `test` and `os-macos` read `failing`, and that is `main`'s own
red rather than a stale branch's, which is the property the qualifier buys.

This cites `(issue btclib-org/.github#579)` without a closing keyword —
cross-repository keywords do fire here, and #579 is a family-wide issue closed
by hand once every row has landed.

### One red on this branch that is not this branch's

`btclib-org/btclib#1538`: `tests/copyright_test.py` imports
`docs/source/conf.py`, which needs `tomllib` and `docutils`, and no CI job
that runs the suite installs either. The required `test` check has been red on
`main` for six consecutive runs, and `os-macos` fails in every matrix cell on
the same test; one cause reports as two failures because coverage then drags
to `99.99` against `fail_under=100`. A local `uv run pytest` passes at 100%
because `uv sync` installs every group, which is how it reached `main`.

This branch changes no Python, no test, no workflow logic and no dependency
group — `git diff <base>..<head> -- tests/ docs/` is empty — so it can neither
cause nor cure that failure, and inherits it from its base.

## Summary by Sourcery

Align release workflow documentation and status badges with the behavior and conventions of the main branch.

Enhancements:
- Clarify the release workflow comments to accurately describe how the public API check orders publication jobs.
- Pin all GitHub Actions workflow-status badges in the README to report the main branch and document the badge convention.

Documentation:
- Add changelog entries documenting the corrected release workflow ordering and main-branch badge qualification.