### PR TITLE
The documentation job's commands are compared where they are written (closes #1609, closes #1610)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -97,8 +97,10 @@ jobs:
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
-      # the same command .readthedocs.yaml runs and CONTRIBUTING.md
-      # documents, so what CI checks is what gets published.
+      # the same command .readthedocs.yaml runs, CONTRIBUTING.md
+      # documents and docs/README.rst quotes, so what CI checks is what
+      # gets published; tests/docs_commands_test.py is what compares the
+      # spellings.
       # Not --only-group docs: autodoc imports every module of the package,
       # so btclib and its bindings have to be installed -- which is the
       # defect issue 151 was opened for, read the docs having installed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1406,6 +1406,35 @@ documented at release-notes length in the first place, and are still in
   `python` there and the txid command wrote `2`; neither writes after the
   change, `${name:?}` failing before the command it feeds is reached.
 
+### The documentation job's commands are compared where they are written
+
+- **`CONTRIBUTING.md` documented the unresolved-link grep as `grep -rn
+  'href="#\./'` where `.github/workflows/docs.yml` runs `grep -rnE
+  'href="#\.\.?/'`** (closes #1610). The documented pattern matches the
+  `./` spelling alone, so a contributor reproducing the job saw nothing
+  on a tree the job fails on -- exactly the `../` spelling the
+  workflow's pattern also matches. The paragraph beside the command now
+  says why it carries both, `.pre-commit-config.yaml`'s
+  `local-link-prefix` hook being what leaves a broken link those two
+  spellings and no other.
+- **`tests/docs_commands_test.py` compares the spellings of both
+  commands** (closes #1609). The build is written in
+  `.github/workflows/docs.yml`, `.readthedocs.yaml`, `CONTRIBUTING.md`
+  and `docs/README.rst`, and the grep in the first and the third:
+  changing one of them and not the others is red. The output directory
+  is read against the site that holds it rather than across the sites,
+  read the docs naming its destination in an environment variable of
+  its own.
+- **A site has to yield exactly one command for those comparisons to
+  say anything**, which is a test of its own: a reindented block or a
+  rewritten fence leaves an extraction empty, and what a comparison
+  over nothing reports is agreement. It found one while it was being
+  written -- a closing markdown fence read as the tail of the command
+  above it -- which is the shape it exists for.
+- **`docs.yml`'s comment names every file that spells the build
+  command, and the test that compares them**, so the agreement it
+  states is checked rather than asserted.
+
 ## v2026.8.29
 
 ### Repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1075,7 +1075,7 @@ That job has a second step, which reads the pages the first one wrote and
 must find nothing — the job fails if this grep exits 0:
 
 ```shell
-grep -rn 'href="#\./' docs/build/html --include='*.html'
+grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'
 ```
 
 A link between the root markdown files — `./SECURITY.md` in README.md, the
@@ -1086,6 +1086,11 @@ warning. `docs/source/conf.py` resolves those links and suppresses no
 `myst.xref_missing`, so `-W` fails on the next one that has no target; the
 grep asks the same question of the HTML, where no suppression can hide the
 answer.
+
+The pattern matches `#../` as well as `#./` because a link to another file
+here begins one of those two ways and no other: `.pre-commit-config.yaml`'s
+`local-link-prefix` hook refuses the rest in the commit that writes the
+link, so those are the two spellings a broken one can render.
 
 A link into a heading of another root file carries a fragment spelled the
 way GitHub derives it from the heading text, as in

--- a/tests/docs_commands_test.py
+++ b/tests/docs_commands_test.py
@@ -1,0 +1,152 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The documentation job's commands are spelled one way each.
+
+The build is written in `.github/workflows/docs.yml`, which is what the
+merge gate runs; in `.readthedocs.yaml`, which is what the published site
+is built with; in `CONTRIBUTING.md`, which is what a contributor is told
+to run; and in `docs/README.rst`, which is where `RELEASING.md` sends a
+release. The grep over the pages that build wrote is in the workflow and
+in `CONTRIBUTING.md`.
+
+Each of those files is separately valid, so only reading them together
+says they have diverged, and a divergence is not reported by any run: a
+contributor whose local build passes a flag the gate does not, or a
+published site built by a command no merge ever ran, is a difference the
+green everywhere hides.
+
+Both commands are here because the failure is one -- a command spelled in
+more than one place with nothing comparing the spellings -- and the
+reading that finds either finds both.
+
+`docs/Makefile` and `docs/make.bat` are not sites of the build.
+`docs/README.rst` says they drive the same build "without the flags", and
+`SPHINXOPTS` is empty in each, so they spell nothing there is to agree
+about.
+
+Read with a regex rather than parsed, for the reason
+`interpreters_test.py` gives: no dependency group here carries a yaml
+parser. What a regex has to cross is a broken line, and these files break
+theirs two ways, one of which leaves no mark in the file at all, so a
+line is offered to the pattern joined to the one above it as well as
+alone -- and joined only where that one was no command itself, which is
+what keeps a closing fence off the end of a command already read. A site
+yielding anything other than one command is `test_every_site_was_read`'s
+failure, which is what keeps the comparisons below from passing over a
+file they could not read.
+"""
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).parents[1]
+
+# a POSIX line continuation, which is how the markdown and the rst break
+# the build command. The two yaml files fold theirs instead, and folding
+# leaves no marker, which is why `_commands` joins each line to the one
+# above it rather than this pattern reaching that case too
+_CONTINUATION = re.compile(r"\\\n[ \t]*")
+
+# the build, from `uv run` to the end of the line it is written on. The
+# match has to reach `sphinx-build` for the prefix to be compared as
+# well: `--group docs` is what installs the toolchain, and a site that
+# dropped it would build against a different environment
+_BUILD = re.compile(r"uv run\b.*\bsphinx-build\b.*")
+# the grep over the built pages, to the end of the command rather than of
+# the line: the workflow wraps it in an `if ...; then`, and the `;` is
+# where the command a reader is given stops
+_GREP = re.compile(r"grep -r.*?(?=;|$)")
+
+# where each site writes, which is the one argument that does not agree
+# and must not: read the docs names its destination in an environment
+# variable of its own. So the last word is read against the site that
+# holds it rather than across the sites, and one that changes where it
+# builds to is red here rather than agreeing with itself
+_BUILD_SITES = {
+    ".github/workflows/docs.yml": "docs/build/html",
+    ".readthedocs.yaml": "$READTHEDOCS_OUTPUT/html",
+    "CONTRIBUTING.md": "docs/build/html",
+    "docs/README.rst": "docs/build/html",
+}
+_GREP_SITES = (".github/workflows/docs.yml", "CONTRIBUTING.md")
+
+
+def _commands(path: str, pattern: re.Pattern[str]) -> tuple[str, ...]:
+    """Return every distinct command `pattern` finds in `path`.
+
+    Each line is offered to the pattern alone, and joined to the one
+    above it where that one held no command of its own: a folded yaml
+    scalar continues a line that is incomplete, which is what reads one
+    without a parser, and the same condition keeps a closing markdown
+    fence off the end of a command already read whole.
+    """
+    text = _CONTINUATION.sub(" ", (_ROOT / path).read_text(encoding="utf-8"))
+    lines = text.splitlines()
+    found = [pattern.search(line) for line in lines]
+    folded = [
+        f"{above} {below}"
+        for above, below, matched in zip(lines, lines[1:], found, strict=False)
+        if matched is None
+    ]
+    found += [pattern.search(line) for line in folded]
+    return tuple(sorted({" ".join(m.group().split()) for m in found if m}))
+
+
+def _one(found: tuple[str, ...]) -> str:
+    """Return the command of a site that holds exactly one.
+
+    Joined rather than indexed: a site holding none, or more than one, is
+    `test_every_site_was_read`'s failure, and joining leaves the
+    comparisons below a string that agrees with nothing rather than an
+    `IndexError` that says which file was read and not which check was
+    being made.
+    """
+    return " ".join(found)
+
+
+_BUILDS = {path: _commands(path, _BUILD) for path in _BUILD_SITES}
+_GREPS = {path: _commands(path, _GREP) for path in _GREP_SITES}
+
+
+def test_every_site_was_read() -> None:
+    """Each file yielded the one command it holds.
+
+    A renamed workflow key, a reindented block, a fence rewritten as
+    something else: each leaves an extraction empty, and a comparison
+    over nothing is true.
+    """
+    builds = {path: len(found) for path, found in _BUILDS.items()}
+    assert set(builds.values()) == {1}, (
+        f"one documentation build command per site, and instead: {builds}"
+    )
+    greps = {path: len(found) for path, found in _GREPS.items()}
+    assert set(greps.values()) == {1}, (
+        f"one unresolved-link grep per site, and instead: {greps}"
+    )
+
+
+def test_every_site_spells_one_build_command() -> None:
+    """What the gate runs is what publishes the site and what a reader gets."""
+    spellings = {path: _one(found).rsplit(" ", 1)[0] for path, found in _BUILDS.items()}
+    assert len(set(spellings.values())) == 1, (
+        f"the documentation build is spelled more than one way: {spellings}"
+    )
+
+
+def test_every_site_names_its_own_output_directory() -> None:
+    """The argument that differs differs by site, and by no other."""
+    outdirs = {path: _one(found).rsplit(" ", 1)[-1] for path, found in _BUILDS.items()}
+    assert outdirs == _BUILD_SITES, (
+        f"the documentation build writes to {outdirs}, where the sites are"
+        f" {_BUILD_SITES}"
+    )
+
+
+def test_the_documented_grep_is_the_one_the_job_runs() -> None:
+    """A reader who runs it and sees nothing has run the job's question."""
+    spellings = {path: _one(found) for path, found in _GREPS.items()}
+    assert len(set(spellings.values())) == 1, (
+        f"the unresolved-link grep is spelled more than one way: {spellings}"
+    )


### PR DESCRIPTION
Closes #1609
Closes #1610

## What this is

The documentation build command is written in **four** files —
`.github/workflows/docs.yml`, `.readthedocs.yaml`, `CONTRIBUTING.md`,
`docs/README.rst` — and the unresolved-link grep in **two**. Nothing
compared any of them, and two had already diverged: `CONTRIBUTING.md`
documented `grep -rn 'href="#\./'` where the job runs
`grep -rnE 'href="#\.\.?/'`, so a contributor reproducing the job locally
**passed on a tree the job fails** — exactly the `../` spelling the
widening was for.

`tests/docs_commands_test.py` compares the spellings where they are
written.

## Why one pull request

ISS 1610 states the pairing itself: "the same class as issue #1609 — a
command spelled in more than one place with nothing comparing the
spellings — but here the two have already diverged rather than merely
being unguarded." 1610 alone is a one-line correction that can diverge
again tomorrow; 1609 is what stops it.

## The trap this shape falls into, and the guard against it

A comparison over an empty set passes for the wrong reason. Deleting the
build command from **all four** sites leaves
`test_every_site_spells_one_build_command` green — four empty strings
agree — and only `test_every_site_was_read` goes red. The same holds on
the grep side. That guard is why the test is not decorative.

It earned its place during development: the first extractor read
`CONTRIBUTING.md` as holding *two* commands, the real one and the same
line with the closing fence glued on, and `test_every_site_was_read` is
what surfaced it.

## Done when — satisfied one file at a time

Changing the command in one of the four and not the others makes the
suite red. Eleven mutations, each proved to tamper before its run and
restored after: four build-flag mutations, two output-directory, two
grep, two block deletions, and a second differing command. All red, each
on the test that should catch it.

Dropped onto the pre-fix tree, `test_the_documented_grep_is_the_one_the_job_runs`
goes red naming both spellings and the other three stay green — ISS
1610's defect, found by ISS 1609's mechanism.

## A decision this now enforces

All four sites spell the build **without** `--keep-going`, deliberately
— btclib-org/.github#347, recorded at `CHANGELOG.md:1043`. Adding
`--keep-going` to any one site now turns the suite red. That decision had
prose behind it and no check; it has one now.

## Gates

Exit codes captured per step, all 0, on the rebased tip:
`pre-commit run --all-files`; `pytest` — 31455 passed, 30 skipped,
1 xfailed, coverage 100.00%; `sphinx-build -n -W -b html docs/source
docs/build/html` (the tree's own spelling); `pre-commit` again after the
docs build; `git status --porcelain` empty.

## Summary by Sourcery

Keep documentation build and unresolved-link check commands consistent across every place they are documented or executed.

Bug Fixes:
- Correct the documented unresolved-link grep so contributors run the same check as the documentation workflow.

Enhancements:
- Add tests that verify documentation build and link-check commands remain consistent across CI, Read the Docs, contributor, and release documentation, while preserving site-specific output directories.
- Ensure command extraction tests fail when expected documentation command sites are missing or malformed.
- Document the rationale for matching both relative-link spellings and identify the command consistency checks in the workflow.

Documentation:
- Update contributor documentation and release changelog with the corrected link-check command and command consistency guarantees.

Tests:
- Add coverage for command presence, matching build command spellings, site-specific output directories, and matching unresolved-link grep commands.