### PR TITLE
`btclib.consensus` carries a consensus parameter table per network (closes #1578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -902,6 +902,53 @@ documented at release-notes length in the first place, and are still in
   `--multipath-index`, and `psbt_signer.display_address` has no
   multipath index to pass one through with.
 
+### `btclib.consensus` answers for the consensus rules of each network
+
+- **`CONSENSUS_PARAMS` carries a row per network `btclib.network` names,
+  and `NETWORKS[name].consensus` is that row** (closes #1578). A frozen
+  `ConsensusParams` holds the activation heights Bitcoin Core keeps as
+  buried deployments (BIP34, BIP66, BIP65, CSV and segwit), the subsidy
+  halving interval, the easiest target the network allows, Core's
+  `fPowAllowMinDifficultyBlocks`, `enforce_BIP94` and
+  `fPowNoRetargeting`, the minimum chain work, and the blocks the
+  chain's own history exempts from BIP30 and from the default script
+  flags. Each of those three is data here and nothing more: the header
+  arithmetic that reads them per network is issue #1579's, and BIP94's
+  timewarp rule is not enforced anywhere yet.
+  `ConsensusParams.script_flags_at` is Core's `GetBlockScriptFlags`, and
+  answers the `ScriptFlag` bitmask `btclib.script.engine.verify_input`
+  takes. Every value is transcribed
+  from `src/kernel/chainparams.cpp` at Bitcoin Core v31.1,
+  `bitcoin/bitcoin@9be056a8a7`, with the line it was read at beside it;
+  a released tag rather than a `master` tip, so that a line citation
+  names a blob that cannot move, and because `master` no longer keeps
+  taproot's deployment in that file at all. `tests/consensus_test.py`
+  holds each field to that transcription, and derives `pow_limit_bits`
+  from Core's own `powLimit` rather than restating it.
+- **P2SH, segwit v0 and taproot bind from the genesis block of every
+  chain**, and a height gates only DERSIG, CHECKLOCKTIMEVERIFY,
+  CHECKSEQUENCEVERIFY and NULLDUMMY. Core names the blocks that predate
+  a rule and would fail it one by one, by hash, rather than switching
+  the rule on at a height, so `script_flags_at` takes an optional block
+  hash and the table has no taproot activation height to be wrong about.
+- **`btclib.consensus` imports no module of this library**, which is
+  what lets `btclib.block`, `btclib.tx`, `btclib.script` and
+  `btclib.network` all read it. `script_flags_at` imports the script
+  engine when it is called rather than when the module is: the enum it
+  answers with sits inside the cycle that would otherwise close,
+  `btclib.script.engine` importing `btclib.script.witness`, which
+  imports this module. `tests/imports_test.py` measures both halves.
+- **`btclib.block.proof_of_work`'s `MAINNET_POW_LIMIT_BITS` and
+  `REGTEST_POW_LIMIT_BITS`, and `btclib.block.block_context`'s
+  `BIP34_HEIGHT`, read their numbers from the table** rather than
+  stating them a second time. Each keeps its name and its value. The
+  comment beside the first pair no longer says every network's limit is
+  exactly representable in the compact form: signet's is, and mainnet's
+  and regtest's round down. What the encoding preserves is the
+  comparison, the next target the compact form can express above the
+  rounded value being already above Core's own limit, so a header's
+  `bits` fall on the same side of either.
+
 ## v2026.8.29
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,6 +36,21 @@ full year, short month, short day (YYYY-M-D)
   `"MIT License"`. `btclib.__version__` and `btclib.__copyright__` are
   unaffected.
 
+- **`Network` takes a `consensus` row, and its dict carries a
+  `consensus` key** (closes #1578). `btclib.network.Network` gained a
+  field naming the consensus parameters of the chain it spells keys for,
+  `to_dict` writes the row's name, and `from_dict` reads it back.
+
+  Act on it if you build a `Network` yourself or load one from a dict
+  you stored. The constructor takes it as a required keyword argument —
+  `Network(..., consensus=CONSENSUS_PARAMS["mainnet"])`, from
+  `btclib.consensus` — and a dict without the key raises
+  `BTClibValueError: missing network field: consensus`, a dict naming a
+  row that does not exist `BTClibValueError: unknown consensus
+  parameters`. Add `"consensus": "mainnet"` to a stored dict, spelled
+  with the name of the network it is. Reading `NETWORKS`, and everything
+  that resolves a network by name or by prefix, is unaffected.
+
 ### Worth knowing, though nothing raises
 
 - **`btclib.org` is no longer this project's site, and this repository

--- a/src/btclib/_data/mainnet.json
+++ b/src/btclib/_data/mainnet.json
@@ -1,6 +1,7 @@
 {
     "curve": "secp256k1",
     "network_type": "main",
+    "consensus": "mainnet",
     "genesis_block": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
     "wif": "80",
     "p2pkh": "00",

--- a/src/btclib/_data/regtest.json
+++ b/src/btclib/_data/regtest.json
@@ -1,6 +1,7 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
+    "consensus": "regtest",
     "genesis_block": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
     "wif": "ef",
     "p2pkh": "6f",

--- a/src/btclib/_data/signet.json
+++ b/src/btclib/_data/signet.json
@@ -1,6 +1,7 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
+    "consensus": "signet",
     "genesis_block": "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
     "wif": "ef",
     "p2pkh": "6f",

--- a/src/btclib/_data/testnet.json
+++ b/src/btclib/_data/testnet.json
@@ -1,6 +1,7 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
+    "consensus": "testnet",
     "genesis_block": "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
     "wif": "ef",
     "p2pkh": "6f",

--- a/src/btclib/_data/testnet4.json
+++ b/src/btclib/_data/testnet4.json
@@ -1,6 +1,7 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
+    "consensus": "testnet4",
     "genesis_block": "00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043",
     "wif": "ef",
     "p2pkh": "6f",

--- a/src/btclib/alias.py
+++ b/src/btclib/alias.py
@@ -202,6 +202,7 @@ ScriptType = Literal[
 NetworkField = Literal[
     "curve",
     "network_type",
+    "consensus",
     "genesis_block",
     "wif",
     "p2pkh",

--- a/src/btclib/block/block_context.py
+++ b/src/btclib/block/block_context.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 
+from btclib.consensus import CONSENSUS_PARAMS
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.utils import assert_type, is_integer
 
@@ -40,16 +41,16 @@ __all__ = [
     "BlockContext",
 ]
 
-# Core's chainparams: 227,931 on mainnet, 21,111 on testnet3, and 1 on
-# testnet4, signet and regtest. Mainnet is the default, as it is
-# everywhere else in btclib.
+# mainnet's, which is the default here as it is everywhere else in
+# btclib. Every network's is a field of its `btclib.consensus` row, so a
+# caller validating another chain writes
+# `NETWORKS[name].consensus.bip34_height` rather than the number.
 #
-# A field of this dataclass rather than one of `Network`, which holds no
-# consensus parameter at all: the first one to go in belongs there with
-# the others a chain-aware validator needs -- the retarget interval,
-# BIP66's and BIP65's heights, the subsidy halving interval -- and putting
-# this one there alone would answer for a table that is otherwise absent.
-BIP34_HEIGHT = 227_931
+# A default of this dataclass and not a second copy: the context is what
+# a validator hands to one block, and the chain it came from is the table
+# -- which is also where the rest of what such a validator reads is, the
+# other activation heights and the subsidy interval among them
+BIP34_HEIGHT = CONSENSUS_PARAMS["mainnet"].bip34_height
 
 
 @dataclass(frozen=True)

--- a/src/btclib/block/proof_of_work.py
+++ b/src/btclib/block/proof_of_work.py
@@ -31,6 +31,7 @@ from collections.abc import Sequence
 from datetime import datetime
 
 from btclib.alias import Octets
+from btclib.consensus import CONSENSUS_PARAMS
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.utils import assert_type, bytes_from_octets, is_integer, is_octets
 
@@ -69,19 +70,28 @@ POW_TARGET_SPACING = 10 * 60
 DIFFICULTY_ADJUSTMENT_INTERVAL = POW_TARGET_TIMESPAN // POW_TARGET_SPACING
 
 # the easiest target a network allows, as bits rather than as the 32
-# bytes Core's params.powLimit holds: every network's limit is exactly
-# representable in the compact form -- it is where the compact form came
-# from -- so nothing is lost, and a caller reads the same four bytes a
-# header carries. Mainnet's is the genesis block target, which is why the
-# genesis difficulty is 1, and testnet3 and testnet4 share it
-MAINNET_POW_LIMIT_BITS = b"\x1d\x00\xff\xff"
+# bytes Core's params.powLimit holds, so that a caller reads the same
+# four bytes a header carries. The compact form rounds down -- mainnet's
+# limit and regtest's are both wider than three significand bytes, and
+# only signet's survives the encoding unchanged -- and the rounding
+# reaches no comparison anybody makes: the next target the compact form
+# can express above the rounded value is already above Core's own limit,
+# so a header's bits fall on the same side of either. Mainnet's is the
+# genesis block target, which is why the genesis difficulty is 1, and
+# testnet3 and testnet4 share it.
+#
+# The numbers are `btclib.consensus`'s, where every network has a row and
+# where each is transcribed from Core with the line it was read at. These
+# two names are the defaults of the signatures below, and they stay names
+# because that is what a default is written as
+MAINNET_POW_LIMIT_BITS = CONSENSUS_PARAMS["mainnet"].pow_limit_bits
 # regtest's, the one loose enough to mine against in a test. Not
 # something to hand to next_bits as a starting target: regtest sets
 # fPowNoRetargeting, so Core never retargets from it, and 2^255 is a
 # target the retarget's own multiplication overflows -- see the note
 # there. As the pow_limit_bits of a network that does retarget it is
 # fine, being compared and never multiplied
-REGTEST_POW_LIMIT_BITS = b"\x20\x7f\xff\xff"
+REGTEST_POW_LIMIT_BITS = CONSENSUS_PARAMS["regtest"].pow_limit_bits
 
 
 def _value_from_bits(bits: bytes) -> int:

--- a/src/btclib/consensus.py
+++ b/src/btclib/consensus.py
@@ -2,35 +2,118 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""The consensus constants more than one package measures against.
+"""The consensus constants and the per-network table, below every package.
 
-Two names of Bitcoin Core's `consensus/consensus.h` and one bound derived
-from them, in a module that imports nothing and is therefore below every
-package that reads them. `btclib.block.limits` is where the rest of that
-header is and where a caller reading a block's own rules goes; these two
-are here because of who else divides by them. A transaction's input and
-output counts (`btclib.tx.limits`) and a witness stack's element count are
-arithmetic on `MAX_BLOCK_WEIGHT`, and neither `btclib.tx` nor
-`btclib.script` can import `btclib.block`: `btclib.block` imports
-`btclib.tx`, which imports `btclib.script`, so either edge back closes a
-cycle on a half-initialized package -- issue #147's shape, and what
-`tests/imports_test.py` reports.
+Bitcoin Core keeps a consensus rule's numbers in two shapes and so does
+this module: the bounds that are the same on every chain, which are
+`consensus/consensus.h`, and the ones that are a fact about one network,
+which are `Consensus::Params` and are `ConsensusParams` below.
 
-`btclib.block.limits` re-exports both, so nothing that reads them from
-there has to move.
+Nothing of btclib is imported here, and that is the whole of why the
+table can live at this depth: `btclib.block`, `btclib.tx` and
+`btclib.script` all read something of it, `btclib.network` reads the
+table to give each `Network` its `consensus` row, and any import back
+would close a cycle on a half-initialized package -- issue #147's shape,
+and what `tests/imports_test.py` reports.
+
+`MAX_BLOCK_WEIGHT` and `WITNESS_SCALE_FACTOR` are here rather than in
+`btclib.block.limits`, which is where the rest of that header is and
+where a caller reading a block's own rules goes, because of who else
+divides by them: a transaction's input and output counts
+(`btclib.tx.limits`) and a witness stack's element count are arithmetic
+on `MAX_BLOCK_WEIGHT`. `btclib.block.limits` re-exports both, so nothing
+that reads them from there has to move.
 
 `MAX_WITNESS_STACK_ITEMS` is here and not in `btclib.script.limits` for a
-second reason on top of the layering. That module holds the five caps the
+second reason on top of the layering. That module holds the caps the
 script *engine* enforces, and reading an execution limit in a decoder is
 what let a 1443-byte push be refused as unparsable when it was merely
 unspendable (issue #123). The bound below is not `MAX_STACK_SIZE`: it
 refuses a count no block could carry, not a witness no script could run.
+
+## The per-network table
+
+`CONSENSUS_PARAMS` answers for every network `btclib.network.NETWORKS`
+names, and `NETWORKS[name].consensus` is the same row reached from the
+encoding side, so the two tables cannot disagree about which networks
+exist. A row is what a validator needs and a node's own file has no
+claim on: an activation height, the subsidy interval, the easiest target
+the network allows, and the exceptions the chain's own history forces.
+What identifies a *node* rather than a network -- a port, a DNS seed, a
+pruning floor, a custom signet's p2p magic -- is not here, and
+`bitcoin_core_rpc` is where the last of those lives.
+
+Every value is transcribed from `src/kernel/chainparams.cpp` at Bitcoin
+Core v31.1 (bitcoin/bitcoin@9be056a8a7), with the line it was read at
+beside it, and `tests/consensus_test.py` holds each field to that
+transcription. A released tag rather than a `master` tip, for two
+reasons: these are the numbers a node on the network enforces, and a tag
+names a blob that cannot move under a line citation. `master` also no
+longer keeps all of them in that one file -- taproot's deployment is
+gone from it, buried the way `script_flags_at` below describes.
+
+What a row carries that `chainparams.cpp` does not hold is cited to
+`src/validation.cpp` at the same tag: `bip30_exceptions` is
+`IsBIP30Repeat` there. So is the rule that combines a row's heights into
+script flags, `GetBlockScriptFlags`, which `script_flags_at` names.
+
+Fields of `Consensus::Params` that are deliberately absent, so that a
+reader looking for one knows it was decided rather than missed:
+
+- `hashGenesisBlock` is `Network.genesis_block`, which every one of these
+  rows is reached through
+- `BIP34Hash` is the hash Core compares at `bip34_height` to decide
+  whether it may stop making the BIP30 check above it. A validator that
+  keeps making it answers the same, BIP34 being what makes a duplicate
+  coinbase impossible once the coinbase commits to its own height, so
+  the field buys work rather than an accept or a reject
+- `vDeployments` is BIP9 signalling, which a table of heights does not
+  model and no caller of this table asks for
+- `MinBIP9WarningHeight` is the height below which a node stays quiet
+  about an unknown deployment, which is a warning and not a rule
+- `defaultAssumeValid` is what a node skips signature checks below by
+  default, which is a startup option and not a fact about the chain
+- `nPowTargetSpacing` and `nPowTargetTimespan` are the retarget window,
+  which `btclib.block.proof_of_work` states as mainnet's; issue #1579 is
+  where the header arithmetic that reads them per network goes, and it is
+  what moves them here
+- `signet_challenge` is per deployment rather than per network, which is
+  the reason `btclib.network` gives for keeping the p2p magic out too
+- `signet_blocks` is the switch in front of the check that reads that
+  challenge, so a caller given the one without the other could not act
+  on it; whoever holds the challenge holds this with it
+
+A row validates nothing it is built with, alone among this library's
+dataclasses: validating means raising a `BTClibTypeError`, which means
+importing `btclib.exceptions`, which is the import this module does not
+take. Nothing parses a row -- the five below are constants of this
+module -- and the boundary that does read json is `Network.from_dict`,
+which asks `Network.assert_valid` whether its `consensus` field is one
+of these.
 """
 
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    # the whole dotted path, and the module rather than the name:
+    # `btclib.script.engine` re-exports `ScriptFlag`, so the bare name
+    # has two targets in the documentation and the `-n` build fails on
+    # the ambiguity rather than on anything being missing
+    import btclib.script.engine.flags
+    from btclib.alias import Octets
+
 __all__ = [
+    "CONSENSUS_PARAMS",
     "MAX_BLOCK_WEIGHT",
     "MAX_WITNESS_STACK_ITEMS",
     "WITNESS_SCALE_FACTOR",
+    "ConsensusParams",
 ]
 
 # Maximum allowed weight for a block, see BIP141 (network rule)
@@ -45,3 +128,312 @@ WITNESS_SCALE_FACTOR = 4
 # in it can exceed either -- which is what lets a parser refuse a count
 # before allocating a Python object per declared element (issue #569)
 MAX_WITNESS_STACK_ITEMS = MAX_BLOCK_WEIGHT
+
+# what Core's GetBlockScriptFlags turns on for every block of every chain,
+# before a height is consulted at all: P2SH, segwit v0 and taproot are
+# enforced from the genesis block down, and the blocks that predate each
+# and would fail it are named one by one in `script_flag_exceptions`
+# rather than gated on an activation height. A validator that gates them
+# on a height instead accepts a P2SH spend Core rejects, in the window
+# between the fork's activation and the height it reads
+_ALWAYS_ON_FLAGS: tuple[str, ...] = ("P2SH", "WITNESS", "TAPROOT")
+
+
+@dataclass(frozen=True)
+class ConsensusParams:
+    """The consensus parameters of one network: heights, limits, exceptions.
+
+    Bitcoin Core's `Consensus::Params` for the fields a validator reads
+    off a chain rather than off a block. The module docstring says which
+    of Core's fields are deliberately not here, and where each value was
+    transcribed from.
+
+    Frozen and hashable, as `Network` is: a row is a value, the five in
+    `CONSENSUS_PARAMS` are read by every caller at once, and a `Network`
+    carrying one must stay usable as a dict key.
+    """
+
+    # the name this row answers to in CONSENSUS_PARAMS, so that a row
+    # says which network it is without being looked up backwards --
+    # `Network` carries the row and no name of its own, and `to_dict`
+    # writes this
+    name: str
+
+    # Core's nSubsidyHalvingInterval: the number of blocks the coinbase
+    # reward stays at one level before halving again. Issue #1118's
+    # subsidy function is what reads it; no arithmetic on it is here,
+    # so that the halving is stated in one place rather than two
+    subsidy_halving_interval: int
+
+    # Core's five buried deployments, i.e. `Consensus::Params`'s
+    # DeploymentHeight: the first height at which each rule binds. Buried
+    # means the height is hardcoded rather than signalled (BIP90), which
+    # is what makes a table of integers the whole answer
+    bip34_height: int  # DEPLOYMENT_HEIGHTINCB: the coinbase commits to it
+    bip66_height: int  # DEPLOYMENT_DERSIG: strict DER signatures
+    bip65_height: int  # DEPLOYMENT_CLTV: OP_CHECKLOCKTIMEVERIFY
+    csv_height: int  # DEPLOYMENT_CSV: BIP68, BIP112 and BIP113
+    segwit_height: int  # DEPLOYMENT_SEGWIT: BIP141, BIP143 and BIP147
+
+    # Core's powLimit, as the four compact bytes a header carries rather
+    # than as the 32 Core holds: `bits_from_target` of Core's own value is
+    # what the transcription test compares, and a caller reads the same
+    # width `BlockHeader.bits` has
+    pow_limit_bits: bytes
+
+    # Core's fPowAllowMinDifficultyBlocks: a block more than two target
+    # spacings after its parent may be mined at `pow_limit_bits`, so that
+    # a chain nobody is hashing still moves
+    pow_allow_min_difficulty_blocks: bool
+
+    # Core's enforce_BIP94: the timewarp mitigation, which bounds a
+    # block's timestamp below by the first block of the previous
+    # difficulty period rather than by the median of eleven ancestors,
+    # and on testnet4 also the block storm mitigation. Data here and a
+    # rule elsewhere, as the flags either side of it are: issue #1579 is
+    # where the header arithmetic that reads it goes
+    enforce_bip94: bool
+
+    # Core's fPowNoRetargeting: the target never moves off the one the
+    # genesis carries, which is what makes regtest minable at will
+    pow_no_retargeting: bool
+
+    # Core's nMinimumChainWork, as the integer `proof_of_work.chain_work`
+    # answers rather than as Core's 32 bytes: the work below which a node
+    # stays in initial block download whatever its tip's age
+    minimum_chain_work: int
+
+    # Core's IsBIP30Repeat: the (height, hash) of every block whose own
+    # history already carries a BIP30 violation, exempted from the check
+    # rather than failing it. A pair and not a bare height, because Core
+    # asks both questions -- a chain that forked below one of these
+    # heights has a different block there and is not exempt
+    bip30_exceptions: tuple[tuple[int, bytes], ...]
+
+    # Core's script_flag_exceptions: the blocks that are consensus-valid,
+    # buried, and fail the flags every other block is checked with. The
+    # value is the flag names `to_script_flags` accepts, replacing the
+    # default set rather than adding to it, which is what
+    # GetBlockScriptFlags does with the entry it finds.
+    # A tuple of pairs and not a mapping: the row has to stay hashable,
+    # and the lookup is over a handful of blocks in the whole chain
+    script_flag_exceptions: tuple[tuple[bytes, tuple[str, ...]], ...]
+
+    def script_flags_at(
+        self, height: int, block_hash: Octets | None = None
+    ) -> btclib.script.engine.flags.ScriptFlag:
+        """Return the script rules a block at this height is checked with.
+
+        Bitcoin Core's `GetBlockScriptFlags`
+        (`src/validation.cpp`, at bitcoin/bitcoin@9be056a8a7), which is
+        what `btclib.script.engine.verify_input` takes as its `flags`.
+
+        P2SH, segwit v0 and taproot are on for every block of every
+        chain, and the height decides only the four that Core gates on a
+        buried deployment: DERSIG, CHECKLOCKTIMEVERIFY,
+        CHECKSEQUENCEVERIFY, and NULLDUMMY with segwit. The blocks that
+        predate a rule and would fail it are exceptions by hash, not by
+        height -- pass `block_hash` to have them answered, and the flags
+        such a block gets are the entry's own rather than the default
+        set, with the height-gated rules still added on top.
+
+        The standardness flags are never returned: a block breaking one
+        of those is valid, which is `btclib.script.engine.flags`'s own
+        split between what `ALL_FLAGS` carries and what it leaves off.
+        """
+        # imported here and not above: `btclib.script.engine` imports
+        # `btclib.script.witness`, which imports this module, so an
+        # import at module level is issue #147's cycle. Deferring it
+        # keeps this module's import graph empty, which is the property
+        # `tests/imports_test.py` holds it to, and costs the caller a
+        # sys.modules lookup once the engine is loaded -- which it is,
+        # anybody asking for these flags being about to run a script
+        from btclib.script.engine.flags import to_script_flags  # noqa: PLC0415
+        from btclib.utils import bytes_from_octets, is_integer  # noqa: PLC0415
+
+        if not is_integer(height):
+            from btclib.exceptions import BTClibTypeError  # noqa: PLC0415
+
+            err_msg = f"invalid height type: {type(height).__name__}"
+            raise BTClibTypeError(err_msg)
+
+        names = _ALWAYS_ON_FLAGS
+        if block_hash is not None:
+            hash_ = bytes_from_octets(block_hash)
+            for exception_hash, exception_names in self.script_flag_exceptions:
+                if hash_ == exception_hash:
+                    names = exception_names
+                    break
+
+        # the four Core asks DeploymentActiveAt about, in its order. A
+        # height at or above the activation height is where the rule
+        # binds, which is the same comparison `BlockContext.is_bip34_active`
+        # makes for the fifth buried deployment
+        gated = (
+            (self.bip66_height, "DERSIG"),
+            (self.bip65_height, "CHECKLOCKTIMEVERIFY"),
+            (self.csv_height, "CHECKSEQUENCEVERIFY"),
+            (self.segwit_height, "NULLDUMMY"),
+        )
+        names = (*names, *(name for at, name in gated if height >= at))
+        return to_script_flags(names)
+
+
+# Core's mainnet and testnet3 powLimit, 00000000ffff...ffff, and
+# regtest's 7fff...ffff and signet's 00000377ae00...00, each as the
+# compact form `bits_from_target` answers for it
+_POW_LIMIT_BITS_MAIN = b"\x1d\x00\xff\xff"
+_POW_LIMIT_BITS_REGTEST = b"\x20\x7f\xff\xff"
+_POW_LIMIT_BITS_SIGNET = b"\x1e\x03\x77\xae"
+
+# every network of btclib.network.NETWORKS, in its order. Fixed at
+# import and read-only for the reason that catalogue is: a row added
+# afterwards would be in one table and in neither the other nor the
+# Network instances built from it
+_consensus_params: dict[str, ConsensusParams] = {
+    # read at lines 84 to 117 of chainparams.cpp, and at IsBIP30Repeat in
+    # validation.cpp for the blocks of 2010 whose coinbase repeats an earlier
+    # one
+    "mainnet": ConsensusParams(
+        name="mainnet",
+        subsidy_halving_interval=210_000,
+        bip34_height=227_931,
+        bip66_height=363_725,
+        bip65_height=388_381,
+        csv_height=419_328,
+        segwit_height=481_824,
+        pow_limit_bits=_POW_LIMIT_BITS_MAIN,
+        pow_allow_min_difficulty_blocks=False,
+        enforce_bip94=False,
+        pow_no_retargeting=False,
+        minimum_chain_work=0x0000000000000000000000000000000000000001128750F82F4C366153A3A030,
+        bip30_exceptions=(
+            (
+                91_842,
+                bytes.fromhex(
+                    "00000000000a4d0a398161ffc163c503763b1f4360639393e0e4c8e300e0caec"
+                ),
+            ),
+            (
+                91_880,
+                bytes.fromhex(
+                    "00000000000743f190a18c5577a3c2d2a1f610ae9601ac046a38084ccb7cd721"
+                ),
+            ),
+        ),
+        script_flag_exceptions=(
+            # the BIP16 exception: a block mined the day P2SH took effect
+            # whose spend is not a valid P2SH one, checked with no flag
+            # at all
+            (
+                bytes.fromhex(
+                    "00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22"
+                ),
+                (),
+            ),
+            # the taproot exception: an annex was spent here before the
+            # rule refusing it bound, so this block is checked with
+            # taproot off and the two older rules on
+            (
+                bytes.fromhex(
+                    "0000000000000000000f14c35b2d841e986ab5441de8c585d5ffe55ea1e395ad"
+                ),
+                ("P2SH", "WITNESS"),
+            ),
+        ),
+    ),
+    # read at lines 217 to 248 of chainparams.cpp
+    "testnet": ConsensusParams(
+        name="testnet",
+        subsidy_halving_interval=210_000,
+        bip34_height=21_111,
+        bip66_height=330_776,
+        bip65_height=581_885,
+        csv_height=770_112,
+        segwit_height=834_624,
+        pow_limit_bits=_POW_LIMIT_BITS_MAIN,
+        pow_allow_min_difficulty_blocks=True,
+        enforce_bip94=False,
+        pow_no_retargeting=False,
+        minimum_chain_work=0x0000000000000000000000000000000000000000000017DDE1C649F3708D14B6,
+        bip30_exceptions=(),
+        script_flag_exceptions=(
+            # testnet3's own BIP16 exception, the mainnet one's twin
+            (
+                bytes.fromhex(
+                    "00000000dd30457c001f4095d208cc1296b0eed002427aa599874af7a432b105"
+                ),
+                (),
+            ),
+        ),
+    ),
+    # read at lines 567 to 596 of chainparams.cpp. Every rule binds at
+    # height 1 except
+    # segwit, which binds at the genesis block: a chain mined for a test
+    # is not a chain with a history to be compatible with
+    "regtest": ConsensusParams(
+        name="regtest",
+        subsidy_halving_interval=150,
+        bip34_height=1,
+        bip66_height=1,
+        bip65_height=1,
+        csv_height=1,
+        segwit_height=0,
+        pow_limit_bits=_POW_LIMIT_BITS_REGTEST,
+        pow_allow_min_difficulty_blocks=True,
+        # the only row whose value is not written in chainparams.cpp:
+        # line 579 assigns `opts.enforce_bip94`, and the option defaults
+        # to false at chainparams.h:154, so false is what a regtest node
+        # runs unless `-test=bip94` is passed. The same shape as the
+        # heights above it, which the file marks "always active unless
+        # overridden": the table carries what Core ships, not what a
+        # command line can make of it
+        enforce_bip94=False,
+        pow_no_retargeting=True,
+        minimum_chain_work=0,
+        bip30_exceptions=(),
+        script_flag_exceptions=(),
+    ),
+    # read at lines 478 to 491 of chainparams.cpp for the heights and the
+    # limit, and at line 447 for the work, which the default signet carries
+    # and a custom challenge leaves empty
+    "signet": ConsensusParams(
+        name="signet",
+        subsidy_halving_interval=210_000,
+        bip34_height=1,
+        bip66_height=1,
+        bip65_height=1,
+        csv_height=1,
+        segwit_height=1,
+        pow_limit_bits=_POW_LIMIT_BITS_SIGNET,
+        pow_allow_min_difficulty_blocks=False,
+        enforce_bip94=False,
+        pow_no_retargeting=False,
+        minimum_chain_work=0x00000000000000000000000000000000000000000000000000000B463EA0A4B8,
+        bip30_exceptions=(),
+        script_flag_exceptions=(),
+    ),
+    # read at lines 326 to 356 of chainparams.cpp
+    "testnet4": ConsensusParams(
+        name="testnet4",
+        subsidy_halving_interval=210_000,
+        bip34_height=1,
+        bip66_height=1,
+        bip65_height=1,
+        csv_height=1,
+        segwit_height=1,
+        pow_limit_bits=_POW_LIMIT_BITS_MAIN,
+        pow_allow_min_difficulty_blocks=True,
+        # true here alone, testnet4 being the chain BIP94 was written for
+        enforce_bip94=True,
+        pow_no_retargeting=False,
+        minimum_chain_work=0x0000000000000000000000000000000000000000000009A0FE15D0177D086304,
+        bip30_exceptions=(),
+        script_flag_exceptions=(),
+    ),
+}
+
+# a mapping and not a dict, for the reason NETWORKS is one: `Network`
+# instances are built from these rows at import, so a row added
+# afterwards would answer here and nowhere else
+CONSENSUS_PARAMS: Mapping[str, ConsensusParams] = MappingProxyType(_consensus_params)

--- a/src/btclib/network.py
+++ b/src/btclib/network.py
@@ -12,7 +12,9 @@ version, plus the two version sets a caller matches against.
 fields are the prefixes and version bytes a network spells its keys and
 addresses with, plus the genesis block; every one of them is the same for
 every deployment of that network, so there is nothing here for a caller to
-register and the catalogue is a read-only mapping. What *is* per
+register and the catalogue is a read-only mapping.
+
+What *is* per
 deployment -- a custom signet's p2p magic, which its challenge determines
 -- is a fact about a node rather than about an encoding, and lives where
 the node is spoken to: `bitcoin_core_rpc.magic_from_signet_challenge`, and
@@ -20,6 +22,15 @@ the node is spoken to: `bitcoin_core_rpc.magic_from_signet_challenge`, and
 Fixed at import is what lets the reverse lookups below be tables built
 once: a network registered afterwards would be found by a scan and missed
 by a precomputed index, which is the disagreement issue 683 recorded.
+
+The one field that is not an encoding is `consensus`, and it is a
+reference rather than a copy: `btclib.consensus.CONSENSUS_PARAMS` holds
+the rules each of these networks validates by, this module holds the
+spellings a chain's keys and addresses are written in, and a `Network`
+carries the row so that the two tables cannot disagree about which
+networks exist. That module imports nothing of btclib, so reading an
+activation height costs no import of this one, which is the direction
+that decides where the table lives.
 
 `datadir` stays out, and this is where that decision is recorded: it is
 where this package keeps the five json files loaded at the bottom of this
@@ -39,6 +50,7 @@ from types import MappingProxyType
 from typing import Any
 
 from btclib.alias import NetworkField, NetworkName, NetworkType, Octets
+from btclib.consensus import CONSENSUS_PARAMS, ConsensusParams
 from btclib.curves import Curve
 from btclib.curves.curve import CURVES, _assert_valid_ec
 from btclib.exceptions import BTClibTypeError, BTClibValueError
@@ -95,16 +107,33 @@ def _curve_from_name(name: Any) -> Curve:
     return CURVES[name]
 
 
+def _consensus_from_name(name: Any) -> ConsensusParams:
+    """Return the consensus row a name names, refusing what names none.
+
+    `_curve_from_name` above, for the other table a network dict points
+    at, and refusing for the same two reasons: `CONSENSUS_PARAMS[...]`
+    answers an unknown name with a `KeyError` and an unhashable one with
+    a `TypeError` about dict keys, neither of which this library tells a
+    caller to catch.
+    """
+    assert_type(name, str, "consensus name")
+    if name not in CONSENSUS_PARAMS:
+        raise BTClibValueError(f"unknown consensus parameters: {name}")
+    return CONSENSUS_PARAMS[name]
+
+
 @dataclass(frozen=True)
 class Network:
     """The encoding table of one network: prefixes, versions, genesis.
 
     What tells a mainnet spelling from a test one -- wif and address
     prefixes, the bech32 hrp, the BIP32 and SLIP132 version bytes --
-    plus the genesis block hash. No consensus parameter lives here, and
-    no p2p one: the message start belongs to the code that speaks to a
-    node, `bitcoin_core_rpc.magic_from_chain` being where it is, because
-    a custom signet's is a function of its challenge and therefore not a
+    plus the genesis block hash and the consensus row of the chain those
+    spell keys for. No consensus parameter is written out here, `consensus`
+    being a reference to `btclib.consensus`'s own table; and no p2p one at
+    all: the message start belongs to the code that speaks to a node,
+    `bitcoin_core_rpc.magic_from_chain` being where it is, because a
+    custom signet's is a function of its challenge and therefore not a
     field any table can hold. NETWORKS holds the built-in instances, and
     the ``*_from_network`` and ``*_from_xkeyversion`` functions below
     are the lookups.
@@ -116,6 +145,12 @@ class Network:
     # one question the version bytes can still answer, and the three
     # network_type_from_* functions below for the answering
     network_type: NetworkType
+
+    # the rules this chain validates by, one of btclib.consensus's rows.
+    # A field and not a lookup keyed on something else: a Network carries
+    # no name of its own, and a caller building one for a chain this
+    # library does not ship has a row to hand it
+    consensus: ConsensusParams
 
     genesis_block: bytes
 
@@ -174,10 +209,16 @@ class Network:
         # a forgotten argument claim a made-up chain is the real one
         network_type: NetworkType = "test",
         *,
+        # keyword-only and required, where network_type is positional and
+        # defaulted: no row is the safe answer for a network nobody named,
+        # the way "test" is the safe network type, so this is asked for
+        # rather than guessed
+        consensus: ConsensusParams,
         check_validity: bool = True,
     ) -> None:
         object.__setattr__(self, "curve", curve)
         object.__setattr__(self, "network_type", network_type)
+        object.__setattr__(self, "consensus", consensus)
         object.__setattr__(self, "genesis_block", bytes_from_octets(genesis_block))
 
         object.__setattr__(self, "wif", bytes_from_octets(wif))
@@ -229,6 +270,10 @@ class Network:
         return {
             "curve": self.curve.name,
             "network_type": self.network_type,
+            # the row's name and not its fields: this dict is the network's
+            # own spellings, and the consensus parameters are written once,
+            # where they are transcribed
+            "consensus": self.consensus.name,
             "genesis_block": self.genesis_block.hex(),
             "wif": self.wif.hex(),
             "p2pkh": self.p2pkh.hex(),
@@ -272,6 +317,7 @@ class Network:
             # .get, alone among these keys: a dict serialized before the
             # field existed still loads, as a test network
             dict_.get("network_type", "test"),
+            consensus=_consensus_from_name(dict_["consensus"]),
             check_validity=check_validity,
         )
 
@@ -291,6 +337,11 @@ class Network:
         # bytes fields, TypeError being what they raise for a field
         # rebound to something else
         assert_type(self.hrp, str, "hrp")
+
+        # the row a dict points at is resolved by from_dict, so what this
+        # catches is a Network built in code with something else in the
+        # field -- and every reader of it below expects the dataclass
+        assert_type(self.consensus, ConsensusParams, "consensus")
 
         # NetworkType is a Literal, which is a mypy fact and not a runtime
         # one: from_dict takes whatever the json says, so this is the only

--- a/tests/_generated_files/mainnet.json
+++ b/tests/_generated_files/mainnet.json
@@ -1,6 +1,7 @@
 {
     "curve": "secp256k1",
     "network_type": "main",
+    "consensus": "mainnet",
     "genesis_block": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
     "wif": "80",
     "p2pkh": "00",

--- a/tests/_generated_files/regtest.json
+++ b/tests/_generated_files/regtest.json
@@ -1,6 +1,7 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
+    "consensus": "regtest",
     "genesis_block": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
     "wif": "ef",
     "p2pkh": "6f",

--- a/tests/_generated_files/signet.json
+++ b/tests/_generated_files/signet.json
@@ -1,6 +1,7 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
+    "consensus": "signet",
     "genesis_block": "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
     "wif": "ef",
     "p2pkh": "6f",

--- a/tests/_generated_files/testnet.json
+++ b/tests/_generated_files/testnet.json
@@ -1,6 +1,7 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
+    "consensus": "testnet",
     "genesis_block": "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
     "wif": "ef",
     "p2pkh": "6f",

--- a/tests/_generated_files/testnet4.json
+++ b/tests/_generated_files/testnet4.json
@@ -1,6 +1,7 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
+    "consensus": "testnet4",
     "genesis_block": "00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043",
     "wif": "ef",
     "p2pkh": "6f",

--- a/tests/consensus_test.py
+++ b/tests/consensus_test.py
@@ -1,0 +1,383 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the per-network consensus table.
+
+`CONSENSUS_PARAMS` is a transcription, so what a test can do for it is
+say what it was transcribed from: `_CHAINPARAMS` below writes Core's
+values out a second time, off the same lines of the same blob the module
+cites, and the first test compares them field by field. A value edited in
+one of the two places is then a failing test rather than a silent
+agreement -- which is the whole of what a table copied from another
+project can be held to, short of building that project.
+
+Two of them are not restatements but derivations, and are the stronger
+half. `pow_limit_bits` is compared against `bits_from_target` of Core's
+own 32-byte `powLimit`, so the compact form is computed here rather than
+read off the module; and `script_flags_at` is compared against Core's
+`GetBlockScriptFlags` written out as a rule -- the three flags on for
+every block, the four gated on a buried deployment, and the exception
+looked up by hash -- rather than against a table of answers.
+
+The blob is Bitcoin Core v31.1, `bitcoin/bitcoin@9be056a8a7`. A tag and
+not a branch tip, so the line numbers beside each row cannot move under
+the citation; `src/btclib/consensus.py` says why that release.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from typing import Any
+
+import pytest
+
+from btclib.block.proof_of_work import bits_from_target
+from btclib.consensus import CONSENSUS_PARAMS, ConsensusParams
+from btclib.exceptions import BTClibTypeError
+from btclib.network import NETWORKS
+from btclib.script.engine.flags import NO_FLAGS, ScriptFlag
+
+# Core's own `powLimit`, the 32 bytes `uint256{"..."}` spells, per
+# network. The module stores the compact form of each; that this is what
+# it is the compact form *of* is what the derivation below asks
+_POW_LIMIT = {
+    "mainnet": "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "testnet": "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "regtest": "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "signet": "00000377ae000000000000000000000000000000000000000000000000000000",
+    "testnet4": "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+}
+
+# src/kernel/chainparams.cpp, at the tag above: the class of each chain
+# type, read at the lines the module's own rows cite. `bip30_exceptions`
+# is src/validation.cpp's `IsBIP30Repeat` instead, which is where Core
+# hardcodes the pair rather than keeping it in the params struct
+_CHAINPARAMS: dict[str, dict[str, Any]] = {
+    "mainnet": {
+        "subsidy_halving_interval": 210000,
+        "bip34_height": 227931,
+        "bip66_height": 363725,
+        "bip65_height": 388381,
+        "csv_height": 419328,
+        "segwit_height": 481824,
+        "pow_allow_min_difficulty_blocks": False,
+        "enforce_bip94": False,
+        "pow_no_retargeting": False,
+        "minimum_chain_work": int(
+            "0000000000000000000000000000000000000001128750f82f4c366153a3a030", 16
+        ),
+        "bip30_exceptions": (
+            (
+                91842,
+                bytes.fromhex(
+                    "00000000000a4d0a398161ffc163c503763b1f4360639393e0e4c8e300e0caec"
+                ),
+            ),
+            (
+                91880,
+                bytes.fromhex(
+                    "00000000000743f190a18c5577a3c2d2a1f610ae9601ac046a38084ccb7cd721"
+                ),
+            ),
+        ),
+        "script_flag_exceptions": (
+            (
+                bytes.fromhex(
+                    "00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22"
+                ),
+                (),
+            ),
+            (
+                bytes.fromhex(
+                    "0000000000000000000f14c35b2d841e986ab5441de8c585d5ffe55ea1e395ad"
+                ),
+                ("P2SH", "WITNESS"),
+            ),
+        ),
+    },
+    "testnet": {
+        "subsidy_halving_interval": 210000,
+        "bip34_height": 21111,
+        "bip66_height": 330776,
+        "bip65_height": 581885,
+        "csv_height": 770112,
+        "segwit_height": 834624,
+        "pow_allow_min_difficulty_blocks": True,
+        "enforce_bip94": False,
+        "pow_no_retargeting": False,
+        "minimum_chain_work": int(
+            "0000000000000000000000000000000000000000000017dde1c649f3708d14b6", 16
+        ),
+        "bip30_exceptions": (),
+        "script_flag_exceptions": (
+            (
+                bytes.fromhex(
+                    "00000000dd30457c001f4095d208cc1296b0eed002427aa599874af7a432b105"
+                ),
+                (),
+            ),
+        ),
+    },
+    "regtest": {
+        "subsidy_halving_interval": 150,
+        "bip34_height": 1,
+        "bip66_height": 1,
+        "bip65_height": 1,
+        "csv_height": 1,
+        # zero, alone among the five buried deployments and alone among
+        # the networks: segwit binds on regtest from the genesis block
+        "segwit_height": 0,
+        "pow_allow_min_difficulty_blocks": True,
+        # `opts.enforce_bip94` at chainparams.cpp:579, and the option's
+        # own default is false at chainparams.h:154: what a regtest node
+        # runs with, `-test=bip94` not being passed
+        "enforce_bip94": False,
+        "pow_no_retargeting": True,
+        # `uint256{}`, which is no work at all: a chain mined for a test
+        # never leaves initial block download on this comparison
+        "minimum_chain_work": 0,
+        "bip30_exceptions": (),
+        "script_flag_exceptions": (),
+    },
+    "signet": {
+        "subsidy_halving_interval": 210000,
+        "bip34_height": 1,
+        "bip66_height": 1,
+        "bip65_height": 1,
+        "csv_height": 1,
+        "segwit_height": 1,
+        "pow_allow_min_difficulty_blocks": False,
+        "enforce_bip94": False,
+        "pow_no_retargeting": False,
+        # the default signet's, which chainparams assigns above the class
+        # body's own block: a custom challenge gets `uint256{}` instead
+        "minimum_chain_work": int(
+            "00000000000000000000000000000000000000000000000000000b463ea0a4b8", 16
+        ),
+        "bip30_exceptions": (),
+        "script_flag_exceptions": (),
+    },
+    "testnet4": {
+        "subsidy_halving_interval": 210000,
+        "bip34_height": 1,
+        "bip66_height": 1,
+        "bip65_height": 1,
+        "csv_height": 1,
+        "segwit_height": 1,
+        "pow_allow_min_difficulty_blocks": True,
+        # true on testnet4 alone, the chain BIP94 was written for
+        "enforce_bip94": True,
+        "pow_no_retargeting": False,
+        "minimum_chain_work": int(
+            "0000000000000000000000000000000000000000000009a0fe15d0177d086304", 16
+        ),
+        "bip30_exceptions": (),
+        "script_flag_exceptions": (),
+    },
+}
+
+# Core's GetBlockScriptFlags, as the rule rather than as an answer: the
+# three it turns on for every block of every chain, and the four it asks
+# a buried deployment about, each named by the field holding the height
+_ALWAYS_ON = ScriptFlag.P2SH | ScriptFlag.WITNESS | ScriptFlag.TAPROOT
+_GATED = (
+    ("bip66_height", ScriptFlag.DERSIG),
+    ("bip65_height", ScriptFlag.CHECKLOCKTIMEVERIFY),
+    ("csv_height", ScriptFlag.CHECKSEQUENCEVERIFY),
+    ("segwit_height", ScriptFlag.NULLDUMMY),
+)
+
+
+def test_the_transcription_covers_every_field_a_row_has() -> None:
+    """Every field of a row is one `_CHAINPARAMS` holds to Core's value.
+
+    The test below walks `_CHAINPARAMS`, so a field added to
+    `ConsensusParams` and left out of the table above runs no assertion
+    rather than failing one -- which is the defect this has the shape of,
+    and it is how a field arrives: beside the others, in the dataclass
+    first.
+
+    Two fields are held elsewhere and are named here rather than left to
+    be noticed: `name` has nothing in Core to compare against, being
+    btclib's own key into `CONSENSUS_PARAMS`, and
+    `test_the_table_answers_for_the_networks_the_encodings_name` holds
+    it; `pow_limit_bits` is derived from `_POW_LIMIT` rather than
+    restated, which is the stronger check and is why it is not in the
+    table above.
+    """
+    held_elsewhere = {"name", "pow_limit_bits"}
+    assert {f.name for f in fields(ConsensusParams)} == {
+        *held_elsewhere,
+        *_CHAINPARAMS["mainnet"],
+    }
+    assert set(_POW_LIMIT) == set(_CHAINPARAMS)
+    for network, transcribed in _CHAINPARAMS.items():
+        assert set(transcribed) == set(_CHAINPARAMS["mainnet"]), network
+
+
+@pytest.mark.parametrize("network", sorted(_CHAINPARAMS))
+def test_every_field_is_the_one_core_carries(network: str) -> None:
+    """Compare each field of a row with the transcription above."""
+    row = CONSENSUS_PARAMS[network]
+    for field, expected in _CHAINPARAMS[network].items():
+        assert getattr(row, field) == expected, (network, field)
+
+
+@pytest.mark.parametrize("network", sorted(_POW_LIMIT))
+def test_the_pow_limit_is_the_compact_form_of_cores_own(network: str) -> None:
+    """Derive `pow_limit_bits` from Core's 32-byte powLimit.
+
+    The compact form rounds down, so this is not a round trip and cannot
+    be written as one: `target_from_bits` of the answer is below Core's
+    value for every network but signet. What the encoding preserves is
+    the comparison, the next target the compact form can express above
+    the rounded one being already above Core's own limit.
+    """
+    core_limit = bytes.fromhex(_POW_LIMIT[network])
+    assert CONSENSUS_PARAMS[network].pow_limit_bits == bits_from_target(core_limit)
+
+
+def test_the_table_answers_for_the_networks_the_encodings_name() -> None:
+    """Every network of NETWORKS has a row, and carries that row.
+
+    The two tables are keyed by the same names on purpose: a network
+    reachable from one and not the other is what having a single
+    `consensus` field on `Network` is there to make impossible.
+    """
+    assert set(CONSENSUS_PARAMS) == set(NETWORKS)
+    for name, row in CONSENSUS_PARAMS.items():
+        assert row.name == name
+        assert NETWORKS[name].consensus is row
+
+
+def test_the_table_is_read_only() -> None:
+    """Refuse a row assigned into the catalogue after import.
+
+    `NETWORKS` is fixed at import for the reason its own module gives,
+    and every `Network` in it holds one of these rows: a row replaced
+    here afterwards would answer in this table and nowhere else.
+    """
+    mutable: Any = CONSENSUS_PARAMS
+    with pytest.raises(TypeError, match="does not support item assignment"):
+        mutable["mainnet"] = CONSENSUS_PARAMS["regtest"]
+
+
+def test_a_row_is_hashable_as_the_network_holding_it_is() -> None:
+    """Verify a row can be a dict key, which `Network` needs it to be."""
+    assert len(set(CONSENSUS_PARAMS.values())) == len(CONSENSUS_PARAMS)
+    assert hash(NETWORKS["mainnet"]) == hash(NETWORKS["mainnet"])
+
+
+@pytest.mark.parametrize("network", sorted(_CHAINPARAMS))
+def test_script_flags_at_is_cores_get_block_script_flags(network: str) -> None:
+    """Answer each activation height and its neighbours as Core does.
+
+    Every height at which the answer can change is asked about, and the
+    one below it: the four buried deployments' own heights, and zero,
+    which is where segwit binds on regtest and no rule binds anywhere
+    else.
+    """
+    row = CONSENSUS_PARAMS[network]
+    heights = {0}
+    for field, _ in _GATED:
+        at = getattr(row, field)
+        heights |= {at - 1, at, at + 1}
+    for height in sorted(h for h in heights if h >= 0):
+        expected = _ALWAYS_ON
+        for field, flag in _GATED:
+            if height >= getattr(row, field):
+                expected |= flag
+        assert row.script_flags_at(height) == expected, (network, height)
+
+
+def test_taproot_is_on_from_the_genesis_block_of_every_chain() -> None:
+    """Verify no height gates P2SH, segwit v0 or taproot.
+
+    Core turns the three on for every block and names the blocks that
+    fail them one by one, so a table of activation heights has no row
+    for taproot to be wrong about -- which is the value btclib-node's
+    own copy records as a date rather than a height.
+    """
+    for row in CONSENSUS_PARAMS.values():
+        assert row.script_flags_at(0) & ScriptFlag.TAPROOT
+        assert row.script_flags_at(0) & ScriptFlag.P2SH
+        assert row.script_flags_at(0) & ScriptFlag.WITNESS
+
+
+def test_an_exception_block_is_answered_by_its_hash() -> None:
+    """Replace the default flags with the exception's, and gate the rest.
+
+    Core's `GetBlockScriptFlags` assigns the entry it finds over the
+    three defaults and then adds the height-gated rules on top, so an
+    exception block high enough on the chain is not checked with no rule
+    at all.
+    """
+    mainnet = CONSENSUS_PARAMS["mainnet"]
+    bip16_block, taproot_block = (h for h, _ in mainnet.script_flag_exceptions)
+
+    # the BIP16 exception sits below every gated height, so nothing is
+    # added back and the block is checked with no rule at all
+    assert mainnet.script_flags_at(170_060, bip16_block) == NO_FLAGS
+    # the taproot exception sits above all four, so the entry's own two
+    # flags come back with the four gated ones on top -- and without the
+    # taproot flag the block fails
+    at_taproot = mainnet.script_flags_at(709_632, taproot_block)
+    assert not at_taproot & ScriptFlag.TAPROOT
+    assert at_taproot & ScriptFlag.NULLDUMMY
+    assert at_taproot & ScriptFlag.P2SH
+
+
+def test_a_hash_that_is_not_an_exception_changes_nothing() -> None:
+    """Answer the same for an ordinary block as for no hash at all.
+
+    Both halves: a chain with exceptions to scan through, and one with
+    none to scan at all.
+    """
+    ordinary = bytes(32)
+    for name in ("mainnet", "regtest"):
+        row = CONSENSUS_PARAMS[name]
+        assert row.script_flags_at(500_000, ordinary) == row.script_flags_at(500_000)
+
+    # and the hex spelling of a hash is an Octets like any other
+    mainnet = CONSENSUS_PARAMS["mainnet"]
+    bip16_block = mainnet.script_flag_exceptions[0][0]
+    assert mainnet.script_flags_at(170_060, bip16_block.hex()) == NO_FLAGS
+
+
+@pytest.mark.parametrize("height", ["227931", 227931.0, True, None])
+def test_script_flags_at_refuses_a_height_that_is_not_one(height: Any) -> None:
+    """Refuse a height that is not an integer, a bool included.
+
+    `btclib.exceptions` is imported inside the method for the reason the
+    module docstring gives, so this is also what says that import runs.
+    """
+    with pytest.raises(BTClibTypeError, match="invalid height type"):
+        CONSENSUS_PARAMS["mainnet"].script_flags_at(height)
+
+
+def test_a_row_can_be_built_for_a_chain_this_library_does_not_ship() -> None:
+    """Build a row of one's own, which a custom signet needs.
+
+    `Network` takes the row as a required keyword argument rather than
+    defaulting it, so a caller with a chain of their own supplies both
+    halves; nothing here validates it, the module docstring saying why.
+    """
+    custom = ConsensusParams(
+        name="custom-signet",
+        subsidy_halving_interval=210_000,
+        bip34_height=1,
+        bip66_height=1,
+        bip65_height=1,
+        csv_height=1,
+        segwit_height=1,
+        pow_limit_bits=CONSENSUS_PARAMS["signet"].pow_limit_bits,
+        pow_allow_min_difficulty_blocks=False,
+        enforce_bip94=False,
+        pow_no_retargeting=False,
+        minimum_chain_work=0,
+        bip30_exceptions=(),
+        script_flag_exceptions=(),
+    )
+    assert custom.script_flags_at(1) == CONSENSUS_PARAMS["signet"].script_flags_at(1)
+    assert custom != CONSENSUS_PARAMS["signet"]

--- a/tests/curve_parameter_test.py
+++ b/tests/curve_parameter_test.py
@@ -80,6 +80,7 @@ import pytest
 
 from btclib.b58 import wif_from_prv_key
 from btclib.bip32.bip32 import BIP32KeyData, rootxprv_from_seed, xpub_from_xprv
+from btclib.consensus import CONSENSUS_PARAMS
 from btclib.curves import CurveGroup, secp256k1
 from btclib.curves.curve import (
     Curve,
@@ -144,9 +145,16 @@ _GROUP_G = (1, 9)
 
 # every field of mainnet but its curve, in the hex spelling to_dict writes
 # and the constructor takes
-_NETWORK_ARGS = {
-    key: value for key, value in NETWORKS["mainnet"].to_dict().items() if key != "curve"
+# `to_dict` writes the curve and the consensus row as the names they are
+# catalogued under, so each is put back here as the object the
+# constructor takes rather than as the name -- the curve by the case
+# below, which is what this file varies, and the row by hand
+_NETWORK_ARGS: dict[str, Any] = {
+    key: value
+    for key, value in NETWORKS["mainnet"].to_dict().items()
+    if key not in {"curve", "consensus"}
 }
+_NETWORK_ARGS["consensus"] = CONSENSUS_PARAMS["mainnet"]
 
 
 @dataclass(frozen=True)
@@ -378,9 +386,9 @@ _CASES = (
     ),
     # the one curve parameter that is a field rather than an argument to
     # compute with, and the one not called `ec`. `to_dict`'s keys are the
-    # constructor's parameter names, the curve excepted -- it goes out as a
-    # name and comes back as the catalogued curve -- so the valid call is
-    # mainnet rebuilt from its own dict
+    # constructor's parameter names, so the valid call is mainnet rebuilt
+    # from its own dict, with the two names `_NETWORK_ARGS` resolves back
+    # into objects
     _Case(
         "btclib.network.Network.__init__",
         Network,

--- a/tests/imports_test.py
+++ b/tests/imports_test.py
@@ -113,6 +113,29 @@ def test_exceptions_imports_nothing_of_btclibs_and_no_client(
     assert "'urllib.request'" not in loaded
 
 
+def test_consensus_imports_nothing_of_btclibs(unimported_btclib: None) -> None:
+    """btclib.consensus declares its constants and reaches nothing.
+
+    The per-network table lives there rather than beside `Network`
+    because of this: `btclib.block`, `btclib.tx` and `btclib.script` all
+    read something of it, `btclib.network` reads it to give each network
+    its `consensus` row, and an import in the other direction would be
+    the cycle of issue #147 -- `btclib.script.engine` imports
+    `btclib.script.witness`, which imports this module.
+
+    The second half is what makes `ConsensusParams.script_flags_at`
+    possible at all. It answers a `ScriptFlag`, whose enum is inside that
+    cycle, so it imports the engine when it is called rather than when
+    this module is: importing costs nothing, and asking for the flags is
+    what brings the engine in.
+    """
+    consensus = importlib.import_module("btclib.consensus")
+    assert set(btclib_modules()) == {"btclib", "btclib.consensus"}
+
+    consensus.CONSENSUS_PARAMS["mainnet"].script_flags_at(0)
+    assert "btclib.script.engine.flags" in btclib_modules()
+
+
 def test_the_codec_does_not_pay_for_the_rpc_package() -> None:
     """`btclib.p2p` publishes the message start without importing it.
 

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -222,7 +222,7 @@ KEYWORD_ONLY: dict[str, list[str]] = {
     ],
     "btclib.key:PrvKeyData.__init__": ["check_validity"],
     "btclib.key:PubKeyData.__init__": ["check_validity"],
-    "btclib.network:Network.__init__": ["check_validity"],
+    "btclib.network:Network.__init__": ["consensus", "check_validity"],
     "btclib.network:Network.from_dict": ["check_validity"],
     "btclib.network:Network.to_dict": ["check_validity"],
     "btclib.p2p:Addr.__init__": ["check_validity"],

--- a/tests/network_test.py
+++ b/tests/network_test.py
@@ -10,6 +10,7 @@ from typing import Any, get_args
 import pytest
 
 from btclib.alias import NetworkField, NetworkName
+from btclib.consensus import CONSENSUS_PARAMS
 from btclib.curves.curve import CURVES
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.network import (
@@ -52,6 +53,7 @@ def test_bad_network() -> None:
             slip132_p2wsh_pub="02aa7ed3",
             slip132_p2wsh_p2sh_prv="0295b005",
             slip132_p2wsh_p2sh_pub="0295b43f",
+            consensus=CONSENSUS_PARAMS["mainnet"],
         )
 
 
@@ -159,12 +161,13 @@ def test_dataclasses_json_dict(json_golden: JsonGolden) -> None:
         json_golden(f"{network_name}.json", net.to_dict())
 
 
-def test_the_test_networks_differ_from_testnet_in_the_genesis_block() -> None:
-    """Signet and testnet4 reuse everything of testnet but the chain.
+def test_the_test_networks_differ_from_testnet_in_the_chain_not_the_spelling() -> None:
+    """Signet and testnet4 reuse every spelling of testnet, and no rule.
 
     The wif, p2pkh, p2sh, hrp and bip32 version bytes are testnet's,
     which is the whole reason the reverse lookups have an ambiguity to
-    answer for; what a network of its own buys them is a genesis block --
+    answer for; what a network of its own buys them is a chain, which is
+    a genesis block and the consensus row that chain is validated by --
     and, outside this table, a p2p magic, which identifies a *node* and
     lives in `bitcoin_core_rpc` with the rest of what Core reports.
     """
@@ -175,7 +178,7 @@ def test_the_test_networks_differ_from_testnet_in_the_genesis_block() -> None:
             for key, value in NETWORKS[name].to_dict().items()
             if testnet[key] != value
         }
-        expected = {"genesis_block"}
+        expected = {"genesis_block", "consensus"}
         if name == "regtest":
             expected.add("hrp")  # bcrt, where signet and testnet4 are tb
         assert differing == expected, name

--- a/tests/serialization_boundary_test.py
+++ b/tests/serialization_boundary_test.py
@@ -472,17 +472,17 @@ def test_a_json_array_is_asked_before_it_is_walked(
             cls.from_dict(broken)
 
 
-def test_the_two_fields_from_dict_converts_itself() -> None:
-    """The two fields no constructor sees as they were written.
+def test_the_fields_from_dict_converts_itself() -> None:
+    """The fields no constructor sees as they were written.
 
-    A header's time and a network's curve. Every other field of every
-    `from_dict` here is handed to a constructor, which is where
-    `assert_valid` asks about it; these two
-    are converted first -- one by `datetime.fromisoformat`, which
+    A header's time, and a network's curve and consensus row. Every other
+    field of every `from_dict` here is handed to a constructor, which is
+    where `assert_valid` asks about it; these
+    are converted first -- the time by `datetime.fromisoformat`, which
     refuses what is not a string with a TypeError of its own and an
-    unreadable one with a bare ValueError, and one by a lookup in
-    `CURVES`, which answers an unknown name with a `KeyError` and an
-    unhashable one with a TypeError about dict keys.
+    unreadable one with a bare ValueError, and the other two by a lookup
+    in a catalogue, which answers an unknown name with a `KeyError` and
+    an unhashable one with a TypeError about dict keys.
     """
     header = _as_json(_BLOCK.header)
     for wrong in _WRONG_TYPES:
@@ -497,6 +497,12 @@ def test_the_two_fields_from_dict_converts_itself() -> None:
             Network.from_dict({**network, "curve": wrong})
     with pytest.raises(BTClibValueError, match="unknown curve"):
         Network.from_dict({**network, "curve": "secp256k2"})
+
+    for wrong in (*_WRONG_TYPES, {"a": 1}):
+        with pytest.raises(BTClibTypeError, match="invalid consensus name type"):
+            Network.from_dict({**network, "consensus": wrong})
+    with pytest.raises(BTClibValueError, match="unknown consensus parameters"):
+        Network.from_dict({**network, "consensus": "mainnet2"})
 
 
 def test_a_json_null_is_not_an_amount() -> None:


### PR DESCRIPTION
`btclib.consensus` gains `CONSENSUS_PARAMS`, one frozen row per network,
and `Network` gains the `consensus` field that reaches it. The commit
message carries what the table holds and why each value is where it is;
this is what the issue asked for that the branch answers differently.

**Two of the issue's own premises did not survive being measured**, and
the branch follows the measurement rather than the issue.

The issue expected a corrected taproot activation height, testnet3's
being wrong in btclib-node. Core's `GetBlockScriptFlags` turns P2SH,
segwit v0 and taproot on for **every block of every chain** and consults
no height for any of the three; only DERSIG, CHECKLOCKTIMEVERIFY,
CHECKSEQUENCEVERIFY and NULLDUMMY are gated on a buried deployment, and
the blocks that predate a rule are named one by one, by hash. So there
is no taproot height in the table to be right or wrong about. The row
is removed rather than corrected, and `script_flags_at(height,
block_hash=None)` carries the exceptions — which is also why
`script_flag_exceptions` is a field the issue does not name: without it
the function is silently wrong for the historical blocks Core exempts.

The issue also says of `minimum_chain_work` and `bip30_exceptions` that
"Both are `Consensus::Params` fields in Core". `nMinimumChainWork` is;
the BIP30 pair is not — Core hardcodes it in `src/validation.cpp`'s
`IsBIP30Repeat`, outside the params struct and outside
`chainparams.cpp`. The decision that both go in still stands and is
implemented; the module cites `validation.cpp` for the second, and
nothing in the diff repeats the issue's clause.

**Transcription.** Every value comes from `src/kernel/chainparams.cpp`
at Bitcoin Core v31.1 (`bitcoin/bitcoin@9be056a8a7`), with the line it
was read at beside it, and `tests/consensus_test.py` holds each field to
that transcription. A released tag rather than `master`: a tag names a
blob a line citation cannot slip under, and `master` has moved taproot's
deployment out of that file entirely.

Regtest's `enforce_BIP94` is the one value no line of `chainparams.cpp`
writes — it is assigned `opts.enforce_bip94`, whose default is false at
`chainparams.h:154` — so the table carries what a regtest node runs
with, not what `-test=bip94` can make of it.

**Source-breaking.** `Network` gains a required keyword-only `consensus`
field and its json a `consensus` key naming the row.
`RELEASE_NOTES.md`'s breaking-changes list says what a caller does about
it.

**Follow-on.** `btclib-node`'s own copy of these rules is
[ISS 801](https://github.com/btclib-org/btclib-node/issues/801) row 1,
opened once this lands. Reviewing Core for the taproot question also
turned up [ISS 809](https://github.com/btclib-org/btclib-node/issues/809),
filed rather than carried: that tree's `interpreter.get_flags` gates
P2SH, segwit v0 and taproot on activation heights, so a mainnet block
below 170061 is verified with P2SH off where Core has it on — a
divergence in the permissive direction.

Closes #1578

Reviewed locally at fresh context before opening, per `REVIEWING.md`,
three rounds. Round 1 re-derived the five networks' values, the taproot
reading and the `IsBIP30Repeat` provenance from Core's own sources, and
requested one change: `enforce_BIP94`, a per-network field
[ISS 1579](https://github.com/btclib-org/btclib/issues/1579) is premised
on this table carrying. Round 2 re-enumerated `Consensus::Params`
member by member to check the module's completeness claim, and ran the
new coverage test to confirm it fires on the defect the old one is
blind to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Centralize Bitcoin Core consensus parameters per network and connect them to network validation and serialization.

New Features:
- Add immutable, per-network consensus parameter rows covering Bitcoin Core’s buried deployments, proof-of-work settings, chain work, and historical rule exceptions.
- Expose consensus parameters through each built-in Network and include the consensus row name in network serialization.
- Provide network-aware script flag calculation with support for historical block-hash exceptions.

Bug Fixes:
- Align script-rule activation behavior with Bitcoin Core by enabling P2SH, segwit, and taproot from genesis while applying height and historical exceptions correctly.
- Eliminate duplicated consensus constants by sourcing BIP34 and proof-of-work defaults from the centralized table.

Enhancements:
- Keep consensus data independent of the rest of btclib to preserve the import dependency structure and support custom network rows.

Documentation:
- Document the new consensus table and the required Network constructor and serialization changes, including the source-breaking migration.

Tests:
- Add comprehensive transcription, derivation, script-flag, immutability, network association, serialization, and import-boundary coverage for consensus parameters.