### PR TITLE
btclib.tx.tx_context answers finality, sequence locks and coinbase rules (closes #1580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1090,6 +1090,36 @@ documented at release-notes length in the first place, and are still in
   interactive one ran, and in a directory holding a file named `version`
   it also wrote `-py3-none-any.whl`, `.tar.gz` and `.cdx.json` there.
 
+### `btclib.tx.tx_context` answers finality, sequence locks and coinbase rules
+
+- **`is_final`, `assert_sequence_locks`, `assert_coinbase_maturity` and
+  `assert_coinbase_value` are functions over a `Tx`, a `Sequence[Coin]`
+  of its prevouts, or both** (closes #1580): Bitcoin Core's `IsFinalTx`,
+  `CalculateSequenceLocks`/`EvaluateSequenceLocks`, the
+  `bad-txns-premature-spend-of-coinbase` half of
+  `Consensus::CheckTxInputs`, and `bad-cb-amount`
+  (`src/consensus/tx_verify.cpp` and `src/validation.cpp`, at
+  bitcoin/bitcoin@9be056a8a7), published from `btclib.tx`. `Coin`, also
+  new there, is a frozen `(tx_out, height, is_coinbase)` with no `parse`
+  and no `serialize`: how a node stores a prevout on disk is that node's
+  own decision, not this library's, and #1123 already declined Core's.
+- **`assert_sequence_locks` takes no `enforce_bip68` flag**: Core's own
+  `fEnforceBIP68` combines a fact about the transaction, its version,
+  with chain state the caller already holds before it is worth building
+  a `Coin` sequence at all, so activation stays the caller's `if` and
+  the version check alone stays in the function — the smaller contract,
+  and the one that cannot be handed the wrong flag by accident.
+  `is_final`'s `block_time` cutoff is the caller's the same way, BIP113
+  deciding between a parent's median time past and a block's own
+  timestamp from the chain's own activation height.
+- **`LOCKTIME_THRESHOLD`, `SEQUENCE_FINAL`, every `SEQUENCE_LOCKTIME_*`
+  bit-layout constant and `COINBASE_MATURITY` move to `btclib.tx.limits`**,
+  read off Core's `src/script/script.h`, `src/primitives/transaction.h`
+  and `src/consensus/consensus.h` at the same tag. `block/limits.py`'s
+  docstring, which named `COINBASE_MATURITY`'s absence as "a rule about
+  spending an output, so it needs the chain the output was created on",
+  now points at `Coin` and `assert_coinbase_maturity` as that chain.
+
 ## v2026.8.29
 
 ### Repository

--- a/docs/source/btclib.tx.rst
+++ b/docs/source/btclib.tx.rst
@@ -4,6 +4,13 @@ btclib.tx package
 Submodules
 ----------
 
+btclib.tx.coin module
+---------------------
+
+.. automodule:: btclib.tx.coin
+   :members:
+   :show-inheritance:
+
 btclib.tx.limits module
 -----------------------
 
@@ -22,6 +29,13 @@ btclib.tx.tx module
 -------------------
 
 .. automodule:: btclib.tx.tx
+   :members:
+   :show-inheritance:
+
+btclib.tx.tx\_context module
+----------------------------
+
+.. automodule:: btclib.tx.tx_context
    :members:
    :show-inheritance:
 

--- a/src/btclib/block/limits.py
+++ b/src/btclib/block/limits.py
@@ -27,7 +27,9 @@ Some of `consensus.h`'s constants are deliberately absent.
 `MAX_BLOCK_SERIALIZED_SIZE` is marked in Core's own comment as a buffer
 bound and not a network rule, the weight being what consensus caps.
 `COINBASE_MATURITY` is a rule about spending an output, so it needs the
-chain the output was created on.
+chain the output was created on: `btclib.tx.coin.Coin` carries that
+height, and the constant is `btclib.tx.limits`'s, beside
+`btclib.tx.tx_context.assert_coinbase_maturity`, which reads it.
 
 `MAX_TIMEWARP` is here and not among those: it is BIP94's bound on the
 first block of a new retarget period, checked against that block's own

--- a/src/btclib/tx/__init__.py
+++ b/src/btclib/tx/__init__.py
@@ -2,11 +2,36 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Transactions: OutPoint, TxIn, TxOut, Tx, join, and input_weight."""
+"""Transactions: OutPoint, TxIn, TxOut, Tx, Coin, join, and input_weight."""
 
+from btclib.tx.coin import Coin
 from btclib.tx.out_point import OutPoint
 from btclib.tx.tx import Tx, join
+from btclib.tx.tx_context import (
+    AncestorMedianTimePast,
+    assert_coinbase_maturity,
+    assert_coinbase_value,
+    assert_sequence_locks,
+    is_final,
+)
 from btclib.tx.tx_in import TxIn, input_weight
 from btclib.tx.tx_out import TxOut
 
-__all__ = ["OutPoint", "Tx", "TxIn", "TxOut", "input_weight", "join"]
+# AncestorMedianTimePast, assert_coinbase_maturity, assert_coinbase_value,
+# assert_sequence_locks and is_final are flattened out of tx_context the
+# same way btclib.block flattens header_context: each is the one
+# operation a caller reaches for, not a namespace of related constants
+__all__ = [
+    "AncestorMedianTimePast",
+    "Coin",
+    "OutPoint",
+    "Tx",
+    "TxIn",
+    "TxOut",
+    "assert_coinbase_maturity",
+    "assert_coinbase_value",
+    "assert_sequence_locks",
+    "input_weight",
+    "is_final",
+    "join",
+]

--- a/src/btclib/tx/coin.py
+++ b/src/btclib/tx/coin.py
@@ -1,0 +1,81 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The Coin dataclass: a prevout, and what a rule about spending it needs.
+
+Bitcoin Core's `Coin` (`src/coins.h`, at bitcoin/bitcoin@9be056a8a7) is
+the shape matched -- an output, the height of the block that created it,
+and whether that block's own coinbase created it -- and not matched in
+full: Core's `Coin` also runs the output through `TxOutCompression`, a
+storage optimization no caller of `btclib.tx.tx_context` needs, and
+issue #1123 already declined it. How a node keeps one
+on disk is that node's decision and not this class's: no `parse` and no
+`serialize`, `to_dict` and `from_dict` included, since there is no wire
+or json shape to round-trip.
+
+A caller checking a mempool acceptance rather than a block connecting
+builds a `Coin` at one past the active chain's tip -- Core's own
+`MEMPOOL_HEIGHT` reading -- rather than this module special-casing the
+mempool: the rules in `btclib.tx.tx_context` read `Coin.height` and
+nothing about where it came from.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.tx.tx_out import TxOut
+from btclib.utils import assert_type, is_integer
+
+__all__ = [
+    "Coin",
+]
+
+
+# frozen, as OutPoint and TxOut are: a Coin is a value read off a chain at
+# one instant, not something a caller mutates in place, and the generated
+# __hash__ needs every field hashable -- TxOut already is (issue 416)
+@dataclass(frozen=True)
+class Coin:
+    """One prevout: an output, the height it was created at, a coinbase bit.
+
+    Everything `btclib.tx.tx_context`'s rules need about an output that
+    the output's own bytes do not carry -- `Consensus::CheckTxInputs`'s
+    coinbase maturity check and the BIP68 sequence lock both read a
+    prevout's creation height, which is chain state and not part of the
+    spending transaction.
+    """
+
+    tx_out: TxOut
+    height: int
+    is_coinbase: bool
+
+    def __init__(
+        self,
+        tx_out: TxOut,
+        height: int,
+        is_coinbase: bool,
+        *,
+        check_validity: bool = True,
+    ) -> None:
+        object.__setattr__(self, "tx_out", tx_out)
+        object.__setattr__(self, "height", height)
+        object.__setattr__(self, "is_coinbase", is_coinbase)
+
+        if check_validity:
+            self.assert_valid()
+
+    def assert_valid(self) -> None:
+        """Refuse a wrong-typed tx_out, a bad height, or a non-bool bit."""
+        assert_type(self.tx_out, TxOut, "tx_out")
+        self.tx_out.assert_valid()
+
+        if not is_integer(self.height):
+            err_msg = f"invalid height type: {type(self.height).__name__}"
+            raise BTClibTypeError(err_msg)
+        if self.height < 0:
+            raise BTClibValueError(f"invalid height: {self.height}")
+
+        assert_type(self.is_coinbase, bool, "is_coinbase")

--- a/src/btclib/tx/limits.py
+++ b/src/btclib/tx/limits.py
@@ -4,6 +4,9 @@
 
 """How many inputs and outputs a transaction may declare.
 
+And the numbers `btclib.tx.tx_context`'s rules compare a lock time or a
+sequence against.
+
 A module of its own, as `block/limits.py` and `script/limits.py` are and
 for the same reason: `tx.py` is the dataclass and its serialization, while
 each name here is a rule about the transaction the wire declares.
@@ -18,15 +21,34 @@ divided here come from, and its docstring is why they are not read from
 
 The minimum sizes are the same arithmetic's other half, and they are
 `tests/tx`'s to check against a serialization rather than to be believed.
+
+`LOCKTIME_THRESHOLD`, `SEQUENCE_FINAL` and the four `SEQUENCE_LOCKTIME_*`
+constants are Core's `src/script/script.h` and `src/primitives/
+transaction.h`, at bitcoin/bitcoin@9be056a8a7; `COINBASE_MATURITY` is
+`src/consensus/consensus.h`, same tag. `block/limits.py` used to carry a
+paragraph explaining why `COINBASE_MATURITY` was absent from it -- "a
+rule about spending an output, so it needs the chain the output was
+created on" -- and that reasoning is what put it here instead: a
+`btclib.tx.coin.Coin` carrying its own creation height is that chain, so
+the rule is a function of its arguments and belongs beside the module
+that reads it rather than beside `block/limits.py`'s header rules, which
+`btclib.tx` cannot import.
 """
 
 from btclib.consensus import MAX_BLOCK_WEIGHT, WITNESS_SCALE_FACTOR
 
 __all__ = [
+    "COINBASE_MATURITY",
+    "LOCKTIME_THRESHOLD",
     "MAX_TX_IN_COUNT",
     "MAX_TX_OUT_COUNT",
     "MIN_TX_IN_SIZE",
     "MIN_TX_OUT_SIZE",
+    "SEQUENCE_FINAL",
+    "SEQUENCE_LOCKTIME_DISABLE_FLAG",
+    "SEQUENCE_LOCKTIME_GRANULARITY",
+    "SEQUENCE_LOCKTIME_MASK",
+    "SEQUENCE_LOCKTIME_TYPE_FLAG",
 ]
 
 # The smallest a TxIn serializes to: a 32-octet previous transaction id, a
@@ -42,3 +64,30 @@ MIN_TX_OUT_SIZE = 8 + 1
 # -- which is what lets a parser refuse it before allocating for it
 MAX_TX_IN_COUNT = MAX_BLOCK_WEIGHT // (MIN_TX_IN_SIZE * WITNESS_SCALE_FACTOR)
 MAX_TX_OUT_COUNT = MAX_BLOCK_WEIGHT // (MIN_TX_OUT_SIZE * WITNESS_SCALE_FACTOR)
+
+# Core's LOCKTIME_THRESHOLD: a lock_time below this is a block height, at
+# or above it a unix timestamp -- Tue Nov 5 00:53:20 1985 UTC, far past any
+# height a chain will reach and far before any timestamp a block will carry
+LOCKTIME_THRESHOLD = 500_000_000
+
+# Core's CTxIn::SEQUENCE_FINAL: every input carrying it makes lock_time
+# irrelevant, whatever lock_time says (Consensus::CheckTxInputs never
+# reads it once every input is this)
+SEQUENCE_FINAL = 0xFFFFFFFF
+
+# Core's CTxIn::SEQUENCE_LOCKTIME_*: bit 31 opts a whole input out of
+# BIP68 entirely, bit 22 picks a time-based relative lock over a
+# height-based one, and the low sixteen bits are the lock itself, in
+# whichever unit bit 22 named -- GRANULARITY is how far that field is
+# shifted to turn 512-second units into seconds
+SEQUENCE_LOCKTIME_DISABLE_FLAG = 1 << 31
+SEQUENCE_LOCKTIME_TYPE_FLAG = 1 << 22
+SEQUENCE_LOCKTIME_MASK = 0x0000FFFF
+SEQUENCE_LOCKTIME_GRANULARITY = 9
+
+# Core's own COINBASE_MATURITY: how many blocks a coinbase output has to
+# sit before a spend of it may connect (Consensus::CheckTxInputs,
+# bad-txns-premature-spend-of-coinbase). The same on every network,
+# regtest included -- unlike the heights and limits `btclib.consensus`
+# tabulates per network, nothing in chainparams.cpp relaxes this one
+COINBASE_MATURITY = 100

--- a/src/btclib/tx/tx_context.py
+++ b/src/btclib/tx/tx_context.py
@@ -1,0 +1,240 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""What a transaction owes the chain before it: finality and locks.
+
+Sequence locks, coinbase maturity, and the coinbase's own value ceiling.
+
+`Tx.assert_valid` is Core's `CheckTransaction`, and `script.engine`'s
+`verify_amounts`/`verify_input` are what a transaction can be held to
+against its prevouts. Between those two and a block connecting there is
+a third set of rules, Core's `src/consensus/tx_verify.cpp` plus
+`bad-cb-amount` in `src/validation.cpp`'s `ConnectBlock`, that each need
+one fact per prevout beyond the output itself -- the height it was
+created at, and whether by a coinbase, which `btclib.tx.coin.Coin`
+carries -- and a height and a time to judge against. Every function here
+takes those as parameters rather than reading them off a UTXO set or a
+block index: btclib must not learn what either is, the same precedent
+`btclib.block.header_context`'s `ParentOf` sets for a header walking the
+chain through a callable rather than an index.
+
+Bitcoin Core v31.1 (bitcoin/bitcoin@9be056a8a7) is the reference for
+every rule, `src/consensus/tx_verify.cpp` and `src/validation.cpp`,
+cited beside the code that transcribes it.
+
+## What each function does not take, and why
+
+`is_final`'s `block_time` is a cutoff, not a choice: Core evaluates
+`IsFinalTx` in `ContextualCheckBlock` against `pindexPrev->
+GetMedianTimePast()` once BIP113 (the CSV deployment) is active on the
+chain, and against the block's own timestamp before that -- a decision
+made from the chain's own activation height, which this module does not
+carry. The caller passes whichever Core would have passed; the
+function's own docstring repeats this rather than deciding it.
+
+`assert_sequence_locks` takes no `enforce_bip68` flag. Core's own
+`fEnforceBIP68` is `tx.version >= 2 && DeploymentActiveAt(...,
+DEPLOYMENT_CSV)`: the first half is a fact about the transaction and
+stays in this function, the second is chain state a caller already knows
+before it is worth building a `Coin` sequence at all -- a function that
+only evaluates the locks once asked, with activation decided outside, is
+the smaller contract, and the one that cannot be handed the wrong flag
+by accident.
+
+A mempool acceptance, where a coin has no block yet, is not special-cased
+here either: `coin.py`'s docstring is where that is, and it is the
+caller's `Coin` to build, at Core's `MEMPOOL_HEIGHT` reading, rather than
+a branch these functions would otherwise need.
+
+`assert_coinbase_value` takes the fee sum and the subsidy rather than
+every other transaction of the block and their own prevouts: Core's own
+`ConnectBlock` accumulates `nFees` transaction by transaction as it
+connects them, and `btclib.consensus.subsidy` is already the halving
+arithmetic -- summing fees from a block's own transactions a second time
+here would be a second implementation of what a caller connecting a
+block already does once.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.tx.coin import Coin
+from btclib.tx.limits import (
+    COINBASE_MATURITY,
+    LOCKTIME_THRESHOLD,
+    SEQUENCE_FINAL,
+    SEQUENCE_LOCKTIME_DISABLE_FLAG,
+    SEQUENCE_LOCKTIME_GRANULARITY,
+    SEQUENCE_LOCKTIME_MASK,
+    SEQUENCE_LOCKTIME_TYPE_FLAG,
+)
+from btclib.tx.tx import Tx
+from btclib.utils import is_integer
+
+__all__ = [
+    "AncestorMedianTimePast",
+    "assert_coinbase_maturity",
+    "assert_coinbase_value",
+    "assert_sequence_locks",
+    "is_final",
+]
+
+# a height, and the median time past of the block at it: what
+# `assert_sequence_locks` asks for a time-based lock, over however many
+# ancestors the caller's own chain state holds rather than over an index
+# this module never sees -- the same shape `header_context.ParentOf` is,
+# and for the same reason
+AncestorMedianTimePast = Callable[[int], int]
+
+
+def is_final(tx: Tx, height: int, block_time: int) -> bool:
+    """Answer whether `tx` is final at `height`, against a `block_time` cutoff.
+
+    Core's `IsFinalTx` (`src/consensus/tx_verify.cpp`, at
+    bitcoin/bitcoin@9be056a8a7): a zero `lock_time` is always final;
+    otherwise `tx` is final once `height` or `block_time` -- whichever
+    `lock_time`'s own units name, decided against `LOCKTIME_THRESHOLD` --
+    has passed it, or regardless if every one of `tx`'s own inputs opts
+    out of `lock_time` by carrying `SEQUENCE_FINAL`.
+
+    Which instant `block_time` is, is the caller's: `pindexPrev->
+    GetMedianTimePast()` once BIP113 (the CSV deployment) is active on
+    the chain being validated against, the block's own timestamp before
+    that -- Core's `ContextualCheckBlock` decides it from the chain's own
+    activation height, which this function does not carry. A caller
+    checking a block reports `False` here as Core's own
+    `bad-txns-nonfinal`.
+    """
+    for name, value in (("height", height), ("block_time", block_time)):
+        if not is_integer(value):
+            err_msg = f"invalid {name} type: {type(value).__name__}"
+            raise BTClibTypeError(err_msg)
+
+    if tx.lock_time == 0:
+        return True
+    cutoff = height if tx.lock_time < LOCKTIME_THRESHOLD else block_time
+    if tx.lock_time < cutoff:
+        return True
+    return all(tx_in.sequence == SEQUENCE_FINAL for tx_in in tx.vin)
+
+
+def assert_sequence_locks(
+    tx: Tx,
+    prevouts: Sequence[Coin],
+    height: int,
+    tip_median_time_past: int,
+    ancestor_median_time_past: AncestorMedianTimePast,
+) -> None:
+    """Refuse `tx` if a BIP68 relative lock time of its inputs is unmet.
+
+    Core's `CalculateSequenceLocks` and `EvaluateSequenceLocks`, combined
+    as `SequenceLocks` is (`src/consensus/tx_verify.cpp`, at
+    bitcoin/bitcoin@9be056a8a7): `prevouts` aligned with `tx.vin`, one
+    `Coin` per input, in place of a freshly-read `CCoinsViewCache`.
+
+    A transaction below version 2 is skipped, matching BIP68 -- the
+    module docstring says why no `enforce_bip68` flag is here to skip
+    the rest of it too. An input whose sequence carries
+    `SEQUENCE_LOCKTIME_DISABLE_FLAG` is skipped the same way, on its own
+    rather than the whole transaction's.
+
+    `height` is `Core`'s own `block.nHeight` -- the height of the block
+    the transaction is connecting into, one past its own parent's --
+    and `tip_median_time_past` is that parent's `GetMedianTimePast()`,
+    the reference a height-based lock is compared against directly and a
+    time-based one after `ancestor_median_time_past` has turned each
+    input's own relative lock into an absolute one.
+    `ancestor_median_time_past(h)` is `header_context.median_time_past`
+    of the block at height `h`, called once per time-locked input at
+    `max(coin.height - 1, 0)` -- the block before the one that confirmed
+    the coin, matching Core's own comment on why: "the smallest allowed
+    timestamp of the block containing the txout being spent".
+
+    Refuses with `bad-txns-nonfinal`, the message Core's own
+    `ConnectBlock` reports a failure of this rule with.
+    """
+    if len(prevouts) != len(tx.vin):
+        err_msg = f"{len(prevouts)} prevouts for {len(tx.vin)} transaction inputs"
+        raise BTClibValueError(err_msg)
+    for name, value in (
+        ("height", height),
+        ("tip_median_time_past", tip_median_time_past),
+    ):
+        if not is_integer(value):
+            err_msg = f"invalid {name} type: {type(value).__name__}"
+            raise BTClibTypeError(err_msg)
+
+    if tx.version < 2:
+        return
+
+    min_height = -1
+    min_time = -1
+    for tx_in, coin in zip(tx.vin, prevouts, strict=True):
+        sequence = tx_in.sequence
+        if sequence & SEQUENCE_LOCKTIME_DISABLE_FLAG:
+            continue
+        if sequence & SEQUENCE_LOCKTIME_TYPE_FLAG:
+            coin_time = ancestor_median_time_past(max(coin.height - 1, 0))
+            min_time = max(
+                min_time,
+                coin_time
+                + ((sequence & SEQUENCE_LOCKTIME_MASK) << SEQUENCE_LOCKTIME_GRANULARITY)
+                - 1,
+            )
+        else:
+            min_height = max(
+                min_height, coin.height + (sequence & SEQUENCE_LOCKTIME_MASK) - 1
+            )
+
+    if min_height >= height or min_time >= tip_median_time_past:
+        raise BTClibValueError("bad-txns-nonfinal")
+
+
+def assert_coinbase_maturity(prevouts: Sequence[Coin], spend_height: int) -> None:
+    """Refuse a spend of a coinbase output not yet `COINBASE_MATURITY` deep.
+
+    Core's `Consensus::CheckTxInputs`, `bad-txns-premature-spend-of-
+    coinbase` (`src/consensus/tx_verify.cpp`, at
+    bitcoin/bitcoin@9be056a8a7): `spend_height - coin.height <
+    COINBASE_MATURITY`, for whichever of `prevouts` is a coinbase output.
+
+    `spend_height` is not always the height of the block connecting the
+    spend: a mempool acceptance passes one past the active chain's own
+    tip instead, matching Core's own `MemPoolAccept::PreChecks`
+    (`m_active_chainstate.m_chain.Height() + 1`, `src/validation.cpp`,
+    same tag).
+    """
+    if not is_integer(spend_height):
+        err_msg = f"invalid spend_height type: {type(spend_height).__name__}"
+        raise BTClibTypeError(err_msg)
+
+    for coin in prevouts:
+        if coin.is_coinbase and spend_height - coin.height < COINBASE_MATURITY:
+            raise BTClibValueError("bad-txns-premature-spend-of-coinbase")
+
+
+def assert_coinbase_value(coinbase: Tx, subsidy: int, fees: int) -> None:
+    """Refuse a coinbase paying more than the subsidy plus the fees it collects.
+
+    Core's `bad-cb-amount` (`ConnectBlock`, `src/validation.cpp`, at
+    bitcoin/bitcoin@9be056a8a7): `blockReward = nFees +
+    GetBlockSubsidy(...)`, refused if `coinbase.GetValueOut() >
+    blockReward`. `subsidy` is `btclib.consensus.subsidy`'s answer at the
+    block's own height; `fees` is the caller's own sum of what every
+    other transaction of the block pays in -- the module docstring says
+    why summing them again here would be a second implementation of a
+    block connector's own bookkeeping.
+    """
+    for name, value in (("subsidy", subsidy), ("fees", fees)):
+        if not is_integer(value):
+            err_msg = f"invalid {name} type: {type(value).__name__}"
+            raise BTClibTypeError(err_msg)
+
+    coinbase_value = sum(tx_out.value for tx_out in coinbase.vout)
+    ceiling = subsidy + fees
+    if coinbase_value > ceiling:
+        err_msg = f"bad-cb-amount: {coinbase_value} instead of {ceiling}"
+        raise BTClibValueError(err_msg)

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -262,7 +262,15 @@ CHILD_MODULES = {
     },
     "btclib.tx": {
         "groups": [],
-        "unpublished": ["limits", "out_point", "tx", "tx_in", "tx_out"],
+        "unpublished": [
+            "coin",
+            "limits",
+            "out_point",
+            "tx",
+            "tx_context",
+            "tx_in",
+            "tx_out",
+        ],
     },
     "btclib.wallet": {
         "groups": [],

--- a/tests/bool_parameter_test.py
+++ b/tests/bool_parameter_test.py
@@ -160,6 +160,7 @@ from btclib.to_pub_key import (
     pub_keyinfo_from_prv_key,
     pub_keyinfo_from_pub_key,
 )
+from btclib.tx.coin import Coin
 from btclib.tx.out_point import OutPoint
 from btclib.tx.tx import Tx
 from btclib.tx.tx import join as tx_join
@@ -545,6 +546,16 @@ _KINDS = (
         "include_witness",
         BlockPayload,
         {"block": _BLOCK},
+    ),
+    # a stored fact rather than a switch: `is_coinbase` is not read to
+    # decide how `Coin.__init__` behaves, it is the value `assert_
+    # coinbase_maturity` later branches on for the coin it is handed, so
+    # a misread "no" would carry a wrong fact into a rule miles from here
+    _Case(
+        "btclib.tx.coin.Coin.__init__",
+        "is_coinbase",
+        Coin,
+        {"tx_out": TxOut(1_000, b"\x51"), "height": 100},
     ),
     _Case(
         "btclib.b32.power_of_2_base_conversion",

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -380,6 +380,7 @@ KEYWORD_ONLY: dict[str, list[str]] = {
     "btclib.script:Witness.parse": ["check_validity"],
     "btclib.script:Witness.serialize": ["check_validity"],
     "btclib.script:Witness.to_dict": ["check_validity"],
+    "btclib.tx:Coin.__init__": ["check_validity"],
     "btclib.tx:OutPoint.__init__": ["check_validity"],
     "btclib.tx:OutPoint.from_dict": ["check_validity"],
     "btclib.tx:OutPoint.parse": ["check_validity"],

--- a/tests/tx/coin_test.py
+++ b/tests/tx/coin_test.py
@@ -1,0 +1,80 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the `btclib.tx.coin` module."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.script import ScriptPubKey
+from btclib.tx import Coin, TxOut
+
+A_TX_OUT = TxOut(1_000, ScriptPubKey(b""))
+
+
+def test_coin() -> None:
+    """Check the three fields, one coinbase and one not."""
+    coin = Coin(A_TX_OUT, 100, is_coinbase=True)
+    assert coin.tx_out == A_TX_OUT
+    assert coin.height == 100
+    assert coin.is_coinbase
+
+    coin = Coin(A_TX_OUT, 0, is_coinbase=False)
+    assert coin.height == 0
+    assert not coin.is_coinbase
+
+
+def test_frozen() -> None:
+    """Refuse assignment to any field: a frozen Coin is hashable."""
+    coin = Coin(A_TX_OUT, 100, is_coinbase=True)
+
+    with pytest.raises(FrozenInstanceError):
+        coin.height = 101  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        coin.is_coinbase = False  # type: ignore[misc]
+
+    assert hash(coin) == hash(Coin(A_TX_OUT, 100, is_coinbase=True))
+    assert len({coin, Coin(A_TX_OUT, 100, is_coinbase=True)}) == 1
+
+
+def test_invalid_tx_out() -> None:
+    """Refuse a tx_out of the wrong type."""
+    with pytest.raises(BTClibTypeError, match="invalid tx_out type"):
+        Coin("not a tx_out", 100, is_coinbase=True)  # type: ignore[arg-type]
+
+
+def test_invalid_height() -> None:
+    """Refuse a non-integer or negative height."""
+    with pytest.raises(BTClibTypeError, match="invalid height type"):
+        Coin(A_TX_OUT, "100", is_coinbase=True)  # type: ignore[arg-type]
+
+    with pytest.raises(BTClibValueError, match="invalid height"):
+        Coin(A_TX_OUT, -1, is_coinbase=True)
+
+    with pytest.raises(BTClibTypeError, match="invalid height type"):
+        Coin(A_TX_OUT, True, is_coinbase=True)  # bool is not a height
+
+
+def test_invalid_is_coinbase() -> None:
+    """Refuse an is_coinbase of the wrong type."""
+    with pytest.raises(BTClibTypeError, match="invalid is_coinbase type"):
+        Coin(A_TX_OUT, 100, is_coinbase=1)  # type: ignore[arg-type]
+
+
+def test_invalid_tx_out_content() -> None:
+    """A malformed tx_out is refused through TxOut.assert_valid."""
+    bad = TxOut(1_000, ScriptPubKey(b""), check_validity=False)
+    object.__setattr__(bad, "value", -1)
+    with pytest.raises(BTClibValueError):
+        Coin(bad, 100, is_coinbase=True)
+
+
+def test_check_validity_false_skips_the_check() -> None:
+    """check_validity=False builds a Coin nothing here has judged yet."""
+    coin = Coin(A_TX_OUT, -1, is_coinbase=True, check_validity=False)
+    assert coin.height == -1
+    with pytest.raises(BTClibValueError, match="invalid height"):
+        coin.assert_valid()

--- a/tests/tx/tx_context_test.py
+++ b/tests/tx/tx_context_test.py
@@ -1,0 +1,261 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the `btclib.tx.tx_context` module.
+
+Every case is synthetic and hand-computed against Bitcoin Core v31.1's
+own `src/consensus/tx_verify.cpp` (bitcoin/bitcoin@9be056a8a7): the four
+rules under test each need a chain around the transaction that no vector
+file carries, and Core's own coverage of them lives in the functional
+suite (`feature_cltv.py`, `feature_csv_activation.py`), which drives a
+running node rather than a table of inputs and outputs.
+"""
+
+import pytest
+
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.script import ScriptPubKey
+from btclib.tx import Coin, OutPoint, Tx, TxIn, TxOut
+from btclib.tx.limits import (
+    LOCKTIME_THRESHOLD,
+    SEQUENCE_FINAL,
+    SEQUENCE_LOCKTIME_DISABLE_FLAG,
+    SEQUENCE_LOCKTIME_TYPE_FLAG,
+)
+from btclib.tx.tx_context import (
+    assert_coinbase_maturity,
+    assert_coinbase_value,
+    assert_sequence_locks,
+    is_final,
+)
+
+A_SCRIPT_PUB_KEY = ScriptPubKey(b"")
+A_PREV_OUT = OutPoint(b"\x11" * 32, 0)
+
+
+def _tx_out(value: int = 1_000) -> TxOut:
+    """Return a TxOut of the given value, script_pub_key held fixed."""
+    return TxOut(value, A_SCRIPT_PUB_KEY)
+
+
+def _tx(version: int = 2, lock_time: int = 0, sequence: int = 0) -> Tx:
+    """Return a one-input, one-output Tx over the given fields."""
+    return Tx(
+        version,
+        lock_time,
+        [TxIn(A_PREV_OUT, sequence=sequence)],
+        [_tx_out()],
+    )
+
+
+def _coinbase(script_sig: bytes = b"\x02\x00\x00", value: int = 50 * 100_000_000) -> Tx:
+    """Return a coinbase Tx paying `value`."""
+    return Tx(
+        2,
+        0,
+        [TxIn(OutPoint(), script_sig=script_sig)],
+        [_tx_out(value)],
+    )
+
+
+# --- is_final --------------------------------------------------------
+
+
+def test_a_zero_lock_time_is_always_final() -> None:
+    """Core's IsFinalTx: lock_time 0 is final regardless of height or time."""
+    tx = _tx(lock_time=0, sequence=0)
+    assert is_final(tx, height=0, block_time=0)
+
+
+def test_a_height_lock_time_is_read_against_height() -> None:
+    """lock_time is the last invalid height: not final at or below it.
+
+    Final once `height` has passed it, Core's own nLockTime semantics.
+    """
+    tx = _tx(lock_time=500, sequence=0)
+    assert not is_final(tx, height=500, block_time=10**9)
+    assert is_final(tx, height=501, block_time=0)
+
+
+def test_a_timestamp_lock_time_is_read_against_block_time() -> None:
+    """A lock_time at or above LOCKTIME_THRESHOLD is read as a timestamp."""
+    tx = _tx(lock_time=LOCKTIME_THRESHOLD + 100, sequence=0)
+    assert not is_final(tx, height=10**9, block_time=LOCKTIME_THRESHOLD + 100)
+    assert is_final(tx, height=0, block_time=LOCKTIME_THRESHOLD + 101)
+
+
+def test_every_input_final_overrides_an_unmet_lock_time() -> None:
+    """SEQUENCE_FINAL on every input makes lock_time irrelevant."""
+    tx = _tx(lock_time=500, sequence=SEQUENCE_FINAL)
+    assert is_final(tx, height=0, block_time=0)
+
+
+def test_is_final_refuses_a_non_integer_height_or_block_time() -> None:
+    """A malformed height or block_time is refused, not silently coerced."""
+    tx = _tx()
+    with pytest.raises(BTClibTypeError, match="invalid height type"):
+        is_final(tx, height="0", block_time=0)  # type: ignore[arg-type]
+    with pytest.raises(BTClibTypeError, match="invalid block_time type"):
+        is_final(tx, height=0, block_time="0")  # type: ignore[arg-type]
+
+
+# --- assert_coinbase_maturity -----------------------------------------
+
+
+def test_a_coinbase_below_the_maturity_depth_is_refused() -> None:
+    """bad-txns-premature-spend-of-coinbase, below and at the boundary."""
+    coin = Coin(_tx_out(), height=100, is_coinbase=True)
+    with pytest.raises(BTClibValueError, match="bad-txns-premature-spend-of-coinbase"):
+        assert_coinbase_maturity([coin], spend_height=199)
+    assert_coinbase_maturity([coin], spend_height=200)
+
+
+def test_a_non_coinbase_prevout_is_never_refused_on_maturity() -> None:
+    """A prevout that is not a coinbase has no maturity rule at all."""
+    coin = Coin(_tx_out(), height=100, is_coinbase=False)
+    assert_coinbase_maturity([coin], spend_height=100)
+
+
+def test_assert_coinbase_maturity_refuses_a_non_integer_spend_height() -> None:
+    """A malformed spend_height is refused, not silently coerced."""
+    coin = Coin(_tx_out(), height=100, is_coinbase=True)
+    with pytest.raises(BTClibTypeError, match="invalid spend_height type"):
+        assert_coinbase_maturity([coin], spend_height="200")  # type: ignore[arg-type]
+
+
+# --- assert_coinbase_value ---------------------------------------------
+
+
+def test_a_coinbase_at_or_below_subsidy_plus_fees_is_accepted() -> None:
+    """A coinbase paying exactly the ceiling, or under it, is accepted."""
+    coinbase = _coinbase(value=100)
+    assert_coinbase_value(coinbase, subsidy=90, fees=10)
+    assert_coinbase_value(coinbase, subsidy=100, fees=0)
+
+
+def test_a_coinbase_above_subsidy_plus_fees_is_refused() -> None:
+    """bad-cb-amount: a coinbase paying more than subsidy plus fees."""
+    coinbase = _coinbase(value=101)
+    with pytest.raises(BTClibValueError, match="bad-cb-amount"):
+        assert_coinbase_value(coinbase, subsidy=90, fees=10)
+
+
+def test_assert_coinbase_value_refuses_a_non_integer_subsidy_or_fees() -> None:
+    """A malformed subsidy or fees is refused, not silently coerced."""
+    coinbase = _coinbase()
+    with pytest.raises(BTClibTypeError, match="invalid subsidy type"):
+        assert_coinbase_value(coinbase, subsidy="90", fees=0)  # type: ignore[arg-type]
+    with pytest.raises(BTClibTypeError, match="invalid fees type"):
+        assert_coinbase_value(coinbase, subsidy=90, fees="0")  # type: ignore[arg-type]
+
+
+# --- assert_sequence_locks ----------------------------------------------
+
+
+def test_a_version_1_transaction_is_never_sequence_locked() -> None:
+    """BIP68 does not apply below version 2, whatever the sequence is."""
+    tx = _tx(version=1, sequence=5)
+    coin = Coin(_tx_out(), height=100, is_coinbase=False)
+    assert_sequence_locks(
+        tx,
+        [coin],
+        height=0,
+        tip_median_time_past=0,
+        ancestor_median_time_past=lambda h: 0,
+    )
+
+
+def test_a_disabled_sequence_is_never_sequence_locked() -> None:
+    """SEQUENCE_LOCKTIME_DISABLE_FLAG opts a single input out of BIP68."""
+    tx = _tx(sequence=SEQUENCE_LOCKTIME_DISABLE_FLAG | 5)
+    coin = Coin(_tx_out(), height=100, is_coinbase=False)
+    assert_sequence_locks(
+        tx,
+        [coin],
+        height=0,
+        tip_median_time_past=0,
+        ancestor_median_time_past=lambda h: 0,
+    )
+
+
+def test_a_height_based_lock_is_read_against_height() -> None:
+    """A height-based lock of 5 over a coin at height 100 matures at 105."""
+    tx = _tx(sequence=5)
+    coin = Coin(_tx_out(), height=100, is_coinbase=False)
+    with pytest.raises(BTClibValueError, match="bad-txns-nonfinal"):
+        assert_sequence_locks(
+            tx,
+            [coin],
+            height=104,
+            tip_median_time_past=0,
+            ancestor_median_time_past=lambda h: 0,
+        )
+    assert_sequence_locks(
+        tx,
+        [coin],
+        height=105,
+        tip_median_time_past=0,
+        ancestor_median_time_past=lambda h: 0,
+    )
+
+
+def test_a_time_based_lock_is_read_against_tip_median_time_past() -> None:
+    """A time-based lock of 5 units (2560s) over a 1_000s ancestor."""
+    coin = Coin(_tx_out(), height=100, is_coinbase=False)
+    tx = _tx(sequence=SEQUENCE_LOCKTIME_TYPE_FLAG | 5)
+
+    def ancestor_median_time_past(height: int) -> int:
+        assert height == coin.height - 1
+        return 1_000
+
+    with pytest.raises(BTClibValueError, match="bad-txns-nonfinal"):
+        assert_sequence_locks(
+            tx,
+            [coin],
+            height=0,
+            tip_median_time_past=1_000 + 2_560 - 1,
+            ancestor_median_time_past=ancestor_median_time_past,
+        )
+    assert_sequence_locks(
+        tx,
+        [coin],
+        height=0,
+        tip_median_time_past=1_000 + 2_560,
+        ancestor_median_time_past=ancestor_median_time_past,
+    )
+
+
+def test_assert_sequence_locks_refuses_a_prevouts_count_mismatch() -> None:
+    """Prevouts must align with tx.vin one for one."""
+    tx = _tx(sequence=5)
+    with pytest.raises(BTClibValueError, match="prevouts for"):
+        assert_sequence_locks(
+            tx,
+            [],
+            height=0,
+            tip_median_time_past=0,
+            ancestor_median_time_past=lambda h: 0,
+        )
+
+
+def test_assert_sequence_locks_refuses_a_non_integer_height_or_time() -> None:
+    """A malformed height or tip_median_time_past is refused."""
+    tx = _tx(sequence=5)
+    coin = Coin(_tx_out(), height=100, is_coinbase=False)
+    with pytest.raises(BTClibTypeError, match="invalid height type"):
+        assert_sequence_locks(
+            tx,
+            [coin],
+            height="0",  # type: ignore[arg-type]
+            tip_median_time_past=0,
+            ancestor_median_time_past=lambda h: 0,
+        )
+    with pytest.raises(BTClibTypeError, match="invalid tip_median_time_past type"):
+        assert_sequence_locks(
+            tx,
+            [coin],
+            height=0,
+            tip_median_time_past="0",  # type: ignore[arg-type]
+            ancestor_median_time_past=lambda h: 0,
+        )


### PR DESCRIPTION
Closes #1580

`is_final`, `assert_sequence_locks`, `assert_coinbase_maturity` and
`assert_coinbase_value` are the four `Consensus::CheckTxInputs` /
`ConnectBlock` rules btclib-node's `interpreter.py` wrote on its own,
transcribed from Bitcoin Core v31.1 (bitcoin/bitcoin@9be056a8a7) as
functions over a `Tx`, over a `Sequence[Coin]` of prevouts, or over
both. `Coin` is a new frozen `(tx_out, height, is_coinbase)` in
`btclib.tx`, with no `parse` and no `serialize`, a node's on-disk form
being its own decision (issue #1123).

`assert_sequence_locks` takes no `enforce_bip68` flag: activation stays
the caller's, the transaction's own version check stays here. The
lock-time and sequence constants move to `btclib.tx.limits`.

Gates: `pytest` exit 0 (31306 passed, 30 skipped, 1 xfailed, 100.00%
coverage), `pre-commit run --all-files` exit 0, `sphinx-build -n -W
--keep-going` exit 0. Three rounds of local review at fresh context;
round 2 caught a false clause in the commit message body, which
`squash_merge_commit_message = COMMIT_MESSAGES` would have landed
unrewritable on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Add Bitcoin transaction-context consensus checks and prevout metadata support for validating finality, relative locks, coinbase maturity, and coinbase rewards.

New Features:
- Add transaction-context checks for finality, BIP68 sequence locks, coinbase maturity, and coinbase reward limits.
- Introduce an immutable Coin type for associating prevouts with creation height and coinbase status.

Enhancements:
- Expose transaction-context rules and related consensus constants through btclib.tx and btclib.tx.limits.
- Align the new consensus checks with Bitcoin Core v31.1 behavior while leaving chain-state decisions to callers.

Documentation:
- Document the new transaction-context APIs, Coin model, and relocated transaction consensus constants.

Tests:
- Add coverage for Coin validation and immutability plus transaction finality, sequence-lock, coinbase-maturity, and coinbase-value boundary cases.