### PR TITLE
REPOSITORY.md's check-run count puts the placeholder in its own fence (issue #1613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1776,6 +1776,28 @@ dereferences it, and `refs/tags/v1^{}` does the same from a checkout.
   the octets of an object end -- and say nothing about the exception a
   refusal is raised with, which is what this file asks.
 
+### `REPOSITORY.md`'s check-run count puts the placeholder in its own fence
+
+- **The `gh api` call no longer sits under a line that ends in a
+  placeholder** (issue #1613). The assignment above it is a parse error
+  before it is a command, and a shell that discards a parse error reads
+  the next line as a fresh command, so a paste made before the pull
+  request was filled in asked the API for
+  `repos/btclib-org/btclib/commits//check-runs`. The placeholder's line
+  stands in a fence of its own now, with prose between the two fences
+  saying why the first closes early.
+- **The fence below reads the head as `${head:?}`**, the shell's
+  must-be-set form, so a paste of that fence alone fails naming the
+  variable rather than reaching the forge with no sha.
+- **Measured by feeding each fence, unfilled, to an interactive `zsh` and
+  `bash` and to `zsh`, `bash` and `sh` reading a file**, every cell in a
+  fresh directory of its own bound with `env -C`, seeded with a file
+  named for the placeholder's first word, with stubs ahead of the real
+  `PATH` logging their argv and their `$PWD`. A control fence whose
+  redirection names an absolute path writes in every cell, which is what
+  says the harness can write at all. No fence invokes a stub or gains a
+  file now.
+
 ## v2026.8.29
 
 ### Repository

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -262,7 +262,19 @@ because it is not one number.
 
 ```shell
 head=$(gh pr view --json headRefOid --jq .headRefOid <an open pull request>)
-gh api "repos/btclib-org/btclib/commits/$head/check-runs" --jq '.total_count'
+```
+
+The placeholder's line stands in a fence of its own, which is section 9
+of the organization standard's rule: a parse error guards only the line
+it sits on, so an interactive shell discards the unfilled line and reads
+what stands below it as a fresh command. The fence below reads the head
+as `${head:?}`, the shell's must-be-set form, so a paste of it alone
+fails naming the variable rather than asking the API for the check runs
+of a commit with no sha.
+
+```shell
+gh api "repos/btclib-org/btclib/commits/${head:?}/check-runs" \
+  --jq '.total_count'
 # 14 and 15, the two open when this was written
 ```
 


### PR DESCRIPTION
`REPOSITORY.md:264` put a bare placeholder where a word follows it:

```
head=$(gh pr view --json headRefOid --jq .headRefOid <an open pull request>)
gh api "repos/btclib-org/btclib/commits/$head/check-runs" --jq '.total_count'
```

The placeholder ends the command but not the line — the `)` of the
command substitution follows it — so a paste made before the placeholder
is filled in gets a parse error on line 1, an interactive shell discards
that line, and line 2 runs against an unset `head`, reaching
`repos/btclib-org/btclib/commits//check-runs`.

Section 9 of the organization standard names the remedy where a
command's own shape refuses the end position: the placeholder's line is a
block of its own. The fence is split, prose between the two says why the
first closes early, and the second reads the head as `${head:?}`, so a
paste of that fence alone fails naming the variable rather than reaching
the forge with no sha.

This is one half of a bundle, so it cites `(issue #1613)` rather than a
closing keyword. Three of the four lines that issue tabulates were
answered on `main` by `12f8b17a`; the three `RELEASING.md` lines of its
*third form* — `<version>` inside a path, at `:632`, `:641`, `:643` and
`:645` — are live, and are answered by
`iss-745-releasing-splits-its-placeholder-fences`, which a peer session
holds and which will carry the closing keyword as the half that lands
second.

## Review

Three rounds at fresh context, same reviewer throughout. Two blocking
findings, both against what the branch claimed rather than what it does:

1. The rebase left the changelog block **second to last** in the open
   section, where the standard puts a new entry at the end, immediately
   above the latest released version's heading. `CHANGELOG.md` is
   append-only, so it would have landed as a permanent misplacement.
2. The branch claimed the issue outright. The reviewer refuted that from
   the peer's own commit body — "which is part of btclib#1613" — and
   from the four executable lines still live on `main`. The citation is
   now the bundle form.

The mechanism was measured rather than read: both fences extracted from
the blob and fed unfilled to five shells, each cell a fresh directory
with stubs logging their argv, a control fence that writes in all five,
and `${head:?}` checked in both directions — unset it never reaches `gh`,
filled it produces the right URL.

The union driver ate the blank line above the entry's heading on **both**
rebases this branch went through, each time with `git merge-tree` exiting
0 in silence. Repaired by hand both times so it stays visible. The
assertion that stands is not a boundary check but a deletion test:
removing exactly the branch's block from the committed file reproduces
the base blob byte for byte, with a control deleting one line fewer that
does report a difference.

## Summary by Sourcery

Separate the pull-request head placeholder from the check-run command and fail safely when the head reference is missing.

Bug Fixes:
- Prevent the repository documentation's check-run command from being pasted with an unset commit SHA after an unfilled placeholder causes an interactive shell to discard the preceding line.
- Require the head reference to be set before querying pull-request check runs.

Enhancements:
- Document the corrected command layout and explain the safe paste behavior.

Documentation:
- Add a changelog entry describing the repository command correction and its validation.