### PR TITLE
The `undocumented-public-init` comment gives section 5's reason (closes btclib-org/.github#588)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -583,6 +583,19 @@ documented at release-notes length in the first place, and are still in
   while `documented` is guarded by the event and a branch ref would
   spend the whole deadline on a URL that answers 404 by construction.
 
+### The `undocumented-public-init` comment gave the class as the place
+
+- **`pyproject.toml`'s `ignore` comment said `__init__` is documented by
+  its class** (closes btclib-org/.github#588), where section 5 of the
+  organization standard puts the constructor's documentation in
+  `__init__`'s own docstring, after PEP 257. The comment now gives that
+  section's reason for the entry: the rule checks that a docstring
+  exists and never that it says anything, so declining it declines the
+  presence check and never the documentation -- an argument's meaning, a
+  raised exception, an invariant the constructor establishes still has
+  nowhere else to go. It names the section, as the comments beside it
+  carrying an organization-wide decision already do.
+
 ## v2026.8.29
 
 ### Repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -939,12 +939,21 @@ ignore = [
     # docstrings: every public module, class, method and function must
     # carry one -- D100/D104 and the D101/D102/D103 left out of this
     # list enforce exactly that (issue #290). The two still ignored are
-    # the ones pep257 does not ask for: __init__ is documented by its
-    # class, and a magic method by the data model it implements. Neither
-    # is off because of `convention = "pep257"` below -- that convention
-    # leaves both rules enabled, so it is these two entries doing the
-    # exempting, and dropping either would gate a docstring on every
-    # __init__ or magic method (btclib-org/.github#178)
+    # the ones pep257 does not ask for. A magic method is documented by
+    # the data model it implements. `undocumented-public-init` is
+    # declined for a different reason: it checks that a docstring exists,
+    # never that it says anything, and the cheapest line satisfying it
+    # restates what the constructor's own annotations and strict mypy
+    # already carry. PEP 257 puts the constructor's documentation in
+    # `__init__`'s own docstring, so declining the rule declines that
+    # presence check and never the documentation -- an argument's
+    # meaning, a raised exception, an invariant the constructor
+    # establishes still has nowhere else to go. Section 5 of
+    # btclib-org/.github gives the reason. Neither is off because of
+    # `convention = "pep257"` below -- that convention leaves both rules
+    # enabled, so it is these two entries doing the exempting, and
+    # dropping either would gate a docstring on every __init__ or magic
+    # method (btclib-org/.github#178)
     "undocumented-magic-method",
     "undocumented-public-init",
     # code length is enforced by the formatter, which reflows to its 88


### PR DESCRIPTION
The `undocumented-public-init` comment gives section 5's reason (closes btclib-org/.github#588)

Section 5 of the organization standard declines the rule because it
checks that a docstring exists and never that it says anything, and
because PEP 257 puts the constructor's documentation in `__init__`'s own
docstring: declining the rule declines that presence check and never the
documentation. The comment beside the entry now says that, in place of
the class being where the constructor is documented, and it names
section 5 as the source, which is what the other comments in this file
carrying an organization-wide decision do. The other half of the
sentence, a magic method being documented by the data model it
implements, is the reason the same section gives for
`undocumented-magic-method` and is left as it stands.

`bitcoin-core-rpc` carries the same clause and is corrected on a branch
of its own, cited there rather than closed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016oqSogXvCL55uWFmn3z2vh


Local review: CLEARED 8913b6c (this sha carries the identical tree, re-parented onto main after the landing below it). Gates on that tree, as this repository's `CONTRIBUTING.md` writes them: exit 0.

## Summary by Sourcery

Clarify why public constructor docstring presence checks are intentionally excluded while preserving the requirement to document constructor behavior.

Bug Fixes:
- Correct the `undocumented-public-init` ignore rationale to reflect the organization standard’s Section 5 decision and PEP 257’s placement of constructor documentation.

Documentation:
- Document the corrected rationale in the changelog.
