### PR TITLE
CHANGELOG.md's unreleased Repository bullet cites REPOSITORY.md's current heading (closes #1552)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,9 +206,9 @@ documented at release-notes length in the first place, and are still in
   environment, created by enabling Pages rather than by the repository
   — so the sample readback under *Publishing waits for an approval*
   now selects `pypi` and `testpypi` only, and the sentence recording
-  `github-pages`'s branch restriction is gone; the branch Pages serves
-  is what *Pages, which is btclib.org*'s own `source.branch` already
-  answers.
+  `github-pages`'s branch restriction is gone; there is no such branch
+  left to restrict, which is what *Pages, which this repository does
+  not use*'s own 404 already answers.
 - **`REPOSITORY.md`'s *Code quality* readback names `python` alone**
   (issue btclib-org/.github#530). Autodetection listed `ruby` for as long
   as a `Gemfile` sat at the root, and removing the website took the


### PR DESCRIPTION
Closes #1552

`CHANGELOG.md`'s still-unreleased `v2026.9` section had a bullet citing
`REPOSITORY.md`'s *Pages, which is btclib.org* heading by title; PR 1551
renamed that section to *Pages, which this repository does not use* and
changed its content (a 404 rather than `source.branch`). Since the bullet
is still unreleased and not covered by
`tests/changelog_immutability_test.py`'s guard, this corrects it in
place — updating both the heading citation and the clause that depended
on the section's old content.

Locally reviewed and CLEARED at fresh context before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvtGgCtGYwgXEwCZfc4omr

## Summary by Sourcery

Bug Fixes:
- Correct the unreleased changelog entry to reference the repository's current Pages heading and accurately describe its 404 response instead of the removed branch configuration.