### PR TITLE
REPOSITORY.md reads both variable stores back for the review switch (issue btclib-org/.github#682)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -660,6 +660,20 @@ documented at release-notes length in the first place, and are still in
   prose between the two fences saying why the first closes early, so a
   reader reaches it only by pasting it on purpose.
 
+### `REPOSITORY.md` reads both variable stores back for the review switch
+
+- **The file records `vars.CLAUDE_REVIEW_ENABLED`, the switch
+  `claude-review.yml` guards its jobs with** (issue
+  btclib-org/.github#682). Both variable stores are read back: the
+  repository's because a variable set here would take precedence over
+  one of the same name set on the organization, and the organization's
+  for the empty name list section 11 reads as the switch's off state --
+  with a `total_count` beside it, a store that prints nothing at all
+  when it answers needing one to show the call reached it. The
+  repository's Actions variables leave the list of facilities whose
+  empty answer records no decision, that zero now being half of what
+  records this one.
+
 ## v2026.8.29
 
 ### Repository

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -908,13 +908,39 @@ zeros absences rather than an endpoint that answers empty for everyone,
 and an empty store here is where the standard's decision shows rather
 than a facility nobody reached for.
 
-**A facility nobody reached for.** The repository's Actions variables,
-self-hosted runners, deploy keys, autolinks and custom property values
-each answer empty here, and an empty answer records no decision.
-Webhooks are not among them: *Read the Docs* above reads those back,
-with the control that makes the `0` an absence rather than a permission
-ceiling. Whichever of the rest is reached for one day arrives with the
-section that uses it.
+**A switch this repository does not set.** `claude-review.yml` guards
+its jobs with `vars.CLAUDE_REVIEW_ENABLED`, and neither variable store
+holds it:
+
+```shell
+gh api repos/btclib-org/btclib/actions/variables --jq '.total_count'
+# 0
+gh api orgs/btclib-org/actions/variables --jq '.variables[].name'
+# (nothing)
+gh api orgs/btclib-org/actions/variables --jq '.total_count'
+# 0
+```
+
+The organization's secret stores above answering with a name are what
+make these zeros absences rather than an endpoint that answers empty for
+everyone. The variable store prints nothing at all when it answers, so
+its own `total_count` of `0` is what shows the call reached it: one that
+does not reach it prints an error and exits non-zero. Section 11 reads
+that empty name list as `vars.CLAUDE_REVIEW_ENABLED`'s off state, an
+undefined `vars.X` being the empty string. Both stores are read because
+a variable set here would take precedence over one of the same name set
+on the organization, so the organization's answer alone would not show
+the switch off for this tree.
+
+**A facility nobody reached for.** The repository's self-hosted
+runners, deploy keys, autolinks and custom property values each answer
+empty here, and an empty answer records no decision. Webhooks are not
+among them: *Read the Docs* above reads those back, with the control
+that makes the `0` an absence rather than a permission ceiling. The
+repository's Actions variables are not among them either: *A switch this
+repository does not set* above reads that store, its zero being half of
+what records the review switch's off state. Whichever of the rest is
+reached for one day arrives with the section that uses it.
 
 **A service's own settings, past the ones the standard states a rule
 for.** [Section 11's *Pages and Read the


### PR DESCRIPTION
REPOSITORY.md reads both variable stores back for the review switch (issue btclib-org/.github#682)

`claude-review.yml` guards its jobs with `vars.CLAUDE_REVIEW_ENABLED`,
and section 11 of the standard states the rule for it: the variable is
the organization's, and its absence is the off state. This file's scope
takes in a setting a section of the standard states a rule for, so the
switch is inside its perimeter, and neither the variable nor either
store was named anywhere in it.

A block beside the credential one now reads the repository's variable
store and the organization's. The repository's is read because a
variable set here would take precedence over one of the same name set on
the organization, so the organization's answer alone would not show the
switch off for this tree. The organization's is read for the name list
section 11 calls the off state, and for a `total_count` beside it: a
variable store prints nothing at all when it answers, so the count is
what shows the call reached it, one that does not reach it printing an
error and exiting non-zero. The organization secret stores the block
above already reads answer with a name, which is what makes these zeros
absences rather than an endpoint that answers empty for everyone.

The repository's Actions variables leave the prose list under *A
facility nobody reached for*, which says an empty answer records no
decision: that zero is now half of what records this one, so the
sentence excluding webhooks from the list gains its counterpart for the
variable store.

`btclib-benchmarks` and `bitcoin-core-rpc` carry this passage; the
remaining REPOSITORY.md copies owe it, and the issue closes on the last
of them.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016oqSogXvCL55uWFmn3z2vh


Local review: CLEARED 9f2743f (this sha carries the identical tree, re-parented onto main after the landing below it). Gates on that tree, as this repository's `CONTRIBUTING.md` writes them: exit 0.

## Summary by Sourcery

Document the Claude review switch's unset state and verify it across both variable scopes.

Enhancements:
- Document the Claude review switch by reading both repository and organization Actions variable stores and distinguishing an unset switch from an unreachable or empty response.

Documentation:
- Update the repository guidance and changelog to explain that an absent `CLAUDE_REVIEW_ENABLED` variable represents the review switch's off state.
