### PR TITLE
tests/interpreters_test.py's PyPy example and dist-job comment match the tree (closes #1541, closes #1544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -673,6 +673,20 @@ documented at release-notes length in the first place, and are still in
   repository's Actions variables leave the list of facilities whose
   empty answer records no decision, that zero now being half of what
   records this one.
+### `tests/interpreters_test.py`'s PyPy and `dist` comments match the tree
+
+- **The comment above `_CPYTHON` quoted the PyPy matrix cell as
+  `"pypy-3.11"`; none of the three sweeps write it with a hyphen**
+  (closes #1541). `os-ubuntu.yml`, `os-macos.yml` and `os-windows.yml`
+  all spell it `pypy3.11` (`os-ubuntu.yml` also carries `pypy3.10`), and
+  the comment now quotes that form.
+- **The comment above `_GATE` said every merge-gate job "writes the
+  interpreter it runs into itself"; `dist`'s build and its
+  wheel-smoke-test step take theirs from `.python-version` instead**
+  (closes #1544). `_gate_interpreters()`'s own read is unaffected -- the
+  three jobs that do pin `python-version:` inline are what make the
+  token read work -- but the universal claim was false of `dist`, and
+  the comment now names it as the exception.
 
 ## v2026.8.29
 

--- a/tests/interpreters_test.py
+++ b/tests/interpreters_test.py
@@ -68,7 +68,11 @@ _SWEEPS = ("os-macos.yml", "os-ubuntu.yml", "os-windows.yml")
 # are read as tokens off the file rather than out of a matrix block. A
 # free-threaded build there is a "3.14t" of the same shape. Comments go
 # first, so that a sentence about a sweep's free-threaded cell does not
-# read as the gate running one
+# read as the gate running one. The `dist` job is the exception: its
+# `astral-sh/setup-uv` step passes no `python-version:`, and its bare
+# `uv build` and "Smoke-test the wheel" step's `uv venv` take their
+# interpreter from `.python-version` instead of naming it in the job, so
+# a change to that file would move `dist`'s interpreter unseen here
 _GATE = _ROOT / ".github/workflows/test.yml"
 _COMMENT = re.compile(r"(?:^|\s)#.*$", re.MULTILINE)
 _INTERPRETER = re.compile(r"\b3\.\d+t?\b")
@@ -113,7 +117,7 @@ _CLASSIFIED = _versions(_CLASSIFIER, _PYPROJECT)
 _MATRIX = _matrix()
 # the free-threaded build and PyPy are the same interpreter version as
 # far as a classifier is concerned: "3.14t" is CPython 3.14, and
-# "pypy-3.11" is what the PyPy classifier covers rather than a version
+# "pypy3.11" is what the PyPy classifier covers rather than a version
 # of its own
 _CPYTHON = tuple(sorted({v.rstrip("t") for v in _MATRIX if not v.startswith("pypy")}))
 


### PR DESCRIPTION
Closes #1541
Closes #1544

`tests/interpreters_test.py`'s comment above `_CPYTHON` quoted the PyPy
matrix cell as `"pypy-3.11"`; none of `os-ubuntu.yml`, `os-macos.yml` or
`os-windows.yml` write it with a hyphen. The comment above `_GATE`
claimed every merge-gate job "writes the interpreter it runs into
itself," which is false of the `dist` job: its build and wheel-smoke-test
steps take their interpreter from `.python-version` instead. Both are
comment-only corrections; `_gate_interpreters()`'s own reads are
unchanged.

Locally reviewed and CLEARED at fresh context before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvtGgCtGYwgXEwCZfc4omr

## Summary by Sourcery

Align interpreter test comments with the workflow configuration without changing interpreter detection behavior.

Enhancements:
- Correct documentation comments in the interpreter tests to match the PyPy version naming and accurately describe the `dist` job's interpreter source.

Documentation:
- Update the changelog with the corrected PyPy and `dist` job comment descriptions.