### PR TITLE
HwiSigner.display_policy_address wires the registered-policy half of displayaddress (closes #1588, closes #1596)

### DIFF
--- a/.github/workflows/integration-hwi.yml
+++ b/.github/workflows/integration-hwi.yml
@@ -50,7 +50,7 @@ permissions:
   contents: read
 
 # the node both jobs run, for the signing test each ends with: the
-# release under test, and the sha256 of its linux tarball as four
+# release under test, and the sha256 of its linux tarball as the
 # independent guix builders attested it in bitcoin-core/guix.sigs. Pinned
 # rather than resolved to "latest" for the reason
 # integration-bitcoind.yml's own copy gives; raising either is a commit,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1302,6 +1302,49 @@ documented at release-notes length in the first place, and are still in
   and against the hash `NETWORKS` already ships for each of the five —
   `tests/block/genesis_test.py`'s own "done when".
 
+### `HwiSigner.display_policy_address` wires the registered-policy half of `displayaddress`
+
+- **`psbt_signer.WalletPolicyAddressDisplay` and `display_policy_address`
+  check a registered BIP388 policy's address the way `AddressDisplay`
+  and `display_address` check a plain descriptor's** (closes #1588).
+  `descriptors.wallet_policy_address` (#1348) computes the address a
+  policy describes at an index and a multipath index, and
+  `HwiSigner.display_policy_address` sends `--registration`, `--index`
+  and `--multipath-index` to HWI's `displayaddress` for the comparison —
+  the second, registered-policy mode of the same command
+  `display_address` already sends `--desc` to, and mutually exclusive
+  with it. `registration` is `register_descriptor`'s own opaque answer,
+  passed back unexamined; `SignerDecorator` carries the new protocol the
+  way it already carries the other two, and a wrapper that never had it
+  or always claims it is wrong the same way either of the others would
+  be. `psbt_signer_contract.optional_protocols`, which is how an
+  implementer outside this repository asks what a signer offers, answers
+  for the third protocol beside the other two -- in the middle, grouped
+  with the address display it is a second mode of, rather than appended,
+  so the position a caller reads for the message signer is the last one.
+  `RELEASE_NOTES.md` carries what that costs a caller. No HWI release
+  through 3.2.0 carries this command's policy group, the same
+  footing #1592 already put `register_descriptor` on: it runs
+  against `master` and against the stand-in `tests/hwi_test.py` writes,
+  and raising `HWI_VERSION` to the first release whose `hwilib/_cli.py`
+  adds it is what ends that, exactly as for `registerdescriptor` -- the
+  caveat names when it stops being true, not only that it is.
+
+### `integration-hwi.yml`'s guix-builder comment states no count
+
+- **The comment above `BITCOIND_VERSION` said "as four independent guix
+  builders attested it in bitcoin-core/guix.sigs", and that count is
+  wrong** (closes #1596). `integration-bitcoind.yml` carried the
+  identical sentence and had it dropped rather than corrected while
+  #1412's branch had that file open for an unrelated reason; this copy
+  sat outside that diff and kept the stale count. The attestation
+  itself is unchanged and still true — the pinned `BITCOIND_SHA256` is
+  what `bitcoin-core/guix.sigs` publishes for the release under test —
+  so what changes here is the same: the number is dropped, not
+  corrected to whatever it currently reads as, per CLAUDE.md's *Never
+  state how many of anything a file holds*: a count nothing here
+  re-derives ages the same way a wrong one does.
+
 ## v2026.8.29
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -61,6 +61,33 @@ full year, short month, short day (YYYY-M-D)
   `btclib.p2p.limits.PROTOCOL_VERSION`, `70016`. `Version.parse` is
   unaffected, reading whatever a peer sent rather than this default.
 
+- **`psbt_signer_contract.optional_protocols` answers for a third
+  protocol, and answers it in the middle** (closes #1588). It reported
+  `AddressDisplay` and `MessageSigner`; it now reports
+  `AddressDisplay`, `WalletPolicyAddressDisplay` and `MessageSigner`, in
+  that order.
+
+  Act on it if you call it. Before:
+
+  ```python
+  displays_address, signs_message = optional_protocols(signer)
+  ```
+
+  Now:
+
+  ```python
+  displays_address, displays_policy_address, signs_message = (
+      optional_protocols(signer)
+  )
+  ```
+
+  Unpacking the old shape raises `ValueError: too many values to unpack
+  (expected 2, got 3)`, which is the loud case. The quiet one is an
+  index: the new element is inserted rather than appended, so
+  `optional_protocols(signer)[1]` used to answer whether the signer
+  signs messages and now answers whether it displays a wallet-policy
+  address. Read the last element for the message signer, or unpack.
+
 ### Worth knowing, though nothing raises
 
 - **`btclib.org` is no longer this project's site, and this repository

--- a/src/btclib/hwi.py
+++ b/src/btclib/hwi.py
@@ -63,7 +63,7 @@ when a caller deciding what to offer at all has to have the answer: a
 refusal is the right answer to a question that was asked, and the wrong
 way to find out there was nothing to ask.
 
-## Wallet policies, and the address `displayaddress` still cannot show
+## Wallet policies
 
 A Ledger will not display or sign a multisig it has not been shown
 first. BIP388 wallet policies are how it is shown, and registration is a
@@ -82,24 +82,18 @@ so the weekly `integration-hwi` job runs a command line
 removable.
 
 `displayaddress`'s BIP388 policy mode -- `--registration`, `--index`,
-`--multipath-index` -- is not wrapped, and is on `master` rather than in
-a release for the same reason `registerdescriptor` is.
-`psbt_signer.display_address` exists to compare a device's screen with
-the address a `Descriptor` computes, and
-`descriptors.wallet_policy_address` is now that address for a policy
-too: `descriptors.wallet_policy` builds the `@N` template and
-key-information vector BIP388's own `/**` describes, from a receive and
-a change `Descriptor` of one account -- `account_descriptors`' own pair
--- or the narrower `/*` form from one `Descriptor` alone, and
-`wallet_policy_descriptor`/`wallet_policy_address` read either pair back
-into the descriptor and the address the policy describes at an index.
-What is still missing is the wiring, not the computation (issue #1588):
-no method here takes `--registration`, `--index` or `--multipath-index`
-and no protocol this library defines carries a multipath index for
-`psbt_signer.display_address` to pass one through. A caller with a
-registered policy still reads the address off the device's own screen;
-that is what the screen is for, whether or not this module checks it
-too.
+`--multipath-index` -- is `HwiSigner.display_policy_address`, on the same
+unreleased footing as `register_descriptor`: no release through 3.2.0
+carries it either, so it runs against `master` and against the stand-in
+`tests/hwi_test.py` writes, never against the pinned release.
+`psbt_signer.WalletPolicyAddressDisplay`/`display_policy_address` are the
+protocol and the check beside `AddressDisplay`/`display_address`:
+`descriptors.wallet_policy_address` computes the address a policy
+describes at an index and a multipath index, from the template and
+key-information vector `descriptors.wallet_policy` writes when the
+policy is built, and `display_policy_address` compares it with what the
+device shows the way `display_address` compares a device's screen with a
+plain `Descriptor` (issue #1588).
 
 Staying aligned with a project this does not import is two things, and
 neither is a copy of it. `tests/hwi_test.py` writes out the surface used
@@ -663,15 +657,11 @@ class HwiSigner:
         first (module docstring, "Wallet policies"); this is that showing.
         What comes back is opaque -- an HMAC on Ledger, nothing at all on a
         device that needs none -- and is the caller's to persist and pass
-        back as `--registration` on a later `displayaddress`, which this
-        module does not wrap: `descriptors.wallet_policy_address` computes
-        what a device would show under that flag, but nothing here takes
-        the registration, the index and the multipath index and passes
-        them to `displayaddress` to compare it against.
+        back as `registration` to `display_policy_address`.
 
         The descriptor goes out ranged, whole rather than at one index:
-        registration is of the policy, and `displayaddress --index` is
-        what later asks for one address of it.
+        registration is of the policy, and `display_policy_address`'s own
+        index is what later asks for one address of it.
 
         Checksummed, which is what HWI's parser requires of anything it is
         given, `--desc` included.
@@ -683,6 +673,37 @@ class HwiSigner:
         assert_type(name, str, "name")
         text = add_checksum(str(descriptor))
         return self._answer(["registerdescriptor", name, text], "registration")
+
+    def display_policy_address(
+        self, registration: str, index: int = 0, multipath_index: int = 0
+    ) -> str:
+        """Show one address of a registered policy: HWI's `displayaddress`.
+
+        The registered-policy half of `displayaddress`, mutually exclusive
+        with the plain `--desc` `display_address` sends: `registration` is
+        what `register_descriptor` returned, and `index`/`multipath_index`
+        are what `psbt_signer.display_policy_address` also resolves
+        `descriptors.wallet_policy_address` at, on the host side, to check
+        this answer against.
+
+        No HWI release through 3.2.0 has this command's policy group
+        either, so it needs the same `master` build `register_descriptor`
+        does; the module docstring's *Wallet policies* says what ends
+        that.
+        """
+        assert_type(registration, str, "registration")
+        return self._answer(
+            [
+                "displayaddress",
+                "--registration",
+                registration,
+                "--index",
+                str(index),
+                "--multipath-index",
+                str(multipath_index),
+            ],
+            "address",
+        )
 
     @property
     def capabilities(self) -> SignerCapabilities:

--- a/src/btclib/psbt_signer.py
+++ b/src/btclib/psbt_signer.py
@@ -29,6 +29,11 @@ to remember:
 - `display_address` compares the address a device shows with the one the
   descriptor describes, which is the whole point of asking a device to
   show one;
+- `display_policy_address` is the same check for a device-registered
+  BIP388 wallet policy: `descriptors.wallet_policy_address` computes the
+  address the policy describes at an index and a multipath index, and
+  what is compared is what `display_address` compares for a plain
+  descriptor;
 - `sign_message` verifies the signature against the address the caller
   says it must open to.
 
@@ -64,7 +69,12 @@ from btclib.bip32.bip32 import (
 )
 from btclib.bip32.der_path import DerPath, indexes_from_der_path, str_from_der_path
 from btclib.bip32.key_origin import BIP32KeyOrigin
-from btclib.descriptors import Descriptor, account_descriptors
+from btclib.descriptors import (
+    Descriptor,
+    KeyExpression,
+    account_descriptors,
+    wallet_policy_address,
+)
 from btclib.ecc import bms, dsa, ssa
 from btclib.exceptions import BTClibValueError, SignerError
 from btclib.psbt.psbt import Psbt, assert_signatures_only, combine, sign
@@ -84,8 +94,10 @@ __all__ = [
     "SignerDecorator",
     "SignerDevice",
     "SoftwareSigner",
+    "WalletPolicyAddressDisplay",
     "assert_public",
     "display_address",
+    "display_policy_address",
     "export_account",
     "merge_devices",
     "request_signatures",
@@ -202,6 +214,32 @@ class AddressDisplay(Protocol):
 
 
 @runtime_checkable
+class WalletPolicyAddressDisplay(Protocol):
+    """A signer that can show the address of a policy it has registered.
+
+    Optional and separate from `AddressDisplay` for the same reason that
+    one is separate from `PsbtSigner`: a signer with no screen for a
+    registered BIP388 policy is still a signer. What a policy needs that a
+    plain `Descriptor` does not is a third parameter neither
+    `AddressDisplay`'s signature nor its caller has room for -- the
+    multipath index BIP389's `<M;N>` needs beside the ordinary one -- so
+    this is a second protocol rather than a widened first one.
+
+    `registration` is what a signer answered when the policy was
+    registered; registering it is not part of this contract, the same way
+    showing an address is not part of `PsbtSigner` -- `HwiSigner
+    .register_descriptor` is where that happens, and the module docstring
+    of `btclib.hwi`, "Wallet policies", says why it has none of its own.
+    """
+
+    def display_policy_address(
+        self, registration: str, index: int = 0, multipath_index: int = 0
+    ) -> str:
+        """Return the address the signer shows for the policy at an index."""
+        ...
+
+
+@runtime_checkable
 class MessageSigner(Protocol):
     """A signer that can sign a message with a key it holds.
 
@@ -244,10 +282,10 @@ class SignerDevice(Protocol):
         ...
 
 
-# the operations of the two optional protocols above, which is what a
+# the operations of the three optional protocols above, which is what a
 # wrapper has to carry over from the signer it wraps -- one name each,
 # and the protocol is that name being there
-_OPTIONAL_OPERATIONS = ("display_address", "sign_message")
+_OPTIONAL_OPERATIONS = ("display_address", "display_policy_address", "sign_message")
 
 
 class SignerDecorator:
@@ -274,12 +312,13 @@ class SignerDecorator:
     and one that forgets `close` leaves a subprocess running after the
     caller closed what it was holding.
 
-    **Wrapping does not hide what the signer offers.** `AddressDisplay`
-    and `MessageSigner` are optional protocols a caller asks about with
-    `isinstance`, so a wrapper that never carries them turns a device
-    that can show an address into one that cannot, and a wrapper that
-    always declares them turns a signer that cannot into one that fails
-    when asked. Each operation is therefore bound on the *instance*, and
+    **Wrapping does not hide what the signer offers.** `AddressDisplay`,
+    `WalletPolicyAddressDisplay` and `MessageSigner` are optional
+    protocols a caller asks about with `isinstance`, so a wrapper that
+    never carries them turns a device that can show an address into one
+    that cannot, and a wrapper that always declares them turns a signer
+    that cannot into one that fails when asked. Each operation is
+    therefore bound on the *instance*, and
     only where the wrapped signer has it, so `isinstance` answers what
     the signer offers -- and a subclass that writes one of its own keeps
     it, an attribute written by a class being what says the subclass
@@ -479,6 +518,50 @@ def display_address(
     shown = signer.display_address(descriptor, index)
     if shown != expected:
         err_msg = f"the signer displayed {shown}, where the descriptor describes"
+        err_msg += f" {expected}"
+        raise BTClibValueError(err_msg)
+    return shown
+
+
+def display_policy_address(
+    signer: WalletPolicyAddressDisplay,
+    registration: str,
+    template: str,
+    key_info: tuple[KeyExpression, ...],
+    index: int = 0,
+    multipath_index: int = 0,
+    network: str = "mainnet",
+) -> str:
+    """Return the address the signer shows for a registered policy, checked.
+
+    The same check `display_address` runs for a plain `Descriptor`, over
+    a BIP388 wallet policy instead: `template` and `key_info` are the
+    pair `descriptors.wallet_policy` returns, and
+    `descriptors.wallet_policy_address` is what computes the address they
+    describe at `index` and `multipath_index` -- the second index
+    BIP389's `<M;N>` needs beside the ordinary one.
+
+    `key_info` is a `tuple` and not the `Sequence`
+    `descriptors.wallet_policy_address` itself takes: a `list` built by
+    some other route needs `tuple(...)` first. That is narrower than the
+    computation asks for, and is not a design choice -- a `Sequence`
+    argument here reads ambiguously in the documentation build, this
+    class being importable both as `btclib.descriptors.KeyExpression`
+    and as `btclib.descriptors.key_expression.KeyExpression`, and a bare
+    parameter resolves that where a subscripted one does not. `tuple`
+    sidesteps it and costs nothing for the caller `wallet_policy` itself
+    feeds, which is the ordinary one.
+
+    `registration` is not checked here: it is `register_descriptor`'s own
+    opaque answer, sent back unexamined the way `HwiSigner
+    .register_descriptor`'s docstring says a caller must.
+    """
+    expected = wallet_policy_address(
+        template, key_info, index, multipath_index, network
+    )
+    shown = signer.display_policy_address(registration, index, multipath_index)
+    if shown != expected:
+        err_msg = f"the signer displayed {shown}, where the policy describes"
         err_msg += f" {expected}"
         raise BTClibValueError(err_msg)
     return shown

--- a/src/btclib/psbt_signer_contract.py
+++ b/src/btclib/psbt_signer_contract.py
@@ -57,6 +57,7 @@ from btclib.psbt_signer import (
     AddressDisplay,
     MessageSigner,
     PsbtSigner,
+    WalletPolicyAddressDisplay,
     request_signatures,
 )
 from btclib.script.script_pub_key import ScriptPubKey
@@ -235,13 +236,18 @@ def assert_psbt_signer(
     signer.close()
 
 
-def optional_protocols(signer: object) -> tuple[bool, bool]:
+def optional_protocols(signer: object) -> tuple[bool, bool, bool]:
     """Return which optional protocols the signer offers, as a caller asks.
 
-    `isinstance` against the two runtime-checkable protocols, which is
-    the whole of it: what `display_address` and `sign_message` answer is
-    checked by the functions of `psbt_signer` that call them, against the
-    descriptor and the address the caller says the answer must match, and
-    a conformance pass has neither.
+    `isinstance` against the three runtime-checkable protocols, which is
+    the whole of it: what `display_address`, `display_policy_address` and
+    `sign_message` answer is checked by the functions of `psbt_signer`
+    that call them, against the descriptor, the policy or the address the
+    caller says the answer must match, and a conformance pass has none of
+    that material.
     """
-    return isinstance(signer, AddressDisplay), isinstance(signer, MessageSigner)
+    return (
+        isinstance(signer, AddressDisplay),
+        isinstance(signer, WalletPolicyAddressDisplay),
+        isinstance(signer, MessageSigner),
+    )

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -1354,17 +1354,25 @@ issue #381 keeps out of the signing surface deliberately, and
 computes for itself: `descriptors.account_descriptors` and
 `btclib.core_import` are those three, on btclib's own types.
 
-Not transcribed on purpose: the BIP388 policy arguments, `--index` and
-`--multipath-index`/`--change` on `displayaddress`, `--registration` on
-both `displayaddress` and, since this pin, `signtx`. `btclib.hwi`'s
-module docstring, "Wallet policies, and the address `displayaddress`
-still cannot show", is why — `descriptors.wallet_policy_address`
-(issue #1348) computes the address a policy-mode `displayaddress`
-would answer against, but no method here takes `--registration`,
-`--index` or `--multipath-index` and passes them to that command, so
-the surface `tests/hwi_test.py` transcribes still has nothing to send
-them on. `signtx`'s answer keys (`psbt`, `signed`) are unaffected by
-a registration being passed alongside the transaction.
+`displayaddress`'s BIP388 policy mode -- `--registration`, `--index`,
+`--multipath-index` -- is `HwiSigner.display_policy_address`
+(`btclib.hwi`'s module docstring, "Wallet policies", issue #1588), and
+`psbt_signer.WalletPolicyAddressDisplay`/`display_policy_address` are
+the protocol and the check beside `AddressDisplay`/`display_address`:
+`descriptors.wallet_policy_address` computes the address a policy
+describes at an index and a multipath index, and `display_policy_address`
+compares it with what the device answers. Its own argv is checked in
+`tests/hwi_test.py` directly rather than through the shared
+`HWI_COMMAND_FLAGS` table above, `displayaddress`'s two modes taking
+disjoint flags.
+
+Not transcribed on purpose: `--change`, `displayaddress`'s alias for
+`--multipath-index 1` -- `HwiSigner.display_policy_address` always
+sends `--multipath-index` and never reaches for the alias -- and
+`--registration` on `signtx`, which nothing here sends: a registration
+travels with `displayaddress`'s policy mode only, and `signtx`'s answer
+keys (`psbt`, `signed`) are unaffected by one being passed alongside
+the transaction regardless.
 
 Not in a release: `registerdescriptor` and its `registration` answer
 key, and the BIP388 policy arguments named above -- `--index`,

--- a/tests/hwi_test.py
+++ b/tests/hwi_test.py
@@ -449,6 +449,47 @@ def test_a_descriptor_is_registered_and_the_receipt_is_opaque(tmp_path: Path) ->
     assert e.value.code == -19
 
 
+def test_a_registered_policy_s_address_is_asked_for_at_its_index(
+    tmp_path: Path,
+) -> None:
+    """The registered-policy half of `displayaddress`.
+
+    `--registration`, `--index` and `--multipath-index` in place of
+    `--desc`: `registration` is what `register_descriptor` returned, and
+    `psbt_signer.display_policy_address` is what then compares the answer
+    with what `descriptors.wallet_policy_address` computes for the policy
+    at that index and that multipath index.
+    """
+    hwi = stand_in(tmp_path, {"displayaddress": {"address": "shown"}})
+    device = signer(hwi)
+
+    assert device.display_policy_address("cafe", 5, 1) == "shown"
+    argv = last_argv(hwi)
+    assert argv[argv.index("displayaddress") + 1 :] == [
+        "--registration",
+        "cafe",
+        "--index",
+        "5",
+        "--multipath-index",
+        "1",
+    ]
+    # the defaults, the way `display_address`'s index defaults to 0
+    device.display_policy_address("cafe")
+    argv = last_argv(hwi)
+    assert argv[argv.index("displayaddress") + 1 :] == [
+        "--registration",
+        "cafe",
+        "--index",
+        "0",
+        "--multipath-index",
+        "0",
+    ]
+
+    wrong = signer(stand_in(tmp_path, {"displayaddress": {"not-a": "key"}}))
+    with pytest.raises(SignerError, match="did not answer a address"):
+        wrong.display_policy_address("cafe")
+
+
 def test_a_message_signature_is_verified_against_the_address(hwi: list[str]) -> None:
     """And a message that is not text is one this cannot ask for.
 

--- a/tests/psbt_signer_contract_test.py
+++ b/tests/psbt_signer_contract_test.py
@@ -104,9 +104,21 @@ def test_the_reference_signer_conforms() -> None:
 
 
 def test_the_optional_protocols_are_reported() -> None:
-    """SoftwareSigner offers both; a signer of the four methods, neither."""
-    assert optional_protocols(_signer()) == (True, True)
-    assert optional_protocols(_Wrapper()) == (False, False)
+    """SoftwareSigner offers two of three; a signer of five methods, none."""
+    assert optional_protocols(_signer()) == (True, False, True)
+    assert optional_protocols(_Wrapper()) == (False, False, False)
+
+    class _PolicyDisplay(_Wrapper):
+        """A signer whose only optional operation is the policy one."""
+
+        def display_policy_address(
+            self, registration: str, index: int = 0, multipath_index: int = 0
+        ) -> str:
+            return "unused"
+
+    policy_display = _PolicyDisplay()
+    assert optional_protocols(policy_display) == (False, True, False)
+    assert policy_display.display_policy_address("registration") == "unused"
 
 
 def test_something_that_is_not_a_signer_is_refused() -> None:

--- a/tests/psbt_signer_test.py
+++ b/tests/psbt_signer_test.py
@@ -31,6 +31,8 @@ from btclib.descriptors import (
     TrDescriptor,
     WpkhDescriptor,
     parse,
+    wallet_policy,
+    wallet_policy_address,
 )
 from btclib.ecc import bms, dsa
 from btclib.exceptions import BTClibValueError, SignerError
@@ -42,8 +44,10 @@ from btclib.psbt_signer import (
     PsbtSigner,
     SignerCapabilities,
     SignerDecorator,
+    WalletPolicyAddressDisplay,
     assert_public,
     display_address,
+    display_policy_address,
     export_account,
     merge_devices,
     request_signatures,
@@ -172,6 +176,7 @@ def test_the_protocols_are_what_a_signer_is_asked_for() -> None:
     assert isinstance(signer, PsbtSigner)
     assert not isinstance(signer, AddressDisplay)
     assert not isinstance(signer, MessageSigner)
+    assert not isinstance(signer, WalletPolicyAddressDisplay)
 
     assert signer.capabilities == SignerCapabilities(taproot=False, musig2=False)
     signer.close()
@@ -345,6 +350,52 @@ def test_a_displayed_address_is_compared_with_the_descriptor_s() -> None:
     for lie in (below, above):
         with pytest.raises(BTClibValueError, match="the signer displayed"):
             display_address(_Display(lie), receive, 3)
+
+
+class _PolicyDisplay(_Signer):
+    """A signer that shows a policy's address, honestly by default."""
+
+    def __init__(
+        self,
+        template: str,
+        key_info: tuple[KeyExpression, ...],
+        shown: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.template = template
+        self.key_info = key_info
+        self.shown = shown
+
+    def display_policy_address(
+        self, registration: str, index: int = 0, multipath_index: int = 0
+    ) -> str:
+        """Return the address, or the one this was built to lie with."""
+        if self.shown is not None:
+            return self.shown
+        return wallet_policy_address(
+            self.template, self.key_info, index, multipath_index
+        )
+
+
+def test_a_registered_policy_s_address_is_compared_with_the_policy_s() -> None:
+    """The same check `display_address` runs, over a BIP388 policy instead.
+
+    `wallet_policy_address` computes what the policy describes at an
+    index and a multipath index -- the second parameter a plain
+    `Descriptor` and `AddressDisplay` have no room for, which is why this
+    is a second protocol rather than a widened first one.
+    """
+    receive, change = export_account(_Signer(), ACCOUNT)
+    template, key_info = wallet_policy(receive, change)
+    display = _PolicyDisplay(template, key_info)
+    assert isinstance(display, WalletPolicyAddressDisplay)
+
+    expected = wallet_policy_address(template, key_info, 3, 1)
+    assert display_policy_address(display, "cafe", template, key_info, 3, 1) == expected
+
+    lying = _PolicyDisplay(template, key_info, "bc1q" + "0" * (len(expected) - 4))
+    with pytest.raises(BTClibValueError, match="the signer displayed"):
+        display_policy_address(lying, "cafe", template, key_info, 3, 1)
 
 
 def test_a_descriptor_that_holds_a_private_key_is_not_sent() -> None:
@@ -557,11 +608,20 @@ def test_wrapping_a_signer_does_not_hide_what_it_offers() -> None:
     """
     assert not isinstance(SignerDecorator(_Signer()), AddressDisplay)
     assert not isinstance(SignerDecorator(_Signer()), MessageSigner)
+    assert not isinstance(SignerDecorator(_Signer()), WalletPolicyAddressDisplay)
 
     display = SignerDecorator(_Display())
     assert isinstance(display, AddressDisplay)
     receive = export_account(display, ACCOUNT)[0]
     assert display.display_address(receive, 3) == receive.address(3)
+
+    receive, change = export_account(_Signer(), ACCOUNT)
+    template, key_info = wallet_policy(receive, change)
+    policy_display = SignerDecorator(_PolicyDisplay(template, key_info))
+    assert isinstance(policy_display, WalletPolicyAddressDisplay)
+    assert policy_display.display_policy_address("cafe", 3, 1) == wallet_policy_address(
+        template, key_info, 3, 1
+    )
 
     assert isinstance(SignerDecorator(_MessageSigner()), MessageSigner)
 


### PR DESCRIPTION
Closes #1588
Closes #1596

`HwiSigner.display_policy_address` wires the registered-policy half of
HWI's `displayaddress`, the second mode of the same command
`display_address` already sends `--desc` to and mutually exclusive with
it. `descriptors.wallet_policy_address` (#1348) computes the address a
BIP388 policy describes at an index and a multipath index;
`psbt_signer.WalletPolicyAddressDisplay` and `display_policy_address`
check it on the device the way `AddressDisplay` and `display_address`
check a plain descriptor's.

No HWI release through 3.2.0 carries that command's policy group. The
caveat is stated as a bound rather than a hedge — raising `HWI_VERSION`
to the first release whose `hwilib/_cli.py` adds it is what ends it —
which is the shape #1592 already put `register_descriptor` on.

`integration-hwi.yml`'s guix-builder comment stated a count that had
gone stale; it states none now, the same edit `3509a4bc` made to the
sibling workflow's identical sentence.

## One source break, and it is quieter than it looks

`psbt_signer_contract.optional_protocols` reported `AddressDisplay` and
`MessageSigner`; it now reports three, with
`WalletPolicyAddressDisplay` **in the middle**, grouped with the address
display it is a second mode of.

Unpacking the old shape raises, which is the loud case. The quiet one is
an index: `optional_protocols(signer)[1]` meant "signs messages" in
`v2026.8.29` and means "displays a wallet-policy address" now — a `bool`
of the wrong question, with nothing raised. `RELEASE_NOTES.md`'s
breaking-changes list carries both, with before and after.

Whether that position should stop being load-bearing at all — a
`NamedTuple`, so the next protocol added in the middle changes no
caller's meaning — is [ISS 1624](https://github.com/btclib-org/btclib/issues/1624),
filed rather than folded in here: it is a public return type, and an
unreviewed API decision does not belong inside a landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Wire registered BIP388 wallet-policy address display through HWI and signer protocols, including compatibility documentation and integration coverage.

New Features:
- Add support for displaying and verifying addresses derived from registered BIP388 wallet policies through HWI.
- Expose wallet-policy address display as an optional signer protocol and preserve it through signer decorators.

Enhancements:
- Extend optional protocol reporting to include wallet-policy address display, with the new protocol inserted alongside address display.

CI:
- Update the HWI integration workflow comment to remove a stale Guix builder count.

Documentation:
- Document the HWI wallet-policy display support and the compatibility impact of the expanded optional-protocol result.

Tests:
- Add coverage for HWI policy-address display arguments, address verification, protocol detection, and decorator propagation.