### PR TITLE
CachingFetcher and FallbackFetcher, two decorators over a Fetcher (closes #1129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1573,6 +1573,31 @@ The tag is annotated, which is the part worth writing down. `gh api
 and pinning that is a reference no runner can check out. `git/tags/<sha>`
 dereferences it, and `refs/tags/v1^{}` does the same from a checkout.
 
+### `CachingFetcher` and `FallbackFetcher`, two decorators over a `Fetcher`
+
+- **`btclib.fetch.decorators` adds `CachingFetcher`, which amortizes
+  `get_tx_out` by caching `get_tx`, and `FallbackFetcher`, which tries a
+  sequence of backends in order** (closes #1129). Both compose a
+  `Fetcher` rather than subclass a backend, and both are exported from
+  `btclib.fetch`. `Fetcher.get_tx_out` is concrete and calls `self.get_tx`,
+  so `CachingFetcher` does not override it: caching `get_tx` amortizes
+  every call to `get_tx_out` for free, twenty outpoints spending one
+  transaction costing one fetch of it instead of twenty. `get_tx` and
+  `get_block_header` are cached with no expiry; `get_block_count` and
+  `get_best_block_id` are never cached, both being the chain tip. A
+  `FetchError` is never cached, so a backend that is briefly down is
+  asked again rather than having its failure remembered. `max_size`
+  bounds each of the two caches separately, with LRU eviction; the
+  default is unbounded. `FallbackFetcher` moves on to the next backend
+  only for a `FetchError` -- `HttpError` and `RpcError` both subclass it
+  -- and lets a `BTClibValueError` propagate, a node serving the wrong
+  chain being a configuration error to fix rather than a failure to try
+  the next backend past. When every backend fails it raises a
+  `FetchError` naming each of them, chained from the last. It also
+  refuses, at construction, a sequence whose backends disagree about the
+  network, and an empty one. `CachingFetcher` has no such check and needs
+  none: wrapping a single fetcher, it has nothing to compare against.
+
 ## v2026.8.29
 
 ### Repository

--- a/docs/source/btclib.fetch.rst
+++ b/docs/source/btclib.fetch.rst
@@ -19,6 +19,13 @@ btclib.fetch.bitcoin_core integration module
    :show-inheritance:
    :exclude-members: BitcoinCoreRpcClient
 
+btclib.fetch.decorators module
+------------------------------
+
+.. automodule:: btclib.fetch.decorators
+   :members:
+   :show-inheritance:
+
 btclib.fetch.esplora module
 ---------------------------
 

--- a/src/btclib/fetch/__init__.py
+++ b/src/btclib/fetch/__init__.py
@@ -61,11 +61,19 @@ which layer it is reaching into.
 `FetchError`, `HttpError` and `RpcError` are not here because no exception
 is: `btclib.exceptions` holds every one of them together, which is what
 lets a caller see at a glance what the library raises.
+
+**`CachingFetcher` and `FallbackFetcher` answer the same interface from
+another `Fetcher`, not from a network.** Neither is a third backend:
+both compose one or more `Fetcher`s and are exported beside the two that
+open a connection because a caller reaches for them the same way,
+`btclib.fetch.decorators` naming the module they actually live in the
+way `btclib.fetch.fetcher` does for the interface itself.
 """
 
 from bitcoin_core_rpc import BitcoinCoreRpcClient
 
 from btclib.fetch.bitcoin_core import BitcoinCoreFetcher
+from btclib.fetch.decorators import CachingFetcher, FallbackFetcher
 from btclib.fetch.esplora import BLOCKSTREAM_INFO, EsploraFetcher
 from btclib.fetch.fetcher import Fetcher
 from btclib.fetch.transport import (
@@ -80,7 +88,9 @@ __all__ = [
     "DEFAULT_TIMEOUT",
     "BitcoinCoreFetcher",
     "BitcoinCoreRpcClient",
+    "CachingFetcher",
     "EsploraFetcher",
+    "FallbackFetcher",
     "Fetcher",
     "HttpTransport",
     "SessionTransport",

--- a/src/btclib/fetch/decorators.py
+++ b/src/btclib/fetch/decorators.py
@@ -1,0 +1,262 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Two `Fetcher`s that answer from another `Fetcher`, not from a network.
+
+`CachingFetcher` composes one backend and remembers what it answered;
+`FallbackFetcher` composes several and tries them in order. Both are
+`Fetcher` subclasses in their own right -- calling code takes a `Fetcher`
+and does not learn that either is standing in front of something else.
+
+**Nesting order is not free to choose either way.**
+`CachingFetcher(FallbackFetcher([a, b]))` is the recommended shape: one
+cache shared across the failover, so a backend going down and the next
+one taking over does not re-fetch what is already held.
+`FallbackFetcher([CachingFetcher(a), CachingFetcher(b)])` builds two
+caches that each learn the same transactions separately -- twice the
+memory for the overlap, and a fetch that fails over to `b` still pays
+for what `a`'s cache already knew.
+"""
+
+from __future__ import annotations
+
+# imported at runtime and not under TYPE_CHECKING, which the annotations
+# below would not need and the documentation build does:
+# `sphinx.ext.autodoc`'s resolution of the deferred annotation falls back
+# to the annotation's own text when a name it uses is missing from the
+# module, and that text is a cross-reference with two targets for a name
+# btclib re-exports at its package root -- `Tx` and `BlockHeader` both
+# are -- which is one warning per occurrence for `-W` to fail the build
+# on. `core_import.py`'s own comment documents the same failure for
+# `Descriptor`
+from collections import OrderedDict
+from collections.abc import Callable, Sequence
+from typing import TypeVar
+
+from typing_extensions import override
+
+from btclib.alias import Octets
+from btclib.block.block_header import BlockHeader
+from btclib.exceptions import BTClibValueError, FetchError
+from btclib.fetch.fetcher import Fetcher, tx_id_hex
+from btclib.tx import Tx
+
+__all__ = ["CachingFetcher", "FallbackFetcher"]
+
+_T = TypeVar("_T")
+_K = TypeVar("_K")
+_V = TypeVar("_V")
+
+
+class CachingFetcher(Fetcher):
+    """A `Fetcher` that remembers `get_tx` and `get_block_header` answers.
+
+    Composes a `Fetcher` rather than subclassing one: the wrapped fetcher
+    is an attribute, `fetcher`, and any backend satisfies the interface
+    without knowing it is being cached. `get_tx_out` is **not**
+    overridden here, and that is what makes the caching pay off rather
+    than being one more place to keep in step -- `Fetcher.get_tx_out` is
+    concrete and calls `self.get_tx`, so caching `get_tx` amortizes it
+    for free: twenty outpoints spending one transaction cost one fetch of
+    it. The consequence is that a wrapped backend which overrides
+    `get_tx_out` with an answer of its own has that override bypassed --
+    this class's `get_tx_out` is the ABC's, inherited, and never reaches
+    the wrapped fetcher's. Neither `BitcoinCoreFetcher` nor
+    `EsploraFetcher` overrides it, so this only matters for a third-party
+    backend.
+
+    **What is cached, and for how long, differs per method:**
+
+    - `get_tx` is cached with no expiry. The id is a hash of the bytes,
+      so the answer cannot change without the question changing.
+    - `get_block_header` is cached with no expiry too, and that has a
+      consequence worth stating rather than leaving implicit: a height is
+      not an identity, and a reorg can replace the block at one. This
+      class holds no chain tip and has no way to notice. Caching it
+      anyway is still the right default -- the caller that repeatedly
+      asks for headers by height is building a chain of them, verified
+      by each header's `previous_block_hash` link to the one before it,
+      so a stale entry fails that check loudly rather than being trusted
+      silently.
+    - `get_block_count` and `get_best_block_id` are **never** cached --
+      both are the chain tip, and it moves. Every call reaches the
+      wrapped fetcher.
+
+    No expiry was rejected as the general policy for the same two: a
+    lifetime is a second parameter with a clock behind it, untestable
+    without freezing time and wrong for somebody at whatever value it
+    defaulted to. Nothing here hammers the tip -- `get_tx_out` never
+    touches it -- so a caller who wants it held briefly holds it in a
+    local variable, which costs one line and needs no policy here.
+
+    **A raised `FetchError` is never cached.** `get_tx` and
+    `get_block_header` write their cache only after the wrapped fetcher
+    answers successfully, so a transaction that does not exist yet, or a
+    backend that is briefly down, is asked again next time rather than
+    having its failure remembered forever -- negative caching is a policy
+    nobody asked for.
+
+    `max_size` bounds each of the two caches separately rather than
+    pooling them under one shared count: they hold answers of different
+    shape and different traffic -- a header is a fixed eighty bytes, a
+    transaction is not -- and a caller who floods one by asking for many
+    headers should not evict transactions it never touched. `None`, the
+    default, leaves both unbounded, which is a real leak in a
+    long-running process; a caller that holds a fetcher for a long time
+    is the one to set it. Eviction is least-recently-used, a hit moving
+    an entry to the end of its `OrderedDict` and an overflow popping from
+    the front.
+    """
+
+    fetcher: Fetcher
+    max_size: int | None
+
+    def __init__(self, fetcher: Fetcher, max_size: int | None = None) -> None:
+        super().__init__(fetcher.network)
+        self.fetcher = fetcher
+        self.max_size = max_size
+        self._tx_cache: OrderedDict[str, Tx] = OrderedDict()
+        self._header_cache: OrderedDict[int, BlockHeader] = OrderedDict()
+
+    def _remember(self, cache: OrderedDict[_K, _V], key: _K, value: _V) -> None:
+        """Store an answer and evict the oldest entry past `max_size`."""
+        cache[key] = value
+        if self.max_size is not None and len(cache) > self.max_size:
+            cache.popitem(last=False)
+
+    @override
+    def get_tx(self, tx_id: Octets) -> Tx:
+        """Return the cached transaction, or fetch and cache it.
+
+        Keyed on `tx_id_hex(tx_id)` and not on `tx_id` itself: `Octets`
+        is bytes, a bytearray, a memoryview or a hex string, so the same
+        transaction asked for two different ways would otherwise be
+        cached under two different keys and fetched twice -- the very
+        amortization this class exists for, lost to the argument's
+        spelling rather than its value. `tx_id_hex` is the normalizer
+        `Fetcher` already validates ids with, so this reuses it rather
+        than writing a second one.
+        """
+        key = tx_id_hex(tx_id)
+        if key in self._tx_cache:
+            self._tx_cache.move_to_end(key)
+            return self._tx_cache[key]
+        tx = self.fetcher.get_tx(tx_id)
+        self._remember(self._tx_cache, key, tx)
+        return tx
+
+    @override
+    def get_block_header(self, height: int) -> BlockHeader:
+        """Return the cached header, or fetch and cache it."""
+        if height in self._header_cache:
+            self._header_cache.move_to_end(height)
+            return self._header_cache[height]
+        header = self.fetcher.get_block_header(height)
+        self._remember(self._header_cache, height, header)
+        return header
+
+    @override
+    def get_block_count(self) -> int:
+        """Pass the call through, uncached: this is the chain tip."""
+        return self.fetcher.get_block_count()
+
+    @override
+    def get_best_block_id(self) -> bytes:
+        """Pass the call through, uncached: this is the chain tip."""
+        return self.fetcher.get_best_block_id()
+
+    def clear(self) -> None:
+        """Forget every cached transaction and header."""
+        self._tx_cache.clear()
+        self._header_cache.clear()
+
+
+class FallbackFetcher(Fetcher):
+    """A `Fetcher` that tries a sequence of backends, in order.
+
+    Composes the backends rather than subclassing one, `fetchers`
+    holding the sequence as given. The first one that does not raise
+    answers; a later one is tried only when an earlier one raises
+    `FetchError` -- which `HttpError` and `RpcError` both subclass, so a
+    dead socket, an HTTP 500 and "no such transaction" all fall through
+    the same way. `BTClibValueError`, which `Fetcher.__init__` raises for
+    an unknown network and which `client_errors` raises for a node
+    serving the wrong chain, propagates instead: a misconfigured backend
+    is a caller error to fix, not a failure to paper over by asking the
+    next one.
+
+    When every backend raises, this raises a `FetchError` naming each of
+    them and its failure, chained (`raise ... from`) off the last one --
+    not the last one's message alone, which would report a second-string
+    backend's 404 for what began as the primary's dead socket.
+
+    **This never compares two answers.** It stops at the first backend
+    that does not raise, so on the disagreement two backends could have
+    about the tip, nothing is thrown away: there is only ever one answer
+    in hand. An object that asked every backend and compared their
+    answers would be a quorum fetcher, a different policy with a
+    different cost -- worth its own issue if anyone wants it, and not
+    this class.
+
+    Refuses an empty sequence at construction: a `FallbackFetcher` with
+    nothing to fall back to answers no question at all. Refuses a
+    `network` mismatch too, comparing every backend's `network` rather
+    than trusting the first: a mainnet node and a testnet explorer behind
+    one `FallbackFetcher` is a configuration error that would otherwise
+    surface as a transaction whose outputs are labelled for the wrong
+    chain, wherever the failover happened to land.
+    """
+
+    fetchers: tuple[Fetcher, ...]
+
+    def __init__(self, fetchers: Sequence[Fetcher]) -> None:
+        if len(fetchers) == 0:
+            raise BTClibValueError("no backends given")
+        networks = {fetcher.network for fetcher in fetchers}
+        if len(networks) > 1:
+            err_msg = f"mismatched networks: {sorted(networks)}"
+            raise BTClibValueError(err_msg)
+        super().__init__(fetchers[0].network)
+        self.fetchers = tuple(fetchers)
+
+    def _first_answer(self, description: str, call: Callable[[Fetcher], _T]) -> _T:
+        """Try each backend in order, falling through `FetchError` alone."""
+        failures: list[str] = []
+        exceptions: list[FetchError] = []
+        for fetcher in self.fetchers:
+            try:
+                return call(fetcher)
+            except FetchError as e:
+                failures.append(f"{type(fetcher).__name__}: {e}")
+                exceptions.append(e)
+        err_msg = f"{description}: every backend failed -- " + "; ".join(failures)
+        # `self.fetchers` is non-empty by construction, so the loop above
+        # ran at least once and `exceptions` holds the last backend's error
+        raise FetchError(err_msg) from exceptions[-1]
+
+    @override
+    def get_tx(self, tx_id: Octets) -> Tx:
+        """Answer from the first backend that does not raise `FetchError`."""
+        return self._first_answer("get_tx", lambda fetcher: fetcher.get_tx(tx_id))
+
+    @override
+    def get_block_count(self) -> int:
+        """Answer from the first backend that does not raise `FetchError`."""
+        return self._first_answer(
+            "get_block_count", lambda fetcher: fetcher.get_block_count()
+        )
+
+    @override
+    def get_best_block_id(self) -> bytes:
+        """Answer from the first backend that does not raise `FetchError`."""
+        return self._first_answer(
+            "get_best_block_id", lambda fetcher: fetcher.get_best_block_id()
+        )
+
+    @override
+    def get_block_header(self, height: int) -> BlockHeader:
+        """Answer from the first backend that does not raise `FetchError`."""
+        return self._first_answer(
+            "get_block_header", lambda fetcher: fetcher.get_block_header(height)
+        )

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -204,7 +204,13 @@ CHILD_MODULES = {
     },
     "btclib.fetch": {
         "groups": [],
-        "unpublished": ["bitcoin_core", "esplora", "fetcher", "transport"],
+        "unpublished": [
+            "bitcoin_core",
+            "decorators",
+            "esplora",
+            "fetcher",
+            "transport",
+        ],
     },
     "btclib.mnemonic": {
         "groups": [

--- a/tests/fetch/decorators_test.py
+++ b/tests/fetch/decorators_test.py
@@ -1,0 +1,294 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for btclib.fetch.decorators: CachingFetcher and FallbackFetcher.
+
+`CountingFetcher` below, and not the `Recorded` transport seam
+`tests/fetch/bitcoin_core_test.py` and `tests/fetch/esplora_test.py`
+build their fetchers over: what these tests check is how many times a
+decorator reaches the `Fetcher` it wraps, never how a backend turns a
+wire response into one, so a fetcher with no wire underneath it at all
+is the simpler tool -- the transport seam would add a layer of
+serialization these tests have no use for.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typing_extensions import override
+
+from btclib.alias import Octets
+from btclib.block.block_header import BlockHeader
+from btclib.exceptions import BTClibValueError, FetchError
+from btclib.fetch.decorators import CachingFetcher, FallbackFetcher
+from btclib.fetch.fetcher import Fetcher
+from btclib.tx import OutPoint, Tx
+from tests.fetch import TIP_HEADER_RAW, TIP_HEIGHT, TIP_ID, TX_ID, recorded_body
+
+RAW = recorded_body("esplora_tx_hex.txt").decode().strip()
+
+
+class CountingFetcher(Fetcher):
+    """A Fetcher answering one fixed transaction and header, call-counted.
+
+    `fail_with`, settable at any time, is raised exactly once and then
+    cleared -- which is what lets a test script a single failure between
+    two otherwise identical calls without a second class.
+    """
+
+    def __init__(
+        self,
+        tx: Tx | None = None,
+        header: BlockHeader | None = None,
+        network: str = "mainnet",
+    ) -> None:
+        super().__init__(network)
+        self.tx = tx
+        self.header = header
+        self.fail_with: Exception | None = None
+        self.calls = {
+            "get_tx": 0,
+            "get_block_count": 0,
+            "get_best_block_id": 0,
+            "get_block_header": 0,
+        }
+
+    def _maybe_fail(self) -> None:
+        if self.fail_with is not None:
+            error, self.fail_with = self.fail_with, None
+            raise error
+
+    @override
+    def get_tx(self, tx_id: Octets) -> Tx:
+        self.calls["get_tx"] += 1
+        self._maybe_fail()
+        assert self.tx is not None
+        return self.tx
+
+    @override
+    def get_block_count(self) -> int:
+        self.calls["get_block_count"] += 1
+        self._maybe_fail()
+        return TIP_HEIGHT
+
+    @override
+    def get_best_block_id(self) -> bytes:
+        self.calls["get_best_block_id"] += 1
+        self._maybe_fail()
+        return bytes.fromhex(TIP_ID)
+
+    @override
+    def get_block_header(self, height: int) -> BlockHeader:
+        self.calls["get_block_header"] += 1
+        self._maybe_fail()
+        assert self.header is not None
+        return self.header
+
+
+# --- CachingFetcher -----------------------------------------------------
+
+
+def test_get_tx_out_amortizes_across_many_outpoints() -> None:
+    """The issue this module answers: twenty calls, one backend fetch."""
+    tx = Tx.parse(RAW)
+    backend = CountingFetcher(tx=tx)
+    caching = CachingFetcher(backend)
+    for i in range(20):
+        out = caching.get_tx_out(OutPoint(TX_ID, i % 2))
+        assert out == tx.vout[i % 2]
+    assert backend.calls["get_tx"] == 1
+
+
+def test_get_tx_key_normalizes_octets_spellings() -> None:
+    """Every spelling of one id shares one cache entry.
+
+    Keying on the raw argument would cache the same transaction under
+    several keys -- this is the amortization the issue is about, lost to
+    the argument's spelling rather than its value.
+    """
+    backend = CountingFetcher(tx=Tx.parse(RAW))
+    caching = CachingFetcher(backend)
+    caching.get_tx(TX_ID)
+    caching.get_tx(bytes.fromhex(TX_ID))
+    caching.get_tx(bytearray.fromhex(TX_ID))
+    caching.get_tx(memoryview(bytes.fromhex(TX_ID)))
+    caching.get_tx(f"  {TX_ID}  ")
+    assert backend.calls["get_tx"] == 1
+
+
+def test_the_tip_passes_through_uncached() -> None:
+    """Two calls to either tip method are two calls to the backend."""
+    backend = CountingFetcher(tx=Tx.parse(RAW))
+    caching = CachingFetcher(backend)
+    assert caching.get_block_count() == TIP_HEIGHT
+    assert caching.get_block_count() == TIP_HEIGHT
+    assert caching.get_best_block_id().hex() == TIP_ID
+    assert caching.get_best_block_id().hex() == TIP_ID
+    assert backend.calls["get_block_count"] == 2
+    assert backend.calls["get_best_block_id"] == 2
+
+
+def test_get_block_header_is_cached() -> None:
+    """A second call for the same height answers from the cache."""
+    header = BlockHeader.parse(TIP_HEADER_RAW)
+    backend = CountingFetcher(tx=Tx.parse(RAW), header=header)
+    caching = CachingFetcher(backend)
+    assert caching.get_block_header(TIP_HEIGHT).hash.hex() == TIP_ID
+    assert caching.get_block_header(TIP_HEIGHT).hash.hex() == TIP_ID
+    assert backend.calls["get_block_header"] == 1
+
+
+def test_a_raising_call_does_not_poison_the_cache() -> None:
+    """A FetchError is never cached: the next call reaches the backend."""
+    backend = CountingFetcher(tx=Tx.parse(RAW))
+    caching = CachingFetcher(backend)
+    backend.fail_with = FetchError("the node is down")
+    with pytest.raises(FetchError, match="the node is down"):
+        caching.get_tx(TX_ID)
+    assert backend.calls["get_tx"] == 1
+
+    # the failed call left nothing behind, so this one reaches the backend
+    tx = caching.get_tx(TX_ID)
+    assert tx.id.hex() == TX_ID
+    assert backend.calls["get_tx"] == 2
+
+    # and this one is now served from the cache the successful call filled
+    caching.get_tx(TX_ID)
+    assert backend.calls["get_tx"] == 2
+
+
+def test_lru_eviction_at_max_size() -> None:
+    """The least recently used entry is the one an overflow evicts.
+
+    Three ids over a cache of two: `id_a` is read again before `id_c` is
+    inserted, so the eviction that makes room for `id_c` falls on `id_b`
+    instead -- the one thing a plain "oldest inserted first" eviction
+    would get wrong.
+    """
+    id_a, id_b, id_c = "a1" * 32, "b2" * 32, "c3" * 32
+    backend = CountingFetcher(tx=Tx.parse(RAW))
+    caching = CachingFetcher(backend, max_size=2)
+
+    caching.get_tx(id_a)
+    caching.get_tx(id_b)
+    assert backend.calls["get_tx"] == 2  # cache: id_a, id_b
+
+    caching.get_tx(id_a)  # a hit, and moves id_a to the most-recent end
+    assert backend.calls["get_tx"] == 2
+
+    caching.get_tx(id_c)  # a miss: evicts id_b, the least recently used
+    assert backend.calls["get_tx"] == 3  # cache: id_a, id_c
+
+    caching.get_tx(id_a)  # still cached, thanks to the read above
+    assert backend.calls["get_tx"] == 3
+
+    caching.get_tx(id_b)  # id_b was evicted: a miss
+    assert backend.calls["get_tx"] == 4
+
+
+def test_clear_forgets_every_cached_answer() -> None:
+    """Both caches are emptied, and the next call reaches the backend."""
+    header = BlockHeader.parse(TIP_HEADER_RAW)
+    backend = CountingFetcher(tx=Tx.parse(RAW), header=header)
+    caching = CachingFetcher(backend)
+    caching.get_tx(TX_ID)
+    caching.get_block_header(TIP_HEIGHT)
+
+    caching.clear()
+
+    caching.get_tx(TX_ID)
+    caching.get_block_header(TIP_HEIGHT)
+    assert backend.calls["get_tx"] == 2
+    assert backend.calls["get_block_header"] == 2
+
+
+# --- FallbackFetcher -----------------------------------------------------
+
+
+def test_fallback_answers_all_four_from_the_first_backend() -> None:
+    """A working primary answers every question; the secondary is unused."""
+    tx = Tx.parse(RAW)
+    header = BlockHeader.parse(TIP_HEADER_RAW)
+    primary = CountingFetcher(tx=tx, header=header)
+    secondary = CountingFetcher(tx=tx, header=header)
+    fallback = FallbackFetcher([primary, secondary])
+
+    assert fallback.get_tx(TX_ID).id.hex() == TX_ID
+    assert fallback.get_block_count() == TIP_HEIGHT
+    assert fallback.get_best_block_id().hex() == TIP_ID
+    assert fallback.get_block_header(TIP_HEIGHT).hash.hex() == TIP_ID
+    assert secondary.calls == {
+        "get_tx": 0,
+        "get_block_count": 0,
+        "get_best_block_id": 0,
+        "get_block_header": 0,
+    }
+
+
+def test_fallback_moves_on_past_a_fetch_error() -> None:
+    """A dead primary is skipped in favour of the one that answers."""
+    tx = Tx.parse(RAW)
+    primary = CountingFetcher(tx=tx)
+    secondary = CountingFetcher(tx=tx)
+    primary.fail_with = FetchError("connection refused")
+    fallback = FallbackFetcher([primary, secondary])
+
+    result = fallback.get_tx(TX_ID)
+
+    assert result.id.hex() == TX_ID
+    assert primary.calls["get_tx"] == 1
+    assert secondary.calls["get_tx"] == 1
+
+
+def test_fallback_does_not_move_on_past_a_value_error() -> None:
+    """A misconfigured backend is a caller error, not papered over."""
+    tx = Tx.parse(RAW)
+    primary = CountingFetcher(tx=tx)
+    secondary = CountingFetcher(tx=tx)
+    primary.fail_with = BTClibValueError("node serves another chain")
+    fallback = FallbackFetcher([primary, secondary])
+
+    with pytest.raises(BTClibValueError, match="node serves another chain"):
+        fallback.get_tx(TX_ID)
+    assert secondary.calls["get_tx"] == 0
+
+
+def test_fallback_names_every_backend_when_all_fail() -> None:
+    """The message and the chain both name every backend that was tried."""
+    tx = Tx.parse(RAW)
+    first, second, third = (
+        CountingFetcher(tx=tx),
+        CountingFetcher(tx=tx),
+        CountingFetcher(tx=tx),
+    )
+    errors = (
+        FetchError("first is down"),
+        FetchError("second is down"),
+        FetchError("third is down"),
+    )
+    first.fail_with, second.fail_with, third.fail_with = errors
+    fallback = FallbackFetcher([first, second, third])
+
+    with pytest.raises(FetchError) as exc_info:
+        fallback.get_tx(TX_ID)
+
+    message = str(exc_info.value)
+    assert "first is down" in message
+    assert "second is down" in message
+    assert "third is down" in message
+    assert exc_info.value.__cause__ is errors[-1]
+
+
+def test_fallback_refuses_a_network_mismatch() -> None:
+    """A mainnet backend and a testnet one are refused before any call."""
+    mainnet = CountingFetcher(tx=Tx.parse(RAW), network="mainnet")
+    testnet = CountingFetcher(tx=Tx.parse(RAW), network="testnet")
+    with pytest.raises(BTClibValueError, match="mismatched networks"):
+        FallbackFetcher([mainnet, testnet])
+
+
+def test_fallback_refuses_an_empty_sequence() -> None:
+    """A FallbackFetcher with nothing to fall back to answers nothing."""
+    with pytest.raises(BTClibValueError, match="no backends given"):
+        FallbackFetcher([])

--- a/tests/name_contract_test.py
+++ b/tests/name_contract_test.py
@@ -229,9 +229,9 @@ def _argument_less_bools() -> dict[str, bool]:
 #   can fail; the prefix is the warning and a property would hide it
 # - `to_*` converts, and hands back a new object rather than a read of
 #   this one
-# - `close` is an action with a side effect
+# - `close`, `wipe` and `clear` are each an action with a side effect
 _NOT_A_READ = ("assert_", "get_", "to_")
-_AN_ACTION = frozenset({"close", "wipe"})
+_AN_ACTION = frozenset({"clear", "close", "wipe"})
 
 # hashlib's own API, mirrored in a Protocol, and hashlib draws the line
 # itself: `digest()`, `hexdigest()` and `copy()` are calls where


### PR DESCRIPTION
Closes #1129

Nothing amortized `get_tx_out`. Computing one transaction's fee calls it
once per input, each call fetching the whole previous transaction to
read one output of it — so twenty inputs spending twenty outputs of one
transaction fetched that transaction twenty times. Against a local node
that is wasted work; against a public Esplora deployment it is the
caller's rate-limit budget, which `EsploraFetcher.text`'s own docstring
says is the caller's to spend.

Two decorators in `btclib/fetch/decorators.py`, decided together because
a cache in front of a fallback and a fallback in front of a cache are
not the same object.

## `CachingFetcher`

| method | policy |
| --- | --- |
| `get_tx` | cached, no expiry — the id is a hash of the bytes, so the answer cannot change without the question changing |
| `get_block_header` | cached, no expiry, with a stated cost |
| `get_block_count` | **passes straight through** |
| `get_best_block_id` | **passes straight through** |

**`get_tx_out` is deliberately not overridden, and that is the fix rather
than an omission.** It is concrete on the ABC and its body calls
`self.get_tx`, so caching `get_tx` amortizes it for free — the twenty
calls above become one fetch. The consequence is stated in the
docstring: a backend that overrides `get_tx_out` with a cheaper answer
of its own has that override bypassed. Neither backend here does.

**The tip is not cached at all, and there is no lifetime.** The issue
offered one; it is a second policy with a clock in it, untestable
without freezing time and wrong for somebody at every value it could
default to. No caller here hammers the tip — `get_tx_out` never touches
it — and a caller who wants it held holds it in a local. Answering the
tip from a cache is a correctness choice, and it should be the caller's
rather than one they inherit.

**`get_block_header` is cached forever and a height is not an identity.**
A reorg replaces the block at a height and the decorator cannot notice,
holding no tip. Caching it anyway is right: the caller that asks
repeatedly is [ISS 1127](https://github.com/btclib-org/btclib/issues/1127)'s
chain of headers, and a chain is verified by its `previous_block_hash`
links, so a stale entry fails loudly rather than quietly. The docstring
says so, and `clear()` is the answer.

Keyed on `tx_id_hex(tx_id)` rather than the argument: `Octets` is bytes,
a bytearray, a memoryview or a hex string, so the same transaction asked
for two ways would otherwise be cached twice — the amortization lost to
the argument's spelling rather than its value. A raised `FetchError` is
never stored.

## `FallbackFetcher`

Tries each backend in order and **moves on `FetchError` and nothing
else**, which the exception hierarchy already gets right: `HttpError`
and `RpcError` subclass it, so a dead host, a 500 and "no such
transaction" all fall through — the last genuinely answerable by a node
with `-txindex` when the first has none. The `BTClibValueError` that
`assert_chain` raises for a node serving another chain is not a
`FetchError` and propagates: a misconfigured backend is not something to
paper over by trying the next one.

When all of them fail it raises a `FetchError` naming every backend and
its failure, chained from the last — not the last one's message alone,
which would report the second-string backend's 404 for what began as the
primary's dead socket. It also refuses, at construction, a sequence
whose backends disagree about the network, and an empty one.
`CachingFetcher` has no such check and needs none: wrapping a single
fetcher, it has nothing to compare against.

**On the disagreement the issue raises:** a fallback never sees two
answers — it stops at the first that does not raise, so nothing is
thrown away. The object that could compare answers asks all of them,
which is a quorum fetcher and a different policy with a different cost.

**Nesting**, which is why the two were decided together:
`CachingFetcher(FallbackFetcher([a, b]))` is one cache shared across a
failover, so falling over does not re-fetch what is already held. The
other order is two caches learning the same transactions separately. The
module docstring carries this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Add composable caching and ordered fallback fetchers to improve fetch efficiency and resilience.

New Features:
- Add `CachingFetcher` and `FallbackFetcher` decorators to compose, cache, and fail over between `Fetcher` implementations.

Bug Fixes:
- Amortize repeated transaction retrievals performed through `get_tx_out` by caching transactions.

Enhancements:
- Cache transactions and block headers with configurable LRU limits while passing chain-tip queries through uncached.
- Fall back only on `FetchError`, aggregate backend failures, and reject empty or mixed-network backend sets.

Documentation:
- Document and export the new fetcher decorators and their composition policies.

Tests:
- Add coverage for caching behavior, LRU eviction, cache clearing, fallback handling, and configuration validation.