### PR TITLE
tests/wait_for_pypi_release_test.py closes its HTTPError, per its sibling (closes #1550)

### DIFF
--- a/tests/wait_for_pypi_release_test.py
+++ b/tests/wait_for_pypi_release_test.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
-from contextlib import contextmanager
+from contextlib import closing, contextmanager
 from email.message import Message
 from http import HTTPStatus
 from pathlib import Path
@@ -290,10 +290,33 @@ def test_a_2xx_that_is_not_ok_is_not_the_index_serving_it(
     assert not script.served(_URL, 10.0)
 
 
+def test_a_404_is_not_the_index_serving_the_version(
+    script: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 404 while the upload is still landing is one more reason to wait.
+
+    `closing` is what keeps the failure from ending the run somewhere
+    else: `HTTPError` is a response as well as an exception, and inherits
+    `tempfile._TemporaryFileWrapper` through `urllib.response.addbase`,
+    so one collected without being closed raises `ResourceWarning` --
+    which this suite turns into an error, against whichever test happens
+    to be running when the collector reaches it.
+    """
+    failure = HTTPError(_URL, HTTPStatus.NOT_FOUND, "Not Found", Message(), None)
+
+    def urlopen(*_args: object, **_kwargs: object) -> AbstractContextManager[_Answer]:
+        """Fail the way the index fails while the upload is still landing."""
+        raise failure
+
+    monkeypatch.setattr(script, "urlopen", urlopen)
+
+    with closing(failure):
+        assert not script.served(_URL, 10.0)
+
+
 @pytest.mark.parametrize(
     "failure",
     [
-        HTTPError(_URL, HTTPStatus.NOT_FOUND, "Not Found", Message(), None),
         TimeoutError("timed out"),
         ConnectionResetError("reset by peer"),
     ],


### PR DESCRIPTION
Closes #1550

`tests/wait_for_pypi_release_test.py` built an `HTTPError` at module
scope inside a `@pytest.mark.parametrize` list and never closed it.
`HTTPError` is also a file-like response object (inherits
`tempfile._TemporaryFileWrapper` via `urllib.response.addbase`), so an
unclosed one raises `ResourceWarning` on GC, which this suite's
`filterwarnings` turns into a hard error against whichever test happens
to be running when the collector reaches it. The 404 case is now its own
test, built inside the test body and wrapped in `contextlib.closing`,
matching the pattern `tests/wait_for_readthedocs_build_test.py` already
uses for the same class of object.

Locally reviewed and CLEARED at fresh context before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvtGgCtGYwgXEwCZfc4omr

## Summary by Sourcery

Ensure the PyPI release tests close HTTPError responses reliably during 404 handling.

Bug Fixes:
- Prevent resource warnings from an unclosed HTTPError from causing unrelated tests to fail.

Enhancements:
- Align the 404 response test with the existing resource-management pattern used by sibling tests.

Tests:
- Separate the 404 PyPI response case into a dedicated test while retaining parameterized coverage for connection failures.