### PR TITLE
A link into another root file's heading resolves in the built docs (closes #1587)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -802,6 +802,22 @@ documented at release-notes length in the first place, and are still in
   already stated a section below. `README.md`'s opening paragraph links
   the section beside its own sentence on why btclib stays marked beta.
 
+### A link into another root file's heading resolves in the built docs
+
+- **`docs/source/conf.py` sets `myst_heading_anchors` to four levels,
+  the depth the root markdown files head their sections to** (closes
+  #1587). Left unset it defaults to 0, myst gives no heading an id, and
+  a link into a heading of another root file becomes an xref to a target
+  no page has: `-W` fails on a link the forge renders correctly, which
+  is what makes the failure silent to whoever wrote it. The fragment
+  that resolves is the one GitHub derives from the heading text, so one
+  spelling answers on the forge and in the build; the id it reaches is
+  the one docutils gives the section, and need not be spelled the same.
+  `README.md`'s link to *Breaking a caller is not an argument* reaches
+  the section its text names rather than the whole file, and
+  `CONTRIBUTING.md` says beside the documentation gate how such a
+  fragment is spelled; that gate is what checks both.
+
 ## v2026.8.29
 
 ### Repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1087,6 +1087,12 @@ warning. `docs/source/conf.py` resolves those links and suppresses no
 grep asks the same question of the HTML, where no suppression can hide the
 answer.
 
+A link into a heading of another root file carries a fragment spelled the
+way GitHub derives it from the heading text, as in
+[the gates are the evidence](./REVIEWING.md#the-gates-are-the-evidence),
+and `docs/source/conf.py`'s `myst_heading_anchors` is what makes that
+spelling resolve here too.
+
 Both steps ask whether a page renders and whether its links resolve, and
 nothing more. Whether the worked examples on it are still true is a
 different question, asked by `tests/docs_examples_test.py`: any page under

--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ Ferdinando Ametrano's
 *[Bitcoin and Blockchain Technology](https://www.ametrano.net/bbt/)*
 course, it is used in production today (still marked as beta
 because it is often refactored for improved clarity — [CONTRIBUTING.md's
-*Breaking a caller is not an argument*](./CONTRIBUTING.md) says what
-that promises a caller and what it does not).
+*Breaking a caller is not an
+argument*](./CONTRIBUTING.md#breaking-a-caller-is-not-an-argument) says
+what that promises a caller and what it does not).
 
 The test suite covers virtually the whole code base, a floor the build
 enforces, and it answers to vectors their authors publish: the BIPs' and

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,6 +68,20 @@ extensions = [
 
 source_suffix = [".rst", ".md"]
 
+# anchors for h1 to h4, which is what makes a link into a heading of
+# another root markdown file resolve here: README.md links into
+# CONTRIBUTING.md's "Breaking a caller is not an argument" that way.
+# Left unset this defaults to 0, myst generates no anchor at all, and
+# the fragment becomes an xref to a target no page has -- -W fails on a
+# link the forge renders correctly, which is what makes the failure
+# silent to whoever wrote it (issue #1587). The fragment that resolves
+# is the one GitHub derives from the heading text, so the spelling
+# written for where these files are read is the spelling this build
+# accepts; the id it reaches is the one docutils gives the section, and
+# need not be spelled the same. Four levels, because that is how deep
+# the root markdown files head their sections
+myst_heading_anchors = 4
+
 # -n on the build (CONTRIBUTING.md's documented command, and docs.yml)
 # turns an unresolved cross-reference into a warning for -W to fail on.
 # Without an inventory to resolve against, a name from outside this tree


### PR DESCRIPTION
**This closes a decision [ISS 1587](https://github.com/btclib-org/btclib/issues/1587)
deliberately reserved** — *"whether that is worth the cost … is a decision
this issue does not make."* It is taken here, on this ground, and the
cut-back if the answer is unwanted is one integer.

**The ground.** The cost the issue weighed against does not exist. It
warned of "an id on every heading in every included root file". Whole
HTML trees built at 0, 3 and 6 from one source differ **only inside
`.doctrees`** — `diff -r -q` names no `.html`. The mechanism, read in
both `myst_parser` versions `uv.lock` pins: `generate_heading_target`
calls `note_implicit_target` *before* the depth test, unconditionally,
and above the depth it returns having done nothing else. Docutils already
gives every section an id from its title. What the setting changes is
which fragments myst **accepts as targets**, not what a page emits.

**The cut-back.** Both new links resolve at 3, 4, 5, 6 and 7; only 0, 1
and 2 break them. If
[btclib-org/.github ISS 715](https://github.com/btclib-org/.github/issues/715)
settles the family on a different depth, `docs/source/conf.py:83` is the
whole of the migration — no file needs re-spelling, and no option is
foreclosed by landing now.

## The depth is measured, not defaulted

At 2 the reproduction still fails, the heading being an `h3`. The deepest
heading across the six included root files is an `h4` — `#### The editor`
in `CONTRIBUTING.md` — found with a fence-aware parse rather than a bare
grep, so a `####` inside a code fence could not have inflated it. At 3
that heading would be unlinkable.

The comment ends "Four levels, because that is how deep the root markdown
files head their sections", which is `btclib-node`'s and
`bitcoin-core-rpc`'s sentence verbatim, applied to a tree whose files go
one level deeper. **The five trees currently sit at four different
values, and reconciling them is ISS 715's**, filed rather than answered
here: what a `conf.py` should say across the family is a change to what
the standard says.

## The failure this ends

A link into a heading of another root file renders correctly on GitHub
and fails only under `-W`, silently to whoever wrote it:

```
README.md:383: WARNING: local id not found in doc 'contributing_link':
'breaking-a-caller-is-not-an-argument' [myst.xref_missing]
```

The spelling that resolves is **GitHub's**, derived from the heading
text — `myst_refs.py` looks the fragment up in the slug map and nowhere
else, so the docutils id, which need not match, is what the map returns
rather than a spelling to write. `CONTRIBUTING.md` now says so beside
the documentation gate, and says it *as* such a link, so the gate
exercises the setting rather than leaving it inert until someone writes
the first fragment. `README.md`'s link to *Breaking a caller is not an
argument* — the ISS 651 workaround — recovers the section its text
already named.

## The rebase ate a blank line, and the reconstruction caught it

`origin/main` moved mid-flight, `merge=union` fused the seam, and the new
`###` heading landed with **no blank line above it** — invisible to `git
diff`, `--numstat` and a clean rebase exit alike. It was found by
rebuilding the base's blob plus this branch's block at its measured
anchor and comparing byte for byte, and repaired from that
reconstruction. The review re-derived it independently with a normalized
block and three controls, including the misordering case that a
"nothing was removed" check passes. The fused tip is tagged locally and
was never pushed.

## Gates

`uv run --locked pre-commit run --all-files`, `uv run --locked pytest`,
and `sphinx-build -n -W --keep-going` all exit 0, with `heading_anchors=4`
in the build's own startup log; `docs.yml`'s second step,
`grep -rn 'href="#\./' docs/build/html`, finds nothing. `git status
--porcelain` empty afterwards.

Not run anywhere: `links.yml`/lychee, which is not one of the three gates
and is not installed locally. It runs with `--include-fragments`, so CI is
the first check of both new fragments.

Closes #1587.

## Summary by Sourcery

Enable GitHub-compatible links to headings in other root Markdown files during documentation builds.

Bug Fixes:
- Enable cross-file links to headings in the built documentation to resolve using GitHub-compatible fragments.
- Update the README link to target the specific “Breaking a caller is not an argument” section.

Enhancements:
- Document the required fragment spelling and heading-anchor behavior for contributors.

Documentation:
- Add a changelog entry describing cross-file heading links and their supported anchor depth.