### PR TITLE
The .gitattributes comment names the driver's sides and one anchor (issue btclib-org/.github#646)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,16 +1,22 @@
-# The changelog and the release notes are append-only lists, and every
-# branch appends to the same few groups: two branches each adding a bullet
-# conflict on the insertion point, which is a conflict with nothing to
-# decide. `union` resolves it by keeping both sides' added lines, in the
-# order base-then-ours, and it is built into git — nobody has to configure
-# anything for it to apply.
+# The changelog and the release notes are append-only lists, and the
+# standard gives an entry one place to go, so two branches each writing
+# one arrive at the same anchor: a conflict on the insertion point, with
+# nothing to decide. `union` resolves it by keeping both sides' added
+# lines, ours first and then theirs, the base's own lines staying where
+# they are, and it is built into git — nobody has to configure anything
+# for it to apply.
 #
-# It applies to rebases too, which is where it earns its keep, and it has
-# a price worth knowing: on a checkout these two files never conflict at
-# all, so the same existing entry edited on two branches merges in
-# silence rather than being flagged. That is why neither states how many
-# entries it has — a count is exactly such an edit, and union would have
-# kept both numbers.
+# Which side is `ours` is decided by the operation and not by whose work
+# it is: merging, `ours` is the branch checked out and `theirs` the
+# branch being merged into it; rebasing, `ours` is the upstream and
+# `theirs` each commit being replayed onto it.
+#
+# The rebase is where the driver earns its keep, and it has a price
+# worth knowing: on a checkout these two files never conflict at all, so
+# the same existing entry edited on two branches merges in silence
+# rather than being flagged. That is why neither states how many entries
+# it has — a count is exactly such an edit, and union would have kept
+# both numbers.
 #
 # The driver is a checkout's, and the forge does not apply it: a pull
 # request whose changelog or release notes overlap its base is reported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -609,6 +609,15 @@ documented at release-notes length in the first place, and are still in
   the column falls, which nothing enforces. `btclib-benchmarks` reads its
   own line this way, its wrap falling inside a name.
 
+### The `.gitattributes` comment names the driver's sides and one anchor
+
+- **The comment above the two `merge=union` lines is `btclib-org/.github`'s
+  wording** (issue btclib-org/.github#646): `union` keeps `ours` first
+  and then `theirs`, each of merging and rebasing is named for which
+  side it calls `ours`, and the comment reads the driver as resolving
+  two branches writing an entry at one anchor rather than a bullet
+  appended to one of a few changelog groups.
+
 ## v2026.8.29
 
 ### Repository


### PR DESCRIPTION
The .gitattributes comment names the driver's sides and one anchor (issue btclib-org/.github#646)

The comment above the two `merge=union` lines now carries
`btclib-org/.github`'s wording verbatim, replacing the text that named
`ours` and `theirs` "in the order base-then-ours" and argued from a few
changelog groups. The corrected comment keeps `ours` first and `theirs`
second, names which side each of merging and rebasing calls `ours`, and
reads the driver as resolving two branches writing an entry at one
anchor rather than a bullet appended to a group. This tree's own
`## This repository in particular` section, the Electrum Portuguese
word-list attribute, is unchanged.

The issue closes with the last of the eight repositories it names; this
landing does not close it.


Local review: CLEARED dc4806f (this sha carries the identical tree, re-parented onto main after the landing below it). Gates on that tree, as this repository's `CONTRIBUTING.md` writes them: exit 0.

## Summary by Sourcery

Bug Fixes:
- Correct the `.gitattributes` merge-driver comment so it accurately identifies `ours` and `theirs` for merging and rebasing and describes union resolution at a shared anchor.
