### PR TITLE
`tests/p2p` compares its command set with Bitcoin Core's (closes #1598)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1688,6 +1688,37 @@ dereferences it, and `refs/tags/v1^{}` does the same from a checkout.
   below it answer `testnet` for every test network, and that is what it
   says.
 
+### `tests/p2p` compares its command set with Bitcoin Core's
+
+- **`tests/p2p/core_commands_test.py` holds Core's `NetMsgType` and
+  asserts the census both ways** (closes #1598): a message type Core
+  declares is one `src/btclib/p2p/` carries or one that module names
+  under the issue deciding otherwise, and a command this package carries
+  is Core's or is named there as one Core dropped -- BIP61's `reject`
+  being that. A command misspelled here round-trips as well as the real
+  one, the payload classes being the only thing that reads the constant,
+  so a comparison with Core is what a typo falls into.
+- **Core's set is transcribed rather than fetched**, pinned in
+  `tests/_data/README.md` to `src/protocol.h`, so
+  `.github/workflows/vendored-vectors.yml` reports the commit that moves
+  it. A test reading Core over the network would have a verdict that
+  depends on somebody else's uptime, which that file declines for every
+  vector it pins; a test reading a Core checkout behind an environment
+  switch measures nothing on the run that gates a merge; and vendoring
+  the header would put a file in the tree whose bytes answer for the
+  service flags and the inventory type codes as much as for a message
+  type.
+- **The walk over `Payload.__subclasses__` is `tests/p2p/__init__.py`'s**,
+  which is where `tests/__init__.py` says shared test code lives:
+  `payload_test.py` asks it whether every payload type is driven by a
+  value, and the census asks it for the commands.
+- **`tests/_data/README.md` puts its no-network stopping point on the
+  suite alone**: the file said no hook re-fetches an upstream and that it
+  goes stale silently, where `.github/workflows/vendored-vectors.yml`
+  runs weekly, opens an issue on a pin that has moved, and reaches no
+  entry whose `behind` reads other than 0. The pin above is checked by
+  that run, so the two sentences could not both stand.
+
 ## v2026.8.29
 
 ### Repository

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -1319,6 +1319,49 @@ refactor -- which
 [ISS 1334](https://github.com/btclib-org/btclib/issues/1334) tracks,
 including whether btclib's own musig derivation shares either defect.
 
+### Not vendored as a file: the message types of Core's `NetMsgType`
+
+```text
+repo    bitcoin/bitcoin
+path    src/protocol.h
+commit  fad753611b5c074f38120fd9c1a87e37cc44bf6a  2026-08-05
+pulled  2026-09-03
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **transcribed**. `tests/p2p/core_commands_test.py` holds every
+name that namespace declares, in the order it declares them, and asserts
+the census both ways: a message type Core has is one `src/btclib/p2p/`
+carries or one that module names under the issue deciding otherwise, and
+a command this package carries is Core's or is named there as one Core
+dropped.
+
+Not vendored as a file because there is no file: the names are string
+literals in a C++ header this project cannot compile, and the same header
+declares the service flags and the inventory type codes, so its bytes
+answer about far more than the message types. What the pin buys instead
+is the upstream re-check: a message type added to that namespace moves
+the commit, and the weekly run says so.
+
+`test/functional/test_framework/p2p.py`'s `MESSAGEMAP` is the rejected
+alternative, and it is the list a census here has been run against
+before. The two hold the same names, compared on 2026-09-03, and the
+header is what decides: `src/net_processing.cpp` reads the protocol off
+`NetMsgType`, where the map is the Python functional test framework's own
+dispatch and reads nothing.
+
+Not carried, and named as such: `merkleblock`, `filterload`, `filteradd`
+and `filterclear`, which are BIP37's bloom set and the answer a loaded
+filter draws.
+[ISS 1120](https://github.com/btclib-org/btclib/issues/1120) is where
+whether they belong here is argued, and the transcription points at it
+rather than restating it.
+
+Carried and not Core's: BIP61's `reject`, of which Core removed both
+directions in `bitcoin/bitcoin#15437`. `src/btclib/p2p/reject.py` says
+why a codec for it is here anyway, and the pin is what would make Core
+declaring the name again a red run rather than a stale sentence.
+
 ## bitcoin-core/HWI
 
 Nothing is vendored from HWI and nothing is imported from it: `btclib.hwi`
@@ -2341,10 +2384,15 @@ Composed 2026-08-02.
   upstream: the cases are btclib's, so the pin says where the psbts were
   read and nothing about the cases built on them. A refresh of it is a
   contradiction in terms.
-- **Nothing here is enforced.** No hook re-fetches an upstream and no
-  test compares a blob, so this file goes stale silently. That is a
-  deliberate stopping point: a network call in the test suite would trade
-  a documented drift for a flaky one.
+- **Nothing here is enforced by the suite.** No hook re-fetches an
+  upstream and no test compares a blob, and that is a deliberate stopping
+  point: a network call in the test suite would trade a documented drift
+  for a flaky one. Where a pin goes stale is
+  `.github/workflows/vendored-vectors.yml`'s to say instead, weekly and
+  outside the suite, and it opens an issue rather than refreshing
+  anything -- which vector to take next is a decision. What it does not
+  reach is an entry whose `behind` already reads other than 0, a gap
+  somebody has decided not to close being one it would report every week.
 
 ## Summary
 

--- a/tests/p2p/__init__.py
+++ b/tests/p2p/__init__.py
@@ -2,4 +2,38 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Non-regression tests for btclib.p2p."""
+"""Non-regression tests for btclib.p2p, and the walk two of them share."""
+
+from typing import Any
+
+from btclib import p2p
+
+
+def payload_types() -> set[type[Any]]:
+    """Return every concrete payload type of the library.
+
+    The package is imported rather than the module: `Payload` fills
+    `__subclasses__` as each payload module is read, and
+    `btclib/p2p/__init__.py` is what reads them all.
+
+    Two things are skipped, and each for its own reason: a name starting
+    with an underscore is a shared body rather than a message type --
+    `keepalive._NoncePayload`, `inventory._InventoryPayload` and
+    `inventory._LocatorPayload` are those -- and a class defined outside
+    `btclib` is another test's, `__subclasses__` being a live registry
+    that whatever ran before this leaves its own subclasses in.
+
+    Here rather than in the module that first needed it, which is what
+    `tests/__init__.py` says shared test code does: two modules ask this
+    walk different questions -- whether every payload type is driven by a
+    value, and whether every command is one Bitcoin Core declares -- and
+    neither owns it.
+    """
+    found: set[type[Any]] = set()
+    pending = list(p2p.Payload.__subclasses__())
+    while pending:
+        cls = pending.pop()
+        pending.extend(cls.__subclasses__())
+        if not cls.__name__.startswith("_") and cls.__module__.startswith("btclib"):
+            found.add(cls)
+    return found

--- a/tests/p2p/core_commands_test.py
+++ b/tests/p2p/core_commands_test.py
@@ -1,0 +1,201 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Every message type Core declares is carried here, or named as not carried.
+
+`src/btclib/p2p/` publishes one `Payload` subclass per command and holds
+no table of them, which is `btclib/p2p/payload.py`'s decision (issue
+#1098). So this package's command set is what its classes answer, Bitcoin
+Core's is what `src/protocol.h` declares, and the two are separately
+valid: only reading them together says they have drifted. A message type
+Core adds is one nothing here is red about, and a command misspelled here
+round-trips as well as the real thing -- which is how btclib_node came to
+send `sendcmpt` to the whole network.
+
+Core's set is transcribed below rather than read from a checkout of it.
+A test that goes and fetches its own input has a verdict that depends on
+somebody else's uptime, which is the trade `tests/_data/README.md`
+declines for every vector it pins: "a network call in the test suite
+would trade a documented drift for a flaky one". What the transcription
+catches is this package's set changing; Core changing its own is what the
+pin is for, and the two together are the whole of the census.
+
+That division is `tests/hwi_test.py`'s, and for the same reason. What is
+pinned there is an interface rather than a file, upstream publishing no
+file to compare bytes with, and `.github/workflows/vendored-vectors.yml`
+re-checks the pin weekly and opens an issue where upstream's tip has
+moved past it. `src/protocol.h` is that shape too: the message types are
+declarations in C++ source, so a copy of the file would be a copy of a
+header this project cannot compile, and the pin buys the re-check
+instead.
+
+Two alternatives were open, and each is refused for its own reason. A
+test reading a Core checkout behind an environment switch -- which is
+[ISS 198](https://github.com/btclib-org/btclib/issues/198)'s eventual
+ambition -- measures nothing on the run that gates a merge, which is the
+run this issue is about. Vendoring `src/protocol.h` under
+`tests/p2p/_data/` puts a file in the tree whose bytes move for reasons
+that are not the message types, so the refresh it asks for would be a
+chore answering a question nobody asked.
+
+What this cannot do is notice a message type Core added since the pin.
+Nothing offline can: the weekly re-check is what says the pin has moved,
+the refresh of the tuple below is what makes the new name visible, and
+`test_every_command_core_declares_is_carried_or_named` is what then holds
+somebody to a decision about it rather than to silence.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tests.p2p import payload_types
+
+_PACKAGE = Path(__file__).parents[2] / "src" / "btclib" / "p2p"
+
+# a payload class's own command constant, which `btclib/p2p/payload.py`
+# puts on the class so that the name serialized and the name matched on
+# are one string
+_COMMAND = re.compile(r'^    command = "([a-z0-9]+)"$', re.MULTILINE)
+
+# Bitcoin Core's `NetMsgType`, transcribed from `src/protocol.h` in the
+# order it declares them; `tests/_data/README.md` pins the revision, and
+# a refresh of it is a diff over this tuple.
+_CORE_COMMANDS = (
+    "version",
+    "verack",
+    "addr",
+    "addrv2",
+    "sendaddrv2",
+    "inv",
+    "getdata",
+    "merkleblock",
+    "getblocks",
+    "getheaders",
+    "tx",
+    "headers",
+    "block",
+    "getaddr",
+    "mempool",
+    "ping",
+    "pong",
+    "notfound",
+    "filterload",
+    "filteradd",
+    "filterclear",
+    "sendheaders",
+    "feefilter",
+    "sendcmpct",
+    "cmpctblock",
+    "getblocktxn",
+    "blocktxn",
+    "getcfilters",
+    "cfilter",
+    "getcfheaders",
+    "cfheaders",
+    "getcfcheckpt",
+    "cfcheckpt",
+    "wtxidrelay",
+    "sendtxrcncl",
+    "feature",
+)
+
+# what Core declares and this package does not carry, under the issue
+# holding the decision. BIP37's bloom set and the `merkleblock` a loaded
+# filter is answered with are one question -- whether a deprecated
+# privacy leak belongs in a library whose defence is that parsing is not
+# endorsing -- and it is argued in the issue rather than here.
+_NOT_CARRIED = {
+    "merkleblock": 1120,
+    "filterload": 1120,
+    "filteradd": 1120,
+    "filterclear": 1120,
+}
+
+# what this package carries and Core's `NetMsgType` does not declare.
+# `src/btclib/p2p/reject.py` is where the reason is: Core removed both
+# directions of BIP61's `reject` in bitcoin/bitcoin#15437, and an
+# implementation that has not followed it off the wire sends one anyway,
+# so there is a message to parse under a name Core no longer names.
+_NOT_CORE_S = ("reject",)
+
+_DECLARED = frozenset(
+    command
+    for path in sorted(_PACKAGE.glob("*.py"))
+    for command in _COMMAND.findall(path.read_text(encoding="utf-8"))
+)
+_PUBLISHED = frozenset(cls.command for cls in payload_types())
+
+
+def test_both_sides_of_the_census_were_read() -> None:
+    """A comparison over a side that came up empty is true of nothing.
+
+    This package's set is read twice, and the two readings fail
+    differently: the walk over `Payload.__subclasses__` answers short
+    where a payload module is not reached by `btclib/p2p/__init__.py`, so
+    a caller importing the package could not name the type either, and
+    the regex over the source answers short where the constant is spelled
+    some other way. Neither can be believed on its own, and an empty one
+    is what makes every comparison below pass.
+    """
+    assert _PUBLISHED == _DECLARED, (
+        f"the payload types the package publishes are {sorted(_PUBLISHED)},"
+        f" where its source declares {sorted(_DECLARED)}"
+    )
+    assert _PUBLISHED, "no payload type was found at all"
+    assert len(set(_CORE_COMMANDS)) == len(_CORE_COMMANDS), (
+        f"a message type is transcribed twice: {sorted(_CORE_COMMANDS)}"
+    )
+
+
+def test_every_name_left_out_is_a_name_the_other_side_has() -> None:
+    """An exemption outliving its own subject is how this rots.
+
+    A message type Core drops, or one this package starts carrying, would
+    otherwise leave a line below excusing a difference that is not there
+    any more -- and an exemption nothing holds to a subject excuses
+    whatever it is next pointed at.
+    """
+    assert set(_NOT_CARRIED) <= set(_CORE_COMMANDS), (
+        f"named as not carried, and not Core's: "
+        f"{sorted(set(_NOT_CARRIED) - set(_CORE_COMMANDS))}"
+    )
+    assert not set(_NOT_CORE_S) & set(_CORE_COMMANDS), (
+        f"named as Core's own absence, and declared by Core: "
+        f"{sorted(set(_NOT_CORE_S) & set(_CORE_COMMANDS))}"
+    )
+    assert not set(_NOT_CARRIED) & _PUBLISHED, (
+        f"named as not carried, and carried: {sorted(set(_NOT_CARRIED) & _PUBLISHED)}"
+    )
+
+
+def test_every_command_core_declares_is_carried_or_named() -> None:
+    """The census: a message type Core has is answered for, either way.
+
+    This is what the issue bodies used to hold. A name arriving in the
+    transcription above and in neither this package nor `_NOT_CARRIED` is
+    red here, so the decision to leave it out is written down rather than
+    taken by nobody.
+    """
+    unaccounted = sorted(set(_CORE_COMMANDS) - _PUBLISHED - set(_NOT_CARRIED))
+    assert not unaccounted, (
+        f"Core declares {unaccounted}, which this package neither carries"
+        " nor names in _NOT_CARRIED with the issue that decided it"
+    )
+
+
+def test_every_command_this_package_carries_is_core_s_or_named() -> None:
+    """The other direction, which is the one a misspelling falls into.
+
+    A command Core does not declare is either a name it dropped -- BIP61's
+    `reject` is that, and says so -- or a typo in a string constant no
+    round trip can see, this package's classes being the only thing that
+    reads it.
+    """
+    unaccounted = sorted(_PUBLISHED - set(_CORE_COMMANDS) - set(_NOT_CORE_S))
+    assert not unaccounted, (
+        f"this package carries {unaccounted}, which Core's NetMsgType does"
+        " not declare and _NOT_CORE_S does not name"
+    )

--- a/tests/p2p/payload_test.py
+++ b/tests/p2p/payload_test.py
@@ -70,6 +70,7 @@ from btclib.p2p import (
 )
 from btclib.p2p.message import Message as MessageClass
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
+from tests.p2p import payload_types
 
 _MAINNET = bytes.fromhex("f9beb4d9")
 
@@ -123,29 +124,9 @@ _PAYLOADS: tuple[Payload, ...] = (
 _IDS = tuple(type(payload).__name__ for payload in _PAYLOADS)
 
 
-def _payload_subclasses() -> set[type[Any]]:
-    """Return every concrete payload type of the library.
-
-    Two things are skipped, and each for its own reason: a name starting
-    with an underscore is a shared body rather than a message type --
-    `keepalive._NoncePayload`, `inventory._InventoryPayload` and
-    `inventory._LocatorPayload` are those -- and a class defined outside
-    `btclib` is another test's, `__subclasses__` being a live registry
-    that whatever ran before this leaves its own subclasses in.
-    """
-    found: set[type[Any]] = set()
-    pending = list(Payload.__subclasses__())
-    while pending:
-        cls = pending.pop()
-        pending.extend(cls.__subclasses__())
-        if not cls.__name__.startswith("_") and cls.__module__.startswith("btclib"):
-            found.add(cls)
-    return found
-
-
 def test_every_payload_type_is_driven_here() -> None:
     """The inventory is a promise only if omission is what fails."""
-    assert {type(payload) for payload in _PAYLOADS} == _payload_subclasses()
+    assert {type(payload) for payload in _PAYLOADS} == payload_types()
 
 
 @pytest.mark.parametrize("payload", _PAYLOADS, ids=_IDS)


### PR DESCRIPTION
`tests/p2p` now compares its command set with Bitcoin Core's, in both
directions, against a pinned interface.

closes #1598

## Two-directional, because the issue's own measurement is false

ISS 1598 asserts `comm -13 core btclib` is empty. It is not: btclib
carries `reject`, landed as `17223293` the same day the issue was
written. So a one-directional census would have been green on a premise
the tree had already broken, and the census runs both ways.

## The pattern is the tree's, not a new one

Pin an *interface* in `tests/_data/README.md`, transcribe it into a
test, let `.github/workflows/vendored-vectors.yml` re-check it weekly —
the same shape as the HWI CLI pin already landed there. The entry is
checkable rather than skipped: `check_vendored_vectors.py`'s own
`_entries_at_tip` returns it, and the skipped count is unchanged from
the base.

## Review

Cleared at `e22cfb50`. This is that sha rebased onto `c2eadef2`, with
the substance unchanged — the non-changelog diffs normalise to
byte-identical once the `index` line and one hunk offset are accounted
for, both moved because `main` added an unrelated entry above in
`tests/_data/README.md`.

The review ran ten deliberate mutations with a stdlib-only loader,
stating plainly that this is not the suite and does not stand in for it.
Emptying either side of the census makes the vacuity guard fail;
duplicating a transcribed name makes it fail; dropping one makes a
sibling test fail. The transcription was checked line for line against
`src/protocol.h` at the pinned Core commit — 36 declarations, 36
entries, identical in content and order — with a control confirming the
extraction pattern was not silently narrow.

Gates on the rebased tip: `31664 passed, 30 skipped, 1 xfailed`,
coverage 100.00%, docs `-n -W` clean over 150 pages from a **cold**
build, and the second docs step exiting 1 as required. The one non-zero
was `markdownlint-cli2` restoring the blank line the union driver ate at
the changelog seam; its whole fixup was that one line, and the repair is
committed.

## A note on the second docs step, for anyone comparing runs

`c44c9b20` moved that grep to carry `--include='*.html'`. Both spellings
were run on the same cold build and they do **not** agree: the
documented one exits 1, the bare one exits 0 on
`docs/build/html/.doctrees/changelog_link.doctree` — sphinx's binary
pickles hold the source text unescaped, where the built HTML renders it
escaped. The hit traces to landed changelog prose quoting the pattern,
not to this branch, whose own block has none.

## Deliberately not fixed here

[ISS 1636](https://github.com/btclib-org/btclib/issues/1636) —
`tests/_data/README.md`'s *Reading an entry* section describes a shape
most of its entries no longer have. Already wrong at the base for
entries that predate this branch; this one adds another instance of an
established pattern rather than promoting a false sentence into
load-bearing.

## Summary by Sourcery

Add a bidirectional, pinned-interface census to keep btclib's P2P command set aligned with Bitcoin Core while documenting intentional differences.

New Features:
- Add bidirectional tests comparing btclib's P2P command set with Bitcoin Core's pinned `NetMsgType` interface.

Enhancements:
- Centralize discovery of concrete P2P payload types for reuse across tests.
- Document the pinned Bitcoin Core protocol interface and its intentional command-set exceptions.

CI:
- Enable weekly monitoring of the pinned Bitcoin Core interface through the vendored-vector workflow.

Documentation:
- Update the changelog and vendored-interface documentation with the P2P command census and maintenance policy.

Tests:
- Add safeguards against empty or duplicated command inventories and stale command exemptions.
- Reuse the shared payload-type census in payload coverage tests.