### PR TITLE
descriptors builds a BIP388 wallet-policy template from a receive/change pair, and derives its address (closes #1348, closes #1589)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -868,6 +868,40 @@ documented at release-notes length in the first place, and are still in
   non-hwi test in the job**, so a p2p test that skips itself fails the
   required check the same way a regtest one already does.
 
+### `descriptors` builds a BIP388 wallet-policy template, and derives its address
+
+- **`descriptors.wallet_policy` turns a `Descriptor`, or a receive and a
+  change `Descriptor` of one account, into the `@N` placeholder template
+  and key-information vector BIP388 defines, and
+  `descriptors.wallet_policy_descriptor`/`wallet_policy_address` read
+  the pair back into the descriptor, and the address, a policy
+  describes at an index** (closes #1348, closes #1589). Given the
+  receive/change pair `account_descriptors` already returns — checked,
+  key by key, to be the same policy apart from one explicit chain digit
+  before the wildcard — this writes BIP388's own canonical `/**`
+  shorthand (`/<M;N>/*` for a pair other than 0/1), every one of the
+  BIP's own Test Vectors reconstructed from its multipath descriptor
+  this way, byte for byte. Given one `Descriptor` alone, the only
+  trailing wildcard it can write is still the plain, unhardened `/*`
+  BIP388's "Optional derivation paths" section allows — a single parsed
+  `Descriptor` holding one path, and `/**` needing two. What neither
+  shape can become — a fixed public key, a hardened or explicit step
+  before the wildcard beyond the one unhardened chain digit the pair
+  accounts for, a `musig()` with derivation on a participant or
+  repeating one, receive and change disagreeing on a key or on the
+  shape around it, a key or a `musig()` group reused at a chain digit
+  that is not disjoint from an earlier use, or a function BIP388's
+  SCRIPT grammar does not list — is refused rather than silently
+  dropped, naming the fragment that was wrong. `wallet_policy_descriptor`
+  and `wallet_policy_address` read any BIP388 template this way, not
+  only one this module built.
+- **`hwi.py`'s module docstring and `HwiSigner.register_descriptor`
+  drop the "nothing here to check it against" reasoning `displayaddress`'s
+  policy mode was left unwrapped for.** What is still missing is the
+  wiring: no method here takes `--registration`, `--index` or
+  `--multipath-index`, and `psbt_signer.display_address` has no
+  multipath index to pass one through with.
+
 ## v2026.8.29
 
 ### Repository

--- a/src/btclib/descriptors/__init__.py
+++ b/src/btclib/descriptors/__init__.py
@@ -54,6 +54,9 @@ from btclib.descriptors.descriptors import (
     parse,
     satisfaction_sizer,
     strip_checksum,
+    wallet_policy,
+    wallet_policy_address,
+    wallet_policy_descriptor,
 )
 from btclib.descriptors.key_expression import KeyExpression, PrvKeys
 from btclib.descriptors.miniscript import Miniscript, SpendContext
@@ -92,4 +95,7 @@ __all__ = [
     "parse",
     "satisfaction_sizer",
     "strip_checksum",
+    "wallet_policy",
+    "wallet_policy_address",
+    "wallet_policy_descriptor",
 ]

--- a/src/btclib/descriptors/descriptors.py
+++ b/src/btclib/descriptors/descriptors.py
@@ -238,6 +238,9 @@ __all__ = [
     "parse",
     "satisfaction_sizer",
     "strip_checksum",
+    "wallet_policy",
+    "wallet_policy_address",
+    "wallet_policy_descriptor",
 ]
 
 INPUT_CHARSET = "0123456789()[],'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#\"\\ "
@@ -2736,6 +2739,480 @@ def multipath_descriptors(descriptor: str) -> list[str]:
         pieces[1::2] = [step[i] for step in steps]
         descriptors.append(add_checksum("".join(pieces)))
     return descriptors
+
+
+_POLICY_TOP_LEVEL = (
+    PkhDescriptor,
+    WpkhDescriptor,
+    ShDescriptor,
+    WshDescriptor,
+    MultiDescriptor,
+    TrDescriptor,
+)
+
+
+def _assert_policy_top_level(descriptor: Descriptor) -> None:
+    """Refuse a descriptor whose own function BIP388 does not list.
+
+    ``sh``, ``wsh``, ``pkh``, ``wpkh``, ``multi``/``sortedmulti`` and
+    ``tr`` are the SCRIPT functions BIP388 names, the miniscript
+    templates it also lists living inside ``wsh`` or ``tr`` only;
+    ``combo``, ``addr``, ``raw``, a bare ``pk`` and Core's own ``rawtr``
+    extension are not, and none of them is a policy an external signer's
+    registration flow reads.
+    This checks the function alone, not BIP388's position for it --
+    ``multi``/``sortedmulti`` inside ``sh``/``wsh`` only, ``wpkh`` at the
+    top level or inside ``sh`` only, ``pkh`` never inside ``tr`` -- so a
+    function BIP388 places nowhere the descriptor puts it still passes
+    this and reaches a template no device will register.
+    """
+    if not isinstance(descriptor, _POLICY_TOP_LEVEL):
+        err_msg = f"{type(descriptor).__name__} is not a BIP388 SCRIPT expression"
+        raise BTClibValueError(err_msg)
+
+
+def _assert_policy_wildcard(key: KeyExpression) -> None:
+    """Refuse anything but the bare, unhardened wildcard a placeholder takes.
+
+    A ``KEY`` expression of a wallet-policy template is *always* followed
+    by a wildcard and never by an explicit step in front of it -- BIP388's
+    own invalid examples are ``pkh(@0)``, with none, and ``pkh(@0/0/**)``,
+    with one. Hardened is refused too: the trailing step is what a device
+    holding only the account xpub still has to compute, which a hardened
+    step never lets it. A fixed public key fails this the same way a
+    hardened or absent wildcard does -- `_parse_key` never gives one a
+    `wildcard`, deriving further from a public key not being a thing -- so
+    it is refused here rather than by a check of its own that nothing
+    would ever reach: every key BIP390 lets an aggregate's own wildcard
+    reach is extended already, `_parse_musig`'s own rule.
+    """
+    if key.der_path:
+        err_msg = f"explicit derivation step before the wildcard: {key}"
+        raise BTClibValueError(err_msg)
+    if key.wildcard != 0:
+        err_msg = f"not an unhardened wildcard, no wallet-policy placeholder: {key}"
+        raise BTClibValueError(err_msg)
+
+
+def _placeholder_index(
+    key: KeyExpression,
+    pool: dict[tuple[BIP32KeyOrigin | None, str], int],
+    key_info: list[KeyExpression],
+) -> int:
+    """Return `key`'s position in the key-information vector, filing a new one.
+
+    Shared across every occurrence of the same origin and extended key,
+    whichever position writes it: a participant read from two ``musig()``
+    groups, or a key used once on its own and once inside one, is one
+    entry of the vector wherever it is written.
+    """
+    identity = (key.origin, key.xkey)
+    if identity not in pool:
+        pool[identity] = len(key_info)
+        key_info.append(replace(key, der_path=(), wildcard=None))
+    return pool[identity]
+
+
+def _assert_distinct_participants(indexes: tuple[int, ...], musig: str) -> None:
+    """Refuse a `musig()` naming the same key-information entry twice.
+
+    BIP388's *Additional rules*: a placeholder is not allowed to repeat
+    inside one aggregate, whether or not the whole group is written more
+    than once elsewhere -- that second question is `written`'s, not this
+    one's.
+    """
+    if len(set(indexes)) != len(indexes):
+        err_msg = f"musig() repeats a participant: {musig}"
+        raise BTClibValueError(err_msg)
+
+
+def _template_key(
+    key: KeyExpression,
+    pool: dict[tuple[BIP32KeyOrigin | None, str], int],
+    key_info: list[KeyExpression],
+    written: set[int | frozenset[int]],
+) -> KeyExpression:
+    """Return the `@N` placeholder a wallet-policy template writes for `key`.
+
+    A ``musig()`` aggregate numbers its participants and writes none for
+    itself, BIP388's placeholder there being the whole ``musig(@i,@j)``;
+    a plain key numbers itself. Either way the trailing wildcard this
+    `Descriptor` holds is the only shape the placeholder can carry --
+    a single, unhardened `/*` -- so a key or a participant set written
+    a second time cannot take a different suffix to stay disjoint by, and
+    is refused rather than folded into the first: BIP388 lists exactly
+    that repetition, ``sh(multi(1,@0/**,@0/**))``, as invalid.
+
+    A participant is never itself a ``musig()``: `_parse_key` reads one
+    with `musig_allowed=False`, refusing the nesting before this is ever
+    reached, so there is no check of that here for a test to have to
+    reach past.
+    """
+    if key.participants:
+        for participant in key.participants:
+            if participant.der_path or participant.wildcard is not None:
+                err_msg = "derivation before aggregation is not allowed in a"
+                err_msg += f" wallet policy: {participant}"
+                raise BTClibValueError(err_msg)
+        _assert_policy_wildcard(key)
+        indexes = tuple(
+            _placeholder_index(participant, pool, key_info)
+            for participant in key.participants
+        )
+        _assert_distinct_participants(indexes, str(key))
+        group = frozenset(indexes)
+        if group in written:
+            err_msg = f"musig() placeholder used more than once: {key}"
+            raise BTClibValueError(err_msg)
+        written.add(group)
+        return replace(
+            key, participants=tuple(KeyExpression(xkey=f"@{i}") for i in indexes)
+        )
+    _assert_policy_wildcard(key)
+    index = _placeholder_index(key, pool, key_info)
+    if index in written:
+        raise BTClibValueError(f"key expression used more than once: {key}")
+    written.add(index)
+    return KeyExpression(xkey=f"@{index}", wildcard=key.wildcard)
+
+
+def _skeleton_key(key: KeyExpression) -> KeyExpression:
+    """Return `key` with every wildcard, path and identity blanked out.
+
+    What is left is the shape alone: a plain key becomes the same stand-in
+    everywhere, and a ``musig()`` becomes one stand-in per participant, so
+    two structures compare equal exactly when they nest the same functions
+    over the same count of keys -- never mind which keys, and never mind
+    where either one's wildcard is.
+    """
+    if key.participants:
+        return KeyExpression(participants=tuple(map(_skeleton_key, key.participants)))
+    return KeyExpression(xkey="K")
+
+
+def _skeleton(descriptor: Descriptor) -> str:
+    """Return `descriptor` as text with every key replaced by the same stand-in.
+
+    Two descriptors with the same skeleton agree on every function, every
+    threshold and the shape of every tree and every ``musig()`` -- on
+    everything but which keys they name and where each one's wildcard
+    sits, which is exactly what a receive and a change descriptor of one
+    account are allowed to differ on.
+    """
+    return str(_mapped_keys(descriptor, _skeleton_key))
+
+
+def _paired_chain_digits(
+    recv_key: KeyExpression, chg_key: KeyExpression
+) -> tuple[int, int]:
+    """Return the receive and change chain digits a paired suffix picks between.
+
+    Each side is exactly one explicit, unhardened step before an
+    unhardened wildcard -- `account_descriptors`' own receive/change
+    shape, and the only trailing path BIP388's `/<M;N>/*` grammar allows
+    in front of one, whose own grammar spells `NUM` as "representing
+    unhardened derivations". The two digits are BIP388's own requirement
+    too: "two distinct decimal numbers", the receive and the change
+    descriptor naming the same account key at the same depth being no
+    policy at all.
+    """
+    for key in (recv_key, chg_key):
+        if (
+            len(key.der_path) != 1
+            or key.wildcard != 0
+            or key.der_path[0] >= _HARDENED_OFFSET
+        ):
+            err_msg = f"not a receive/change chain step before the wildcard: {key}"
+            raise BTClibValueError(err_msg)
+    recv, chg = recv_key.der_path[0], chg_key.der_path[0]
+    if recv == chg:
+        err_msg = f"receive and change use the same chain step: {recv}"
+        raise BTClibValueError(err_msg)
+    return recv, chg
+
+
+def _pair_suffix(recv: int, chg: int) -> str:
+    """Return BIP388's `/**`, its `<0;1>` shorthand, or `/<M;N>/*` otherwise.
+
+    `recv` and `chg` are the receive and change digit in that order, not
+    a low/high pair: BIP389's `<M;N>` positions M at multipath index 0
+    and N at index 1, so `<1;0>` and `<0;1>` are different templates and
+    neither is the other sorted.
+    """
+    return "**" if (recv, chg) == (0, 1) else f"<{recv};{chg}>/*"
+
+
+def _assert_disjoint_pair(
+    placeholder: int | frozenset[int],
+    recv: int,
+    chg: int,
+    seen: dict[int | frozenset[int], set[int]],
+    text: str,
+) -> None:
+    """Refuse a placeholder reused with a chain digit already written for it.
+
+    BIP388's own rule for a repeated placeholder is that its chain
+    digits are pairwise *disjoint*, not merely a different pair:
+    ``sh(multi(1,@0/<0;1>/*,@0/<1;2>/*))`` -- sharing digit 1 -- is
+    BIP388's own invalid example, and the identical pair twice,
+    ``sh(multi(1,@0/**,@0/**))``, is the one case that always shares
+    both. `seen` accumulates every digit written for `placeholder` so
+    far; catching the second is what catches the first too.
+    """
+    used = seen.setdefault(placeholder, set())
+    if used & {recv, chg}:
+        err_msg = f"chain digits are not disjoint from an earlier use: {text}"
+        raise BTClibValueError(err_msg)
+    used.update((recv, chg))
+
+
+def _paired_key(
+    recv_key: KeyExpression,
+    chg_key: KeyExpression,
+    pool: dict[tuple[BIP32KeyOrigin | None, str], int],
+    key_info: list[KeyExpression],
+    written: dict[int | frozenset[int], set[int]],
+) -> str:
+    """Return the placeholder and suffix one paired key position writes.
+
+    A key or a ``musig()`` group may be written more than once, but only
+    at chain digits pairwise disjoint from every earlier use of it,
+    BIP388's own rule (`_assert_disjoint_pair`): the sortedmulti_a()
+    vector reuses one key as `@0/**` (digits 0, 1) and, elsewhere in the
+    same tree, as `@0/<2;3>/*` (digits 2, 3) -- disjoint, and allowed.
+    """
+    if recv_key.participants or chg_key.participants:
+        # a participant count mismatch is already refused by `_skeleton`,
+        # `wallet_policy`'s own precondition for reaching this at all --
+        # `zip`'s `strict=True` is the defense that would fire if that
+        # were ever wrong, not a check of its own
+        indexes = []
+        for recv_participant, chg_participant in zip(
+            recv_key.participants, chg_key.participants, strict=True
+        ):
+            for participant in (recv_participant, chg_participant):
+                if participant.der_path or participant.wildcard is not None:
+                    err_msg = "derivation before aggregation is not allowed in a"
+                    err_msg += f" wallet policy: {participant}"
+                    raise BTClibValueError(err_msg)
+            if (recv_participant.origin, recv_participant.xkey) != (
+                chg_participant.origin,
+                chg_participant.xkey,
+            ):
+                err_msg = "receive and change disagree on a musig() participant:"
+                err_msg += f" {recv_participant} / {chg_participant}"
+                raise BTClibValueError(err_msg)
+            indexes.append(_placeholder_index(recv_participant, pool, key_info))
+        _assert_distinct_participants(tuple(indexes), str(recv_key))
+        recv, chg = _paired_chain_digits(recv_key, chg_key)
+        group = frozenset(indexes)
+        _assert_disjoint_pair(group, recv, chg, written, str(recv_key))
+        keys = ",".join(f"@{i}" for i in indexes)
+        return f"musig({keys})/{_pair_suffix(recv, chg)}"
+    if (recv_key.origin, recv_key.xkey) != (chg_key.origin, chg_key.xkey):
+        err_msg = f"receive and change disagree on a key: {recv_key} / {chg_key}"
+        raise BTClibValueError(err_msg)
+    recv, chg = _paired_chain_digits(recv_key, chg_key)
+    index = _placeholder_index(recv_key, pool, key_info)
+    _assert_disjoint_pair(index, recv, chg, written, f"@{index}")
+    return f"@{index}/{_pair_suffix(recv, chg)}"
+
+
+def wallet_policy(
+    descriptor: Descriptor, change: Descriptor | None = None
+) -> tuple[str, tuple[KeyExpression, ...]]:
+    """Return the BIP388 wallet-policy template of a Descriptor, and its keys.
+
+    Every KEY expression is written as its `@N` placeholder, in the order
+    it is first read -- BIP388's own pair, a *wallet descriptor template*
+    and the *key information vector* it indexes into, which is what an
+    external signer's registration flow reads and what
+    `wallet_policy_descriptor` reads back.
+
+    `change` is the account's change descriptor, `descriptor` its receive
+    one -- `account_descriptors`' own pair, or two built by hand the same
+    way. Given one, this writes BIP388's own `/<M;N>/*` (`/**` where the
+    pair is `<0;1>`), the shorthand its Test Vectors use throughout:
+    `descriptor` and `change` must share every function, threshold and
+    tree shape (`_skeleton` is the check), and must differ, key by key,
+    in nothing but one explicit, unhardened step in front of the wildcard
+    -- BIP389's own two-element multipath, read back out of two already
+    single-path descriptors rather than out of the `<a;b>` text
+    `multipath_descriptors` expands away before either one is parsed.
+
+    Left at its default, `change` is None and `descriptor` is read alone:
+    the only placeholder this writes then is the plain, unhardened `/*`
+    BIP388's "Optional derivation paths" section allows as an
+    implementation-specific pattern, a `Descriptor` holding one
+    derivation path and `/<M;N>/*` needing two. What cannot be written
+    either way is refused rather than silently dropped: a fixed public
+    key, a hardened or explicit step before the wildcard beyond the one
+    unhardened chain digit `change` accounts for, a ``musig()`` with
+    derivation on its participants, receive and change disagreeing on a
+    key or on the shape around it, and a key or a ``musig()`` group
+    written more than once with a chain digit that is not disjoint from
+    an earlier use -- each with the fragment that was wrong. So is a
+    descriptor whose own function is not one of BIP388's SCRIPT
+    expressions -- ``combo()``, ``addr()``, ``raw()``, ``rawtr()`` and a
+    bare ``pk()`` among them. Not checked: BIP388's position for a
+    function within another (`_assert_policy_top_level` says so), and
+    that every key is pairwise distinct from every other.
+    """
+    assert_type(descriptor, Descriptor, "descriptor")
+    _assert_policy_top_level(descriptor)
+    pool: dict[tuple[BIP32KeyOrigin | None, str], int] = {}
+    key_info: list[KeyExpression] = []
+    if change is None:
+        template_written: set[int | frozenset[int]] = set()
+        template = _mapped_keys(
+            descriptor,
+            lambda key: _template_key(key, pool, key_info, template_written),
+        )
+        return str(template), tuple(key_info)
+    assert_type(change, Descriptor, "change")
+    _assert_policy_top_level(change)
+    if _skeleton(descriptor) != _skeleton(change):
+        err_msg = "receive and change descriptors do not share the same structure"
+        raise BTClibValueError(err_msg)
+    recv_keys = descriptor.key_expressions
+    chg_keys = change.key_expressions
+    pair_written: dict[int | frozenset[int], set[int]] = {}
+    # a key-count mismatch is already refused by the skeleton check above;
+    # `zip`'s `strict=True` is the defense that would fire if that were
+    # ever wrong, not a check of its own
+    resolved = {
+        id(recv_key): _paired_key(recv_key, chg_key, pool, key_info, pair_written)
+        for recv_key, chg_key in zip(recv_keys, chg_keys, strict=True)
+    }
+    template = _mapped_keys(
+        descriptor, lambda key: KeyExpression(xkey=resolved[id(key)])
+    )
+    return str(template), tuple(key_info)
+
+
+# BIP388's KI index: a non-negative decimal integer, no leading zero
+# unless the integer is 0 itself -- so `@0` and `@10` are indexes and
+# `@00` is not one, the same digit string BIP388's own grammar spells
+_POLICY_INDEX = r"@(?:0|[1-9]\d*)"
+# a lone placeholder or a musig() group of them, immediately followed by
+# the one trailing wildcard BIP388 allows: the canonical `/**` shorthand,
+# BIP389's own `/<M;N>/*` it stands for, or the plain `/*` a `Descriptor`
+# writes, `/\*\*` tried first so it is not read as `/\*` with a stray `*`
+# left over
+_POLICY_PLACEHOLDER = re.compile(
+    rf"(?:musig\((?P<musig>{_POLICY_INDEX}(?:,{_POLICY_INDEX})*)\)"
+    rf"|@(?P<index>0|[1-9]\d*))"
+    r"(?P<suffix>/\*\*|/<(?P<recv>\d+);(?P<chg>\d+)>/\*|/\*)"
+)
+# every musig() call the template holds, checked before substitution: the
+# placeholder grammar allows nothing inside but comma-separated indexes,
+# so a participant carrying its own path -- derivation before aggregation,
+# which BIP388 forbids and BIP390 does not -- is refused here rather than
+# read as a lone placeholder that happens to sit after "musig("
+_POLICY_MUSIG_CALL = re.compile(r"musig\([^()]*\)")
+_POLICY_MUSIG_GROUP = re.compile(rf"musig\({_POLICY_INDEX}(?:,{_POLICY_INDEX})*\)")
+
+
+def _assert_multipath_index(multipath_index: int) -> None:
+    """Refuse anything but the two branches BIP388's cardinality allows."""
+    if multipath_index not in (0, 1):
+        raise BTClibValueError(f"invalid multipath index: {multipath_index}")
+
+
+def _assert_bare_key_info(key: KeyExpression) -> None:
+    """Refuse a key-information entry that carries its own derivation.
+
+    BIP388's vector holds an origin and an extended key and nothing past
+    it, the trailing path being the template's to write; `wallet_policy`
+    hands one back this way, and a caller building its own has to as well.
+    """
+    if key.der_path or key.wildcard is not None or key.participants:
+        raise BTClibValueError(f"not a bare key-information entry: {key}")
+
+
+def _resolved_placeholder(
+    match: re.Match[str], key_info: Sequence[KeyExpression], multipath_index: int
+) -> str:
+    """Return the text a wallet-policy placeholder and its suffix resolve to."""
+    try:
+        if match["musig"] is not None:
+            indexes = [int(token[1:]) for token in match["musig"].split(",")]
+            keys = ",".join(str(key_info[i]) for i in indexes)
+            text = f"musig({keys})"
+        else:
+            text = str(key_info[int(match["index"])])
+    except IndexError:
+        err_msg = f"key placeholder out of range: {match[0]}"
+        raise BTClibValueError(err_msg) from None
+    suffix = match["suffix"]
+    if suffix == "/**":
+        return f"{text}/{multipath_index}/*"
+    if suffix == "/*":
+        return f"{text}/*"
+    branch = match["chg"] if multipath_index else match["recv"]
+    return f"{text}/{branch}/*"
+
+
+def wallet_policy_descriptor(
+    template: str,
+    key_info: Sequence[KeyExpression],
+    multipath_index: int = 0,
+    network: str = "mainnet",
+) -> Descriptor:
+    """Return the ranged Descriptor a BIP388 wallet-policy template describes.
+
+    `template` and `key_info` are the pair `wallet_policy` returns, or the
+    same pair read off any other source of them -- BIP388's own test
+    vectors, or an external signer's registration flow. Every placeholder
+    is replaced with its key-information text, and every trailing wildcard
+    is resolved at `multipath_index`: BIP389's `/<M;N>/*` positions M at
+    index 0 and N at index 1, in that order and never by which digit is
+    the smaller, and `/**` is `/<0;1>/*` by definition; the plain `/*`
+    BIP388 also allows takes neither branch and reads the same descriptor
+    whatever `multipath_index` is. The result still holds the
+    index-selecting wildcard: `Descriptor.address` and the rest of what a
+    ranged descriptor answers are what `multipath_index` was resolved
+    *for*.
+
+    No `prv_keys`: every wildcard a wallet-policy template writes is
+    unhardened, which is the whole of BIP388's "the seed alone is no
+    longer enough" guarantee working in reverse -- the account xpub in
+    `key_info` computes every script the policy describes, hardened step
+    or not.
+    """
+    assert_type(template, str, "template")
+    _assert_multipath_index(multipath_index)
+    for key in key_info:
+        _assert_bare_key_info(key)
+    for call in _POLICY_MUSIG_CALL.findall(template):
+        if not _POLICY_MUSIG_GROUP.fullmatch(call):
+            raise BTClibValueError(f"not a wallet-policy musig() placeholder: {call}")
+    text, count = _POLICY_PLACEHOLDER.subn(
+        lambda match: _resolved_placeholder(match, key_info, multipath_index),
+        template,
+    )
+    if count == 0 or "@" in text:
+        raise BTClibValueError(f"not a BIP388 wallet-policy template: {template}")
+    return parse(text, network)
+
+
+def wallet_policy_address(
+    template: str,
+    key_info: Sequence[KeyExpression],
+    index: int = 0,
+    multipath_index: int = 0,
+    network: str = "mainnet",
+) -> str:
+    """Return the address a BIP388 wallet policy describes at `index`.
+
+    `wallet_policy_descriptor` resolved at `multipath_index`, then
+    `Descriptor.address` at `index` -- the derivation and the address
+    encoding are answered by the descriptor code every other caller of
+    this module uses, a wallet policy being a second way to name one of
+    its descriptors and not a second way to compute one.
+    """
+    descriptor = wallet_policy_descriptor(template, key_info, multipath_index, network)
+    return descriptor.address(index)
 
 
 # BIP44's fourth level, the two chains every wallet keeps: 0 receives and

--- a/src/btclib/hwi.py
+++ b/src/btclib/hwi.py
@@ -63,7 +63,7 @@ when a caller deciding what to offer at all has to have the answer: a
 refusal is the right answer to a question that was asked, and the wrong
 way to find out there was nothing to ask.
 
-## Wallet policies, and the address this still cannot verify
+## Wallet policies, and the address `displayaddress` still cannot show
 
 A Ledger will not display or sign a multisig it has not been shown
 first. BIP388 wallet policies are how it is shown, and registration is a
@@ -76,16 +76,20 @@ here to check it against.
 `displayaddress`'s BIP388 policy mode -- `--registration`, `--index`,
 `--multipath-index` -- is not wrapped. `psbt_signer.display_address`
 exists to compare a device's screen with the address a `Descriptor`
-computes, and a BIP388 policy's address is not one this library
-computes: `descriptors` reads the fragments a policy template may hold
-(issue #187) without building the template or deriving its address.
-Wiring those flags through with nothing to compare the device's answer
-against is the one thing `display_address`'s own docstring warns
-against -- "a caller that shows the user its own answer instead has
-checked nothing" -- so it stays out until that comparison exists. A
-caller with a registered policy still reads the address off the
-device's own screen; that is what the screen is for, whether or not
-this module checks it too.
+computes, and `descriptors.wallet_policy_address` is now that address for
+a policy too: `descriptors.wallet_policy` builds the `@N` template and
+key-information vector BIP388's own `/**` describes, from a receive and
+a change `Descriptor` of one account -- `account_descriptors`' own pair
+-- or the narrower `/*` form from one `Descriptor` alone, and
+`wallet_policy_descriptor`/`wallet_policy_address` read either pair back
+into the descriptor and the address the policy describes at an index.
+What is still missing is the wiring, not the computation (issue #1588):
+no method here takes `--registration`, `--index` or `--multipath-index`
+and no protocol this library defines carries a multipath index for
+`psbt_signer.display_address` to pass one through. A caller with a
+registered policy still reads the address off the device's own screen;
+that is what the screen is for, whether or not this module checks it
+too.
 
 Staying aligned with a project this does not import is two things, and
 neither is a copy of it. `tests/hwi_test.py` writes out the surface used
@@ -650,13 +654,10 @@ class HwiSigner:
         What comes back is opaque -- an HMAC on Ledger, nothing at all on a
         device that needs none -- and is the caller's to persist and pass
         back as `--registration` on a later `displayaddress`, which this
-        module does not wrap: there is nothing here to compare it against.
-        `psbt_signer.display_address` checks a device's screen against the
-        address a `Descriptor` computes, and a BIP388 policy's address is
-        not one this library computes: `descriptors` reads the fragments
-        a policy template may hold (issue #187) without building the
-        template or deriving its address, which registration does not
-        change.
+        module does not wrap: `descriptors.wallet_policy_address` computes
+        what a device would show under that flag, but nothing here takes
+        the registration, the index and the multipath index and passes
+        them to `displayaddress` to compare it against.
 
         The descriptor goes out ranged, whole rather than at one index:
         registration is of the policy, and `displayaddress --index` is

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -904,6 +904,42 @@ holding multipath participants is refused because `parse` takes no `<a;b>`
 step at all, `multipath_descriptors` being what expands them textually as
 BIP389 defines.
 
+### Not vendored as a file: BIP388's wallet-policy vectors
+
+```text
+repo    bitcoin/bips
+path    bip-0388.mediawiki
+commit  cfff9719405fa35113cab637958809824873750f  2026-04-15
+pulled  2026-09-02
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **transcribed**, complete and cited inline in
+`tests/descriptors/descriptors_test.py`'s `BIP388_VECTORS`: every valid
+policy of the Test Vectors section, its template, its key-information
+vector and the multipath descriptor the two compile to, checked branch by
+branch against `wallet_policy_descriptor` and `wallet_policy_address`
+rather than restated as an address of its own -- `multipath_descriptors`
+and `parse` already answer for what a branch of that descriptor is. The
+same vectors are read the other way too, in
+`test_wallet_policy_reconstructs_bip388s_own_vectors`: `wallet_policy`,
+given the receive and change `Descriptor` `multipath_descriptors` splits
+that same descriptor into, rebuilds the vector's own template and
+key-information vector, byte for byte. Four
+of the Invalid policies section's nine are checked too, in
+`test_bip388_invalid_templates`: the no-path, explicit-path,
+cardinality-above-two and derivation-before-aggregation ones, each a
+property of the template text alone. The other five are not:
+out-of-order and skipped placeholders are a canonicalization
+`wallet_policy_descriptor` does not need to enforce to compute one
+address correctly; repeated keys and non-disjoint multipath steps for the
+same placeholder need the two occurrences compared against each other,
+which nothing here does across an `re.subn` callback; and a non-KP key
+present in a template position is refused anyway, but by `parse`'s own
+"use multipath_descriptors first" -- a coincidence of the raw `<0;1>`
+text reaching it unconsumed, not a check this module makes. That one is
+in the module too, as what it is.
+
 ### Not vendored as a file: BIP328's synthetic xpub vectors
 
 ```text
@@ -1258,11 +1294,14 @@ computes for itself: `descriptors.account_descriptors` and
 Not transcribed on purpose: the BIP388 policy arguments, `--index` and
 `--multipath-index`/`--change` on `displayaddress`, `--registration` on
 both `displayaddress` and, since this pin, `signtx`. `btclib.hwi`'s
-module docstring, "Wallet policies, and the address this still cannot
-verify", is why — there is nothing yet in this library to check the
-address a policy-mode `displayaddress` would answer against, and
-`signtx`'s answer keys (`psbt`, `signed`) are unaffected by a
-registration being passed alongside the transaction.
+module docstring, "Wallet policies, and the address `displayaddress`
+still cannot show", is why — `descriptors.wallet_policy_address`
+(issue #1348) computes the address a policy-mode `displayaddress`
+would answer against, but no method here takes `--registration`,
+`--index` or `--multipath-index` and passes them to that command, so
+the surface `tests/hwi_test.py` transcribes still has nothing to send
+them on. `signtx`'s answer keys (`psbt`, `signed`) are unaffected by
+a registration being passed alongside the transaction.
 
 The parser has only ever grown, and only additively, since 2021:
 `--emulators` in 2024, `--chain` and `--expert` on enumerate in 2022,

--- a/tests/descriptors/descriptors_test.py
+++ b/tests/descriptors/descriptors_test.py
@@ -66,6 +66,9 @@ from btclib.descriptors import (
     normalized,
     parse,
     strip_checksum,
+    wallet_policy,
+    wallet_policy_address,
+    wallet_policy_descriptor,
 )
 from btclib.descriptors.descriptors import __descsum_expand
 from btclib.descriptors.miniscript import _ARITY, Miniscript
@@ -627,6 +630,409 @@ def test_invalid_multipath() -> None:
     # and parse() does not read one, rather than reading it wrong
     with pytest.raises(BTClibValueError, match="multipath_descriptors"):
         parse(f"pk({xpub}/<0;1>)")
+
+
+# BIP388's own Test Vectors section (bitcoin/bips, bip-0388.mediawiki,
+# commit cfff9719405fa35113cab637958809824873750f): every valid policy,
+# its template, its key-information vector as descriptor text -- read the
+# way `wallet_policy` hands one back, by parsing a lone `pk()` of it -- and
+# the multipath descriptor the two compile to. That descriptor is what
+# each vector is checked against, branch by branch, rather than restated
+# as an address of its own: `multipath_descriptors` and `parse` already
+# answer for what one branch is.
+BIP388_VECTORS = (
+    pytest.param(
+        "pkh(@0/**)",
+        (
+            "[6738736c/44'/0'/0']xpub6Br37sWxruYfT8ASpCjVHKGwgdnYFEn98DwiN76i2oyY6fgH1LAPmmDcF46xjxJr22gw4jmVjTE2E3URMnRPEPYyo1zoPSUba563ESMXCeb",
+        ),
+        "pkh([6738736c/44'/0'/0']xpub6Br37sWxruYfT8ASpCjVHKGwgdnYFEn98DwiN76i2oyY6fgH1LAPmmDcF46xjxJr22gw4jmVjTE2E3URMnRPEPYyo1zoPSUba563ESMXCeb/<0;1>/*)",
+        id="bip44-first-account",
+    ),
+    pytest.param(
+        "sh(wpkh(@0/**))",
+        (
+            "[6738736c/49'/0'/1']xpub6Bex1CHWGXNNwGVKHLqNC7kcV348FxkCxpZXyCWp1k27kin8sRPayjZUKDjyQeZzGUdyeAj2emoW5zStFFUAHRgd5w8iVVbLgZ7PmjAKAm9",
+        ),
+        "sh(wpkh([6738736c/49'/0'/1']xpub6Bex1CHWGXNNwGVKHLqNC7kcV348FxkCxpZXyCWp1k27kin8sRPayjZUKDjyQeZzGUdyeAj2emoW5zStFFUAHRgd5w8iVVbLgZ7PmjAKAm9/<0;1>/*))",
+        id="bip49-second-account",
+    ),
+    pytest.param(
+        "wpkh(@0/**)",
+        (
+            "[6738736c/84'/0'/2']xpub6CRQzb8u9dmMcq5XAwwRn9gcoYCjndJkhKgD11WKzbVGd932UmrExWFxCAvRnDN3ez6ZujLmMvmLBaSWdfWVn75L83Qxu1qSX4fJNrJg2Gt",
+        ),
+        "wpkh([6738736c/84'/0'/2']xpub6CRQzb8u9dmMcq5XAwwRn9gcoYCjndJkhKgD11WKzbVGd932UmrExWFxCAvRnDN3ez6ZujLmMvmLBaSWdfWVn75L83Qxu1qSX4fJNrJg2Gt/<0;1>/*)",
+        id="bip84-third-account",
+    ),
+    pytest.param(
+        "tr(@0/**)",
+        (
+            "[6738736c/86'/0'/0']xpub6CryUDWPS28eR2cDyojB8G354izmx294BdjeSvH469Ty3o2E6Tq5VjBJCn8rWBgesvTJnyXNAJ3QpLFGuNwqFXNt3gn612raffLWfdHNkYL",
+        ),
+        "tr([6738736c/86'/0'/0']xpub6CryUDWPS28eR2cDyojB8G354izmx294BdjeSvH469Ty3o2E6Tq5VjBJCn8rWBgesvTJnyXNAJ3QpLFGuNwqFXNt3gn612raffLWfdHNkYL/<0;1>/*)",
+        id="bip86-first-account",
+    ),
+    pytest.param(
+        "wsh(sortedmulti(2,@0/**,@1/**))",
+        (
+            "[6738736c/48'/0'/0'/2']xpub6FC1fXFP1GXLX5TKtcjHGT4q89SDRehkQLtbKJ2PzWcvbBHtyDsJPLtpLtkGqYNYZdVVAjRQ5kug9CsapegmmeRutpP7PW4u4wVF9JfkDhw",
+            "[b2b1f0cf/48'/0'/0'/2']xpub6EWhjpPa6FqrcaPBuGBZRJVjzGJ1ZsMygRF26RwN932Vfkn1gyCiTbECVitBjRCkexEvetLdiqzTcYimmzYxyR1BZ79KNevgt61PDcukmC7",
+        ),
+        "wsh(sortedmulti(2,[6738736c/48'/0'/0'/2']xpub6FC1fXFP1GXLX5TKtcjHGT4q89SDRehkQLtbKJ2PzWcvbBHtyDsJPLtpLtkGqYNYZdVVAjRQ5kug9CsapegmmeRutpP7PW4u4wVF9JfkDhw/<0;1>/*,[b2b1f0cf/48'/0'/0'/2']xpub6EWhjpPa6FqrcaPBuGBZRJVjzGJ1ZsMygRF26RwN932Vfkn1gyCiTbECVitBjRCkexEvetLdiqzTcYimmzYxyR1BZ79KNevgt61PDcukmC7/<0;1>/*))",
+        id="bip48-p2wsh-multisig",
+    ),
+    pytest.param(
+        "wsh(thresh(3,pk(@0/**),s:pk(@1/**),s:pk(@2/**),sln:older(12960)))",
+        (
+            "[6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa",
+            "[b2b1f0cf/44'/0'/0'/100']xpub6EYajCJHe2CK53RLVXrN14uWoEttZgrRSaRztujsXg7yRhGtHmLBt9ot9Pd5ugfwWEu6eWyJYKSshyvZFKDXiNbBcoK42KRZbxwjRQpm5Js",
+            "[a666a867/44'/0'/0'/100']xpub6Dgsze3ujLi1EiHoCtHFMS9VLS1UheVqxrHGfP7sBJ2DBfChEUHV4MDwmxAXR2ayeytpwm3zJEU3H3pjCR6q6U5sP2p2qzAD71x9z5QShK2",
+        ),
+        "wsh(thresh(3,pk([6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa/<0;1>/*),s:pk([b2b1f0cf/44'/0'/0'/100']xpub6EYajCJHe2CK53RLVXrN14uWoEttZgrRSaRztujsXg7yRhGtHmLBt9ot9Pd5ugfwWEu6eWyJYKSshyvZFKDXiNbBcoK42KRZbxwjRQpm5Js/<0;1>/*),s:pk([a666a867/44'/0'/0'/100']xpub6Dgsze3ujLi1EiHoCtHFMS9VLS1UheVqxrHGfP7sBJ2DBfChEUHV4MDwmxAXR2ayeytpwm3zJEU3H3pjCR6q6U5sP2p2qzAD71x9z5QShK2/<0;1>/*),sln:older(12960)))",
+        id="miniscript-3-of-3-degrading",
+    ),
+    pytest.param(
+        "wsh(or_d(pk(@0/**),and_v(v:multi(2,@1/**,@2/**,@3/**),older(65535))))",
+        (
+            "[6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa",
+            "[b2b1f0cf/44'/0'/0'/100']xpub6EYajCJHe2CK53RLVXrN14uWoEttZgrRSaRztujsXg7yRhGtHmLBt9ot9Pd5ugfwWEu6eWyJYKSshyvZFKDXiNbBcoK42KRZbxwjRQpm5Js",
+            "[a666a867/44'/0'/0'/100']xpub6Dgsze3ujLi1EiHoCtHFMS9VLS1UheVqxrHGfP7sBJ2DBfChEUHV4MDwmxAXR2ayeytpwm3zJEU3H3pjCR6q6U5sP2p2qzAD71x9z5QShK2",
+            "[bb641298/44'/0'/0'/100']xpub6Dz8PHFmXkYkykQ83ySkruky567XtJb9N69uXScJZqweYiQn6FyieajdiyjCvWzRZ2GoLHMRE1cwDfuJZ6461YvNRGVBJNnLA35cZrQKSRJ",
+        ),
+        "wsh(or_d(pk([6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa/<0;1>/*),and_v(v:multi(2,[b2b1f0cf/44'/0'/0'/100']xpub6EYajCJHe2CK53RLVXrN14uWoEttZgrRSaRztujsXg7yRhGtHmLBt9ot9Pd5ugfwWEu6eWyJYKSshyvZFKDXiNbBcoK42KRZbxwjRQpm5Js/<0;1>/*,[a666a867/44'/0'/0'/100']xpub6Dgsze3ujLi1EiHoCtHFMS9VLS1UheVqxrHGfP7sBJ2DBfChEUHV4MDwmxAXR2ayeytpwm3zJEU3H3pjCR6q6U5sP2p2qzAD71x9z5QShK2/<0;1>/*,[bb641298/44'/0'/0'/100']xpub6Dz8PHFmXkYkykQ83ySkruky567XtJb9N69uXScJZqweYiQn6FyieajdiyjCvWzRZ2GoLHMRE1cwDfuJZ6461YvNRGVBJNnLA35cZrQKSRJ/<0;1>/*),older(65535))))",
+        id="miniscript-singlesig-inheritance",
+    ),
+    pytest.param(
+        "tr(@0/**,{sortedmulti_a(1,@0/<2;3>/*,@1/**),or_b(pk(@2/**),s:pk(@3/**))})",
+        (
+            "[6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa",
+            "xpub6Fc2TRaCWNgfT49nRGG2G78d1dPnjhW66gEXi7oYZML7qEFN8e21b2DLDipTZZnfV6V7ivrMkvh4VbnHY2ChHTS9qM3XVLJiAgcfagYQk6K",
+            "xpub6GxHB9kRdFfTqYka8tgtX9Gh3Td3A9XS8uakUGVcJ9NGZ1uLrGZrRVr67DjpMNCHprZmVmceFTY4X4wWfksy8nVwPiNvzJ5pjLxzPtpnfEM",
+            "xpub6GjFUVVYewLj5no5uoNKCWuyWhQ1rKGvV8DgXBG9Uc6DvAKxt2dhrj1EZFrTNB5qxAoBkVW3wF8uCS3q1ri9fueAa6y7heFTcf27Q4gyeh6",
+        ),
+        "tr([6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa/<0;1>/*,{sortedmulti_a(1,[6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa/<2;3>/*,xpub6Fc2TRaCWNgfT49nRGG2G78d1dPnjhW66gEXi7oYZML7qEFN8e21b2DLDipTZZnfV6V7ivrMkvh4VbnHY2ChHTS9qM3XVLJiAgcfagYQk6K/<0;1>/*),or_b(pk(xpub6GxHB9kRdFfTqYka8tgtX9Gh3Td3A9XS8uakUGVcJ9NGZ1uLrGZrRVr67DjpMNCHprZmVmceFTY4X4wWfksy8nVwPiNvzJ5pjLxzPtpnfEM/<0;1>/*),s:pk(xpub6GjFUVVYewLj5no5uoNKCWuyWhQ1rKGvV8DgXBG9Uc6DvAKxt2dhrj1EZFrTNB5qxAoBkVW3wF8uCS3q1ri9fueAa6y7heFTcf27Q4gyeh6/<0;1>/*))})",
+        id="taproot-sortedmulti-a-and-miniscript-leaf",
+    ),
+    pytest.param(
+        "tr(musig(@0,@1,@2)/**,{and_v(v:pk(musig(@0,@1)/**),older(12960)),{and_v(v:pk(musig(@0,@2)/**),older(12960)),and_v(v:pk(musig(@1,@2)/**),older(12960))}})",
+        (
+            "[6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa",
+            "[b2b1f0cf/44'/0'/0'/100']xpub6EYajCJHe2CK53RLVXrN14uWoEttZgrRSaRztujsXg7yRhGtHmLBt9ot9Pd5ugfwWEu6eWyJYKSshyvZFKDXiNbBcoK42KRZbxwjRQpm5Js",
+            "[a666a867/44'/0'/0'/100']xpub6Dgsze3ujLi1EiHoCtHFMS9VLS1UheVqxrHGfP7sBJ2DBfChEUHV4MDwmxAXR2ayeytpwm3zJEU3H3pjCR6q6U5sP2p2qzAD71x9z5QShK2",
+        ),
+        "tr(musig([6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa,[b2b1f0cf/44'/0'/0'/100']xpub6EYajCJHe2CK53RLVXrN14uWoEttZgrRSaRztujsXg7yRhGtHmLBt9ot9Pd5ugfwWEu6eWyJYKSshyvZFKDXiNbBcoK42KRZbxwjRQpm5Js,[a666a867/44'/0'/0'/100']xpub6Dgsze3ujLi1EiHoCtHFMS9VLS1UheVqxrHGfP7sBJ2DBfChEUHV4MDwmxAXR2ayeytpwm3zJEU3H3pjCR6q6U5sP2p2qzAD71x9z5QShK2)/<0;1>/*,{and_v(v:pk(musig([6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa,[b2b1f0cf/44'/0'/0'/100']xpub6EYajCJHe2CK53RLVXrN14uWoEttZgrRSaRztujsXg7yRhGtHmLBt9ot9Pd5ugfwWEu6eWyJYKSshyvZFKDXiNbBcoK42KRZbxwjRQpm5Js)/<0;1>/*),older(12960)),{and_v(v:pk(musig([6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa,[a666a867/44'/0'/0'/100']xpub6Dgsze3ujLi1EiHoCtHFMS9VLS1UheVqxrHGfP7sBJ2DBfChEUHV4MDwmxAXR2ayeytpwm3zJEU3H3pjCR6q6U5sP2p2qzAD71x9z5QShK2)/<0;1>/*),older(12960)),and_v(v:pk(musig([b2b1f0cf/44'/0'/0'/100']xpub6EYajCJHe2CK53RLVXrN14uWoEttZgrRSaRztujsXg7yRhGtHmLBt9ot9Pd5ugfwWEu6eWyJYKSshyvZFKDXiNbBcoK42KRZbxwjRQpm5Js,[a666a867/44'/0'/0'/100']xpub6Dgsze3ujLi1EiHoCtHFMS9VLS1UheVqxrHGfP7sBJ2DBfChEUHV4MDwmxAXR2ayeytpwm3zJEU3H3pjCR6q6U5sP2p2qzAD71x9z5QShK2)/<0;1>/*),older(12960))}})",
+        id="taproot-musig2-with-recovery-paths",
+    ),
+)
+
+
+@pytest.mark.parametrize("template, keys, descriptor", BIP388_VECTORS)
+def test_bip388_vectors(template: str, keys: tuple[str, ...], descriptor: str) -> None:
+    """Reproduce every valid policy of BIP388's Test Vectors section.
+
+    Each key-information string is a lone KEY expression, read the way
+    `wallet_policy` hands one back: `pk()` is the trivial wrapper that
+    parses one without a SCRIPT function of its own. Both multipath
+    branches are checked, index 9 standing for "any index": what matters
+    is that the descriptor and the address agree with the branch the BIP
+    itself publishes, not a property special to one index.
+    """
+    key_info = tuple(parse(f"pk({key})").key_expressions[0] for key in keys)
+    for multipath_index, branch in enumerate(multipath_descriptors(descriptor)):
+        expected = parse(branch)
+        resolved = wallet_policy_descriptor(template, key_info, multipath_index)
+        assert str(resolved) == str(expected)
+        assert resolved.script_pub_key(9) == expected.script_pub_key(9)
+        address = wallet_policy_address(template, key_info, 9, multipath_index)
+        assert address == expected.address(9)
+
+
+def test_bip388_invalid_templates() -> None:
+    """Refuse the templates BIP388's Invalid policies section lists.
+
+    Four of the nine: a placeholder with no path following it, one with
+    an explicit path in front of the wildcard, a multipath cardinality
+    above two, and derivation on a ``musig()`` participant. The other
+    five are not checked here -- `tests/_data/README.md` says which and
+    why -- except for the one refused anyway, by `parse`'s own
+    "multipath_descriptors first" rather than by anything this checks.
+    """
+    key = "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
+    key_info = (parse(f"pk({key})").key_expressions[0],)
+    with pytest.raises(BTClibValueError, match="not a BIP388 wallet-policy template"):
+        wallet_policy_descriptor("pkh(@0)", key_info)
+    with pytest.raises(BTClibValueError, match="not a BIP388 wallet-policy template"):
+        wallet_policy_descriptor("pkh(@0/0/**)", key_info)
+    with pytest.raises(BTClibValueError, match="not a BIP388 wallet-policy template"):
+        wallet_policy_descriptor("pkh(@0/<0;1;2>/*)", key_info)
+    with pytest.raises(BTClibValueError, match="musig[(][)] placeholder"):
+        wallet_policy_descriptor("tr(musig(@0/**,@1/**))", (key_info[0], key_info[0]))
+    # a non-KP key present: parse()'s own multipath refusal catches it,
+    # the raw `<0;1>` text reaching it unconsumed rather than substituted
+    non_kp = f"sh(multi(1,@0/**,{key}/<0;1>/*))"
+    with pytest.raises(BTClibValueError, match="multipath_descriptors"):
+        wallet_policy_descriptor(non_kp, key_info)
+
+
+@pytest.mark.parametrize("template, keys, descriptor", BIP388_VECTORS)
+def test_wallet_policy_reconstructs_bip388s_own_vectors(
+    template: str, keys: tuple[str, ...], descriptor: str
+) -> None:
+    """Reconstruct every valid policy of BIP388's vectors, from a descriptor.
+
+    BIP388's vectors read as an input to `wallet_policy` and not only as
+    an output of `wallet_policy_descriptor`.
+
+    `multipath_descriptors` splits the vector's own descriptor into the
+    receive and change branches BIP389's `<0;1>` (or, for the
+    sortedmulti_a() vector, `<2;3>`) always describes, and `wallet_policy`
+    given both reassembles the very template and key-information vector
+    the BIP publishes beside it -- byte for byte, key for key.
+    """
+    branch0, branch1 = multipath_descriptors(descriptor)
+    recv, chg = parse(branch0), parse(branch1)
+    built_template, built_key_info = wallet_policy(recv, chg)
+    assert built_template == template
+    expected_key_info = tuple(parse(f"pk({key})").key_expressions[0] for key in keys)
+    assert built_key_info == expected_key_info
+
+
+def test_wallet_policy_of_an_account_level_descriptor_agrees_with_it() -> None:
+    """A policy built from a `Descriptor` derives what the descriptor does.
+
+    Which is the property that makes a wallet policy worth having: an
+    account-level descriptor -- no chain step of its own, `wallet_policy`
+    refusing the more common two-chain shape (`test_wallet_policy_refuses`
+    says why) -- and the policy built from it must describe the very same
+    scripts, at every index, whichever multipath branch is asked for.
+    """
+    xpub = "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
+    other = "xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y"
+    descriptor = parse(f"wsh(sortedmulti(2,[6738736c/48h/0h/0h]{xpub}/*,{other}/*))")
+    template, key_info = wallet_policy(descriptor)
+    assert template == "wsh(sortedmulti(2,@0/*,@1/*))"
+    for index in (0, 1, 9):
+        for multipath_index in (0, 1):
+            resolved = wallet_policy_descriptor(template, key_info, multipath_index)
+            assert resolved.script_pub_key(index) == descriptor.script_pub_key(index)
+            address = wallet_policy_address(template, key_info, index, multipath_index)
+            assert address == descriptor.address(index)
+
+
+def test_wallet_policy_of_a_musig_descriptor_agrees_with_it() -> None:
+    """A ``musig()`` aggregate numbers its participants and none for itself.
+
+    The same agreement as the plain-key case above, over the one shape a
+    plain key does not reach: the wildcard sits on the aggregate, and
+    `@0`, `@1` are the participants rather than the group.
+    """
+    xpub = "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
+    other = "xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y"
+    descriptor = parse(f"tr(musig({xpub},{other})/*)")
+    template, key_info = wallet_policy(descriptor)
+    assert template == "tr(musig(@0,@1)/*)"
+    for index, multipath_index in ((0, 0), (0, 1), (5, 0)):
+        resolved = wallet_policy_descriptor(template, key_info, multipath_index)
+        assert resolved.script_pub_key(index) == descriptor.script_pub_key(index)
+        address = wallet_policy_address(template, key_info, index, multipath_index)
+        assert address == descriptor.address(index)
+
+
+def test_wallet_policy_of_a_receive_change_pair_agrees_with_both() -> None:
+    """`account_descriptors`' own pair produces BIP388's own `/**` shorthand.
+
+    That pair -- a BIP44 account's receive and change descriptors,
+    `.../0/*` and `.../1/*` -- is the shape most callers actually hold,
+    and the one shape `wallet_policy(descriptor)` alone refuses
+    (`test_wallet_policy_refuses_what_cannot_become_one` measures that).
+    Given both, the policy answers the very scripts the two descriptors
+    it was built from answer, at every index and on both branches.
+    """
+    xpub = "xpub6C7Mz3RXdDAhrx7ECcAg29du1qTQeFHwk1WEUz3JHCNUhZQNeGAdkUb19AZZheLWLqWL71ZEL5G93Uxpj7BXE5TxU3P9mnEaj8itk5V5n7Z"
+    recv, chg = account_descriptors(xpub, "84h/0h/0h", master_fingerprint="6738736c")
+    template, key_info = wallet_policy(recv, chg)
+    assert template == "wpkh(@0/**)"
+    for index in (0, 1, 9):
+        for multipath_index, expected in ((0, recv), (1, chg)):
+            resolved = wallet_policy_descriptor(template, key_info, multipath_index)
+            assert resolved.script_pub_key(index) == expected.script_pub_key(index)
+            address = wallet_policy_address(template, key_info, index, multipath_index)
+            assert address == expected.address(index)
+
+
+def test_wallet_policy_pair_refuses_what_cannot_pair() -> None:
+    """Refuse a receive/change pair that is not one, and say why."""
+    xpub = "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
+    other = "xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y"
+    third = "xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa"
+    # a different function entirely: `_skeleton` catches it before any key
+    # is even looked at
+    with pytest.raises(BTClibValueError, match="do not share the same structure"):
+        wallet_policy(parse(f"wpkh({xpub}/0/*)"), parse(f"pkh({xpub}/1/*)"))
+    # the same chain digit on both sides: no pair to pick between at all
+    with pytest.raises(BTClibValueError, match="use the same chain step"):
+        wallet_policy(parse(f"wpkh({xpub}/0/*)"), parse(f"wpkh({xpub}/0/*)"))
+    # the same shape, a different key: not a receive and a change of one
+    # account, whatever `_skeleton` cannot see about it
+    with pytest.raises(BTClibValueError, match="disagree on a key"):
+        wallet_policy(parse(f"wpkh({xpub}/0/*)"), parse(f"wpkh({other}/1/*)"))
+    # a musig() participant that differs between the two sides
+    with pytest.raises(
+        BTClibValueError, match="disagree on a musig[(][)] participant:"
+    ):
+        wallet_policy(
+            parse(f"tr(musig({xpub},{other})/0/*)"),
+            parse(f"tr(musig({xpub},{third})/1/*)"),
+        )
+    # derivation before aggregation, on the paired side of the same check
+    # `test_wallet_policy_refuses_what_cannot_become_one` makes alone
+    with pytest.raises(BTClibValueError, match="derivation before aggregation"):
+        wallet_policy(
+            parse(f"tr(musig({xpub}/0/*,{other}/0/*))"),
+            parse(f"tr(musig({xpub}/1/*,{other}/1/*))"),
+        )
+    # the same key at the same pair, twice: BIP388's own invalid shape,
+    # `sh(multi(1,@0/**,@0/**))`, over one chain pair rather than the
+    # single suffix the unpaired path is limited to -- the identical
+    # pair is the one case that always shares both digits with itself
+    with pytest.raises(
+        BTClibValueError, match="chain digits are not disjoint from an earlier use"
+    ):
+        wallet_policy(
+            parse(f"multi(1,{xpub}/0/*,{xpub}/0/*)"),
+            parse(f"multi(1,{xpub}/1/*,{xpub}/1/*)"),
+        )
+    # the same key at two pairs that share one digit rather than the
+    # whole pair: BIP388's own invalid-list entry 6,
+    # `sh(multi(1,@0/<0;1>/*,@0/<1;2>/*))`, sharing digit 1
+    with pytest.raises(
+        BTClibValueError, match="chain digits are not disjoint from an earlier use"
+    ):
+        wallet_policy(
+            parse(f"sh(multi(1,{xpub}/0/*,{xpub}/1/*))"),
+            parse(f"sh(multi(1,{xpub}/1/*,{xpub}/2/*))"),
+        )
+    # the same participant twice inside one musig() group, on the paired
+    # side of the check `test_wallet_policy_refuses_what_cannot_become_one`
+    # makes alone
+    with pytest.raises(BTClibValueError, match="musig\\(\\) repeats a participant"):
+        wallet_policy(
+            parse(f"tr(musig({xpub},{xpub})/0/*)"),
+            parse(f"tr(musig({xpub},{xpub})/1/*)"),
+        )
+    # a receive side that is not one explicit chain step before the
+    # wildcard -- the same origin and extended key stay no defense once
+    # the two sides no longer agree on the shape of the step in front
+    with pytest.raises(BTClibValueError, match="not a receive/change chain step"):
+        wallet_policy(parse(f"wpkh({xpub}/0/0/*)"), parse(f"wpkh({xpub}/1/*)"))
+    # a hardened step on either side: BIP388's `/<M;N>/*` grammar spells
+    # `NUM` as "representing unhardened derivations"
+    with pytest.raises(BTClibValueError, match="not a receive/change chain step"):
+        wallet_policy(parse(f"wpkh({xpub}/0/*)"), parse(f"wpkh({xpub}/1h/*)"))
+    with pytest.raises(BTClibValueError, match="not a receive/change chain step"):
+        wallet_policy(parse(f"wpkh({xpub}/0h/*)"), parse(f"wpkh({xpub}/1h/*)"))
+    # the same musig() group at the same pair, twice: the paired form of
+    # the plain-key case above, over the participant set rather than one
+    # key
+    with pytest.raises(
+        BTClibValueError, match="chain digits are not disjoint from an earlier use"
+    ):
+        wallet_policy(
+            parse(f"tr(musig({xpub},{other})/0/*,pk(musig({xpub},{other})/0/*))"),
+            parse(f"tr(musig({xpub},{other})/1/*,pk(musig({xpub},{other})/1/*))"),
+        )
+    # the same musig() group at two pairs sharing one digit, the musig
+    # form of the sharing-one-digit case above
+    with pytest.raises(
+        BTClibValueError, match="chain digits are not disjoint from an earlier use"
+    ):
+        wallet_policy(
+            parse(f"tr(musig({xpub},{other})/0/*,pk(musig({xpub},{other})/1/*))"),
+            parse(f"tr(musig({xpub},{other})/1/*,pk(musig({xpub},{other})/2/*))"),
+        )
+    # the control: the same key at two genuinely disjoint pairs, still
+    # allowed -- the sortedmulti_a() vector's own shape
+    template, _ = wallet_policy(
+        parse(f"wsh(multi(1,{xpub}/0/*,{xpub}/2/*))"),
+        parse(f"wsh(multi(1,{xpub}/1/*,{xpub}/3/*))"),
+    )
+    assert template == "wsh(multi(1,@0/**,@0/<2;3>/*))"
+
+
+def test_wallet_policy_refuses_what_cannot_become_one() -> None:
+    """Refuse a `Descriptor` no wallet-policy template can hold, and say why."""
+    xpub = "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
+    # the standard receive-or-change account descriptor: an explicit
+    # chain step in front of the wildcard, which is `pkh(@0/0/**)`'s own
+    # invalid shape and not the `/**` a `Descriptor` cannot spell anyway
+    with pytest.raises(BTClibValueError, match="explicit derivation step"):
+        wallet_policy(parse(f"wpkh({xpub}/0/*)"))
+    # a fixed public key: never ranged, so it fails the wildcard check the
+    # same way a hardened or absent one does, `_parse_key` giving a fixed
+    # key no `wildcard` to be zero
+    with pytest.raises(BTClibValueError, match="not an unhardened wildcard"):
+        wallet_policy(parse(f"wpkh({KEY})"))
+    # a hardened wildcard: the one step an account xpub cannot compute
+    with pytest.raises(BTClibValueError, match="not an unhardened wildcard"):
+        wallet_policy(parse(f"wpkh({xpub}/*h)"))
+    # not ranged at all
+    with pytest.raises(BTClibValueError, match="not an unhardened wildcard"):
+        wallet_policy(parse(f"wpkh({xpub})"))
+    # the same key twice: with no change descriptor the only suffix
+    # this writes is the single `/*`, so any repeat is BIP388's own
+    # invalid shape, `sh(multi(1,@0/**,@0/**))`, over that one suffix
+    with pytest.raises(BTClibValueError, match="used more than once"):
+        wallet_policy(parse(f"multi(1,{xpub}/*,{xpub}/*)"))
+    # derivation before aggregation: BIP390 allows it, BIP388 does not
+    with pytest.raises(BTClibValueError, match="derivation before aggregation"):
+        wallet_policy(parse(f"tr(musig({xpub}/*,{MUSIG_XPUB_B}/*))"))
+    # the same musig() group twice: the aggregate's own trailing wildcard
+    # is the same collision as a plain key's, over the participant set
+    # rather than over one key
+    with pytest.raises(BTClibValueError, match="musig\\(\\) placeholder"):
+        wallet_policy(
+            parse(
+                f"tr(musig({xpub},{MUSIG_XPUB_B})/*,pk(musig({xpub},{MUSIG_XPUB_B})/*))"
+            )
+        )
+    # the same participant twice inside one musig() group: BIP388's
+    # *Additional rules* forbid it whether or not the whole group repeats
+    with pytest.raises(BTClibValueError, match="musig\\(\\) repeats a participant"):
+        wallet_policy(parse(f"tr(musig({xpub},{xpub})/*)"))
+    # a function BIP388's SCRIPT grammar does not list
+    with pytest.raises(BTClibValueError, match="not a BIP388 SCRIPT expression"):
+        wallet_policy(parse(f"combo({xpub}/*)"))
+    with pytest.raises(BTClibValueError, match="not a BIP388 SCRIPT expression"):
+        wallet_policy(parse(f"pk({xpub}/*)"))
+
+
+def test_wallet_policy_descriptor_validates_its_own_input() -> None:
+    """Refuse a multipath index BIP388 has no branch for, and a torn-up pair."""
+    key = "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
+    key_info = (parse(f"pk({key})").key_expressions[0],)
+    with pytest.raises(BTClibValueError, match="invalid multipath index"):
+        wallet_policy_descriptor("wpkh(@0/**)", key_info, multipath_index=2)
+    with pytest.raises(BTClibValueError, match="key placeholder out of range"):
+        wallet_policy_descriptor("wpkh(@1/**)", key_info)
+    # a key-information entry that still carries its own path: not what
+    # `wallet_policy` ever hands back, but a caller building one by hand
+    # can still get this wrong
+    ranged = parse(f"pk({key}/*)").key_expressions[0]
+    with pytest.raises(BTClibValueError, match="not a bare key-information entry"):
+        wallet_policy_descriptor("wpkh(@0/**)", (ranged,))
+    # a leading zero: BIP388's `KI` grammar spells the index as a decimal
+    # integer with none, so `@00` is not a placeholder at all and is left
+    # unconsumed, the same refusal a template with no placeholder gets
+    with pytest.raises(BTClibValueError, match="not a BIP388 wallet-policy template"):
+        wallet_policy_descriptor("wpkh(@00/**)", key_info)
+    # one placeholder resolved and one left over: `count` alone would let
+    # this through, `text` still holding an unconsumed `@` is what refuses
+    # it -- `test_bip388_invalid_templates`'s `pkh(@0)` exercises
+    # `count == 0` without ever making `text` hold one
+    pair = (key_info[0], key_info[0])
+    with pytest.raises(BTClibValueError, match="not a BIP388 wallet-policy template"):
+        wallet_policy_descriptor("sh(multi(1,@0/**,@1))", pair)
 
 
 # Bitcoin Core's own, from the multipath example of doc/descriptors.md


### PR DESCRIPTION
`descriptors` gains BIP388 wallet policies: a template built from an
account's own receive/change descriptor pair, and the descriptor and
address read back out of one.

`wallet_policy` takes `account_descriptors`' pair, checks the two agree
on everything but one explicit, unhardened chain digit before the
wildcard, and writes BIP388's canonical `/**` shorthand -- `/<M;N>/*`
for a pair other than 0/1, positioned as BIP389 says and never sorted.
Every one of BIP388's own Test Vectors is reconstructed from its
multipath descriptor this way, byte for byte. A key or a `musig()`
group may be reused across the tree, but only at chain digits pairwise
disjoint from every earlier use of it -- BIP388's own rule, and entry 6
of its invalid-policy list when it is not enforced. Given a single
`Descriptor` instead of a pair it writes the narrower unhardened `/*`
that BIP388's *Optional derivation paths* section allows, one parsed
descriptor holding one path where `/**` needs two.

`wallet_policy_descriptor` and `wallet_policy_address` read either
template back: the descriptor at a `multipath_index`, and the address
that policy describes at an index.

`hwi.py`'s module docstring and `HwiSigner.register_descriptor` drop
the "nothing here to check it against" reasoning that justified leaving
`displayaddress`'s policy-mode flags unwrapped. Wiring them through
`psbt_signer.display_address` is left for
[ISS 1588](https://github.com/btclib-org/btclib/issues/1588), which
needs a multipath index the current `AddressDisplay` protocol has no
place for.

Closes #1348
Closes #1589

Reviewed locally at fresh context before opening, per `REVIEWING.md`;
five rounds, the last two on prose claims measured against BIP388 at
`cfff9719`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Implement BIP388 wallet-policy construction and resolution for descriptor-based wallets, including address derivation and comprehensive validation.

New Features:
- Add BIP388 wallet-policy generation from single descriptors or receive/change descriptor pairs, including canonical multipath templates and key-information vectors.
- Add utilities to resolve wallet-policy templates into descriptors and derive addresses for either multipath branch.

Enhancements:
- Validate supported policy script forms, wildcard paths, descriptor-pair compatibility, MuSig participant reuse, and disjoint derivation-chain requirements.
- Expose the wallet-policy APIs through the descriptors package and update HWI documentation to reflect policy address computation while retaining the pending command-line integration limitation.

Documentation:
- Document BIP388 wallet-policy support, validation behavior, and the remaining HWI displayaddress integration gap.

Tests:
- Add coverage for all valid BIP388 wallet-policy vectors, reconstruction of templates from descriptors, address and descriptor derivation, and invalid policy cases.