### PR TITLE
A pasted documentation block writes nothing in the reader's directory (closes #1605, closes #1606, issue #1613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1345,6 +1345,67 @@ documented at release-notes length in the first place, and are still in
   state how many of anything a file holds*: a count nothing here
   re-derives ages the same way a wrong one does.
 
+### A pasted documentation block writes nothing in the reader's directory
+
+- **`RELEASING.md`'s attestation check names the file it verifies at the
+  end of the command** (closes #1605). `--repository` is a flag and
+  precedes the positional the tool's own usage puts last, so `<file>`
+  ends the line and the `>` closing it has nothing to take as a target;
+  with a word after it, a paste made in a directory holding a file named
+  `file` wrote one named `--repository`.
+- **The griffe check, the `gh run rerun` of a failed publish and
+  `REPOSITORY.md`'s check-run count put their flags ahead of their
+  placeholder for the same reason** (issue #1613). Each wrote a file
+  named for the word that followed it: `-s`, `--failed`, `--json`.
+- **The TestPyPI smoke test names the rehearsal version in a fence of
+  its own** (issue #1613), `--with` having to precede the command uv
+  runs, so the position section 9 of the organization standard asks for
+  is one this command's shape refuses. The fence below reads the value
+  as `${dev:?}`, which is what makes a paste of that fence alone fail
+  naming the variable rather than resolving a spec with a hole in it.
+- **`SECURITY.md`'s `gh attestation verify` takes the release asset as a
+  placeholder standing whole at the end of the command.** Written
+  `btclib-<version>-py3-none-any.whl`, the `>` took the rest of the
+  filename as its target and the paste wrote `-py3-none-any.whl`; one
+  attestation covers every asset of the release, which the file already
+  says, so naming a file pattern there bought nothing the placeholder
+  does not.
+- **`tests/_data/README.md`'s re-checking commands hold their
+  placeholder in a fence of its own**, an API path and a verbosity
+  argument each refusing to let it end the command.
+  `bitcoin-cli getrawtransaction <txid> 2` wrote a file named `2`; the
+  `gh api` line's target is a path under a directory a fresh run does
+  not have, so it failed where the other wrote.
+- **`CLAUDE.md`'s worktree block holds no line that writes** (closes
+  #1606). `uv sync --locked` sat under a line that is a parse error, and
+  a parse error guards only the line it sits on: `bash` and `sh` submit
+  a paste a line at a time, and the `&&` ahead of the sync is no guard,
+  an unset `WT` making `cd "$WT"` a `cd ""`. That empty path is what
+  `zsh` 5.9 and the `bash` 3.2 macOS ships as `/bin/bash` and `/bin/sh`
+  answer 0 to; `bash` 5 refuses it and stops the chain there, so the
+  reach is the reader's shell rather than every reader's. The sync
+  running in the reader's own directory — which for a reader of that
+  file is the primary checkout the same page forbids working in — is
+  `uv sync`'s documented behaviour and was never observed: the probe
+  that would have written was declined. `uv run` syncs before every
+  gate, so the line is gone rather than moved.
+- **Measured by pasting every fenced line of every markdown file in the
+  tree, unfilled, into `zsh`, `bash` and `sh`** with `git`, `uv`, `gh`
+  and `bitcoin-cli` replaced by stubs on an otherwise empty `PATH`, in a
+  fresh directory seeded with a file named for each placeholder's first
+  word, and reading back what the directory gained. A line holding
+  `echo hi > outfile` writes in every cell, which is the positive
+  control. Every line this entry names is in the log taken before the
+  change and in none of the logs taken after it. `RELEASING.md`'s three
+  rebuild lines still write on a partial paste, and are left to
+  btclib-org/.github#745, which rewrites that block around the same
+  must-be-set form.
+- **The whole passage dragged as one paste — prose, both fences and what
+  stands between them — is the channel a fence split does not cover, and
+  it was measured on the same harness.** The smoke test wrote `.dev` and
+  `python` there and the txid command wrote `2`; neither writes after the
+  change, `${name:?}` failing before the command it feeds is reached.
+
 ## v2026.8.29
 
 ### Repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ once, which the ordinary sequence avoids by each removing its own.
 ```shell
 WT=<scratchpad>/wt-<tracker>-<issue>-<repo>-<role>  # wt-github-255-btclib-coder
 git worktree add "$WT" origin/main -b <branch>
-cd "$WT" && uv sync --locked          # a second venv, about a minute
+cd "$WT"                              # no uv sync: the gate does it
 # edit, gate and commit here, then
 git push origin HEAD:refs/heads/<branch>
 ```
@@ -116,6 +116,14 @@ placeholder ends the command, which is section 9 of the organization
 standard's rule. With the placeholder ahead of `"$WT"` the `>` closing it
 takes that path as its target, and a path with no directory at it is a
 file the paste creates.
+
+No line in the block writes. `uv sync` is absent because `uv run` syncs
+before every gate, and because the `&&` that used to carry it is no
+guard: with `WT` unset, `cd "$WT"` is `cd ""`, which `zsh` and the
+`bash` 3.2 macOS ships answer 0, where `bash` 5 refuses it. So the reach
+is the reader's shell rather than every reader's, and where the chain
+does proceed a sync line here runs in the reader's own directory, which
+for a reader of this file is the primary checkout.
 
 Removing the worktree is part of finishing, and it stands in a block of
 its own: the block above ends in a placeholder, and a shell that

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -127,13 +127,21 @@ unconstrained — and publishes the very files those checks passed to
    its own version instead of colliding with the one it repeats.
 
 1. Check the upload on <https://test.pypi.org/project/btclib/>, and
-   optionally install it (its dependencies come from the real PyPI):
+   optionally install it (its dependencies come from the real PyPI). The
+   rehearsal version stands in a fence of its own, `--with` having to
+   precede the command uv runs; the fence below reads it as `${dev:?}`,
+   the shell's must-be-set form, so a paste of that fence alone fails
+   naming the variable rather than resolving a spec with a hole in it:
+
+   ```shell
+   dev=<version>.dev<run*100+attempt>
+   ```
 
    ```shell
    uv run --isolated --no-project \
      --index https://test.pypi.org/simple/ \
      --index-strategy unsafe-best-match \
-     --with btclib==<version>.dev<run*100+attempt> \
+     --with "btclib==${dev:?}" \
      python -c "import btclib; print(btclib.__version__)"
    ```
 
@@ -221,7 +229,7 @@ to `deps-latest`'s own result.
    automates on a commit:
 
    ```shell
-   uv run --with griffe griffe check btclib -a <previous release tag> -s . -s src
+   uv run --with griffe griffe check btclib -s . -s src -a <previous release tag>
    ```
 
    `tests/release_notes_test.py` keeps both release-note files count-free:
@@ -507,8 +515,8 @@ to `deps-latest`'s own result.
 
    ```shell
    uv run --isolated --no-project --with pypi-attestations \
-     pypi-attestations verify pypi <file> \
-     --repository https://github.com/btclib-org/btclib
+     pypi-attestations verify pypi \
+     --repository https://github.com/btclib-org/btclib <file>
    ```
 
 1. Read the bill of materials attached to the release,
@@ -692,7 +700,7 @@ above needs no `uv sync` to produce the published bytes.
   the publish job alone against what is already built:
 
   ```shell
-  gh run rerun <run id> --failed
+  gh run rerun --failed <run id>
   ```
 
   a fresh approval of the `pypi` environment is still required, the

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -261,7 +261,7 @@ How large is read off a pull request rather than written down here,
 because it is not one number.
 
 ```shell
-head=$(gh pr view <an open pull request> --json headRefOid --jq .headRefOid)
+head=$(gh pr view --json headRefOid --jq .headRefOid <an open pull request>)
 gh api "repos/btclib-org/btclib/commits/$head/check-runs" --jq '.total_count'
 # 14 and 15, the two open when this was written
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,9 +60,9 @@ a build provenance attestation of their own, signed in the run that built
 them:
 
 ```shell
-gh attestation verify btclib-<version>-py3-none-any.whl \
-  --repo btclib-org/btclib \
-  --signer-workflow btclib-org/btclib/.github/workflows/release.yml
+gh attestation verify --repo btclib-org/btclib \
+  --signer-workflow btclib-org/btclib/.github/workflows/release.yml \
+  <a distribution file from the release>
 ```
 
 `--signer-workflow` is what makes that say which workflow signed, rather

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -144,9 +144,18 @@ out: an absent vector hides the defect it would have shown, and
 
 ## Re-checking a pin
 
+The commit stands in a fence of its own, sitting inside the API path
+rather than at the end of the command; the fence below reads it as
+`${commit:?}`, the shell's must-be-set form, so a paste of that fence
+alone fails naming the variable.
+
+```shell
+commit=<the pin the entry gives>
+```
+
 ```shell
 git hash-object tests/script_engine/_data/script_tests.json
-gh api repos/bitcoin/bitcoin/git/trees/<commit>:src/test/data \
+gh api "repos/bitcoin/bitcoin/git/trees/${commit:?}:src/test/data" \
     --jq '.tree[] | select(.path == "script_tests.json") | .sha'
 ```
 
@@ -2059,10 +2068,18 @@ bytes stopped being a script.
 
 This is the one file here that does not verify itself. A `scriptPubKey`
 is a *part* of a transaction, so no txid can be recomputed from it; the
-txid says where it came from, and re-deriving it is what checks the copy:
+txid says where it came from, and re-deriving it is what checks the copy.
+The txid stands in a fence of its own, the verbosity argument having to
+follow it; the fence below reads it as `${txid:?}`, the shell's
+must-be-set form, so a paste of that fence alone fails naming the
+variable.
 
 ```shell
-bitcoin-cli getrawtransaction <txid> 2 \
+txid=<the txid the entry gives>
+```
+
+```shell
+bitcoin-cli getrawtransaction "${txid:?}" 2 \
     | jq -r '.vout[<n>].scriptPubKey.hex'
 ```
 


### PR DESCRIPTION
Closes #1605
Closes #1606

Part of #1613 — four of the seven lines it names. The three in
`RELEASING.md`'s rebuild block are left to btclib-org/.github#745, whose
branch rewrites that whole block around the same must-be-set form, so
they are not answered twice.

## What this is

`<` and `>` are the shell's redirection operators, so an unfilled
`<...>` placeholder is a pair of them wherever it sits, and what its
position decides is whether the line can run at all. Where a word
follows the placeholder the `>` takes that word as its target, and in a
directory holding a file of the placeholder's own name the `<` succeeds
and **the line writes in the reader's own directory**.

Section 9 of the organization standard is the rule: the placeholder goes
at the end of its command, and where the command's own shape refuses
that position its line stands in a fence of its own.

## How it was measured

Every fenced shell line of every markdown file in the tree, sliced out
of the blob unfilled and never retyped, run in `zsh`, `bash` and `sh`
with `git`, `uv`, `gh` and `bitcoin-cli` replaced by stubs on an
otherwise empty `PATH`, inside a fresh directory seeded with a file
named for each placeholder's first word. What the run reports is what
the directory gained.

`echo hi > outfile` gains its file in every cell, which is the positive
control; a placeholder-last line gains nothing, which is the negative
one. **Eleven lines wrote before the change and none of the lines this
touches writes after it.**

The whole passage dragged as one paste — prose, both fences and the
prose between them — was run on the same harness, that being the channel
a fence split does not cover and the open question of
btclib-org/.github#750. `${name:?}` fails before the command it feeds is
reached, so the split here takes the safe side of that question rather
than waiting on it.

## Review

Reviewed locally at fresh context before this was opened, per
`REVIEWING.md`. Round 1 returned CHANGES REQUESTED with two blocking
findings, both prose in files that land and stay:

- the entry claimed `cd ""` "succeeds in `zsh`, `bash` and `sh` alike".
  **bash 5.3 refuses an empty path**, exit 1, so the `&&` chain does
  short-circuit there. `CHANGELOG.md` is append-only, so the sentence
  could not be corrected after landing. It now names the shells, and
  says outright that the sync writing `.venv` in the reader's directory
  is `uv sync`'s documented behaviour and was **never observed** — the
  probe that would have written was declined. ISS 1606's own "all three
  shells" came from a probe whose `/bin/bash` and `/bin/sh` are the same
  bash 3.2; that issue has been corrected too.
- the `${txid:?}` split site had no prose saying what `:?` is doing
  there, which section 9 requires and which this branch's two other
  split sites already do. A reader who is not told deletes it, and the
  plain `"$txid"` is the form that puts the reach back on the drag
  channel.

## The rebase

`origin/main` moved under this branch, and the landing touched
`CHANGELOG.md` — a `merge=union` file — at the same insertion index as
this branch. The fusion **ate the blank line above the new `###`
heading** and kept the one below.

Rebuilt rather than patched: the branch's 61-line block was isolated and
verified by `parent + block == pre-rebase tip` byte for byte, the blank
framing re-supplied from `origin/main`'s blob, and the result confirmed
to differ from the as-rebased file by exactly one added blank line and
nothing else. `CHANGELOG.md` at the tip is a pure insertion over
`origin/main`, 61 lines added and 0 removed, and the entry that landed
meanwhile is intact.

## Gates

All exit 0 on the final tip, exit codes captured per step:

- `uv run --locked pre-commit run --all-files`
- `uv run --locked pytest` — 31451 passed, 30 skipped, 1 xfailed,
  coverage 100.00%
- `uv run --locked --no-default-groups --group docs sphinx-build -n -W
  --keep-going -b html docs/source docs/build/html`
- `uv run --locked pre-commit run --all-files` again, after the docs
  build
- `git status --porcelain` empty

## Summary by Sourcery

Make pasted documentation commands safe by preventing unfilled placeholders from being interpreted as shell redirections.

Bug Fixes:
- Prevent pasted documentation commands from creating files in the reader’s working directory by moving placeholders to safe positions or isolating them in validated shell fences.
- Remove the unsafe `uv sync` step from the worktree example and clarify its shell-dependent behavior.

Enhancements:
- Update release, repository, security, and test-data documentation to use safer placeholder patterns and explicit must-be-set variables.
- Add documentation explaining the safety rationale and validation behavior for affected command examples.

Documentation:
- Document safe placeholder placement across release, repository, security, worktree, and transaction-validation instructions.