### PR TITLE
`btclib.hwi` sends a chain for testnet4, and its pin drops its counts (closes #1599, closes #1595)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1454,6 +1454,40 @@ documented at release-notes length in the first place, and are still in
   interpreter's own reading of it: the two places that apply it now name
   the layout the same way.
 
+### `btclib.hwi` sends a chain for btclib's testnet4 network
+
+- **`_HWI_CHAIN` maps every network `NETWORKS` holds** (closes #1599).
+  `HwiSigner` takes any name that catalogue has, so a testnet4 signer
+  was built and then refused by the chain lookup at its first command.
+  The chain it goes out as is `test`, and HWI's own `testnet4` -- which
+  its parser takes -- is the rejected alternative. In 3.2.0, the release
+  `.github/workflows/integration-hwi.yml` pins, a chain is compared with
+  `Chain.MAIN` and with no other, `JadeClient.NETWORKS` excepted, so an
+  xpub comes back under the testnet version prefix and BIP44 coin type 1
+  for either name -- and that exception is what decides: it holds `test`
+  and answers `BadArgumentError: Unhandled network` for `testnet4`, so
+  sending the name would change no answer `btclib.hwi` reads and would
+  cost the Jade. btclib's testnet4 and testnet share
+  every version prefix, differing in the genesis block and the consensus
+  parameters, which no encoding reads.
+- **`tests/hwi_test.py` walks `NETWORKS` against the mapping**, which is
+  what a sixth btclib network is red on here rather than at a caller's
+  first command; the chains it transcribes from HWI's parser are what
+  the mapping's values are checked against, as a subset rather than as
+  the same set.
+
+### The HWI command-line pin names what it leaves out, and counts none of it
+
+- **`tests/_data/README.md`'s HWI CLI entry names the commands
+  `btclib.hwi` leaves alone, under the reason each is left alone for**
+  (closes #1595). `installudevrules` was under neither reason the entry
+  gave, and it has one of its own: it talks to no device -- it copies
+  HWI's udev rules onto the host -- and it is the one subcommand of that
+  pin the parser registers behind a platform guard,
+  `sys.platform.startswith("linux")`. The entry's counts of upstream's
+  parser and of its chains are gone with it, the names beside them being
+  what a reader checks and a number being what the next pin falsifies.
+
 ## v2026.8.29
 
 ### Repository

--- a/src/btclib/hwi.py
+++ b/src/btclib/hwi.py
@@ -165,15 +165,30 @@ _POLL_INTERVAL = 0.05
 # in every language that has them and a ruff finding in this one
 NO_CAPABILITIES = SignerCapabilities()
 
-# btclib names five networks and HWI takes four chains: `--chain` is what
-# decides the version bytes of the xpubs it answers with, so the mapping
-# is what makes `account_descriptors` agree with the device about which
-# chain the account is on. testnet4 has no HWI chain of its own
+# `--chain` decides the version bytes of the xpubs HWI answers with, so
+# this mapping is what makes `account_descriptors` agree with the device
+# about which chain the account is on. Every btclib network has a chain
+# here, which is what `bitcoin_core_rpc.chain_from_network` is for Core's
+# vocabulary -- and unlike that one this is not a bijection: testnet4
+# goes out as `test`, HWI's own `testnet4`, which its parser takes, being
+# the rejected alternative.
+#
+# Both decide the same bytes. In 3.2.0, the release
+# `.github/workflows/integration-hwi.yml` pins, a chain is compared with
+# `Chain.MAIN` and with no other, `JadeClient.NETWORKS` excepted, so an
+# xpub comes back under the testnet version prefix and BIP44 coin type 1
+# for either name -- and that exception is what decides: it holds `test`
+# and answers `BadArgumentError: Unhandled network` for `testnet4`. So
+# sending `testnet4` would change no answer read here and would cost the
+# Jade. btclib's own testnet4 and testnet share every version prefix,
+# differing in the genesis block and the consensus parameters, which no
+# encoding reads
 _HWI_CHAIN = {
     "mainnet": "main",
     "testnet": "test",
     "regtest": "regtest",
     "signet": "signet",
+    "testnet4": "test",
 }
 
 
@@ -446,7 +461,12 @@ def enumerate_devices(
 
 
 def _chain_args(network: str) -> list[str]:
-    """Return HWI's `--chain` flag for a btclib network name."""
+    """Return HWI's `--chain` flag for a btclib network name.
+
+    `enumerate_devices` is the caller that can reach the refusal: it
+    takes a network name and names no device, where `HwiSigner` has
+    already refused a name `NETWORKS` does not hold.
+    """
     chain = _HWI_CHAIN.get(network)
     if chain is None:
         known = ", ".join(sorted(_HWI_CHAIN))

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -1351,17 +1351,25 @@ behind  0 revisions; that commit is the tip of the path
 ```
 
 Verdict: **transcribed**, and a subset by design. `tests/hwi_test.py`
-holds the six commands `btclib.hwi` runs — `enumerate`, `getxpub`,
+holds the commands `btclib.hwi` runs — `enumerate`, `getxpub`,
 `signtx`, `signmessage`, `displayaddress`, `registerdescriptor` — with
-the positional arguments of each, the three global flags it passes
+the positional arguments of each, the global flags it passes
 (`--chain`, `--fingerprint`, `--emulators`), the `--desc` of
-`displayaddress`, the four chains `--chain` takes, and the keys read out
-of each answer. The other eleven commands are the device lifecycle —
-setup, wipe, restore, backup, the PIN and passphrase flows — which
-issue #381 keeps out of the signing surface deliberately, and
-`getdescriptors`, `getkeypool` and `getmasterxpub`, which btclib
-computes for itself: `descriptors.account_descriptors` and
-`btclib.core_import` are those three, on btclib's own types.
+`displayaddress`, the chains `--chain` takes, and the keys read out of
+each answer. Not every chain it transcribes is one btclib sends:
+testnet4 goes out as `test`, and `btclib.hwi`'s `_HWI_CHAIN` says why.
+
+What the parser declares and `btclib.hwi` leaves alone, under the reason
+each is left alone for. `setup`, `wipe`, `restore`, `backup`,
+`promptpin`, `togglepassphrase` and `sendpin` are the device lifecycle,
+which issue #381 keeps out of the signing surface deliberately.
+`getdescriptors`, `getkeypool` and `getmasterxpub` are what btclib
+computes for itself, on its own types, in
+`descriptors.account_descriptors` and `btclib.core_import`.
+`installudevrules` talks to no device -- it copies HWI's udev rules onto
+the host -- and it is the one subcommand of the pin above that the
+parser registers behind a platform guard,
+`sys.platform.startswith("linux")`.
 
 `displayaddress`'s BIP388 policy mode -- `--registration`, `--index`,
 `--multipath-index` -- is `HwiSigner.display_policy_address`

--- a/tests/hwi_test.py
+++ b/tests/hwi_test.py
@@ -55,6 +55,7 @@ from btclib.hwi import (
     enumerate_devices,
     is_available,
 )
+from btclib.network import NETWORKS
 from btclib.psbt.psbt import Psbt
 from btclib.psbt_signer import (
     AddressDisplay,
@@ -152,8 +153,9 @@ HWI_ANSWER_KEYS = {
 }
 
 # the chains `--chain` takes, which is what decides the version bytes of
-# every extended key HWI answers with
-HWI_CHAINS = ("main", "test", "signet", "regtest")
+# every extended key HWI answers with. `btclib.hwi` sends a subset:
+# `_HWI_CHAIN` says why btclib's testnet4 network goes out as `test`
+HWI_CHAINS = ("main", "test", "signet", "regtest", "testnet4")
 
 # every error code HWI defines, with the name it gives it: the numbers a
 # caller acts on, and `exceptions.SignerError` carries them through
@@ -311,26 +313,35 @@ def last_argv(hwi: list[str]) -> list[str]:
 def test_the_network_is_the_chain_hwi_is_told(tmp_path: Path) -> None:
     """`--chain` decides the version bytes of the xpubs that come back.
 
-    So a btclib network name is translated rather than passed on, and the
-    one btclib has and HWI has not — testnet4 — is named rather than sent
-    as a chain the command line would refuse.
+    So a btclib network name is translated rather than passed on, and
+    testnet4 is translated to `test`: `btclib.hwi`'s `_HWI_CHAIN` says
+    why the chain of that name is not what goes out.
+
+    Every network btclib has is a chain HWI is told, which is what a
+    sixth network would have to be given here: the mapping stands between
+    `NETWORKS` and a command line, and a network missing from it reaches
+    a caller as a refusal after the signer was built.
     """
     for network, chain in (
         ("mainnet", "main"),
         ("testnet", "test"),
         ("regtest", "regtest"),
+        ("signet", "signet"),
+        ("testnet4", "test"),
     ):
         hwi = stand_in(tmp_path, {})
         HwiSigner(FINGERPRINT, executable=hwi, network=network).xpub("m/0")
         argv = last_argv(hwi)
         assert argv[argv.index("--chain") + 1] == chain
 
+    assert set(_HWI_CHAIN) == set(NETWORKS)
+
     with pytest.raises(BTClibValueError, match="unknown network"):
         HwiSigner(FINGERPRINT, executable=stand_in(tmp_path, {}), network="nosuchnet")
-    with pytest.raises(BTClibValueError, match="no HWI chain for network testnet4"):
-        HwiSigner(
-            FINGERPRINT, executable=stand_in(tmp_path, {}), network="testnet4"
-        ).xpub("m/0")
+    # `enumerate_devices` names no device and checks no name against
+    # `NETWORKS`, so it is where the chain lookup can be asked for one
+    with pytest.raises(BTClibValueError, match="no HWI chain for network nosuchnet"):
+        enumerate_devices(executable=stand_in(tmp_path, {}), network="nosuchnet")
 
 
 def account_psbt(device: HwiSigner) -> tuple[Psbt, Descriptor]:
@@ -761,8 +772,8 @@ def test_btclib_runs_the_commands_hwi_publishes(tmp_path: Path) -> None:
         assert len(positional) == len(HWI_COMMANDS[command]) + len(command_flags)
         assert tuple(command_flags) == HWI_COMMAND_FLAGS.get(command, ())
 
-    # and the chain is one of the four HWI names
-    assert set(_HWI_CHAIN.values()) == set(HWI_CHAINS)
+    # and the chain is one of the names HWI takes
+    assert set(_HWI_CHAIN.values()) <= set(HWI_CHAINS)
     assert ran["getxpub"][ran["getxpub"].index("--chain") + 1] in HWI_CHAINS
 
 


### PR DESCRIPTION
Closes #1599
Closes #1595

## What was wrong

Two sentences this tree tells about HWI, both false against the release
`integration-hwi.yml` actually pins.

- `src/btclib/hwi.py` said **"testnet4 has no HWI chain of its own"**.
  HWI has had one since 3.2.0: `hwilib/common.py` declares
  `TESTNET4 = 4`, and `_cli.py` declares `--chain` as
  `choices=list(Chain)`, so `--chain testnet4` is a valid argument of
  the pinned release.
- `tests/_data/README.md` said **"the other eleven commands"** and then
  enumerated ten. `installudevrules` was in neither clause.

## The obvious fix would have been a regression

If HWI accepts `--chain testnet4`, the naive change is
`_HWI_CHAIN["testnet4"] = "testnet4"`. **That breaks the Jade**, and the
measurement is what decided it rather than the reading:

```python
# hwilib/devices/jade.py:95-104, in the pinned 3.2.0 wheel
NETWORKS = {Chain.MAIN: 'mainnet', Chain.TEST: 'testnet',
            Chain.SIGNET: 'testnet', Chain.REGTEST: 'localtest'}

def _network(self) -> str:
    if self.chain not in self.NETWORKS:
        raise BadArgumentError(f'Unhandled network: {self.chain}')
```

`TESTNET4` is absent, and `_network()` is called at seven sites
including `auth_user` and `get_xpub` — so `--chain testnet4` fails a
Jade at its **first** command, not in a corner.

And sending it buys nothing. Every other discrimination of a chain
anywhere in `hwilib/` is a test against `Chain.MAIN` — `get_bip44_chain`
returns `1` for everything that is not `MAIN`, and each driver picks its
version bytes with `self.chain != Chain.MAIN`. `test` and `testnet4` are
indistinguishable to all of them. On btclib's side, `testnet.json` and
`testnet4.json` differ in `consensus` and `genesis_block` and share
**every version prefix**.

So `_HWI_CHAIN` maps `testnet4` to `test`, with the rejected alternative
recorded at the key.

## No count survives

ISS 1595's *Done when* asks for the excluded commands **without a
total**, because a landed count rots: HWI's parser has grown additively
at every pin, so the next command upstream adds makes the sentence false
with nothing here red. The enumeration is now complete — eleven names
under three reasons — and states no number.

`installudevrules` gets a reason of its own, defended by measurement: of
the seventeen `add_parser` calls it is the **only one behind a guard**,
`if sys.platform.startswith("linux")`, and its handler copies rule files
to `/etc/udev/rules.d/`. It talks to no device.

## Behaviour

`HwiSigner(network="testnet4")` used to raise at its first command and
now works. `tests/hwi_test.py` asserts `set(_HWI_CHAIN) == set(NETWORKS)`
— so whoever adds a sixth network is told in the suite rather than at a
caller's first command, which is the defect ISS 1599 reports.

## Gates

Exit codes captured per step, all as required, on the final tip: the
suite 0 — 31455 passed, 30 skipped, 1 xfailed, coverage 100.00%; lint 0;
`sphinx-build -n -W -b html docs/source docs/build/html` 0, the tree's
own spelling; and the docs job's second step,
`grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'`, exit 1,
which is what the job requires. `git status --porcelain` empty.

One run fell and is worth recording: the first suite run exited 1 on
`changelog_immutability_test`, the entry having been appended **inside**
the released `v2026.8.29` section. Moved to the end of the open section;
four runs green since. That test is why it was caught.

## Summary by Sourcery

Enable btclib's testnet4 network in HWI while preserving device compatibility and make the HWI command documentation and regression coverage resilient to upstream changes.

New Features:
- Support HWI signing for btclib's testnet4 network by translating it to the compatible HWI test chain.

Bug Fixes:
- Prevent testnet4 signers from being rejected before their first HWI command.
- Keep HWI command documentation aligned with the pinned parser, including the platform-specific udev command.

Enhancements:
- Add coverage ensuring every btclib network has an HWI chain mapping and that translated chains remain valid.
- Document excluded HWI commands by purpose without brittle command counts.

Documentation:
- Update HWI test-data documentation to enumerate delegated and excluded commands and clarify testnet4 chain translation.

Tests:
- Extend HWI tests for testnet4 support, network-to-chain completeness, and the expanded HWI chain set.