### PR TITLE
`interpreters_test.py` gates the `Free Threading` classifier on the merge gate's interpreters (closes #1539) (issue btclib-org/.github#577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -446,6 +446,19 @@ documented at release-notes length in the first place, and are still in
   *Plan-gated settings* for the ceiling's figure (issue
   btclib-org/.github#412).
 
+### Tests
+
+- **`tests/interpreters_test.py` gates the `Free Threading` classifier
+  on the merge gate running a free-threaded build** (closes #1539, issue
+  btclib-org/.github#577). Section 3 of the organization standard
+  declares the classifier where the gate exercises that build and names
+  the enforcement: the biconditional that gates the PyPy classifier,
+  with the gate's own interpreters as its second side. That side is
+  `test.yml` and not the platform sweeps, whose `3.14t` cell runs beside
+  a landing and blocks nothing — a sweep passing is the ground the
+  standard declines. Neither side holds in this tree, so the test lands
+  green, and it goes red on whichever side moves alone.
+
 ## v2026.8.29
 
 ### Repository

--- a/tests/interpreters_test.py
+++ b/tests/interpreters_test.py
@@ -42,6 +42,13 @@ _CLASSIFIER = re.compile(
     r'^    "Programming Language :: Python :: (?P<version>3\.\d+)",$', re.MULTILINE
 )
 _PYPY_CLASSIFIER = "Programming Language :: Python :: Implementation :: PyPy"
+# PyPI's free-threading classifiers, the bare one and its maturity levels
+# alike: each is a claim about the code under a free-threaded build, and
+# which is claimed is not this module's question
+_FREE_THREADING_CLASSIFIER = re.compile(
+    r'^    "Programming Language :: Python :: Free Threading(?: :: .+)?",$',
+    re.MULTILINE,
+)
 # the matrix list a suite workflow builds its cells from. The gate runs
 # one interpreter, so the list lives in the weekly platform sweeps now --
 # in each of them, which is why they are read together below rather than
@@ -55,6 +62,16 @@ _PYTHONS = re.compile(
 # -- would drop out of the comparison below in silence, leaving the
 # remaining two to agree with each other and the test green
 _SWEEPS = ("os-macos.yml", "os-ubuntu.yml", "os-windows.yml")
+# the merge gate, which its own header says is one cell rather than a
+# matrix: each job writes the interpreter it runs into itself, as
+# `python-version: "3.14"` or `--python 3.14`, so the gate's interpreters
+# are read as tokens off the file rather than out of a matrix block. A
+# free-threaded build there is a "3.14t" of the same shape. Comments go
+# first, so that a sentence about a sweep's free-threaded cell does not
+# read as the gate running one
+_GATE = _ROOT / ".github/workflows/test.yml"
+_COMMENT = re.compile(r"(?:^|\s)#.*$", re.MULTILINE)
+_INTERPRETER = re.compile(r"\b3\.\d+t?\b")
 
 
 def _versions(pattern: re.Pattern[str], text: str) -> tuple[str, ...]:
@@ -76,6 +93,12 @@ def _declared() -> dict[str, tuple[str, ...]]:
         if listed:
             found[workflow.name] = tuple(sorted(listed))
     return found
+
+
+def _gate_interpreters() -> tuple[str, ...]:
+    """Return every interpreter the merge gate names outside its comments."""
+    text = _COMMENT.sub("", _GATE.read_text(encoding="utf-8"))
+    return tuple(sorted(set(_INTERPRETER.findall(text))))
 
 
 def _matrix() -> tuple[str, ...]:
@@ -142,6 +165,26 @@ def test_pypy_is_classified_exactly_when_it_is_run() -> None:
     assert classified == run, (
         f"the PyPy classifier is {'present' if classified else 'absent'} and"
         f" the matrix {'runs' if run else 'does not run'} a PyPy interpreter"
+    )
+
+
+def test_free_threading_is_classified_exactly_when_the_gate_runs_it() -> None:
+    """The free-threading classifier is a claim about the merge gate.
+
+    The organization standard declares one where the gate exercises the
+    free-threaded build: a gate refuses the landing that breaks that
+    build, where a sweep runs beside a landing and blocks nothing. So the
+    second side here is test.yml alone and not `_MATRIX` -- the sweeps
+    name "3.14t" as readily as the gate would, and a sweep passing is the
+    ground the standard declines.
+    """
+    gate = _gate_interpreters()
+    assert gate, "test.yml names no interpreter"
+    classified = bool(_FREE_THREADING_CLASSIFIER.search(_PYPROJECT))
+    run = [v for v in gate if v.endswith("t")]
+    assert classified == bool(run), (
+        f"the free-threading classifier is {'present' if classified else 'absent'}"
+        f" and test.yml names {', '.join(run) or 'no free-threaded interpreter'}"
     )
 
 


### PR DESCRIPTION
`interpreters_test.py` gates the `Free Threading` classifier on the merge gate's interpreters (closes #1539) (issue btclib-org/.github#577)

Section 3 of the organization standard declares a `Free Threading`
classifier where the merge gate exercises the free-threaded build, and
names the enforcement: the biconditional that already gates the PyPy
`Implementation` classifier, with the gate's own matrix as its second
side. `tests/interpreters_test.py` carried the PyPy half and nothing
about free threading: its version regex cannot match the classifier and
it strips the `t` before comparing.

`test_free_threading_is_classified_exactly_when_the_gate_runs_it` reads
the classifier off `pyproject.toml` and the interpreters off `test.yml`,
comments stripped, and refuses one side without the other.

Which workflow is the gate is the question btclib-org/.github#577 leaves
open. This branch answers it the way the module already does, by file:
section 10 of the standard lists `test` among the workflows that gate,
those running on a pull request and on a push, and this tree's
`test.yml` header calls itself the merge gate. The rejected alternative
reads the ruleset's required checks from the forge (`gh api
repos/btclib-org/btclib/rulesets`); that is the standard's own suite's
half, and a tree's test reads the tree. What it costs: a gate renamed
away from `test.yml` passes here and fails only in `.github`'s suite.

Measured at origin/main c9d9ffb1: `grep -c 'Free Threading'
pyproject.toml` is 0, `grep -oE '3\.[0-9]+t' .github/workflows/test.yml`
finds nothing, and the same grep over `os-ubuntu.yml` finds `3.14t`,
which is the cell the test must not read. On a scratch copy of the
tree, the classifier added alone and `"3.14t"` written into `test.yml`'s
`python-version` alone each turn the test red, both together turn it
green, and `3.14t` in a comment of `test.yml` leaves it green.

Closes #1539
btclib-org/.github#577


Local review: CLEARED 4b9c277 (this sha carries the identical tree, re-parented onto main after the landing below it). Gates on that tree, as this repository's `CONTRIBUTING.md` writes them: exit 0.

## Summary by Sourcery

Align Free Threading classifier validation with the merge gate's configured interpreters.

Bug Fixes:
- Ensure the Free Threading classifier is present exactly when the merge-gate workflow runs a free-threaded Python interpreter.

Enhancements:
- Extend interpreter consistency checks to parse non-commented merge-gate interpreter declarations independently from platform sweep matrices.

Tests:
- Add coverage for the bidirectional relationship between the Free Threading classifier and the merge gate's free-threaded interpreter.
