### PR TITLE
RELEASING.md's placeholder lines stand in fences of their own (closes btclib-org/.github#745, closes #1613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1798,6 +1798,80 @@ dereferences it, and `refs/tags/v1^{}` does the same from a checkout.
   says the harness can write at all. No fence invokes a stub or gains a
   file now.
 
+### `RELEASING.md`'s placeholder lines stand in fences of their own
+
+- **Pasted before its placeholder was filled in, the tag step reached
+  `git push origin v2026.8.4`** (closes btclib-org/.github#745). Its
+  first line ended in `<sha of the release commit>`, which an
+  interactive shell answers with a parse error and discards, reading
+  what stood below it as fresh commands; those lines named the tag as a
+  literal, so they parsed and they ran.
+- **The recovery step under *If something goes wrong* reached
+  `gh run download` the same way.** An empty run id is not an error
+  there: `gh` resolves it to a run of its own choosing and writes
+  `dist/`, `sbom/` and `attestation/` into whatever directory the reader
+  is standing in.
+- **The two fences after that download consume `$version` and `$tag`,
+  and carry the same guards.** Pasted unfilled, the digest check reached
+  `curl`, `jq`, `basename` and `sha256sum`, and the `mv` above
+  `gh release create` renamed `attestation/attestation.jsonl` to
+  `.attestation.jsonl` in the reader's own directory — a dotfile, which
+  a listing does not show.
+- **Each of those steps, and the rebuild block, is a fence holding its
+  placeholder lines with nothing under them to reach and a fence
+  holding what uses those values.** Section 9 of the organization
+  standard is the rule and the reason it gives: the parse error guards
+  only the line it sits on, so an interactive shell reads the line below
+  it as a fresh command.
+- **The same section says the fence a split leaves below is live, so
+  each second fence writes every value it consumes from outside itself
+  as `${name:?}` and chains what follows with `&&`.** `${name:?}` is the
+  shell's must-be-set form and turns an unfilled paste into a run-time
+  failure naming the variable, and the chain short-circuits the lines
+  under that failure, an interactive shell otherwise answering a failed
+  command by reading the next one. A sentence beside each says so: a
+  reader who meets `:?` and is not told what it is for deletes it.
+- **The job-listing step's placeholder splits too, though no parse error
+  ever guarded it: quoted, it is text rather than a pair of
+  redirections.** Nothing in that line fails at the parse, so a paste
+  made before the run id was filled in ran it and sent `gh` the literal.
+  The fence below the placeholder reads it as `${run_id:?}`, and is one
+  command with nothing under it to chain.
+- **The tagging chain puts the read-back in front of the push.** The
+  `git show` that reads the tagged `pyproject.toml` back was already
+  there; chained, a grep that finds nothing now stops the tag from going
+  up rather than being something to notice.
+- **The rebuild block's `&&` chain is no longer the whole of what
+  refuses an unfilled paste.** What it guarded rested on the `cd` below
+  the placeholder failing — a property of that line rather than of the
+  chain — and btclib-org/.github#745 measured the other case: where the
+  line below a discarded placeholder succeeds, the chain forms below it
+  and runs. The placeholder sits in a fence of its own now, and the
+  chain is one of the two guards on the fence that reads it. At release
+  time it does what it always did, stopping the rebuild where a build or
+  a verification fails.
+- **The rebuild block's `gh attestation verify` lines name the
+  distribution files from `${version:?}`** (closes #1613), where each
+  spelled `btclib-<version>-` with the rest of the filename after it. A
+  bare placeholder with a word following it is a pair of redirections
+  whose `>` has a target, so in a directory holding a file named
+  `version` those lines wrote `-py3-none-any.whl`, `.tar.gz` and
+  `.cdx.json` rather than verifying anything.
+- **Measured by pasting each fence this entry names, unfilled, into a
+  shell whose `PATH` carries the real coreutils with stubs ahead of them
+  logging their argv and their `$PWD`** — interactively and not, in an
+  empty directory and in one seeded with a file named for each
+  placeholder's own first word. Two controls say a cell measures
+  something: a block holding `echo hi > outfile` writes in every one of
+  them, and one holding `gh run list` reaches its stub in every one. The
+  second is what tells a guarded command from a binary that is not on
+  the path, and a `PATH` holding only the stubs cannot tell them apart.
+  The push, the download, the rename and the job listing above are in
+  the log the fences produced before the change and in none of it after;
+  no fence this entry names invokes a stub or creates a file in any
+  cell; and each second fence, filled in, runs what the block it
+  replaces ran.
+
 ## v2026.8.29
 
 ### Repository

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -414,9 +414,32 @@ to `deps-latest`'s own result.
    the tag back before pushing it:
 
    ```shell
-   git tag -s v2026.8.4 -m "release v2026.8.4" <sha of the release commit>
-   git show v2026.8.4:pyproject.toml | grep '^version'
-   git push origin v2026.8.4
+   version=<the version being released>
+   sha=<sha of the release commit>
+   ```
+
+   The placeholders stand in a fence with nothing under them to reach,
+   which is section 9 of the organization standard's rule: a parse error
+   guards only the line it sits on, so an interactive shell discards an
+   unfilled placeholder line and reads the next as a fresh command. The
+   fence below carries the other two guards, which are that section's
+   too: the first stops at the fence, and the fence a split leaves below
+   is live. Every value it consumes from outside itself is written
+   `${name:?}`, the shell's own "this must be set" form, and its lines
+   are chained: the first makes an unfilled paste a run-time failure
+   naming the variable, and the second short-circuits the lines under
+   that failure, an interactive shell otherwise answering a failed
+   command by reading the next one. The chain does a second job at
+   release time, putting the read-back in front of the push: a grep that
+   finds nothing — a tag that is not there, or a `pyproject.toml`
+   carrying no `version` line — stops the tag from going up. Which
+   version it found is still the releaser's to read, `grep '^version'`
+   matching that line whatever value it holds.
+
+   ```shell
+   git tag -s "v${version:?}" -m "release v${version:?}" "${sha:?}" &&
+   git show "v${version:?}:pyproject.toml" | grep '^version' &&
+   git push origin "v${version:?}"
    ```
 
    `git tag` with no commit tags whatever HEAD the shell is in, and every
@@ -465,7 +488,19 @@ to `deps-latest`'s own result.
    steps in it:
 
    ```shell
-   gh api "repos/btclib-org/btclib/actions/runs/<run id>/jobs?per_page=100" \
+   run_id=<the release.yml run>
+   ```
+
+   The placeholder stands in a fence of its own. Quoted, it is text
+   rather than a pair of redirections, so nothing in the line below
+   fails at the parse: pasted before the run id is filled in, it runs
+   and sends `gh` the literal. What stops it is the `${run_id:?}` the
+   fence below carries, the form the tagging step of *Release to PyPI*
+   describes.
+
+   ```shell
+   gh api \
+     "repos/btclib-org/btclib/actions/runs/${run_id:?}/jobs?per_page=100" \
      --jq '.jobs[] | [.conclusion, .name] | @tsv'
    ```
 
@@ -609,27 +644,20 @@ A worktree and not `git checkout`, for the reason CLAUDE.md gives: the
 primary checkout is the maintainer's, and a rebuild wants a tree of its
 own regardless.
 
-The block chains so that a paste made before `<version>` is filled in
-reaches no command outside the rebuild tree: an interactive shell answers
-the placeholder line with a parse error and reads the `cd` below it as a
-fresh command, and a failing `cd` inside the chain takes every line under
-it with it. What the chain buys is not that it forms across the first
-line, which the shell discards together with its trailing `&&`; it is
-that the `cd` is inside it.
+```shell
+version=<the released version>
+```
 
-Section 9 of the organization standard names a different remedy for this
-shape — the writing line in a fence of its own — and calls the
-trailing-`&&` guard the weaker of the two, resting "on the reader's
-directory rather than on the line". So which of the two is here is not
-settled by that section, and it is not settled by the block emptying
-either: the rejected alternative makes the `cd` fatal on its own — `||
-exit`, or a `set -e` above the block — and empties it just as
-completely. What separates them is that both of those refuse the paste by
-ending the shell the reader pasted into, where the chain leaves the
-session standing.
+The placeholder stands in a fence with nothing under it to reach, and the
+fence below carries the guard pair the tagging step of *Release to PyPI*
+describes: `version` is what it consumes from outside itself and is
+written `${version:?}`, where `repo` is assigned inside it, and its lines
+are chained. The chain does a second job at release time, stopping the
+rebuild where a build or a verification fails rather than carrying on
+against a tree that is not the one the tag names.
 
 ```shell
-git worktree add --detach /tmp/btclib-rebuild v<version> &&
+git worktree add --detach /tmp/btclib-rebuild "v${version:?}" &&
 cd /tmp/btclib-rebuild &&
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) &&
 uv build &&
@@ -638,11 +666,11 @@ uv run --no-project --python 3.14 \
 uv run --no-project --python 3.14 \
   .github/scripts/generate_sbom.py dist/ sbom/ &&
 repo=btclib-org/btclib &&
-gh attestation verify dist/btclib-<version>-py3-none-any.whl \
+gh attestation verify "dist/btclib-${version:?}-py3-none-any.whl" \
   --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml" &&
-gh attestation verify dist/btclib-<version>.tar.gz \
+gh attestation verify "dist/btclib-${version:?}.tar.gz" \
   --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml" &&
-gh attestation verify sbom/btclib-<version>.cdx.json \
+gh attestation verify "sbom/btclib-${version:?}.cdx.json" \
   --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml"
 ```
 
@@ -732,8 +760,18 @@ above needs no `uv sync` to produce the published bytes.
   ```shell
   run_id=<the release.yml run>
   version=<the released version, e.g. 2026.8.4>
-  tag="v$version"
-  gh run download "$run_id" -n dist -n sbom -n attestation
+  ```
+
+  The placeholders stand in a fence with nothing under them to reach: a
+  paste made before they are filled in would otherwise reach the
+  `gh run download` below, which takes an empty run id as a run of its
+  own choosing and writes it into the reader's directory. Every fence
+  under it carries the guard pair the tagging step of *Release to PyPI*
+  describes.
+
+  ```shell
+  tag="v${version:?}" &&
+  gh run download "${run_id:?}" -n dist -n sbom -n attestation
   ```
 
   Check the distribution files against the digests PyPI already
@@ -743,8 +781,9 @@ above needs no `uv sync` to produce the published bytes.
   against.
 
   ```shell
+  pypi_json="https://pypi.org/pypi/btclib/${version:?}/json" &&
   for f in dist/*.whl dist/*.tar.gz; do
-    sha=$(curl -sf "https://pypi.org/pypi/btclib/$version/json" |
+    sha=$(curl -sf "$pypi_json" |
       jq -r --arg n "$(basename "$f")" \
         '.urls[] | select(.filename==$n) | .digests.sha256')
     echo "$sha  $f" | sha256sum -c -
@@ -757,8 +796,8 @@ above needs no `uv sync` to produce the published bytes.
   materials:
 
   ```shell
-  mv attestation/attestation.jsonl "$tag.attestation.jsonl"
-  gh release create "$tag" dist/*.whl dist/*.tar.gz \
-    sbom/*.cdx.json "$tag.attestation.jsonl" \
-    --title "$tag" --notes-file <the tag's RELEASE_NOTES.md section>
+  mv attestation/attestation.jsonl "${tag:?}.attestation.jsonl" &&
+  gh release create "${tag:?}" dist/*.whl dist/*.tar.gz \
+    sbom/*.cdx.json "${tag:?}.attestation.jsonl" \
+    --title "${tag:?}" --notes-file <the tag's RELEASE_NOTES.md section>
   ```


### PR DESCRIPTION
RELEASING.md's placeholder lines stand in fences of their own (closes btclib-org/.github#745, closes #1613)

The tag step, the rebuild block and the artifact recovery each held an
unfilled placeholder on one line and a line below it that a shell
reaches: pasted before the values were filled in, the first pushed a tag
and the third downloaded a run's artifacts into whatever directory the
reader was standing in. Each is now a fence holding the placeholder
lines with nothing under them and a fence holding what uses those
values, which is the remedy section 9 of the organization standard names
for this shape.

That remedy stops at the fence, and the same section says the fence a
split leaves below is live, so each second fence writes every value it
consumes from outside itself as `${name:?}` and chains what follows with
`&&`. Neither substitutes for the other: a parse error takes its line
together with the trailing `&&`, so a chain below a discarded line never
forms, where a `${name:?}` failure is a run-time failure and is what
`&&` short-circuits. The digest check under the recovery step is the
measurement of that: with `${version:?}` written in and the `&&` left
off, the expansion fails inside a command substitution, whose subshell
is the only thing it ends, and `jq`, `basename` and `sha256sum` are
reached below it.

The job-listing step splits for a reason of its own: its placeholder is
quoted, so it is text rather than a pair of redirections and nothing in
the line fails at the parse. Pasted unfilled, the line ran and sent `gh`
the literal, which is what the split and the `${run_id:?}` below it
stop.

Converting the rebuild block revises what btclib-org/.github#657 landed
in this same file, and does so deliberately: the chain guarded that
block only because the line below its placeholder is a `cd` that fails,
which is a property of that line rather than of the chain. The chain
stays, as one of the two guards and as the run-time stop it always was.
Its `gh attestation verify` lines lose their placeholder with the split,
which is part of btclib#1613.

Measured by pasting every fence this commit changes, unfilled, into an
interactive and a non-interactive shell, from stdin and from a file, in
an empty directory and in one seeded with a file named for each
placeholder's first word. PATH carries the real coreutils with stubs
ahead of them logging their argv and their $PWD: a PATH holding only the
stubs cannot tell a command a fence guards from one the shell cannot
find, and reads a live fence as inert.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WpcKzs2UfKjjrgU6bj1b5i


Local review: CLEARED at fresh context, with the reviewer running the paste measurements itself rather than reading them — 17 fence cells across four shells and two seedings, the recorder proved live first and both positive controls firing in 8 of 8 cells. Every fence at the tip reached no stub and created no file in all eight; every "before" claim of the entry was reproduced at the base. The union seam was re-asserted independently: deleting the block reproduces the base blob byte for byte, against three controls that differ. The gates were not re-run by the reviewer and stand on the coder’s report. Gates on that tree, from the coder’s report and attributed to it: `uv sync --locked` exit 0; `uv run pre-commit run --all-files` exit 0 with 41 passed and no Failed line; `uv run pytest` exit 0 with 31671 passed and coverage 100.00%; `sphinx-build -n -W` exit 0, repeated cold to an output directory outside the worktree; and `grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'` exit 1 as the pass, with an unchained control matching 150 of 150 HTML files. Loads 8 to 15, one suite run, nothing re-run to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpcKzs2UfKjjrgU6bj1b5i

## Summary by Sourcery

Harden the release instructions against unsafe execution when shell placeholders have not yet been filled in.

Bug Fixes:
- Prevent unfilled release-documentation placeholders from executing unintended tagging, artifact download, file operations, or attestation commands when pasted into a shell.

Enhancements:
- Harden release procedures by isolating placeholder assignments and requiring all externally supplied values before executing dependent commands.
- Chain release, rebuild, artifact recovery, verification, and publishing commands so failures stop subsequent operations.
- Improve release instructions for tagging, job listing, rebuild attestation verification, artifact recovery, digest checks, and GitHub release creation.

Documentation:
- Update RELEASING.md with safer, explicitly guarded shell examples and explanations of placeholder handling.

Chores:
- Record the release-procedure safety fixes in CHANGELOG.md.