### PR TITLE
`links.yml` passes `--include-fragments` (issue btclib-org/.github#583)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -146,13 +146,27 @@ jobs:
           # unreachable for one minute is the failure mode this workflow was
           # built not to gate on, and 45 seconds is the cheapest way to stop
           # reporting it. If a URL times out run after run it belongs in
-          # .lycheeignore with that measurement, and not here
+          # .lycheeignore with that measurement, and not here.
+          # --include-fragments, so a link into a heading is checked as
+          # an anchor and not only as a page: the forge serves the page
+          # and drops a fragment it cannot resolve, so a heading renamed
+          # in the tree a link here points into is red here and nowhere
+          # else. The check reads a page already fetched for the link
+          # above, so it adds no request. REPOSITORY.md's links into the
+          # standard carry blob/main/README.md and are checked; the
+          # root-shape github.com/<owner>/<repo>#heading links
+          # CONTRIBUTING.md carries are not, a missing fragment there
+          # being overridden by the token below -- lychee falls back to
+          # the repositories API on the failed link and takes the
+          # repository's existence as the answer.
+          # btclib-org/.github#630 is where that is weighed
           args: >-
             --no-progress
             --max-retries 3
             --retry-wait-time 10
             --timeout 45
             --accept 100..=103,200..=299,429
+            --include-fragments
             "*.md" "docs/**/*.rst" "docs/**/*.md" "tests/**/*.md"
           # fail the job, rather than only summarizing: a green run that
           # found dead links is the state this workflow exists to end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -481,6 +481,19 @@ documented at release-notes length in the first place, and are still in
   gives one fact one place, and section 11 makes this file the home for
   a setting.
 
+### `links.yml` asks lychee for the fragment too
+
+- **`.github/workflows/links.yml` passes `--include-fragments`** (issue
+  btclib-org/.github#583). A link into a heading is then checked as an
+  anchor and not only as a page, so a heading renamed in the tree a link
+  here points into is red in this run rather than nowhere. The check
+  reads a page already fetched for the link beside it and adds no
+  request; run over the tree with the workflow's flags and the token, it
+  reports no broken anchor. `REPOSITORY.md`'s links into the standard
+  carry `blob/main/README.md` and are checked; the root-shape ones
+  `CONTRIBUTING.md` carries are overridden by the token, which
+  btclib-org/.github#630 weighs.
+
 ## v2026.8.29
 
 ### Repository


### PR DESCRIPTION
`links.yml` passes `--include-fragments` (issue btclib-org/.github#583)

Section 10 of the standard has every `links.yml` run lychee with
`--include-fragments`, and `tests/links_test.py` there asks each tree's
lychee step for the flag: a heading renamed in the tree a link points
into breaks that link with nothing red in the renaming tree, so the run
that would notice is the linking tree's. This tree's step now passes
it, with the comment beside the other flags.

Measured before pushing with lychee 0.24.2, the version lychee-action
v2.9.0 installs, over the tree at `61869179` with the workflow's own
flags and the token: 196 total, 161 unique, one error either way, and
that error is `conventionalcomments.org` failing to resolve on the
machine that ran it rather than a fragment. So the flag adds no request
and no fragment red here.

What it reaches differs by link shape, and this tree carries both.
`REPOSITORY.md`'s three links into the standard spell
`blob/main/README.md#<heading>`, and that shape is checked: the same
anchors misspelt by one character are `Cannot find fragment` with the
token. The root-shape `github.com/<owner>/<repo>#heading` links the
shared `CONTRIBUTING.md` carries are not: a missing fragment there is
detected and then overridden, lychee falling back to the repositories
API on the failed link and taking the repository's existence as the
answer -- shown by holding an invalid token, where the fallback fails
and the fragment error stands. btclib-org/.github#630 weighs that, and
the comment and the entry say which of this tree's links are covered
rather than claiming all of them are.

Every other flag is left as the tree has it.

btclib-org/.github#583
btclib-org/.github#630


Local review: CLEARED fa5c636 (this sha carries the identical tree, re-parented onto main after the landing below it). Gates on that tree, as this repository's `CONTRIBUTING.md` writes them: exit 0.

## Summary by Sourcery

Enable lychee fragment checking in the links workflow to catch broken heading anchors.

Enhancements:
- Enable fragment validation in the link-checking workflow so links to renamed or missing headings are detected where supported.

Documentation:
- Document the fragment-checking behavior and its coverage limitations in the changelog.
