### PR TITLE
The prose around `network.py` names what a sentence is about (closes #1647, #1648, #1650)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,40 @@ documented at release-notes length in the first place, and are still in
 
 ## v2026.9 (work in progress, not released yet)
 
+### The prose around `network.py` names what a sentence is about
+
+- **`alias`, `bip44`, `consensus`, `block.genesis`, `p2p.magic` and
+  `script.script_pub_key` name the networks their comments and
+  docstrings are about, in place of a total of them** (closes #1647).
+  `tests/network_test.py`'s `test_numbers_of_networks` is where the size
+  of the catalogue is asserted; a sixth network turns that assertion red
+  and leaves each of those sentences reading exactly as it read before,
+  which is what makes them worth removing rather than correcting.
+- **The suite that tests those modules states no total either** (closes
+  #1648). `test_no_prefix_crosses_the_main_test_boundary` is the
+  contrast that decides which counts go: its comment stated a number the
+  assertion two lines under it writes as `len(NETWORKS) - 1`.
+  `test_genesis_block_testnet4_differs_from_the_others` is renamed for
+  the same reason, a test's name being prose that a report prints and
+  `-k` selects on.
+- **`network.py`'s module docstring says how the lookups are keyed and
+  leaves the list of what the module exports to `__all__`** (closes
+  #1650). Nothing re-derives a sentence from that list, so the two part
+  company at the next export with nothing red. The comment over `__all__`
+  is where the decision is recorded, beside the list it is about, and it
+  says which names the built page carries: `automodule::` under
+  `:members:` renders the classes and functions and not the three
+  module-level constants, which is why the docstring still names those
+  three itself.
+- **A count of a fixed structure stays where the sentence keeps it
+  distinguishable from the catalogue**, which is what each of the three
+  issues asks of a count that remains: `alias.py`'s address encodings a
+  purpose level can name, listed there by purpose number; `bip44.py`'s
+  encoders, which the table under the comment holds; `network_test.py`'s
+  SLIP132 pairs, a field group of the `Network` dataclass, and its
+  candidates on the base58 fields, which the assertions under it name. A
+  network added to the catalogue moves none of them.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/alias.py
+++ b/src/btclib/alias.py
@@ -126,10 +126,10 @@ Integer = Octets | int
 #
 # This is the distinction the version bytes were designed to draw --
 # Satoshi's 0x6f, BIP32's tpub, SLIP132, and SLIP44 giving every test
-# chain one coin type -- and it is the one they can still draw now that
-# five networks are known: no prefix of any test network equals any
-# prefix of mainnet, on any field, so "main or test" always has an
-# answer where "which chain" does not. testnet, regtest, signet and
+# chain one coin type -- and every network in the catalogue can still be
+# placed by it: no prefix of any test network equals any prefix of
+# mainnet, on any field, so "main or test" always has an answer where
+# "which chain" does not. testnet, regtest, signet and
 # testnet4 share one set of prefixes on purpose, Core copying testnet's
 # into the newer two, so a prefix cannot tell them apart. See issue #207
 # and btclib.network's three network_type_from_* functions.
@@ -227,12 +227,12 @@ NetworkField = Literal[
 # Still not a parameter type, and issue #216 is where that is decided: the
 # `network: str` parameters accept a name with spaces around it and in any
 # case -- `network.network_from_name` is what they run it through -- so the
-# set they take is wider than these five spellings, and narrowing the
+# set they take is wider than the spellings named here, and narrowing the
 # annotation without dropping that tolerance would reject calls that work.
 # One converter and not a `strip().lower()` per call site, which is what
 # left b32 and the mnemonic modules indexing NETWORKS raw and refusing the
 # tolerance this paragraph promised (issue #744).
-# It names the five for a caller who wants mypy to hold them to it;
+# It names the spellings for a caller who wants mypy to hold them to it;
 # network.py annotates with it the tuple of names it loads, which is what
 # keeps this list equal to the data
 NetworkName = Literal["mainnet", "testnet", "regtest", "signet", "testnet4"]

--- a/src/btclib/bip44.py
+++ b/src/btclib/bip44.py
@@ -89,7 +89,7 @@ with _PURPOSES_FILE.open(encoding="ascii") as _purposes:
 # BIP44's registered coin types, and the only two it registers: 0 is
 # Bitcoin and 1 is "Bitcoin Testnet", which SLIP44 widens to the test
 # chain of every coin. That is why what they are checked against is the
-# network *type* of the extended key and not its name: btclib's four test
+# network *type* of the extended key and not its name: btclib's test
 # networks share one set of version bytes, so an xkey cannot say which of
 # them it is, and coin type 1 does not distinguish them either
 _NETWORK_TYPE_FROM_COIN_TYPE: dict[int, NetworkType] = {0: "main", 1: "test"}

--- a/src/btclib/block/genesis.py
+++ b/src/btclib/block/genesis.py
@@ -69,9 +69,9 @@ _STANDARD_PUBKEY = (
 )
 _STANDARD_SCRIPT_PUB_KEY = serialize([_STANDARD_PUBKEY, "OP_CHECKSIG"])
 
-# testnet4's own text and output script, neither shared with the other
-# four: pays to thirty-three zero bytes rather than to Satoshi's pubkey,
-# a script nothing can spend.
+# testnet4's own text and output script, shared with no other network:
+# pays to thirty-three zero bytes rather than to Satoshi's pubkey, a
+# script nothing can spend.
 _TESTNET4_MESSAGE = (
     b"03/May/2024 000000000000000000001ebd58c244970b3aa9d783bb001011fbe8ea8e98e00e"
 )
@@ -98,8 +98,8 @@ class _GenesisParams:
 # time, bits and nonce transcribed from Bitcoin Core's own
 # kernel/chainparams.cpp, at bitcoin/bitcoin@9be056a8a7, one
 # CreateGenesisBlock call per network; message and script_pub_key from
-# the same file, standard for four of the five and testnet4's own for
-# the fifth
+# the same file, the standard pair everywhere but testnet4 and
+# testnet4's own there
 _GENESIS_PARAMS: dict[str, _GenesisParams] = {
     "mainnet": _GenesisParams(
         1231006505, "1d00ffff", 2083236893, _STANDARD_MESSAGE, _STANDARD_SCRIPT_PUB_KEY
@@ -136,7 +136,7 @@ def genesis_block(network: str = "mainnet") -> Block:
     The block is checked against the network's own easiest target before
     it is returned (`Block.assert_valid`, at that network's
     `pow_limit_bits`), and reproduces the hash `Network.genesis_block`
-    already carries for the same network -- verified for all five in
+    already carries for the same network -- verified for every network in
     `tests/block/genesis_test.py`.
     """
     net = network_from_name(network)

--- a/src/btclib/consensus.py
+++ b/src/btclib/consensus.py
@@ -82,7 +82,7 @@ reader looking for one knows it was decided rather than missed:
 A row validates nothing it is built with, alone among this library's
 dataclasses: validating means raising a `BTClibTypeError`, which means
 importing `btclib.exceptions`, which is the import this module does not
-take. Nothing parses a row -- the five below are constants of this
+take. Nothing parses a row -- the rows below are constants of this
 module -- and the boundary that does read json is `Network.from_dict`,
 which asks `Network.assert_valid` whether its `consensus` field is one
 of these.
@@ -174,7 +174,7 @@ class ConsensusParams:
     of Core's fields are deliberately not here, and where each value was
     transcribed from.
 
-    Frozen and hashable, as `Network` is: a row is a value, the five in
+    Frozen and hashable, as `Network` is: a row is a value, the rows in
     `CONSENSUS_PARAMS` are read by every caller at once, and a `Network`
     carrying one must stay usable as a dict key.
     """

--- a/src/btclib/network.py
+++ b/src/btclib/network.py
@@ -4,9 +4,11 @@
 
 """The Network dataclass, NETWORKS, and the lookups over them.
 
-What this module exports is the dataclass, the catalogue, the three
-questions asked of a key-value pair and the three asked of an extended-key
-version, plus the two version sets a caller matches against.
+Each lookup is keyed by a network name, by a (field, value) pair off the
+dataclass, or by an extended-key version, and answers with the part of
+that network the caller asked for. `XPRV_VERSIONS_ALL` and
+`XPUB_VERSIONS_ALL` are what a version is tested against where no network
+is in hand.
 
 **A Network is an encoding table, and NETWORKS is fixed at import.** The
 fields are the prefixes and version bytes a network spells its keys and
@@ -56,6 +58,14 @@ from btclib.curves.curve import CURVES, _assert_valid_ec
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.utils import assert_type, bytes_from_octets, fields_from_json_object
 
+# `docs/source/btclib.rst` passes `:members:` to `automodule::`, which
+# renders the classes and functions below and not the three module-level
+# constants: `automodule` documents data only under `:undoc-members:`,
+# which that file does not pass, so `NETWORKS` and the two version sets
+# get no entry and the docstring names those three itself. The docstring
+# says how the lookups are keyed rather than accounting for the names
+# here, since nothing re-derives a sentence from this list and the two
+# part company at the next export with nothing red (issue #1650).
 __all__ = [
     "NETWORKS",
     "XPRV_VERSIONS_ALL",

--- a/src/btclib/p2p/magic.py
+++ b/src/btclib/p2p/magic.py
@@ -13,13 +13,14 @@ not a field any table can hold."
 
 So the question this module answers is not which of two designs to
 choose. Giving `Network` a `magic` field would contradict a docstring
-that states its own reason, and the reason is the fifth network:
+that states its own reason, and the reason is signet:
 `NETWORKS` is an encoding table fixed at import, every field of which is
 the same for every deployment of the network it describes, while a custom
 signet's message start is the first four octets of the sha256d of its
 block challenge and differs between two deployments that report the same
-chain. A field would be right for four networks and a lie for the fifth,
-which is an annotation accepting the mistake rather than refusing it.
+chain. A field would be right for every other network and a lie for
+signet, which is an annotation accepting the mistake rather than
+refusing it.
 `btclib.fetch.transport` re-exports the same package's HTTP transport on
 the same reasoning: a second copy is a second thing to keep true.
 

--- a/src/btclib/script/script_pub_key.py
+++ b/src/btclib/script/script_pub_key.py
@@ -576,7 +576,7 @@ class ScriptPubKey(Script):
         if not isinstance(other, ScriptPubKey):
             return NotImplemented
 
-        # the network *type*, not the name. Four test networks share one
+        # the network *type*, not the name. The test networks share one
         # set of address prefixes, so from_address answers "testnet" for
         # a signet address too -- and comparing names made a signet
         # ScriptPubKey unequal to the very address it renders, identical

--- a/tests/block/genesis_test.py
+++ b/tests/block/genesis_test.py
@@ -59,14 +59,15 @@ def test_genesis_block_has_one_coinbase_and_no_witness() -> None:
     assert not block.transactions[0].is_segwit
 
 
-def test_genesis_block_testnet4_differs_from_the_other_four() -> None:
+def test_genesis_block_testnet4_differs_from_the_others() -> None:
     """testnet4's coinbase is not the mainnet one under a later timestamp.
 
     The issue that opened this module said every network shared the
-    mainnet coinbase; true of four of the five, and corrected here rather
-    than repeated -- bitcoin/bitcoin@9be056a8a7's kernel/chainparams.cpp
-    gives testnet4 its own message and an output script that pays to
-    thirty-three zero bytes rather than to Satoshi's pubkey.
+    mainnet coinbase; true of every network but testnet4, and corrected
+    here rather than repeated -- bitcoin/bitcoin@9be056a8a7's
+    kernel/chainparams.cpp gives testnet4 its own message and an output
+    script that pays to thirty-three zero bytes rather than to Satoshi's
+    pubkey.
     """
     mainnet_coinbase = genesis_block("mainnet").transactions[0]
     testnet4_coinbase = genesis_block("testnet4").transactions[0]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -187,8 +187,8 @@ def as_regtest(descriptor: Descriptor) -> Descriptor:
     """Return the descriptor read again as a regtest one.
 
     Version bytes cannot say which test chain a key is for -- btclib's
-    four test networks share them, which `bip44` documents where it
-    refuses to guess -- so `account_descriptors` answers with the first,
+    test networks share them, which `bip44` documents where it refuses to
+    guess -- so `account_descriptors` answers with the first,
     testnet, and its addresses are `tb1`. The scripts are the same
     scripts; what differs is the human encoding, and regtest spells it
     `bcrt1`. Reading the text back with the network named is how a caller

--- a/tests/key_io_test.py
+++ b/tests/key_io_test.py
@@ -95,10 +95,10 @@ def test_address_script(address: str, script_pub_key: str, network: str) -> None
 
 @pytest.mark.parametrize("address, script_pub_key, network", ADDRESS_VECTORS)
 def test_address_network(address: str, script_pub_key: str, network: str) -> None:
-    """Which chain the address itself can name, which is fewer than four.
+    """Which chain the address itself can name, which is not all of them.
 
-    Four test networks share one pair of base58 version bytes and three
-    of them share the hrp `tb`, so the reverse lookup answers with the
+    The test networks share one pair of base58 version bytes, and all but
+    regtest share the hrp `tb`, so the reverse lookup answers with the
     first network holding the value: "testnet" for a testnet4, signet or
     base58 regtest string alike (issue #207). `bcrt` is the one test
     prefix that is nobody else's. Core has the same ambiguity and
@@ -169,9 +169,9 @@ def test_wif_without_a_network(
 
     0x80 is mainnet's and 0xef is testnet's, regtest's, signet's and
     testnet4's alike, so a WIF read without a network argument answers
-    "testnet" for all four -- the oldest network holding the prefix,
-    issue #207 again. Naming the chain is what the argument above is
-    for, and passing it is not a workaround: `_wif_network` checks the
+    "testnet" for every one of them -- the oldest network holding the
+    prefix, issue #207 again. Naming the chain is what the argument above
+    is for, and passing it is not a workaround: `_wif_network` checks the
     prefix against that network rather than comparing lookup names, so
     every one of the sixteen rows is accepted on the chain Core names.
     Nothing else moves -- the key and the compression flag are the

--- a/tests/network_test.py
+++ b/tests/network_test.py
@@ -63,11 +63,10 @@ def test_curve_from_xkeyversion() -> None:
         all_versions = xpubversions_from_network(net_str)
         all_versions += xprvversions_from_network(net_str)
         for version in all_versions:
-            # four of the five networks carry testnet's version bytes, so
-            # the singular lookup answers with testnet, the oldest of
-            # them: the contract issue #207 documents, and the right
-            # network to re-encode with, all four agreeing on every
-            # version prefix
+            # every test network carries testnet's version bytes, so the
+            # singular lookup answers with testnet, the oldest of them:
+            # the contract issue #207 documents, and the right network
+            # to re-encode with, since they agree on every version prefix
             expected = "mainnet" if net_str == "mainnet" else "testnet"
             assert expected == network_from_xkeyversion(version)
             assert net.curve == curve_from_xkeyversion(version)
@@ -81,9 +80,9 @@ def test_the_xpub_version_paired_with_an_xprv_one() -> None:
     The pairing is by position within a network -- bip32_prv with
     bip32_pub, and so on for the four SLIP132 pairs -- which is what
     `xprvversions_from_network` and `xpubversions_from_network` spell out,
-    one network at a time. Four networks share testnet's versions, so a
-    shared xprv version answers with the shared xpub version, the same
-    bytes for all four.
+    one network at a time. The test networks share testnet's versions, so
+    a shared xprv version answers with the shared xpub version, the same
+    bytes for every one of them.
     """
     for name in NETWORKS:
         prv_versions = xprvversions_from_network(name)
@@ -245,9 +244,9 @@ _PREFIX_FIELDS: tuple[NetworkField, ...] = (
 def test_no_prefix_crosses_the_main_test_boundary() -> None:
     """The invariant the network type rests on, checked rather than assumed.
 
-    A network *name* cannot be recovered from a prefix -- four networks
-    share one set of them -- but "main or test" always can, and only
-    because no test network prefix equals a mainnet prefix. Every field
+    A network *name* cannot be recovered from a prefix -- the test
+    networks share one set of them -- but "main or test" always can, and
+    only because no test network prefix equals a mainnet prefix. Every field
     against every field, not field against same field: the type would be
     just as wrong if testnet's p2sh were mainnet's p2pkh, since a caller
     asks the lookups one field at a time and a collision anywhere makes
@@ -261,8 +260,8 @@ def test_no_prefix_crosses_the_main_test_boundary() -> None:
         for field in _PREFIX_FIELDS:
             assert getattr(net, field) not in mainnet_prefixes, (name, field)
 
-    # so mainnet is the only network of its type, and the four test
-    # networks are the rest: the shape the type is a name for
+    # so mainnet is the only network of its type, and the test networks
+    # are the rest: the shape the type is a name for
     types = [net.network_type for net in NETWORKS.values()]
     assert types.count("main") == 1
     assert types.count("test") == len(NETWORKS) - 1
@@ -399,7 +398,7 @@ def test_a_network_name_no_network_has_is_refused() -> None:
     KeyError is a LookupError, so a caller filtering bad input with an
     `except BTClibValueError` -- which is what this library's own
     docstrings tell it to write -- did not catch it (issue #744). The
-    message names the five, a typo being the case it exists for.
+    message names every network, a typo being the case it exists for.
     """
     for name in NETWORKS:
         assert network_from_name(name) is NETWORKS[name]


### PR DESCRIPTION
`network.py`'s catalogue is read by prose in eight files, and that prose
counted it. A count is a second statement of a fact the catalogue already
makes, so it goes stale the moment a network is added and nothing turns
red — the tree carries no test that reads a sentence.

This replaces the counts with the names they were standing in for, in
`alias.py`, `bip44.py`, `consensus.py`, `block/genesis.py`, `p2p/magic.py`
and `script/script_pub_key.py`, and in the suite's own prose in
`block/genesis_test.py`, `integration/conftest.py`, `key_io_test.py` and
`network_test.py`. Where a sentence was about *which* networks rather than
how many, naming them is shorter as well as durable.

`network.py`'s own `__all__` comment carried a stronger claim than the
build supports: that `:members:` makes that list what the built page
documents. Measured against the built HTML, it does not — 13 anchors
against 16 names, the three missing being exactly the module-level
constants `NETWORKS`, `XPRV_VERSIONS_ALL` and `XPUB_VERSIONS_ALL`, because
`automodule` documents data only under `:undoc-members:`, which
`docs/source/btclib.rst` does not pass. The independent control is
`btclib.curves.html`, which has an anchor for `Curve` and none for
`CURVES`. The comment now names that mechanism and says the docstring
carries those three itself.

closes #1647
closes #1648
closes #1650

## Summary by Sourcery

Make network-related prose durable by naming the networks and clarifying documentation coverage instead of repeating catalogue counts.

Enhancements:
- Replace brittle network-count prose with durable descriptions of the networks and behaviors being discussed across library documentation, comments, and tests.
- Clarify the `network.py` module documentation and accurately describe which exports are rendered by the API documentation configuration.

Documentation:
- Update user-facing changelog entries to document the network-prose and API documentation clarifications.

Tests:
- Remove network-count assumptions from test names and explanatory prose while preserving assertions for catalogue size and network-specific invariants.