### PR TITLE
REPOSITORY.md records what section 11's perimeter decides (issue btclib-org/.github#550) (issue btclib-org/.github#568) (issue btclib-org/.github#582) (issue btclib-org/.github#584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -459,6 +459,28 @@ documented at release-notes length in the first place, and are still in
   standard declines. Neither side holds in this tree, so the test lands
   green, and it goes red on whichever side moves alone.
 
+### `REPOSITORY.md`'s perimeter is section 11's
+
+- **The scope statement carries section 11's three limbs in the
+  standard's own words** (issue btclib-org/.github#582), the third --
+  the settings a behaviour the standard describes rests on -- being what
+  admits `.visibility` and `has_issues` below.
+- **`.visibility` and `has_issues` are read back, under *Features***
+  (issue btclib-org/.github#584, issue btclib-org/.github#550): section
+  10's `scorecard` sentinel reads a public repository and nothing else,
+  and `CONTRIBUTING.md`'s tracker rule rests on the issues switch, which
+  the foot no longer carries as a premise outside the perimeter.
+- **`has_wiki` and `has_projects` are outside the perimeter** (issue
+  btclib-org/.github#550), by section 11's sentence rather than as a
+  question the foot held open.
+- **`squash_merge_commit_title` and `squash_merge_commit_message` are in
+  the merge-settings object** (issue btclib-org/.github#568), read back
+  here beside the flags. `CONTRIBUTING.md`'s *What a squash writes here*
+  keeps what a squash writes and why and points here for the value,
+  dropping the second call and the second answer it carried: section 9
+  gives one fact one place, and section 11 makes this file the home for
+  a setting.
+
 ## v2026.8.29
 
 ### Repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1617,13 +1617,9 @@ for a private advisory, or for an email if you would rather not open one.
 ### What a squash writes here
 
 What the landing commit says is a repository setting and not a decision
-made once per pull request, so there is one place to read it from:
-
-```shell
-gh api repos/btclib-org/btclib --jq \
-  '{t: .squash_merge_commit_title, m: .squash_merge_commit_message}'
-# {"t": "COMMIT_OR_PR_TITLE", "m": "COMMIT_MESSAGES"}
-```
+made once per pull request, so there is one place to read it from, and
+it is REPOSITORY.md's *Merge methods*: the two `squash_merge_commit_*`
+settings are recorded there, beside the call that answers them.
 
 A branch of one commit therefore lands under that commit's own subject, a
 branch of several under the pull request's title with its number, and the

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -11,10 +11,11 @@ is recorded is the settings
 [the standard](https://github.com/btclib-org/.github/blob/main/README.md)
 asks about — the ones
 [section 16's checklist](https://github.com/btclib-org/.github/blob/main/README.md#16-checklists)
-sets on a new repository, and the ones a section of the standard states
-a rule for — together with whatever a call quoted for one of those answers
-alongside it. That is this file's scope, and *What this file passes
-over*, at the foot, says what falls outside it.
+sets on a new repository, the ones a section of the standard states a
+rule for, and the ones a behaviour it describes rests on — together with
+whatever a call quoted for one of those answers alongside it. That is
+this file's scope, and *What this file passes over*, at the foot, says
+what falls outside it.
 
 *Code quality* is recorded past that edge: no section of the standard
 states a rule about that setting, and it is here because turning off the
@@ -408,10 +409,14 @@ a particular signer.
 ```shell
 gh api repos/btclib-org/btclib \
   --jq '{allow_squash_merge, allow_merge_commit, allow_rebase_merge,
-         allow_auto_merge}'
+         allow_auto_merge, squash_merge_commit_title,
+         squash_merge_commit_message}'
+# {"allow_auto_merge":true,"allow_merge_commit":false,
+#  "allow_rebase_merge":false,"allow_squash_merge":true,
+#  "squash_merge_commit_message":"COMMIT_MESSAGES",
+#  "squash_merge_commit_title":"COMMIT_OR_PR_TITLE"}
 ```
 
-answers `true` for the first and the last, `false` for the middle two.
 `allow_auto_merge` is what makes "auto-merge presses it" above a setting
 this file reads back rather than a fact about a workflow: turned off,
 every landing here would wait for somebody to press *Squash and merge* by
@@ -447,9 +452,9 @@ on, with nothing asking again. One method is one entry: there is no wrong
 one to preselect, and nothing to read before pressing.
 
 What the commit a squash writes then says is
-`squash_merge_commit_title` and `squash_merge_commit_message`, which
-CONTRIBUTING.md reads back and explains, both being where a contributor
-meets them.
+`squash_merge_commit_title` and `squash_merge_commit_message`, the last
+two fields above; CONTRIBUTING.md explains the pair where a contributor
+meets it.
 
 ## Head branches after a merge
 
@@ -774,6 +779,22 @@ against this same ceiling. Whether that is worth paying for is a
 question for whoever would pay, and it is recorded here so that it is
 asked with the second column in view.
 
+## Features
+
+```shell
+gh api repos/btclib-org/btclib --jq '{visibility, has_issues}'
+# {"has_issues":true,"visibility":"public"}
+```
+
+Section 10's `scorecard` sentinel rests on the first answer: public is
+what it reads at all, so a flip to private leaves `scorecard.yml` and
+`README.md`'s badge standing while the run stops producing a score, and
+`.visibility` above is what puts that flip one command from being seen.
+
+`has_issues` is what `CONTRIBUTING.md`'s *The issue tracker* rests on —
+an issue about this tree alone stays here — and so does the
+`.github/ISSUE_TEMPLATE/` section 16's checklist gives every repository.
+
 ## Topics
 
 ```shell
@@ -805,9 +826,8 @@ diff <(gh api repos/btclib-org/btclib --jq '.topics[]' | sort) \
 ## What this file passes over
 
 The scope at the top is a perimeter, and this is its other edge: what an
-endpoint answers for and no section above reaches. What follows says of
-each which it is — outside that scope, or a question the standard has
-not answered.
+endpoint answers for and no section above reaches, each with the reason
+it stays outside.
 
 **What no call sets.** `gh api repos/btclib-org/btclib` answers with the
 repository document, most of which is URLs, counts and state GitHub
@@ -839,17 +859,11 @@ printf '%s' "$std" | grep -c delete_branch_on_merge  # not 0, which is
 Recording a field on no rule grows this file with GitHub's API rather
 than with the standard.
 
-**The wiki and the projects board are where that reasoning stops.**
-`has_wiki` and `has_projects` are in the same document and in no rule of
-the standard either, and what a `REPOSITORY.md` owes a reader about them
-is the open question of issue btclib-org/.github#550. Nothing here
-answers it.
-
-**The tracker is a premise rather than a setting.** `has_issues` is on,
-and the standard's own maintenance runs on the issue tracker —
-`CONTRIBUTING.md`'s *The issue tracker* is what a session reads before
-filing — so no section states it as a setting to read back. It is here as
-a premise of the process rather than as a field on no rule.
+**The wiki and the projects board are outside the perimeter by section
+11's own sentence**, which states no rule about either, so this file
+neither reads `has_wiki` and `has_projects` back nor explains an answer
+to them; that sentence is what the loop above would count, which is why
+the pair is not in its list.
 
 **A credential this repository does not hold.** `claude-review.yml`
 spends `secrets.CLAUDE_CODE_OAUTH_TOKEN`, and section 11 of the standard


### PR DESCRIPTION
REPOSITORY.md records what section 11's perimeter decides (issue btclib-org/.github#550) (issue btclib-org/.github#568) (issue btclib-org/.github#582) (issue btclib-org/.github#584)

Section 11 of the organization standard now fixes the perimeter a
`REPOSITORY.md` records: the settings section 16's checklist sets, the
ones a section of the standard states a rule for, and the ones a
behaviour it describes rests on. This copy carried the first two limbs,
held the wiki and the projects board open as a question at its foot,
carried `has_issues` there as a premise outside the perimeter, read
`.visibility` back nowhere, and pointed at `CONTRIBUTING.md` for the two
squash fields rather than reading them back itself.

What changes, each read back from the API today: the scope statement
takes the third limb; a *Features* section reads `.visibility` and
`has_issues`, since section 10's `scorecard` sentinel reads public and
`CONTRIBUTING.md`'s tracker rule rests on the issues switch; the foot
names `has_wiki` and `has_projects` outside by section 11's sentence and
drops the tracker premise; the merge-settings object gains
`squash_merge_commit_title` and `squash_merge_commit_message` with the
answer recorded.

That last one would otherwise leave the pair recorded in two files, so
`CONTRIBUTING.md`'s *What a squash writes here* drops its own `gh api`
call and its own copy of the answer and points at *Merge methods* here
for the value, keeping what a squash writes and why. Section 9 asks one
fact of one place and section 11 makes this file a setting's home; that
section of `CONTRIBUTING.md` is this tree's own half, below *This
repository in particular*, so no other repository's copy moves with it.

What section 11 already asked of this copy and is untouched: the
recoverability clause, the default branch, Pages, Read the Docs, the
ceiling's section, the credential bullet, and `allow_auto_merge`, whose
record is unchanged though the line carrying it is rewrapped by the two
fields joining the same object.

btclib-org/.github#550, btclib-org/.github#582 and
btclib-org/.github#584 are advanced here and closed by a later tree's
port. btclib-org/.github#568 is closed already, by btclib-benchmarks;
this tree is not one of the two it named, and converges with it.


Local review: CLEARED c1ba5bb (this sha carries the identical tree, re-parented onto main after the landing below it). Gates on that tree, as this repository's `CONTRIBUTING.md` writes them: exit 0.

## Summary by Sourcery

Align repository configuration documentation with the section 11 perimeter and centralize repository setting values in REPOSITORY.md.

New Features:
- Document repository visibility and issue-tracker settings in REPOSITORY.md as values that support documented standards and behavior.
- Record squash merge title and message settings alongside the other merge methods.

Enhancements:
- Clarify REPOSITORY.md's scope according to the organization's section 11 perimeter and explicitly identify wiki and projects settings as out of scope.
- Make REPOSITORY.md the single source for squash merge setting values referenced by CONTRIBUTING.md.

Documentation:
- Update the changelog and repository guidance to reflect the revised repository-settings perimeter and centralized merge-setting documentation.
