### PR TITLE
tests/copyright_test.py reads conf.py's author line instead of executing it, closing the docs/tomllib gap the coverage and os-macos-3.10 jobs hit (closes #1538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -709,6 +709,22 @@ documented at release-notes length in the first place, and are still in
   that reasoned about the default now point at that section instead of
   naming the value inline.
 
+### `tests/copyright_test.py` checks `conf.py`'s `author` without executing it
+
+- **The test added for issue #1519 stopped loading `docs/source/conf.py`
+  by path and executing it, and reads its `author = ...` line's source
+  text instead** (closes #1538). Executing the module runs its
+  unconditional top-of-file imports too -- `tomllib`, stdlib only from
+  3.11, and `docutils`/`sphinx`, installed only by the `docs` dependency
+  group -- which neither `test.yml`'s coverage jobs (`test`/`harness`,
+  no `docs`) nor `os-macos.yml`'s 3.10 cells carry, so the test failed
+  on every push and every scheduled macOS run; a contributor's own
+  `uv sync` installs every group including `docs`, so the failure never
+  reproduced locally as documented. The check itself is unchanged: that
+  `author` derives from `PYPROJECT`'s `authors` table rather than
+  repeating it as a literal, the same idiom `_pyproject_author` already
+  uses on `pyproject.toml` for the same reason.
+
 ## v2026.8.29
 
 ### Repository

--- a/tests/copyright_test.py
+++ b/tests/copyright_test.py
@@ -47,16 +47,26 @@ reads `pyproject.toml`'s `authors` table the same way, through the
 `PYPROJECT` dict that file already parses for its own `release` and
 `BLOB` -- a derivation rather than a fourth vertex to compare, since
 unlike LICENSE and pyproject.toml above, `conf.py`'s copy has
-nowhere it needs to diverge from the source it names. The test below
-loads `conf.py` by path, the way it is not a package to import, and
-checks the read rather than a value that can no longer drift on its
-own.
+nowhere it needs to diverge from the source it names.
+
+Issue #1538: the test below used to load `conf.py` by path and execute
+it, the way it is not a package to import, and check the resulting
+`author` attribute. Executing the module also runs its unconditional
+top-of-file imports -- `tomllib`, stdlib only from 3.11, and
+`docutils`/`sphinx`, installed only by the `docs` dependency group --
+which neither the coverage jobs' `test`/`harness` groups nor
+os-macos's 3.10 cells carry, so the test failed everywhere but a
+contributor's own `uv sync`, which installs every group including
+`docs` and so never reproduces this locally. `_conf_author_expr`
+below reads the `author = ...` line's source text instead, the same
+idiom `_pyproject_author` above already uses on `pyproject.toml` and
+for the same reason: it checks that `author` derives from `PYPROJECT`
+rather than repeating it, without importing anything `conf.py`
+imports.
 """
 
-import importlib.util
 import re
 from pathlib import Path
-from types import ModuleType
 
 import btclib
 
@@ -64,6 +74,8 @@ _ROOT = Path(__file__).parents[1]
 _LICENSE_RE = r"Copyright \([Cc]\) (.+)"
 _COPYRIGHT_RE = r"Copyright \([Cc]\) \d{4}-\d{4} (.+)"
 _AUTHOR_RE = r'authors\s*=\s*\[\{\s*name\s*=\s*"([^"]+)"'
+_CONF_AUTHOR_RE = r"(?m)^author = (.+)$"
+_CONF_AUTHOR_EXPECTED = 'PYPROJECT["project"]["authors"][0]["name"]'
 
 
 def _license_holder() -> str:
@@ -88,15 +100,17 @@ def _pyproject_author() -> str:
     return match.group(1)
 
 
-def _conf_module() -> ModuleType:
-    """Load docs/source/conf.py by path: no package, so no import."""
-    path = _ROOT / "docs" / "source" / "conf.py"
-    spec = importlib.util.spec_from_file_location("conf", path)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+def _conf_author_expr() -> str:
+    """Return docs/source/conf.py's `author = ...` line, right-hand side.
+
+    Read as source text rather than executed: see issue #1538 in the
+    module docstring above for why executing conf.py is not an option
+    here.
+    """
+    text = (_ROOT / "docs" / "source" / "conf.py").read_text(encoding="utf-8")
+    match = re.search(_CONF_AUTHOR_RE, text)
+    assert match, "docs/source/conf.py has no top-level 'author = ...' line"
+    return match.group(1)
 
 
 def test_license_and_copyright_name_the_same_holder() -> None:
@@ -141,11 +155,10 @@ def test_no_duplicate_author_or_license_dunders() -> None:
 
 def test_conf_py_author_reads_pyproject_rather_than_repeating_it() -> None:
     """Sphinx's `author` is `pyproject.toml`'s, read back, not retyped."""
-    conf_author = _conf_module().author
-    pyproject_author = _pyproject_author()
-    assert conf_author == pyproject_author, (
-        f"docs/source/conf.py's author is {conf_author!r}, pyproject.toml's "
-        f"is {pyproject_author!r}. conf.py reads pyproject.toml's `authors` "
-        "table for this value (issue #1519); if the two differ here the "
-        "read itself, not a stale literal, is what to look at"
+    conf_author_expr = _conf_author_expr()
+    assert conf_author_expr == _CONF_AUTHOR_EXPECTED, (
+        f"docs/source/conf.py's author line reads {conf_author_expr!r}, not "
+        f"{_CONF_AUTHOR_EXPECTED!r}. conf.py should read pyproject.toml's "
+        "`authors` table for this value (issue #1519) rather than a "
+        "literal"
     )


### PR DESCRIPTION
Closes #1538

`tests/copyright_test.py::test_conf_py_author_reads_pyproject_rather_than_repeating_it`
loaded and executed `docs/source/conf.py` by path to check its Sphinx
`author` derives from `pyproject.toml` rather than repeating it. Executing
the module runs its unconditional top-of-file imports — `tomllib`
(stdlib only from 3.11) and `docutils`/`sphinx.*` (only installed by the
`docs` group) — which neither the coverage/no-bindings jobs (3.14,
lacking `docs`) nor `os-macos`'s 3.10 cells (lacking `tomllib` entirely)
carry. `test` was red on `main` as a result.

The test now reads `conf.py`'s `author = ...` line as source text and
compares it against the expected derivation expression, the same idiom
`_pyproject_author()` in the same file already uses on `pyproject.toml`
for the identical reason. `docs.yml`'s `sphinx-build -n -W` still
executes `conf.py` for real on every push/PR.

Locally reviewed and CLEARED at fresh context before opening (including
an independent look at the runtime-vs-source-text trade-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvtGgCtGYwgXEwCZfc4omr

## Summary by Sourcery

Make the conf.py author consistency test work across all supported environments without requiring documentation dependencies.

Bug Fixes:
- Prevent the copyright test from failing in environments without documentation dependencies or Python 3.11+ by avoiding execution of docs/source/conf.py.

Enhancements:
- Verify that conf.py derives its Sphinx author value from pyproject.toml by inspecting the source declaration.
- Remove the test's runtime dependency on importing conf.py and its Sphinx-related dependencies.

Documentation:
- Document the conf.py test compatibility fix and its resolution of issue #1538.

Tests:
- Update the copyright test to validate the conf.py author expression without executing the module.