### PR TITLE
`Fetcher` and `Wallet` take a network name as the rest of the library does (closes #1641)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,26 @@ documented at release-notes length in the first place, and are still in
   example sections are transcribed whole; the file's entry in
   `tests/_data/README.md` says so, and says what refuses this one.
 
+### `Fetcher` and `Wallet` take a network name as the rest of the library does
+
+- **`Fetcher.__init__` and `Wallet.__init__` put their `network: str`
+  through `network._validated_network_name`** (closes #1641). The two
+  abstract bases every backend and every wallet calls up into accept the
+  spellings issue #216 decided to keep — `" Testnet "` resolves to
+  `testnet` — where each checked membership of `NETWORKS` itself and
+  refused them. Reaching that helper across modules is what
+  `descriptors.parse` and `p2p.magic.magic_from_network` already do.
+- **`Fetcher.network` and `Wallet.network` hold the name
+  `network_from_name` answers to**, which is what a subclass reads to
+  label a transaction or to derive an address.
+- **A `network` of a type no conversion accepts is a `BTClibTypeError`**,
+  which is a `TypeError` and not a `ValueError`;
+  [RELEASE_NOTES.md](./RELEASE_NOTES.md) has what a caller catching
+  `BTClibValueError` around either constructor does about it. An
+  unhashable one was hashed as a dict key by the membership test and
+  left as a builtin `TypeError`, which `btclib.exceptions` does not
+  declare.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,6 +36,20 @@ full year, short month, short day (YYYY-M-D)
   `btclib.bolt9.unknown_even_bits` is the same lookup over any feature
   vector. An unknown *odd* bit is carried as it was.
 
+- **`btclib.fetch` and `btclib.wallet` refuse a `network` that is not a
+  string with `BTClibTypeError`** (closes #1641). `Fetcher.__init__` and
+  `Wallet.__init__` — the bases every backend and every wallet calls up
+  into — put the name through `btclib.network._validated_network_name`,
+  which raises `BTClibTypeError`, a `TypeError`, where each raised
+  `BTClibValueError: unknown network: None`.
+
+  Act on it if you catch `BTClibValueError` around building a fetcher or
+  a wallet to handle a name you have not checked is a `str`: catch
+  `BTClibException`, which is the base of both, or check the type
+  yourself. A `str` no network answers to is still a `BTClibValueError`,
+  and the names accepted are wider than before — `" Testnet "` resolves
+  here as it does everywhere else in the library.
+
 ## v2026.9.3
 
 ### Breaking changes

--- a/src/btclib/fetch/fetcher.py
+++ b/src/btclib/fetch/fetcher.py
@@ -34,7 +34,7 @@ from btclib.exceptions import (
     HttpError,
     RpcError,
 )
-from btclib.network import NETWORKS, network_from_name
+from btclib.network import NETWORKS, _validated_network_name, network_from_name
 from btclib.script import ScriptPubKey
 from btclib.tx import OutPoint, Tx, TxOut
 from btclib.utils import bytes_from_octets, is_integer, is_octets
@@ -170,9 +170,15 @@ class Fetcher(ABC):
     network: str
 
     def __init__(self, network: str = "mainnet") -> None:
-        if network not in NETWORKS:
-            raise BTClibValueError(f"unknown network: {network}")
-        self.network = network
+        """Bind the fetcher to a network, by the name btclib resolves.
+
+        `_validated_network_name` is the converter `descriptors.parse`
+        and `p2p.magic.magic_from_network` reach for across modules, so
+        the `strip().lower()` tolerance issue #216 decided to keep
+        reaches a backend too. `self.network` is a key of `NETWORKS`, and
+        it is what `tx_from_raw` labels a transaction with.
+        """
+        self.network = _validated_network_name(network)
 
     @abstractmethod
     def get_tx(self, tx_id: Octets) -> Tx:

--- a/src/btclib/wallet/wallet.py
+++ b/src/btclib/wallet/wallet.py
@@ -64,7 +64,7 @@ from dataclasses import dataclass
 from btclib import b32
 from btclib.alias import Octets, String
 from btclib.exceptions import BTClibValueError
-from btclib.network import NETWORKS
+from btclib.network import _validated_network_name
 from btclib.script.script_pub_key import ScriptPubKey, _validated_script_from
 from btclib.utils import str_from_string
 
@@ -142,9 +142,15 @@ class Wallet(ABC):
     script_type: str
 
     def __init__(self, network: str = "mainnet") -> None:
-        if network not in NETWORKS:
-            raise BTClibValueError(f"unknown network: {network}")
-        self.network = network
+        """Bind the wallet to a network, by the name btclib resolves.
+
+        `_validated_network_name` is the converter `descriptors.parse`
+        and `p2p.magic.magic_from_network` reach for across modules, so
+        the `strip().lower()` tolerance issue #216 decided to keep
+        reaches a wallet too. `self.network` is a key of `NETWORKS`,
+        which is what a subclass reads to derive an address.
+        """
+        self.network = _validated_network_name(network)
         # insertion ordered, which is the order the addresses were handed
         # out in: `addresses` is that order and nothing else records it
         self._handed_out: dict[str, AddressInfo] = {}

--- a/tests/fetch/esplora_test.py
+++ b/tests/fetch/esplora_test.py
@@ -72,7 +72,7 @@ def test_a_session_transport_can_drive_the_fetcher() -> None:
 
 def test_an_unknown_network_is_refused() -> None:
     """Refuse a network name that is none of the three known ones."""
-    with pytest.raises(BTClibValueError, match="unknown network: liquid"):
+    with pytest.raises(BTClibValueError, match="unknown network: 'liquid'"):
         EsploraFetcher(BASE, network="liquid")
 
 

--- a/tests/fetch/fetcher_test.py
+++ b/tests/fetch/fetcher_test.py
@@ -285,15 +285,25 @@ def test_leaving_any_one_of_the_four_abstract_refuses_construction(
         incomplete("mainnet")
 
 
-def test_an_unknown_network_is_refused_at_construction() -> None:
-    """Refuse a misspelled network before any request is made."""
-    with pytest.raises(BTClibValueError, match="unknown network: mainnnet"):
+def test_a_network_name_is_taken_as_the_rest_of_the_library_takes_one() -> None:
+    """`Fetcher` normalizes the name it is given, and refuses before fetching.
+
+    `__init__` puts the name through `network._validated_network_name`,
+    so the spellings issue #216 decided to keep reach a backend, and
+    `Fetcher.network` is the name `network_from_name` answers to.
+    """
+    assert StubFetcher(Tx.parse(RAW), " TestNet4 ").network == "testnet4"
+    with pytest.raises(BTClibValueError, match="unknown network: 'mainnnet'"):
         StubFetcher(Tx.parse(RAW), "mainnnet")
+    # a name that is not a string is the type rule, which RELEASE_NOTES.md
+    # tells a caller to act on
+    with pytest.raises(BTClibTypeError, match="not a network name"):
+        StubFetcher(Tx.parse(RAW), [])  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("network", ["mainnet", "testnet", "testnet4", "regtest"])
 def test_the_network_is_the_one_it_was_given(network: str) -> None:
-    """Expose the constructor's network unchanged, for all four."""
+    """Expose the name the constructor resolved, for all four."""
     assert StubFetcher(Tx.parse(RAW), network).network == network
 
 

--- a/tests/wallet/key_wallet_test.py
+++ b/tests/wallet/key_wallet_test.py
@@ -15,7 +15,7 @@ from btclib.alias import BIP44ScriptType
 from btclib.bip32 import bip32
 from btclib.curves import curve, sec_point
 from btclib.ecc import bms
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.wallet import AddressInfo, BIP32KeyWallet, KeyWallet
 from tests import needs_bindings, replace_unchecked
 
@@ -230,10 +230,20 @@ def test_an_unknown_script_type_is_refused() -> None:
         KeyWallet().add(_PUB_KEY, "p2wsh")  # type: ignore[arg-type]
 
 
-def test_an_unknown_network_is_refused() -> None:
-    """Refuse a network name btclib does not register."""
-    with pytest.raises(BTClibValueError, match="unknown network: regtest2"):
+def test_a_network_name_is_taken_as_the_rest_of_the_library_takes_one() -> None:
+    """`Wallet` normalizes the name it is given, and refuses the rest.
+
+    `__init__` puts the name through `network._validated_network_name`,
+    so the spellings issue #216 decided to keep reach a wallet, and
+    `Wallet.network` is the name `network_from_name` answers to.
+    """
+    assert KeyWallet(network=" RegTest ").network == "regtest"
+    with pytest.raises(BTClibValueError, match="unknown network: 'regtest2'"):
         KeyWallet(network="regtest2")
+    # a name that is not a string is the type rule, which RELEASE_NOTES.md
+    # tells a caller to act on
+    with pytest.raises(BTClibTypeError, match="not a network name"):
+        KeyWallet(network=[])  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("purpose", [44, 49, 84])


### PR DESCRIPTION
`Fetcher.__init__` and `Wallet.__init__` — the abstract bases every backend
and every wallet calls up into — checked membership of `NETWORKS` directly,
where the rest of the library goes through
`network._validated_network_name`. That cost three things: the
`strip().lower()` tolerance issue #216 decided to keep did not reach them,
so `" Testnet "` was refused; an unhashable name was hashed as a dict key
and left as a builtin `TypeError`, which `btclib.exceptions` does not
declare; and the refusal did not name what it would have accepted.

Both now delegate, so `" Testnet "` resolves to `testnet`, a name of a type
no conversion accepts raises `BTClibTypeError`, and the message enumerates
`sorted(NETWORKS)`.

**Breaking**: `BTClibTypeError` is a `TypeError` and **not** a
`ValueError`, so a caller with `except BTClibValueError` around either
constructor stops catching `Fetcher(None)`.
[RELEASE_NOTES.md](./RELEASE_NOTES.md) carries it under *Breaking changes*,
beside what to catch instead. The widened spellings are in `CHANGELOG.md`
only: they were previously *refused*, so no existing caller can hold an
un-normalized `network`.

`src/btclib/script/script_pub_key.py` carries the same three defects and is
deliberately not joined — `ScriptPubKey` is a frozen dataclass whose check
sits in `assert_valid`, so normalizing would mean writing the field during
a validity check. That is a design question rather than a port, and it is
[ISS 1662](https://github.com/btclib-org/btclib/issues/1662).

closes #1641

## Summary by Sourcery

Route Fetcher and Wallet network validation through the library-wide network-name resolver.

Bug Fixes:
- Make fetchers and wallets consistently normalize network names and report invalid network types through btclib's declared exception hierarchy.

Enhancements:
- Store the canonical resolved network name on Fetcher and Wallet instances.
- Document the changed exception behavior and accepted network spellings.

Documentation:
- Add changelog and release-note entries covering network normalization and the breaking exception-type change.

Tests:
- Update fetcher and wallet tests to cover normalized names, canonical stored values, unknown networks, and invalid network types.