### PR TITLE
btclib.org is released: this repository holds no custom domain (issue btclib-org/.github#530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,6 +296,15 @@ documented at release-notes length in the first place, and are still in
   Sigstore OIDC exchange; the review gate the sentence was arguing for
   still holds, `attest` only running via `needs:` after a publish job
   succeeds, but the sentence itself was false (shipped in v2026.8.27).
+- **`btclib.org` is released: this repository holds no custom domain**
+  (issue btclib-org/.github#530). The domain was this repository's
+  project site, and the decision on that issue gives the organization's
+  domain a role above any one tree. A domain belongs to one repository
+  at a time, so the release is what lets another claim it; Pages reads
+  the claim from a `CNAME` in the built site, which is why releasing it
+  is the deletion of that file rather than a settings call.
+  `REPOSITORY.md`'s *Pages* is where the endpoint is read back. The site
+  itself stays for now, and the same issue's step 5 is what removes it.
 
 ### Packaging, linting and CI
 

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-btclib.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1119,7 +1119,7 @@ Jekyll leftovers, which is the opposite of the natural first assumption:
 
 ```shell
 gh api repos/btclib-org/btclib/pages
-# {"cname": "btclib.org", "build_type": "legacy",
+# {"cname": null, "build_type": "legacy",
 #  "source": {"branch": "main", "path": "/"}}
 ```
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -24,9 +24,8 @@ quality analysis running, so stopping it is a decision of this
 repository's.
 
 Where an answer has a copy in the tree, the section recording it says so:
-`CNAME` carries the Pages custom domain, and `pyproject.toml` carries the
-topics as `keywords` and the documentation site as `[project.urls]
-homepage`.
+`pyproject.toml` carries the topics as `keywords` and the documentation
+site as `[project.urls] homepage`.
 
 ## Required checks on main
 
@@ -580,20 +579,20 @@ it — the same call against `testpypi` 404s, where it answers for `pypi`
 `release.yml`'s own `workflow_dispatch` trigger is what narrows it
 further.
 
-## Pages, which is btclib.org
+## Pages
 
-**The website is this repository's own root**, served by GitHub Pages, and
-the three things that decide it are settings rather than files:
+**The website is this repository's own root**, served by GitHub Pages,
+and the three things that decide it are settings rather than files:
 
 ```shell
 gh api repos/btclib-org/btclib/pages \
   --jq '{cname, build_type, source, https_enforced}'
-# {"cname": "btclib.org", "build_type": "legacy",
+# {"cname": null, "build_type": "legacy",
 #  "source": {"branch": "main", "path": "/"}, "https_enforced": true}
 ```
 
 `source` is what makes `README.md` the homepage and every other file in
-the root a URL under btclib.org — CONTRIBUTING.md's "The website" section
+the root a URL under the site — CONTRIBUTING.md's "The website" section
 is what that costs and `_config.yml`'s `exclude:` is what limits it.
 Moving the source to `/docs` or to another branch would republish the site
 as whatever that path holds, silently and immediately.
@@ -607,10 +606,16 @@ builds the same site with the same gem, where a failure is a red check.
 and make the failure visible by itself; it is a change of its own, and
 what it costs is a deploy that no longer happens by pushing to `main`.
 
-`cname` is the custom domain, and `CNAME` in the root is the same value: A
-records for `btclib.org` and the `https_enforced` certificate hang off it.
-The file is what Pages reads on each build, so deleting it from the tree
-un-sets the setting on the next push.
+**`cname` is `null`: this repository holds no custom domain.**
+`btclib.org` was its project site's, and btclib-org/.github#530 is the
+decision that gives the organization's domain a role above any one tree,
+together with the sequence that moves it. A domain belongs to one
+repository at a time, so releasing it here is what lets another claim
+it, and Pages reads the claim from a `CNAME` in the built site — which
+is why the release is the deletion of that file rather than a settings
+call. Whichever tree holds it answers for it in its own
+`REPOSITORY.md`, this one having no call that reads another
+repository's setting for it.
 
 ## Read the Docs, which is btclib.readthedocs.io
 
@@ -659,8 +664,9 @@ curl -s https://app.readthedocs.org/api/v3/projects/btclib/ \
 
   `[project.urls] homepage` in `pyproject.toml` carries the identical
   string (issue btclib-org/.github#533): a releasing tree's home is its
-  own documentation, not `btclib.org`, which the *Pages* section above
-  still serves and which the two fields no longer name.
+  own documentation, which is what the two fields name and what
+  `btclib.org` never was, the *Pages* section above recording that this
+  repository holds no domain at all.
 
 Tags older than the rule are mostly not activatable rather than merely not
 activated: a build needs `.readthedocs.yaml`, which reaches back to


### PR DESCRIPTION
## What

`CNAME` is deleted, so this repository releases `btclib.org`. That is
step 1 of the sequence recorded on
[ISS 530](https://github.com/btclib-org/.github/issues/530), and it is
the step the rest waits on: a custom domain belongs to one repository at
a time, and Pages reads the claim from a `CNAME` in the *built* site, so
the release is the deletion of that file rather than a settings call.

**No closing keyword.** The issue is owed by two trees and by section 2
of the standard, and it stays open until the last of those lands.

## Which tree holds the domain is deliberately not asserted here

`REPOSITORY.md`'s discipline is quoting the answer an endpoint gives, and
no call in it reads another repository's setting. A sentence naming the
new holder would also be a claim about a landing this branch does not
perform — at this commit the domain is claimed by nobody, the sequence
having the release land first. So the section says only that this
repository holds none, and that whichever tree does answers for it in
its own `REPOSITORY.md`.

That is a correction: the first draft of this branch named the holder,
and named it in the changelog too, in an append-only file. Local review
refuted both against `gh api`.

## What the release falsifies is corrected with it

`REPOSITORY.md`'s *Pages* section, its list of settings with a copy in
the tree, and its *Read the Docs* back-reference, which had this
repository still serving the domain. `CONTRIBUTING.md` carries a second
readback of the same endpoint, and it moves with them.

## What stays, and why that is the point

The site's own sources — `_config.yml`, the `Gemfile`, `_layouts/`,
`assets/`, `website.yml` — and the prose describing them stay. That is
the maintainer's own sequence: they go once the domain is verified
serving from the tree that claims it, so that a failed cutover is
answered by restoring one file rather than by reverting a tree's worth
of them. `iss-530-remove-website` is stacked on this branch and does it,
and it is what corrects `README.md`'s own link to the domain and
`CONTRIBUTING.md`'s *The website*.

## Evidence

Gates, on `3c8a5be2`, after the rebase onto `1b9a97a4` that voided the
first set:

- `uv run pre-commit run --all-files` — exit 0
- `uv run pytest` — exit 0, 31097 passed, 29 skipped, 1 xfailed
- `sphinx-build -n -W --keep-going` — exit 0

Local review at fresh context, two rounds: **CLEARED `3c8a5be2`**. Round
one found four blocking defects, three of them the same mistake —
sentences true only after a *later* landing, one of them in an
append-only entry — and the fourth that the commit message carried the
same claim into a `COMMIT_MESSAGES` squash. All four accepted.

One non-blocking finding is knowingly carried rather than fixed here:
`REPOSITORY.md`'s "what `btclib.org` never was" has a parse under which
it contradicts a landed changelog entry, since `[project.urls] homepage`
did name the domain before btclib-org/.github#533. The stacked branch
replaces that sentence whole, with one that makes no claim about the
past, so the fix is a landing away rather than a round away.

## Summary by Sourcery

Release btclib.org from this repository while keeping the existing site sources in place for the subsequent cutover.

Bug Fixes:
- Release the repository's btclib.org custom domain by removing its CNAME file and updating documentation and endpoint examples to show that no custom domain is held.

Enhancements:
- Clarify Pages and Read the Docs documentation to reflect the repository's post-release domain ownership and preserve the site sources for the later cutover.

Documentation:
- Update the changelog and repository guidance to document the custom-domain release and current Pages configuration.