### PR TITLE
btclib.coin_selection chooses which candidates fund a payment, above tx_builder.build_psbt (closes #1586)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1631,6 +1631,26 @@ dereferences it, and `refs/tags/v1^{}` does the same from a checkout.
   the two state the same fact -- the network, and the amount where both
   give one -- the same pairing Electrum's `bip21.py` makes.
 
+### `btclib.coin_selection` chooses which candidates fund a payment, above `tx_builder.build_psbt`
+
+- **A new top-level module adds branch-and-bound, knapsack and
+  single-random-draw coin selection, stateless and above
+  `tx_builder.build_psbt`** (closes #1586): `Candidate` names an
+  outpoint, the `TxOut` it spends, and the weight its input will add;
+  `select_coins` runs whichever of the three algorithms it is asked to
+  -- every one of them by default -- and keeps the selection of lowest
+  waste, Bitcoin Core's own `SelectionResult::GetWaste` metric
+  (`bitcoin/bitcoin@4ec6ff022a`, `src/wallet/coinselection.cpp`).
+  `branch_and_bound`, `knapsack` and `single_random_draw` are public on
+  their own, for a caller who wants one algorithm rather than the
+  composition. Selection is on effective value -- an output's value less
+  its own input's fee at the chosen rate -- so a candidate costing more
+  to spend than it holds is excluded rather than needing a filter a
+  caller writes by hand. `knapsack` and `single_random_draw` take a
+  `random.Random` rather than reading the module-level `random`
+  functions, so a test -- or a caller after a reproducible selection --
+  seeds it.
+
 ## v2026.8.29
 
 ### Repository

--- a/docs/source/btclib.rst
+++ b/docs/source/btclib.rst
@@ -100,6 +100,13 @@ btclib.bolt11 module
    :members:
    :show-inheritance:
 
+btclib.coin_selection module
+----------------------------
+
+.. automodule:: btclib.coin_selection
+   :members:
+   :show-inheritance:
+
 btclib.consensus module
 -----------------------
 

--- a/src/btclib/__init__.py
+++ b/src/btclib/__init__.py
@@ -92,6 +92,7 @@ __all__ = [
     "bip322",
     "block",
     "bolt11",
+    "coin_selection",
     "consensus",
     "core_import",
     "curves",

--- a/src/btclib/coin_selection.py
+++ b/src/btclib/coin_selection.py
@@ -1,0 +1,926 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Choose which candidates fund a payment, before `tx_builder.build_psbt` runs.
+
+`build_psbt` spends every input it is handed, all of them --
+`tx_builder`'s module docstring draws that boundary in as many words.
+Something upstream of it has to decide *which* utxos those are, and
+nothing in the tree did: a caller with a set of unspent outputs and a
+target picked by hand, and a hand pick gets two things wrong that this
+module exists to compute instead -- change worth less than
+`fee.dust_threshold` that should have gone to the fee, and an input
+whose own weight costs more than it is worth at the chosen rate.
+
+**Stateless and caller-driven**, the same boundary `fee` and
+`tx_builder` draw for the same reason: no wallet, no utxo database, no
+node. A `Candidate` is an outpoint, the `TxOut` it names, and the
+weight its input will add -- `tx.input_weight`'s answer, supplied by the
+caller rather than guessed here, since guessing a script's future
+satisfaction is exactly what `psbt.psbt_size.SolutionSizer` exists to
+refuse doing blindly. `select_coins` and each of the three algorithms
+behind it take those candidates, the outputs being paid, a fee rate, and
+answer with the ones to spend and what change, if any, is worth
+creating -- `build_psbt` turns that answer into the funded psbt, and is
+the authority on the transaction's own final fee: this module's `change`
+is what the selection expects, priced on its own simpler arithmetic, not
+a second computation of what `build_psbt` will price exactly once the
+psbt exists. A candidate's own fee is what its own weight costs, at
+`fee_rate`; `target` is that plus what the rest of the transaction costs
+-- `tx_builder._target_overhead_vsize`, the version, the lock time, the
+output count and the outputs themselves, `build_psbt`'s own estimate
+read off a psbt of no inputs rather than a second copy of its
+arithmetic, so the two cannot drift apart. Padded by one virtual byte
+for the segwit marker, present once any selected input carries a
+witness and absent otherwise -- a fact this function, asked before a
+single input is chosen, cannot know -- the pad rounding the estimate up
+so that a witness-only selection is never short, at the cost of a
+witness-free one being asked for one virtual byte it will not spend.
+Padded again for the input count's own var_int, bounded by the size of
+the candidate pool rather than by the selection chosen from it -- also
+not yet decided when this is asked, but never larger than the pool it
+is chosen from -- so a pool of 253 candidates or more, where a var_int
+grows past one byte, is never short either; below that the pad is zero
+and this changes nothing.
+
+**Effective value** -- an output's value less the fee its own input
+costs at the chosen rate -- is the quantity every algorithm here selects
+on, `Candidate.effective_value`. It is what makes a candidate costing
+more to spend than it holds fall out of a selection on its own, rather
+than needing a filter a caller has to remember to write.
+
+**The algorithms are Bitcoin Core's**, because they are the ones with
+published behaviour to check a port against: `branch_and_bound` searches
+for a changeless match within a window above the target, sized by the
+cost of creating and later spending change; `knapsack` is Core's
+original stochastic subset-sum solver; `single_random_draw` shuffles the
+candidates and takes them in that order until the target, plus a lower
+bound on the change worth creating, is covered. `select_coins` runs
+whichever of the three the caller names -- every one of them, by default
+-- and keeps the result of lowest waste, Core's own
+`SelectionResult::GetWaste` metric: the difference between what each
+selected input costs now and what it would cost at the long-term rate,
+plus the cost of the change it creates or, where none is worth creating,
+the excess dropped to the fee. `bitcoin/bitcoin@4ec6ff022a`'s
+`src/wallet/coinselection.cpp` is where all four are read from.
+
+**What Core's own implementation carries that this one does not, and
+why**: an `OutputGroup` batching several utxos of one address, ancestor
+and cluster tracking for mempool policy, a maximum selection weight, and
+`CoinGrinder`, the fourth algorithm Core added for the weight-minimising
+case a `-maxtxweight` policy asks for. Every one of them is wallet
+state or mempool policy this module has no access to and the parent
+issue draws the same line in front of: privacy-aware grouping is
+Electrum's `coinchooser`, named in the issue this module answers as the
+pluggable policy a caller brings on top rather than the default here.
+
+`_branch_and_bound` also drops three of Core's own pruning and ordering
+refinements. None of them changes which selection the search returns --
+the search space is still fully explored inside `_BNB_TOTAL_TRIES`,
+only in a different order or with a different early exit along the way:
+Core's `descending` comparator
+breaks a tie on equal effective value by the lower-waste candidate
+(`coinselection.cpp:27-36`), where this module's own sort leaves such a
+tie in whatever order the pool arrived in; the `is_feerate_high &&
+curr_selection_waste > best_waste` cut (`coinselection.cpp:192-198`)
+abandons a partial selection early once no number of further inputs
+could beat the best one found at a high fee rate, which this module
+does not check and instead lets the budget spend on to the same
+conclusion; and the SHIFT loop's skip-clone step
+(`coinselection.cpp:243-259`) advances past a run of candidates of
+equal effective value rather than evaluating each, which this module
+evaluates individually within the same `TOTAL_TRIES` budget.
+
+**Randomness is a parameter, not a call.** `knapsack` and
+`single_random_draw` both shuffle, and both take a `random.Random`
+instead of reading the module-level `random` functions, so that a test
+-- or a caller who wants a reproducible selection -- seeds it. Bitcoin
+Core's own reason is the opposite one: `FastRandomContext` is unseeded
+by default because a wallet's coin selection must not be predictable
+from the outside. Nothing here waives that for a production caller who
+passes no seed; `random.Random()` reads system entropy exactly as the
+module-level functions do, and is only ever a caller's *explicit*
+choice of engine, never this module's own hidden one.
+
+**RBF, CPFP and cancel-by-double-spend stay out**, as the parent issue
+lists them: each needs the ownership and change metadata of a change
+this module does not track once `select_coins` returns it.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Sequence
+from dataclasses import dataclass
+from math import ceil
+
+from btclib import var_int
+from btclib.alias import Octets
+from btclib.consensus import WITNESS_SCALE_FACTOR
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.fee import DUST_RELAY_FEE_RATE, FeeRate, dust_threshold, fee_from_vsize
+from btclib.tx import OutPoint, TxOut
+from btclib.tx_builder import _target_overhead_vsize
+from btclib.utils import assert_type, bytes_from_octets, is_integer
+
+__all__ = [
+    "CHANGE_LOWER",
+    "Candidate",
+    "SelectionResult",
+    "branch_and_bound",
+    "knapsack",
+    "select_coins",
+    "single_random_draw",
+]
+
+# Core's wallet/coinselection.h CHANGE_LOWER: the smallest change amount
+# single random draw ever aims to create, so that a selection landing
+# just past the target does not leave a change output worth a handful of
+# satoshi. Only single_random_draw reads it -- branch_and_bound and
+# knapsack are given the cost of change directly, and size their own
+# window from it -- but it is public for the same reason FeeRate's own
+# constant is: a caller comparing this module's numbers against Core's
+# wants the figure named rather than repeated.
+CHANGE_LOWER = 50_000
+
+# the total tries branch_and_bound explores before it stops looking for a
+# better solution and returns the best one found so far -- Core's own
+# TOTAL_TRIES, coinselection.cpp:113. Search space, not calendar time:
+# raised only if a real candidate set is shown to exhaust it short of a
+# solution that exists
+_BNB_TOTAL_TRIES = 100_000
+
+# ApproximateBestSubset's own iteration count, coinselection.cpp:678 --
+# how many random restarts the stochastic subset-sum solver tries before
+# giving up on an exact match and falling back to its closest one
+_KNAPSACK_ITERATIONS = 1_000
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One utxo under consideration for spending: what and how much it costs.
+
+    `outpoint` and `tx_out` are what any input needs; `weight` is what
+    only a caller can answer -- `tx.input_weight` given the scriptSig and
+    witness this input's future satisfaction will carry, the same figure
+    `psbt.psbt_size.SolutionSizer` computes for an input already claimed
+    by a psbt. Guessing it here from `tx_out.script_pub_key` alone would
+    be wrong for exactly the inputs `SolutionSizer` itself refuses to
+    guess: a script of no standard type, or a taproot script-path spend
+    naming a leaf nothing but the caller knows.
+    """
+
+    outpoint: OutPoint
+    tx_out: TxOut
+    weight: int
+
+    def __init__(
+        self,
+        outpoint: OutPoint,
+        tx_out: TxOut,
+        weight: int,
+        *,
+        check_validity: bool = True,
+    ) -> None:
+        object.__setattr__(self, "outpoint", outpoint)
+        object.__setattr__(self, "tx_out", tx_out)
+        object.__setattr__(self, "weight", weight)
+
+        if check_validity:
+            self.assert_valid()
+
+    def assert_valid(self) -> None:
+        """Refuse a wrong-typed outpoint or output, or a non-positive weight."""
+        assert_type(self.outpoint, OutPoint, "outpoint")
+        self.outpoint.assert_valid()
+        assert_type(self.tx_out, TxOut, "tx_out")
+        self.tx_out.assert_valid()
+
+        if not is_integer(self.weight):
+            raise BTClibTypeError(f"invalid weight type: {type(self.weight).__name__}")
+        if self.weight <= 0:
+            # zero is refused beside a negative one: a weightless input
+            # spends for free, which no scriptSig and no witness do, and
+            # every arithmetic below divides by it or through it
+            raise BTClibValueError(f"non-positive weight: {self.weight}")
+
+    @property
+    def vsize(self) -> int:
+        """Return this input's own virtual size, `Tx.vsize`'s own rounding."""
+        return ceil(self.weight / WITNESS_SCALE_FACTOR)
+
+    def fee(self, fee_rate: FeeRate) -> int:
+        """Return what spending this input costs at `fee_rate`."""
+        return fee_from_vsize(self.vsize, fee_rate)
+
+    def effective_value(self, fee_rate: FeeRate) -> int:
+        """Return the value less what spending this input costs, at `fee_rate`.
+
+        Non-positive for an input whose own weight costs at least what it
+        holds -- every algorithm here excludes such a candidate from its
+        search, matching Core's own precondition that an `OutputGroup`
+        entering coin selection already has a positive one.
+        """
+        return self.tx_out.value - self.fee(fee_rate)
+
+
+@dataclass(frozen=True)
+class SelectionResult:
+    """What a selection chose, the change it leaves, and its waste score.
+
+    `change` is 0 where none is worth creating -- below
+    `fee.dust_threshold` for `change_script_pub_key`, or where the caller
+    named none -- in which case the excess this selection leaves over
+    the outputs is dropped to the fee instead, exactly as `build_psbt`
+    treats a change output it finds itself unable to create.
+
+    `waste` is Core's `SelectionResult::GetWaste`: comparable across
+    algorithms and across selections of the same candidates, and it is
+    what `select_coins` orders its attempts by. It is not a fee -- a
+    negative value means the long-term rate exceeds the current one, so
+    that spending these inputs now rather than consolidating them later
+    is a saving instead of a cost.
+    """
+
+    selected: tuple[Candidate, ...]
+    change: int
+    waste: int
+    algorithm: str
+
+
+def _eligible(candidates: Sequence[Candidate], fee_rate: FeeRate) -> list[Candidate]:
+    """Return the candidates worth spending at all, at this rate.
+
+    Every algorithm below calls this before it searches: a candidate
+    whose effective value is not positive can only ever make a selection
+    worse by joining it, so none of the three ever considers one.
+    """
+    return [c for c in candidates if c.effective_value(fee_rate) > 0]
+
+
+def _change_output_vsize(change_script_pub_key: bytes) -> int:
+    """Return the size a change output of this script adds to the transaction.
+
+    An output is never in the witness, so its virtual size is its size:
+    8 bytes of value, the script's own var_int length, and the script.
+    The same arithmetic `fee.dust_threshold` computes for the output half
+    of its own threshold.
+    """
+    return (
+        8
+        + len(var_int.serialize(len(change_script_pub_key)))
+        + len(change_script_pub_key)
+    )
+
+
+def _change_cost(
+    change_script_pub_key: bytes,
+    change_spend_weight: int,
+    fee_rate: FeeRate,
+    long_term_fee_rate: FeeRate,
+) -> int:
+    """Return the cost of creating this change output now and spending it later.
+
+    Core's `CoinSelectionParams.m_cost_of_change`: the fee `fee_rate`
+    charges the output's own bytes, plus the fee `long_term_fee_rate`
+    charges spending it -- `change_spend_weight` being that future
+    input's own weight, the same figure a `Candidate` carries for a
+    present one, since this module has no more business guessing it for
+    an output that does not exist yet than `Candidate.weight` lets it
+    guess for one that already does.
+    """
+    creation_fee = fee_from_vsize(_change_output_vsize(change_script_pub_key), fee_rate)
+    spend_vsize = ceil(change_spend_weight / WITNESS_SCALE_FACTOR)
+    spend_fee = fee_from_vsize(spend_vsize, long_term_fee_rate)
+    return creation_fee + spend_fee
+
+
+def _waste(
+    selected: Sequence[Candidate],
+    target: int,
+    fee_rate: FeeRate,
+    long_term_fee_rate: FeeRate,
+    change: int,
+    change_cost: int,
+) -> int:
+    """Return Core's waste score for this selection: `RecalculateWaste`.
+
+    The cost of spending every selected input now rather than at the
+    long-term rate, plus -- where `change` is worth creating -- the cost
+    of creating and later spending it, or -- where it is not -- the
+    excess this selection leaves over `target`, which is what is dropped
+    to the fee instead.
+    """
+    fee_diff = sum(c.fee(fee_rate) - c.fee(long_term_fee_rate) for c in selected)
+    if change:
+        return fee_diff + change_cost
+    effective_total = sum(c.effective_value(fee_rate) for c in selected)
+    return fee_diff + (effective_total - target)
+
+
+def _score(
+    selected: Sequence[Candidate],
+    target: int,
+    fee_rate: FeeRate,
+    long_term_fee_rate: FeeRate,
+    change_script_pub_key: bytes | None,
+    change_spend_weight: int | None,
+    dust_fee_rate: FeeRate,
+    algorithm: str,
+) -> SelectionResult:
+    """Turn a raw selection into the `SelectionResult` a caller reads.
+
+    Where `build_psbt` decides a change output against the psbt's own
+    estimated size, this decides it against this selection's own simpler
+    one -- the two agree unless a selection lands exactly on the
+    boundary, which is `build_psbt`'s decision to make, this module's
+    `change` being what the selection expected rather than a claim about
+    the funded psbt.
+    """
+    effective_total = sum(c.effective_value(fee_rate) for c in selected)
+    change = 0
+    change_cost = 0
+    if change_script_pub_key is not None:
+        assert change_spend_weight is not None  # noqa: S101 -- _prepare's own contract
+        change_cost = _change_cost(
+            change_script_pub_key, change_spend_weight, fee_rate, long_term_fee_rate
+        )
+        creation_fee = fee_from_vsize(
+            _change_output_vsize(change_script_pub_key), fee_rate
+        )
+        candidate_change = effective_total - target - creation_fee
+        if candidate_change >= dust_threshold(change_script_pub_key, dust_fee_rate):
+            change = candidate_change
+    waste = _waste(selected, target, fee_rate, long_term_fee_rate, change, change_cost)
+    return SelectionResult(tuple(selected), change, waste, algorithm)
+
+
+def _assert_selection_arguments(
+    candidates: Sequence[Candidate],
+    outputs: Sequence[TxOut],
+    fee_rate: FeeRate,
+    long_term_fee_rate: FeeRate,
+    change_script_pub_key: Octets | None,
+    change_spend_weight: int | None,
+    dust_fee_rate: FeeRate,
+) -> None:
+    """Refuse an argument of the wrong type or shape before anything runs.
+
+    The shape every one of `select_coins` and the three algorithms
+    beside it shares, walked the way `tx_builder._assert_arguments` walks
+    its own two sequences: as a sequence first, then element by element.
+    `assert_valid` on each candidate and output, and not the type check
+    alone, is what a `check_validity=False` instance -- a `Candidate` of
+    a weight no `tx.input_weight` ever answers, a `TxOut` of no valid
+    amount -- needs: nothing downstream of this function builds another
+    object that would validate them the way `tx_builder.build_psbt`
+    defers to `Psbt`'s own.
+    """
+    assert_type(candidates, Sequence, "candidates")
+    for candidate in candidates:
+        assert_type(candidate, Candidate, "candidate")
+        candidate.assert_valid()
+    assert_type(outputs, Sequence, "outputs")
+    for tx_out in outputs:
+        assert_type(tx_out, TxOut, "output")
+        tx_out.assert_valid()
+    assert_type(fee_rate, FeeRate, "fee rate")
+    assert_type(long_term_fee_rate, FeeRate, "long-term fee rate")
+    assert_type(dust_fee_rate, FeeRate, "dust fee rate")
+    if change_script_pub_key is not None and change_spend_weight is None:
+        err_msg = "change_spend_weight is required together with change_script_pub_key"
+        raise BTClibValueError(err_msg)
+    if change_spend_weight is not None:
+        if not is_integer(change_spend_weight):
+            err_msg = f"invalid change_spend_weight type: {type(change_spend_weight).__name__}"
+            raise BTClibTypeError(err_msg)
+        if change_spend_weight <= 0:
+            raise BTClibValueError(
+                f"non-positive change_spend_weight: {change_spend_weight}"
+            )
+
+
+def _prepare(
+    candidates: Sequence[Candidate],
+    outputs: Sequence[TxOut],
+    fee_rate: FeeRate,
+    long_term_fee_rate: FeeRate,
+    change_script_pub_key: Octets | None,
+    change_spend_weight: int | None,
+    dust_fee_rate: FeeRate,
+) -> tuple[list[Candidate], int, int, bytes | None]:
+    """Validate, then return the eligible pool, the target and change budget.
+
+    Shared by `select_coins` and the three algorithms it composes, so
+    that "which candidates are worth considering" and "how large a
+    window is change worth" are answered once rather than once per
+    algorithm. `target` is `sum(outputs)` plus what the transaction's
+    own non-input bytes cost at `fee_rate` -- `tx_builder`'s own
+    `_target_overhead_vsize`, so that a selection matching this target is
+    one `build_psbt` can actually fund rather than one that is short by
+    the bytes only the whole transaction, and not one candidate, carries.
+    """
+    _assert_selection_arguments(
+        candidates,
+        outputs,
+        fee_rate,
+        long_term_fee_rate,
+        change_script_pub_key,
+        change_spend_weight,
+        dust_fee_rate,
+    )
+    change_script = (
+        None
+        if change_script_pub_key is None
+        else bytes_from_octets(change_script_pub_key)
+    )
+    overhead_vsize = _target_overhead_vsize(outputs, len(candidates))
+    overhead_fee = fee_from_vsize(overhead_vsize, fee_rate)
+    target = sum(tx_out.value for tx_out in outputs) + overhead_fee
+    eligible = _eligible(candidates, fee_rate)
+    change_cost = 0
+    if change_script is not None:
+        assert change_spend_weight is not None  # noqa: S101 -- asserted above
+        change_cost = _change_cost(
+            change_script, change_spend_weight, fee_rate, long_term_fee_rate
+        )
+    return eligible, target, change_cost, change_script
+
+
+def branch_and_bound(
+    candidates: Sequence[Candidate],
+    outputs: Sequence[TxOut],
+    fee_rate: FeeRate,
+    long_term_fee_rate: FeeRate,
+    change_script_pub_key: Octets | None = None,
+    change_spend_weight: int | None = None,
+    *,
+    dust_fee_rate: FeeRate = DUST_RELAY_FEE_RATE,
+) -> SelectionResult:
+    """Search for a changeless selection, Core's `SelectCoinsBnB`.
+
+    A depth-first search over the candidates sorted by descending
+    effective value, exploring inclusion before omission: a selection
+    landing within `[target, target + cost_of_change]` -- the window a
+    change output would otherwise have to absorb -- is a solution, and
+    the search keeps the one of lowest waste rather than stopping at the
+    first. `cost_of_change` is 0 where `change_script_pub_key` is None,
+    which asks this search for an exact match to the satoshi -- the
+    window a caller sweeping every last one of a set of candidates to a
+    single output wants.
+
+    Raised as `BTClibValueError`: no combination of `candidates` reaches
+    `target` within the window, at this rate.
+    """
+    eligible, target, cost_of_change, change_script = _prepare(
+        candidates,
+        outputs,
+        fee_rate,
+        long_term_fee_rate,
+        change_script_pub_key,
+        change_spend_weight,
+        dust_fee_rate,
+    )
+    selected = _branch_and_bound(
+        eligible, target, cost_of_change, fee_rate, long_term_fee_rate
+    )
+    if selected is None:
+        err_msg = f"branch and bound: no changeless selection reaches {target} satoshi"
+        raise BTClibValueError(err_msg)
+    return _score(
+        selected,
+        target,
+        fee_rate,
+        long_term_fee_rate,
+        change_script,
+        change_spend_weight,
+        dust_fee_rate,
+        "bnb",
+    )
+
+
+# translated close to Core's own branching shape rather than split apart:
+# splitting it risks diverging from SelectCoinsBnB's exact search order,
+# which is what a caller checking against Core's own vectors relies on
+def _branch_and_bound(  # noqa: C901, PLR0912
+    pool: Sequence[Candidate],
+    target: int,
+    cost_of_change: int,
+    fee_rate: FeeRate,
+    long_term_fee_rate: FeeRate,
+) -> list[Candidate] | None:
+    """Translate `coinselection.cpp`'s `SelectCoinsBnB`: the search itself.
+
+    Working on indices into `pool`, sorted once by descending effective
+    value, exactly as Core's own `utxo_pool` is: the sort is what makes
+    the lookahead sum below answer "how much could still be added"
+    without recomputing it at every node.
+    """
+    if not pool:
+        return None
+    ordered = sorted(pool, key=lambda c: c.effective_value(fee_rate), reverse=True)
+    eff = [c.effective_value(fee_rate) for c in ordered]
+    waste_i = [c.fee(fee_rate) - c.fee(long_term_fee_rate) for c in ordered]
+    n = len(ordered)
+
+    lookahead = [0] * n
+    total = 0
+    for i in range(n - 1, -1, -1):
+        lookahead[i] = total
+        total += eff[i]
+
+    if total < target:
+        return None
+
+    curr_selection: list[int] = []
+    best_selection: list[int] | None = None
+    curr_amount = 0
+    curr_waste = 0
+    best_waste: int | None = None
+    next_index = 0
+    curr_try = 0
+
+    def deselect_last() -> None:
+        nonlocal curr_amount, curr_waste
+        i = curr_selection.pop()
+        curr_amount -= eff[i]
+        curr_waste -= waste_i[i]
+
+    is_done = False
+    while not is_done:
+        should_cut = False
+        should_shift = False
+
+        i = next_index
+        curr_amount += eff[i]
+        curr_waste += waste_i[i]
+        curr_selection.append(i)
+        next_index += 1
+        curr_try += 1
+
+        tail_lookahead = lookahead[curr_selection[-1]]
+        if curr_amount + tail_lookahead < target:
+            should_cut = True
+        elif curr_amount > target + cost_of_change:
+            should_shift = True
+        elif curr_amount >= target:
+            should_shift = True
+            excess = curr_amount - target
+            waste = curr_waste + excess
+            if best_waste is None or waste <= best_waste:
+                best_selection = list(curr_selection)
+                best_waste = waste
+
+        if curr_try >= _BNB_TOTAL_TRIES:
+            break
+
+        if next_index == n:
+            should_cut = True
+
+        if should_cut:
+            deselect_last()
+            should_shift = True
+
+        while should_shift:
+            if not curr_selection:
+                is_done = True
+                break
+            next_index = curr_selection[-1] + 1
+            deselect_last()
+            should_shift = False
+
+    if best_selection is None:
+        return None
+    return [ordered[i] for i in best_selection]
+
+
+def knapsack(
+    candidates: Sequence[Candidate],
+    outputs: Sequence[TxOut],
+    fee_rate: FeeRate,
+    long_term_fee_rate: FeeRate,
+    change_script_pub_key: Octets | None = None,
+    change_spend_weight: int | None = None,
+    *,
+    dust_fee_rate: FeeRate = DUST_RELAY_FEE_RATE,
+    rng: random.Random | None = None,
+) -> SelectionResult:
+    """Solve subset sum by stochastic approximation, Core's `KnapsackSolver`.
+
+    Every candidate below `target + change_target` is a subset-sum
+    candidate; a search of `ApproximateBestSubset` random restarts looks
+    for the closest sum at or above `target`, falling back to the single
+    smallest candidate that alone covers `target` where the search does
+    not do better. `change_target` is `cost_of_change` -- 0 where
+    `change_script_pub_key` is None, which asks this search for the
+    smallest excess over `target` rather than for room to leave change
+    in.
+
+    `rng` seeds the shuffle and the stochastic search; unseeded, a fresh
+    `random.Random()` reads system entropy, matching Core's own
+    `FastRandomContext` default.
+
+    Raised as `BTClibValueError`: no combination of `candidates` reaches
+    `target`, at this rate.
+    """
+    eligible, target, change_target, change_script = _prepare(
+        candidates,
+        outputs,
+        fee_rate,
+        long_term_fee_rate,
+        change_script_pub_key,
+        change_spend_weight,
+        dust_fee_rate,
+    )
+    # not cryptographic on purpose, matching Core's FastRandomContext --
+    # the module docstring's own reasoning
+    engine = random.Random() if rng is None else rng  # noqa: S311
+    selected = _knapsack(eligible, target, change_target, fee_rate, engine)
+    if selected is None:
+        err_msg = f"knapsack: no selection of the candidates reaches {target} satoshi"
+        raise BTClibValueError(err_msg)
+    return _score(
+        selected,
+        target,
+        fee_rate,
+        long_term_fee_rate,
+        change_script,
+        change_spend_weight,
+        dust_fee_rate,
+        "knapsack",
+    )
+
+
+def _approximate_best_subset(
+    engine: random.Random,
+    pool: Sequence[Candidate],
+    fee_rate: FeeRate,
+    total_lower: int,
+    target: int,
+    iterations: int,
+) -> tuple[list[bool], int]:
+    """Core's `ApproximateBestSubset`: random restarts over a subset-sum.
+
+    Two passes per restart, the first including each candidate on a coin
+    flip, the second sweeping in whatever the first pass left out --
+    Core's own comment is that the randomness buys nothing but avoiding a
+    degenerate worst case, not privacy or security, which is why a
+    caller-seeded `random.Random` costs this module nothing to expose.
+    """
+    values = [c.effective_value(fee_rate) for c in pool]
+    n = len(pool)
+    best_included = [True] * n
+    best_total = total_lower
+
+    rep = 0
+    while rep < iterations and best_total != target:
+        included = [False] * n
+        total = 0
+        reached_target = False
+        for pass_ in range(2):
+            if reached_target:
+                break
+            for i in range(n):
+                take = bool(engine.getrandbits(1)) if pass_ == 0 else not included[i]
+                if not take:
+                    continue
+                total += values[i]
+                included[i] = True
+                if total >= target:
+                    reached_target = True
+                    if total < best_total:
+                        best_total = total
+                        best_included = list(included)
+                    total -= values[i]
+                    included[i] = False
+        rep += 1
+    return best_included, best_total
+
+
+def _knapsack(
+    pool: Sequence[Candidate],
+    target: int,
+    change_target: int,
+    fee_rate: FeeRate,
+    engine: random.Random,
+) -> list[Candidate] | None:
+    """Translate `coinselection.cpp`'s `KnapsackSolver`: the solver itself."""
+    shuffled = list(pool)
+    engine.shuffle(shuffled)
+
+    lowest_larger: Candidate | None = None
+    applicable: list[Candidate] = []
+    total_lower = 0
+    for candidate in shuffled:
+        value = candidate.effective_value(fee_rate)
+        if value == target:
+            return [candidate]
+        if value < target + change_target:
+            applicable.append(candidate)
+            total_lower += value
+        elif lowest_larger is None or value < lowest_larger.effective_value(fee_rate):
+            lowest_larger = candidate
+
+    if total_lower == target:
+        return list(applicable)
+
+    if total_lower < target:
+        return None if lowest_larger is None else [lowest_larger]
+
+    applicable.sort(key=lambda c: c.effective_value(fee_rate), reverse=True)
+    best_included, best_total = _approximate_best_subset(
+        engine, applicable, fee_rate, total_lower, target, _KNAPSACK_ITERATIONS
+    )
+    if best_total != target and total_lower >= target + change_target:
+        best_included, best_total = _approximate_best_subset(
+            engine,
+            applicable,
+            fee_rate,
+            total_lower,
+            target + change_target,
+            _KNAPSACK_ITERATIONS,
+        )
+
+    if lowest_larger is not None and (
+        (best_total != target and best_total < target + change_target)
+        or lowest_larger.effective_value(fee_rate) <= best_total
+    ):
+        return [lowest_larger]
+
+    return [
+        c for c, included in zip(applicable, best_included, strict=True) if included
+    ]
+
+
+def single_random_draw(
+    candidates: Sequence[Candidate],
+    outputs: Sequence[TxOut],
+    fee_rate: FeeRate,
+    long_term_fee_rate: FeeRate,
+    change_script_pub_key: Octets | None = None,
+    change_spend_weight: int | None = None,
+    *,
+    dust_fee_rate: FeeRate = DUST_RELAY_FEE_RATE,
+    rng: random.Random | None = None,
+) -> SelectionResult:
+    """Shuffle the candidates and take them in order, Core's `SelectCoinsSRD`.
+
+    The simplest of the three, and Core's own fallback where the other
+    two find nothing: a random ordering is accumulated until it covers
+    `target` plus `CHANGE_LOWER` and the cost of creating a change
+    output -- so that a selection landing just past the target still
+    leaves a change worth creating rather than a handful of satoshi --
+    or, where `change_script_pub_key` is None, `target` alone.
+
+    `rng` is the shuffle's own engine; unseeded, a fresh `random.Random()`
+    reads system entropy.
+
+    Raised as `BTClibValueError`: the shuffled candidates never reach the
+    target, at this rate.
+    """
+    eligible, target, change_cost, change_script = _prepare(
+        candidates,
+        outputs,
+        fee_rate,
+        long_term_fee_rate,
+        change_script_pub_key,
+        change_spend_weight,
+        dust_fee_rate,
+    )
+    # not cryptographic on purpose, matching Core's FastRandomContext --
+    # the module docstring's own reasoning
+    engine = random.Random() if rng is None else rng  # noqa: S311
+    srd_target = target
+    if change_script is not None:
+        srd_target += CHANGE_LOWER + change_cost
+    selected = _single_random_draw(eligible, srd_target, fee_rate, engine)
+    if selected is None:
+        err_msg = f"single random draw: no shuffle reaches {srd_target} satoshi"
+        raise BTClibValueError(err_msg)
+    return _score(
+        selected,
+        target,
+        fee_rate,
+        long_term_fee_rate,
+        change_script,
+        change_spend_weight,
+        dust_fee_rate,
+        "srd",
+    )
+
+
+def _single_random_draw(
+    pool: Sequence[Candidate],
+    srd_target: int,
+    fee_rate: FeeRate,
+    engine: random.Random,
+) -> list[Candidate] | None:
+    """Translate `coinselection.cpp`'s `SelectCoinsSRD`: the draw itself."""
+    shuffled = list(pool)
+    engine.shuffle(shuffled)
+
+    selected: list[Candidate] = []
+    total = 0
+    for candidate in shuffled:
+        selected.append(candidate)
+        total += candidate.effective_value(fee_rate)
+        if total >= srd_target:
+            return selected
+    return None
+
+
+_ALGORITHMS = ("bnb", "knapsack", "srd")
+
+
+def select_coins(
+    candidates: Sequence[Candidate],
+    outputs: Sequence[TxOut],
+    fee_rate: FeeRate,
+    long_term_fee_rate: FeeRate,
+    change_script_pub_key: Octets | None = None,
+    change_spend_weight: int | None = None,
+    *,
+    dust_fee_rate: FeeRate = DUST_RELAY_FEE_RATE,
+    algorithms: Sequence[str] = _ALGORITHMS,
+    rng: random.Random | None = None,
+) -> SelectionResult:
+    """Run the named algorithms and return the selection of lowest waste.
+
+    `algorithms` names which of `"bnb"`, `"knapsack"` and `"srd"` to try
+    -- every one of them by default, Core's own policy of running all
+    three and keeping the best. A caller who wants exactly one names
+    it, `algorithms=("bnb",)`, which answers precisely as calling
+    `branch_and_bound` would; the composition here is what spares that
+    caller from also having to catch its own `BTClibValueError` in
+    the presence of the other two.
+
+    Raised as `BTClibValueError`: `algorithms` names something other
+    than the three above, or none of the algorithms named finds a
+    selection that reaches `outputs` at this rate.
+    """
+    if not algorithms:
+        raise BTClibValueError("no algorithm named")
+    unknown = sorted(set(algorithms) - set(_ALGORITHMS))
+    if unknown:
+        raise BTClibValueError(f"unknown algorithm: {', '.join(unknown)}")
+
+    results: list[SelectionResult] = []
+    errors: list[str] = []
+    if "bnb" in algorithms:
+        try:
+            results.append(
+                branch_and_bound(
+                    candidates,
+                    outputs,
+                    fee_rate,
+                    long_term_fee_rate,
+                    change_script_pub_key,
+                    change_spend_weight,
+                    dust_fee_rate=dust_fee_rate,
+                )
+            )
+        except BTClibValueError as e:
+            errors.append(str(e))
+    if "knapsack" in algorithms:
+        try:
+            results.append(
+                knapsack(
+                    candidates,
+                    outputs,
+                    fee_rate,
+                    long_term_fee_rate,
+                    change_script_pub_key,
+                    change_spend_weight,
+                    dust_fee_rate=dust_fee_rate,
+                    rng=rng,
+                )
+            )
+        except BTClibValueError as e:
+            errors.append(str(e))
+    if "srd" in algorithms:
+        try:
+            results.append(
+                single_random_draw(
+                    candidates,
+                    outputs,
+                    fee_rate,
+                    long_term_fee_rate,
+                    change_script_pub_key,
+                    change_spend_weight,
+                    dust_fee_rate=dust_fee_rate,
+                    rng=rng,
+                )
+            )
+        except BTClibValueError as e:
+            errors.append(str(e))
+
+    if not results:
+        # each algorithm's own message already names the target it
+        # computed against -- the same figure across all three, `_prepare`
+        # being where every one of them reads it -- so this is not repeated
+        err_msg = "no selection of the candidates covers the outputs at this "
+        err_msg += f"rate: {'; '.join(errors)}"
+        raise BTClibValueError(err_msg)
+
+    return min(results, key=lambda result: result.waste)

--- a/src/btclib/tx_builder.py
+++ b/src/btclib/tx_builder.py
@@ -67,8 +67,11 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from math import ceil
 
+from btclib import var_int
 from btclib.alias import Octets
+from btclib.consensus import WITNESS_SCALE_FACTOR
 from btclib.exceptions import BTClibValueError
 from btclib.fee import DUST_RELAY_FEE_RATE, FeeRate, dust_threshold, fee_from_vsize
 from btclib.psbt.psbt import Psbt, prevouts
@@ -77,6 +80,7 @@ from btclib.psbt.psbt_out import PsbtOut
 from btclib.psbt.psbt_size import SolutionSizer
 from btclib.psbt.psbt_utils import PSBT_V0
 from btclib.tx import TxOut
+from btclib.tx.tx import _SEGWIT_MARKER
 from btclib.utils import assert_type, bytes_from_octets
 
 __all__ = [
@@ -110,6 +114,58 @@ class FundedPsbt:
         if self.change_index is None:
             return 0
         return self.psbt.outputs[self.change_index].amount or 0
+
+
+def _target_overhead_vsize(outputs: Sequence[TxOut], candidate_count: int) -> int:
+    """Return what a transaction's own bytes cost, no input counted.
+
+    Version, lock time, the output count and the outputs themselves,
+    read off `Psbt.vsize_estimate` over a psbt of these outputs and no
+    inputs at all -- this function is that estimate, not a second copy
+    of its arithmetic, so a change to one reaches the other. Version and
+    lock time cost four bytes each whatever value they hold, so the
+    placeholder's own 2 and 0 answer for a caller who will pass
+    `build_psbt` something else too.
+
+    Padded by one virtual byte for the segwit marker `build_psbt` writes
+    once any selected input carries a witness, which this function --
+    given only the outputs, before a single input is chosen -- cannot
+    know either way. The pad rounds up rather than down: left off, a
+    selection built entirely of witness inputs would ask `build_psbt`
+    for a few satoshi it does not have; left on, a selection of
+    non-witness inputs alone asks for one virtual byte more than
+    `build_psbt` will actually charge, an overshoot rather than a
+    shortfall.
+
+    `candidate_count` bounds the other unknown, the input count's own
+    var_int: the placeholder above prices it at zero inputs, one byte,
+    but the true count is whatever the selection this overhead feeds
+    ends up choosing, which is not yet decided when this is asked and
+    can be as large as the whole pool it is choosing from. Read from
+    `candidate_count` -- the pool's own size, always at least the
+    selected count -- rather than the placeholder's zero, so the
+    estimate never charges for fewer input-count bytes than the real
+    selection can turn out to need; below 253 candidates the two
+    var_ints are one byte either way and this adds nothing.
+
+    `coin_selection` is the caller this exists for: what one input costs
+    is `tx.input_weight`'s answer, supplied per candidate; what the rest
+    of the transaction costs is this one, and a selection's own target is
+    the two added together, so that a match to it is a match `build_psbt`
+    can fund.
+    """
+    psbt_outputs = [
+        PsbtOut(amount=tx_out.value, script_pub_key=tx_out.script_pub_key.script)
+        for tx_out in outputs
+    ]
+    placeholder = Psbt(
+        2, [], psbt_outputs, PSBT_V0, {}, fallback_lock_time=0, check_validity=False
+    )
+    marker_pad = ceil(len(_SEGWIT_MARKER) / WITNESS_SCALE_FACTOR)
+    # the placeholder above already prices a zero-input var_int, one byte;
+    # this is only the extra width a pool of 253 or more candidates can add
+    input_count_pad = var_int._size(candidate_count) - var_int._size(0)
+    return placeholder.vsize_estimate() + marker_pad + input_count_pad
 
 
 def _assert_arguments(

--- a/tests/coin_selection_test.py
+++ b/tests/coin_selection_test.py
@@ -1,0 +1,994 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the `btclib.coin_selection` module.
+
+Three oracles, one per claim the module docstring makes.
+
+**The waste formula** is checked against Bitcoin Core's own
+`waste_test` (`bitcoin/bitcoin@4ec6ff022a`,
+`src/wallet/test/coinselector_tests.cpp:720`), transcribed rather than
+re-derived: each of Core's `add_coin(amount, n, selection, fee,
+long_term_fee)` calls fixes a fee and a long-term fee directly, which
+this module answers from a rate and a weight instead, so each vector is
+reproduced with a weight of one virtual byte and a `FeeRate` chosen so
+that `fee_from_vsize` returns exactly Core's own figure.
+
+**The three algorithms** are checked against hand-built candidate sets
+small enough to verify by inspection, against two of Core's own
+`knapsack_solver_test` vectors (`coinselector_tests.cpp:436` and
+`:452-453`, fee-independent at `CFeeRate(0)` and transcribed the same
+way as the waste vectors), and against the property every one of them
+shares: every candidate a selection returns is one of the candidates it
+was given, and the effective value of the selection covers the target.
+
+**The pair with `tx_builder.build_psbt`** is checked the way the issue
+that asked for this module says to: a selection is turned into `PsbtIn`
+maps and handed to `build_psbt`, whose own fee is asserted against the
+rate exactly as `tx_builder_test.py` asserts it independently.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Sequence
+
+import pytest
+
+import btclib.coin_selection as coin_selection_module
+from btclib.coin_selection import (
+    CHANGE_LOWER,
+    Candidate,
+    SelectionResult,
+    _branch_and_bound,
+    _waste,
+    branch_and_bound,
+    knapsack,
+    select_coins,
+    single_random_draw,
+)
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.fee import DUST_RELAY_FEE_RATE, FeeRate, dust_threshold, fee_from_vsize
+from btclib.psbt.psbt_in import PsbtIn
+from btclib.script import ScriptPubKey, Witness
+from btclib.tx import OutPoint, TxOut, input_weight
+from btclib.tx_builder import _target_overhead_vsize, build_psbt
+
+# two public keys of no private key anybody holds, as tx_builder_test.py
+# uses them: nothing here signs, the scripts existing to be measured and
+# dust-checked
+PAY_KEY = "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
+CHANGE_KEY = "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9"
+PAY_SCRIPT = ScriptPubKey.p2wpkh(PAY_KEY)
+CHANGE_SCRIPT = ScriptPubKey.p2wpkh(CHANGE_KEY)
+
+# a p2wpkh input's own weight: no scriptSig, a DER signature and a
+# compressed public key in the witness -- the same worst-case satisfaction
+# psbt_size.SIG_SIZE and COMPRESSED_PUB_KEY_SIZE assume elsewhere in the
+# tree
+P2WPKH_WEIGHT = input_weight(b"", Witness(["00" * 72, "00" * 33]))
+
+ONE_SAT_PER_VBYTE = FeeRate.from_sats_per_vbyte(1)
+TEN_SAT_PER_VBYTE = FeeRate.from_sats_per_vbyte(10)
+
+
+def candidate(
+    value: int,
+    index: int,
+    weight: int = P2WPKH_WEIGHT,
+    script: ScriptPubKey = PAY_SCRIPT,
+) -> Candidate:
+    """Return a candidate spending a p2wpkh output of that value."""
+    return Candidate(OutPoint(bytes([index]) * 32, 0), TxOut(value, script), weight)
+
+
+def _rate(sats_per_vbyte: int) -> FeeRate:
+    """Return a `FeeRate` that prices exactly `sats_per_vbyte` at 1 vbyte.
+
+    The waste vectors below fix a per-candidate fee directly, the way
+    Core's own `add_coin` does; this is what turns such a fee back into a
+    `FeeRate` for a `Candidate` of `_ONE_VBYTE_WEIGHT`.
+    """
+    return FeeRate(sats_per_kvbyte=sats_per_vbyte * 1_000)
+
+
+# a candidate weighing exactly one virtual byte, so that fee_from_vsize
+# of it at _rate(n) is exactly n satoshi -- what turns Core's fixed fee
+# figures back into a rate and a weight
+_ONE_VBYTE_WEIGHT = 4
+
+
+def _cents(values: Sequence[int]) -> list[Candidate]:
+    """Return one-vbyte candidates of these values, Core's own `add_coin` unit.
+
+    The `knapsack_solver_test` vectors below name their coins in cents;
+    the unit does not matter to the arithmetic, only the ratios between
+    the values, so this reads them back as bare satoshi.
+    """
+    return [
+        Candidate(
+            OutPoint(bytes([i + 1]) * 32, 0), TxOut(v, PAY_SCRIPT), _ONE_VBYTE_WEIGHT
+        )
+        for i, v in enumerate(values)
+    ]
+
+
+def _target(outputs: Sequence[TxOut], fee_rate: FeeRate, candidate_count: int) -> int:
+    """Return what `_prepare` computes as the target: outputs plus overhead.
+
+    Read off `_target_overhead_vsize`, the same production arithmetic
+    `_prepare` itself calls, rather than a figure hand-derived and left
+    to go stale the day that arithmetic changes -- what the module's own
+    boundary is checked against is
+    `test_a_changeless_match_funds_build_psbt_with_no_change_script`,
+    which asks `build_psbt` and not this module for the answer.
+    `candidate_count` is the size of the pool the test at hand actually
+    passes in -- `_prepare` reads it from `candidates`, not `outputs`.
+    """
+    overhead = _target_overhead_vsize(outputs, candidate_count)
+    return sum(tx_out.value for tx_out in outputs) + fee_from_vsize(overhead, fee_rate)
+
+
+def test_candidate_rejects_a_wrong_outpoint() -> None:
+    """Refuse an outpoint of the wrong type."""
+    for wrong in (None, 1.5, "not an outpoint"):
+        with pytest.raises(BTClibTypeError):
+            Candidate(wrong, TxOut(1_000, PAY_SCRIPT), P2WPKH_WEIGHT)  # type: ignore[arg-type]
+
+
+def test_candidate_rejects_a_wrong_tx_out() -> None:
+    """Refuse a tx_out of the wrong type."""
+    for wrong in (None, 1.5, "not a tx_out"):
+        with pytest.raises(BTClibTypeError):
+            Candidate(OutPoint(b"\x01" * 32, 0), wrong, P2WPKH_WEIGHT)  # type: ignore[arg-type]
+
+
+def test_candidate_rejects_a_weight_of_the_wrong_type() -> None:
+    """Refuse a weight of the wrong type."""
+    for wrong in (None, 1.5, "68"):
+        with pytest.raises(BTClibTypeError):
+            Candidate(OutPoint(b"\x01" * 32, 0), TxOut(1_000, PAY_SCRIPT), wrong)  # type: ignore[arg-type]
+
+
+def test_candidate_rejects_a_non_positive_weight() -> None:
+    """Refuse a weight of zero or below."""
+    for wrong in (0, -1):
+        with pytest.raises(BTClibValueError, match="non-positive weight"):
+            Candidate(OutPoint(b"\x01" * 32, 0), TxOut(1_000, PAY_SCRIPT), wrong)
+
+
+def test_candidate_effective_value_is_the_value_less_its_own_fee() -> None:
+    """Match fee_from_vsize's own arithmetic rather than a second one."""
+    c = candidate(100_000, 1)
+    assert c.vsize == P2WPKH_WEIGHT // 4
+    assert c.fee(TEN_SAT_PER_VBYTE) == fee_from_vsize(c.vsize, TEN_SAT_PER_VBYTE)
+    assert c.effective_value(TEN_SAT_PER_VBYTE) == 100_000 - c.fee(TEN_SAT_PER_VBYTE)
+
+
+# a check_validity=False candidate, of a shape select_coins has to catch
+# on its own: a weight downstream fee_from_vsize does not refuse by
+# itself, since a vsize of 0 owes 0 at every rate
+_FREE_CANDIDATE = Candidate(
+    OutPoint(b"\x02" * 32, 0), TxOut(1_000, PAY_SCRIPT), 0, check_validity=False
+)
+
+
+@pytest.mark.parametrize(
+    "algorithm",
+    [branch_and_bound, knapsack, single_random_draw],
+)
+def test_a_check_validity_false_candidate_of_zero_weight_is_refused(
+    algorithm: object,
+) -> None:
+    """Catch what check_validity=False lets through, at every algorithm."""
+    with pytest.raises(BTClibValueError, match="non-positive weight"):
+        algorithm(  # type: ignore[operator]
+            [_FREE_CANDIDATE],
+            [TxOut(500, PAY_SCRIPT)],
+            TEN_SAT_PER_VBYTE,
+            ONE_SAT_PER_VBYTE,
+        )
+
+
+def test_select_coins_refuses_a_wrong_typed_candidate_sequence() -> None:
+    """Refuse a candidates argument that is not a sequence."""
+    with pytest.raises(BTClibTypeError):
+        select_coins(
+            "not a sequence",  # type: ignore[arg-type]
+            [TxOut(500, PAY_SCRIPT)],
+            TEN_SAT_PER_VBYTE,
+            ONE_SAT_PER_VBYTE,
+        )
+
+
+def test_select_coins_refuses_change_spend_weight_without_a_change_script() -> None:
+    """Read a change_spend_weight of None as no change wanted."""
+    result = select_coins(
+        [candidate(100_000, 1)],
+        [TxOut(500, PAY_SCRIPT)],
+        TEN_SAT_PER_VBYTE,
+        ONE_SAT_PER_VBYTE,
+    )
+    assert result.change == 0
+
+
+def test_select_coins_requires_change_spend_weight_with_a_change_script() -> None:
+    """Refuse a change script with no change_spend_weight beside it."""
+    with pytest.raises(BTClibValueError, match="change_spend_weight is required"):
+        select_coins(
+            [candidate(100_000, 1)],
+            [TxOut(500, PAY_SCRIPT)],
+            TEN_SAT_PER_VBYTE,
+            ONE_SAT_PER_VBYTE,
+            CHANGE_SCRIPT.script,
+        )
+
+
+def test_select_coins_refuses_a_non_positive_change_spend_weight() -> None:
+    """Refuse a change_spend_weight of zero or below."""
+    for wrong in (0, -1):
+        with pytest.raises(BTClibValueError, match="non-positive change_spend_weight"):
+            select_coins(
+                [candidate(100_000, 1)],
+                [TxOut(500, PAY_SCRIPT)],
+                TEN_SAT_PER_VBYTE,
+                ONE_SAT_PER_VBYTE,
+                CHANGE_SCRIPT.script,
+                wrong,
+            )
+
+
+def test_select_coins_refuses_an_unknown_algorithm_name() -> None:
+    """Refuse an algorithms entry naming none of the three."""
+    with pytest.raises(BTClibValueError, match="unknown algorithm"):
+        select_coins(
+            [candidate(100_000, 1)],
+            [TxOut(500, PAY_SCRIPT)],
+            TEN_SAT_PER_VBYTE,
+            ONE_SAT_PER_VBYTE,
+            algorithms=("bnb", "coinjoin"),
+        )
+
+
+def test_select_coins_refuses_an_empty_algorithms_sequence() -> None:
+    """Refuse an empty algorithms sequence."""
+    with pytest.raises(BTClibValueError, match="no algorithm named"):
+        select_coins(
+            [candidate(100_000, 1)],
+            [TxOut(500, PAY_SCRIPT)],
+            TEN_SAT_PER_VBYTE,
+            ONE_SAT_PER_VBYTE,
+            algorithms=(),
+        )
+
+
+def test_select_coins_reports_insufficient_funds() -> None:
+    """Raise with a specific message rather than answering None."""
+    with pytest.raises(BTClibValueError, match="no selection of the candidates covers"):
+        select_coins(
+            [candidate(1_000, 1)],
+            [TxOut(60_000, PAY_SCRIPT)],
+            TEN_SAT_PER_VBYTE,
+            ONE_SAT_PER_VBYTE,
+        )
+
+
+# ---------------------------------------------------------------------------
+# The waste formula, transcribed from Core's waste_test
+# (bitcoin/bitcoin@4ec6ff022a, src/wallet/test/coinselector_tests.cpp:720).
+# Core fixes a fee and a long-term fee per coin directly; here each is
+# `_rate(n)` over a one-virtual-byte candidate, so that `Candidate.fee`
+# answers exactly `n`.
+# ---------------------------------------------------------------------------
+
+
+def _two_coins(fee: int, long_term_fee: int) -> list[Candidate]:
+    """Two candidates, Core's `add_coin(1 * COIN, ..)` and `(2 * COIN, ..)`."""
+    return [
+        Candidate(
+            OutPoint(b"\x01" * 32, 0), TxOut(100_000_000, PAY_SCRIPT), _ONE_VBYTE_WEIGHT
+        ),
+        Candidate(
+            OutPoint(b"\x02" * 32, 0), TxOut(200_000_000, PAY_SCRIPT), _ONE_VBYTE_WEIGHT
+        ),
+    ]
+
+
+def test_waste_with_change_is_the_change_cost_and_the_fee_difference() -> None:
+    """Core's first waste_test case: change cost plus the fee difference."""
+    fee, fee_diff, change_cost, target = 100, 40, 125, 200_000_000
+    selected = _two_coins(fee, fee - fee_diff)
+    waste = _waste(
+        selected,
+        target,
+        _rate(fee),
+        _rate(fee - fee_diff),
+        change=1,
+        change_cost=change_cost,
+    )
+    assert waste == fee_diff * 2 + change_cost
+
+
+def test_waste_grows_with_the_fee_and_a_fixed_long_term_fee() -> None:
+    """A higher fee at the same long-term rate raises the waste."""
+    fee, fee_diff, change_cost, target = 100, 40, 125, 200_000_000
+    lower = _waste(
+        _two_coins(fee, fee - fee_diff),
+        target,
+        _rate(fee),
+        _rate(fee - fee_diff),
+        change=1,
+        change_cost=change_cost,
+    )
+    higher = _waste(
+        _two_coins(fee * 2, fee - fee_diff),
+        target,
+        _rate(fee * 2),
+        _rate(fee - fee_diff),
+        change=1,
+        change_cost=change_cost,
+    )
+    assert higher > lower
+
+
+def test_waste_shrinks_when_the_long_term_fee_exceeds_the_fee() -> None:
+    """A long-term rate above the fee lowers the waste."""
+    fee, fee_diff, change_cost, target = 100, 40, 125, 200_000_000
+    below_long_term = _waste(
+        _two_coins(fee, fee + fee_diff),
+        target,
+        _rate(fee),
+        _rate(fee + fee_diff),
+        change=1,
+        change_cost=change_cost,
+    )
+    assert below_long_term == fee_diff * -2 + change_cost
+
+    above_long_term = _waste(
+        _two_coins(fee, fee - fee_diff),
+        target,
+        _rate(fee),
+        _rate(fee - fee_diff),
+        change=1,
+        change_cost=change_cost,
+    )
+    assert below_long_term < above_long_term
+
+
+def test_waste_without_change_is_the_excess_and_the_fee_difference() -> None:
+    """No change: the excess over target stands in for the change cost."""
+    fee, fee_diff, excess = 100, 40, 80
+    in_amt = 300_000_000
+    exact_target = in_amt - fee * 2
+    target = exact_target - excess
+    waste = _waste(
+        _two_coins(fee, fee - fee_diff), target, _rate(fee), _rate(fee - fee_diff), 0, 0
+    )
+    assert waste == fee_diff * 2 + excess
+
+    waste_above_long_term = _waste(
+        _two_coins(fee, fee + fee_diff), target, _rate(fee), _rate(fee + fee_diff), 0, 0
+    )
+    assert waste_above_long_term == fee_diff * -2 + excess
+    assert waste_above_long_term < waste
+
+
+def test_waste_is_just_the_change_cost_when_fee_equals_long_term_fee() -> None:
+    """A fee equal to the long-term rate leaves only the change cost."""
+    fee, change_cost, target = 100, 125, 200_000_000
+    waste = _waste(
+        _two_coins(fee, fee),
+        target,
+        _rate(fee),
+        _rate(fee),
+        change=1,
+        change_cost=change_cost,
+    )
+    assert waste == change_cost
+
+
+def test_waste_is_zero_at_the_exact_target_with_no_fee_difference() -> None:
+    """No excess, no fee difference, no change: zero waste."""
+    fee, in_amt = 100, 300_000_000
+    exact_target = in_amt - fee * 2
+    waste = _waste(_two_coins(fee, fee), exact_target, _rate(fee), _rate(fee), 0, 0)
+    assert waste == 0
+
+
+def test_waste_is_negative_when_the_long_term_fee_dominates() -> None:
+    """A long-term rate above the fee can make the waste negative."""
+    fee, in_amt = 100, 300_000_000
+    exact_target = in_amt - fee * 2
+    fee_diff = 90
+    waste = _waste(
+        _two_coins(fee, fee + fee_diff),
+        exact_target,
+        _rate(fee),
+        _rate(fee + fee_diff),
+        0,
+        0,
+    )
+    assert waste == -2 * fee_diff
+
+
+def test_waste_is_negative_with_change_when_the_cost_does_not_offset_it() -> None:
+    """A large fee difference can outweigh the change cost too."""
+    fee, change_cost, target = 100, 125, 200_000_000
+    large_fee_diff = 90
+    waste = _waste(
+        _two_coins(fee, fee + large_fee_diff),
+        target,
+        _rate(fee),
+        _rate(fee + large_fee_diff),
+        change=1,
+        change_cost=change_cost,
+    )
+    assert waste == -55
+
+
+# ---------------------------------------------------------------------------
+# The three algorithms
+# ---------------------------------------------------------------------------
+
+
+def _covers(result: SelectionResult, candidates: Sequence[Candidate]) -> bool:
+    """Every selected candidate is one of the candidates offered, once each."""
+    pool = list(candidates)
+    for c in result.selected:
+        if c not in pool:
+            return False
+        pool.remove(c)
+    return True
+
+
+def test_covers_helper_reports_a_selection_outside_the_pool() -> None:
+    """The helper's own negative case, which no algorithm result trips."""
+    outside = candidate(1_000, 1)
+    result = SelectionResult((outside,), 0, 0, "bnb")
+    assert not _covers(result, [candidate(2_000, 2)])
+
+
+def test_branch_and_bound_finds_the_exact_changeless_match() -> None:
+    """The one candidate matching the target exactly is the selection."""
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    fee = candidate(0, 9).fee(TEN_SAT_PER_VBYTE)
+    exact = candidate(_target(outputs, TEN_SAT_PER_VBYTE, 2) + fee, 9)
+    result = branch_and_bound(
+        [exact, candidate(1_000_000, 1)], outputs, TEN_SAT_PER_VBYTE, ONE_SAT_PER_VBYTE
+    )
+    assert result.selected == (exact,)
+    assert result.change == 0
+    assert result.algorithm == "bnb"
+
+
+def test_branch_and_bound_prefers_the_exact_match_within_the_window() -> None:
+    """Two candidates both fall in the window; the exact one wastes less."""
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    fee = candidate(0, 9).fee(TEN_SAT_PER_VBYTE)
+    target = _target(outputs, TEN_SAT_PER_VBYTE, 2)
+    exact = candidate(target + fee, 1)
+    # the excess this one leaves is waste the exact match does not carry
+    within_window = candidate(target + fee + 50, 2)
+    result = branch_and_bound(
+        [exact, within_window],
+        outputs,
+        TEN_SAT_PER_VBYTE,
+        ONE_SAT_PER_VBYTE,
+        CHANGE_SCRIPT.script,
+        P2WPKH_WEIGHT,
+    )
+    assert result.selected == (exact,)
+
+
+def test_branch_and_bound_raises_when_no_window_match_exists() -> None:
+    """No combination lands in the window: bnb raises rather than guesses."""
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    with pytest.raises(BTClibValueError, match="no changeless selection"):
+        branch_and_bound(
+            [candidate(100_000, 1), candidate(50_000, 2), candidate(30_000, 3)],
+            outputs,
+            TEN_SAT_PER_VBYTE,
+            ONE_SAT_PER_VBYTE,
+            CHANGE_SCRIPT.script,
+            P2WPKH_WEIGHT,
+        )
+
+
+def test_knapsack_covers_the_target_with_change() -> None:
+    """A selection whose effective value covers the target, with change."""
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    candidates = [candidate(100_000, 1), candidate(50_000, 2), candidate(30_000, 3)]
+    result = knapsack(
+        candidates,
+        outputs,
+        TEN_SAT_PER_VBYTE,
+        ONE_SAT_PER_VBYTE,
+        CHANGE_SCRIPT.script,
+        P2WPKH_WEIGHT,
+        rng=random.Random(0),
+    )
+    assert _covers(result, candidates)
+    total = sum(c.effective_value(TEN_SAT_PER_VBYTE) for c in result.selected)
+    assert total >= 60_000
+    assert result.algorithm == "knapsack"
+
+
+def test_knapsack_finds_the_single_exact_match() -> None:
+    """An exact match short-circuits the subset-sum search."""
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    fee = candidate(0, 9).fee(TEN_SAT_PER_VBYTE)
+    exact = candidate(_target(outputs, TEN_SAT_PER_VBYTE, 2) + fee, 9)
+    result = knapsack(
+        [exact, candidate(1_000_000, 1)],
+        outputs,
+        TEN_SAT_PER_VBYTE,
+        ONE_SAT_PER_VBYTE,
+        rng=random.Random(0),
+    )
+    assert result.selected == (exact,)
+
+
+def test_knapsack_falls_back_to_the_lowest_larger_candidate() -> None:
+    """Nothing below target: the smallest candidate above it is picked."""
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    # every candidate below target is missing entirely: the only way to
+    # reach it is the smallest one that alone exceeds it
+    result = knapsack(
+        [candidate(1_000_000, 1), candidate(2_000_000, 2)],
+        outputs,
+        TEN_SAT_PER_VBYTE,
+        ONE_SAT_PER_VBYTE,
+        rng=random.Random(0),
+    )
+    assert result.selected == (candidate(1_000_000, 1),)
+
+
+def test_knapsack_raises_when_the_pool_is_short_of_the_target() -> None:
+    """Every candidate together still short of the target: knapsack raises."""
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    with pytest.raises(BTClibValueError, match="knapsack"):
+        knapsack(
+            [candidate(1_000, 1), candidate(2_000, 2)],
+            outputs,
+            TEN_SAT_PER_VBYTE,
+            ONE_SAT_PER_VBYTE,
+            rng=random.Random(0),
+        )
+
+
+def test_single_random_draw_is_deterministic_under_a_seeded_engine() -> None:
+    """The same seed draws the same selection twice."""
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    candidates = [candidate(100_000, 1), candidate(50_000, 2), candidate(30_000, 3)]
+    first = single_random_draw(
+        candidates, outputs, TEN_SAT_PER_VBYTE, ONE_SAT_PER_VBYTE, rng=random.Random(42)
+    )
+    second = single_random_draw(
+        candidates, outputs, TEN_SAT_PER_VBYTE, ONE_SAT_PER_VBYTE, rng=random.Random(42)
+    )
+    assert first.selected == second.selected
+    assert first.waste == second.waste
+
+
+def test_single_random_draw_leaves_room_for_change_lower_bound() -> None:
+    """The target SRD draws to includes CHANGE_LOWER, not just the payment."""
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    result = single_random_draw(
+        [candidate(1_000_000, 1)],
+        outputs,
+        TEN_SAT_PER_VBYTE,
+        ONE_SAT_PER_VBYTE,
+        CHANGE_SCRIPT.script,
+        P2WPKH_WEIGHT,
+        rng=random.Random(0),
+    )
+    total = sum(c.effective_value(TEN_SAT_PER_VBYTE) for c in result.selected)
+    assert total >= 60_000 + CHANGE_LOWER
+
+
+def test_single_random_draw_raises_when_the_shuffle_never_covers_target() -> None:
+    """Every candidate shuffled in and still short: SRD raises."""
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    with pytest.raises(BTClibValueError, match="single random draw"):
+        single_random_draw(
+            [candidate(1_000, 1)],
+            outputs,
+            TEN_SAT_PER_VBYTE,
+            ONE_SAT_PER_VBYTE,
+            rng=random.Random(0),
+        )
+
+
+def test_select_coins_keeps_the_lowest_waste_result() -> None:
+    """Among several algorithms that succeed, the lowest waste wins."""
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    fee = candidate(0, 9).fee(TEN_SAT_PER_VBYTE)
+    exact = candidate(_target(outputs, TEN_SAT_PER_VBYTE, 4) + fee, 9)
+    candidates = [
+        exact,
+        candidate(100_000, 1),
+        candidate(50_000, 2),
+        candidate(30_000, 3),
+    ]
+    result = select_coins(
+        candidates,
+        outputs,
+        TEN_SAT_PER_VBYTE,
+        ONE_SAT_PER_VBYTE,
+        CHANGE_SCRIPT.script,
+        P2WPKH_WEIGHT,
+        rng=random.Random(3),
+    )
+    # the exact bnb match has zero change and the least waste among any
+    # combination reaching the same target
+    assert result.selected == (exact,)
+    assert result.algorithm == "bnb"
+
+
+def test_select_coins_runs_only_the_named_algorithms() -> None:
+    """`algorithms` restricts which of the three actually run."""
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    candidates = [candidate(100_000, 1), candidate(50_000, 2), candidate(30_000, 3)]
+    result = select_coins(
+        candidates,
+        outputs,
+        TEN_SAT_PER_VBYTE,
+        ONE_SAT_PER_VBYTE,
+        CHANGE_SCRIPT.script,
+        P2WPKH_WEIGHT,
+        algorithms=("knapsack",),
+        rng=random.Random(0),
+    )
+    assert result.algorithm == "knapsack"
+
+
+# ---------------------------------------------------------------------------
+# The pair with tx_builder.build_psbt
+# ---------------------------------------------------------------------------
+
+
+def test_a_selection_funds_the_payment_build_psbt_asks_for() -> None:
+    """A selection's candidates, turned into PsbtIn maps, fund build_psbt."""
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    candidates = [candidate(100_000, 1), candidate(50_000, 2), candidate(30_000, 3)]
+    result = select_coins(
+        candidates,
+        outputs,
+        TEN_SAT_PER_VBYTE,
+        ONE_SAT_PER_VBYTE,
+        CHANGE_SCRIPT.script,
+        P2WPKH_WEIGHT,
+        rng=random.Random(11),
+    )
+    psbt_inputs = [
+        PsbtIn(
+            witness_utxo=c.tx_out,
+            previous_tx_id=c.outpoint.tx_id,
+            output_index=c.outpoint.vout,
+        )
+        for c in result.selected
+    ]
+    built = build_psbt(psbt_inputs, outputs, TEN_SAT_PER_VBYTE, CHANGE_SCRIPT.script)
+    assert built.fee == fee_from_vsize(built.psbt.vsize_estimate(), TEN_SAT_PER_VBYTE)
+    total_in = sum(c.tx_out.value for c in result.selected)
+    assert total_in == sum(o.value for o in outputs) + built.fee + built.change
+
+
+def test_a_changeless_match_funds_build_psbt_with_no_change_script() -> None:
+    """The target's own overhead term closes the gap `build_psbt` would find.
+
+    `branch_and_bound`'s target is `sum(outputs)` plus what the
+    transaction's own version, lock time, output count and output bytes
+    cost -- `_target_overhead_vsize`, read from `build_psbt`'s own
+    estimate rather than a second copy of it. A changeless match built
+    to the satoshi against this target now funds `build_psbt` exactly,
+    where matching `sum(outputs)` alone once left it short by the bytes
+    only the whole transaction, and not one candidate, carries.
+    """
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    exact = candidate(
+        _target(outputs, TEN_SAT_PER_VBYTE, 1) + candidate(0, 9).fee(TEN_SAT_PER_VBYTE),
+        9,
+    )
+    result = branch_and_bound([exact], outputs, TEN_SAT_PER_VBYTE, ONE_SAT_PER_VBYTE)
+    assert result.change == 0
+    psbt_inputs = [
+        PsbtIn(
+            witness_utxo=c.tx_out,
+            previous_tx_id=c.outpoint.tx_id,
+            output_index=c.outpoint.vout,
+        )
+        for c in result.selected
+    ]
+    built = build_psbt(psbt_inputs, outputs, TEN_SAT_PER_VBYTE)
+    assert built.change_index is None
+
+
+def test_target_overhead_is_padded_at_the_pool_size_var_int_boundary() -> None:
+    """253 candidates: the pool's own var_int grows past one byte.
+
+    `_target_overhead_vsize` bounds the input count's own var_int by the
+    candidate pool's size, `len(candidates)`, since the count actually
+    selected is not yet known and can never exceed it. Below 253
+    candidates that var_int is one byte either way and the pad is zero;
+    here the pool is exactly 253, and every one of them has to be
+    selected to reach the target, so the built transaction's own
+    var_int really does grow to three bytes -- `build_psbt` is the
+    oracle that proves the padded target still funds it. Real p2wpkh
+    candidates, not the one-vbyte trick: `build_psbt`'s own size
+    estimate reads each input's script, not `Candidate.weight`, so a
+    weight this module is not actually asked to price would misprice
+    the very thing this test checks.
+    """
+    pool_size = 253
+    per_candidate = 100
+    fee = candidate(0, 254).fee(TEN_SAT_PER_VBYTE)
+    overhead = _target_overhead_vsize([TxOut(0, PAY_SCRIPT)], pool_size)
+    overhead_fee = fee_from_vsize(overhead, TEN_SAT_PER_VBYTE)
+    target = pool_size * per_candidate
+    outputs = [TxOut(target - overhead_fee, PAY_SCRIPT)]
+    # summed effective value across the whole pool matches target exactly
+    candidates = [candidate(per_candidate + fee, i) for i in range(1, pool_size + 1)]
+    result = knapsack(
+        candidates, outputs, TEN_SAT_PER_VBYTE, TEN_SAT_PER_VBYTE, rng=random.Random(0)
+    )
+    assert len(result.selected) == pool_size
+    psbt_inputs = [
+        PsbtIn(
+            witness_utxo=c.tx_out,
+            previous_tx_id=c.outpoint.tx_id,
+            output_index=c.outpoint.vout,
+        )
+        for c in result.selected
+    ]
+    built = build_psbt(psbt_inputs, outputs, TEN_SAT_PER_VBYTE)
+    assert built.change_index is None
+
+
+def test_dust_fee_rate_decides_whether_change_survives() -> None:
+    """Below the dust threshold change is dropped; above it, it is created."""
+    outputs = [TxOut(1_000, PAY_SCRIPT)]
+    threshold = dust_threshold(CHANGE_SCRIPT.script, DUST_RELAY_FEE_RATE)
+    # what a candidate's own value has to clear before a single satoshi of
+    # change exists: the target, the change output's own creation fee, and
+    # this candidate's own fee at the same weight every candidate() below
+    # carries
+    fee = candidate(0, 9).fee(TEN_SAT_PER_VBYTE)
+    creation_fee = fee_from_vsize(
+        coin_selection_module._change_output_vsize(CHANGE_SCRIPT.script),
+        TEN_SAT_PER_VBYTE,
+    )
+    base = _target(outputs, TEN_SAT_PER_VBYTE, 1) + creation_fee + fee
+
+    # too little left over for change to clear the dust threshold: dropped
+    dropped = select_coins(
+        [candidate(base + threshold - 1, 1)],
+        outputs,
+        TEN_SAT_PER_VBYTE,
+        ONE_SAT_PER_VBYTE,
+        CHANGE_SCRIPT.script,
+        P2WPKH_WEIGHT,
+        dust_fee_rate=DUST_RELAY_FEE_RATE,
+        rng=random.Random(0),
+    )
+    assert dropped.change == 0
+
+    # plenty left over: change clears the threshold and is created
+    created = select_coins(
+        [candidate(base + threshold + 10_000, 2)],
+        outputs,
+        TEN_SAT_PER_VBYTE,
+        ONE_SAT_PER_VBYTE,
+        CHANGE_SCRIPT.script,
+        P2WPKH_WEIGHT,
+        dust_fee_rate=DUST_RELAY_FEE_RATE,
+        rng=random.Random(0),
+    )
+    assert created.change >= threshold
+
+
+# ---------------------------------------------------------------------------
+# The corners the tests above do not reach on their own
+# ---------------------------------------------------------------------------
+
+
+def test_change_spend_weight_of_the_wrong_type_is_a_type_error() -> None:
+    """A change_spend_weight of the wrong type leaves as a type error."""
+    for wrong in (1.5, "68"):
+        with pytest.raises(BTClibTypeError, match="invalid change_spend_weight type"):
+            select_coins(
+                [candidate(100_000, 1)],
+                [TxOut(500, PAY_SCRIPT)],
+                TEN_SAT_PER_VBYTE,
+                ONE_SAT_PER_VBYTE,
+                CHANGE_SCRIPT.script,
+                wrong,  # type: ignore[arg-type]
+            )
+
+
+def test_branch_and_bound_raises_on_an_empty_eligible_pool() -> None:
+    """Every candidate priced out at this rate: the search pool is empty."""
+    outputs = [TxOut(500, PAY_SCRIPT)]
+    worthless = candidate(1, 1)  # a p2wpkh input's own fee alone exceeds this
+    with pytest.raises(BTClibValueError, match="no changeless selection"):
+        branch_and_bound([worthless], outputs, TEN_SAT_PER_VBYTE, ONE_SAT_PER_VBYTE)
+
+
+def test_branch_and_bound_keeps_the_lower_waste_of_two_window_matches() -> None:
+    """A whitebox check of the search itself: the second match found is worse.
+
+    Two single-candidate matches both fall in a `[target, target +
+    cost_of_change]` window of 5000; the higher-effective-value one is
+    explored first (the pool is sorted descending) and has the lower
+    total waste, so when the second is evaluated the search must keep
+    the first rather than replace it -- the `waste <= best_waste` branch
+    answering False, which a single-solution search never exercises.
+    """
+    fee_rate = _rate(10)
+    long_term_fee_rate = _rate(1)
+    # weight 48 -> vsize 12 -> fee 120, long-term fee 12, waste_i 108
+    tried_first = Candidate(OutPoint(b"\x01" * 32, 0), TxOut(64_120, PAY_SCRIPT), 48)
+    # weight 1780 -> vsize 445 -> fee 4450, long-term fee 445, waste_i 4005
+    tried_second = Candidate(OutPoint(b"\x02" * 32, 0), TxOut(64_950, PAY_SCRIPT), 1780)
+    assert tried_first.effective_value(fee_rate) == 64_000
+    assert tried_second.effective_value(fee_rate) == 60_500
+    selected = _branch_and_bound(
+        [tried_first, tried_second], 60_000, 5_000, fee_rate, long_term_fee_rate
+    )
+    assert selected == [tried_first]
+
+
+def test_branch_and_bound_stops_at_the_search_budget() -> None:
+    """`_BNB_TOTAL_TRIES` bounds the search; a tiny budget hits it at once."""
+    original = coin_selection_module._BNB_TOTAL_TRIES
+    coin_selection_module._BNB_TOTAL_TRIES = 1
+    try:
+        candidates = [candidate(40_000, 1), candidate(35_000, 2), candidate(30_000, 3)]
+        with pytest.raises(BTClibValueError, match="no changeless selection"):
+            branch_and_bound(
+                candidates,
+                [TxOut(60_000, PAY_SCRIPT)],
+                TEN_SAT_PER_VBYTE,
+                ONE_SAT_PER_VBYTE,
+            )
+    finally:
+        coin_selection_module._BNB_TOTAL_TRIES = original
+
+
+def test_knapsack_approximate_best_subset_improves_on_the_first_pass() -> None:
+    """Three candidates admit several subsets; the search finds a smaller one.
+
+    `total_lower`, every applicable candidate summed, is only ever the
+    starting guess -- `ApproximateBestSubset` keeps searching as long as
+    a restart lands on a smaller total that still covers the target, and
+    with three candidates admitting several such subsets it must find one.
+    """
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    candidates = [candidate(40_000, 1), candidate(35_000, 2), candidate(30_000, 3)]
+    result = knapsack(
+        candidates, outputs, ONE_SAT_PER_VBYTE, ONE_SAT_PER_VBYTE, rng=random.Random(2)
+    )
+    assert _covers(result, candidates)
+    total = sum(c.effective_value(ONE_SAT_PER_VBYTE) for c in result.selected)
+    assert (
+        60_000 <= total < sum(c.effective_value(ONE_SAT_PER_VBYTE) for c in candidates)
+    )
+
+
+def test_knapsack_skips_the_widened_search_short_of_the_change_window() -> None:
+    """`total_lower` short of `target + change_target`: no second pass.
+
+    A change script asks the subset-sum search for a total anywhere up to
+    `target + change_target`, but only once the first pass, aimed at
+    `target` alone, has already failed to find an exact match *and*
+    `total_lower` reaches that wider window -- short of it, as here, a
+    second restart at the wider target would only repeat the first
+    search's own answer, so `_knapsack` does not run it.
+    """
+    fee_rate = _rate(0)
+    long_term_fee_rate = _rate(5)
+    outputs = [TxOut(16, PAY_SCRIPT)]
+    # 6+7+7 = 20: at or above target, short of target + change_target (21),
+    # and no subset of the three sums to 16 exactly
+    cents = _cents([6, 7, 7])
+    result = knapsack(
+        cents,
+        outputs,
+        fee_rate,
+        long_term_fee_rate,
+        CHANGE_SCRIPT.script,
+        _ONE_VBYTE_WEIGHT,
+        rng=random.Random(0),
+    )
+    assert sorted(c.tx_out.value for c in result.selected) == [6, 7, 7]
+    assert result.change == 0
+
+
+def test_knapsack_returns_every_applicable_candidate_on_an_exact_total() -> None:
+    """`total_lower == target`: nothing is left out and nothing is added."""
+    fee_rate = _rate(1)
+    outputs = [TxOut(1_998, PAY_SCRIPT)]
+    target = _target(outputs, fee_rate, 2)
+    # each candidate weighs one vbyte, so its own fee at fee_rate is 1 --
+    # split target plus the two fees between the two candidate values
+    half = target // 2
+    a = Candidate(
+        OutPoint(b"\x01" * 32, 0), TxOut(half + 1, PAY_SCRIPT), _ONE_VBYTE_WEIGHT
+    )
+    b = Candidate(
+        OutPoint(b"\x02" * 32, 0),
+        TxOut(target - half + 1, PAY_SCRIPT),
+        _ONE_VBYTE_WEIGHT,
+    )
+    result = knapsack([a, b], outputs, fee_rate, fee_rate, rng=random.Random(0))
+    assert set(result.selected) == {a, b}
+
+
+def test_knapsack_prefers_the_lowest_larger_when_it_beats_the_subset() -> None:
+    """A single candidate just above target can beat every subset found."""
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    just_above = candidate(61_000, 4)
+    candidates = [
+        candidate(40_000, 1),
+        candidate(35_000, 2),
+        candidate(30_000, 3),
+        just_above,
+    ]
+    result = knapsack(
+        candidates, outputs, ONE_SAT_PER_VBYTE, ONE_SAT_PER_VBYTE, rng=random.Random(5)
+    )
+    assert result.selected == (just_above,)
+
+
+def test_knapsack_prefers_the_single_bigger_coin_over_a_larger_subset() -> None:
+    """Core's `knapsack_solver_test`, result10: `bitcoin/bitcoin@4ec6ff022a`.
+
+    `coinselector_tests.cpp:436`: candidates of 6, 7, 8, 20 and 30 cents
+    against a target of 16 -- the smaller coins best only 6+7+8=21, not as
+    good as the next biggest coin alone, 20, so the single 20-cent coin
+    is what `KnapsackSolver` returns. `CFeeRate(0)` in Core's own
+    `add_coin` calls, transcribed as `_rate(0)` here, is what makes the
+    vector fee-independent: effective value is the coin's own amount.
+    """
+    fee_rate = _rate(0)
+    cents = _cents([6, 7, 8, 20, 30])
+    result = knapsack(
+        cents, [TxOut(16, PAY_SCRIPT)], fee_rate, fee_rate, rng=random.Random(0)
+    )
+    assert [c.tx_out.value for c in result.selected] == [20]
+
+
+def test_knapsack_breaks_a_subset_sum_tie_toward_the_single_coin() -> None:
+    """Core's `knapsack_solver_test`, result12: `bitcoin/bitcoin@4ec6ff022a`.
+
+    `coinselector_tests.cpp:452-453`: candidates of 5, 6, 7, 8, 18, 20 and 30
+    cents against a target of 16 -- the smaller coins can make 5+6+7=18,
+    exactly what the next biggest coin, 18, holds alone. `KnapsackSolver`
+    ties in favour of the single coin, `ApproximateBestSubset`'s own
+    `best_included` starting from `total_lower`'s all-included subset and
+    only ever replacing it with a *smaller* total, so a tie never
+    displaces the single coin already ahead of it in `lowest_larger`.
+    """
+    fee_rate = _rate(0)
+    cents = _cents([5, 6, 7, 8, 18, 20, 30])
+    result = knapsack(
+        cents, [TxOut(16, PAY_SCRIPT)], fee_rate, fee_rate, rng=random.Random(0)
+    )
+    assert [c.tx_out.value for c in result.selected] == [18]
+
+
+def test_select_coins_with_a_single_algorithm_skips_the_other_two() -> None:
+    """algorithms=('bnb',) answers precisely as branch_and_bound would."""
+    outputs = [TxOut(60_000, PAY_SCRIPT)]
+    fee = candidate(0, 9).fee(TEN_SAT_PER_VBYTE)
+    exact = candidate(_target(outputs, TEN_SAT_PER_VBYTE, 2) + fee, 9)
+    result = select_coins(
+        [exact, candidate(100_000, 1)],
+        outputs,
+        TEN_SAT_PER_VBYTE,
+        ONE_SAT_PER_VBYTE,
+        algorithms=("bnb",),
+    )
+    assert result.algorithm == "bnb"
+    assert result.selected == (exact,)

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -126,6 +126,11 @@ KEYWORD_ONLY: dict[str, list[str]] = {
         "check_validity",
     ],
     "btclib.bolt11:RouteHintHop.__init__": ["check_validity"],
+    "btclib.coin_selection:Candidate.__init__": ["check_validity"],
+    "btclib.coin_selection:branch_and_bound": ["dust_fee_rate"],
+    "btclib.coin_selection:knapsack": ["dust_fee_rate", "rng"],
+    "btclib.coin_selection:select_coins": ["dust_fee_rate", "algorithms", "rng"],
+    "btclib.coin_selection:single_random_draw": ["dust_fee_rate", "rng"],
     "btclib.core_import:account_import_requests": ["active", "key_range"],
     "btclib.core_import:import_request": [
         "internal",


### PR DESCRIPTION
Closes #1586

The last of the three children of
[ISS 382](https://github.com/btclib-org/btclib/issues/382), and the
layer [ISS 1068](https://github.com/btclib-org/btclib/issues/1068) said
would sit above `tx_builder.build_psbt` rather than inside it:
`build_psbt` takes the inputs it is given, and until now nothing chose
them.

`Candidate`, `SelectionResult`, and `branch_and_bound`, `knapsack` and
`single_random_draw` — each independently public — composed by
`select_coins`, which runs whichever are named and keeps the
lowest-waste result. Waste is Core's own `SelectionResult::GetWaste`,
and the algorithms are ported from `src/wallet/coinselection.cpp` at
`bitcoin/bitcoin@4ec6ff022a`, with `_BNB_TOTAL_TRIES`,
`_KNAPSACK_ITERATIONS`, `CHANGE_LOWER` and SRD's own target adjustment
all matching Core's.

Randomness is a caller-supplied `random.Random`, never a bare
module-level call: `pytest-randomly` reseeds the global generator per
test, so a module-level call would make the suite's own result depend on
its seed.

## The target is what `build_psbt` will charge, not the sum of outputs

This is the part that took three rounds to get right, so it is worth
stating plainly.

Selecting against `sum(outputs)` alone is short: a transaction also pays
for its own version, locktime, output count and output bytes, and a
changeless match built exactly to that smaller target then asks
`build_psbt` for more than it has. The first attempt documented that as
a boundary and offered the caller a mitigation — supply a change script,
and the window `cost_of_change` opens covers it. **That mitigation is
false**, and reproducibly so: `_score` and BnB prefer the lowest-waste
selection, so an exact match keeps `change == 0` whether or not a change
script was passed.

So the target is computed instead, and from `tx_builder`'s own estimate
rather than a second copy of its arithmetic — `_target_overhead_vsize`
builds a `Psbt` of these outputs with zero inputs and reads
`Psbt.vsize_estimate()`. `coin_selection` importing `tx_builder` is what
this issue's *Where it lives* bullet asked for in the first place, and
following it would have closed this by construction.

Two conservative pads on top, each of which can only ever ask for more:

- **one virtual byte for the segwit marker**, since whether the final
  selection carries a witness is not knowable from the outputs alone.
  The marker is 2 weight units and `2 < WITNESS_SCALE_FACTOR`, so it can
  shift the true combined `ceil(weight/4)` up by at most one vbyte —
  making this the tight bound rather than a guess.
- **the input-count `var_int` priced at the candidate pool's size.** The
  selected count is not known when the target is computed, but it can
  never exceed the pool it is chosen from, and `var_int._size` is
  non-decreasing. Below 253 candidates the pad is zero and nothing
  changes; at 253 the var_int grows to three bytes and the target grows
  with it. `test_target_overhead_is_padded_at_the_pool_size_var_int_boundary`
  is that case, built from real p2wpkh-weight candidates rather than the
  one-vbyte trick the other tests use — `build_psbt` prices each input
  from its actual script, so the trick would misprice the very term
  under test.

There is no residual left to document, which is the point: the earlier
sentence about one could not be made true, so the thing it described was
removed instead.

## What is deliberately not here

Core's `OutputGroup` and ancestor tracking, `max_selection_weight`, and
the `CoinGrinder` fourth algorithm — all wallet and mempool-policy
machinery a stateless layer has no access to.

Three of Core's optimizations are also absent and named in the module's
own disclosure paragraph rather than left to be discovered: the
`descending` comparator's waste tie-break on equal effective value, the
`is_feerate_high && curr_selection_waste > best_waste` early cut, and
the SHIFT loop's skip-clone step. None changes which selection comes
back — they are pruning and ordering, and the search space is still
fully explored inside the budget.

`get_tx_out`-style shortcuts aside, the one thing this cannot do is
choose a fee rate; that stays the caller's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Add a stateless, Core-compatible coin selection layer that chooses and scores UTXOs before building funded PSBTs.

New Features:
- Add stateless coin selection through public branch-and-bound, knapsack, and single-random-draw algorithms, with composition by lowest waste.
- Expose candidate and selection result types for choosing UTXOs before PSBT construction.

Bug Fixes:
- Calculate selection targets from transaction overhead estimated by tx_builder, including conservative segwit-marker and input-count varint padding, so changeless selections can fund build_psbt transactions without falling short.

Enhancements:
- Use effective input value and Core-compatible waste scoring, change costs, dust handling, and caller-supplied randomness for deterministic selection when desired.
- Keep coin selection above tx_builder.build_psbt while sharing its transaction-size estimation.

Documentation:
- Document the new coin_selection module and its Bitcoin Core algorithm compatibility and stateless scope.
- Record the new coin selection API and behavior in the changelog.

Tests:
- Add comprehensive coverage for candidate validation, selection algorithms, waste scoring, change handling, transaction funding, size-boundary padding, and Core reference cases.