### PR TITLE
release.yml's documented wait is a script with a test (issue btclib-org/.github#573)

### DIFF
--- a/.github/scripts/wait_for_readthedocs_build.py
+++ b/.github/scripts/wait_for_readthedocs_build.py
@@ -1,0 +1,145 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Wait until read the docs serves the documentation a tag names.
+
+`release.yml`'s `documented` job is the sentinel on a release whose
+documentation build never starts, and this is the wait behind it:
+`/en/<tag>/` answers 200 once read the docs has built the tag.
+
+The budget is a deadline and not a count of attempts. A wait stated as
+attempts times an interval is a product to be multiplied out before it
+can be compared with the job's own `timeout-minutes`, and a wait that
+outlasts that is killed inside itself: the run then carries the runner's
+message about a cancelled job where this was written to name the page to
+go and read (issue #1165). Every request is bounded by what is left of
+the deadline as well as by its own timeout, so the whole wait ends within
+`--timeout` of its first request for anything read the docs does between
+answers. What is not bounded here is a single answer arriving a byte at a
+time: `urlopen`'s timeout is a socket timeout and applies per blocking
+read, so that case is the job's `timeout-minutes` to end.
+
+The last answer is carried to the end rather than discarded, so the
+annotation names the HTTP status or the transport failure it saw and not
+only that nothing was served, and sends a reader to the builds page
+beside it. What the rendered URL cannot distinguish, and why the v3 API
+is not asked instead, is `release.yml`'s comment above the job.
+
+No trigger reaches the verdict this exists for. The job runs on a tag
+push alone, so a rehearsal has no tag to ask about and a dispatch
+pointing the wait at a branch would spend the whole deadline on a URL
+that answers 404 by construction -- which is why this takes no empty tag
+as nothing to wait for, the way the release wait beside it does.
+`tests/wait_for_readthedocs_build_test.py` is therefore the only thing
+that drives the retry, the deadline and the error path: it substitutes
+the transport and the clock, and advances the clock past the deadline
+itself.
+
+    uv run --no-project --python 3.14 \
+        .github/scripts/wait_for_readthedocs_build.py btclib "$TAG"
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from http import HTTPStatus
+from http.client import HTTPException
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+# read the docs serves this only once the tag has a successful build,
+# which is the whole of the question asked here
+SITE = "https://{project}.readthedocs.io/en/{tag}/"
+BUILDS = "https://app.readthedocs.org/projects/{project}/builds/"
+
+# the Cloudflare zone in front of read the docs bans the interpreter's own
+# default (`Python-urllib/3.14`) outright -- a 403 on every request,
+# measured against a tag that is in fact served -- so a request sent
+# without one never reaches the "build not finished yet" question this
+# exists to ask; `curl`'s default is not banned, which is why the loop
+# this replaces never needed one
+USER_AGENT = "btclib-readthedocs-wait/1.0"
+
+# what a build has to arrive within, in seconds, and the one number the
+# job's `timeout-minutes` is compared against
+DEFAULT_TIMEOUT = 900.0
+# between two questions to the site: long enough not to hammer it, short
+# enough that the wait ends near the build rather than near the deadline
+DEFAULT_INTERVAL = 30.0
+# one question's own bound, so that a connection that hangs spends part of
+# the deadline rather than all of it
+DEFAULT_REQUEST_TIMEOUT = 10.0
+
+
+def unserved(url: str, timeout: float) -> str | None:
+    """Return what stood in the way, or `None` where the page is served."""
+    headers = {"User-Agent": USER_AGENT}
+    request = Request(url, method="GET", headers=headers)  # noqa: S310
+    try:
+        with urlopen(request, timeout=timeout) as answer:  # noqa: S310
+            status: int = answer.status
+    # a 404 while no build has succeeded is an `HTTPError`, which carries
+    # a status; a connection refused or timed out is an `OSError` and a
+    # truncated answer an `HTTPException`, neither of which has one. None
+    # of them is this script's verdict, which the deadline alone decides,
+    # and each is named rather than discarded so that the annotation can
+    # say what the last one was
+    except HTTPError as failure:
+        return f"HTTP {failure.code}"
+    except (OSError, HTTPException) as failure:
+        return f"{type(failure).__name__}: {failure}"
+    return None if status == HTTPStatus.OK else f"HTTP {status}"
+
+
+def wait(
+    project: str,
+    tag: str,
+    timeout: float,
+    interval: float,
+    request_timeout: float,
+) -> int:
+    """Poll the site for one tag, and say what the deadline decided."""
+    url = SITE.format(project=project, tag=tag)
+    started = time.monotonic()
+    deadline = started + timeout
+    last_seen = "no request has been made yet"
+    while (left := deadline - time.monotonic()) > 0:
+        seen = unserved(url, min(request_timeout, left))
+        if seen is None:
+            waited = time.monotonic() - started
+            print(f"{url} is served after {waited:.0f} s")
+            return 0
+        last_seen = seen
+        print(f"{url} answered {seen}")
+        time.sleep(min(interval, max(deadline - time.monotonic(), 0.0)))
+    builds = BUILDS.format(project=project)
+    print(
+        f"::error::tag {tag}: {url} was never served in {timeout:.0f} s;"
+        f" last seen: {last_seen}. Read the builds page on {builds}"
+        " -- it says why, this job only says that"
+    )
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Read the tag from the command line and wait for what it names."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project", help="the name read the docs serves it under")
+    parser.add_argument("tag", help="the release tag, which is also the version")
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    parser.add_argument("--interval", type=float, default=DEFAULT_INTERVAL)
+    parser.add_argument(
+        "--request-timeout", type=float, default=DEFAULT_REQUEST_TIMEOUT
+    )
+    args = parser.parse_args(argv)
+
+    return wait(
+        args.project, args.tag, args.timeout, args.interval, args.request_timeout
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -752,24 +752,18 @@ jobs:
   # a late documentation build is not a reason to withhold a wheel, and the
   # fix for a red run here is a build on their side, not a moved tag
   #
-  # The loop below used to spend the same budget as the job's
-  # timeout-minutes: 30 attempts of a 10s curl (--max-time) plus a 30s
-  # sleep, on every attempt including the last, is 30 * 40 = 1200s -- and
-  # 20 minutes is 1200s too. A response slow enough to spend its own
-  # --max-time on every attempt without ever answering -- reachable, just
-  # never inside 10s -- ran the loop into that wall, and the job was
-  # killed before its `::error::` line, the one line it exists to print,
-  # ever ran (issue #1165). An ordinary fast failure never came close: RTD
-  # answers a 404 in well under a second while a build has not started,
-  # so 30 attempts at ~0s + 30s is 900s, five minutes under. The bug only
-  # bit the slow-response case, never the everyday one -- but it did bite,
-  # which is what made it worth fixing rather than a hypothetical. 20
-  # attempts at the same 10s/30s keeps the loop's worst case at
-  # 20 * 10 + 19 * 30 = 770s against the job's 1200s, a fixed 430s (36%)
-  # margin the loop can never spend into: the print always runs now. The
-  # last attempt no longer sleeps either, which used to buy nothing.
+  # The wait itself is `.github/scripts/wait_for_readthedocs_build.py`
+  # rather than a shell loop written out here, which is what gives it a
+  # test: a tag is the only trigger that reaches it, so a loop kept in
+  # this file is first executed on the day a release depends on it. The
+  # script's budget is a deadline and not a count of attempts, and that
+  # deadline is set below this job's timeout-minutes, so the script's
+  # `::error::` runs rather than being killed inside the wait it exists
+  # to report on (issue #1165).
+  # `tests/wait_for_readthedocs_build_test.py` is what drives the retry,
+  # the deadline and the annotation.
   #
-  # What the loop cannot do is tell "still building" from "will never
+  # What the wait cannot do is tell "still building" from "will never
   # build": a push that matches no version is accepted and triggers
   # nothing -- a green delivery with nothing behind it, whatever carries
   # it -- and /en/<tag>/ answers 404 in both
@@ -779,15 +773,14 @@ jobs:
   # `v2026.8.21` build seconds after it finished) but the comment above
   # already rules the API out for this job, and states the reason once
   # rather than twice: what rules it out is the credential a runner would
-  # have to carry. Querying it from this loop would mean storing an RTD
+  # have to carry. Querying it from the script would mean storing an RTD
   # credential in a job that gates nothing, to buy a distinction the job
   # already gestures at by naming the builds page. Scraping the builds
   # *page* instead of the API was considered and dropped too: same
   # bot-facing defenses, with an HTML shape nothing here would notice
-  # changing under it. What the fix below does instead is stop discarding
-  # the one signal the existing curl call already carries for free: the
-  # last HTTP status or transport failure it saw, which the final message
-  # now names instead of "is not served yet"
+  # changing under it. What the script does instead is carry the last
+  # answer to the end, so that the annotation names a status or a
+  # transport failure rather than only that nothing was served
   documented:
     name: Check read the docs built the tag
     needs: version-check
@@ -795,49 +788,30 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      # sparse, for the reason `pypi-install.yml`'s wait job gives: what
+      # lands is .github/scripts plus the repository root, cone mode
+      # being the default and root files always being in the cone. This
+      # job builds nothing and installs nothing, and the root's
+      # pyproject.toml is inert besides, --no-project ignoring it
+      - name: Check out the wait script
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+      # caching off, as in version-check above and for the same reason:
+      # this is the workflow whose jobs hold an OIDC token PyPI accepts,
+      # so no job of it reads a cache entry a run it cannot vouch for
+      # wrote. There is little to cache here in any case, the step below
+      # installing nothing
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: false
+      # --no-project, so it runs on the interpreter uv fetches and
+      # installs nothing: the script takes the standard library alone
       - name: Wait for the tag's documentation to be served
         env:
           TAG: ${{ github.ref_name }}
         run: |
-          url="https://btclib.readthedocs.io/en/${TAG}/"
-          builds_page="https://app.readthedocs.org/projects/btclib/builds/"
-          attempts=20
-          interval=30
-          last_seen="no attempt has run yet"
-          for attempt in $(seq "$attempts"); do
-            # no -f: a non-2xx response is read, not discarded, so a
-            # failure below can name it. curl_rc is 0 whenever a response
-            # arrived at all, including a 404 -- $status is what tells
-            # the two apart, and stays empty on a transport-level failure
-            # (timeout, DNS, connection refused), which curl_rc alone
-            # then names.
-            # The assignment is the condition of the if rather than a
-            # statement of its own: this script runs under the shell's
-            # default `set -e`, which a bare `status=$(curl ...)` is not
-            # exempt from -- a hung or unreachable server makes curl exit
-            # 28, and that would end the step right there, on the first
-            # slow response, before curl_rc is even read. Measured against
-            # this file's own extracted step, in isolation
-            if status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$url"); then
-              curl_rc=0
-            else
-              curl_rc=$?
-            fi
-            if [ "$curl_rc" -eq 0 ] && [ "$status" = "200" ]; then
-              echo "${url} is served"
-              exit 0
-            fi
-            if [ "$curl_rc" -eq 0 ]; then
-              last_seen="HTTP ${status}"
-            else
-              last_seen="curl exit ${curl_rc} (no response within 10s)"
-            fi
-            echo "attempt ${attempt}/${attempts}: ${url} answered ${last_seen}"
-            if [ "$attempt" -lt "$attempts" ]; then
-              sleep "$interval"
-            fi
-          done
-          msg="tag ${TAG}: ${url} was never served after ${attempts} attempts;"
-          echo "::error::${msg} last seen: ${last_seen}. Read the builds page" \
-            "on ${builds_page} -- it says why, this job only says that"
-          exit 1
+          uv run --no-project --python 3.14 \
+            .github/scripts/wait_for_readthedocs_build.py btclib "$TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -525,6 +525,41 @@ documented at release-notes length in the first place, and are still in
   `CONTRIBUTING.md` carries are overridden by the token, which
   btclib-org/.github#630 weighs.
 
+### `release.yml`'s documentation wait is a script with a test
+
+- **The `documented` job runs
+  `.github/scripts/wait_for_readthedocs_build.py`** (issue
+  btclib-org/.github#573). A tag push is the only trigger that reaches
+  the wait, so a shell loop kept in the workflow is first executed on the
+  day a release depends on it. The script is what
+  `tests/wait_for_readthedocs_build_test.py` substitutes a transport and
+  a clock into, and that test is what drives the retry, the deadline and
+  the `::error::` naming the builds page. The job checks out
+  `.github/scripts`, plus the repository root that cone mode always
+  lands, and runs the script under `--no-project`, which is the shape
+  `pypi-install.yml`'s wait job already has.
+- **The request carries a `User-Agent`.** The Cloudflare zone in front
+  of read the docs bans the interpreter's own default
+  (`Python-urllib/3.14`) outright, so a request sent without one is a
+  403 on every attempt against a tag that is in fact served, and the
+  wait would burn its whole deadline and annotate an error on every
+  release. `curl`, which the loop this replaces called, is not banned,
+  so the loop never needed one.
+- **The budget is a deadline rather than a count of attempts**, so there
+  is one number to compare with the job's own `timeout-minutes`, where
+  attempts times an interval is a product to multiply out first -- the
+  arithmetic of issue #1165. The loop this replaces was already inside
+  that timeout, so the deadline is chosen against the job's figure
+  rather than to repair it, and it leaves the annotation a margin the
+  wait cannot spend into. Every request is bounded by what is left of
+  the deadline as well as by its own timeout, so a connection that hangs
+  spends part of the wait rather than the whole of it.
+- **This takes no empty tag as nothing to wait for**, which is where it
+  parts from the release wait beside it: that one runs on every
+  schedule and dispatch and takes an empty version as nothing to do,
+  while `documented` is guarded by the event and a branch ref would
+  spend the whole deadline on a URL that answers 404 by construction.
+
 ## v2026.8.29
 
 ### Repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,6 +276,7 @@ source-exclude = [
     "/tests/verify_dist_contents_test.py",
     "/tests/wait_for_hwi_device_test.py",
     "/tests/wait_for_pypi_release_test.py",
+    "/tests/wait_for_readthedocs_build_test.py",
     # the same reasoning, for fuzz/ rather than .github/scripts: git-only
     # below is why it is not in the sdist, and this test reads
     # fuzz/fuzz_*.py and fuzz/corpus/ off the tree, both absent from an
@@ -1160,6 +1161,11 @@ ignore = [
 # answer when it comes, or the ::error:: annotation naming the version
 # that never arrived
 ".github/scripts/wait_for_pypi_release.py" = ["T201"]
+# and the documentation wait, the same shape one service over: one line
+# per answer read the docs gave that was not the page, the page when it
+# comes, or the ::error:: annotation naming the last answer and the
+# builds page that says why
+".github/scripts/wait_for_readthedocs_build.py" = ["T201"]
 # and the py-arm authority re-derivation: which module it is
 # measuring, one line per disagreement found, and the all-clear or count
 # at the end are what a weekly run's log says happened

--- a/tests/wait_for_readthedocs_build_test.py
+++ b/tests/wait_for_readthedocs_build_test.py
@@ -1,0 +1,385 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the documentation wait of `.github/scripts`.
+
+No run of `release.yml` shows any of what this drives. The `documented`
+job runs on a tag push alone, so the wait is entered on release day and
+on no other day, and what it does then is decided by somebody else's
+build: neither a release nor a rehearsal can arrange for read the docs to
+be late. The retry, the deadline and the `::error::` naming the builds
+page are therefore reached here or nowhere.
+
+Both of the wait's inputs are substituted for that. `_Transport` is the
+site: a scripted sequence of answers that also records what it was asked,
+timeout included. `_Clock` is the clock, and it moves only when the
+script sleeps on it, which is what makes the deadline arrive in no time
+at all and the requests before it exact rather than approximate.
+
+The script is loaded by path, `.github/scripts` being no package, as the
+other scripts under it are tested.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from contextlib import closing, contextmanager
+from email.message import Message
+from http import HTTPStatus
+from http.client import HTTPException
+from pathlib import Path
+from types import ModuleType
+from typing import TYPE_CHECKING, NamedTuple
+from urllib.error import HTTPError
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from contextlib import AbstractContextManager
+
+_SCRIPT = (
+    Path(__file__).parents[1] / ".github" / "scripts" / "wait_for_readthedocs_build.py"
+)
+_URL = "https://btclib.readthedocs.io/en/v2026.9.1/"
+_BUILDS = "https://app.readthedocs.org/projects/btclib/builds/"
+
+
+class _Clock:
+    """A monotonic clock that stands still until the script sleeps on it."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.slept: list[float] = []
+
+    def monotonic(self) -> float:
+        """Return the reading, which only `sleep` below moves."""
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        """Spend the seconds a wait on a real clock would have spent."""
+        self.slept.append(seconds)
+        self.now += seconds
+
+
+class _Transport:
+    """The answers the site gives, in order, and the questions it got."""
+
+    def __init__(self, answers: list[str | None]) -> None:
+        self.answers = answers
+        self.asked: list[tuple[str, float]] = []
+
+    def __call__(self, url: str, timeout: float) -> str | None:
+        """Answer the next verdict in the script, and record the question."""
+        self.asked.append((url, timeout))
+        return self.answers.pop(0) if self.answers else "HTTP 404"
+
+
+class _Answer(NamedTuple):
+    """What `unserved` reads of a response, which is its status alone."""
+
+    status: int
+
+
+@contextmanager
+def _answering(status: int) -> Iterator[_Answer]:
+    """Hand out a response the way `urlopen` hands one to a `with`."""
+    yield _Answer(status)
+
+
+@pytest.fixture
+def script(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Return the script, imported by path, registered before it runs."""
+    spec = importlib.util.spec_from_file_location("wait_for_readthedocs_build", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "wait_for_readthedocs_build", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def clock(script: ModuleType, monkeypatch: pytest.MonkeyPatch) -> _Clock:
+    """Put a clock this test moves where the script reads a real one."""
+    fake = _Clock()
+    monkeypatch.setattr(script, "time", fake)
+    return fake
+
+
+def _site(
+    script: ModuleType, monkeypatch: pytest.MonkeyPatch, answers: list[str | None]
+) -> _Transport:
+    """Put a scripted sequence of answers where read the docs would be."""
+    transport = _Transport(answers)
+    monkeypatch.setattr(script, "unserved", transport)
+    return transport
+
+
+def test_the_page_asked_for_is_the_one_the_tag_names(
+    script: ModuleType,
+    clock: _Clock,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The tag is the version read the docs serves, `v` and all.
+
+    Where the index wants the version the tag names, this one wants the
+    tag itself: read the docs activates the tag under the name it was
+    pushed under, so stripping the `v` would ask for a version that is
+    not there and wait out the whole deadline on it.
+    """
+    site = _site(script, monkeypatch, [None])
+
+    assert script.main(["btclib", "v2026.9.1"]) == 0
+
+    assert site.asked == [(_URL, 10.0)]
+    assert clock.slept == []
+    assert f"{_URL} is served after 0 s" in capsys.readouterr().out
+
+
+def test_a_build_that_has_not_finished_is_waited_for(
+    script: ModuleType,
+    clock: _Clock,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A build still running costs an interval, not the release."""
+    site = _site(script, monkeypatch, ["HTTP 404", "HTTP 404", None])
+
+    assert script.main(["btclib", "v2026.9.1", "--interval", "30"]) == 0
+
+    assert [url for url, _ in site.asked] == [_URL, _URL, _URL]
+    assert clock.slept == [30.0, 30.0]
+    reported = capsys.readouterr().out
+    assert reported.count(f"{_URL} answered HTTP 404") == 2
+    assert f"{_URL} is served after 60 s" in reported
+
+
+def test_a_build_that_never_arrives_is_the_deadline_speaking(
+    script: ModuleType,
+    clock: _Clock,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The wait ends where its deadline is, and names what it last saw.
+
+    The two answers differ so that the annotation is pinned to the last
+    of them rather than to whatever the site said first, which is the
+    signal a reader needs: a 404 throughout is a build that never
+    started, and a 404 turning into something else is a build that did.
+    """
+    site = _site(script, monkeypatch, ["HTTP 404", "HTTP 500"])
+
+    assert script.main(["btclib", "v2026.9.1", "--timeout", "60"]) == 1
+
+    assert clock.now == pytest.approx(60.0)
+    assert len(site.asked) == 2
+    reported = capsys.readouterr().out
+    assert f"::error::tag v2026.9.1: {_URL} was never served in 60 s;" in reported
+    assert "last seen: HTTP 500." in reported
+    assert f"Read the builds page on {_BUILDS}" in reported
+
+
+def test_a_deadline_already_spent_asks_nothing_and_still_annotates(
+    script: ModuleType,
+    clock: _Clock,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A budget of nothing is the one case with no answer to report.
+
+    Every other path through the wait leaves `last_seen` holding what a
+    request came back with, so what the annotation says here is the only
+    thing that says a request was never made -- which is what tells a
+    reader looking at the log that the site was never asked, rather than
+    asked and silent.
+    """
+    site = _site(script, monkeypatch, [])
+
+    assert script.main(["btclib", "v2026.9.1", "--timeout", "0"]) == 1
+
+    assert site.asked == []
+    assert clock.slept == []
+    assert "last seen: no request has been made yet." in capsys.readouterr().out
+
+
+def test_the_last_wait_is_cut_to_what_is_left_of_the_deadline(
+    script: ModuleType, clock: _Clock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A deadline that is no multiple of the interval is still the deadline."""
+    site = _site(script, monkeypatch, [])
+
+    assert (
+        script.main(["btclib", "v2026.9.1", "--timeout", "40", "--interval", "30"]) == 1
+    )
+
+    assert clock.slept == [30.0, 10.0]
+    assert clock.now == pytest.approx(40.0)
+    assert [timeout for _, timeout in site.asked] == [10.0, 10.0]
+
+
+def test_a_request_outlasting_the_deadline_leaves_no_negative_sleep(
+    script: ModuleType,
+    clock: _Clock,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A request that overruns its share still ends in the annotation.
+
+    `unserved` is bounded by a socket timeout, which applies per blocking
+    read, so a site answering a byte at a time can return after the
+    deadline has already passed. What is left is then negative, and the
+    clamp is what keeps `time.sleep` from being handed it -- a real one
+    raises on a negative number, which would replace the `::error::` this
+    exists to print with a traceback.
+    """
+    asked: list[tuple[str, float]] = []
+
+    def slow(url: str, timeout: float) -> str | None:
+        """Answer nothing served, having spent longer than the budget."""
+        asked.append((url, timeout))
+        clock.now += 40.0
+        return "TimeoutError: timed out"
+
+    monkeypatch.setattr(script, "unserved", slow)
+
+    assert script.main(["btclib", "v2026.9.1", "--timeout", "30"]) == 1
+
+    assert asked == [(_URL, 10.0)]
+    assert clock.slept == [0.0]
+    reported = capsys.readouterr().out
+    assert "last seen: TimeoutError: timed out." in reported
+
+
+def test_the_request_bound_is_cut_to_what_is_left_of_the_deadline(
+    script: ModuleType, clock: _Clock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A request cannot be given longer than the whole wait has left."""
+    site = _site(script, monkeypatch, [])
+
+    assert (
+        script.main(["btclib", "v2026.9.1", "--timeout", "34", "--interval", "30"]) == 1
+    )
+
+    assert [timeout for _, timeout in site.asked] == [10.0, 4.0]
+
+
+def test_the_defaults_are_the_budget_a_release_actually_gets(
+    script: ModuleType, clock: _Clock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The workflow passes no budget, so the shipped one is what bounds it.
+
+    `DEFAULT_TIMEOUT` is the figure the job's `timeout-minutes` is set
+    above, and no other case's outcome turns on it: the cases that reach
+    the deadline state one of their own, and the two that do not are
+    answered well inside any deadline they could have been given. So the
+    shipped number could be changed without a red run. This is the run
+    the workflow makes.
+    """
+    site = _site(script, monkeypatch, [])
+
+    assert script.main(["btclib", "v2026.9.1"]) == 1
+
+    assert clock.now == pytest.approx(900.0)
+    assert clock.slept == [30.0] * 30
+    assert [timeout for _, timeout in site.asked] == [10.0] * 30
+
+
+def test_the_site_answering_the_page_is_it_serving_the_tag(
+    script: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The transport reads the status, not merely that something answered.
+
+    The `User-Agent` it sends is asserted here too: the Cloudflare zone in
+    front of read the docs bans the interpreter's own default outright, a
+    403 this suite cannot reproduce without a live request, so nothing
+    else in the tree would notice the header being dropped.
+    """
+    asked: list[tuple[str, float]] = []
+    agents: list[str | None] = []
+
+    def urlopen(request: object, *, timeout: float) -> AbstractContextManager[_Answer]:
+        """Answer as the site does once the tag's build has succeeded."""
+        asked.append((request.full_url, timeout))  # type: ignore[attr-defined]
+        agents.append(request.get_header("User-agent"))  # type: ignore[attr-defined]
+        return _answering(HTTPStatus.OK)
+
+    monkeypatch.setattr(script, "urlopen", urlopen)
+
+    assert script.unserved(_URL, 10.0) is None
+    assert asked == [(_URL, 10.0)]
+    assert agents == [script.USER_AGENT]
+
+
+def test_a_2xx_that_is_not_ok_is_not_the_site_serving_it(
+    script: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`unserved` compares the status rather than that a status arrived.
+
+    The test above hands it `OK` alone, so it holds just as well against
+    an `unserved` that returns `None` for whatever answers. This is the
+    case that kills that one, and it is what carries the status into the
+    annotation rather than a bare "not served".
+    """
+    monkeypatch.setattr(
+        script,
+        "urlopen",
+        lambda request, *, timeout: _answering(HTTPStatus.NO_CONTENT),
+    )
+
+    assert script.unserved(_URL, 10.0) == "HTTP 204"
+
+
+def test_a_status_the_site_refuses_with_is_named_by_its_number(
+    script: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The ordinary answer while no build has succeeded is a 404.
+
+    `urlopen` raises rather than returns on it, so the status the
+    annotation names comes off the exception and not off a response.
+
+    `closing` is what keeps the refusal from ending the run somewhere
+    else: `HTTPError` is a response as well as an exception, and inherits
+    `tempfile._TemporaryFileWrapper` through `urllib.response.addbase`,
+    so one collected without being closed raises `ResourceWarning` --
+    which this suite turns into an error, against whichever test happens
+    to be running when the collector reaches it.
+    """
+    refusal = HTTPError(_URL, HTTPStatus.NOT_FOUND, "Not Found", Message(), None)
+
+    def urlopen(*_args: object, **_kwargs: object) -> AbstractContextManager[_Answer]:
+        """Refuse the way the site refuses a version it has not built."""
+        raise refusal
+
+    monkeypatch.setattr(script, "urlopen", urlopen)
+
+    with closing(refusal):
+        assert script.unserved(_URL, 10.0) == "HTTP 404"
+
+
+@pytest.mark.parametrize(
+    "failure,named",
+    [
+        (TimeoutError("timed out"), "TimeoutError: timed out"),
+        (ConnectionResetError("reset by peer"), "ConnectionResetError: reset by peer"),
+        (HTTPException("truncated"), "HTTPException: truncated"),
+    ],
+)
+def test_a_site_that_does_not_answer_is_named_by_the_failure(
+    script: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: Exception,
+    named: str,
+) -> None:
+    """A failure with no status of its own still reaches the annotation."""
+
+    def urlopen(*_args: object, **_kwargs: object) -> AbstractContextManager[_Answer]:
+        """Fail the way the exchange fails when nothing comes back."""
+        raise failure
+
+    monkeypatch.setattr(script, "urlopen", urlopen)
+
+    assert script.unserved(_URL, 10.0) == named


### PR DESCRIPTION
release.yml's documented wait is a script with a test (issue btclib-org/.github#573)

btclib-org/.github#466 chose the shape for a wait no trigger exercises --
extract it to .github/scripts/ and test it -- and this carries that
decision into btclib, one of the three trees it names. The wait is
.github/scripts/wait_for_readthedocs_build.py, run by the documented job
under a sparse checkout of .github/scripts and --no-project, which is the
shape pypi-install.yml's wait job already has.

The request carries a User-Agent. The Cloudflare zone in front of read
the docs bans the interpreter's own default (Python-urllib/3.14)
outright -- measured against a tag that is in fact served, no UA and
that default both answered 403 where curl and a custom UA answered 200
-- so a request sent without one would burn the whole deadline and
annotate an error on every release for documentation that is being
served. tests/wait_for_readthedocs_build_test.py now asserts the header
the transport receives, so nothing can drop it silently. The one thing
this cannot measure is a GitHub runner: documented has no trigger a
rehearsal can reach, and Cloudflare can weigh address reputation
alongside the UA.

The budget is a deadline rather than a count of attempts, so there is one
number to compare with the job's timeout-minutes. The arithmetic already
fitted: the loop this replaces was 20 attempts of a 10 s request plus 19
intervals of 30 s, 770 s against the job's 1200 s, so nothing here
repairs an overrun. What issue #1165 asked for is the shape, and that is
what the deadline is.

The script takes no empty tag as nothing to wait for, which is where it
parts from the release wait beside it: documented is guarded by
github.event_name == 'push', a rehearsal has no tag, and a branch ref
would spend the whole deadline on a URL that answers 404 by
construction. That is #466's own reason for saying the guard does not
transfer.

tests/wait_for_readthedocs_build_test.py substitutes the transport and
the clock and is the only thing that drives the retry, the deadline, the
clamp on a request that outlasts it and the ::error:: naming the builds
page. pyproject.toml gains the test in [tool.uv.build-backend]
source-exclude, which tests/build_system_test.py gates, and the script in
ruff's per-file T201 ignore beside its siblings.

btclib-org/.github#573


Local review: CLEARED 6d4d01d (this sha carries the identical tree, re-parented onto main after the landing below it). Gates on that tree, as this repository's `CONTRIBUTING.md` writes them: exit 0.

## Summary by Sourcery

Replace the inline release-workflow loop with a tested, deadline-bounded Read the Docs wait script that reliably reports documentation build failures.

New Features:
- Add a reusable Read the Docs wait script for release documentation checks, including User-Agent handling and diagnostic failure reporting.

Bug Fixes:
- Prevent the documentation wait from exhausting the workflow timeout before emitting its error annotation.

Enhancements:
- Use a deadline-based polling budget with request timeouts bounded by the remaining wait time.
- Run the documentation check from a sparse checkout independently of the project installation.

Build:
- Exclude the new wait test from source distributions and configure the script's required logging allowance.

Documentation:
- Document the new documentation-wait behavior and its release-workflow integration in the changelog.

Tests:
- Add deterministic tests covering polling, deadlines, timeout clamping, HTTP and transport failures, status handling, URL construction, and the required User-Agent.
