### PR TITLE
REPOSITORY.md's Code quality section is read back, not transcribed (closes #1549) (issue btclib-org/.github#530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,29 @@ documented at release-notes length in the first place, and are still in
   `github-pages`'s branch restriction is gone; the branch Pages serves
   is what *Pages, which is btclib.org*'s own `source.branch` already
   answers.
+- **`REPOSITORY.md`'s *Code quality* readback names `python` alone**
+  (issue btclib-org/.github#530). Autodetection listed `ruby` for as long
+  as a `Gemfile` sat at the root, and removing the website took the
+  `Gemfile` with it, so `code-quality/setup` now answers
+  `{"state":"not-configured","languages":["python"], ...}`. The control is the
+  tree that took the site: the same call against
+  `btclib-org/btclib-org.github.io`, which holds a `Gemfile` and no
+  Python, answers `["ruby"]`. The section's argument is unchanged —
+  `state=configured` is still the way back, and what an `Analyze (ruby)`
+  job ever found is still what an argument against taking it rests on;
+  the `Gemfile` autodetection saw is what is gone, not the finding.
+- **The same section reads its job count off a pull request instead of
+  stating one** (closes #1549). Section 9 of the organization standard
+  refuses a figure in prose that nothing re-derives, and this one was
+  load-bearing rather than decorative — the argument is that two CodeQL
+  jobs mattered *against a ceiling*, so the sentence keeps the argument
+  and the figure becomes a call. It was never one number in any case:
+  `check-runs` answers 14 and 15 on the two pull requests open when this
+  was written. The call is on an *open* head, and the section says why:
+  every workflow that triggers on a pull request takes `closed` in its
+  `types:` bar `claude-review.yml`, so a merged head carries a second,
+  wholly skipped set of runs on top of the first — 23 on PR 1546's, one
+  of which succeeded.
 
 ### Documentation and the website
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -245,17 +245,35 @@ owns. The endpoint that reports it is the one that sets it:
 
 ```shell
 gh api repos/btclib-org/btclib/code-quality/setup
-# {"state":"not-configured","languages":["python","ruby"], ...}
+# {"state":"not-configured","languages":["python"], ...}
 
 gh api -X PATCH repos/btclib-org/btclib/code-quality/setup \
   -F state=not-configured
 ```
 
 What decided it is the concurrency ceiling measured above, not the
-queries: a pull request here asks for twenty-one jobs on purpose, and
-`Analyze (python)` and `Analyze (ruby)` were two more on every pull
-request and every push to `main` — `Code Quality: PR #N` in the run
-list, 80 seconds and 32.
+queries: the check set a pull request here already asks for is large on
+purpose, and `Analyze (python)` and `Analyze (ruby)` were two more on
+every pull request and every push to `main` — `Code Quality: PR #N` in
+the run list, 80 seconds and 32.
+
+How large is read off a pull request rather than written down here,
+because it is not one number.
+
+```shell
+head=$(gh pr view <an open pull request> --json headRefOid --jq .headRefOid)
+gh api "repos/btclib-org/btclib/commits/$head/check-runs" --jq '.total_count'
+# 14 and 15, the two open when this was written
+```
+
+**An open one.** Every workflow here that triggers on a pull request
+takes `closed` in its `types:`, `claude-review.yml` excepted, so that a
+landing cancels the run its own group is still holding. A merged head
+therefore carries a second set of runs on top of the first, skipped
+entire, for all but that one. PR 1546's merged head answers 23 to the
+call above, of which one run succeeded and the other 22 were cancelled or
+skipped. A figure taken there measures what the forge recorded, not what
+a pull request asks a runner for.
 
 What they produced in exchange cannot be read from here at all. There is
 no `code-quality/alerts` and no `code-quality/analyses`, both 404, and a
@@ -278,7 +296,11 @@ most of the reason nobody read them.
 `Analyze (ruby)` is the plainest half of it: there is no Ruby in this
 library. A `Gemfile` sat beside the package for as long as this
 repository served a Jekyll site from `main`'s root, and autodetection
-read a Ruby project from it. `codeql.yml`'s `matrix.language` names
+read a Ruby project from it — which the endpoint above now says in
+its own voice, `ruby` having left that list when the `Gemfile` did. The
+control is the tree that took the site: the same call against
+`btclib-org/btclib-org.github.io`, which holds a `Gemfile` and no
+Python, answers `["ruby"]`. `codeql.yml`'s `matrix.language` names
 `actions` and `python` and nothing else — an absence rather than an
 exclusion, there being no Ruby for either configuration to analyse —
 and that workflow's own header carries the measurement.


### PR DESCRIPTION
Two figures in `REPOSITORY.md`'s *Code quality* section were written down
rather than derived, and removing the website moved one of them.

## `languages`

The readback recorded `["python","ruby"]`. Autodetection was reading the
`Gemfile`, which
[PR 1551](https://github.com/btclib-org/btclib/pull/1551) removed with
the rest of the site, so:

```shell
gh api repos/btclib-org/btclib/code-quality/setup --jq '{state, languages}'
# {"languages":["python"],"state":"not-configured"}
```

Three reads, the same answer. What excludes a stale value is that this
repository's own answer moved when the `Gemfile` left; what the control
adds is which input moved it — the same call against
`btclib-org/btclib-org.github.io`, which holds a `Gemfile` and no Python,
answers `["ruby"]`.

## The job count, which is [ISS 1549](https://github.com/btclib-org/btclib/issues/1549)

"a pull request here asks for twenty-one jobs on purpose" is a figure
nothing re-derives, which section 9 of the standard refuses. It is
load-bearing rather than decorative — the argument is that two CodeQL
jobs mattered *against a ceiling* — so the sentence keeps the argument
and the figure becomes the call that answers it.

**On an open pull request's head**, and the section says why: every
workflow here that triggers on a pull request takes `closed` in its
`types:`, `claude-review.yml` excepted, so a merged head carries a
second set of runs on top of the first, skipped entire. PR 1546's merged
head answers 23 — one run succeeded, and the other 22 were cancelled or
skipped. A figure taken there measures what the forge recorded, not what
a pull request asks a runner for.

## What does not move

`state=configured` is still argued as the way back, and what an
`Analyze (ruby)` job ever found is still what an argument against taking
it rests on: the `Gemfile` autodetection saw is what is gone, not the
finding. `codeql.yml`'s header carries that measurement and is left
alone.

## Gates

`pre-commit run --all-files` exit 0; `pytest` exit 0, 31111 passed / 29
skipped / 1 xfailed; `sphinx-build -n -W --keep-going` exit 0. `check
sdist` and `Pyroma` passed on the commit hook.

`btclib-org/.github#530` is cited as provenance and closes nothing: it is
another repository's issue and its boxes are ticked by hand.

Closes #1549
