### PR TITLE
CONTRIBUTING.md states the API deprecation policy (closes #651)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,10 +238,16 @@ jobs:
   # as a merge gate -- btclib-org/.github#326's own decision -- because
   # before 1.0 the surface breaks deliberately and often, and a gate
   # reporting every such break on every pull request has nothing to say
-  # about which ones are allowed; that needs the deprecation policy
-  # btclib-org/btclib#651 has not settled yet. Here the answer arrives
-  # while RELEASE_NOTES.md is already being written, so a break with no
-  # entry is refused at the moment somebody is already writing entries.
+  # about which ones are allowed. CONTRIBUTING.md's deprecation policy
+  # settles that much -- there is no window, and a break is announced by
+  # its RELEASE_NOTES.md breaking-changes entry and by nothing earlier,
+  # so that entry is what any such gate would read. What it does not
+  # settle is the comparison: the walk is against the last release, so a
+  # per-pull-request run reports every break already entered earlier in
+  # the same cycle, once more on each pull request that follows. Here
+  # the answer arrives while RELEASE_NOTES.md is already being written,
+  # so a break with no entry is refused at the moment somebody is
+  # already writing entries.
   # No `needs:` of its own, so it starts when the run does, beside the
   # platform sweeps rather than ahead of them. What the graph orders
   # after it is the upload: publish-testpypi and publish-pypi list it,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -789,6 +789,19 @@ documented at release-notes length in the first place, and are still in
   `suppress_warnings` staying empty being a configuration this grep
   does not depend on.
 
+### `CONTRIBUTING.md` states the API deprecation policy
+
+- **`CONTRIBUTING.md`'s *Breaking a caller is not an argument* now says
+  that there is no deprecation window** (closes #651): a source-breaking
+  change is announced by its `RELEASE_NOTES.md` breaking-changes entry
+  and by nothing earlier, and a warning-then-removal mechanism -- a
+  deprecated alias, a `DeprecationWarning`, a `deprecated()` helper -- is
+  deliberately not provided. A security fix is exempt from all of it,
+  `SECURITY.md` is where a reader is sent for what that covers, and what
+  the promise covers where it applies at all is *The public surface*,
+  already stated a section below. `README.md`'s opening paragraph links
+  the section beside its own sentence on why btclib stays marked beta.
+
 ## v2026.8.29
 
 ### Repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1126,6 +1126,20 @@ The one thing this does not license is a break nobody can act on. An
 entry says the old spelling, the new one, and what a caller does about
 it; a rename with no note is the defect, not the rename.
 
+**There is no deprecation window.** Versions are calendar-based
+(`YYYY.M.D`), a checkout of `main` is a release cycle in progress with no
+promise attached to any name in it, and a source-breaking change is
+announced by its [RELEASE_NOTES.md](./RELEASE_NOTES.md) breaking-changes
+entry and by nothing earlier — a warning-then-removal mechanism, a
+deprecated alias kept alongside its replacement, a `DeprecationWarning`,
+is deliberately not provided. What the promise covers where it applies at
+all is *The public surface* below: `__all__`, at every depth.
+
+**A security fix is exempt from all of the above.** It may break
+anything this section otherwise asks for, on the same terms as any other
+reasonable refactoring; [SECURITY.md](./SECURITY.md) is where a reader
+goes for what is covered and how a fix reaches a release.
+
 ### The public surface
 
 **Every module and every package declares `__all__`**, at every depth of

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ cryptography and bitcoin's blockchain. It started as a teaching tool for
 Ferdinando Ametrano's
 *[Bitcoin and Blockchain Technology](https://www.ametrano.net/bbt/)*
 course, it is used in production today (still marked as beta
-because it is often refactored for improved clarity).
+because it is often refactored for improved clarity — [CONTRIBUTING.md's
+*Breaking a caller is not an argument*](./CONTRIBUTING.md) says what
+that promises a caller and what it does not).
 
 The test suite covers virtually the whole code base, a floor the build
 enforces, and it answers to vectors their authors publish: the BIPs' and


### PR DESCRIPTION
`CONTRIBUTING.md`'s *Breaking a caller is not an argument* now states the
policy [ISS 651](https://github.com/btclib-org/btclib/issues/651)
decided: no deprecation window, CalVer and `RELEASE_NOTES.md`'s
breaking-changes entry are the whole of the notice, and a security fix
is exempt. No warn-then-removal mechanism, no deprecated alias kept
beside its replacement, no `DeprecationWarning` — the issue declined the
`deprecated()` helper its own body had proposed. `README.md` links the
section beside its sentence on why btclib stays marked beta.

`release.yml`'s `public-api` comment gave this issue's being unsettled
as part of its reason for walking the surface at the release cut rather
than as a merge gate. This commit settles it, so the comment says what
the policy settles and what it does not: the `RELEASE_NOTES.md` entry a
gate would read is defined, while the walk's comparison against the last
release is what would make a per-pull-request run report every break
already entered earlier in the same cycle. That sentence was falsified
by this diff, so it belongs in this diff.

Local review at fresh context cleared `4b806491`. It measured the
comparison claim against the job's own steps — on a `pull_request` event
`public-api` resolves `git describe --tags --abbrev=0 --match 'v*' HEAD`,
which is the last release and not the merge base — and confirmed the new
paragraphs sit past `## This repository in particular`, so
`btclib-org/.github`'s verbatim comparison does not reach them.

Gates, run over this content: `uv run --locked pytest -q` exit 0, 31119
passed; `uv run --locked pre-commit run --all-files` exit 0, every hook,
`actionlint` and `zizmor` included; `sphinx-build -n -W --keep-going`
exit 0.

An anchored link to the section failed the docs build, `docs/source/conf.py`
never setting `myst_heading_anchors`; the link is to the whole file with
the section named in prose, and the limitation is filed as
[ISS 1587](https://github.com/btclib-org/btclib/issues/1587).

closes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Document the API deprecation policy and align repository guidance with the release-time public API check.

Enhancements:
- Document the project's API deprecation policy, including its no-deprecation-window approach, release-note notice, public-surface scope, and security-fix exception.
- Clarify the release workflow's public API check rationale now that the deprecation policy is established.
- Link the API compatibility policy from the README and record the change in the changelog.

Documentation:
- Document the API deprecation and breaking-change policy in CONTRIBUTING.md and reference it from README.md.