### PR TITLE
The walk over btclib's module names has one home in tests/ (closes #1649)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,35 @@ documented at release-notes length in the first place, and are still in
   candidates on the base58 fields, which the assertions under it name. A
   network added to the catalogue moves none of them.
 
+### The walk over btclib's module names has one home in `tests/`
+
+- **`tests/__init__.py` offers `module_names`, and every test asking a
+  question of every btclib module takes the list from it** (closes
+  #1649). What the walk covers -- a second package root, a different
+  prefix, a module it has to skip -- is settled at one place, and a copy
+  that disagreed would be red nowhere: a site asserts against whatever
+  its own walk found, so two of them covering different sets are both
+  green.
+- **`all_test.py`'s `library_modules` is that list filtered to the
+  public names and imported**, rather than a traversal of its own: it
+  walks the same package root under the same prefix, so it is one of the
+  sites a change to the walk has to reach, and what is its own is the
+  filter and the import. Measured equivalent to what it replaces -- the
+  same module objects in the same order, `btclib._libsecp256k1` and
+  `btclib._ripemd160` being all the filter drops.
+- **A helper and not a shared constant**, so that the walk runs when a
+  site asks for it: `pkgutil.walk_packages` imports each package it
+  descends into, where importing the `tests` package on its own leaves
+  `btclib` alone in `sys.modules`.
+- **The alternative of writing down that each site owns its own
+  traversal is declined**: nothing goes red when two of them disagree,
+  so the sentence would have recorded that state rather than answered
+  it.
+- **`public_classes_with`'s docstring gives the shared reason without
+  counting the files that call it**, a count being what every new caller
+  would have to correct; `module_names` points at that reason rather
+  than restating it.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -44,6 +44,21 @@ import btclib
 _TESTS_DIR = Path(__file__).parent
 
 
+def module_names() -> list[str]:
+    """Return every module of the installed btclib, the top-level one included.
+
+    Here rather than at each site that walks the package, for the reason
+    `public_classes_with` below gives. What the walk covers -- a second
+    package root, a different prefix, a module it has to skip -- is
+    settled here for all of them, and a copy that disagreed would be red
+    nowhere: each site asserts against whatever its own walk found.
+    """
+    return [
+        "btclib",
+        *(module.name for module in pkgutil.walk_packages(btclib.__path__, "btclib.")),
+    ]
+
+
 def public_classes_with(method_name: str) -> set[str]:
     """Return every public btclib class offering that method, module included.
 
@@ -56,16 +71,12 @@ def public_classes_with(method_name: str) -> set[str]:
     `Sig`. A private class is skipped, the contract being about what a
     caller can reach.
 
-    Here rather than in the one test that first needed it: two files hold
-    the same classes to two different contracts -- where the bytes end,
-    and what type the argument is -- and neither owns the walk.
+    Here rather than in the one test that first needed it: the files that
+    call it hold the same classes to contracts of their own, and none of
+    them owns the walk.
     """
-    module_names = [
-        "btclib",
-        *(module.name for module in pkgutil.walk_packages(btclib.__path__, "btclib.")),
-    ]
     found = set()
-    for module_name in module_names:
+    for module_name in module_names():
         module = importlib.import_module(module_name)
         for obj in vars(module).values():
             if not isinstance(obj, type):

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -34,7 +34,7 @@ import ast
 from collections.abc import Iterable, Iterator
 from importlib import import_module
 from pathlib import Path
-from pkgutil import iter_modules, walk_packages
+from pkgutil import iter_modules
 from types import ModuleType
 
 import bitcoin_core_rpc
@@ -50,6 +50,7 @@ from btclib import consensus
 from btclib.curves import curve_group, curve_group_2
 from btclib.psbt import psbt_utils
 from btclib.script import script_pub_key
+from tests import module_names
 
 # what a module defines without a leading underscore and deliberately does
 # not export, with the reason beside the list in each module's docstring.
@@ -310,15 +311,12 @@ def library_modules() -> list[ModuleType]:
     module whose name opens with an underscore is not part of the surface,
     so what is public *in* it is not reachable by any spelling a caller is
     offered.
+
+    The walk is `tests/__init__.py`'s, which is where the sites asking a
+    question of every btclib module take it from; what is this file's own
+    is the filter and the import.
     """
-    return [
-        btclib,
-        *(
-            import_module(name)
-            for _, name, _ in walk_packages(btclib.__path__, "btclib.")
-            if public_name(name)
-        ),
-    ]
+    return [import_module(name) for name in module_names() if public_name(name)]
 
 
 def module_scope(body: Iterable[ast.stmt]) -> Iterator[ast.stmt]:

--- a/tests/fuzz_test.py
+++ b/tests/fuzz_test.py
@@ -21,7 +21,6 @@ green rather than for having written it once.
 import contextlib
 import importlib
 import json
-import pkgutil
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -30,7 +29,6 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-import btclib
 from btclib import b32, b58, base58, bech32, bip322, descriptors, var_bytes, var_int
 from btclib.bip21 import Bip21
 from btclib.bip32.bip32 import BIP32KeyData
@@ -97,7 +95,7 @@ from btclib.tx.out_point import OutPoint
 from btclib.tx.tx import Tx
 from btclib.tx.tx_in import TxIn
 from btclib.tx.tx_out import TxOut
-from tests import public_classes_with
+from tests import module_names, public_classes_with
 
 # What a btclib parser is allowed to raise. Anything else -- an
 # IndexError off a short slice, an OverflowError off an unchecked size,
@@ -257,14 +255,6 @@ def _functions_driven_here() -> set[str]:
     }
 
 
-def _module_names() -> list[str]:
-    """Every module of the installed btclib, the top-level one included."""
-    return [
-        "btclib",
-        *(module.name for module in pkgutil.walk_packages(btclib.__path__, "btclib.")),
-    ]
-
-
 def test_every_class_that_parses_is_driven_here() -> None:
     """The inventory is a promise only if omission is what fails.
 
@@ -293,7 +283,7 @@ def test_every_module_function_that_parses_is_driven_here() -> None:
     wide enough to find those is a census this file does not keep.
     """
     found = set()
-    for module_name in _module_names():
+    for module_name in module_names():
         module = importlib.import_module(module_name)
         for name in ("parse", "decode"):
             function = getattr(module, name, None)

--- a/tests/imports_test.py
+++ b/tests/imports_test.py
@@ -20,19 +20,13 @@ time -- with nothing in that file to say so.
 from __future__ import annotations
 
 import importlib
-import pkgutil
 import subprocess
 import sys
 from collections.abc import Iterator
 
 import pytest
 
-import btclib
-
-MODULE_NAMES = [
-    "btclib",
-    *(module.name for module in pkgutil.walk_packages(btclib.__path__, "btclib.")),
-]
+from tests import module_names
 
 
 def btclib_modules() -> list[str]:
@@ -72,7 +66,7 @@ def unimported_btclib() -> Iterator[None]:
         sys.modules.update(saved)
 
 
-@pytest.mark.parametrize("module_name", MODULE_NAMES)
+@pytest.mark.parametrize("module_name", module_names())
 def test_import_first(module_name: str, unimported_btclib: None) -> None:
     """Import each module first, with no other btclib module loaded."""
     assert importlib.import_module(module_name).__name__ == module_name

--- a/tests/serialization_boundary_test.py
+++ b/tests/serialization_boundary_test.py
@@ -73,7 +73,6 @@ every flag in the library and with the reason for each.
 from __future__ import annotations
 
 import json
-import pkgutil
 from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass
@@ -83,7 +82,6 @@ from typing import Any
 
 import pytest
 
-import btclib
 from btclib import bip322, var_bytes, var_int
 from btclib.bip21 import Bip21
 from btclib.bip32.bip32 import BIP32KeyData
@@ -140,7 +138,7 @@ from btclib.psbt.psbt_utils import PSBT_V0, PSBT_V2
 from btclib.script import Witness, script, taproot
 from btclib.to_pub_key import pub_keyinfo_from_prv_key
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
-from tests import load_bin, public_classes_with
+from tests import load_bin, module_names, public_classes_with
 from tests.psbt import psbt_cases
 
 # a value of no type any of these positions declares. `Any`, because
@@ -822,10 +820,7 @@ def test_every_codec_that_is_a_function_is_covered() -> None:
         for _, function, _, _ in _MODULE_WRITERS
     }
     found = {}
-    for module_name in (
-        "btclib",
-        *(module.name for module in pkgutil.walk_packages(btclib.__path__, "btclib.")),
-    ):
+    for module_name in module_names():
         module = import_module(module_name)
         for method in _FAMILY:
             function = getattr(module, method, None)
@@ -903,10 +898,7 @@ def test_the_family_takes_no_ec_or_hf() -> None:
             cls = getattr(import_module(module_name), class_name)
             found[f"{name}.{method}"] = set(signature(getattr(cls, method)).parameters)
 
-    for module_name in (
-        "btclib",
-        *(module.name for module in pkgutil.walk_packages(btclib.__path__, "btclib.")),
-    ):
+    for module_name in module_names():
         module = import_module(module_name)
         for method in _FAMILY:
             function = getattr(module, method, None)


### PR DESCRIPTION
Five files under `tests/` each ran their own `pkgutil.walk_packages` over
`btclib`, and a site asserts against whatever its own walk found — so two
of them covering different sets are both green, and a copy that disagreed
would be red nowhere. What the walk covers is not a fact any of them can
check about the others.

`tests/__init__.py` now offers `module_names`, and the sites that ask a
question of every btclib module take the list from it: `imports_test.py`,
`fuzz_test.py`, `serialization_boundary_test.py`, and `all_test.py`'s
`library_modules` filtered to the public names and imported. A second
package root, a different prefix, a module the walk has to skip — all
settled at one place.

**A helper rather than a shared constant**, deliberately, so the walk runs
when a site asks for it: `pkgutil.walk_packages` imports each package it
descends into, and importing the `tests` package on its own leaves
`btclib` alone in `sys.modules`. A constant would pull the library in at
that package's import for every session.

**`all_test.py` joins rather than keeping a traversal of its own.** It
walks the same root under the same prefix, so a change to the walk has to
reach it; what stays its own is the filter and the import. It is not
missing the head element the other sites carry, as the issue reads it —
the head is the `btclib` module object and `import_module("btclib")`
returns that same object. Measured equivalent before and after: the same
module objects in the same order, the only names its `public_name` filter
drops being `btclib._libsecp256k1` and `btclib._ripemd160`.

**The third answer the issue offers is declined** — writing down that each
site owns its own traversal. Nothing goes red when two of them disagree,
so that sentence would have recorded the state rather than answered it.

The sites were re-derived at `496b36c5` rather than taken from the issue,
which measured at `cdd1b985`. `git grep -n 'walk_packages(btclib.__path__'
-- tests/` answered in all five; the same command with
`nosuchpkg.__path__` exits 1, which is what says the first was matching
rather than matching anything. After this it answers in
`tests/__init__.py` alone.

closes #1649

## Summary by Sourcery

Centralize btclib module discovery so all module-wide tests use the same package traversal.

Enhancements:
- Centralize discovery of all btclib module names in a lazily evaluated test helper and reuse it across module-wide tests.

Documentation:
- Document the centralized module traversal and its rationale in the changelog.

Tests:
- Update import, fuzz, serialization, and library-surface tests to share the centralized module inventory.