### PR TITLE
`tests/fuzz_test.py`'s inventory is a walk's promise (closes #1629)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1744,6 +1744,38 @@ dereferences it, and `refs/tags/v1^{}` does the same from a checkout.
   the reason to derive with `testnet` — that they agree on every version
   prefix, not only on the one looked up — is said once.
 
+### `tests/fuzz_test.py`'s parser inventory is a walk's promise
+
+- **`Reject.parse` is driven by the hypothesis layer, in
+  `BINARY_PARSERS` and with a mutation sample of its own** (closes
+  #1629). BIP61's payload is two var_bytes strings around a code octet
+  and then a hash carrying no length of its own, either exactly
+  thirty-two octets or absent, so `_mutations`' truncation and its
+  extension both land in the gap between the two. `fuzz/fuzz_reject.py`
+  already generates input nobody wrote down — it is `atheris.Fuzz()`, an
+  hour of libFuzzer on `fuzz.yml`'s weekly schedule — and
+  `tests/fuzz_corpus_test.py` replays, on every commit, seeds somebody
+  wrote down. What neither is is a per-commit run over a declared
+  strategy, which is what `tests/fuzz_test.py`'s docstring means by
+  keeping it green rather than having written it once.
+- **`test_every_class_that_parses_is_driven_here` and
+  `test_every_module_function_that_parses_is_driven_here` are what make
+  the dicts a promise rather than a list**: a parser added to the
+  package and given no line is red here instead of held to nothing. The
+  class walk is `tests/__init__.py`'s `public_classes_with`, which
+  `parse_contract_test.py` and `serialization_boundary_test.py` already
+  hold these same classes to their own contracts through; the module
+  functions get a walk of their own, `var_int.parse` and `bech32.decode`
+  being invisible to one over classes. Each asserts the walk found
+  something before comparing, an empty walk being what a containment
+  assertion passes.
+- **`BasicBlockFilter.parse` and `BorromeanSig.parse` join
+  `BINARY_PARSERS`, and `Bip21.parse` joins `TEXT_PARSERS`**, which is
+  what the walk answered with. `parse_contract_test.py` names each of
+  them an exclusion, for reasons that are its own contract's -- where
+  the octets of an object end -- and say nothing about the exception a
+  refusal is raised with, which is what this file asks.
+
 ## v2026.8.29
 
 ### Repository

--- a/tests/fuzz_test.py
+++ b/tests/fuzz_test.py
@@ -19,7 +19,9 @@ green rather than for having written it once.
 """
 
 import contextlib
+import importlib
 import json
+import pkgutil
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -28,14 +30,18 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
+import btclib
 from btclib import b32, b58, base58, bech32, bip322, descriptors, var_bytes, var_int
+from btclib.bip21 import Bip21
 from btclib.bip32.bip32 import BIP32KeyData
 from btclib.bip32.key_origin import BIP32KeyOrigin
 from btclib.block.block import Block
+from btclib.block.block_filter import BasicBlockFilter
 from btclib.block.block_header import BlockHeader
 from btclib.curves.sec_point import point_from_octets
 from btclib.descriptors import miniscript
 from btclib.ecc import bms, dsa, ecies, ssa
+from btclib.ecc.borromean import BorromeanSig
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
 from btclib.p2p.address import Addr, NetworkAddress, TimestampedNetworkAddress
 from btclib.p2p.addrv2 import AddrV2, NetworkAddressV2, SendAddrV2
@@ -78,6 +84,7 @@ from btclib.p2p.negotiation import (
     SendTxRcncl,
     WtxidRelay,
 )
+from btclib.p2p.reject import Reject, RejectCode
 from btclib.psbt import psbt_utils
 from btclib.psbt.psbt import Psbt
 from btclib.psbt.psbt_in import PsbtIn
@@ -90,6 +97,7 @@ from btclib.tx.out_point import OutPoint
 from btclib.tx.tx import Tx
 from btclib.tx.tx_in import TxIn
 from btclib.tx.tx_out import TxOut
+from tests import public_classes_with
 
 # What a btclib parser is allowed to raise. Anything else -- an
 # IndexError off a short slice, an OverflowError off an unchecked size,
@@ -118,6 +126,11 @@ BINARY_PARSERS: dict[str, Callable[[bytes], Any]] = {
     "Tx.parse": Tx.parse,
     "BlockHeader.parse": BlockHeader.parse,
     "Block.parse": Block.parse,
+    # `block_hash` left at its default, which the caller supplies and
+    # the serialization does not carry: what the default reaches is the
+    # count read under MAX_FILTER_ELEMENT_COUNT and the block hash width
+    # refusal, which stands in front of the Golomb decoding
+    "BasicBlockFilter.parse": BasicBlockFilter.parse,
     "Psbt.parse": Psbt.parse,
     "PsbtIn.parse": PsbtIn.parse,
     "PsbtOut.parse": PsbtOut.parse,
@@ -169,11 +182,20 @@ BINARY_PARSERS: dict[str, Callable[[bytes], Any]] = {
     # wrapper adding no octets of its own to flip
     "TxPayload.parse": TxPayload.parse,
     "BlockPayload.parse": BlockPayload.parse,
+    # BIP61's payload: two var_bytes strings around a code octet, and a
+    # trailing hash that is either exactly thirty-two octets or absent
+    "Reject.parse": Reject.parse,
     "BIP32KeyData.parse": BIP32KeyData.parse,
     "BIP32KeyOrigin.parse": BIP32KeyOrigin.parse,
     "dsa.Sig.parse": dsa.Sig.parse,
     "ssa.Sig.parse": ssa.Sig.parse,
     "bms.Sig.parse": bms.Sig.parse,
+    # `rsizes` left at its default, which is the ring structure a
+    # verifier supplies and the wire format does not carry: what the
+    # default reaches is the digest read, the trailing-octet refusal, and
+    # -- for the input of exactly thirty-two octets that passes both --
+    # `assert_valid`'s own "no rings"
+    "BorromeanSig.parse": BorromeanSig.parse,
     # no bip322.Sig.parse: that class has none, its three payloads being
     # three unrelated serializations told apart by the prefix of the text
     # form alone, so the text entry point below is where it is read
@@ -196,6 +218,7 @@ TEXT_PARSERS: dict[str, Callable[[str], Any]] = {
     "bech32.decode": bech32.decode,
     "b32.witness_from_address": b32.witness_from_address,
     "b58.h160_from_address": b58.h160_from_address,
+    "Bip21.parse": Bip21.parse,
     "BIP32KeyData.b58decode": BIP32KeyData.b58decode,
     "bms.Sig.b64decode": bms.Sig.b64decode,
     "bip322.Sig.b64decode": bip322.Sig.b64decode,
@@ -205,6 +228,85 @@ TEXT_PARSERS: dict[str, Callable[[str], Any]] = {
     "descriptors.parse": descriptors.parse,
     "miniscript.parse": miniscript.parse,
 }
+
+
+def _classes_driven_here() -> set[str]:
+    """Every class the two dicts above drive through its own `parse`.
+
+    A bound classmethod carries in `__self__` the class it was read off
+    rather than the one that defines the method, which is what the entry
+    names: `GetCFilters` inherits `_FilterRangeRequest.parse`, and
+    `__qualname__` answers with a private base the walk below never
+    returns. A `b58decode` or a `b64decode` entry is not counted, its
+    class being driven here through a decoder and not through `parse`.
+    """
+    driven = set()
+    for entry_point in (*BINARY_PARSERS.values(), *TEXT_PARSERS.values()):
+        cls = getattr(entry_point, "__self__", None)
+        if isinstance(cls, type) and entry_point.__name__ == "parse":
+            driven.add(f"{cls.__module__}.{cls.__qualname__}")
+    return driven
+
+
+def _functions_driven_here() -> set[str]:
+    """Every module function the two dicts above drive, module included."""
+    return {
+        f"{entry_point.__module__}.{entry_point.__name__}"
+        for entry_point in (*BINARY_PARSERS.values(), *TEXT_PARSERS.values())
+        if getattr(entry_point, "__self__", None) is None
+    }
+
+
+def _module_names() -> list[str]:
+    """Every module of the installed btclib, the top-level one included."""
+    return [
+        "btclib",
+        *(module.name for module in pkgutil.walk_packages(btclib.__path__, "btclib.")),
+    ]
+
+
+def test_every_class_that_parses_is_driven_here() -> None:
+    """The inventory is a promise only if omission is what fails.
+
+    A class added to the library and given no line above is held to
+    nothing here: the tests keep passing on the entry points they were
+    given, and the new parser answers hostile octets however it likes.
+    The walk is `tests/__init__.py`'s, `parse_contract_test.py` and
+    `serialization_boundary_test.py` holding these same classes to their
+    own contracts through it.
+    """
+    found = public_classes_with("parse")
+    # a walk returning nothing is a defect in the walk and not in the
+    # inventory, and the equality alone answers it with a mismatch of
+    # every name: this is what says which of the two a red run is
+    assert found
+    assert found == _classes_driven_here()
+
+
+def test_every_module_function_that_parses_is_driven_here() -> None:
+    """And the same promise where the entry point is a module function.
+
+    The walk above finds classes, so `var_int.parse` and `bech32.decode`
+    would be invisible to it. What is asserted is containment and not
+    equality: the dicts drive entry points these two names do not reach
+    -- `psbt_utils.deserialize_map`, `point_from_octets` -- and a family
+    wide enough to find those is a census this file does not keep.
+    """
+    found = set()
+    for module_name in _module_names():
+        module = importlib.import_module(module_name)
+        for name in ("parse", "decode"):
+            function = getattr(module, name, None)
+            if not callable(function) or isinstance(function, type):
+                continue
+            if getattr(function, "__module__", "") != module_name:
+                continue
+            found.add(f"{module_name}.{name}")
+
+    # the containment below is what an empty walk passes, the class walk
+    # above having an equality to fail instead
+    assert found
+    assert found - _functions_driven_here() == set()
 
 
 def _assert_contract(parse: Callable[[Any], Any], data: Any) -> None:
@@ -340,6 +442,13 @@ CMPCTBLOCK_BIN = CmpctBlock(
     [PrefilledTransaction(1, Block.parse(BLOCK_BIN).transactions[0])],
 ).serialize()
 GETBLOCKTXN_BIN = GetBlockTxn(BLOCK_HEADER_BIN[4:36][::-1], [0, 2, 5]).serialize()
+# BIP61's payload, whose trailing hash carries no length of its own and
+# is either exactly thirty-two octets or absent: a truncation and an
+# extension both land in the gap between the two, and the two var_bytes
+# lengths in front of it are what a flipped octet reaches instead
+REJECT_BIN = Reject(
+    "tx", RejectCode.insufficientfee, "min relay fee not met", bytes(range(32))
+).serialize()
 
 
 def _mutations(sample: bytes) -> st.SearchStrategy[bytes]:
@@ -392,6 +501,7 @@ MUTATED_PARSERS: dict[str, tuple[Callable[[bytes], Any], bytes]] = {
     # the differences a `getblocktxn` is a list of
     "CmpctBlock.parse": (CmpctBlock.parse, CMPCTBLOCK_BIN),
     "GetBlockTxn.parse": (GetBlockTxn.parse, GETBLOCKTXN_BIN),
+    "Reject.parse": (Reject.parse, REJECT_BIN),
     "Tx.parse": (Tx.parse, TX_BIN),
     "BlockHeader.parse": (BlockHeader.parse, BLOCK_HEADER_BIN),
     "Block.parse": (Block.parse, BLOCK_BIN),


### PR DESCRIPTION
`tests/fuzz_test.py`'s `BINARY_PARSERS` was a hand-written dict, so a
parser added to the package joined it only where somebody remembered the
line. `Reject.parse` was one that nobody had. Two walks now make the
dicts a promise rather than a list — one over the public classes, one
over the module functions the class walk cannot reach — and each asserts
the walk found something before comparing, an empty walk being what a
containment assertion passes.

`BasicBlockFilter.parse`, `BorromeanSig.parse` and `Bip21.parse` are what
the walk answered with, not work beside the issue.

closes #1629

## Review

Four rounds at fresh context, all with the same reviewer so the open
threads travelled with it. Three blocking findings, and **two of the
three were in prose I wrote while repairing the previous one** rather
than in the coder's work:

1. A comment claimed the default `block_hash` reaches the Golomb
   decoding. It does not — `assert_valid`'s width refusal stands in
   front of it. Re-derived by the reviewer over 91,793 inputs with
   spies on `_decode`, `_BitReader.__init__` and `_golomb_decode`, all
   three reading zero, and a positive control in the same run.
2. The `BorromeanSig` comment named two of three terminal refusals. The
   missing one, `assert_valid`'s `no rings`, is what answers the single
   input class that passes the other two — exactly thirty-two octets.
   Measured over 20,041 inputs.
3. The changelog sentence justifying the change said `fuzz/fuzz_reject.py`
   does not draw input nobody wrote down. It is `atheris.Fuzz()`, so it
   does. My repair then said the corpus test "replays the seeds it
   recorded" — also false, and `fuzz.yml` says in as many words that a
   recorded input must not go to `fuzz/corpus/`. `CHANGELOG.md` is
   `merge=union` and append-only, so that sentence cannot be corrected
   after it lands.

The union driver ate the blank line above the entry's heading when the
branch was rebased onto the `network.py` landing. `git merge-tree`
exited 0 and said nothing; the damage was found by sweeping every `###`
in the open section for a blank line above it, with a control that
deletes one in a copy and confirms the sweep reports it. Repaired by
hand rather than left to `markdownlint-cli2 --fix`, so it stays visible.

Collateral filed rather than absorbed:
[ISS 1649](https://github.com/btclib-org/btclib/issues/1649), for the
five sites in `tests/` that each rebuild the list of btclib module names.

## Summary by Sourcery

Make fuzz-test parser inventories self-validating and cover the previously omitted parser entry points.

New Features:
- Add automatic inventory checks that ensure all public parser classes and module-level parsing functions are covered by the fuzz-test parser maps.
- Expand fuzz coverage to include Reject, BasicBlockFilter, BorromeanSig, and Bip21 parsing.

Bug Fixes:
- Prevent newly added parsers from being silently omitted from fuzz testing.

Enhancements:
- Use package walks to validate parser coverage and add a dedicated Reject mutation sample.

Documentation:
- Document the parser inventory coverage and newly included parser cases in the changelog.

Tests:
- Add coverage tests that compare discovered parser classes and functions against the fuzz-test inventories.