### PR TITLE
RELEASING.md names documented's own skip and points at REPOSITORY.md for squash_merge_commit_message (closes #1543, closes #1545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -687,6 +687,27 @@ documented at release-notes length in the first place, and are still in
   three jobs that do pin `python-version:` inline are what make the
   token read work -- but the universal claim was false of `dist`, and
   the comment now names it as the exception.
+### RELEASING.md names `documented`'s own skip on a rehearsal
+
+- **The *Check that every job you expected actually ran* step now
+  counts `documented` among what a rehearsal skips by design**
+  (closes #1543). Its `if: github.event_name == 'push'` skips it on
+  every `workflow_dispatch` run for a reason of its own, unrelated to
+  `publish-testpypi`'s and `publish-pypi`'s mutual-trigger exemption, so
+  the step's own instruction sent a releaser who found it skipped there
+  to treat a by-design skip as a defect. The sentence enumerating
+  expected skips now names it, matching `btclib-secp256k1`'s
+  `RELEASING.md`.
+
+### RELEASING.md points at REPOSITORY.md for the squash setting
+
+- **`RELEASING.md` no longer restates or re-queries
+  `squash_merge_commit_message`'s value** (closes #1545).
+  `REPOSITORY.md`'s *Merge methods* is the one place that setting is
+  recorded, the way `CONTRIBUTING.md`'s *What a squash writes here*
+  already reads it from there; the two release-procedure paragraphs
+  that reasoned about the default now point at that section instead of
+  naming the value inline.
 
 ## v2026.8.29
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -327,18 +327,14 @@ to `deps-latest`'s own result.
    Give it its title and its body. The title is the version; the body
    says what the release is — what moved, what did not, and which of the
    two a user would notice. The squash takes its message from the
-   branch's commits and not from that body:
-
-   ```shell
-   gh api repos/btclib-org/btclib --jq .squash_merge_commit_message
-   # COMMIT_MESSAGES
-   ```
-
-   so the pull request is where the body stays, and where a reader
-   arriving from the release commit ends up. A template left unfilled, or
-   a bot's summary of the diff, is not a substitute — the summary can
-   stay, but what the diff cannot say has to be written, and what a
-   reader should not have to discover at the button belongs there too.
+   branch's commits and not from that body — `squash_merge_commit_message`
+   is REPOSITORY.md's *Merge methods* to read, not this file's to
+   restate — so the pull request is where the body stays, and where a
+   reader arriving from the release commit ends up. A template left
+   unfilled, or a bot's summary of the diff, is not a substitute — the
+   summary can stay, but what the diff cannot say has to be written, and
+   what a reader should not have to discover at the button belongs there
+   too.
 
    Write it from the section the retitle above renamed, which the cycle
    has been filling one landed change at a time, and check that
@@ -371,19 +367,20 @@ to `deps-latest`'s own result.
    way. Name the release commit's title and body explicitly when using
    it — `gh pr merge <n> --squash --admin --subject "<title>"
    --body-file <path>` — rather than leave them to
-   `squash_merge_commit_message`'s repository default, `COMMIT_MESSAGES`
-   here: this branch carries more than one commit every time (the
-   paragraph below this one), and that default composes the commit under
-   the tag from all of them rather than from what step 3 wrote.
+   `squash_merge_commit_message`'s repository default, recorded in
+   REPOSITORY.md's *Merge methods*: this branch carries more than one
+   commit every time (the paragraph below this one), and that default
+   composes the commit under the tag from all of them rather than from
+   what step 3 wrote.
 
    `gh api -X PUT repos/{owner}/{repo}/pulls/<n>/merge -f
    merge_method=squash` is the fallback for when `--admin` is
    unavailable, and needs `commit_title` and `commit_message` passed the
    same way for the same reason. It is what landed btclib-secp256k1's
    0.8.0.4 clean — but only because that branch carried a single commit,
-   so `COMMIT_MESSAGES`'s concatenation and that commit's own message
-   were the same string; a multi-commit release branch without the two
-   parameters would not be so lucky.
+   so the repository default's concatenation of every commit and that
+   commit's own message were the same string; a multi-commit release
+   branch without the two parameters would not be so lucky.
 
    This branch carries more than one commit every time, a version bump
    and two retitles never being one, so the commit that lands is one
@@ -465,8 +462,10 @@ to `deps-latest`'s own result.
    ```
 
    `publish-testpypi` is `skipped` on a tag and `publish-pypi` on a
-   rehearsal — each is the other's trigger — and `public-api` is red on
-   any cycle with breaking changes. Everything else should be `success`.
+   rehearsal — each is the other's trigger — `public-api` is red on any
+   cycle with breaking changes, and `documented` skipped on its own
+   account, its guard being the push. Everything else should be
+   `success`.
 
 1. Read the `documented` job rather than the site: read the docs activates
    and builds a new release tag from the automation rule REPOSITORY.md


### PR DESCRIPTION
Closes #1543
Closes #1545

`RELEASING.md`'s *Check that every job you expected actually ran* step
named two expected skips on a rehearsal but not a third: `documented`,
which is push-only and skips on its own account regardless of the other
two. The sentence now names it, matching `btclib-secp256k1`'s
`RELEASING.md`.

`squash_merge_commit_message`'s value was recorded twice
(`REPOSITORY.md`'s *Merge methods* and again in `RELEASING.md`).
`RELEASING.md` now points at `REPOSITORY.md` for the value, the way
`CONTRIBUTING.md` already does, keeping only its own reasoning for why
the release procedure cares.

Locally reviewed and CLEARED at fresh context before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvtGgCtGYwgXEwCZfc4omr

## Summary by Sourcery

Align release guidance with expected rehearsal behavior and centralize the squash merge setting reference.

Bug Fixes:
- Clarify that the `documented` job is expected to skip during rehearsal runs.

Enhancements:
- Make `REPOSITORY.md` the authoritative reference for the repository's squash merge commit message setting instead of duplicating its value in `RELEASING.md`.

Documentation:
- Update release documentation to accurately describe expected job skips and reference the central merge-method configuration documentation.