### PR TITLE
`btclib.hwi` takes a network name the way the rest of the library does (closes #1631, closes #1632)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1651,6 +1651,43 @@ dereferences it, and `refs/tags/v1^{}` does the same from a checkout.
   functions, so a test -- or a caller after a reproducible selection --
   seeds it.
 
+### `btclib.hwi` takes a network name the way the rest of the library takes one
+
+- **`HwiSigner` and `enumerate_devices` put their `network: str` through
+  `network._validated_network_name`** (closes #1631). The two entry
+  points that accept a name accept the spellings issue #216 decided to
+  keep — `" TestNet4 "` resolves — and refuse an unknown one in the same
+  message: `HwiSigner` checked membership of `NETWORKS` itself, and
+  `enumerate_devices` checked nothing, so its refusal came from the
+  private chain lookup, which framed an unknown name as a missing HWI
+  chain. A signer stores the normalized name, so
+  `HwiSigner(network=" Testnet ").network` is what `network_from_name`
+  answers to. Reaching that helper across modules is what
+  `descriptors.parse` and `p2p.magic.magic_from_network` already do.
+- **A `network` of a type no conversion accepts is a `BTClibTypeError`**,
+  which is a `TypeError` and not a `ValueError`;
+  [RELEASE_NOTES.md](./RELEASE_NOTES.md) has what a caller catching
+  `BTClibValueError` around either call does about it.
+- **`_chain_args` is the translation alone**, its own refusal gone with
+  the validation moved ahead of it: what it is given is a key of
+  `NETWORKS` and therefore of `_HWI_CHAIN`, and `tests/hwi_test.py`'s
+  comparison of the two is where a sixth btclib network with no chain is
+  red — rather than at a caller's first command, which is where the
+  removed branch put it.
+
+### `network.py` says what the test-network data files differ in
+
+- **The comment above `_network_names` said `signet.json` and
+  `testnet4.json` differ from `testnet.json` in the genesis block "and
+  in nothing else"** (closes #1632). They differ in `consensus` as well:
+  `Network.from_dict` reads that field off the file, and it names the
+  row `btclib.consensus` answers with, whose `enforce_bip94` is true on
+  testnet4 and false on testnet — so the clause denied a difference that
+  a consensus rule turns on. What the paragraph is for is that those
+  files share every version prefix, which is why the reverse lookups
+  below it answer `testnet` for every test network, and that is what it
+  says.
+
 ## v2026.8.29
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -114,6 +114,20 @@ full year, short month, short day (YYYY-M-D)
   consistent invoice: `Bip21.parse` now raises where it used to store
   the string unexamined, `others` having no validation to fail.
 
+- **`btclib.hwi` refuses a `network` that is not a string with
+  `BTClibTypeError`** (closes #1631). `HwiSigner(network=...)` and
+  `enumerate_devices(network=...)` put the name through
+  `btclib.network._validated_network_name`, which raises
+  `BTClibTypeError` — a `TypeError` — where `HwiSigner` raised
+  `BTClibValueError: unknown network: None`.
+
+  Act on it if you catch `BTClibValueError` around either call to handle
+  a name you have not checked is a `str`: catch `BTClibException`, which
+  is the base of both, or check the type yourself. A `str` no network
+  answers to is still a `BTClibValueError`, and the names accepted are
+  wider than before — `" TestNet4 "` resolves here as it does everywhere
+  else in the library.
+
 ### Worth knowing, though nothing raises
 
 - **`btclib.org` is no longer this project's site, and this repository

--- a/src/btclib/hwi.py
+++ b/src/btclib/hwi.py
@@ -40,6 +40,12 @@ selection is not optional: HWI's `--device-type` connects to "the first
 device of this type enumerated", so two devices of one vendor make which
 one signs a question of enumeration order.
 
+Both take a `network: str`, and both put it through
+`network._validated_network_name`, which normalizes it with the
+`strip().lower()` tolerance issue #216 decided to keep: a name the rest of
+the library resolves is resolved here, and one no network answers to is
+refused in the same words whichever of the two took it.
+
 The subprocess is bounded twice. `timeout` is how long a command may run
 -- a device waiting for a button press is the ordinary case, so the
 default is generous and a caller signing unattended should lower it --
@@ -120,7 +126,7 @@ from btclib.alias import Octets
 from btclib.bip32.der_path import DerPath, str_from_der_path
 from btclib.descriptors import Descriptor, add_checksum, at_index
 from btclib.exceptions import BTClibValueError, SignerError, SignerNotFoundError
-from btclib.network import NETWORKS
+from btclib.network import _validated_network_name
 from btclib.psbt.psbt import Psbt
 from btclib.psbt_signer import SignerCapabilities
 from btclib.utils import assert_type, bytes_from_octets, is_integer
@@ -451,6 +457,7 @@ def enumerate_devices(
     without being asked would make a test fixture look like a signer.
     """
     assert_type(emulators, bool, "emulators")
+    network = _validated_network_name(network)
     argv = [*_executable(executable), *_chain_args(network), "enumerate"]
     if emulators:
         argv.insert(-1, "--emulators")
@@ -463,15 +470,14 @@ def enumerate_devices(
 def _chain_args(network: str) -> list[str]:
     """Return HWI's `--chain` flag for a btclib network name.
 
-    `enumerate_devices` is the caller that can reach the refusal: it
-    takes a network name and names no device, where `HwiSigner` has
-    already refused a name `NETWORKS` does not hold.
+    The name is one `_validated_network_name` has already returned, so it
+    is a key of `NETWORKS` and of `_HWI_CHAIN` with it: refusing belongs
+    to the entry point that took the caller's spelling, and what is left
+    here is the translation. A `HwiSigner.network` assigned after
+    construction goes round that entry point, and reaches this lookup as
+    a `KeyError`.
     """
-    chain = _HWI_CHAIN.get(network)
-    if chain is None:
-        known = ", ".join(sorted(_HWI_CHAIN))
-        raise BTClibValueError(f"no HWI chain for network {network}: not in ({known})")
-    return ["--chain", chain]
+    return ["--chain", _HWI_CHAIN[network]]
 
 
 class HwiSigner:
@@ -509,11 +515,9 @@ class HwiSigner:
         emulators: bool = False,
         capabilities: SignerCapabilities = NO_CAPABILITIES,
     ) -> None:
-        if network not in NETWORKS:
-            raise BTClibValueError(f"unknown network: {network}")
         assert_type(emulators, bool, "emulators")
         self.executable = _executable(executable)
-        self.network = network
+        self.network = _validated_network_name(network)
         self.timeout = timeout
         self.max_output = max_output
         self.emulators = emulators

--- a/src/btclib/network.py
+++ b/src/btclib/network.py
@@ -364,9 +364,10 @@ datadir = Path(__file__).parent / "_data"
 # first network holding a version prefix is the one they answer with, so
 # testnet, the oldest, answers for the four networks that share its
 # prefixes, and appending a newer network cannot change any answer.
-# mainnet first, then the test networks oldest to newest -- signet.json
-# and testnet4.json differ from testnet.json in the genesis block, and in
-# nothing else.
+# mainnet first, then the test networks oldest to newest: signet.json and
+# testnet4.json share every version prefix with testnet.json, differing
+# from it in the consensus parameters and the genesis block, which no
+# prefix encodes.
 #
 # Annotated, where inference would widen it to tuple[str, ...]: this is
 # what ties NetworkName to the data it names, a sixth file loaded here

--- a/tests/hwi_test.py
+++ b/tests/hwi_test.py
@@ -44,7 +44,12 @@ import pytest
 from btclib.bip32 import fingerprint
 from btclib.bip32.bip32 import derive, xpub_from_xprv
 from btclib.descriptors import Descriptor, add_checksum, at_index, parse
-from btclib.exceptions import BTClibValueError, SignerError, SignerNotFoundError
+from btclib.exceptions import (
+    BTClibTypeError,
+    BTClibValueError,
+    SignerError,
+    SignerNotFoundError,
+)
 from btclib.hwi import (
     _HWI_CHAIN,
     DEFAULT_EXECUTABLE,
@@ -319,8 +324,8 @@ def test_the_network_is_the_chain_hwi_is_told(tmp_path: Path) -> None:
 
     Every network btclib has is a chain HWI is told, which is what a
     sixth network would have to be given here: the mapping stands between
-    `NETWORKS` and a command line, and a network missing from it reaches
-    a caller as a refusal after the signer was built.
+    `NETWORKS` and a command line, and the comparison below is where one
+    missing from it is red, rather than at a caller's first command.
     """
     for network, chain in (
         ("mainnet", "main"),
@@ -336,12 +341,49 @@ def test_the_network_is_the_chain_hwi_is_told(tmp_path: Path) -> None:
 
     assert set(_HWI_CHAIN) == set(NETWORKS)
 
-    with pytest.raises(BTClibValueError, match="unknown network"):
+
+def test_a_network_name_is_taken_as_the_rest_of_the_library_takes_one(
+    tmp_path: Path,
+) -> None:
+    """Both normalize the name they are given, and refuse alike.
+
+    The two entry points that accept a `network: str` put it through
+    `network._validated_network_name`, so the spellings issue #216
+    decided to keep reach the chain HWI is told, and the name a signer
+    stores is the one `network_from_name` would answer to.
+    """
+    hwi = stand_in(tmp_path, {})
+    device = HwiSigner(FINGERPRINT, executable=hwi, network=" TestNet4 ")
+    assert device.network == "testnet4"
+    device.xpub("m/0")
+    argv = last_argv(hwi)
+    assert argv[argv.index("--chain") + 1] == "test"
+
+    hwi = stand_in(tmp_path, {"enumerate": []})
+    enumerate_devices(executable=hwi, network=" TestNet4 ")
+    argv = last_argv(hwi)
+    assert argv[argv.index("--chain") + 1] == "test"
+
+    # one bad name, one message, whichever entry point took it
+    match = re.escape("unknown network: 'nosuchnet'")
+    with pytest.raises(BTClibValueError, match=match):
         HwiSigner(FINGERPRINT, executable=stand_in(tmp_path, {}), network="nosuchnet")
-    # `enumerate_devices` names no device and checks no name against
-    # `NETWORKS`, so it is where the chain lookup can be asked for one
-    with pytest.raises(BTClibValueError, match="no HWI chain for network nosuchnet"):
+    with pytest.raises(BTClibValueError, match=match):
         enumerate_devices(executable=stand_in(tmp_path, {}), network="nosuchnet")
+
+    # a name that is not a string is the type rule, which RELEASE_NOTES.md
+    # tells a caller to act on
+    with pytest.raises(BTClibTypeError, match="not a network name"):
+        HwiSigner(
+            FINGERPRINT,
+            executable=stand_in(tmp_path, {}),
+            network=None,  # type: ignore[arg-type]
+        )
+    with pytest.raises(BTClibTypeError, match="not a network name"):
+        enumerate_devices(
+            executable=stand_in(tmp_path, {}),
+            network=None,  # type: ignore[arg-type]
+        )
 
 
 def account_psbt(device: HwiSigner) -> tuple[Psbt, Descriptor]:


### PR DESCRIPTION
`btclib.hwi`'s two entry points that take a `network: str` now put it
through `network._validated_network_name`, as the rest of the library
does, so they accept the spellings the library accepts and refuse an
unknown one in the same message. And `network.py`'s comment above
`_network_names` says what the test-network data files actually differ
in.

closes #1631
closes #1632

## Design

`p2p.magic.magic_from_network` is the landed analogue and states the
shape whole: validate where the caller's spelling arrives, index the
table bare downstream, and assert the correspondence in a test rather
than writing a second guard. `magic.py` puts it in as many words — *"a
`try`/`except` around the call would be a second check of what the first
has already settled, which is the guard this tree does not write"*.

So validation sits at `HwiSigner.__init__` and `enumerate_devices`,
`_chain_args` becomes translation only, and `tests/hwi_test.py` carries
`assert set(_HWI_CHAIN) == set(NETWORKS)` as the property that keeps the
bare lookup safe. Removing `_chain_args`' own refusal also removes an
`if chain is None` branch that would otherwise be unreachable under a
100% coverage floor.

## Review

Cleared at `f48c5aae`; this is that sha rebased twice as `main` moved,
with the substance byte-identical — the non-changelog diff `cmp`s equal
against the cleared one, with a one-byte-mutated copy proving the
comparison discriminates.

Round 1 blocked on a false clause the branch had inherited from ISS
1631's own body: that the removed refusal *named HWI's chains rather
than btclib's networks*. It named btclib's networks —
`sorted(_HWI_CHAIN)` iterates the keys, and the message read
`not in (mainnet, regtest, signet, testnet, testnet4)`. Corrected in
both `CHANGELOG.md` and the commit body, since
`squash_merge_commit_message` lands the latter on `main`. The issue body
still carries it and is annotated so it is not inherited a third time.

Round 2 verified the `BTClibTypeError` pin is real — `not a network
name` occurs at exactly one `raise` in `src/`, so the `match` can be
satisfied by nothing but `_validated_network_name` — and that ISS 1632's
new comment says exactly what the files show: `consensus` and
`genesis_block` for signet and testnet4, with regtest additionally
differing in `hrp`, which is why the comment names only the two.

Gates on the shipped tip: `31660 passed, 30 skipped, 1 xfailed`,
coverage 100.00%, docs `-n -W` clean, `git status --porcelain` empty.
The one non-zero was `markdownlint-cli2` repairing the union seam the
rebase ate, and the repair is committed.

## Deliberately not fixed here

- [ISS 1641](https://github.com/btclib-org/btclib/issues/1641) —
  `Fetcher.__init__` and `Wallet.__init__` carry the byte-identical
  `if network not in NETWORKS` this removes from `hwi.py`. Two further
  public breaks, each wanting its own release-notes entry.
- [ISS 1639](https://github.com/btclib-org/btclib/issues/1639) —
  `network.py`'s prose counts the catalogue in nine places, each needing
  a judgement of its own. This branch adds no count and its new sentence
  names the two files individually rather than by number.

## Summary by Sourcery

Align HWI network handling with the library-wide network naming and validation behavior.

Bug Fixes:
- Make HWI network handling consistent with the rest of the library by accepting normalized network names and reporting unknown names uniformly.
- Raise the standard type error when HWI callers provide a non-string network value.

Enhancements:
- Clarify which network properties differ between the signet, testnet, and testnet4 data files.
- Simplify HWI chain mapping by centralizing network validation at its public entry points.

Documentation:
- Document the updated HWI network validation behavior and its exception-handling implications in the changelog and release notes.

Tests:
- Add coverage for normalized network names, consistent invalid-name errors, non-string network errors, and correspondence between supported networks and HWI chains.