### PR TITLE
docs.yml's grep comment states what -W actually catches (closes #1574)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -113,15 +113,19 @@ jobs:
         run: >
           uv run --locked --no-default-groups --group docs
           sphinx-build -n -W --keep-going -b html docs/source docs/build/html
-      # the one defect the build above cannot report on itself: a link
-      # myst cannot resolve is rendered as an anchor on the page it is
-      # already on -- an id nothing has -- so -W passes over a dead link
-      # (issue 195). conf.py resolves every link the included root files
-      # carry and no longer suppresses myst.xref_missing, which makes the
-      # build fail on the one myst still cannot place; this step is the
-      # same claim made about the artifact rather than about the
-      # configuration, and it is what would catch a suppression added
-      # back.
+      # a second defense against issue 195, not the only one: measured,
+      # sphinx-build -n -W already fails on its own on every link myst
+      # cannot resolve, in the currently pinned toolchain (myst-parser
+      # 5.1.0, sphinx 9.1.0) -- myst_refs.py's MystReferenceResolver logs a
+      # warning unconditionally, independent of -n, before falling back to
+      # the anchor-only node the html then carries (issue #1574). What this
+      # step still answers for is a regression the build's own warning would
+      # stop catching without it: conf.py's suppress_warnings staying empty
+      # is a configuration this grep does not depend on, and a myst-parser
+      # upgrade could in principle stop warning unconditionally the way
+      # 5.1.0 does. Either way the artifact would then carry exactly the
+      # anchor to an id nothing has that conf.py's own comment describes,
+      # and this grep is what would still catch it.
       #
       # One grep, widened to two spellings rather than one. myst's
       # fallback renders the destination verbatim, so what this can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -773,6 +773,22 @@ documented at release-notes length in the first place, and are still in
   render the double-dot form and slip past the grep if `-W`'s own
   defense were ever weakened.
 
+### `docs.yml`'s unresolved-link comment states what `-W` catches
+
+- **The comment above `docs.yml`'s *Check the built pages for
+  unresolved links* step said `-W` "passes over a dead link", making
+  this grep the only defense against issue 195** (closes #1574).
+  Measured, with the toolchain `uv.lock` pins (myst-parser 5.1.0,
+  sphinx 9.1.0): `sphinx-build -n -W` already fails on its own on
+  every unresolved myst link, a deliberately broken `./`-prefixed one
+  included -- `myst_refs.py`'s `MystReferenceResolver` logs a warning
+  unconditionally, independent of `-n`, before falling back to the
+  anchor-only node the built page then carries. The comment now says
+  so, and states what the grep still answers for: a regression the
+  build's own warning would stop catching, `conf.py`'s
+  `suppress_warnings` staying empty being a configuration this grep
+  does not depend on.
+
 ## v2026.8.29
 
 ### Repository


### PR DESCRIPTION
Closes #1574

`docs.yml`'s "Check the built pages for unresolved links" step claimed
`sphinx-build -n -W` "passes over a dead link", making the grep the only
defense against issue 195 recurring. Measured against the pinned
toolchain (myst-parser 5.1.0, sphinx 9.1.0): `-n -W` already fails
directly on any unresolved myst link, independent of `-n`
(`MystReferenceResolver` logs the warning unconditionally). The comment
now states that, and reframes the grep as a second line of defense
against a future `suppress_warnings` regression or an upstream
myst-parser behavior change — both dependencies are unconstrained by an
upper bound in `pyproject.toml`, so the grep still earns its keep even
though it is not, today, the only thing catching this.

Locally reviewed and CLEARED at fresh context, including an independent
reproduction of the core measurement (broken-link probe, with and
without `-n`) and a trace of the mechanism in myst-parser's own source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvtGgCtGYwgXEwCZfc4omr

## Summary by Sourcery

Correct the documentation workflow and changelog comments to accurately describe unresolved-link detection and preserve the artifact check as a second line of defense.

Enhancements:
- Clarify that the documentation build already fails on unresolved MyST links and that the artifact grep provides an independent safeguard against future warning-suppression or dependency behavior changes.

Documentation:
- Document the corrected behavior of Sphinx's `-W` handling for unresolved links and the continuing purpose of the generated-page check.