### PR TITLE
CLAUDE.md records the conf.py import trap ISS 1538 found

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,25 @@ Do not use Fable unless explicitly instructed.
   index, and the version it hands back is plausible enough to be written
   into a release verification. `cd` to the scratchpad first, and print
   `btclib.__file__` beside the version when the answer decides anything.
+- **A test that executes `docs/source/conf.py` by path only reproduces
+  on CI, never locally.** `tomllib` (stdlib from 3.11) and
+  `docutils`/`sphinx.*` (the `docs` group alone) are both imported
+  unconditionally at the top of the file, before anything else runs.
+  `tests/copyright_test.py` once loaded `conf.py` with
+  `importlib.util` and executed it to check that its Sphinx `author`
+  derives from `pyproject.toml` rather than repeating it; the coverage
+  jobs (3.14, no `docs` group) failed on the `docutils` import and
+  `os-macos`'s 3.10 cells failed on `tomllib` itself, and both stayed
+  invisible under a contributor's own `uv sync`, which installs every
+  group including `docs` (issue #1538). `[tool.coverage.run] source =
+  ["btclib", "tests"]` rules out the obvious guard: a
+  `pytest.importorskip` around such a test turns the gap into a
+  100%-floor failure in the very environment that also lacks the
+  import, a skipped test's body counting as uncovered lines of
+  `tests/`. What worked instead was reading the line as source text
+  with a regex — the idiom `_pyproject_author()` in the same file
+  already uses on `pyproject.toml`, for the identical reason — rather
+  than executing the module.
 
 ## Conventions to match
 


### PR DESCRIPTION
Records a Wrap-up finding from this session's `1538 e seguenti` campaign,
requested directly by the maintainer.

A test that loads `docs/source/conf.py` by path and executes it only
reproduces on CI (the coverage jobs' missing `docutils`, `os-macos`'s
3.10 cells' missing `tomllib`), never under a contributor's own
`uv sync`, which installs every group including `docs` — this is what
made ISS 1538's red `test` gate on `main` invisible locally. Compounding
it: `[tool.coverage.run] source = ["btclib", "tests"]` means a
`pytest.importorskip` guard would trade the red gate for a
100%-floor failure in the same environment. Adds one bullet to CLAUDE.md's
*Non-obvious facts that will otherwise waste a session*.

Locally reviewed and CLEARED at fresh context before opening — every
factual claim independently re-verified against the landed source
(`conf.py`, `tests/copyright_test.py`, `pyproject.toml`, both CI workflow
files), not just re-read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvtGgCtGYwgXEwCZfc4omr

## Summary by Sourcery

Document the CI-only `conf.py` import trap and its coverage implications to prevent future debugging sessions from missing the failure.

Enhancements:
- Document the CI-only dependency and coverage pitfalls when tests load `docs/source/conf.py`, including the safer source-text inspection approach.

Documentation:
- Add a CLAUDE.md note capturing the import trap behind issue #1538 and why it is not reproduced under a full local `uv sync`.