### PR TITLE
REPOSITORY.md states the plan ceiling in prose instead of a dated table (closes btclib-org/.github#639)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -635,6 +635,19 @@ documented at release-notes length in the first place, and are still in
   two branches writing an entry at one anchor rather than a bullet
   appended to one of a few changelog groups.
 
+### `REPOSITORY.md` states the plan ceiling in prose, not in a dated table
+
+- **`REPOSITORY.md`'s *Plan-gated settings* states the concurrent-job
+  ceiling and the macOS one beneath it in prose, instead of reproducing
+  GitHub's table with a date beside it** (closes btclib-org/.github#639).
+  Section 10 of the organization standard rejects the dated number: the
+  date says when it was true and nothing says it still is, where
+  `gh api orgs/<org> --jq .plan.name` beside the linked table answers for
+  the day it is read. The sentence that argued from the macOS figure is
+  kept and sourced to that table; the figures for plans this
+  organization is not on go with the table, no command here re-deriving
+  them.
+
 ## v2026.8.29
 
 ### Repository

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -783,29 +783,23 @@ gh api orgs/btclib-org --jq .plan.name        # free
 ```
 
 [GitHub's own table](https://docs.github.com/en/actions/reference/limits)
-is the authority, and two of its columns matter here — the standard
-runner rows, larger runners being a thing nothing here asks for (read on
-2026-08-26, GitHub free to move the numbers without notice):
+is the authority, and two of its numbers matter here — the standard
+runner limit and the macOS-specific one, larger runners being a thing
+nothing here asks for. On the free plan they are twenty concurrent jobs,
+of which five may be macOS runners.
 
-| plan | concurrent jobs | of which macOS |
-| --- | --- | --- |
-| Free | 20 | 5 |
-| Pro | 40 | 5 |
-| Team | 60 | 5 |
-| Enterprise | 500 | 50 |
-
-**Read the second column before spending anything on the first.** The
+**Read the second number before spending anything on the first.** The
 first is what *Required checks on main* above measures a wider gate
-against, and Team would triple it; the second is the ceiling behind the
-macOS queueing `os-macos.yml`'s header records, and Team does not move it
-at all. So taking the platform cells out of the merge gate is not a
-workaround for a plan — below Enterprise no plan changes that
-arithmetic, and Enterprise is not what is being asked about. What a paid
-plan would buy is the rest: the Linux and Windows crowding, and the
-contention with every other repository of the organization, which spends
-against this same ceiling. Whether that is worth paying for is a
-question for whoever would pay, and it is recorded here so that it is
-asked with the second column in view.
+against, and a paid plan raises it well before it moves the second. The
+five is the ceiling behind the macOS queueing `os-macos.yml`'s header
+records, so taking the platform cells out of the merge gate is not a
+workaround for a plan — below Enterprise no plan changes that arithmetic,
+and Enterprise is not what is being asked about. What a paid plan would
+buy is the rest: the Linux and Windows crowding, and the contention with
+every other repository of the organization, which spends against this same
+ceiling. Whether that is worth paying for is a question for whoever would
+pay, and it is recorded here so that it is asked with the second number in
+view.
 
 ## Features
 


### PR DESCRIPTION
REPOSITORY.md states the plan ceiling in prose instead of a dated table (closes btclib-org/.github#639)

Section 10 of the organization standard rejects the dated number: a date
beside a number says only when it was true, not that it still is, where
the command and the link answer for the day they are read.
`REPOSITORY.md`'s *Plan-gated settings* reproduced GitHub's table
anyway, with a dated parenthetical stating the objection out loud and
then keeping the table.

The table carried a second column, *of which macOS*, that a sentence
here argues from: the macOS ceiling is what keeps the platform cells off
the merge gate below Enterprise. Dropping the row would have left that
sentence pointing at a number no longer on the page, so it is kept and
sourced to the linked table rather than to a row of it, alongside the
first figure, stated the same way the six other copies already state
theirs.

The other tiers' figures go with the table rather than into prose. The
cure section 10 names is the command that answers for the day it is run,
and `gh api orgs/<org> --jq .plan.name` answers which plan this
organization is on, not what another plan's numbers are — so a figure for
a plan it is not on has nothing behind it, and in prose it loses even the
date the table carried. The clause the sentence needs is qualitative and
was already there: below Enterprise no plan changes that arithmetic.

The entry goes at the end of the open section under its own heading,
where section 9 puts an entry, rather than as a bullet appended to a
theme group.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016oqSogXvCL55uWFmn3z2vh


Local review: CLEARED a79fef6 (this sha carries the identical tree, re-parented onto main after the landing below it). Gates on that tree, as this repository's `CONTRIBUTING.md` writes them: exit 0.

## Summary by Sourcery

Replace the dated plan-limits table in repository documentation with current, source-backed prose and live verification guidance.

Enhancements:
- Update repository documentation to state the current plan and macOS job ceilings in prose while directing readers to GitHub’s live limits table and organization plan query for authoritative values.

Documentation:
- Record the documentation change in the changelog and clarify how plan tiers affect runner and macOS concurrency limits.
