### PR TITLE
btclib.block.genesis builds the genesis block of a network (closes #1602)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1237,6 +1237,30 @@ documented at release-notes length in the first place, and are still in
   reads it", true of neither module before this, and now true of both --
   the op code's own bare literal included.
 
+### `btclib.block.genesis` builds the genesis block of a network
+
+- **`genesis_block(network="mainnet")` returns the `Block` that
+  `Network.genesis_block` names only the hash of** (closes #1602). It is
+  flattened onto `btclib.block`, not a field of `Network`: `block.block`
+  already reaches `btclib.network` through `btclib.tx`'s
+  `TxOut.script_pub_key`, so a `Network` field holding a `Block` would
+  close issue #147's cycle from the other side. `tests/imports_test.py`'s
+  `test_network_stays_below_block` is the guard that keeps it open.
+- **The coinbase is the shape `build_coinbase` cannot build**: genesis
+  predates BIP34, so its script_sig is the literal timestamp message
+  `bitcoin/bitcoin`'s `CreateGenesisBlock` hardcodes rather than a height
+  commitment, and `build_block`'s header assembly — the reproduction
+  issue #1118's own pull request already verified against mainnet — is
+  what this leans on for the rest. Mainnet, testnet, regtest and signet
+  share one message and one pubkey; testnet4 does not, carrying its own
+  text and an output script paying to thirty-three zero bytes rather
+  than to Satoshi's — both transcribed from `bitcoin/bitcoin@9be056a8a7`'s
+  `kernel/chainparams.cpp`, one `CreateGenesisBlock` call per network.
+- Checked against the network's own `pow_limit_bits` before it is
+  returned, mainnet's default failing every regtest and signet genesis,
+  and against the hash `NETWORKS` already ships for each of the five —
+  `tests/block/genesis_test.py`'s own "done when".
+
 ## v2026.8.29
 
 ### Repository

--- a/docs/source/btclib.block.rst
+++ b/docs/source/btclib.block.rst
@@ -39,6 +39,13 @@ btclib.block.build module
    :members:
    :show-inheritance:
 
+btclib.block.genesis module
+---------------------------
+
+.. automodule:: btclib.block.genesis
+   :members:
+   :show-inheritance:
+
 btclib.block.header\_context module
 -----------------------------------
 

--- a/src/btclib/block/__init__.py
+++ b/src/btclib/block/__init__.py
@@ -15,6 +15,7 @@ from btclib.block.block import (
 from btclib.block.block_context import BlockContext
 from btclib.block.block_filter import BasicBlockFilter, prevout_scripts_from_utxos
 from btclib.block.block_header import BlockHeader
+from btclib.block.genesis import genesis_block
 from btclib.block.header_context import (
     ParentOf,
     header_at_height,
@@ -34,10 +35,10 @@ from btclib.block.header_context import (
 # function rather than a second one written from the BIP. Same reasoning
 # for coinbase_witness_commitment and witness_commitment_output, the pair
 # assert_valid_witness_commitment and build.build_block share. ParentOf,
-# header_at_height, median_time_past and next_bits_required are flattened
-# the same way rather than left under header_context: each is the one
-# operation a caller reaches for, not a namespace of related constants the
-# way proof_of_work and mining are
+# header_at_height, median_time_past, next_bits_required and genesis_block
+# are flattened the same way rather than left under their own modules:
+# each is the one operation a caller reaches for, not a namespace of
+# related constants the way proof_of_work and mining are
 __all__ = [
     "BasicBlockFilter",
     "Block",
@@ -47,6 +48,7 @@ __all__ = [
     "bip34_commitment",
     "build",
     "coinbase_witness_commitment",
+    "genesis_block",
     "header_at_height",
     "median_time_past",
     "merkle_proof",

--- a/src/btclib/block/genesis.py
+++ b/src/btclib/block/genesis.py
@@ -1,0 +1,158 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Build the genesis block of a network, on demand rather than at import.
+
+`Network.genesis_block` is 32 bytes -- the hash a header's
+`previous_block_hash` is checked against -- not a `Block`. It cannot be
+one: `block.block` already reaches `btclib.network` transitively, through
+`btclib.tx`'s `TxOut.script_pub_key` importing `btclib.script`'s
+`script_pub_key` module for the address tables, so a `Network` field
+holding a `Block` would close the cycle issue #147 is about. This module
+is where a caller who wants the actual block gets one instead -- built
+here, on request, rather than carried as a field of `Network` or of
+`NETWORKS`.
+
+`build.build_block` does the header assembly and every structural check a
+pre-mining candidate can pass; what this adds is the one coinbase shape
+it cannot build. `build.build_coinbase` always commits to a height
+(BIP34), and every network's genesis predates that rule: its script_sig
+is the literal timestamp message Bitcoin Core's `CreateGenesisBlock`
+hardcodes (`kernel/chainparams.cpp`, at bitcoin/bitcoin@9be056a8a7), not
+a general-purpose builder's output. `mainnet`, `testnet`, `regtest` and
+`signet` share that message, the same public key, and `OP_CHECKSIG` --
+`tests/block/build_test.py`'s own mainnet vector already builds that
+shape -- and differ only in the header's own time, bits, nonce and
+version, plus the reward `consensus.subsidy` already gives at height
+zero regardless of a chain's halving interval. `testnet4` does not: Core
+gives it its own timestamp text and an output script that pays to
+thirty-three zero bytes and `OP_CHECKSIG` rather than to that key, and
+`_GENESIS_PARAMS` below carries both shapes rather than assuming the one
+mainnet uses is universal.
+
+Every result is checked against the network's own bits before it is
+returned -- `Block.assert_valid`, at that network's `pow_limit_bits`
+rather than mainnet's default, which a regtest or signet genesis would
+fail. `tests/block/genesis_test.py` is the check this module exists for:
+every network's built genesis hashes to the value `NETWORKS` already
+ships for it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+
+from btclib.block.block import Block
+from btclib.block.build import build_block
+from btclib.consensus import subsidy
+from btclib.network import NETWORKS, network_from_name
+from btclib.script.script import serialize
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
+
+__all__ = ["genesis_block"]
+
+# Satoshi's own message and pubkey, shared by mainnet, testnet, regtest
+# and signet -- the fourth reproduced here even though nothing mines
+# against it, so that the same table serves every built-in network the
+# same way. "FFFF001D" and b"\x04" are two of the three pushes Bitcoin
+# Core's CreateGenesisBlock always writes -- 486604799 (0x1D00FFFF) and
+# the message's own byte count -- fixed regardless of the network's own
+# bits, which is why they are not read from `_GenesisParams.bits` below.
+_STANDARD_MESSAGE = (
+    b"The Times 03/Jan/2009 Chancellor on brink of second bailout for banks"
+)
+_STANDARD_PUBKEY = (
+    "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61de"
+    "b649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f"
+)
+_STANDARD_SCRIPT_PUB_KEY = serialize([_STANDARD_PUBKEY, "OP_CHECKSIG"])
+
+# testnet4's own text and output script, neither shared with the other
+# four: pays to thirty-three zero bytes rather than to Satoshi's pubkey,
+# a script nothing can spend.
+_TESTNET4_MESSAGE = (
+    b"03/May/2024 000000000000000000001ebd58c244970b3aa9d783bb001011fbe8ea8e98e00e"
+)
+_TESTNET4_SCRIPT_PUB_KEY = serialize([b"\x00" * 33, "OP_CHECKSIG"])
+
+
+@dataclass(frozen=True)
+class _GenesisParams:
+    """The fields one network's genesis coinbase and header need.
+
+    Everything `build_block` cannot infer on its own: the header's own
+    time, bits and nonce (its version is always 1, every genesis
+    predating BIP9), and the coinbase's own message and output script,
+    which are not always the same across networks -- testnet4's are not.
+    """
+
+    time: int  # unix seconds
+    bits: str  # display-order hex, as Network.consensus and BlockHeader hold it
+    nonce: int
+    message: bytes
+    script_pub_key: bytes
+
+
+# time, bits and nonce transcribed from Bitcoin Core's own
+# kernel/chainparams.cpp, at bitcoin/bitcoin@9be056a8a7, one
+# CreateGenesisBlock call per network; message and script_pub_key from
+# the same file, standard for four of the five and testnet4's own for
+# the fifth
+_GENESIS_PARAMS: dict[str, _GenesisParams] = {
+    "mainnet": _GenesisParams(
+        1231006505, "1d00ffff", 2083236893, _STANDARD_MESSAGE, _STANDARD_SCRIPT_PUB_KEY
+    ),
+    "testnet": _GenesisParams(
+        1296688602, "1d00ffff", 414098458, _STANDARD_MESSAGE, _STANDARD_SCRIPT_PUB_KEY
+    ),
+    "regtest": _GenesisParams(
+        1296688602, "207fffff", 2, _STANDARD_MESSAGE, _STANDARD_SCRIPT_PUB_KEY
+    ),
+    "signet": _GenesisParams(
+        1598918400, "1e0377ae", 52613770, _STANDARD_MESSAGE, _STANDARD_SCRIPT_PUB_KEY
+    ),
+    "testnet4": _GenesisParams(
+        1714777860,
+        "1d00ffff",
+        393743547,
+        _TESTNET4_MESSAGE,
+        _TESTNET4_SCRIPT_PUB_KEY,
+    ),
+}
+
+
+def genesis_block(network: str = "mainnet") -> Block:
+    """Return the genesis block of `network`, built rather than looked up.
+
+    A caller wanting only the hash already has it, cheaply, at
+    `network_from_name(network).genesis_block`; this is for a caller that
+    needs the block itself -- a `datadir` seeding a fresh node, a test
+    fixture -- and is willing to pay for one coinbase transaction and one
+    header assembly to get it, in place of a field this library cannot
+    carry without closing issue #147's cycle.
+
+    The block is checked against the network's own easiest target before
+    it is returned (`Block.assert_valid`, at that network's
+    `pow_limit_bits`), and reproduces the hash `Network.genesis_block`
+    already carries for the same network -- verified for all five in
+    `tests/block/genesis_test.py`.
+    """
+    net = network_from_name(network)
+    name = next(candidate for candidate, value in NETWORKS.items() if value is net)
+    params = _GENESIS_PARAMS[name]
+
+    script_sig = serialize(["FFFF001D", b"\x04", params.message])
+    genesis_tx = Tx(
+        version=1,
+        lock_time=0,
+        vin=[TxIn(OutPoint(), script_sig, 0xFFFFFFFF)],
+        vout=[TxOut(subsidy(0), params.script_pub_key)],
+    )
+
+    time = datetime.fromtimestamp(params.time, tz=timezone.utc)
+    block = build_block(b"\x00" * 32, [genesis_tx], time, params.bits, version=1)
+    block.header = replace(block.header, nonce=params.nonce)
+    block.assert_valid(pow_limit_bits=net.consensus.pow_limit_bits)
+    return block

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -165,6 +165,7 @@ CHILD_MODULES = {
             "block_context",
             "block_filter",
             "block_header",
+            "genesis",
             "header_context",
             "limits",
         ],

--- a/tests/block/genesis_test.py
+++ b/tests/block/genesis_test.py
@@ -1,0 +1,85 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the `btclib.block.genesis` module.
+
+Every network's built genesis is checked against the hash `NETWORKS`
+already carries for it -- ISS 1602's own "done when" -- and against the
+block `Block.assert_valid` accepts at that network's own easiest target,
+never mainnet's default.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from btclib.block.genesis import genesis_block
+from btclib.exceptions import BTClibValueError
+from btclib.network import NETWORKS
+
+
+@pytest.mark.parametrize("name", sorted(NETWORKS))
+def test_genesis_block_reproduces_the_networks_own_hash(name: str) -> None:
+    """The built block's header hash matches Network.genesis_block."""
+    block = genesis_block(name)
+    assert block.header.hash == NETWORKS[name].genesis_block
+
+
+@pytest.mark.parametrize("name", sorted(NETWORKS))
+def test_genesis_block_is_valid_at_its_own_pow_limit(name: str) -> None:
+    """assert_valid, at the network's own bits, raises nothing.
+
+    genesis_block already calls this before returning; the point of
+    calling it again here is that a network whose regtest-or-signet-grade
+    bits were checked against mainnet's default would fail it, so this is
+    where a caller who reads the test rather than the source sees why
+    `pow_limit_bits` is not left at its default.
+    """
+    block = genesis_block(name)
+    block.assert_valid(NETWORKS[name].consensus.pow_limit_bits)
+
+
+def test_genesis_block_defaults_to_mainnet() -> None:
+    """No argument is the same block as the explicit name."""
+    assert genesis_block() == genesis_block("mainnet")
+
+
+def test_genesis_block_has_one_coinbase_and_no_witness() -> None:
+    """The genesis coinbase spends nothing and carries no witness.
+
+    Predating BIP141 as much as it predates BIP34, so build_block adds no
+    witness commitment -- the same shape
+    test_build_block_adds_no_commitment_without_a_witness checks for an
+    ordinary block.
+    """
+    block = genesis_block("mainnet")
+    assert len(block.transactions) == 1
+    assert block.transactions[0].is_coinbase
+    assert not block.transactions[0].is_segwit
+
+
+def test_genesis_block_testnet4_differs_from_the_other_four() -> None:
+    """testnet4's coinbase is not the mainnet one under a later timestamp.
+
+    The issue that opened this module said every network shared the
+    mainnet coinbase; true of four of the five, and corrected here rather
+    than repeated -- bitcoin/bitcoin@9be056a8a7's kernel/chainparams.cpp
+    gives testnet4 its own message and an output script that pays to
+    thirty-three zero bytes rather than to Satoshi's pubkey.
+    """
+    mainnet_coinbase = genesis_block("mainnet").transactions[0]
+    testnet4_coinbase = genesis_block("testnet4").transactions[0]
+    assert mainnet_coinbase.vin[0].script_sig != testnet4_coinbase.vin[0].script_sig
+    assert (
+        mainnet_coinbase.vout[0].script_pub_key
+        != testnet4_coinbase.vout[0].script_pub_key
+    )
+    # and every network still pays the same height-zero subsidy
+    assert mainnet_coinbase.vout[0].value == testnet4_coinbase.vout[0].value
+
+
+def test_genesis_block_refuses_an_unknown_network() -> None:
+    """The same refusal network_from_name gives, not a bare KeyError."""
+    with pytest.raises(BTClibValueError, match="unknown network"):
+        genesis_block("not-a-network")

--- a/tests/imports_test.py
+++ b/tests/imports_test.py
@@ -214,6 +214,20 @@ def test_address_encodings_stay_below_script(unimported_btclib: None) -> None:
     assert not [name for name in btclib_modules() if name.startswith("btclib.script")]
 
 
+def test_network_stays_below_block(unimported_btclib: None) -> None:
+    """btclib.network must not import btclib.block.
+
+    block.block already reaches btclib.network transitively, through
+    btclib.tx's TxOut.script_pub_key importing script.script_pub_key for
+    the address tables -- so a Network field holding a Block would close
+    issue #147's cycle from the other side. ISS 1602's genesis_block is
+    the temptation this guards: it lives in btclib.block.genesis, built
+    on demand, rather than beside NETWORKS.
+    """
+    importlib.import_module("btclib.network")
+    assert not [name for name in btclib_modules() if name.startswith("btclib.block")]
+
+
 def test_script_publishes_sig_hash_and_the_engine_without_importing_them(
     unimported_btclib: None,
 ) -> None:


### PR DESCRIPTION
Closes #1602

`Network.genesis_block` is 32 bytes — the hash a header's
`previous_block_hash` is checked against — not a `Block`. This adds
`genesis_block(network="mainnet")`, which builds the block itself, in
`btclib.block.genesis` and flattened onto `btclib.block`.

Not a field of `Network`: `block.block` already reaches `btclib.network`
through `btclib.tx`'s `TxOut.script_pub_key`, so a `Network` field
holding a `Block` would close issue #147's cycle from the other side.
`tests/imports_test.py`'s `test_network_stays_below_block` is the guard
that keeps it open.

`build_coinbase` cannot build genesis's coinbase: genesis predates
BIP34, so its script_sig is the literal timestamp message
`CreateGenesisBlock` hardcodes rather than a height commitment.
`mainnet`, `testnet`, `regtest` and `signet` share that message, the
same public key and `OP_CHECKSIG`; `testnet4` does not — Core gives it
its own text and a script paying to thirty-three zero bytes — which the
issue's own snippet did not account for, and which btclib-node's
`create_genesis` never covered.

Every result is checked against the network's own `pow_limit_bits`
before it is returned, and against the hash `NETWORKS` already ships for
it. Local review verified the output rather than the inputs: the block
hash and merkle root produced for each of the five networks match the
values Core asserts in `kernel/chainparams.cpp` at
bitcoin/bitcoin@9be056a8a7.

Gates on the pushed sha, after a rebase onto `7a2c6efd`: `pytest` exit 0
(31394 passed, 30 skipped, 1 xfailed, 100.00% coverage), `pre-commit run
--all-files` exit 0, `sphinx-build -n -W --keep-going` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Add on-demand construction and validation of Bitcoin genesis blocks for all supported networks.

New Features:
- Add `genesis_block`, exposed through `btclib.block`, to construct the complete genesis block for each supported network, including testnet4’s distinct coinbase.

Enhancements:
- Validate generated genesis blocks against each network’s proof-of-work limit while preserving the existing network-to-block dependency direction.

Documentation:
- Document the new genesis block construction API and its network-specific behavior.

Tests:
- Add coverage verifying genesis hashes, proof-of-work validity, default behavior, coinbase structure, testnet4 differences, and unknown-network handling.
- Guard the import architecture so `btclib.network` remains below `btclib.block`.