### PR TITLE
BIP112's bit-layout constants are read by name in both places (closes #1617, closes #1626)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1435,6 +1435,25 @@ documented at release-notes length in the first place, and are still in
   command, and the test that compares them**, so the agreement it
   states is checked rather than asserted.
 
+### `op_checksequenceverify` reads its three bit-layout constants from `btclib.tx.limits`
+
+- **`script/engine/script_op_codes.py`'s `op_checksequenceverify` no
+  longer carries `1 << 31`, `1 << 22` and `0x0000FFFF` as bare
+  literals** (closes #1617): it now reads `SEQUENCE_LOCKTIME_DISABLE_FLAG`,
+  `SEQUENCE_LOCKTIME_TYPE_FLAG` and `SEQUENCE_LOCKTIME_MASK` from
+  `btclib.tx.limits`, the same module its sibling `op_checklocktimeverify`
+  already imports `LOCKTIME_THRESHOLD` from (#1608).
+
+### `_Timelock._older` reads the same two constants from `btclib.tx.limits`
+
+- **`descriptors/miniscript.py`'s `_Timelock._older` no longer carries
+  `1 << 31` and `0x0000FFFF` as bare literals** (closes #1626): it reads
+  `SEQUENCE_LOCKTIME_DISABLE_FLAG` and `SEQUENCE_LOCKTIME_MASK` beside
+  the `SEQUENCE_LOCKTIME_TYPE_FLAG` the same function already read from
+  `btclib.tx.limits`. BIP112's rule is one rule, and this is the
+  interpreter's own reading of it: the two places that apply it now name
+  the layout the same way.
+
 ## v2026.8.29
 
 ### Repository

--- a/src/btclib/descriptors/miniscript.py
+++ b/src/btclib/descriptors/miniscript.py
@@ -92,7 +92,12 @@ from btclib.script.script import (
     push_int,
     serialize,
 )
-from btclib.tx.limits import LOCKTIME_THRESHOLD, SEQUENCE_LOCKTIME_TYPE_FLAG
+from btclib.tx.limits import (
+    LOCKTIME_THRESHOLD,
+    SEQUENCE_LOCKTIME_DISABLE_FLAG,
+    SEQUENCE_LOCKTIME_MASK,
+    SEQUENCE_LOCKTIME_TYPE_FLAG,
+)
 from btclib.utils import assert_type, bytes_from_octets, decode_num, encode_num
 from btclib.var_int import serialize as var_int_serialize
 
@@ -2837,13 +2842,13 @@ class SpendContext:
         512-second intervals -- and a relative lock time at least the
         fragment's.
         """
-        if self.version < 2 or self.sequence & (1 << 31):
+        if self.version < 2 or self.sequence & SEQUENCE_LOCKTIME_DISABLE_FLAG:
             return False
         if value & SEQUENCE_LOCKTIME_TYPE_FLAG != (
             self.sequence & SEQUENCE_LOCKTIME_TYPE_FLAG
         ):
             return False
-        return value & 0x0000FFFF <= self.sequence & 0x0000FFFF
+        return value & SEQUENCE_LOCKTIME_MASK <= self.sequence & SEQUENCE_LOCKTIME_MASK
 
 
 @dataclass(frozen=True)

--- a/src/btclib/script/engine/script_op_codes.py
+++ b/src/btclib/script/engine/script_op_codes.py
@@ -31,7 +31,12 @@ from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, hash256, ripemd160, sha1, sha256
 from btclib.script.engine.flags import ScriptFlag
 from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE, MAX_STACK_SIZE
-from btclib.tx.limits import LOCKTIME_THRESHOLD
+from btclib.tx.limits import (
+    LOCKTIME_THRESHOLD,
+    SEQUENCE_LOCKTIME_DISABLE_FLAG,
+    SEQUENCE_LOCKTIME_MASK,
+    SEQUENCE_LOCKTIME_TYPE_FLAG,
+)
 from btclib.tx.tx import Tx
 from btclib.utils import assert_type, decode_num, encode_num
 
@@ -823,18 +828,24 @@ def op_checksequenceverify(
     sequence = _to_num(stack[-1], flags, _MAX_LOCK_TIME_NUM_SIZE)
     if sequence < 0:
         raise BTClibValueError(f"negative sequence: {sequence}")
-    if not sequence & (1 << 31):
+    if not sequence & SEQUENCE_LOCKTIME_DISABLE_FLAG:
         if tx.version < 2:
             raise BTClibValueError(f"transaction version {tx.version} < 2")
-        if tx.vin[i].sequence & (1 << 31):
+        if tx.vin[i].sequence & SEQUENCE_LOCKTIME_DISABLE_FLAG:
             raise BTClibValueError(f"relative lock time disabled for input {i}")
-        if sequence & (1 << 22) != tx.vin[i].sequence & (1 << 22):
+        if (
+            sequence & SEQUENCE_LOCKTIME_TYPE_FLAG
+            != tx.vin[i].sequence & SEQUENCE_LOCKTIME_TYPE_FLAG
+        ):
             raise BTClibValueError(
                 f"relative lock time unit mismatch: {hex(sequence)} against "
                 f"the sequence {hex(tx.vin[i].sequence)} of input {i}"
             )
-        if sequence & 0x0000FFFF > tx.vin[i].sequence & 0x0000FFFF:
+        if (
+            sequence & SEQUENCE_LOCKTIME_MASK
+            > tx.vin[i].sequence & SEQUENCE_LOCKTIME_MASK
+        ):
             raise BTClibValueError(
-                f"relative lock time {sequence & 0x0000FFFF} > "
-                f"{tx.vin[i].sequence & 0x0000FFFF}"
+                f"relative lock time {sequence & SEQUENCE_LOCKTIME_MASK} > "
+                f"{tx.vin[i].sequence & SEQUENCE_LOCKTIME_MASK}"
             )


### PR DESCRIPTION
Closes #1617
Closes #1626

BIP112's bit layout is applied in two places in this tree, and both
spelled it with bare literals where `btclib.tx.limits` already publishes
the names.

- `script/engine/script_op_codes.py`'s `op_checksequenceverify` carried
  `1 << 31`, `1 << 22` and `0x0000FFFF`.
- `descriptors/miniscript.py`'s `_Timelock._older` carried `1 << 31` and
  `0x0000FFFF` — beside a `SEQUENCE_LOCKTIME_TYPE_FLAG` it already read
  by name, because `7a2c6efd` (#1608) moved that one and left these.

Both are here rather than in two pull requests: it is one decision about
one rule, and splitting it would have left a single function naming one
constant and spelling two.

## What was verified rather than assumed

This is consensus code, so a substitution that changed a value would be
a bug in script evaluation and in miniscript satisfaction, invisible in
the prose of a diff.

- Each constant was read from its definition in `btclib.tx.limits` and
  compared with the literal it replaces.
- The completeness sweep was proved against a positive control before
  its zero was believed — the pre-edit blobs do carry the literals — and
  no bare `1 << 31`, `1 << 22` or `0x0000FFFF` remains in either file.
  The `0xFFFFFFFF` still in both is `SEQUENCE_FINAL`, a different
  constant.
- Precedence was tested, not reasoned about: `&` binds tighter than a
  comparison in Python, so `value & MASK <= seq & MASK` is the
  comparison of two masked values, and substituting a name for a literal
  yields an identical parse tree. The parenthesised `(1 << 31)` becoming
  a bare name is safe for the same reason.

`RELEASE_NOTES.md` is owed nothing: no API, no behaviour and no
spelling a caller can see changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Enhancements:
- Use the published BIP112 sequence-locktime constants consistently in script verification and miniscript timelock evaluation instead of duplicating bit-layout literals.