### PR TITLE
tests/integration/p2p_test.py dials a real Core over a socket (closes #1412)

### DIFF
--- a/.github/workflows/integration-bitcoind.yml
+++ b/.github/workflows/integration-bitcoind.yml
@@ -5,9 +5,11 @@ name: integration-bitcoind
 # a bitcoind to talk to. `tests/integration/` skips itself without
 # BTCLIB_INTEGRATION, so every other workflow reports those tests skipped
 # and nothing ever asks a real node whether btclib's psbt is one it will
-# relay. This is where that question is asked: a disposable regtest
-# bitcoind, the account export, the funding, the spend and the broadcast,
-# against Core itself.
+# relay, or whether Core still speaks the p2p octets this library emits
+# and parses. This is where both questions are asked: a disposable
+# regtest bitcoind, the account export, the funding, the spend and the
+# broadcast on one side, and a `Version` this library serialized dialled
+# straight at the node's p2p port on the other, against Core itself.
 #
 # `Regtest against Bitcoin Core` is a required check on main: what it
 # asks is whether Core accepts what this branch built, and the node is a
@@ -99,14 +101,15 @@ on:
     # check on main, and a required check that never runs blocks a merge
     # where a skipped one satisfies it -- a filter and a required check
     # cannot both be had. Every pull request pays it, documentation-only
-    # ones included, which is what 36 seconds of work buys
+    # ones included, and the job below is short enough that paying it is
+    # the cheaper side of the trade
 
 # least privilege for the GITHUB_TOKEN: nothing here writes, and the
 # tarball is fetched from bitcoincore.org, which does not know this token
 permissions:
   contents: read
 
-# the release under test, and the sha256 of its linux tarball as four
+# the release under test, and the sha256 of its linux tarball as the
 # independent guix builders attested it in bitcoin-core/guix.sigs. Pinned
 # rather than resolved to "latest": a run that installs whatever is
 # newest reports the day Core released rather than the day btclib
@@ -142,10 +145,12 @@ jobs:
     # holding
     if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
-    # the whole flow is seconds -- two tests, a node that answers its
-    # first rpc call in well under a second, and a chain of a few blocks
-    # -- so this bounds the download and the failure cases rather than
-    # the work
+    # the whole flow is seconds: the chain is mined locally on regtest
+    # and the node answers its first rpc call in well under a second, so
+    # this bounds the download and the failure cases rather than the
+    # work. Nothing here states how many tests the directory holds,
+    # which drifts as tests are added; `pytest tests/integration
+    # --collect-only -q` is that count whenever it is wanted
     timeout-minutes: 20
     steps:
       # every action is pinned to a commit SHA, the tag in the comment: a
@@ -185,8 +190,8 @@ jobs:
       # whose fixture stopped finding the node would stay green while
       # asking Core nothing -- the failure mode of an unattended run that
       # looks like good news. The hwi tests skip here by design and are
-      # not counted; the regtest ones have a node, so a skip among them
-      # means a prerequisite this job thought it had provided
+      # not counted; the regtest and p2p ones have a node, so a skip
+      # among them means a prerequisite this job thought it had provided
       - name: Fail if the node tests did not run
         run: |
           uv run --locked --no-default-groups --group test python - <<'PY'
@@ -195,15 +200,15 @@ jobs:
 
           cases = ET.parse("integration.xml").getroot().iter("testcase")
           ran = [one for one in cases
-                 if "regtest" in one.get("classname", "")]
+                 if "hwi" not in one.get("classname", "")]
           skipped = [one for one in ran if one.find("skipped") is not None]
           for one in skipped:
               reason = one.find("skipped").get("message", "")
               print(f"::error::{one.get('name')} skipped: {reason}")
           if not ran or skipped:
-              print(f"::error::{len(ran)} regtest tests, {len(skipped)} skipped")
+              print(f"::error::{len(ran)} node tests, {len(skipped)} skipped")
               sys.exit(1)
-          print(f"{len(ran)} regtest tests ran against the node")
+          print(f"{len(ran)} node tests ran against the node")
           PY
       # always(), because a failure is what somebody opens this job for
       # and the report is what says whether the node refused the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -845,6 +845,29 @@ documented at release-notes length in the first place, and are still in
   settled against a cipher, offered instead of Minisketch at Python
   speed to every caller rather than to `tf2`'s test primitives.
 
+### `tests/integration/p2p_test.py` puts `btclib.p2p` in front of a real Core
+
+- **A `Version` this library serializes is sent over a socket straight at
+  a regtest node's p2p port, and read back against whatever Core answers
+  with, up to and including `verack`** (closes #1412). `regtest_test.py`
+  reaches the same node only through `bitcoin_core_rpc`, and
+  `tests/p2p/`'s vectors are a capture frozen the day it was taken, so
+  neither says whether Core still accepts what this library emits or
+  still sends what a fixture once caught. Core's own `version` parses
+  back into this library's `Version`, with the service bits and the
+  user agent this library's own types say they are; every message Core
+  sends before `verack` -- `wtxidrelay` and `sendaddrv2` among them --
+  parses as `Message.parse`'s envelope, an unrecognized command
+  included; and `magic_from_network("regtest")` is the four octets Core
+  actually frames with.
+- **`conftest.py`'s node binds a p2p listener**, on a second ephemeral
+  loopback port `-bind` opens regardless of `-listen`'s own default, so
+  a test can dial it directly rather than only through
+  `bitcoin_core_rpc`.
+- **`integration-bitcoind.yml`'s sentinel step now watches every
+  non-hwi test in the job**, so a p2p test that skips itself fails the
+  required check the same way a regtest one already does.
+
 ## v2026.8.29
 
 ### Repository

--- a/tests/README.md
+++ b/tests/README.md
@@ -77,9 +77,12 @@ BTCLIB_INTEGRATION=1 uv run pytest tests/integration
 
 That runs the regtest flow — btclib exports an account, Core imports it,
 Core pays it, btclib builds and signs the spend, and the node accepts the
-transaction or the test fails. The node is this session's own: a data
-directory under pytest's `tmp_path` and an ephemeral port, so nothing
-reaches a node you are running. Name another binary with
+transaction or the test fails — and the p2p handshake: a `Version` this
+library serialized, sent over a socket straight at the node's p2p port,
+and read back against whatever Core answers with, up to and including
+`verack`. The node is this session's own: a data directory under
+pytest's `tmp_path` and ephemeral rpc and p2p ports, so nothing reaches a
+node you are running. Name another binary with
 `BTCLIB_BITCOIND=/path/to/bitcoind`.
 
 The HWI tests need a device as well, and a second switch for the one that

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,9 +17,9 @@ and the whole flow is one command:
     BTCLIB_INTEGRATION=1 uv run pytest tests/integration
 
 The node is this session's own: a regtest data directory under pytest's
-tmp_path, an ephemeral port, and a cookie file for the credentials. It
-never touches a node the maintainer is running, which is the reason none
-of the defaults -- port 18443, ~/.bitcoin -- is used.
+tmp_path, ephemeral rpc and p2p ports, and a cookie file for the
+credentials. It never touches a node the maintainer is running, which is
+the reason none of the defaults -- port 18443, ~/.bitcoin -- is used.
 """
 
 from __future__ import annotations
@@ -72,8 +72,21 @@ def bitcoind_path() -> str:
 
 
 @pytest.fixture(scope="session")
+def p2p_port() -> int:
+    """Return the port `node` below binds its p2p listener to.
+
+    A fixture of its own rather than a value read off `node` after the
+    fact: a p2p test needs the number before the node exists, to build
+    the `addr_recv` its own `Version` names, and a session-scoped
+    fixture is what lets both `node` and a p2p test request the same
+    port without either constructing it.
+    """
+    return _free_port()
+
+
+@pytest.fixture(scope="session")
 def node(
-    bitcoind_path: str, tmp_path_factory: pytest.TempPathFactory
+    bitcoind_path: str, p2p_port: int, tmp_path_factory: pytest.TempPathFactory
 ) -> Iterator[BitcoinCoreRpcClient]:
     """Yield an rpc client of a regtest node started for this session.
 
@@ -81,6 +94,19 @@ def node(
     from, and Core refuses to fund a transaction without one; the wallet
     calls here fund nothing, but a caller reading this as a recipe would
     meet that on the first `walletcreatefundedpsbt`.
+
+    `-bind` names the one address this node listens for p2p on, and does
+    so regardless of `-listen`'s own default -- Core's own reference for
+    the option is "bind to given address and always listen on it" -- so
+    a fixed, ephemeral, loopback-only port is what a p2p test dials.
+
+    `-natpmp`, `-discover` and `-listenonion` are then switched off by
+    hand, because the interaction that switched all three off for us was
+    `-listen=0`, which naming `-bind` means no longer passing. Each
+    defaults to on and each reaches past this machine -- a port mapping
+    asked of the gateway, a public address looked up, a Tor control port
+    dialled -- which is not what a throwaway regtest node wants of a
+    developer's own network.
     """
     datadir = tmp_path_factory.mktemp("regtest")
     port = _free_port()
@@ -91,7 +117,10 @@ def node(
             f"-datadir={datadir}",
             f"-rpcport={port}",
             "-rpcbind=127.0.0.1",
-            "-listen=0",
+            f"-bind=127.0.0.1:{p2p_port}",
+            "-natpmp=0",
+            "-discover=0",
+            "-listenonion=0",
             "-fallbackfee=0.0002",
             # so that `getrawtransaction` answers for a confirmed
             # transaction of any wallet: what a psbt needs is the previous

--- a/tests/integration/p2p_test.py
+++ b/tests/integration/p2p_test.py
@@ -1,0 +1,178 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""`btclib.p2p` against a real Core, over a socket this test opens itself.
+
+`tests/p2p/` reads a `version` Bitcoin Core sent once, on the day the
+capture was taken; `regtest_test.py` reaches a real node, but only over
+`bitcoin_core_rpc`, so no octet this library serializes for the wire is
+ever framed, sent, and answered by Core. Neither can say that Core still
+sends what a fixture captured, or still accepts what this library still
+emits -- issue #1412 is what both of those being true, once, does not
+establish for the next commit.
+
+**No downstream connection loop, and no fixed list of what Core sends.**
+This dials the node directly, on a plain `socket`, sends a `Version` this
+library built and serialized, and reads back whatever Core answers with
+until `verack` -- the point of `Message` refusing no command being that
+an *unknown* one, whichever BIP adds the next, is exactly what a fixed
+list of expected commands would miss; naming today's here would be a
+hostage to the commit that carries it. "Parses" is `Message.parse` not
+raising: the envelope reads a command it has no `Payload` type for into
+a `command` string and opaque `payload` bytes, which is the contract
+`btclib.p2p.message`'s docstring states and is still the assertion this
+makes of it -- an unparsable message is one
+`Message.parse` refuses outright, typed payload or none.
+
+What this does not do is complete the handshake: nothing here sends a
+`verack` back, and the connection is closed once Core's own has been
+read. `btclib-org/btclib-node#374` is where the two-way exchange, the
+connection promoting, and a synced tip are already exercised, against
+that repository's own connection loop -- reproducing it here would only
+say that loop still works, not this library's wire format.
+"""
+
+from __future__ import annotations
+
+import secrets
+import socket
+import time
+from collections.abc import Iterator
+from io import BytesIO
+
+import pytest
+from bitcoin_core_rpc import BitcoinCoreRpcClient
+
+from btclib.exceptions import IncompleteMessageError
+from btclib.p2p import (
+    Message,
+    NetworkAddress,
+    ServiceFlags,
+    Verack,
+    Version,
+    magic_from_network,
+)
+
+pytestmark = pytest.mark.integration
+
+# Core's node/protocol_version.h: WTXID_RELAY_VERSION. Sending at least
+# this is what makes Core answer `wtxidrelay` and `sendaddrv2` ahead of
+# `verack` -- the two the issue this test answers names as the ones a
+# frozen capture went blind to the day Core started sending them.
+_OUR_VERSION = 70016
+_USER_AGENT = b"/btclib-p2p-integration-test:0/"
+# the whole exchange is a handful of octets on a loopback socket, so this
+# bounds the failure case -- a node that never answers -- rather than the
+# work
+_HANDSHAKE_TIMEOUT = 30.0
+
+
+@pytest.fixture
+def handshake(node: BitcoinCoreRpcClient, p2p_port: int) -> Iterator[list[Message]]:
+    """Dial the node, send a `version`, and return what it answers with.
+
+    `node` is requested for the side effect of it existing -- the process
+    `p2p_port` is bound to -- and never called on: this is the one test
+    in the suite that never goes through `BitcoinCoreRpcClient`, on
+    purpose, an rpc client being no evidence about the wire format an
+    rpc-only test cannot reach.
+
+    Every message up to and including `verack` is read here, and
+    `Message.parse` is what reads each of them: a message this library
+    cannot parse fails inside this fixture rather than inside a test's
+    own assertions, which is `Message`'s own contract doing the work.
+    """
+    magic = magic_from_network("regtest")
+    version = Version(
+        version=_OUR_VERSION,
+        services=ServiceFlags.NODE_NONE,
+        timestamp=int(time.time()),
+        addr_recv=NetworkAddress(ip="127.0.0.1", port=p2p_port),
+        addr_from=NetworkAddress(ip="127.0.0.1", port=0),
+        nonce=secrets.randbits(64),
+        user_agent=_USER_AGENT,
+        start_height=0,
+        relay=True,
+    )
+
+    with socket.create_connection(
+        ("127.0.0.1", p2p_port), timeout=_HANDSHAKE_TIMEOUT
+    ) as sock:
+        sock.sendall(version.to_message(magic).serialize())
+        yield _read_until_verack(sock)
+
+
+def _read_until_verack(sock: socket.socket) -> list[Message]:
+    """Return every message read off `sock` up to and including `verack`.
+
+    A `BytesIO` and not plain bytes, which is what lets one buffer hold
+    several messages at once: `Message.parse` refuses trailing octets in
+    a bytes object -- one whole object in, one whole object out -- and
+    leaves a stream positioned after what it read instead, exactly the
+    two halves `btclib.p2p.message`'s own docstring describes for a
+    socket reader. `IncompleteMessageError` -- "not enough yet" -- is the
+    one parse failure this catches; a message this library refuses
+    outright raises past it and fails the test. A `recv` that times out
+    is caught for the message rather than the behaviour: the socket
+    carries `_HANDSHAKE_TIMEOUT` from `create_connection`, so a stuck
+    node already fails within it, and catching it only says so in the
+    words the deadline below uses instead of a bare traceback.
+    """
+    stream = BytesIO()
+    messages: list[Message] = []
+    deadline = time.monotonic() + _HANDSHAKE_TIMEOUT
+    while not messages or messages[-1].command != "verack":
+        if time.monotonic() > deadline:
+            pytest.fail(f"no verack within {_HANDSHAKE_TIMEOUT}s: {messages}")
+        try:
+            chunk = sock.recv(4096)
+        except TimeoutError:
+            pytest.fail(f"no verack within {_HANDSHAKE_TIMEOUT}s: {messages}")
+        if not chunk:
+            pytest.fail(f"connection closed before verack: {messages}")
+        # what `stream` had not yet consumed, plus what just arrived: a
+        # fresh `BytesIO` rather than seeking back on the old one, which
+        # `Message.parse` already left positioned on the octet after the
+        # last complete message it read
+        stream = BytesIO(stream.read() + chunk)
+        while True:
+            try:
+                message = Message.parse(stream)
+            except IncompleteMessageError:
+                break
+            messages.append(message)
+    return messages
+
+
+def test_core_answers_a_btclib_version_with_one_of_its_own_and_a_verack(
+    handshake: list[Message],
+) -> None:
+    """The shape issue #1412 asks for, over one connection.
+
+    Every message here already parsed -- `handshake` built `messages`
+    with nothing but `Message.parse`, and would have failed the test
+    inside the fixture on the first one that did not.
+    """
+    messages = handshake
+    assert messages
+
+    # Core framed every one of them on the network this test asked for,
+    # which is `magic_from_network`'s own claim about what it returns
+    assert {message.magic for message in messages} == {magic_from_network("regtest")}
+
+    # Core's own `version`, read back into this library's type: what
+    # `nVersion`, the service bits and the user agent are, according to
+    # this library rather than only according to whoever sent them
+    core_version = next(m for m in messages if m.command == "version")
+    parsed = Version.parse(core_version.payload)
+    assert parsed.version >= _OUR_VERSION
+    assert ServiceFlags.NODE_NETWORK in parsed.services
+    assert ServiceFlags.NODE_WITNESS in parsed.services
+    assert b"Satoshi" in parsed.user_agent
+
+    # and Core answered `verack` -- accepting the `version` this library
+    # built and serialized, which is the only way to learn that of
+    # something other than this library's own parser
+    assert messages[-1].command == "verack"
+    assert Verack.parse(messages[-1].payload) == Verack()


### PR DESCRIPTION
`btclib.p2p` was never put in front of a real node: `regtest_test.py`
reaches one only through `bitcoin_core_rpc`, and `tests/p2p/` reads a
`version` Core sent once, the day the capture was taken. Neither says
whether Core still accepts what this library emits, or still sends what
a fixture caught.

`tests/integration/p2p_test.py` opens a plain socket to a regtest
node's p2p port, sends a `Version` this library serialized, and reads
back everything Core answers with up to and including `verack`. It
asserts the four things
[ISS 1412](https://github.com/btclib-org/btclib/issues/1412)'s *The
shape* lists, and deliberately not that a fixed list of commands
arrives — the point of `Message` refusing no command is that an unknown
one is exactly what such a list would miss.

## The question the issue reserved

ISS 1412 left one open: "Whether it belongs in
`integration-bitcoind.yml` beside the regtest job or in a workflow of
its own is worth its own look." This decides it — same workflow, same
job — on the issue's own stated ground: the job fetches the same pinned
tarball and reaches no other external service, so the argument that
separated HWI does not obviously apply here. The cut-back, if that
answer is unwanted, is a job of its own in the same workflow; nothing
in the test or the fixture would change.

## What the fixture change costs, and what pays it

Binding a p2p listener means naming `-bind`, which means no longer
passing `-listen=0` — and `-listen=0` was the interaction under which
Core switched `-natpmp`, `-discover` and `-listenonion` off for us.
Each defaults to on. The fixture names all three off by hand, so a
throwaway regtest node does not ask the gateway for a port mapping or
dial a Tor control port on a developer's own machine.

That was a review finding, and it was then measured rather than traced:
three probe nodes at `bitcoind v31.1.0`, greping each one's own
`debug.log` for the mapport and torcontrol thread starts — `-bind`
alone starts both, `-bind` with the three flags starts neither, and
`-listen=0` alone starts neither. The first is the positive control for
the zeros on the other two. `-i2pacceptincoming`, the fourth option in
Core's own suppression list, needs no flag: with no `-i2psam`,
`SetProxy(NET_I2P, ...)` is never called, so `net.cpp`'s only reader of
the option is unreachable.

## Three counts the workflow stated, and no longer does

Its comments claimed how many tests the job runs, how long the flow
takes, and that four independent guix builders attested the pinned
tarball. Measured during review: the test count was already wrong on
`main` and this branch would have made it wronger, and
`gh api repos/bitcoin-core/guix.sigs/contents/31.1 --jq length` answers
16 today. `CLAUDE.md` forbids the shape rather than the value, so all
three are gone, the reasons they served stay, and the timeout comment
names the command that re-derives its own number. The sha256 the
comment vouches for was checked against a signer's own
`noncodesigned.SHA256SUMS` and matches. `integration-hwi.yml` carries
the twin of the guix sentence and is untouched here:
[ISS 1596](https://github.com/btclib-org/btclib/issues/1596).

## The sentinel

`integration-bitcoind.yml`'s sentinel step, which fails the job if a
node test skipped itself, is widened from `"regtest"` in the testcase
classname to `"hwi" not in` it. Run against a real `integration.xml`
downloaded from a green run on `main`, with a skipped `p2p_test` case
spliced in: the old filter passes it blind, the new one exits 1.

Gates: the integration suite against a real `bitcoind v31.1.0` — the
version the workflow pins — exit 0, 4 passed and 3 skipped, the 3 being
the HWI tests; the unit suite exit 0; `pre-commit run --all-files` exit
0.

closes #1412

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb
