### PR TITLE
RELEASING.md's rebuild block chains from its placeholder line (closes btclib-org/.github#657)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1053,6 +1053,43 @@ documented at release-notes length in the first place, and are still in
   that does it; dropping the token alone would have left a sentence
   crediting nothing.
 
+### `RELEASING.md`'s rebuild block chains from its placeholder line
+
+- **Pasted before `<version>` was filled in, the block reached `uv build`
+  in the reader's own working directory rather than in the rebuild
+  worktree** (closes btclib-org/.github#657). Its first line ends in
+  `v<version>`, which an interactive shell answers with a parse error and
+  discards, reading `cd /tmp/btclib-rebuild` as a fresh command; that
+  `cd` then failed, the worktree never having been created, and
+  `uv build`, `normalize_sdist.py` and `generate_sbom.py` ran where the
+  reader stood — which for a reader following this file is the checkout
+  the prose right above the block tells them to keep out of.
+- **The `cd` sits inside the chain, so no line below it runs unless the
+  `cd` succeeded.** Whatever the reader's directory holds, the build runs
+  in `/tmp/btclib-rebuild` or it does not run. The chain reaching the
+  block's own first line is what stops it when a `git worktree add` fails
+  with `<version>` filled in.
+- **The rejected alternative makes the `cd` fatal on its own** — `||
+  exit`, or a `set -e` above the block — **and it refuses the paste by
+  ending the shell the reader pasted into, where the chain leaves the
+  session standing.** Neither the standard nor the emptied block
+  separates the two: section 9 names `&&` chaining no more than it names
+  those, its own remedy for this shape being the writing line in a fence
+  of its own, and both fatal forms empty the block as completely as the
+  chain does. What separates them is a command written under the block,
+  which reaches its stub after the chained block and after neither fatal
+  form; the same command alone reaches it under every feed, and the same
+  block with the `cd` made non-fatal instead restores it, so what stops
+  it is the `exit` rather than the failing `cd`.
+- **What reports the block harmless is a `<file>` harness, not a script
+  harness in general.** Given the block as a file argument, `zsh`, `bash`
+  and `sh` each abort at the parse error on its first line. `zsh` reading
+  it from stdin — a redirect or a pipe — discards that error and carries
+  on as an interactive shell does, which is the case section 9 of the
+  organization standard names; on the base block that feed ran what the
+  interactive one ran, and in a directory holding a file named `version`
+  it also wrote `-py3-none-any.whl`, `.tar.gz` and `.cdx.json` there.
+
 ## v2026.8.29
 
 ### Repository

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -601,20 +601,39 @@ A worktree and not `git checkout`, for the reason CLAUDE.md gives: the
 primary checkout is the maintainer's, and a rebuild wants a tree of its
 own regardless.
 
+The block chains so that a paste made before `<version>` is filled in
+reaches no command outside the rebuild tree: an interactive shell answers
+the placeholder line with a parse error and reads the `cd` below it as a
+fresh command, and a failing `cd` inside the chain takes every line under
+it with it. What the chain buys is not that it forms across the first
+line, which the shell discards together with its trailing `&&`; it is
+that the `cd` is inside it.
+
+Section 9 of the organization standard names a different remedy for this
+shape — the writing line in a fence of its own — and calls the
+trailing-`&&` guard the weaker of the two, resting "on the reader's
+directory rather than on the line". So which of the two is here is not
+settled by that section, and it is not settled by the block emptying
+either: the rejected alternative makes the `cd` fatal on its own — `||
+exit`, or a `set -e` above the block — and empties it just as
+completely. What separates them is that both of those refuse the paste by
+ending the shell the reader pasted into, where the chain leaves the
+session standing.
+
 ```shell
-git worktree add --detach /tmp/btclib-rebuild v<version>
-cd /tmp/btclib-rebuild
-export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
-uv build
+git worktree add --detach /tmp/btclib-rebuild v<version> &&
+cd /tmp/btclib-rebuild &&
+export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) &&
+uv build &&
 uv run --no-project --python 3.14 \
-  .github/scripts/normalize_sdist.py dist/
+  .github/scripts/normalize_sdist.py dist/ &&
 uv run --no-project --python 3.14 \
-  .github/scripts/generate_sbom.py dist/ sbom/
-repo=btclib-org/btclib
+  .github/scripts/generate_sbom.py dist/ sbom/ &&
+repo=btclib-org/btclib &&
 gh attestation verify dist/btclib-<version>-py3-none-any.whl \
-  --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml"
+  --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml" &&
 gh attestation verify dist/btclib-<version>.tar.gz \
-  --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml"
+  --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml" &&
 gh attestation verify sbom/btclib-<version>.cdx.json \
   --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml"
 ```


### PR DESCRIPTION
Closes btclib-org/.github#657.

The second of two ports and the one that spends the closing keyword;
`btclib-org/btclib-node@ecb310e` landed the other, non-closing. Every citation
here is qualified on purpose: `btclib-org/btclib#657` is a live, unrelated open
issue in this tree, so a bare reference on this subject would have closed that
one instead.

`RELEASING.md`'s rebuild block ends its first line in `v<version>`. Pasted before
that is filled in, an interactive shell answers the line with a parse error,
discards it, and reads the `cd` below as a fresh command; the `cd` fails, the
worktree never having been created, and `uv build` and two scripts then run in
the reader's own working directory — the primary checkout the prose directly
above the block tells them to stay out of. In a directory holding a file named
`version`, the same paste also writes three artefacts there.

The block now chains, and what does the work is that the failing `cd` is *inside*
the chain: chaining the placeholder line alone changes nothing, and a chain
broken anywhere above the writes still reaches them.

The rejected alternative — a fatal `cd`, by `|| exit` or a `set -e` above the
block — empties the block just as completely, so that is not what separates them,
and section 9 does not settle it either: its own remedy for this shape is the
writing line in a fence of its own, and it names `&&` chaining no more than it
names the alternative. What separates them is measured. A command written under
the block reaches its stub after the chained paste and after neither fatal form,
against that command alone reaching it under every feed as the control — and
against the same block with the `cd` made non-fatal, which restores it while the
`cd` still fails. So what stops it is the `exit`, and both fatal forms refuse the
paste by ending the shell the reader pasted into.

Eleven feeds were measured, seeded and unseeded, and the split matters for
whoever sweeps this family next: given the block as a file argument `zsh`, `bash`
and `sh` all abort, but `zsh` reading the same bytes from stdin — a redirect or a
pipe — discards the error and carries on exactly as an interactive shell does.


RELEASING.md's rebuild block chains from its placeholder line (closes btclib-org/.github#657)

The block's first line ends in `v<version>`. An interactive shell answers
that with a parse error, discards the line and reads `cd
/tmp/btclib-rebuild` as a fresh command; the `cd` fails, the worktree
never having been created, and `uv build`, `normalize_sdist.py dist/` and
`generate_sbom.py dist/ sbom/` run in whatever directory the reader is
standing in.

Measured with `git`, `uv`, `gh` and `grep` replaced by stubs logging
their argv and their `$PWD` on an otherwise empty PATH, each block sliced
out of the blob with `git show` and fed to a shell started in an empty
temporary directory under `env -i`. The cells are `zsh`, `bash` and `sh`
each given the block on stdin, through a pipe and as a file argument,
plus `zsh -i` and `bash -i`. `echo hi > outfile` runs and writes in every
one of them, which is the positive control, re-proved live in this round.
Every block under test is asserted non-empty and byte-identical to the
fence it was sliced from before any run of it is read, and the rc column
is proved to be the shell's own status by a block that exits 7.

On the base block, `git log`, `uv build`, `normalize_sdist.py dist/` and
`generate_sbom.py dist/ sbom/` all run with the reader's own cwd as their
working directory under `zsh -i`, `bash -i`, `zsh < block` and `cat block
| zsh` alike; `bash` and `sh` on stdin or through a pipe abort, and a
file argument aborts for all three. So what reports this block harmless
is a `<file>` harness rather than a script harness in general, which is
what section 9 of the organization standard records about `zsh` reading
from stdin. With a zero-byte file named `version` in the run directory
those same four feeds reach the `gh attestation verify` lines besides and
write `-py3-none-any.whl`, `.tar.gz` and `.cdx.json` there.

Chained, no feed reaches a command: nothing invoked and nothing written
in any cell, seeded and unseeded alike. The rc is 1 in the three `zsh`
feeds and in both interactive cells, and 2 in the six `bash` and `sh`
script feeds. Filled in with `v2026.8.27`, and with a `git` stub that
creates the worktree, the chained block runs every command in order and
exits 0.

What the chain buys is not that the chain forms: the placeholder line is
discarded either way. It is that the `cd` is inside it, so no line below
it runs unless the `cd` succeeded. Three counter-variants measured in the
same harness say so: chaining only the placeholder line, chaining as far
as the `export` and no further, and chaining everything from the `export`
down with the `cd` outside it each still invoke `uv build` and both
scripts under `zsh -i` and `bash -i`. Where /tmp/btclib-rebuild already
exists the `cd` succeeds and every stub reports that path as its working
directory, which is the tree the block was meant to run in.

The rejected alternative makes the `cd` fatal on its own -- `|| exit`, or
a `set -e` above the block. Two reasons for rejecting it were measured
and did not hold: section 9 settles nothing, naming `&&` chaining no more
than it names those two and calling the trailing-`&&` guard the weaker
against its own remedy of a fence of its own; and neither form leaves the
block reaching anything, both invoking no stub in any of the eleven
cells. What does separate them is a `git SHELL-SURVIVED-THE-PASTE` line
written under the block: it reaches the stub after the chained block in
each of the four feeds that reach anything, and after neither fatal form
in any cell. Three controls hold that reading up -- the line alone
reaches the stub in all eleven; the same block with the `cd` made
non-fatal, `|| true` in place of `|| exit`, restores it to those same
four with the `cd` still failing; so what stops it is the `exit` rather
than the failing `cd` or the way the line was appended. Both fatal forms
refuse the paste by ending the shell the reader pasted into; the chain
refuses it with the session still standing.

btclib-node's copy of this block landed as ecb310e, citing the issue
without closing it, so this is the port that closes it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016oqSogXvCL55uWFmn3z2vh


Local review: CLEARED 5720c6d, which is this head unchanged — no rebase and no re-parent between the review and this merge. Gates on that tree, as this repository's `CONTRIBUTING.md` writes them: exit 0.

## Summary by Sourcery

Protect the release rebuild instructions by chaining dependent commands from worktree creation through artifact verification.

Bug Fixes:
- Prevent the release rebuild commands from running in the reader’s working directory when the version placeholder is pasted before being filled in.

Enhancements:
- Make the rebuild workflow stop cleanly when worktree creation or changing to the rebuild worktree fails by chaining all dependent commands.
- Document the shell behavior and rationale for the rebuild command chain, including its interaction with different script execution modes.

Documentation:
- Add a changelog entry documenting the rebuild-block safety fix and its shell execution behavior.
