### PR TITLE
`btclib.hwi` records `registerdescriptor` as unreleased HWI (closes #1592)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1120,6 +1120,21 @@ documented at release-notes length in the first place, and are still in
   spending an output, so it needs the chain the output was created on",
   now points at `Coin` and `assert_coinbase_maturity` as that chain.
 
+### `btclib.hwi` says which of its commands no HWI release carries
+
+- **`btclib.hwi`'s module docstring now says that
+  `HwiSigner.register_descriptor` runs a subcommand no HWI release
+  through 3.2.0 carries, and `tests/_data/README.md` says the same of
+  its `hwilib/_cli.py` and `hwilib/errors.py` pins, which are read
+  against `master` where `.github/workflows/integration-hwi.yml`
+  installs a release** (closes #1592). So the weekly `integration-hwi`
+  job runs a command line `register_descriptor` cannot reach, and
+  `tests/hwi_test.py` is green either way, its device being a stand-in it
+  writes itself rather than HWI. Both files name what ends the wait --
+  raising `HWI_VERSION` to the first release whose `hwilib/_cli.py` adds
+  `registerdescriptor` -- so the caveat says when it stops being true and
+  not only that it is.
+
 ## v2026.8.29
 
 ### Repository

--- a/src/btclib/hwi.py
+++ b/src/btclib/hwi.py
@@ -73,11 +73,21 @@ exchange, and `HwiSigner.register_descriptor` wraps it the way `getxpub`
 and `signmessage` are wrapped: one request, one opaque answer, nothing
 here to check it against.
 
+No HWI release through 3.2.0 carries that subcommand -- it is on
+`master` -- and `.github/workflows/integration-hwi.yml` installs 3.2.0,
+so the weekly `integration-hwi` job runs a command line
+`register_descriptor` cannot reach. Raising that workflow's
+`HWI_VERSION` to the first release whose `hwilib/_cli.py` adds
+`registerdescriptor` is what ends the wait, and what makes this paragraph
+removable.
+
 `displayaddress`'s BIP388 policy mode -- `--registration`, `--index`,
-`--multipath-index` -- is not wrapped. `psbt_signer.display_address`
-exists to compare a device's screen with the address a `Descriptor`
-computes, and `descriptors.wallet_policy_address` is now that address for
-a policy too: `descriptors.wallet_policy` builds the `@N` template and
+`--multipath-index` -- is not wrapped, and is on `master` rather than in
+a release for the same reason `registerdescriptor` is.
+`psbt_signer.display_address` exists to compare a device's screen with
+the address a `Descriptor` computes, and
+`descriptors.wallet_policy_address` is now that address for a policy
+too: `descriptors.wallet_policy` builds the `@N` template and
 key-information vector BIP388's own `/**` describes, from a receive and
 a change `Descriptor` of one account -- `account_descriptors`' own pair
 -- or the narrower `/*` form from one `Descriptor` alone, and
@@ -665,6 +675,10 @@ class HwiSigner:
 
         Checksummed, which is what HWI's parser requires of anything it is
         given, `--desc` included.
+
+        No HWI release through 3.2.0 has `registerdescriptor` at all, so
+        this needs a build of `master`; the module docstring's *Wallet
+        policies* says what ends that.
         """
         assert_type(name, str, "name")
         text = add_checksum(str(descriptor))

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -1268,6 +1268,12 @@ working against the next release somebody installs — so the weekly
 re-check is the alignment, and `tests/hwi_test.py` carries the
 transcription it is checked against.
 
+Both pins are read against `master`, and
+`.github/workflows/integration-hwi.yml` installs release 3.2.0, so two
+interfaces are in play and each entry below says what the release does
+not carry. `tests/hwi_test.py` answers from a stand-in it writes itself
+and is green against either; the weekly jobs are what run the release.
+
 ### Not vendored as a file: the commands and flags of HWI's JSON CLI
 
 ```text
@@ -1303,6 +1309,14 @@ the surface `tests/hwi_test.py` transcribes still has nothing to send
 them on. `signtx`'s answer keys (`psbt`, `signed`) are unaffected by
 a registration being passed alongside the transaction.
 
+Not in a release: `registerdescriptor` and its `registration` answer
+key, and the BIP388 policy arguments named above -- `--index`,
+`--multipath-index`/`--change`, and `--registration` on either command.
+All of them entered upstream in 2026-08, after 3.2.0 shipped, so the
+weekly jobs cannot reach `HwiSigner.register_descriptor` at all and
+would refuse those flags. Raising `HWI_VERSION` to the first release
+whose `hwilib/_cli.py` adds them is what makes the two interfaces one.
+
 The parser has only ever grown, and only additively, since 2021:
 `--emulators` in 2024, `--chain` and `--expert` on enumerate in 2022,
 `registerdescriptor` and the BIP388 policy arguments on `displayaddress`
@@ -1327,13 +1341,18 @@ Verdict: **transcribed**. The pin now carries the same commit
 the old name as a compat alias with the same code, -4 — is why
 `tests/hwi_test.py`'s table now reads `UNKNOWN_DEVICE_TYPE`;
 `pyproject.toml`'s typos exception for the old spelling stays, for
-`CHANGELOG.md`'s own narration of it. Nineteen numbers with the names
-HWI gives them, in `tests/hwi_test.py`, and one test per number that a
-`{"error": …, "code": …}` answer arrives as an `exceptions.SignerError`
-carrying it. The numbers are what a caller acts on — -14 is somebody
-pressing the button that says no, -3 is a cable, -9 is a model that will
-never do it — so an adapter that dropped them would leave a caller
-matching on the text of a message.
+`CHANGELOG.md`'s own narration of it. Every number `master` defines,
+under the name it gives, in `tests/hwi_test.py`, and one test per number
+that a `{"error": …, "code": …}` answer arrives as an
+`exceptions.SignerError` carrying it. The numbers are what a caller acts
+on — -14 is somebody pressing the button that says no, -3 is a cable, -9
+is a model that will never do it — so an adapter that dropped them would
+leave a caller matching on the text of a message.
+
+Not in a release: `INVALID_POLICY` (-19). The rest of the table is in
+3.2.0, where -4 carries the misspelling this pin's commit corrects — a
+name that differs and a number that does not, and the number is what
+`tests/hwi_test.py` asserts on.
 
 ## bitcoin-core/qa-assets
 


### PR DESCRIPTION
Answers [ISS 1592](https://github.com/btclib-org/btclib/issues/1592).

`HwiSigner.register_descriptor` runs HWI's `registerdescriptor`, and no
HWI release has that subcommand. `.github/workflows/integration-hwi.yml`
pins `HWI_VERSION: "3.2.0"`, which is still the newest release, so **the
one command in `btclib.hwi` with no released counterpart is also the one
no integration run has ever executed** — the CLI the job installs would
answer `invalid choice`.

## The decision

The issue offered two answers: move the pin, or record the caveat. The
pin cannot move, and there is no version number to wait for either —
`hwilib/__init__.py` on `master` still declares `__version__ = "3.2.0"`.

So the wait is written as **an event with a command attached** rather
than as a version: *the first release whose `hwilib/_cli.py` adds
`registerdescriptor`*. The sentence it rests on — "No HWI release
through 3.2.0 carries that subcommand" — is monotone and cannot become
false, and the expiry is testable in one command against the newest tag.

## What the review found

The three introducing commits are in **no tag at all** —
`git tag --contains` answers nothing for each, with a 3.1.0-era commit
answering three tags as the control. And the claim was checked against
the artifact the workflow installs rather than only against the source:
the published wheel's `hwilib/_cli.py` is byte-identical to tag
`3.2.0`'s.

It also caught a contradiction this diff had introduced: the entry said
"everything else listed above is in 3.2.0" four lines below a paragraph
listing five BIP388 flags that are **also** master-only. They are now
named in the same sentence, with their upstream date.

## What is unmeasured, and now recorded

`tests/hwi_test.py` transcribes `master` and **cannot notice**: its
device is a stand-in it writes itself, so no HWI is installed and no
released CLI is consulted. It lists `registerdescriptor` and carries
`INVALID_POLICY` (-19), and is green against a stub either way.
`tests/integration/hwi_device_test.py` defines three tests and none
calls `register_descriptor`. `tests/_data/README.md` now says which
interface each pin is read against.

## Verification

`CHANGELOG.md` is `merge=union`, whose damage is silent — this campaign
has had it eat the blank line above a new `###` heading five times, every
one on a rebase that exited 0 with a clean tree. So the base was not
rebased onto: the commit was rebuilt on it, with the arriving block's
blank lines discarded and re-supplied rather than copied. 15 added and 0
removed, content read back **from the commit's own sha**, two controls
each proved to differ from the reconstruction before use, and all 35
`###` groups in the open section carry a blank line above and below.

Gates all exit 0: `pre-commit run --all-files`, `pytest`, the
`sphinx-build -n -W --keep-going` docs build, and `check-sdist` re-run
after it. `git status --porcelain` empty.

Filed rather than folded in: [ISS 1599](https://github.com/btclib-org/btclib/issues/1599)
(`hwi.py` says testnet4 has no HWI chain; HWI has had `Chain.TESTNET4`
since 3.2.0) and [ISS 1595](https://github.com/btclib-org/btclib/issues/1595).
Both want their own test and a decision this branch has no business making.

Closes #1592.

## Summary by Sourcery

Document the HWI release gap so unsupported commands, policy options, and error codes are clearly identified until a compatible HWI release is available.

Enhancements:
- Document that `HwiSigner.register_descriptor` and related BIP388 options require unreleased HWI functionality, and identify the first compatible release as the condition for removing the caveat.
- Clarify which HWI interfaces are sourced from `master` versus the released 3.2.0 integration pin, including the unreleased `INVALID_POLICY` error code.

Documentation:
- Update the changelog and HWI test-data documentation to record the release gap and the interfaces covered by each HWI reference.