### PR TITLE
BOLT11 refuses an even feature bit BOLT9 does not assign (closes #1637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,37 @@ documented at release-notes length in the first place, and are still in
   would have to correct; `module_names` points at that reason rather
   than restating it.
 
+### `btclib.bolt9`, and an even feature bit that fails an invoice
+
+- **`Bolt11Invoice.assert_valid` refuses a `9` field setting an even bit
+  BOLT9 does not assign** (closes #1637), naming the bits in the
+  message. BOLT9 hands out feature bits in pairs, the odd half of a pair
+  optional and the even half compulsory, so a reader meeting a bit it
+  does not know fails on the even one and ignores the odd one -- "it's
+  ok to be odd". Answering that is a lookup in BOLT9's assignment table,
+  which BOLT11 does not define: at `496b36c5` the BOLT's own invalid
+  example "adding invalid unknown feature 100" decoded and validated.
+- **`btclib.bolt9` is where that table lives**: `FEATURE_NAMES` gives
+  the even bit of each pair BOLT9 assigns and the name the BOLT gives
+  it, transcribed at the upstream commit named beside it, and
+  `unknown_even_bits` is the lookup. A module of its own rather than a
+  constant inside `bolt11.py` or a mapping every caller supplies, the
+  table being another BOLT's and read the same way by the `init` message
+  and by the gossip announcements, which carry a feature vector too.
+- **A bit is known when BOLT9 assigns it, whichever fields its Context
+  column names.** That column says where a feature may appear, `9` being
+  a BOLT11 invoice, and taking it as the criterion refuses invoices the
+  BOLT itself calls valid: its "supports features 8, 14 and 99" example
+  sets even bits 8 and 14, whose Context column is empty.
+- **Naming a bit is not implementing its feature**, so what
+  `assert_valid` refuses is the half nothing could support; a wallet
+  acting on an invoice checks the assigned even bits against what it has
+  implemented itself, out of the same table.
+- **BOLT11's "Same, but adding invalid unknown feature 100" joins
+  `tests/_data/bolt11_test_vectors.json`**, so both of that document's
+  example sections are transcribed whole; the file's entry in
+  `tests/_data/README.md` says so, and says what refuses this one.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,21 @@ full year, short month, short day (YYYY-M-D)
 
 ## v2026.9 (work in progress, not released yet)
 
+### Breaking changes
+
+- **A Lightning invoice setting an even feature bit BOLT9 does not
+  assign is refused** (closes #1637). `bolt11.Bolt11Invoice.from_invoice`
+  and `assert_valid` accepted one, where BOLT9's rule is that a reader
+  meeting a feature bit it does not know fails on the even half of a
+  pair and ignores the odd half.
+
+  Act on it if you decode invoices carrying such a bit: the refusal is
+  `BTClibValueError: unknown even feature bits: ...`, naming them.
+  `btclib.bolt9.FEATURE_NAMES` is the table that answers it, the even
+  bit of each pair BOLT9 assigns and the name the BOLT gives it, and
+  `btclib.bolt9.unknown_even_bits` is the same lookup over any feature
+  vector. An unknown *odd* bit is carried as it was.
+
 ## v2026.9.3
 
 ### Breaking changes

--- a/docs/source/btclib.rst
+++ b/docs/source/btclib.rst
@@ -100,6 +100,13 @@ btclib.bolt11 module
    :members:
    :show-inheritance:
 
+btclib.bolt9 module
+-------------------
+
+.. automodule:: btclib.bolt9
+   :members:
+   :show-inheritance:
+
 btclib.coin_selection module
 ----------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -640,6 +640,12 @@ Unser = "Unser"
 # spell checker rewrote naming a symbol that is not in the source it
 # points at
 ser_exp = "ser_exp"
+# BOLT9's own name for the feature at bits 8/9, `optin` for opt-in
+# (09-features.md). src/btclib/bolt9.py transcribes that table and the hook
+# runs with --write-changes, so without this line the name becomes
+# `var_onion_option`, which names no feature of the BOLT and reads as a
+# transcription error to anybody checking the table against its source
+var_onion_optin = "var_onion_optin"
 
 [tool.typos.default.extend-words]
 # "nd" is the Neutered Derivation of the bip32 docstrings, as for codespell

--- a/src/btclib/__init__.py
+++ b/src/btclib/__init__.py
@@ -91,6 +91,7 @@ __all__ = [
     "bip85",
     "bip322",
     "block",
+    "bolt9",
     "bolt11",
     "coin_selection",
     "consensus",

--- a/src/btclib/bolt11.py
+++ b/src/btclib/bolt11.py
@@ -87,6 +87,7 @@ from btclib.b32 import (
 from btclib.b58 import address_from_h160, h160_from_address
 from btclib.bech32 import decode as _bech32_decode
 from btclib.bech32 import encode as _bech32_encode
+from btclib.bolt9 import unknown_even_bits
 from btclib.curves import bytes_from_point, secp256k1
 from btclib.ecc.dsa import Sig, gen_keys, recover_pub_key_, sign_recoverable_, verify_
 from btclib.exceptions import BTClibValueError
@@ -409,11 +410,10 @@ class Bolt11Invoice:
         stored signature is checked against it, recovering the payee
         where none was stated.
 
-        One refusal BOLT11 requires is not here, and a caller relying on
-        this method has to know it: an unknown **even** bit in the `9`
-        field must fail the invoice, and does not. `features` says why
-        and issue #1637 is where it is tracked. The spec vector for that
-        case is the one left out of the vendored file.
+        An **even** bit of the `9` field that BOLT9 does not assign
+        fails the invoice, which is BOLT9's rule for a reader that meets
+        a feature bit it does not know; `btclib.bolt9` carries the table
+        that answers it.
         """
         if self.network not in _CURRENCY_FROM_NETWORK:
             raise BTClibValueError(f"not a lightning network: {self.network}")
@@ -437,7 +437,6 @@ class Bolt11Invoice:
         # forces every other accessor's own well-formedness check
         _expiry = self.expiry
         _min_final_cltv_expiry = self.min_final_cltv_expiry
-        _features = self.features
         _metadata = self.metadata
         _fallback_addresses = self.fallback_addresses
         _route_hints = self.route_hints
@@ -446,11 +445,18 @@ class Bolt11Invoice:
             _payment_secret,
             _expiry,
             _min_final_cltv_expiry,
-            _features,
             _metadata,
             _fallback_addresses,
             _route_hints,
         )
+
+        # `features` is read here rather than among the accessors above:
+        # its own well-formedness is the bits, and an even one BOLT9 does
+        # not assign is a requirement no reader has been told how to meet
+        unknown = unknown_even_bits(self.features)
+        if unknown:
+            bits = ", ".join(str(bit) for bit in unknown)
+            raise BTClibValueError(f"unknown even feature bits: {bits}")
 
         # the signature itself: this is what makes an invoice acceptable
         _payee = self.payee
@@ -522,13 +528,10 @@ class Bolt11Invoice:
     def features(self) -> int:
         """Return the `9` field as a bitfield, 0 where none was stated.
 
-        The bitfield, and not a verdict on it. BOLT11 requires a reader
-        to fail an invoice setting an unknown even bit, which is a
-        question about BOLT9's feature table rather than about this
-        encoding -- so answering it here would mean carrying that table,
-        and `assert_valid` does not ask. Issue #1637 is where that is
-        tracked; until it closes, a caller acting on an invoice checks
-        the bits it understands itself.
+        The bitfield, and not a verdict on it: `assert_valid` refuses
+        an even bit BOLT9 does not assign, and a caller acting on the
+        invoice checks the assigned ones against what it has itself
+        implemented, `btclib.bolt9.FEATURE_NAMES` being that table.
         """
         words = _first(self.tagged_fields, _TAG_FEATURES, None)
         return 0 if words is None else _words_to_int(words)

--- a/src/btclib/bolt9.py
+++ b/src/btclib/bolt9.py
@@ -1,0 +1,101 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""BOLT9: the assigned Lightning feature flags.
+
+https://github.com/lightning/bolts/blob/master/09-features.md
+
+Feature bits are assigned in pairs, the odd bit of a pair optional and
+the even one compulsory, so a reader that meets a bit it does not know
+must fail on the even one and may ignore the odd one -- "it's ok to be
+odd". Answering that is a lookup in BOLT9's own assignment table, which
+is the whole of this module: BOLT11's `9` field, BOLT1's `init` message
+and BOLT7's announcements each carry a feature vector, and the rule for
+reading one is the same in all three.
+
+**A bit is known here when BOLT9 assigns it, whichever fields its Context
+column names.** That column says where a feature may appear -- `9` is a
+BOLT11 invoice -- and reading it as the criterion refuses invoices the
+BOLT itself calls valid: its "supports features 8, 14 and 99" example
+sets two even bits, 8 (`var_onion_optin`) and 14 (`payment_secret`),
+whose Context column is empty.
+
+**A bit this table names is one a reader can look up, not one a payer
+implements.** `unknown_even_bits` is the codec's half of the rule -- an
+even bit nothing has been told how to support -- and a wallet acting on
+an invoice takes the other half itself, checking the assigned even bits
+against what it has implemented, with `FEATURE_NAMES` as its table too.
+
+The table is a copy of a document that grows, pinned at the commit it was
+copied from, so a pair assigned upstream after that commit reads as
+unknown here until the pin moves.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import MappingProxyType
+
+from btclib.alias import Integer
+from btclib.exceptions import BTClibValueError
+from btclib.utils import int_from_integer
+
+__all__ = [
+    "FEATURE_NAMES",
+    "unknown_even_bits",
+]
+
+# BOLT9's table, transcribed at lightning/bolts
+# 35e79db504560b9d3494a0ed07bf1e8379c3663a (2026-07-27), the most recent
+# commit touching 09-features.md: the even bit of each assigned pair, and
+# the name the BOLT gives that pair. Every gap in the numbering is a gap
+# in that table
+_feature_names: dict[int, str] = {
+    0: "option_data_loss_protect",
+    4: "option_upfront_shutdown_script",
+    6: "gossip_queries",
+    8: "var_onion_optin",
+    10: "gossip_queries_ex",
+    12: "option_static_remotekey",
+    14: "payment_secret",
+    16: "basic_mpp",
+    18: "option_support_large_channel",
+    22: "option_anchors",
+    24: "option_route_blinding",
+    26: "option_shutdown_anysegwit",
+    28: "option_dual_fund",
+    34: "option_quiesce",
+    36: "option_attribution_data",
+    38: "option_onion_messages",
+    40: "zero_fee_commitments",
+    42: "option_provide_storage",
+    44: "option_channel_type",
+    46: "option_scid_alias",
+    48: "option_payment_metadata",
+    50: "option_zeroconf",
+    60: "option_simple_close",
+    62: "option_splice",
+    66: "option_onion_messages_only_channels",
+}
+
+# a mapping and not a dict, the way network.NETWORKS is one: a caller
+# reads this table to name a bit or to ask whether it is assigned, and an
+# entry added at run time would be an assignment BOLT9 has not made
+FEATURE_NAMES: Mapping[int, str] = MappingProxyType(_feature_names)
+
+
+def unknown_even_bits(features: Integer) -> tuple[int, ...]:
+    """Return the even bits `features` sets that BOLT9 does not assign.
+
+    Lowest first, and never an odd bit: that is the half a reader may
+    ignore, whether or not the table names it.
+    """
+    value = int_from_integer(features)
+    if value < 0:
+        raise BTClibValueError(f"negative feature vector: {value}")
+    return tuple(
+        bit
+        for bit in range(0, value.bit_length(), 2)
+        if value >> bit & 1 and bit not in FEATURE_NAMES
+    )

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -2064,6 +2064,10 @@ address, a routing hop, the feature bits -- is checked against that same
 example's own "Breakdown" in the document, not derived from btclib's own
 decoder. `tests/bolt11_test.py` reads both halves.
 
+Both sections are transcribed whole, the invalid case adding "unknown
+feature 100" included: what refuses that one is `btclib.bolt9`'s
+assignment table, which `Bolt11Invoice.assert_valid` reads.
+
 ## Chain data, not a repository
 
 These are consensus bytes. There is no upstream repository to pin and no

--- a/tests/_data/bolt11_test_vectors.json
+++ b/tests/_data/bolt11_test_vectors.json
@@ -201,6 +201,10 @@
   ],
   "invalid": [
     {
+      "name": "unknown feature bit 100, which is even",
+      "invoice": "lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q4psqqqqqqqqqqqqqqqqsgqtqyx5vggfcsll4wu246hz02kp85x4katwsk9639we5n5yngc3yhqkm35jnjw4len8vrnqnf5ejh0mzj9n3vz2px97evektfm2l6wqccp3y7372"
+    },
+    {
       "name": "bech32 checksum is invalid",
       "invoice": "lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpuyk0sg5g70me25alkluzd2x62aysf2pyy8edtjeevuv4p2d5p76r4zkmneet7uvyakky2zr4cusd45tftc9c5fh0nnqpnl2jfll544esqchsrnt"
     },

--- a/tests/bolt11_test.py
+++ b/tests/bolt11_test.py
@@ -126,7 +126,7 @@ def test_sign_and_decode_round_trip() -> None:
                 )
             ]
         ],
-        features=0b101,
+        features=(1 << 8) | (1 << 14),
         metadata=b"\x01\xfa\xfa\xf0",
         extra_tags=[(31, (1, 2, 3))],
     )
@@ -141,7 +141,7 @@ def test_sign_and_decode_round_trip() -> None:
     assert decoded.expiry == 7200
     assert decoded.min_final_cltv_expiry == 40
     assert decoded.fallback_addresses == invoice.fallback_addresses
-    assert decoded.features == 0b101
+    assert decoded.features == (1 << 8) | (1 << 14)
     assert decoded.metadata == b"\x01\xfa\xfa\xf0"
     assert (31, (1, 2, 3)) in decoded.tagged_fields
     assert decoded.to_invoice() == text
@@ -524,3 +524,31 @@ def test_from_invoice_refuses_a_tagged_field_overrunning_the_data_part() -> None
     text = bech32_encode("lnbc", data, m=1).decode("ascii")
     with pytest.raises(BTClibValueError, match="overruns the data part"):
         Bolt11Invoice.from_invoice(text)
+
+
+def test_an_unknown_even_feature_bit_is_refused() -> None:
+    """The bit BOLT11's own invalid example sets, named in the refusal."""
+    with pytest.raises(BTClibValueError, match="unknown even feature bits: 100"):
+        Bolt11Invoice.sign(
+            _PRV_KEY,
+            "mainnet",
+            0,
+            payment_hash=bytes(32),
+            payment_secret=bytes(32),
+            description="d",
+            features=1 << 100,
+        )
+
+
+def test_an_unknown_odd_feature_bit_is_carried() -> None:
+    """It's ok to be odd: bit 99 is nobody's feature and rides along."""
+    invoice = Bolt11Invoice.sign(
+        _PRV_KEY,
+        "mainnet",
+        0,
+        payment_hash=bytes(32),
+        payment_secret=bytes(32),
+        description="d",
+        features=1 << 99,
+    )
+    assert Bolt11Invoice.from_invoice(invoice.to_invoice()).features == 1 << 99

--- a/tests/bolt9_test.py
+++ b/tests/bolt9_test.py
@@ -1,0 +1,66 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the `btclib.bolt9` module.
+
+The table is a transcription, so what a test can hold it to is its shape
+-- a key per pair, and the even bit of it -- and the two bits BOLT11's
+own examples make load-bearing: 8 and 14, which its valid "supports
+features 8, 14 and 99" invoice sets, and 100, which its one invalid
+feature example sets. `tests/bolt11_test.py` drives those two invoices
+themselves.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from btclib.bolt9 import FEATURE_NAMES, unknown_even_bits
+from btclib.exceptions import BTClibValueError
+
+
+def test_every_key_is_the_even_bit_of_its_pair() -> None:
+    """A pair is recorded once, under the compulsory half of it."""
+    assert all(bit % 2 == 0 for bit in FEATURE_NAMES)
+
+
+def test_no_two_pairs_share_a_name() -> None:
+    """A name is a feature, so a repeated one would be a mistranscription."""
+    assert len(set(FEATURE_NAMES.values())) == len(FEATURE_NAMES)
+
+
+def test_a_feature_vector_of_assigned_bits_is_known() -> None:
+    """Every bit BOLT9 assigns, even and odd halves alike, at once."""
+    features = 0
+    for bit in FEATURE_NAMES:
+        features |= (1 << bit) | (1 << (bit + 1))
+    assert unknown_even_bits(features) == ()
+
+
+def test_no_feature_bits_at_all() -> None:
+    """An invoice stating no `9` field is a zero, and states nothing."""
+    assert unknown_even_bits(0) == ()
+
+
+def test_an_unassigned_odd_bit_is_never_returned() -> None:
+    """It's ok to be odd, whether or not the pair is assigned."""
+    assert unknown_even_bits(1 << 99) == ()
+    assert unknown_even_bits(1 << 3) == ()
+
+
+def test_unassigned_even_bits_come_back_lowest_first() -> None:
+    """Two gaps in BOLT9's own numbering, and the bit past its end."""
+    assert unknown_even_bits((1 << 100) | (1 << 2) | (1 << 30)) == (2, 30, 100)
+
+
+def test_an_assigned_bit_beside_an_unassigned_one() -> None:
+    """`option_payment_metadata` is known; the bit above its pair is not."""
+    assert FEATURE_NAMES[48] == "option_payment_metadata"
+    assert unknown_even_bits((1 << 48) | (1 << 52)) == (52,)
+
+
+def test_a_negative_feature_vector_is_refused() -> None:
+    """A bit vector has no sign, and int_from_integer reads one."""
+    with pytest.raises(BTClibValueError, match="negative feature vector"):
+        unknown_even_bits(-1)


### PR DESCRIPTION
BOLT9 assigns feature bits in pairs, the odd half of a pair optional and
the even half compulsory, so a reader meeting a bit it does not know
fails on the even one and ignores the odd one. Answering that is a lookup
in BOLT9's assignment table, which BOLT11 does not define and which this
tree did not carry: at `496b36c5` the BOLT's own invalid example "adding
invalid unknown feature 100" decoded and passed `assert_valid`.

**The table lives in `btclib.bolt9`, a module of its own** rather than a
constant inside `bolt11.py` or a mapping every caller supplies. It is
another BOLT's table, and the init message and the gossip announcements
carry a feature vector read by the same rule, so the module is where a
second reader of one will look. `FEATURE_NAMES` is the even bit of each
assigned pair with the name the BOLT gives it, transcribed at the
upstream commit named beside it; `unknown_even_bits` is the lookup, over
a feature vector rather than over an invoice.

**A bit is known when BOLT9 assigns it, whichever fields its Context
column names.** Reading that column as the criterion refuses invoices
BOLT11 calls valid: its "supports features 8, 14 and 99" example sets
even bits 8 and 14, whose Context column is empty. And naming a bit is
not implementing its feature, so `assert_valid` refuses the half nothing
could support, and a wallet acting on an invoice checks the assigned even
bits against its own capabilities out of the same table.

BOLT11's "Same, but adding invalid unknown feature 100" joins the
vendored vectors, so both of that document's example sections are now
transcribed whole.

**Breaking**: an invoice that parsed before now raises
`BTClibValueError: unknown even feature bits: …`, naming them.
[RELEASE_NOTES.md](./RELEASE_NOTES.md) carries it under *Breaking
changes*.

closes #1637

## Summary by Sourcery

Enforce BOLT9's compulsory feature-bit rule when validating BOLT11 invoices.

New Features:
- Add a BOLT9 feature-assignment module exposing assigned feature names and lookup support for unknown compulsory bits.

Bug Fixes:
- Reject Lightning invoices containing even feature bits that BOLT9 does not assign while preserving unknown odd bits.

Enhancements:
- Use the BOLT9 assignment table to validate BOLT11 feature vectors and report offending bit numbers.
- Expose the BOLT9 module through the package API.

Documentation:
- Document the breaking invoice-validation change and the BOLT9 feature-table behavior in the changelog and release notes.

Tests:
- Add coverage for assigned, unknown even, and unknown odd feature bits, including BOLT11 specification vectors.