### PR TITLE
CLAUDE.md's `git worktree add` line ends in its placeholder (issue btclib-org/.github#687)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1025,6 +1025,21 @@ documented at release-notes length in the first place, and are still in
   new check runs. A context stays a value either way — nothing here
   gives it a callable of its own.
 
+### `CLAUDE.md`'s `git worktree add` line ends in its placeholder
+
+- **`-b <branch>` sits after the path and the commit-ish** (issue
+  btclib-org/.github#687), which is the placeholder-last shape section 9
+  of the organization standard prescribes. A paste made before the
+  placeholders are filled in reaches the shell with `<branch>` as a pair
+  of redirections, and where a word follows them the `>` takes `"$WT"`
+  as its target; in a reader's directory holding a file named `branch`
+  the `<` succeeds and the line runs, and where the block's own last
+  line has already removed the worktree no directory stands at that path
+  for the `>` to fail on, so it writes a regular file there and the next
+  `git worktree add` refuses the path. With the placeholder last there
+  is nothing for the `>` to open, so the line writes nothing whatever
+  the directory holds.
+
 ## v2026.8.29
 
 ### Repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,11 +105,17 @@ once, which the ordinary sequence avoids by each removing its own.
 
 ```shell
 WT=<scratchpad>/wt-<tracker>-<issue>-<repo>-<role>  # wt-github-255-btclib-coder
-git worktree add -b <branch> "$WT" origin/main
+git worktree add "$WT" origin/main -b <branch>
 cd "$WT" && uv sync --locked          # a second venv, about a minute
 # edit, gate and commit here, then
 git push origin HEAD:refs/heads/<branch>
 ```
+
+`-b <branch>` sits after the path and the commit-ish so that the
+placeholder ends the command, which is section 9 of the organization
+standard's rule. With the placeholder ahead of `"$WT"` the `>` closing it
+takes that path as its target, and a path with no directory at it is a
+file the paste creates.
 
 Removing the worktree is part of finishing, and it stands in a block of
 its own: the block above ends in a placeholder, and a shell that


### PR DESCRIPTION
One of eight ports of [ISS 687](https://github.com/btclib-org/.github/issues/687),
which `btclib-org/.github` answered in its own `CLAUDE.md` first. No closing
keyword here: the issue is closed by the last tree to land, and this is not it.

`git worktree add -b <branch> "$WT" origin/main` writes a file at `$WT` when it
is pasted with the placeholders unfilled — `<` opens a file named `branch` and
`>` takes `"$WT"` as its target. The live-worktree case was covered; the case
the block itself ends in was not, its last line removing the worktree, so the
ordinary state a second paste starts from is a path with no directory at it and
nothing for the redirection to fail on. The argument order moves, so the
placeholder ends the command. `zsh -n` on the two forms, each sliced out of its
fence rather than retyped, is the measurement: the old order parses, the new one
is a parse error before it is a command.

The reason paragraph is `.github`'s, with one clause changed: its citation says
"section 9 of `README.md`'s rule", true only where `README.md` *is* the
standard. Here it is the library's own document with no numbered sections, so
the clause names the organization standard in this file's own idiom.

This branch was rebased across `#1604` and the `merge=union` driver ate the
blank line before its `CHANGELOG.md` heading; the repair is that one byte, and
the gates were re-run on the rebased tip rather than relied on from before it.


CLAUDE.md's `git worktree add` line ends in its placeholder (issue btclib-org/.github#687)

A paste of CLAUDE.md's worktree block made before its placeholders are
filled in reaches the shell with `<branch>` as a pair of redirections,
and with `-b <branch>` ahead of the path the `>` takes `"$WT"` as its
target. In a reader's directory holding a file named `branch` the `<`
succeeds and the line runs, and where the block's own last line has
already removed the worktree no directory stands at that path for the
`>` to fail on: it writes a regular file where the worktree was, and the
next `git worktree add` refuses the path. With `-b <branch>` after the
path and the commit-ish the placeholder ends the command, so there is
nothing for the `>` to open and the line writes nothing whatever the
directory holds.

The paragraph after the fence carries that reason. It cites section 9 of
the organization standard, whose *A bare placeholder goes at the end of
its command* is the rule, and names the standard rather than a section
number of `README.md`: `README.md` here is the library's own document,
so a section number of it would cite nothing.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016oqSogXvCL55uWFmn3z2vh


Local review: CLEARED 954a8b6, which is this head unchanged — no rebase and no re-parent between the review and this merge. Gates on that tree, as this repository's `CONTRIBUTING.md` writes them: exit 0.

## Summary by Sourcery

Make the documented worktree setup command safe to paste before its placeholders are filled in.

Bug Fixes:
- Prevent placeholder-filled `git worktree add` commands from creating a file at the worktree path and breaking subsequent worktree creation.

Enhancements:
- Document why the worktree command places the branch placeholder at the end of the command.

Documentation:
- Add a changelog entry describing the corrected worktree command and its placeholder-safety rule.
