### PR TITLE
CLAUDE.md's worktree block puts the removal line in a fence of its own (issue btclib-org/.github#676)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -648,6 +648,18 @@ documented at release-notes length in the first place, and are still in
   organization is not on go with the table, no command here re-deriving
   them.
 
+### `CLAUDE.md`'s worktree block puts the removal line in a fence of its own
+
+- **`git worktree remove --force "$WT"` no longer sits under a line
+  that ends in a placeholder** (issue btclib-org/.github#676): the
+  assignment above it fails on its own redirection, and a shell that
+  discards that failure as a parse error reads the next line as a fresh
+  command, so a paste made before the placeholders were filled reached
+  the removal against whatever `$WT` a previous run of the same block
+  had left set. The removal now stands in a fence of its own, with
+  prose between the two fences saying why the first closes early, so a
+  reader reaches it only by pasting it on purpose.
+
 ## v2026.8.29
 
 ### Repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,15 @@ git worktree add -b <branch> "$WT" origin/main
 cd "$WT" && uv sync --locked          # a second venv, about a minute
 # edit, gate and commit here, then
 git push origin HEAD:refs/heads/<branch>
-git worktree remove --force "$WT"     # removing it is part of finishing
+```
+
+Removing the worktree is part of finishing, and it stands in a block of
+its own: the block above ends in a placeholder, and a shell that
+discards that line as a parse error reads the next as a fresh command —
+which, in one block, is this line against whatever `$WT` already held.
+
+```shell
+git worktree remove --force "$WT"
 ```
 
 The venv is the whole of the cost, and it buys the thing that matters: a


### PR DESCRIPTION
CLAUDE.md's worktree block puts the removal line in a fence of its own (issue btclib-org/.github#676)

`git worktree remove --force "$WT"` sat under a line ending in a
placeholder, and a shell that discards that line as a parse error reads
the removal as a fresh command against whatever `$WT` a previous run of
the block had left set. The removal now stands in a fence of its own,
with prose between the two fences carrying the reason and the comment
the old line carried.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016oqSogXvCL55uWFmn3z2vh


Local review: CLEARED a024d65 (this sha carries the identical tree, re-parented onto main after the landing below it). Gates on that tree, as this repository's `CONTRIBUTING.md` writes them: exit 0.

## Summary by Sourcery

Separate the worktree removal command from the placeholder block to prevent unintended execution during copy-paste.

Bug Fixes:
- Prevent accidental execution of the worktree removal command when the preceding placeholder command is pasted before being completed.

Enhancements:
- Clarify the worktree cleanup instructions by isolating removal into its own shell block and documenting why it must be run deliberately.

Documentation:
- Document the corrected worktree cleanup block and the circumstances that previously allowed unintended removal.
