### PR TITLE
block/header_context.py holds median time past, the required target and the ancestor at a height (closes #1579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -993,6 +993,38 @@ documented at release-notes length in the first place, and are still in
   a `Network` field pointing back at `btclib.block` closes issue #147's
   cycle.
 
+### `btclib.block.header_context` answers median time past and the next target
+
+- **`median_time_past`, `header_at_height` and `next_bits_required` are
+  functions over a `BlockHeader`, a height and a `ParentOf` callable**
+  (closes #1579): Bitcoin Core's `CBlockIndex::GetMedianTimePast`,
+  `GetAncestor` and `GetNextWorkRequired`/`CalculateNextWorkRequired`,
+  published from `btclib.block` beside `BlockContext`. `ParentOf` is
+  `Callable[[BlockHeader], BlockHeader]`, so a caller supplies the one
+  step back a batch of headers off the wire, or an indexed chain, both
+  answer; none of the three functions reads a block index.
+- **`next_bits_required` includes the minimum-difficulty walk and
+  BIP94's timewarp mitigation, gated on `ConsensusParams.enforce_bip94`**
+  — the rule Core enforces on testnet4 and on regtest under
+  `-test=bip94`. At a period boundary it raises for a header timestamped
+  more than `MAX_TIMEWARP` seconds behind its own parent, `MAX_TIMEWARP`
+  now a constant of `btclib.block.limits`, and where BIP94 is enforced it
+  scales the period's own first target rather than the parent's.
+- **`ConsensusParams` gains `pow_target_spacing`, `pow_target_timespan`
+  and the derived `difficulty_adjustment_interval` property**, Core's own
+  `DifficultyAdjustmentInterval()`. Every network but regtest aims at two
+  weeks of ten-minute blocks; regtest measures one day, which is what
+  makes its own interval 144 rather than 2016, a fact the
+  minimum-difficulty walk reads per network.
+- **`BlockContext` gains `median_time_past` and `required_bits`, both
+  `None` by default**: the two values its own docstring named as arriving
+  once the chain state they need does. A caller that supplies them gets
+  `time-too-old` and `bad-diffbits` checked by `assert_valid_contextual`,
+  in Core's own order ahead of `time-too-new` and `bad-cb-height`; a
+  caller that does not builds a context exactly as before, and neither
+  new check runs. A context stays a value either way — nothing here
+  gives it a callable of its own.
+
 ## v2026.8.29
 
 ### Repository

--- a/docs/source/btclib.block.rst
+++ b/docs/source/btclib.block.rst
@@ -39,6 +39,13 @@ btclib.block.build module
    :members:
    :show-inheritance:
 
+btclib.block.header\_context module
+-----------------------------------
+
+.. automodule:: btclib.block.header_context
+   :members:
+   :show-inheritance:
+
 btclib.block.limits module
 --------------------------
 

--- a/src/btclib/block/__init__.py
+++ b/src/btclib/block/__init__.py
@@ -15,6 +15,12 @@ from btclib.block.block import (
 from btclib.block.block_context import BlockContext
 from btclib.block.block_filter import BasicBlockFilter, prevout_scripts_from_utxos
 from btclib.block.block_header import BlockHeader
+from btclib.block.header_context import (
+    ParentOf,
+    header_at_height,
+    median_time_past,
+    next_bits_required,
+)
 
 # btclib.block.limits is not here, as btclib.script.limits is not in
 # btclib.script: a caller reading a consensus constant names the module it
@@ -27,18 +33,26 @@ from btclib.block.block_header import BlockHeader
 # header against it -- so a caller checking a block by hand needs the same
 # function rather than a second one written from the BIP. Same reasoning
 # for coinbase_witness_commitment and witness_commitment_output, the pair
-# assert_valid_witness_commitment and build.build_block share
+# assert_valid_witness_commitment and build.build_block share. ParentOf,
+# header_at_height, median_time_past and next_bits_required are flattened
+# the same way rather than left under header_context: each is the one
+# operation a caller reaches for, not a namespace of related constants the
+# way proof_of_work and mining are
 __all__ = [
     "BasicBlockFilter",
     "Block",
     "BlockContext",
     "BlockHeader",
+    "ParentOf",
     "bip34_commitment",
     "build",
     "coinbase_witness_commitment",
+    "header_at_height",
+    "median_time_past",
     "merkle_proof",
     "merkle_root_and_mutated_from_transactions",
     "mining",
+    "next_bits_required",
     "prevout_scripts_from_utxos",
     "proof_of_work",
     "witness_commitment_output",

--- a/src/btclib/block/block.py
+++ b/src/btclib/block/block.py
@@ -518,28 +518,48 @@ class Block:
 
         Bitcoin Core's ContextualCheckBlockHeader and
         ContextualCheckBlock, as far as a height and a clock reach:
-        time-too-new, and bad-cb-height wherever BIP34 is in force. In
-        that order, which is Core's -- the header is checked before the
-        block it heads.
+        bad-diffbits and time-too-old wherever the caller has walked the
+        chain for them, time-too-new always, and bad-cb-height wherever
+        BIP34 is in force. In that order, which is Core's -- the header
+        is checked before the block it heads, and within the header
+        proof-of-work before the clock.
 
         Separate from assert_valid, which is CheckBlock: what the bytes
         answer for themselves, and therefore what Block.parse can ask.
         Both are asked of a block being accepted, and by whoever has the
         context; neither implies the other.
 
-        The rest of those two functions needs the chain and not merely a
-        context: time-too-old is the median time past of eleven ancestors,
-        bad-diffbits is the target of a whole retarget period,
-        bad-version the activation heights of BIP34, BIP66 and BIP65,
-        bad-txns-nonfinal every transaction's lock time against the same
-        median time past. Each is a field of BlockContext away, once the
-        chain state it reads is there to put in one.
+        bad-diffbits and time-too-old are the two rules
+        `BlockContext.median_time_past` and `.required_bits` answer for,
+        and each is skipped where the field is None -- a caller that has
+        not walked the chain for it, most of them until now. The rest of
+        Core's two functions still needs more than a context: bad-version
+        the activation heights of BIP34, BIP66 and BIP65, bad-txns-nonfinal
+        every transaction's lock time against the same median time past.
+        Each becomes a field of BlockContext once the chain state it reads
+        is there to put in one.
         """
         # the context is an object a caller builds, and `now` reaches
         # datetime arithmetic below: unasked, a str for it raised
         # AttributeError, which is no ValueError and flies past the handler
         # the contract asks for
         context.assert_valid()
+
+        if (
+            context.required_bits is not None
+            and self.header.bits != context.required_bits
+        ):
+            err_msg = "proof-of-work target not the required one: "
+            err_msg += f"{self.header.bits.hex()}"
+            err_msg += f" instead of {context.required_bits.hex()}"
+            raise BTClibValueError(err_msg)
+
+        if context.median_time_past is not None:
+            time = int(self.header.time.timestamp())
+            if time <= context.median_time_past:
+                err_msg = f"invalid timestamp (not after the median past): {time}"
+                err_msg += f" <= {context.median_time_past}"
+                raise BTClibValueError(err_msg)
 
         self.header.assert_valid_time(context.now)
 

--- a/src/btclib/block/block_context.py
+++ b/src/btclib/block/block_context.py
@@ -20,6 +20,18 @@ more activation heights. Each becomes a field here when the chain state it
 takes arrives, and none of them changes the signature of
 `Block.assert_valid_contextual`.
 
+`median_time_past` and `required_bits` are the first two, arrived: values
+rather than a callable, because a context stays what it always was, a
+photograph of a moment rather than an object with a chain behind it that
+the two rules reading it could disagree about. Computing them is
+`btclib.block.header_context`'s `median_time_past` and
+`next_bits_required`, which walk the chain through a `ParentOf` callable
+the caller supplies and BlockContext never sees; both default to `None`,
+which is how a caller that has not walked the chain -- most of the
+existing callers of this class, checking only `bad-cb-height` and
+`time-too-new` -- still builds one, and how the two rules below stay
+skipped rather than fed a value nobody computed.
+
 The rules underneath take the datum they read and not the whole context --
 `BlockHeader.assert_valid_time(now)`,
 `Block.assert_valid_coinbase_height(height)` -- so a caller holding one
@@ -57,9 +69,10 @@ BIP34_HEIGHT = CONSENSUS_PARAMS["mainnet"].bip34_height
 class BlockContext:
     """What Block.assert_valid_contextual reads: a height and a clock.
 
-    The two facts a block cannot answer for itself, supplied by the
-    caller; bip34_height is the chain's activation height, defaulting
-    to mainnet's.
+    The facts a block cannot answer for itself, supplied by the caller;
+    bip34_height is the chain's activation height, defaulting to
+    mainnet's, and median_time_past and required_bits default to None,
+    which skips the rule each answers for.
     """
 
     # the height the block is being accepted at, i.e. Core's
@@ -69,6 +82,14 @@ class BlockContext:
     now: datetime
     # the height from which the chain enforces BIP34
     bip34_height: int = BIP34_HEIGHT
+    # time-too-old's bound: the caller's own
+    # `header_context.median_time_past(parent, parent_height, parent_of)`,
+    # or None to leave the rule unchecked
+    median_time_past: int | None = None
+    # bad-diffbits' answer: the caller's own
+    # `header_context.next_bits_required(header, parent, parent_height,
+    # parent_of, consensus)`, or None to leave the rule unchecked
+    required_bits: bytes | None = None
 
     @property
     def is_bip34_active(self) -> bool:
@@ -90,21 +111,53 @@ class BlockContext:
         height: int,
         now: datetime,
         bip34_height: int = BIP34_HEIGHT,
+        median_time_past: int | None = None,
+        required_bits: bytes | None = None,
         *,
         check_validity: bool = True,
     ) -> None:
         object.__setattr__(self, "height", height)
         object.__setattr__(self, "now", now)
         object.__setattr__(self, "bip34_height", bip34_height)
+        object.__setattr__(self, "median_time_past", median_time_past)
+        object.__setattr__(self, "required_bits", required_bits)
 
         if check_validity:
             self.assert_valid()
+
+    def _assert_valid_chain_state(self) -> None:
+        """Refuse a median_time_past or required_bits given and malformed.
+
+        Split out of assert_valid to keep it under the complexity floor:
+        both fields are optional, so this is two independent, unrelated
+        checks rather than one.
+        """
+        if self.median_time_past is not None:
+            if not is_integer(self.median_time_past):
+                type_name = type(self.median_time_past).__name__
+                raise BTClibTypeError(f"invalid median_time_past type: {type_name}")
+            if self.median_time_past < 0:
+                err_msg = f"invalid median_time_past: {self.median_time_past}"
+                raise BTClibValueError(err_msg)
+
+        if self.required_bits is not None:
+            # bytes and not Octets: this is a value a caller computed with
+            # next_bits_required, not one read off the wire, so nothing
+            # here coerces a str or a bytearray into it
+            assert_type(self.required_bits, bytes, "required_bits")
+            if len(self.required_bits) != 4:
+                err_msg = f"invalid required_bits length: {len(self.required_bits)}"
+                err_msg += " bytes instead of 4"
+                raise BTClibValueError(err_msg)
 
     def assert_valid(self) -> None:
         """Refuse a negative or non-int height, or a now that is no datetime.
 
         Naive-datetime refusal is assert_valid_time's, the reader of
-        the clock being where the comparison happens.
+        the clock being where the comparison happens. median_time_past
+        and required_bits are refused only when given -- None is what
+        leaves the rule each answers for unchecked, not a value to
+        validate -- and _assert_valid_chain_state is where that happens.
         """
         for key in ("height", "bip34_height"):
             value = getattr(self, key)
@@ -125,3 +178,5 @@ class BlockContext:
         # future on one machine and not on another
         if self.now.tzinfo is None or self.now.tzinfo.utcoffset(self.now) is None:
             raise BTClibValueError(f"naive current time (no time zone): {self.now}")
+
+        self._assert_valid_chain_state()

--- a/src/btclib/block/block_header.py
+++ b/src/btclib/block/block_header.py
@@ -299,8 +299,12 @@ class BlockHeader:
         clock is neither.
 
         time-too-old is the other half of the pair Core checks beside this
-        one, and it stays out of reach: it is the median time past of
-        eleven ancestors, i.e. the chain.
+        one, and it is not asked here: it is the median time past of
+        eleven ancestors, which needs the chain rather than a datum this
+        method takes. `btclib.block.header_context.median_time_past` is
+        where the walk lives, and `Block.assert_valid_contextual` is
+        where the comparison is made, off `BlockContext.median_time_past`
+        rather than off a callable this method could take instead.
         """
         # the type before the time zone: `.tzinfo` on anything else is an
         # AttributeError, which is neither a ValueError nor a TypeError

--- a/src/btclib/block/header_context.py
+++ b/src/btclib/block/header_context.py
@@ -1,0 +1,220 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""What a header owes the chain before it: median time, target, ancestor.
+
+Bitcoin Core's `CBlockIndex::GetMedianTimePast`, `GetNextWorkRequired` /
+`CalculateNextWorkRequired`, and `CBlockIndex::GetAncestor`, over a header,
+its height, and a callable that steps back one header at a time rather
+than over an index: a batch of headers off the wire is checked before any
+of it is indexed, so its own members are what the header after them is
+checked against, and btclib does not learn what a block index is.
+
+`ConsensusParams` is what tells `next_bits_required` which network it is
+answering for -- `pow_limit_bits`, `pow_allow_min_difficulty_blocks`,
+`pow_no_retargeting`, `enforce_bip94`, and the retarget window
+`pow_target_spacing`/`pow_target_timespan` -- and `btclib.block.proof_of_work`
+is where the arithmetic of a single retarget lives; this module is the
+walk that feeds it a period's first header and the two chain-wide
+readings that do not need the whole retarget.
+
+Bitcoin Core v31.1 (bitcoin/bitcoin@9be056a8a7) is the reference for
+every rule, `src/chain.h`, `src/pow.cpp` and `src/validation.cpp`'s
+`ContextualCheckBlockHeader`, cited beside the code that transcribes it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from btclib.block.block_header import BlockHeader
+from btclib.block.limits import MAX_TIMEWARP
+from btclib.block.proof_of_work import next_bits
+from btclib.consensus import ConsensusParams
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.utils import is_integer
+
+__all__ = [
+    "MEDIAN_TIME_SPAN",
+    "ParentOf",
+    "header_at_height",
+    "median_time_past",
+    "next_bits_required",
+]
+
+# Core's CBlockIndex::nMedianTimeSpan
+MEDIAN_TIME_SPAN = 11
+
+# a header, and the one before it: whatever the callable raises for a
+# header it cannot answer for is the caller's exception, since every walk
+# below stops at a height it computed rather than at the callable's own
+# end
+ParentOf = Callable[[BlockHeader], BlockHeader]
+
+
+def _block_time(header: BlockHeader) -> int:
+    """Return the second the header's four timestamp bytes hold.
+
+    Core's `CBlockHeader::GetBlockTime`. `BlockHeader.serialize` writes
+    `int(time.timestamp())`, so that is the value the rules here compare:
+    a header is weighed as it goes on the wire, not as it was built.
+    """
+    return int(header.time.timestamp())
+
+
+def median_time_past(header: BlockHeader, height: int, parent_of: ParentOf) -> int:
+    """Return the median timestamp of a header and its ten ancestors.
+
+    Core's `CBlockIndex::GetMedianTimePast`, whose window is however many
+    of the eleven exist: nearer the genesis than that it is the whole
+    chain, and the median of an even number of times is the later of the
+    two middle ones -- `sort` and take the middle index, as Core's own
+    pointer arithmetic does.
+    """
+    if not is_integer(height):
+        raise BTClibTypeError(f"invalid height type: {type(height).__name__}")
+    if height < 0:
+        raise BTClibValueError(f"invalid height: {height}")
+
+    times = [_block_time(header)]
+    for _ in range(min(MEDIAN_TIME_SPAN, height + 1) - 1):
+        header = parent_of(header)
+        times.append(_block_time(header))
+    times.sort()
+    return times[len(times) // 2]
+
+
+def header_at_height(
+    header: BlockHeader,
+    height: int,
+    target_height: int,
+    parent_of: ParentOf,
+) -> BlockHeader:
+    """Walk back from `header`, at `height`, to its ancestor at `target_height`.
+
+    Core's `CBlockIndex::GetAncestor`, over a skip list there; this walks
+    `parent_of` one header at a time, which is the same cost
+    `median_time_past` already pays to reach its own eleventh ancestor --
+    unbounded here rather than capped at ten, since a caller asking for a
+    BIP68 time-locked input's own coin height can name any past height,
+    not only one within the last eleven blocks.
+    """
+    for name, value in (("height", height), ("target height", target_height)):
+        if not is_integer(value):
+            raise BTClibTypeError(f"invalid {name} type: {type(value).__name__}")
+    if height < 0:
+        raise BTClibValueError(f"invalid height: {height}")
+    if not 0 <= target_height <= height:
+        err_msg = f"invalid target height: {target_height}"
+        err_msg += f" is not between 0 and {height}"
+        raise BTClibValueError(err_msg)
+
+    for _ in range(height - target_height):
+        header = parent_of(header)
+    return header
+
+
+def _min_difficulty_bits(
+    header: BlockHeader,
+    parent: BlockHeader,
+    parent_height: int,
+    parent_of: ParentOf,
+    consensus: ConsensusParams,
+) -> bytes:
+    """Return the target of a block on a min-difficulty-allowing chain.
+
+    Core's own two branches of `GetNextWorkRequired`'s
+    `fPowAllowMinDifficultyBlocks` case: a block more than two target
+    spacings after its parent may be mined at the network's easiest
+    target, and every block after it goes back to the last target that
+    was not that easiest one, so that a single slow block does not make
+    the rest of the period easy.
+    """
+    if _block_time(header) > _block_time(parent) + 2 * consensus.pow_target_spacing:
+        return consensus.pow_limit_bits
+
+    interval = consensus.difficulty_adjustment_interval
+    candidate, candidate_height = parent, parent_height
+    while candidate_height % interval and candidate.bits == consensus.pow_limit_bits:
+        candidate = parent_of(candidate)
+        candidate_height -= 1
+    return candidate.bits
+
+
+def next_bits_required(
+    header: BlockHeader,
+    parent: BlockHeader,
+    parent_height: int,
+    parent_of: ParentOf,
+    consensus: ConsensusParams,
+) -> bytes:
+    """Return the compact target `header`, on this `parent`, has to carry.
+
+    Core's `GetNextWorkRequired` and `CalculateNextWorkRequired` combined,
+    the min-difficulty walk included: the target moves once every
+    `consensus.difficulty_adjustment_interval` blocks and is the parent's
+    the rest of the time, unless the network allows min-difficulty blocks,
+    in which case `_min_difficulty_bits` answers instead.
+
+    Where the network enforces BIP94 (`consensus.enforce_bip94`) and
+    `header` opens a new difficulty period, this also asks Core's own
+    `time-timewarp-attack` question -- whether `header` is timestamped
+    more than `MAX_TIMEWARP` seconds behind its own parent -- and raises
+    rather than returning a target for it: Core asks it in
+    `ContextualCheckBlockHeader`, apart from `GetNextWorkRequired`, but it
+    reads exactly the data this function already holds at exactly the
+    height this function already singles out, so it is answered here
+    instead of asking every caller to open a period boundary a second
+    time.
+
+    Core checks bad-diffbits first and unconditionally, ahead of
+    time-too-old, the timewarp bound and time-too-new
+    (`ContextualCheckBlockHeader`, `src/validation.cpp` at
+    bitcoin/bitcoin@9be056a8a7). Folding the timewarp question in here
+    does not preserve that order: a header failing both bad-diffbits and
+    the timewarp bound never gets a `required_bits` out of this function
+    at all, so the comparison `Block.assert_valid_contextual` would make
+    against it never runs, and no caller-side reordering recovers it --
+    what such a header is reported as failing is the timewarp bound, not
+    the wrong target. It is refused either way, by Core and by this
+    library; only the reported reason can differ, for a header that
+    fails both.
+
+    At a period boundary and `consensus.enforce_bip94`, the retarget
+    scales the period's own first target rather than the parent's,
+    which is what keeps a period's real difficulty from being
+    overwritten by a min-difficulty block mined at its very end.
+    """
+    if not is_integer(parent_height):
+        err_msg = f"invalid parent height type: {type(parent_height).__name__}"
+        raise BTClibTypeError(err_msg)
+    if parent_height < 0:
+        raise BTClibValueError(f"invalid parent height: {parent_height}")
+
+    interval = consensus.difficulty_adjustment_interval
+    height = parent_height + 1
+
+    if height % interval:
+        if consensus.pow_allow_min_difficulty_blocks:
+            return _min_difficulty_bits(
+                header, parent, parent_height, parent_of, consensus
+            )
+        return parent.bits
+
+    if consensus.enforce_bip94 and (
+        _block_time(header) < _block_time(parent) - MAX_TIMEWARP
+    ):
+        err_msg = "invalid timestamp (timewarp attack): "
+        err_msg += f"{_block_time(header)} < {_block_time(parent)} - {MAX_TIMEWARP}"
+        raise BTClibValueError(err_msg)
+
+    if consensus.pow_no_retargeting:
+        return parent.bits
+
+    first_height = parent_height - (interval - 1)
+    first = header_at_height(parent, parent_height, first_height, parent_of)
+    base_bits = first.bits if consensus.enforce_bip94 else parent.bits
+    return next_bits(
+        base_bits, first.time, parent.time, pow_limit_bits=consensus.pow_limit_bits
+    )

--- a/src/btclib/block/limits.py
+++ b/src/btclib/block/limits.py
@@ -27,8 +27,15 @@ Some of `consensus.h`'s constants are deliberately absent.
 `MAX_BLOCK_SERIALIZED_SIZE` is marked in Core's own comment as a buffer
 bound and not a network rule, the weight being what consensus caps.
 `COINBASE_MATURITY` is a rule about spending an output, so it needs the
-chain the output was created on. `MAX_TIMEWARP` is BIP94's bound on the
-first block of a retarget period, which needs the previous block.
+chain the output was created on.
+
+`MAX_TIMEWARP` is here and not among those: it is BIP94's bound on the
+first block of a new retarget period, checked against that block's own
+parent -- the last block of the period before it -- so it needs one
+header rather than the whole chain, which is what makes it a bound
+rather than a rule of its own.
+`btclib.block.header_context.next_bits_required` is where it is read,
+behind `ConsensusParams.enforce_bip94`.
 
 `MIN_SERIALIZABLE_TRANSACTION_WEIGHT` is here, where its neighbour
 `MIN_TRANSACTION_WEIGHT` is not, and the pair is what says why: the second
@@ -45,6 +52,7 @@ __all__ = [
     "MAX_BLOCK_SIGOPS_COST",
     "MAX_BLOCK_WEIGHT",
     "MAX_FUTURE_BLOCK_TIME",
+    "MAX_TIMEWARP",
     "MIN_SERIALIZABLE_TRANSACTION_WEIGHT",
     "WITNESS_SCALE_FACTOR",
 ]
@@ -61,3 +69,10 @@ MIN_SERIALIZABLE_TRANSACTION_WEIGHT = WITNESS_SCALE_FACTOR * 10
 # Maximum number of seconds a block timestamp may exceed the current time,
 # spelled as Core spells it
 MAX_FUTURE_BLOCK_TIME = 2 * 60 * 60
+
+# BIP94: how far behind its own parent the first block of a new retarget
+# period may be timestamped, on the networks ConsensusParams.enforce_bip94
+# names -- testnet4, and regtest under -test=bip94, which the table does
+# not carry since it is a command-line option and not a fact about the
+# chain
+MAX_TIMEWARP = 600

--- a/src/btclib/consensus.py
+++ b/src/btclib/consensus.py
@@ -73,10 +73,6 @@ reader looking for one knows it was decided rather than missed:
   about an unknown deployment, which is a warning and not a rule
 - `defaultAssumeValid` is what a node skips signature checks below by
   default, which is a startup option and not a fact about the chain
-- `nPowTargetSpacing` and `nPowTargetTimespan` are the retarget window,
-  which `btclib.block.proof_of_work` states as mainnet's; issue #1579 is
-  where the header arithmetic that reads them per network goes, and it is
-  what moves them here
 - `signet_challenge` is per deployment rather than per network, which is
   the reason `btclib.network` gives for keeping the p2p magic out too
 - `signet_blocks` is the switch in front of the check that reads that
@@ -216,17 +212,28 @@ class ConsensusParams:
     # a chain nobody is hashing still moves
     pow_allow_min_difficulty_blocks: bool
 
-    # Core's enforce_BIP94: the timewarp mitigation, which bounds a
-    # block's timestamp below by the first block of the previous
-    # difficulty period rather than by the median of eleven ancestors,
-    # and on testnet4 also the block storm mitigation. Data here and a
-    # rule elsewhere, as the flags either side of it are: issue #1579 is
-    # where the header arithmetic that reads it goes
+    # Core's enforce_BIP94: the timewarp mitigation, checked at the first
+    # block of a new difficulty period, which may not be timestamped more
+    # than MAX_TIMEWARP seconds behind its own parent -- the last block of
+    # the period before it -- and, on testnet4 alone, the block storm
+    # mitigation that rides the same flag. Data here and a rule elsewhere,
+    # as the flags either side of it are: `btclib.block.header_context`
+    # is where the header arithmetic that reads it goes
     enforce_bip94: bool
 
     # Core's fPowNoRetargeting: the target never moves off the one the
     # genesis carries, which is what makes regtest minable at will
     pow_no_retargeting: bool
+
+    # Core's nPowTargetSpacing and nPowTargetTimespan: the block interval
+    # a retarget aims at and the window it measures, in seconds. Every
+    # network but regtest aims at two weeks of ten-minute blocks; regtest
+    # measures one day instead, which is what makes its own
+    # difficulty_adjustment_interval 144 rather than 2016 -- a fact the
+    # minimum-difficulty walk of `btclib.block.header_context` reads,
+    # `pow_no_retargeting` making the number otherwise unobservable there
+    pow_target_spacing: int
+    pow_target_timespan: int
 
     # Core's nMinimumChainWork, as the integer `proof_of_work.chain_work`
     # answers rather than as Core's 32 bytes: the work below which a node
@@ -248,6 +255,17 @@ class ConsensusParams:
     # A tuple of pairs and not a mapping: the row has to stay hashable,
     # and the lookup is over a handful of blocks in the whole chain
     script_flag_exceptions: tuple[tuple[bytes, tuple[str, ...]], ...]
+
+    @property
+    def difficulty_adjustment_interval(self) -> int:
+        """Return how many blocks a difficulty period holds on this network.
+
+        Core's `Consensus::Params::DifficultyAdjustmentInterval`, a
+        derived quantity there too rather than a stored one: 2016 blocks
+        on every network but regtest, whose 144 comes from a one-day
+        window over the same ten-minute spacing.
+        """
+        return self.pow_target_timespan // self.pow_target_spacing
 
     def script_flags_at(
         self, height: int, block_hash: Octets | None = None
@@ -336,6 +354,8 @@ _consensus_params: dict[str, ConsensusParams] = {
         pow_allow_min_difficulty_blocks=False,
         enforce_bip94=False,
         pow_no_retargeting=False,
+        pow_target_spacing=10 * 60,  # line 128
+        pow_target_timespan=14 * 24 * 60 * 60,  # line 127, two weeks
         minimum_chain_work=0x0000000000000000000000000000000000000001128750F82F4C366153A3A030,
         bip30_exceptions=(
             (
@@ -385,6 +405,8 @@ _consensus_params: dict[str, ConsensusParams] = {
         pow_allow_min_difficulty_blocks=True,
         enforce_bip94=False,
         pow_no_retargeting=False,
+        pow_target_spacing=10 * 60,  # line 252
+        pow_target_timespan=14 * 24 * 60 * 60,  # line 251, two weeks
         minimum_chain_work=0x0000000000000000000000000000000000000000000017DDE1C649F3708D14B6,
         bip30_exceptions=(),
         script_flag_exceptions=(
@@ -420,6 +442,12 @@ _consensus_params: dict[str, ConsensusParams] = {
         # command line can make of it
         enforce_bip94=False,
         pow_no_retargeting=True,
+        pow_target_spacing=10 * 60,  # line 581
+        # one day, not the two weeks every other network aims at (line
+        # 580): DifficultyAdjustmentInterval() is 144 rather than 2016,
+        # which is what the minimum-difficulty walk's own stop condition
+        # reads on this network
+        pow_target_timespan=24 * 60 * 60,
         minimum_chain_work=0,
         bip30_exceptions=(),
         script_flag_exceptions=(),
@@ -439,6 +467,8 @@ _consensus_params: dict[str, ConsensusParams] = {
         pow_allow_min_difficulty_blocks=False,
         enforce_bip94=False,
         pow_no_retargeting=False,
+        pow_target_spacing=10 * 60,  # line 496
+        pow_target_timespan=14 * 24 * 60 * 60,  # line 495, two weeks
         minimum_chain_work=0x00000000000000000000000000000000000000000000000000000B463EA0A4B8,
         bip30_exceptions=(),
         script_flag_exceptions=(),
@@ -457,6 +487,8 @@ _consensus_params: dict[str, ConsensusParams] = {
         # true here alone, testnet4 being the chain BIP94 was written for
         enforce_bip94=True,
         pow_no_retargeting=False,
+        pow_target_spacing=10 * 60,  # line 352
+        pow_target_timespan=14 * 24 * 60 * 60,  # line 351, two weeks
         minimum_chain_work=0x0000000000000000000000000000000000000000000009A0FE15D0177D086304,
         bip30_exceptions=(),
         script_flag_exceptions=(),

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -165,6 +165,7 @@ CHILD_MODULES = {
             "block_context",
             "block_filter",
             "block_header",
+            "header_context",
             "limits",
         ],
     },

--- a/tests/block/block_context_test.py
+++ b/tests/block/block_context_test.py
@@ -2,15 +2,19 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""The two block rules that need something the block does not carry.
+"""The block rules that need something the block does not carry.
 
 `Block.assert_valid` is Bitcoin Core's `CheckBlock`, and these are the
 reachable part of `ContextualCheckBlockHeader` and `ContextualCheckBlock`:
-`time-too-new`, which needs a clock, and `bad-cb-height`, which needs the
-height the block is being accepted at and the height BIP34 binds from.
-`BlockContext` is what carries the three, and each rule is also a method
-taking the datum it reads, so a caller holding half a context asks the
-half it can answer.
+`time-too-new`, which needs a clock; `bad-cb-height`, which needs the
+height the block is being accepted at and the height BIP34 binds from;
+and, where the caller has walked the chain for them,
+`bad-diffbits` and `time-too-old`. `BlockContext` is what carries all
+five, and each rule but the last two is also a method taking the datum
+it reads, so a caller holding half a context asks the half it can
+answer -- `bad-diffbits` and `time-too-old` are read directly off the
+context instead, `median_time_past` and `required_bits` already being
+the answer rather than something to compute from a height.
 
 The blocks are the vendored ones, which is what makes these vectors and
 not fixtures: block 481,824 is a mainnet block above BIP34's activation
@@ -103,6 +107,38 @@ def test_a_context_is_a_height_and_an_instant() -> None:
     # and a context nobody checks can still be built, as everywhere else
     # in the library
     assert BlockContext(height=-1, now=now, check_validity=False).height == -1
+
+
+def test_median_time_past_and_required_bits_default_to_none_and_are_skipped() -> None:
+    """The two chain-state fields are optional, and refused only when given.
+
+    None is what a caller that has not walked the chain for them passes
+    -- which is every context built above, none of them naming either --
+    and it is not a value the type or range checks below ever see.
+    """
+    now = datetime.now(timezone.utc)
+    context = BlockContext(height=0, now=now)
+    assert context.median_time_past is None
+    assert context.required_bits is None
+    context.assert_valid()
+
+    with pytest.raises(BTClibTypeError, match="invalid median_time_past type: str"):
+        BlockContext(height=0, now=now, median_time_past="0")  # type: ignore[arg-type]
+    with pytest.raises(BTClibValueError, match="invalid median_time_past: -1"):
+        BlockContext(height=0, now=now, median_time_past=-1)
+
+    with pytest.raises(BTClibTypeError, match="invalid required_bits type: str"):
+        BlockContext(height=0, now=now, required_bits="1d00ffff")  # type: ignore[arg-type]
+    err_msg = "invalid required_bits length: 3 bytes instead of 4"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        BlockContext(height=0, now=now, required_bits=b"\x1d\x00\xff")
+
+    # a well-formed pair is accepted and read back unchanged
+    valid = BlockContext(
+        height=0, now=now, median_time_past=0, required_bits=b"\x1d\x00\xff\xff"
+    )
+    assert valid.median_time_past == 0
+    assert valid.required_bits == b"\x1d\x00\xff\xff"
 
 
 def test_the_height_is_committed_as_core_writes_it() -> None:
@@ -233,6 +269,69 @@ def test_a_timestamp_may_be_two_hours_ahead_and_no_more() -> None:
     for not_a_datetime in ("nope", 12345, None, header.time.date()):
         with pytest.raises(BTClibTypeError, match="invalid current time type: "):
             header.assert_valid_time(not_a_datetime)  # type: ignore[arg-type]
+
+
+def test_bad_diffbits_compares_the_header_against_required_bits() -> None:
+    """`assert_valid_contextual` refuses a header not carrying `required_bits`.
+
+    Block 1 carries `1d00ffff`, the genesis target: a context naming that
+    same value accepts it, and a context naming a stricter one refuses it
+    by the bytes each side carries.
+    """
+    block = block_of("block_1.bin")
+    now = block.header.time
+    assert block.header.bits == bytes.fromhex("1d00ffff")
+
+    block.assert_valid_contextual(
+        BlockContext(height=1, now=now, required_bits=bytes.fromhex("1d00ffff"))
+    )
+
+    err_msg = "proof-of-work target not the required one: 1d00ffff"
+    err_msg += " instead of 1c00ffff"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        block.assert_valid_contextual(
+            BlockContext(height=1, now=now, required_bits=bytes.fromhex("1c00ffff"))
+        )
+
+    # None is what leaves the rule unchecked, not a value that happens
+    # to equal every header's own bits
+    block.assert_valid_contextual(BlockContext(height=1, now=now))
+
+
+def test_time_too_old_compares_the_header_against_the_median_past() -> None:
+    """`assert_valid_contextual` refuses a header at or before the median."""
+    block = block_of("block_1.bin")
+    now = block.header.time
+    time = int(block.header.time.timestamp())
+
+    # strictly after the median is required, so the median itself refuses
+    err_msg = f"invalid timestamp \\(not after the median past\\): {time} <= {time}"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        block.assert_valid_contextual(
+            BlockContext(height=1, now=now, median_time_past=time)
+        )
+    block.assert_valid_contextual(
+        BlockContext(height=1, now=now, median_time_past=time - 1)
+    )
+
+
+def test_bad_diffbits_is_checked_before_time_too_old_and_time_too_new() -> None:
+    """Core's own order: bad-diffbits, then time-too-old, then time-too-new.
+
+    A context wrong on all three raises for the first of them, which is
+    what a caller reading the exception alone is told is wrong.
+    """
+    block = block_of("block_1.bin")
+    now = block.header.time
+    time = int(block.header.time.timestamp())
+    context = BlockContext(
+        height=1,
+        now=now - timedelta(days=1),
+        median_time_past=time,
+        required_bits=bytes.fromhex("1c00ffff"),
+    )
+    with pytest.raises(BTClibValueError, match="proof-of-work target not the required"):
+        block.assert_valid_contextual(context)
 
 
 def test_the_contextual_rules_are_not_asked_by_assert_valid() -> None:

--- a/tests/block/header_context_test.py
+++ b/tests/block/header_context_test.py
@@ -1,0 +1,503 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the `btclib.block.header_context` module.
+
+The four `next_bits_required` mainnet vectors are Bitcoin Core's own
+`src/test/pow_tests.cpp`, at bitcoin/bitcoin@9be056a8a7 (v31.1): each
+puts a real height, timestamp and `bits` beside the retarget it computed
+from them, and the comment names the block each timestamp belongs to.
+Every chain built to carry one is a placeholder except at the two
+heights the vector names -- `next_bits_required` reads only the parent
+and the period's first header, so what sits between them cannot change
+the answer, only the cost of the walk to it.
+
+Every other test is synthetic, over headers built with
+`check_validity=False`: the proof-of-work these rules read from a header
+is the timestamp and the `bits`, and Core's own algorithm is checked
+against a target no chain would ever hand out just as readily as
+against a real one.
+"""
+
+import dataclasses
+import secrets
+from collections.abc import Sequence
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from btclib.block.block_header import BlockHeader
+from btclib.block.header_context import (
+    MEDIAN_TIME_SPAN,
+    ParentOf,
+    header_at_height,
+    median_time_past,
+    next_bits_required,
+)
+from btclib.block.limits import MAX_TIMEWARP
+from btclib.block.proof_of_work import next_bits
+from btclib.consensus import CONSENSUS_PARAMS, ConsensusParams
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+
+MAIN = CONSENSUS_PARAMS["mainnet"]
+TESTNET = CONSENSUS_PARAMS["testnet"]
+TESTNET4 = CONSENSUS_PARAMS["testnet4"]
+REGTEST = CONSENSUS_PARAMS["regtest"]
+
+POW_LIMIT = MAIN.pow_limit_bits
+REGTEST_POW_LIMIT = REGTEST.pow_limit_bits
+# 2^216, three bytes into the compact form and a quarter and four times of
+# it as well, so any retarget answer is read straight off the exponent
+HARD = b"\x1c\x01\x00\x00"
+
+EPOCH = datetime.fromtimestamp(1231006505, timezone.utc)  # the mainnet genesis time
+
+
+def _time(timestamp: int) -> datetime:
+    return datetime.fromtimestamp(timestamp, timezone.utc)
+
+
+def _small_interval(
+    *,
+    enforce_bip94: bool,
+    pow_no_retargeting: bool,
+    pow_allow_min_difficulty_blocks: bool = True,
+) -> ConsensusParams:
+    """Return a row with a four-block difficulty period.
+
+    A row of `CONSENSUS_PARAMS` with `pow_target_spacing` and
+    `pow_target_timespan` replaced so `difficulty_adjustment_interval` is
+    4 rather than 2016 or 144 -- short enough that a test builds a whole
+    period without a two-thousand-header chain -- and with the three
+    boolean rules a caller of this function is asking about, which
+    `TESTNET4` does not carry the combination of. `pow_limit_bits` stays
+    testnet4's.
+    """
+    return dataclasses.replace(
+        TESTNET4,
+        pow_target_spacing=600,
+        pow_target_timespan=600 * 4,
+        enforce_bip94=enforce_bip94,
+        pow_no_retargeting=pow_no_retargeting,
+        pow_allow_min_difficulty_blocks=pow_allow_min_difficulty_blocks,
+    )
+
+
+def _header(previous_block_hash: bytes, time: datetime, bits: bytes) -> BlockHeader:
+    """Build a header, skipping the proof-of-work check.
+
+    `check_validity=False` is what lets a test hand it a target no chain
+    hands out.
+    """
+    return BlockHeader(
+        version=1,
+        previous_block_hash=previous_block_hash,
+        merkle_root=secrets.token_bytes(32),
+        time=time,
+        bits=bits,
+        nonce=1,
+        check_validity=False,
+    )
+
+
+def a_chain(
+    times: Sequence[datetime], bits: Sequence[bytes]
+) -> tuple[list[BlockHeader], ParentOf]:
+    """Return headers at heights 0, 1, ... and the walk back over them."""
+    headers: list[BlockHeader] = []
+    previous_block_hash = b"\x00" * 32
+    for time, header_bits in zip(times, bits, strict=True):
+        header = _header(previous_block_hash, time, header_bits)
+        headers.append(header)
+        previous_block_hash = header.hash
+    by_hash = {header.hash: header for header in headers}
+
+    def parent_of(header: BlockHeader) -> BlockHeader:
+        return by_hash[header.previous_block_hash]
+
+    return headers, parent_of
+
+
+# ---------------------------------------------------------------------------
+# median_time_past
+
+
+def test_the_median_of_a_chain_shorter_than_the_window() -> None:
+    """Below height ten the window is the whole chain, not a fixed eleven.
+
+    Core's `GetMedianTimePast` stops at `pindex` becoming null, which is
+    the same as this stopping once `parent_of` has nothing further back.
+    """
+    times = [EPOCH + timedelta(seconds=s) for s in (0, 10, 20, 30)]
+    headers, parent_of = a_chain(times, [POW_LIMIT] * 4)
+    assert median_time_past(headers[0], 0, parent_of) == int(times[0].timestamp())
+    assert median_time_past(headers[1], 1, parent_of) == int(times[1].timestamp())
+    assert median_time_past(headers[3], 3, parent_of) == int(times[2].timestamp())
+
+
+def test_the_median_of_eleven_is_not_the_last_of_them() -> None:
+    """The window sorts the eleven rather than trusting a miner's clock.
+
+    A miner's own timestamp need not be increasing, so the median of a
+    full eleven-block window is not simply the newest header's time.
+    """
+    seconds = [0, 1000, 2000, 300, 400, 500, 600, 700, 800, 900, 100, 950]
+    times = [EPOCH + timedelta(seconds=s) for s in seconds]
+    headers, parent_of = a_chain(times, [POW_LIMIT] * len(times))
+    window = sorted(seconds[1:])
+    expected = int(
+        (EPOCH + timedelta(seconds=window[MEDIAN_TIME_SPAN // 2])).timestamp()
+    )
+    assert median_time_past(headers[-1], len(times) - 1, parent_of) == expected
+
+
+def test_a_header_is_weighed_by_the_second_it_serializes_as() -> None:
+    """A fraction of a second is truncated, as `BlockHeader.serialize` does.
+
+    The four wire bytes hold a whole second, so a header carrying a
+    fraction of one past that is compared as it goes on the wire.
+    """
+    header = _header(b"\x00" * 32, EPOCH, POW_LIMIT)
+    header.time += timedelta(microseconds=999_999)
+    headers, parent_of = a_chain([header.time], [POW_LIMIT])
+    assert median_time_past(headers[0], 0, parent_of) == int(EPOCH.timestamp())
+
+
+def test_median_time_past_refuses_a_height_that_is_not_one() -> None:
+    """A non-integer or negative height is refused before the walk."""
+    headers, _ = a_chain([EPOCH], [POW_LIMIT])
+    header = headers[0]
+    for not_a_height in ("0", None, 1.5):
+        with pytest.raises(BTClibTypeError, match="invalid height type: "):
+            median_time_past(header, not_a_height, lambda h: h)  # type: ignore[arg-type]
+    with pytest.raises(BTClibValueError, match="invalid height: -1"):
+        median_time_past(header, -1, lambda h: h)
+
+
+# ---------------------------------------------------------------------------
+# header_at_height
+
+
+def test_header_at_height_walks_back_to_the_target_height() -> None:
+    """A target height of zero, the height itself, and one in between."""
+    times = [EPOCH + timedelta(seconds=600 * h) for h in range(5)]
+    headers, parent_of = a_chain(times, [POW_LIMIT] * 5)
+    assert header_at_height(headers[4], 4, 0, parent_of) is headers[0]
+    assert header_at_height(headers[4], 4, 4, parent_of) is headers[4]
+    assert header_at_height(headers[4], 4, 2, parent_of) is headers[2]
+
+
+def test_header_at_height_refuses_a_target_height_outside_the_range() -> None:
+    """A target height above the header's own, or a negative one, or type."""
+    headers, parent_of = a_chain([EPOCH, EPOCH], [POW_LIMIT] * 2)
+    with pytest.raises(BTClibValueError, match="invalid target height: 5"):
+        header_at_height(headers[1], 1, 5, parent_of)
+    with pytest.raises(BTClibValueError, match="invalid target height: -1"):
+        header_at_height(headers[1], 1, -1, parent_of)
+    with pytest.raises(BTClibValueError, match="invalid height: -1"):
+        header_at_height(headers[1], -1, 0, parent_of)
+    for not_a_height in ("1", None, 1.5):
+        with pytest.raises(BTClibTypeError, match="invalid height type: "):
+            header_at_height(headers[1], not_a_height, 0, parent_of)  # type: ignore[arg-type]
+        with pytest.raises(BTClibTypeError, match="invalid target height type: "):
+            header_at_height(headers[1], 1, not_a_height, parent_of)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# next_bits_required -- Bitcoin Core's own mainnet vectors
+
+
+def _period(
+    first_time: datetime,
+    parent_time: datetime,
+    parent_bits: bytes,
+) -> tuple[BlockHeader, BlockHeader, ParentOf]:
+    """Build a whole mainnet difficulty period ending at `parent`.
+
+    Only the first header returned and `parent` carry the vector's own
+    time; every block between them is a placeholder a minute apart, which
+    `next_bits_required` never reads -- it asks `header_at_height` for
+    the first header and nothing else.
+    """
+    interval = MAIN.difficulty_adjustment_interval
+    times = [first_time + timedelta(minutes=i) for i in range(interval - 1)] + [
+        parent_time
+    ]
+    bits = ([POW_LIMIT] * (interval - 1)) + [parent_bits]
+    headers, parent_of = a_chain(times, bits)
+    return headers[0], headers[-1], parent_of
+
+
+@pytest.mark.parametrize(
+    "parent_height, first_time, parent_time, parent_bits, expected",
+    [
+        # get_next_work: Block #30240 to Block #32255
+        (32255, 1261130161, 1262152739, "1d00ffff", "1d00d86a"),
+        # get_next_work_pow_limit: Block #0 to Block #2015, already at limit
+        (2015, 1231006505, 1233061996, "1d00ffff", "1d00ffff"),
+        # get_next_work_lower_limit_actual: Block #66528 to Block #68543
+        (68543, 1279008237, 1279297671, "1c05a3f4", "1c0168fd"),
+        # get_next_work_upper_limit_actual: Block #44352 (flagged by Core
+        # itself as "NOT an actual block time") to Block #46367
+        (46367, 1263163443, 1269211443, "1c387f6f", "1d00e1fd"),
+    ],
+)
+def test_next_bits_required_matches_cores_own_mainnet_vectors(
+    parent_height: int,
+    first_time: int,
+    parent_time: int,
+    parent_bits: str,
+    expected: str,
+) -> None:
+    """Reproduce one of Core's own `pow_tests.cpp` retarget vectors."""
+    _first, parent, parent_of = _period(
+        _time(first_time), _time(parent_time), bytes.fromhex(parent_bits)
+    )
+    # next_bits_required does not read the candidate's own bits, only its
+    # time; check_validity=False is what lets it carry an arbitrary one
+    candidate = _header(parent.hash, parent.time, bytes.fromhex(parent_bits))
+    assert next_bits_required(
+        candidate, parent, parent_height, parent_of, MAIN
+    ) == bytes.fromhex(expected)
+
+
+# ---------------------------------------------------------------------------
+# next_bits_required -- off a retarget boundary
+
+
+def test_between_two_retargets_the_target_is_the_parents() -> None:
+    """Off a boundary, with no min-difficulty rule, the target holds."""
+    headers, parent_of = a_chain([EPOCH, EPOCH + timedelta(seconds=600)], [HARD, HARD])
+    candidate = _header(headers[1].hash, EPOCH + timedelta(seconds=1200), HARD)
+    assert next_bits_required(candidate, headers[1], 1, parent_of, MAIN) == HARD
+
+
+def test_a_chain_that_does_not_retarget_keeps_the_target_it_has() -> None:
+    """`pow_no_retargeting` is checked at the boundary, answers the parent's."""
+    consensus = _small_interval(
+        enforce_bip94=False,
+        pow_no_retargeting=True,
+        pow_allow_min_difficulty_blocks=False,
+    )
+    interval = consensus.difficulty_adjustment_interval
+    headers, parent_of = a_chain(
+        [EPOCH + timedelta(seconds=600 * h) for h in range(interval)],
+        [HARD] * interval,
+    )
+    parent = headers[-1]
+    candidate = _header(parent.hash, parent.time + timedelta(seconds=600), HARD)
+    assert (
+        next_bits_required(candidate, parent, interval - 1, parent_of, consensus)
+        == HARD
+    )
+
+
+# ---------------------------------------------------------------------------
+# next_bits_required -- the minimum-difficulty rule
+
+
+def test_a_slow_block_may_be_mined_at_the_limit() -> None:
+    """More than two target spacings after the parent, the limit is allowed."""
+    headers, parent_of = a_chain([EPOCH, EPOCH + timedelta(seconds=600)], [HARD, HARD])
+    parent = headers[1]
+    late = parent.time + timedelta(seconds=2 * TESTNET.pow_target_spacing + 1)
+    on_time = parent.time + timedelta(seconds=2 * TESTNET.pow_target_spacing)
+    assert (
+        next_bits_required(
+            _header(parent.hash, late, HARD), parent, 1, parent_of, TESTNET
+        )
+        == TESTNET.pow_limit_bits
+    )
+    # one second sooner is not enough
+    assert (
+        next_bits_required(
+            _header(parent.hash, on_time, HARD), parent, 1, parent_of, TESTNET
+        )
+        == HARD
+    )
+
+
+def test_the_block_after_a_min_difficulty_one_goes_back_to_the_real_target() -> None:
+    """A min-difficulty block does not make the rest of the period easy."""
+    times = [EPOCH + timedelta(seconds=600 * h) for h in range(4)]
+    headers, parent_of = a_chain(
+        times, [HARD, HARD, TESTNET.pow_limit_bits, TESTNET.pow_limit_bits]
+    )
+    parent = headers[-1]
+    candidate = _header(parent.hash, parent.time + timedelta(seconds=600), HARD)
+    assert next_bits_required(candidate, parent, 3, parent_of, TESTNET) == HARD
+
+
+def test_the_walk_back_stops_at_the_genesis() -> None:
+    """A chain mined at the limit from block zero has no easier target."""
+    headers, parent_of = a_chain(
+        [EPOCH, EPOCH + timedelta(seconds=600)], [TESTNET.pow_limit_bits] * 2
+    )
+    parent = headers[1]
+    candidate = _header(parent.hash, parent.time + timedelta(seconds=600), HARD)
+    assert (
+        next_bits_required(candidate, parent, 1, parent_of, TESTNET)
+        == TESTNET.pow_limit_bits
+    )
+
+
+def test_regtest_min_difficulty_rule_applies_despite_no_retargeting() -> None:
+    """The min-difficulty rule fires on regtest even though it never retargets.
+
+    Core's `GetNextWorkRequired` reads `fPowAllowMinDifficultyBlocks`
+    before it ever looks at `fPowNoRetargeting`, which only gates
+    `CalculateNextWorkRequired` at a period boundary: a slow block off a
+    boundary is answered by the min-difficulty branch regardless. A
+    caller returning the parent's own bits whenever
+    `pow_no_retargeting` is set, without checking the height first, would
+    answer `HARD` here instead of the network's limit.
+    """
+    headers, parent_of = a_chain([EPOCH, EPOCH + timedelta(seconds=600)], [HARD, HARD])
+    parent = headers[1]
+    late = parent.time + timedelta(seconds=2 * REGTEST.pow_target_spacing + 1)
+    candidate = _header(parent.hash, late, HARD)
+    assert (
+        next_bits_required(candidate, parent, 1, parent_of, REGTEST)
+        == REGTEST_POW_LIMIT
+    )
+
+
+def test_regtest_min_difficulty_walk_stops_at_its_own_144_block_boundary() -> None:
+    """The walk-back's stop condition reads regtest's own 144-block interval.
+
+    Heights 0 to 143 carry a non-limit target and 144 to 150 the network
+    limit; asked at height 151 (off any boundary), the walk from the
+    parent back through the limit-carrying blocks has to stop at height
+    144 -- a boundary under regtest's own `pow_target_timespan` of one
+    day, 144 blocks, but not under the 2016-block interval every other
+    network uses. A walk using the wrong interval would not stop there
+    and would answer `HARD`, the target the blocks below 144 carry,
+    instead of the limit height 144 itself carries.
+    """
+    assert REGTEST.difficulty_adjustment_interval == 144
+    times = [EPOCH + timedelta(seconds=600 * h) for h in range(151)]
+    bits = [HARD] * 144 + [REGTEST_POW_LIMIT] * 7
+    headers, parent_of = a_chain(times, bits)
+    parent = headers[150]
+    on_time = parent.time + timedelta(seconds=2 * REGTEST.pow_target_spacing)
+    candidate = _header(parent.hash, on_time, REGTEST_POW_LIMIT)
+    assert (
+        next_bits_required(candidate, parent, 150, parent_of, REGTEST)
+        == REGTEST_POW_LIMIT
+    )
+
+
+# ---------------------------------------------------------------------------
+# next_bits_required -- BIP94
+
+
+def test_bip94_rebases_the_retarget_on_the_periods_first_target() -> None:
+    """Under BIP94 the retarget scales the period's own first bits.
+
+    Core's `CalculateNextWorkRequired`: `bnNew.SetCompact(pindexFirst->nBits)`
+    rather than `pindexLast->nBits`, so a min-difficulty block mined at
+    the very end of the period does not make the whole period's
+    difficulty look easier than it was.
+    """
+    consensus = _small_interval(enforce_bip94=True, pow_no_retargeting=False)
+    interval = consensus.difficulty_adjustment_interval
+    times = [EPOCH + timedelta(seconds=600 * h) for h in range(interval)]
+    bits = [HARD] * (interval - 1) + [consensus.pow_limit_bits]
+    headers, parent_of = a_chain(times, bits)
+    parent = headers[-1]
+    candidate_time = parent.time + timedelta(seconds=600)
+    candidate = _header(parent.hash, candidate_time, HARD)
+
+    expected = next_bits(
+        HARD, headers[0].time, parent.time, pow_limit_bits=consensus.pow_limit_bits
+    )
+    assert (
+        next_bits_required(candidate, parent, interval - 1, parent_of, consensus)
+        == expected
+    )
+    # and it is not simply the parent's own bits scaled instead
+    not_bip94 = next_bits(
+        parent.bits,
+        headers[0].time,
+        parent.time,
+        pow_limit_bits=consensus.pow_limit_bits,
+    )
+    assert expected != not_bip94
+
+
+def test_bip94_refuses_a_period_opening_too_far_behind_its_parent() -> None:
+    """time-timewarp-attack: a new period must not open too early.
+
+    Core's `ContextualCheckBlockHeader`, `enforce_BIP94` branch: the
+    first block of a new difficulty period must not be timestamped more
+    than `MAX_TIMEWARP` seconds behind `pindexPrev->GetBlockTime()`.
+    """
+    consensus = _small_interval(enforce_bip94=True, pow_no_retargeting=False)
+    interval = consensus.difficulty_adjustment_interval
+    times = [EPOCH + timedelta(seconds=600 * h) for h in range(interval)]
+    headers, parent_of = a_chain(times, [HARD] * interval)
+    parent = headers[-1]
+
+    too_early = parent.time - timedelta(seconds=MAX_TIMEWARP + 1)
+    candidate = _header(parent.hash, too_early, HARD)
+    with pytest.raises(BTClibValueError, match="timewarp attack"):
+        next_bits_required(candidate, parent, interval - 1, parent_of, consensus)
+
+    # exactly at the bound is not refused
+    at_bound = parent.time - timedelta(seconds=MAX_TIMEWARP)
+    candidate = _header(parent.hash, at_bound, HARD)
+    next_bits_required(candidate, parent, interval - 1, parent_of, consensus)
+
+
+def test_bip94_timewarp_check_is_independent_of_no_retargeting() -> None:
+    """`-test=bip94` on regtest sets both flags at once, Core's own combination.
+
+    `enforce_BIP94` and `fPowNoRetargeting` are read by two different
+    functions in Core (`ContextualCheckBlockHeader` and
+    `CalculateNextWorkRequired`), so a chain with both set still refuses
+    the timewarped header even though its retarget is always a no-op.
+    """
+    consensus = _small_interval(enforce_bip94=True, pow_no_retargeting=True)
+    interval = consensus.difficulty_adjustment_interval
+    times = [EPOCH + timedelta(seconds=600 * h) for h in range(interval)]
+    headers, parent_of = a_chain(times, [HARD] * interval)
+    parent = headers[-1]
+
+    too_early = parent.time - timedelta(seconds=MAX_TIMEWARP + 1)
+    candidate = _header(parent.hash, too_early, HARD)
+    with pytest.raises(BTClibValueError, match="timewarp attack"):
+        next_bits_required(candidate, parent, interval - 1, parent_of, consensus)
+
+
+def test_bip94_off_the_boundary_is_not_checked() -> None:
+    """The timewarp bound only applies to a period's first block."""
+    consensus = _small_interval(enforce_bip94=True, pow_no_retargeting=False)
+    headers, parent_of = a_chain([EPOCH, EPOCH + timedelta(seconds=600)], [HARD, HARD])
+    parent = headers[1]
+    way_early = parent.time - timedelta(seconds=MAX_TIMEWARP * 10)
+    candidate = _header(parent.hash, way_early, HARD)
+    # height 2 is not a multiple of the four-block interval, so this is
+    # answered instead of refused
+    assert next_bits_required(candidate, parent, 1, parent_of, consensus) == HARD
+
+
+# ---------------------------------------------------------------------------
+# next_bits_required -- input validation
+
+
+def test_next_bits_required_refuses_a_parent_height_that_is_not_one() -> None:
+    """A non-integer or negative parent height is refused up front."""
+    headers, parent_of = a_chain([EPOCH], [POW_LIMIT])
+    candidate = _header(headers[0].hash, EPOCH, POW_LIMIT)
+    for not_a_height in ("0", None, 1.5):
+        with pytest.raises(BTClibTypeError, match="invalid parent height type: "):
+            next_bits_required(
+                candidate,
+                headers[0],
+                not_a_height,  # type: ignore[arg-type]
+                parent_of,
+                MAIN,
+            )
+    with pytest.raises(BTClibValueError, match="invalid parent height: -1"):
+        next_bits_required(candidate, headers[0], -1, parent_of, MAIN)

--- a/tests/consensus_test.py
+++ b/tests/consensus_test.py
@@ -64,6 +64,8 @@ _CHAINPARAMS: dict[str, dict[str, Any]] = {
         "pow_allow_min_difficulty_blocks": False,
         "enforce_bip94": False,
         "pow_no_retargeting": False,
+        "pow_target_spacing": 10 * 60,
+        "pow_target_timespan": 14 * 24 * 60 * 60,
         "minimum_chain_work": int(
             "0000000000000000000000000000000000000001128750f82f4c366153a3a030", 16
         ),
@@ -106,6 +108,8 @@ _CHAINPARAMS: dict[str, dict[str, Any]] = {
         "pow_allow_min_difficulty_blocks": True,
         "enforce_bip94": False,
         "pow_no_retargeting": False,
+        "pow_target_spacing": 10 * 60,
+        "pow_target_timespan": 14 * 24 * 60 * 60,
         "minimum_chain_work": int(
             "0000000000000000000000000000000000000000000017dde1c649f3708d14b6", 16
         ),
@@ -134,6 +138,11 @@ _CHAINPARAMS: dict[str, dict[str, Any]] = {
         # runs with, `-test=bip94` not being passed
         "enforce_bip94": False,
         "pow_no_retargeting": True,
+        "pow_target_spacing": 10 * 60,
+        # one day, not the two weeks every other network aims at: this is
+        # what makes ConsensusParams.difficulty_adjustment_interval 144
+        # on regtest rather than 2016
+        "pow_target_timespan": 24 * 60 * 60,
         # `uint256{}`, which is no work at all: a chain mined for a test
         # never leaves initial block download on this comparison
         "minimum_chain_work": 0,
@@ -150,6 +159,8 @@ _CHAINPARAMS: dict[str, dict[str, Any]] = {
         "pow_allow_min_difficulty_blocks": False,
         "enforce_bip94": False,
         "pow_no_retargeting": False,
+        "pow_target_spacing": 10 * 60,
+        "pow_target_timespan": 14 * 24 * 60 * 60,
         # the default signet's, which chainparams assigns above the class
         # body's own block: a custom challenge gets `uint256{}` instead
         "minimum_chain_work": int(
@@ -169,6 +180,8 @@ _CHAINPARAMS: dict[str, dict[str, Any]] = {
         # true on testnet4 alone, the chain BIP94 was written for
         "enforce_bip94": True,
         "pow_no_retargeting": False,
+        "pow_target_spacing": 10 * 60,
+        "pow_target_timespan": 14 * 24 * 60 * 60,
         "minimum_chain_work": int(
             "0000000000000000000000000000000000000000000009a0fe15d0177d086304", 16
         ),
@@ -375,6 +388,8 @@ def test_a_row_can_be_built_for_a_chain_this_library_does_not_ship() -> None:
         pow_allow_min_difficulty_blocks=False,
         enforce_bip94=False,
         pow_no_retargeting=False,
+        pow_target_spacing=10 * 60,
+        pow_target_timespan=14 * 24 * 60 * 60,
         minimum_chain_work=0,
         bip30_exceptions=(),
         script_flag_exceptions=(),


### PR DESCRIPTION
Median time past, the target a header has to carry, and the ancestor at
a height are consensus arithmetic over headers. `block/header_context.py`
holds them, over a `ParentOf` callable rather than over a block index —
which is what lets a node keep its index and btclib not learn what one
is.

`BlockContext` gains `median_time_past` and `required_bits`, both
optional and both skipping their rule when unset, so every existing
`BlockContext(height, now)` caller is unaffected. `ConsensusParams`
gains `pow_target_spacing` and `pow_target_timespan`, which
`btclib.consensus`'s docstring had listed as deliberately absent and
pointed at this issue, plus the derived
`difficulty_adjustment_interval` — Core's own
`Consensus::Params::DifficultyAdjustmentInterval()`.

**Two things btclib-node gets wrong that this does not**, both measured
against Core at `bitcoin/bitcoin@9be056a8a7` rather than ported:

Core reads `fPowAllowMinDifficultyBlocks` in `GetNextWorkRequired`
*before* it can reach `fPowNoRetargeting`, which gates only
`CalculateNextWorkRequired` and is reached solely at a period boundary.
So a slow block off a boundary takes the min-difficulty branch whatever
`pow_no_retargeting` says. btclib-node short-circuits on
`pow_no_retargeting` first, unconditionally — filed as
[ISS 812](https://github.com/btclib-org/btclib-node/issues/812) rather
than fixed here, since that file is still running.

Regtest's `nPowTargetTimespan` is one day against every other network's
two weeks, so its difficulty adjustment interval is **144**, not 2016.
Two tests discriminate exactly these: each answers differently under
btclib-node's branch order and under a hardcoded 2016.

**BIP94's timewarp bound is enforced**, gated by `enforce_bip94`, inside
`next_bits_required` rather than as a third `BlockContext` field —
keeping that class a frozen value with no callable, which is the design
question the issue itself resolves. The docstring states what that
costs, because it is not free: Core checks bad-diffbits first and
unconditionally, and folding the timewarp question in does not preserve
that order. A header failing both never gets a `required_bits` out of
the function, so the comparison `Block.assert_valid_contextual` would
make against it never runs, and no caller-side reordering recovers it.
Acceptance is unchanged; the reported reason can differ from Core's.

`next_bits_required` is checked against Core's own `pow_tests.cpp`
vectors and `median_time_past` against `CBlockIndex::GetMedianTimePast`,
tie-break included.

Closes #1579

Reviewed locally at fresh context before opening, per `REVIEWING.md`,
two rounds. Round 1 requested two prose corrections and no code: a
`RELEASE_NOTES.md` breaking-changes bullet for a type that has never
shipped — `ConsensusParams` was added earlier in this same unreleased
cycle, so no user has anything to act on — and a docstring sentence
claiming a caller could recover Core's check order, which it cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Add Bitcoin Core-compatible header chain-context calculations and use their results in optional contextual block validation.

New Features:
- Add header-context utilities for median time past, ancestor lookup, and network-specific required proof-of-work targets using a parent traversal callback.
- Support Bitcoin Core-compatible minimum-difficulty handling, difficulty retarget intervals, BIP94 timewarp protection, and BIP94 retarget behavior across consensus networks.

Bug Fixes:
- Correct consensus contextual validation to check required difficulty bits and median-time-past timestamps in Core's validation order.
- Use regtest's one-day proof-of-work timespan and preserve minimum-difficulty behavior independently of no-retargeting.

Enhancements:
- Extend immutable BlockContext with optional median_time_past and required_bits values while preserving existing callers that omit chain state.
- Expose proof-of-work target spacing, timespan, and derived adjustment interval through ConsensusParams, including network-specific values.
- Publish the new header-context APIs and MAX_TIMEWARP consensus constant from btclib.block.

Documentation:
- Document the new header-context consensus arithmetic, optional contextual checks, network retarget parameters, BIP94 behavior, and compatibility considerations.

Tests:
- Add Core vector and synthetic coverage for median-time-past calculation, ancestor traversal, retargeting, minimum-difficulty rules, regtest's 144-block interval, BIP94, and contextual validation order.