### PR TITLE
The documentation build is not passed `--keep-going` (issue btclib-org/.github#347)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -103,8 +103,8 @@ jobs:
       # so btclib and its bindings have to be installed -- which is the
       # defect issue 151 was opened for, read the docs having installed
       # sphinx alone and rendered 70 empty module headings.
-      # -W makes a failed import a failed build, and --keep-going reports
-      # every problem in one run instead of one per push. -n turns an
+      # -W makes a failed import a failed build, and reports every
+      # problem in one run instead of one per push. -n turns an
       # unresolved cross-reference into a warning for -W to fail on --
       # without it a renamed class or a moved function in a :class: role
       # builds green and links nowhere. conf.py's intersphinx_mapping and
@@ -112,7 +112,7 @@ jobs:
       - name: Build the docs
         run: >
           uv run --locked --no-default-groups --group docs
-          sphinx-build -n -W --keep-going -b html docs/source docs/build/html
+          sphinx-build -n -W -b html docs/source docs/build/html
       # a second defense against issue 195, not the only one: measured,
       # sphinx-build -n -W already fails on its own on every link myst
       # cannot resolve, in the currently pinned toolchain (myst-parser

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -60,8 +60,8 @@ build:
   # that, and a uv too old to read the lock fails loudly rather than
   # resolving something else.
   # -W turns a failed import into a failed build, which is the point
-  # of the whole file; --keep-going comes first so one broken module
-  # reports every other problem in the same run instead of one per push.
+  # of the whole file, and reports every other problem in the same run
+  # instead of one per push.
   # -n is docs.yml's own flag, kept in step here so the site this file
   # publishes is built by the same command that gates a merge
   commands:
@@ -69,4 +69,4 @@ build:
     - uv sync --locked --no-default-groups --group docs
     - >-
       uv run --locked --no-default-groups --group docs
-      sphinx-build -n -W --keep-going -b html docs/source $READTHEDOCS_OUTPUT/html
+      sphinx-build -n -W -b html docs/source $READTHEDOCS_OUTPUT/html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1040,6 +1040,19 @@ documented at release-notes length in the first place, and are still in
   is nothing for the `>` to open, so the line writes nothing whatever
   the directory holds.
 
+### The documentation build is not passed `--keep-going`
+
+- **`.github/workflows/docs.yml`, `.readthedocs.yaml`, `CONTRIBUTING.md`
+  and `docs/README.rst` each spell the build as
+  `sphinx-build -n -W -b html`** (issue btclib-org/.github#347). Section 2
+  of the organization standard is where the rule and its rejected
+  alternative are written: `-W` alone reports every warning a build raises
+  and fails at the end of it, so the flag decides nothing.
+- **The comment beside the command in the workflow and in
+  `.readthedocs.yaml` puts that reporting on `-W`**, which is the flag
+  that does it; dropping the token alone would have left a sentence
+  crediting nothing.
+
 ## v2026.8.29
 
 ### Repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1068,7 +1068,7 @@ each with the reason beside it:
 
 ```shell
 uv run --locked --no-default-groups --group docs \
-    sphinx-build -n -W --keep-going -b html docs/source docs/build/html
+    sphinx-build -n -W -b html docs/source docs/build/html
 ```
 
 That job has a second step, which reads the pages the first one wrote and

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -21,7 +21,7 @@ Build from the project root, exactly as ``.readthedocs.yaml`` does:
 .. sourcecode:: bash
 
     $ uv run --locked --no-default-groups --group docs \
-          sphinx-build -n -W --keep-going -b html docs/source docs/build/html
+          sphinx-build -n -W -b html docs/source docs/build/html
 
 Open ``docs/build/html/index.html`` in a browser to see the result. The
 ``Makefile`` and ``make.bat`` here drive the same build, from within this


### PR DESCRIPTION
One of five ports of [ISS 347](https://github.com/btclib-org/.github/issues/347),
whose standard half landed in `btclib-org/.github` as `2376d1d`. No closing
keyword here: the issue is closed by the last tree to land, and this is not it.

`sphinx-build --keep-going` decides nothing at the sphinx this tree's
`.python-version` resolves. It is declared `help=argparse.SUPPRESS` and recorded
in sphinx's own source as `self.keep_going = bool(warningiserror)  # Unused`,
and it is *accepted* rather than rejected — an unknown flag exits 2 with
`unrecognized arguments`, this one exits with the build's own status and prints
no deprecation notice — so nothing in a run says it is no longer read. What it
was credited with is `-W`'s: the warning count accumulates across the whole
build and sets the status at the end of it.

Each site here credited the flag with that behaviour, so this is a comment
rewrite rather than a token deletion: the claim stays and the credit moves to
`-W`. `docs/README.rst` is a fourth site the issue's own table does not list,
found by surveying the tree rather than working from that table. The three
surviving mentions in `CHANGELOG.md` are landed entries narrating builds run at
the time, correct as history.


The documentation build is not passed `--keep-going` (issue btclib-org/.github#347)

In the sphinx `uv.lock` resolves for the interpreter `.python-version`
pins, `--keep-going` is missing from `--help` and is accepted by the
parser rather than refused, and `-W` alone reports every warning a build
raises and fails at the end of it. The rule and its rejected alternative
are section 2 of btclib-org/.github's `README.md`, landed there as
2376d1d, and this branch applies them here.

`docs/README.rst` spells the command too, beside
`.github/workflows/docs.yml`, `.readthedocs.yaml` and `CONTRIBUTING.md`.
The workflow and `.readthedocs.yaml` each carry a comment crediting the
flag with the reporting `-W` does, so each keeps the sentence and drops
the credit; the other two spell the command alone.

Nothing else about the build moves: same `-n`, same builder, same source
and output paths.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016oqSogXvCL55uWFmn3z2vh


Local review: CLEARED 95c164b, which is this head unchanged — no rebase and no re-parent between the review and this merge. Gates on that tree, as this repository's `CONTRIBUTING.md` writes them: exit 0.

## Summary by Sourcery

Remove the ineffective Sphinx `--keep-going` option and update documentation explaining the existing `-W` behavior.

Bug Fixes:
- Remove the ineffective `--keep-going` option from all documented Sphinx documentation build commands.

Enhancements:
- Update documentation-build comments to correctly attribute warning reporting and end-of-build failure behavior to `-W`.
- Align the GitHub Actions, Read the Docs, contributor, and documentation README build instructions.

Documentation:
- Record the documentation build command correction in the changelog.
