### PR TITLE
CLAUDE.md stops sending a CHANGELOG entry to a theme it belongs to (issue btclib-org/.github#586)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,14 +232,21 @@ Do not use Fable unless explicitly instructed.
   It governs the workflows and the pre-commit config too: the reasoning with its
   negative results is what makes those files reviewable, so match it
   rather than trimming it.
-- **CHANGELOG.md gets an entry for anything a user would notice**, in
-  the group it belongs to; RELEASE_NOTES.md is the release notes on top
-  of it and only moves for a change a user has to *act* on. The prose of
-  the two is one fact each, deliberately: the breaking-changes list lives
-  in RELEASE_NOTES.md and the detail behind it in CHANGELOG.md, so
-  neither restates the other. A source-breaking change costs one edit
-  more: a bullet in RELEASE_NOTES.md's breaking-changes list, with the
-  "before" spelling checked against the `v2023.7.12` tag.
+- **CHANGELOG.md gets an entry for anything a user would notice**;
+  RELEASE_NOTES.md is the release notes on top of it and only moves for
+  a change a user has to *act* on. The prose of the two is one fact each,
+  deliberately: the breaking-changes list lives in RELEASE_NOTES.md and
+  the detail behind it in CHANGELOG.md, so neither restates the other. A
+  source-breaking change costs one edit more: a bullet in
+  RELEASE_NOTES.md's breaking-changes list, with the "before" spelling
+  checked against the `v2023.7.12` tag.
+- **A `###` in the open section names one entry, never a theme several
+  entries share** (issue btclib-org/.github#586): section 9 of the
+  organization standard rejects grouping by theme. Where the open
+  section already carries a heading that groups several entries under
+  one theme, that heading is landed text and stays as it is; a new entry
+  never joins it — it takes its own `###` heading at the end of the
+  section instead, naming only that entry.
 - **Never state how many of anything a file holds** — measure it when a
   release wants it, and do not estimate:
 


### PR DESCRIPTION
CLAUDE.md stops sending a CHANGELOG entry to a theme it belongs to (issue btclib-org/.github#586)

Section 9 of the organization standard now rejects grouping the open
section by theme and settles the transitional rule for a tree, like
this one, whose open section already carries theme headings: they are
landed text and stay, and the next entry takes its own heading after
them rather than joining one. CLAUDE.md's own CHANGELOG.md bullet
still told a contributor to file an entry "in the group it belongs
to," which is the superseded instruction; this replaces it with a
bullet stating the transitional rule where the next entry's writer
will find it. CHANGELOG.md itself is untouched: nothing already
written moves.


Local review: CLEARED 6b8f6e5 (this sha carries the identical tree, re-parented onto main after the landing below it). Gates on that tree, as this repository's `CONTRIBUTING.md` writes them: exit 0.

## Summary by Sourcery

Align CHANGELOG contribution guidance with the organization standard by clarifying how new entries are headed in sections that contain legacy theme groupings.

Bug Fixes:
- Update CLAUDE.md to prevent contributors from assigning new CHANGELOG entries to shared theme headings.

Enhancements:
- Document the transitional handling of existing theme headings and require each new open-section entry to use its own heading.
