### PR TITLE
LOCKTIME_THRESHOLD and SEQUENCE_LOCKTIME_TYPE_FLAG read from btclib.tx.limits (closes #1608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1225,6 +1225,18 @@ documented at release-notes length in the first place, and are still in
   here. They need the `Coin` value type the contextual transaction rules
   bring in, and are a second step the issue explicitly deferred.
 
+### `LOCKTIME_THRESHOLD` and `SEQUENCE_LOCKTIME_TYPE_FLAG` read from `btclib.tx.limits`
+
+- **`descriptors/miniscript.py`'s module-private `_LOCKTIME_THRESHOLD` and
+  `_SEQUENCE_LOCKTIME_TYPE_FLAG`, and the bare `500000000` littered twice
+  through `script/engine/script_op_codes.py`'s `op_checklocktimeverify`,
+  now read the two constants `btclib.tx.limits` already publishes**
+  (closes #1608): #1580 made them public there without removing the
+  copies its own diff claimed had "moved". `script/limits.py`'s docstring
+  said of `LOCKTIME_THRESHOLD` "it stays where `OP_CHECKLOCKTIMEVERIFY`
+  reads it", true of neither module before this, and now true of both --
+  the op code's own bare literal included.
+
 ## v2026.8.29
 
 ### Repository

--- a/src/btclib/descriptors/miniscript.py
+++ b/src/btclib/descriptors/miniscript.py
@@ -92,6 +92,7 @@ from btclib.script.script import (
     push_int,
     serialize,
 )
+from btclib.tx.limits import LOCKTIME_THRESHOLD, SEQUENCE_LOCKTIME_TYPE_FLAG
 from btclib.utils import assert_type, bytes_from_octets, decode_num, encode_num
 from btclib.var_int import serialize as var_int_serialize
 
@@ -152,13 +153,6 @@ _MAX_TAPSCRIPT_SIZE = _TAPSCRIPT_WEIGHT_LEFT - len(
 # BIP342 puts no bound of its own on the keys of a multi_a(), so the bound
 # is the stack: one element per key, and no more than 1000 elements
 _MAX_PUBKEYS_PER_MULTI_A = 999
-
-# the lock time that tells a block height from a unix timestamp, and the
-# nSequence bit that tells a block count from a 512-second count: BIP65's
-# and BIP68's own thresholds, which is what the timelock-mixing rules are
-# about -- an expression may not need both kinds of one at once
-_LOCKTIME_THRESHOLD = 500000000
-_SEQUENCE_LOCKTIME_TYPE_FLAG = 1 << 22
 
 # 1 <= n < 2**31 for older() and after(): a script number is signed, so
 # 2**31 is the first value CHECKSEQUENCEVERIFY cannot be handed, and zero
@@ -279,14 +273,14 @@ def _leaf_properties(fragment: str, threshold: int) -> frozenset[str]:
     """Return the type of a fragment that has no subexpressions."""
     if fragment == "older":
         return (
-            _if(bool(threshold & _SEQUENCE_LOCKTIME_TYPE_FLAG), _t("g"))
-            | _if(not threshold & _SEQUENCE_LOCKTIME_TYPE_FLAG, _t("h"))
+            _if(bool(threshold & SEQUENCE_LOCKTIME_TYPE_FLAG), _t("g"))
+            | _if(not threshold & SEQUENCE_LOCKTIME_TYPE_FLAG, _t("h"))
             | _t("Bzfmxk")
         )
     if fragment == "after":
         return (
-            _if(threshold >= _LOCKTIME_THRESHOLD, _t("i"))
-            | _if(threshold < _LOCKTIME_THRESHOLD, _t("j"))
+            _if(threshold >= LOCKTIME_THRESHOLD, _t("i"))
+            | _if(threshold < LOCKTIME_THRESHOLD, _t("j"))
             | _t("Bzfmxk")
         )
     return _t(_LEAF_PROPERTIES[fragment])
@@ -2831,7 +2825,7 @@ class SpendContext:
         set it to 0xffffffff has asked for a transaction with no lock
         time at all.
         """
-        if (value >= _LOCKTIME_THRESHOLD) != (self.locktime >= _LOCKTIME_THRESHOLD):
+        if (value >= LOCKTIME_THRESHOLD) != (self.locktime >= LOCKTIME_THRESHOLD):
             return False
         return value <= self.locktime and self.sequence != 0xFFFFFFFF
 
@@ -2845,8 +2839,8 @@ class SpendContext:
         """
         if self.version < 2 or self.sequence & (1 << 31):
             return False
-        if value & _SEQUENCE_LOCKTIME_TYPE_FLAG != (
-            self.sequence & _SEQUENCE_LOCKTIME_TYPE_FLAG
+        if value & SEQUENCE_LOCKTIME_TYPE_FLAG != (
+            self.sequence & SEQUENCE_LOCKTIME_TYPE_FLAG
         ):
             return False
         return value & 0x0000FFFF <= self.sequence & 0x0000FFFF

--- a/src/btclib/script/engine/script_op_codes.py
+++ b/src/btclib/script/engine/script_op_codes.py
@@ -31,6 +31,7 @@ from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, hash256, ripemd160, sha1, sha256
 from btclib.script.engine.flags import ScriptFlag
 from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE, MAX_STACK_SIZE
+from btclib.tx.limits import LOCKTIME_THRESHOLD
 from btclib.tx.tx import Tx
 from btclib.utils import assert_type, decode_num, encode_num
 
@@ -107,7 +108,8 @@ __all__ = [
 # from four octets at most, so that a script cannot compute with a value
 # outside the signed 32-bit range. The two lock-time op codes are the
 # exception consensus makes, five octets being what a lock time at or
-# above 500000000 needs -- Core spells the same 5 out at each of them
+# above LOCKTIME_THRESHOLD needs -- Core spells the same 5 out at each
+# of them
 _MAX_NUM_SIZE = 4
 _MAX_LOCK_TIME_NUM_SIZE = 5
 
@@ -770,10 +772,10 @@ def op_checklocktimeverify(
     Reads the top element without popping it, as a number of up to 5
     bytes. The refusals are BIP65's: an empty stack, a negative lock
     time, a type mismatch -- block height against timestamp, the two
-    sides of the 500000000 threshold -- a lock time the transaction's
-    has not reached, and a final input sequence, which would let the
-    transaction bypass its own lock_time. A NOP when the flag is off,
-    the op code being a redefined OP_NOP2.
+    sides of the LOCKTIME_THRESHOLD threshold -- a lock time the
+    transaction's has not reached, and a final input sequence, which
+    would let the transaction bypass its own lock_time. A NOP when the
+    flag is off, the op code being a redefined OP_NOP2.
     """
     if ScriptFlag.CHECKLOCKTIMEVERIFY not in flags:
         return
@@ -784,12 +786,12 @@ def op_checklocktimeverify(
         raise BTClibValueError(f"negative lock time: {lock_time}")
 
     # different lock time type
-    if tx.lock_time >= 500000000 > lock_time:
+    if tx.lock_time >= LOCKTIME_THRESHOLD > lock_time:
         raise BTClibValueError(
             f"block height lock time {lock_time} against "
             f"the timestamp lock time {tx.lock_time} of the transaction"
         )
-    if lock_time >= 500000000 > tx.lock_time:
+    if lock_time >= LOCKTIME_THRESHOLD > tx.lock_time:
         raise BTClibValueError(
             f"timestamp lock time {lock_time} against "
             f"the block height lock time {tx.lock_time} of the transaction"

--- a/src/btclib/script/limits.py
+++ b/src/btclib/script/limits.py
@@ -20,8 +20,8 @@ is what says so.
 `LOCKTIME_THRESHOLD` is deliberately not here, though script.h declares it
 in the same block: it is not a limit but the value that tells a lock time
 read as a block height from one read as a timestamp, and it means the same
-in a transaction as in a script. It stays where OP_CHECKLOCKTIMEVERIFY
-reads it.
+in a transaction as in a script. It is `btclib.tx.limits`'s, and
+`OP_CHECKLOCKTIMEVERIFY` imports it from there.
 """
 
 __all__ = [


### PR DESCRIPTION
Closes #1608

`LOCKTIME_THRESHOLD` and `SEQUENCE_LOCKTIME_TYPE_FLAG` became public in
`btclib.tx.limits` with #1580, whose own commit message said the
constants "move" there. They did not move out of
`src/btclib/descriptors/miniscript.py`, which kept module-private
copies, nor out of `src/btclib/script/engine/script_op_codes.py`, where
the first was written twice as a bare `500000000`. Three places stated
the same two facts, with nothing keeping them in step.

The duplicates are deleted and the public constants imported. No new
import edge: `script_op_codes.py` already imported `btclib.tx.tx.Tx`,
and `btclib.script`'s `__init__` reaches `engine` and `sig_hash` only
through its `__getattr__`, which is what keeps issue #147's cycle open.
`btclib.tx.limits` itself imports only `btclib.consensus`.

`src/btclib/script/limits.py` said of `LOCKTIME_THRESHOLD` that "it stays
where `OP_CHECKLOCKTIMEVERIFY` reads it", which was true of no file. It
now says where the constant is and where the op code imports it from.

`op_checksequenceverify` in the same file has the identical defect for
three more constants; that is #1617, not this.

Gates on the pushed sha, after a rebase onto `4d0658d4`: `pytest` exit 0
(31377 passed, 30 skipped, 1 xfailed, 100.00% coverage), `pre-commit run
--all-files` exit 0, `sphinx-build -n -W --keep-going` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Centralize lock-time threshold constants by updating miniscript and script opcode code to consume the public definitions from `btclib.tx.limits`.

Bug Fixes:
- Use the public `LOCKTIME_THRESHOLD` and `SEQUENCE_LOCKTIME_TYPE_FLAG` constants from `btclib.tx.limits` throughout miniscript and script opcode handling.

Enhancements:
- Remove duplicated lock-time constants and literals so transaction and script logic share a single source of truth.
- Clarify the documentation for the location and use of `LOCKTIME_THRESHOLD`.