### PR TITLE
RootFileLinks resolves a `../`-climbing link against its own document (closes #1562)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -123,14 +123,15 @@ jobs:
       # configuration, and it is what would catch a suppression added
       # back.
       #
-      # One grep, because there is one spelling to look for. myst's
+      # One grep, widened to two spellings rather than one. myst's
       # fallback renders the destination verbatim, so what this can
       # match is decided upstream of here, in how the link was written
       # -- and the local-link-prefix hook in .pre-commit-config.yaml
-      # refuses a local destination that does not begin "./", in the
-      # commit that writes it. Every destination the included root files
-      # carry therefore renders href="#./<destination>" when it breaks,
-      # anchor, extension and nested path alike (issue
+      # refuses a local destination that does not begin "./" or "../",
+      # in the commit that writes it (issue #1562). Every destination
+      # the included root files carry therefore renders
+      # href="#./<destination>" or href="#../<destination>" when it
+      # breaks, anchor, extension and nested path alike (issue
       # btclib-org/.github#20; the hook's own comment has the
       # measurement behind that).
       #
@@ -161,7 +162,7 @@ jobs:
       # on the built html
       - name: Check the built pages for unresolved links
         run: |
-          if grep -rn 'href="#\./' docs/build/html --include='*.html'; then
+          if grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'; then
             echo "::error::the links above resolve to no page (unresolved relative path)"
             exit 1
           fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -337,12 +337,14 @@ repos:
   #
   # The rule is the prefix and not the extension, and issue #1175's
   # table is what decides that: "DOES_NOT_EXIST.txt",
-  # "sub/DOES_NOT_EXIST.md", "DOES_NOT_EXIST" and "../DOES_NOT_EXIST.md"
-  # each reach myst's fallback, and each is missed by the union of both
-  # greps a repository ran. An ".md"-scoped rule would leave all four
-  # writable; a prefix refuses all four where they are written, which
+  # "sub/DOES_NOT_EXIST.md" and "DOES_NOT_EXIST" each reach myst's
+  # fallback, and each is missed by the union of both greps a
+  # repository ran. An ".md"-scoped rule would leave all three
+  # writable; a prefix refuses all three where they are written, which
   # answers that issue by prevention rather than by the extra patterns
-  # its Options section contemplates.
+  # its Options section contemplates. The table's fourth row,
+  # "../DOES_NOT_EXIST.md", is answered separately below rather than by
+  # this rule.
   #
   # Measured here as well, by building this repository's documentation
   # with an unresolvable link written each way: "./page.md",
@@ -353,15 +355,18 @@ repos:
   # without also matching the autodoc anchors these pages carry --
   # href="#btclib.ecc.dsa.sign" and href="#module-btclib.b32".
   #
-  # "../" is the row worth naming on its own, because it is the one
-  # shape with nothing downstream behind it. conf.py's transform
-  # declines a target that normalizes above the repository root --
-  # nothing above the root is a document this build can answer for --
-  # so "../page.md" reaches myst's fallback by design rather than by a
-  # gap in the transform, and renders href="#../page.md", which the grep
-  # in docs.yml does not match and should not be widened to. Refusing it
-  # here is the only place that shape can be caught at all, which is why
-  # it is refused rather than allowed as an ordinary relative path.
+  # "../" is accepted, unlike the three rows above: conf.py's
+  # RootFileLinks transform resolves a target written this way against
+  # the document that wrote it, through `doc2path`, rather than
+  # declining anything that normalizes above the repository root
+  # (issue #1562). A working "../" link now resolves for real; a broken
+  # one is left unresolved for myst's own resolver, which -W reports
+  # directly, rather than reaching the silent href="#../page.md"
+  # fallback that the old transform's decline used to hand it.
+  # Measured: `sphinx-build -n -W` alone, with neither lychee nor the
+  # grep in docs.yml running, already fails on an intentionally broken
+  # "../" link, so refusing the shape here no longer buys anything the
+  # build does not already catch on its own.
   #
   # The first branch steps over a nested image, and it has to: a badge is
   # "[![alt](src)](href)", and link text written "[^]]*" stops at the "]"
@@ -401,7 +406,7 @@ repos:
   - repo: local
     hooks:
       - id: local-link-prefix
-        name: a local markdown link destination begins with ./
+        name: a local markdown link destination begins with ./ or ../
         language: pygrep
         # one line, and no literal space in it -- "\x20" is the space the
         # reference branch allows -- so yamllint reads the value as a
@@ -417,7 +422,7 @@ repos:
         # total leaves one of those quotations unpaired with whatever
         # backtick follows it (issue #1302)
         entry: |-
-          (?<![\x60!\[])(?:!?\[(?:[^]]|\]\([^)]*\))*\]\(|^\x20{0,3}\[[^]]+\]:\s*)(?!\./|#|[A-Za-z][A-Za-z0-9+.-]*:)[^)\s]
+          (?<![\x60!\[])(?:!?\[(?:[^]]|\]\([^)]*\))*\]\(|^\x20{0,3}\[[^]]+\]:\s*)(?!\.\.?/|#|[A-Za-z][A-Za-z0-9+.-]*:)[^)\s]
         types: [markdown]
       # a line that ends inside a word, at that word's own hyphen.
       # Section 4 of the organization standard is the rule: what such a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -673,6 +673,7 @@ documented at release-notes length in the first place, and are still in
   repository's Actions variables leave the list of facilities whose
   empty answer records no decision, that zero now being half of what
   records this one.
+
 ### `tests/interpreters_test.py`'s PyPy and `dist` comments match the tree
 
 - **The comment above `_CPYTHON` quoted the PyPy matrix cell as
@@ -687,6 +688,7 @@ documented at release-notes length in the first place, and are still in
   three jobs that do pin `python-version:` inline are what make the
   token read work -- but the universal claim was false of `dist`, and
   the comment now names it as the exception.
+
 ### RELEASING.md names `documented`'s own skip on a rehearsal
 
 - **The *Check that every job you expected actually ran* step now
@@ -746,6 +748,30 @@ documented at release-notes length in the first place, and are still in
   `WYCHEPROOF_COPYING` keep their pin**: each path's own most recent
   commit predates the pinned commit, so the pin already carries their
   current content and there is nothing to move it to.
+
+### `RootFileLinks` resolves a `../` link against the document that wrote it
+
+- **A markdown link that climbs out of `docs/source` with `../`, written
+  inside or outside a `*_link.md` shim, now resolves through
+  `RootFileLinks` against the document that wrote it rather than being
+  left to myst-parser's own doc-domain resolution** (closes #1562).
+  Measured: before this, such a link to a file that exists but sits
+  outside `srcdir` made `sphinx-build -n -W` fail with an "Unknown
+  source document" warning on a real, working link -- `path2doc` strips
+  the suffix off any file that exists on disk and hands back the result
+  as a docname regardless of whether it is one, and neither the old
+  transform nor `docs.yml`'s greps could tell that false failure from a
+  real one. `local-link-prefix` now accepts a `../`-prefixed link
+  destination alongside a `./`-prefixed one: a broken `../` link already
+  failed `-W` on its own, through myst's ordinary "cross-reference
+  target not found" warning, so refusing the shape bought nothing there.
+- **`docs.yml`'s own unresolved-link grep, the artifact-level check for
+  issue 195, now matches `href="#../<destination>"` as well as
+  `href="#./<destination>"`.** Its comment claimed every breaking
+  destination rendered the single-dot form, true only while
+  `local-link-prefix` refused `../`; a broken `../` link would otherwise
+  render the double-dot form and slip past the grep if `-W`'s own
+  defense were ever weakened.
 
 ## v2026.8.29
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,6 @@ documentation: https://www.sphinx-
 doc.org/en/master/usage/configuration.html
 """
 
-import posixpath
 import re
 from pathlib import Path
 from typing import Any
@@ -169,6 +168,14 @@ html_theme = "furo"
 # and a path that exists nowhere is left to myst -- which reports it, and
 # -W then fails, now that suppress_warnings no longer hides the subtype.
 #
+# It also reads a link written this way *outside* a shim, resolved
+# against the document that wrote it rather than against ROOT. A page
+# under docs/source is itself read unrendered on the forge, so a link
+# composed relative to its own file -- climbing out of docs/source the
+# way a checkout resolves it -- works there verbatim, and this is what
+# lets the same link resolve here too, through the shim page that
+# carries the heading once the {include} has run (issue #1562).
+#
 # Not the {include} directive's :relative-docs: option, which is what it
 # looks like the job of. It rewrites destinations that begin with the
 # prefix it is given, so "docs/source/" leaves "./SECURITY.md" untouched;
@@ -215,31 +222,75 @@ BLOB = f"{PYPROJECT['project']['urls']['repository']}/blob/master/"
 
 
 class RootFileLinks(SphinxPostTransform):
-    """Resolve the repository-relative links of the included root files."""
+    """Resolve the repository-relative links naming a file of this tree."""
 
     # ahead of myst's own resolver, which runs at 9 and is what turns an
     # unresolved target into that anchor
     default_priority = 5
+
+    def _broken_doc_target(self, node: pending_xref) -> tuple[Path, str | None] | None:
+        """Recover the file behind a "doc" xref `path2doc` resolved wrong.
+
+        myst already thinks this resolves; a real docname is a working
+        cross-reference and none of this file's business. Anything else is
+        `Project.path2doc` stripping a matching suffix off *any* file that
+        exists on disk, docs or not (sphinx/project.py), so a link climbing
+        out of srcdir into a real file reads as resolved when it is not.
+        Recover the file it actually named: reftarget is that path with its
+        suffix gone, and only one of the two the tree parses still fits.
+        """
+        if node["reftarget"] in self.env.all_docs:
+            return None
+        candidates = (Path(f"{node['reftarget']}{suffix}") for suffix in source_suffix)
+        found = next((c for c in candidates if c.is_file()), None)
+        return None if found is None else (found, node.get("reftargetid"))
+
+    def _unbound_target(
+        self, node: pending_xref, refdoc: str
+    ) -> tuple[Path, str | None]:
+        """Resolve a link myst left with no domain at all.
+
+        A shim's own included content is written relative to the root
+        file it renders, which sits at ROOT itself; any other document is
+        written relative to wherever it actually sits in the source tree
+        -- doc2path is what answers that without assuming every docname
+        sits flat under docs/source.
+        """
+        raw, _, anchor = node["reftarget"].partition("#")
+        origin = (
+            ROOT
+            if refdoc in INCLUDED.values()
+            else Path(self.env.doc2path(refdoc)).parent
+        )
+        return origin / raw, anchor or None
 
     def run(self, **kwargs: Any) -> None:
         """Rewrite every myst xref naming a file of this repository."""
         # the list is taken before the tree is edited: replace_self on a
         # node the generator is standing on reparents its children under it
         for node in list(self.document.findall(pending_xref)):
-            # refdomain "doc" is a link myst has already resolved to a
-            # page; None is one it has given up on, and only the shims
-            # hold links written relative to the repository root, so
-            # anywhere else a path that does not resolve is a defect to
-            # report rather than one to rewrite
-            if node.get("reftype") != "myst" or node.get("refdomain") is not None:
+            if node.get("reftype") != "myst":
                 continue
-            if node.get("refdoc", self.env.docname) not in INCLUDED.values():
+            refdomain = node.get("refdomain")
+            if refdomain == "doc":
+                resolved = self._broken_doc_target(node)
+            elif refdomain is None:
+                refdoc = node.get("refdoc", self.env.docname)
+                resolved = self._unbound_target(node, refdoc)
+            else:
+                resolved = None
+            if resolved is None:
                 continue
-            target, _, anchor = node["reftarget"].partition("#")
-            # "./tests/README.md" -> "tests/README.md"; a path climbing out
-            # of the repository is nothing this can answer
-            target = posixpath.normpath(target)
-            if target.startswith(".."):
+            found, anchor = resolved
+            try:
+                # "./tests/README.md" from a shim resolves to
+                # "tests/README.md"; a link written "../../README.md"
+                # outside a shim resolves to "README.md" the same way,
+                # against the real filesystem, so a path climbing above
+                # ROOT raises rather than reading as one of its own
+                target = str(found.resolve().relative_to(ROOT))
+            except ValueError:
+                # outside the repository: nothing this can answer
                 continue
             if target in INCLUDED:
                 # handed back to myst as the link it would have been


### PR DESCRIPTION
Closes #1562

This closes the reserved question ISS 1562 posed — "whether to port
bitcoin-core-rpc's fix verbatim or address it differently" — by porting
`bitcoin-core-rpc@cf763b446`'s fix verbatim, adapted to this repository's
copy of the same code (`docs/source/conf.py`'s `RootFileLinks`,
`.pre-commit-config.yaml`'s `local-link-prefix`). The cut-back if this
turns out unwanted: revert this PR, which restores the prior refusal of
any `../`-prefixed markdown link destination.

`path2doc` hands myst a suffix-stripped absolute path as a "docname" for
any file outside `srcdir` that exists on disk, so before this fix a
`../`-climbing markdown link to a real file made `sphinx-build -n -W`
fail with "Unknown source document" — a false failure on a working link,
not the silent pass-through the issue originally assumed (measured and
corrected during review). `RootFileLinks` now recovers the real file
behind that bogus doc-domain xref and behind a link myst gave up on
entirely, resolving each against the document that wrote it.
`local-link-prefix` accepts `../` alongside `./`, since a broken `../`
link already fails `-W` on its own. `docs.yml`'s own unresolved-link
grep widens to match either spelling, closing a gap a local-review round
found: it previously matched only the single-dot rendering, which a
broken `../` link would not have produced.

Locally reviewed and CLEARED at fresh context, in two rounds, before
opening — the second round independently reproduced the fix closing the
grep gap rather than re-reading the claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvtGgCtGYwgXEwCZfc4omr

## Summary by Sourcery

Resolve upward-relative documentation links against their originating document and ensure broken variants remain detected by validation checks.

New Features:
- Resolve `../` markdown links against the document that contains them, including links to files outside the documentation source directory.

Bug Fixes:
- Prevent valid links to existing files outside `srcdir` from being reported as unknown source documents during strict documentation builds.

Enhancements:
- Extend local-link validation to allow both `./` and `../` destinations while retaining validation for unresolved links.
- Broaden the built-document unresolved-link check to detect both single-dot and double-dot relative-link fallbacks.

CI:
- Update the documentation workflow's unresolved-link detection to cover `../` links.

Documentation:
- Document the new handling of links that climb out of `docs/source` and the related validation behavior.