### PR TITLE
A convention name wrapped in its middle is read as it is written (issue btclib-org/.github#651)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -596,6 +596,19 @@ documented at release-notes length in the first place, and are still in
   nowhere else to go. It names the section, as the comments beside it
   carrying an organization-wide decision already do.
 
+### A convention name wrapped in its middle is read as it is written
+
+- **`tests/conventions_test.py` collapses the whitespace of the *Not
+  tested here* list and then of each name in it** (issue
+  btclib-org/.github#651). `strip()` takes whitespace off a name's ends
+  and leaves what an eighty-column wrap puts in its middle, so a name the
+  break splits matched none of section 7's and was reported as a
+  convention the declaration invented -- a red test on a declaration that
+  reads correctly in the file. `tests/README.md`'s line here does not
+  wrap at all, so nothing was red; what goes is the dependence on where
+  the column falls, which nothing enforces. `btclib-benchmarks` reads its
+  own line this way, its wrap falling inside a name.
+
 ## v2026.8.29
 
 ### Repository

--- a/tests/conventions_test.py
+++ b/tests/conventions_test.py
@@ -159,8 +159,15 @@ def test_the_two_halves_account_for_every_convention() -> None:
         f'{_README.name} has no "Not tested here: ...." line;'
         " the declaration is half of one"
     )
-    listed = match[1].strip()
-    absent = () if listed == "none" else tuple(s.strip() for s in listed.split(";"))
+    listed = " ".join(match[1].split())
+    # whitespace collapsed inside each name and not only around it: the
+    # list wraps at eighty columns wherever the column falls, which for a
+    # long one is in the middle of a name rather than at a semicolon
+    absent = (
+        ()
+        if listed == "none"
+        else tuple(" ".join(s.split()) for s in listed.split(";"))
+    )
     tested = {convention for convention, _ in _ROWS}
 
     overlap = tested.intersection(absent)


### PR DESCRIPTION
A convention name wrapped in its middle is read as it is written (issue btclib-org/.github#651)

`tests/README.md`'s *Not tested here* line wraps at eighty columns
wherever the column falls, and `strip()` takes whitespace off the ends
of a name rather than out of the middle of one. A name the wrap split
was compared with a newline inside it, matched none of section 7's, and
was reported as a convention the declaration invented -- a red test on a
declaration that reads correctly in the file.

Collapsing the whitespace of the list and then of each name reads such a
name as it is written. `btclib-benchmarks` reads its own line that way,
its wrap falling inside a name.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016oqSogXvCL55uWFmn3z2vh


Local review: CLEARED 43760fb (this sha carries the identical tree, re-parented onto main after the landing below it). Gates on that tree, as this repository's `CONTRIBUTING.md` writes them: exit 0.

## Summary by Sourcery

Make convention-list parsing resilient to line wrapping within names.

Bug Fixes:
- Fix convention validation for names split by line wrapping in the `Not tested here` list.

Enhancements:
- Normalize whitespace in the convention list and individual names so wrapped names are compared according to their written content.
