### PR TITLE
tests/README.md documents replaying a ClusterFuzzLite crash locally with docker (closes #530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,25 @@ documented at release-notes length in the first place, and are still in
   own gates cannot see it: `uv.lock` already pinned 2026.9.3, so the
   suite exercises the locked release and never the declared floor.
 
+### `tests/README.md` documents replaying a ClusterFuzzLite crash locally
+
+- **`tests/README.md` gains a *Fuzzing* section, with the local
+  reproduction command #530 asked for** (closes #530). #530 read "a
+  documented local command" as `uv run` on the machine writing the
+  code, which Atheris's missing macOS and aarch64 wheels since 2.2.2
+  rule out; btclib-org/btclib#1361's `fuzz.yml` answers a different
+  premise, reproducible rather than co-located, and a crash it finds
+  replays with `google/oss-fuzz`'s `infra/helper.py`, against the same
+  `gcr.io/oss-fuzz-base/base-builder-python` image
+  `.clusterfuzzlite/Dockerfile` builds, which is what makes the wheel
+  gap irrelevant to reproducing a finding rather than blocking it. The
+  section also states where a crash and a batch run's corpus land —
+  GitHub Actions artifacts, `crashes-<fuzzer>` and
+  `cifuzz-corpus-<fuzzer>`, `fuzz.yml` naming no `storage-repo` to keep
+  either in a git branch instead — and the minimization step,
+  `-minimize_crash=1` forwarded through `reproduce` to the fuzzer's own
+  libFuzzer binary.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/README.md
+++ b/tests/README.md
@@ -136,6 +136,109 @@ presses the buttons there is `--automation`, matching the text the app
 draws, since Speculos has no DebugLink — the fragile part of that job,
 and why its Speculos logs are uploaded with the reports.
 
+## Fuzzing, and replaying a crash it finds
+
+`tests/fuzz_test.py` is Hypothesis over every parser of the public
+surface, part of the ordinary `uv run pytest` above. Coverage-guided
+fuzzing is a separate job: `fuzz.yml` runs every `fuzz/fuzz_*.py`
+harness with `atheris` under ClusterFuzzLite, weekly and on
+`workflow_dispatch`, never on `uv run pytest` and never inside the
+coverage ratchet. Atheris 3.1.0 ships no wheel for macOS or aarch64, so
+the machine writing the code cannot run a harness with `uv run` the way
+the rest of the suite does; what it can still do is replay a crash the
+workflow already found, in the same images the workflow used —
+`base-builder-python` to build the harness, `base-runner` to run it —
+which is what makes the missing wheel irrelevant to reproducing a
+finding rather than blocking it.
+
+A crash `fuzz.yml` finds is attached to that run as a GitHub Actions
+artifact named `crashes-<fuzzer>` (`<fuzzer>` the crashing
+`fuzz/fuzz_*.py` file's own stem), holding the input under a
+sanitizer-named directory with a `.summary` beside it carrying the
+stack trace. The run id is in the run's own URL, so the two are quoted
+for the download call beside them and stand in an assignment block of
+their own above it, unset being what an unfilled paste of that block
+alone supplies:
+
+```shell
+run_id=<run-id>
+fuzzer=<fuzzer>
+```
+
+```shell
+gh run download "${run_id:?}" -n "crashes-${fuzzer:?}"
+```
+
+Replaying it needs a checkout of
+[google/oss-fuzz](https://github.com/google/oss-fuzz), whose
+`infra/helper.py` drives the same build `.clusterfuzzlite/Dockerfile`
+describes — `gcr.io/oss-fuzz-base/base-builder-python` — for a
+project outside its own `projects/` tree via `--external`
+(`google/clusterfuzzlite`'s `docs/build_integration.md`, "Testing
+locally", which is where `--external` is spelled;
+`google/oss-fuzz`'s `docs/advanced-topics/reproducing.md` has the shape
+of `reproduce` and not that flag):
+
+```shell
+btclib_checkout=<btclib-checkout>
+fuzzer=<fuzzer>
+crash_file=<path-to-crash-file>
+```
+
+`:?` in the commands below is what makes an unfilled paste stop: the
+shell refuses to expand a variable left unset and the command never
+runs. Filling the block above is what arms them; deleting the `:?`
+disarms them.
+
+```shell
+git clone --depth=1 https://github.com/google/oss-fuzz.git
+```
+
+```shell
+python3 oss-fuzz/infra/helper.py build_fuzzers \
+    --external "${btclib_checkout:?}" --sanitizer address
+```
+
+```shell
+python3 oss-fuzz/infra/helper.py reproduce \
+    --external "${btclib_checkout:?}" "${fuzzer:?}" "${crash_file:?}"
+```
+
+`reproduce` forwards trailing arguments to the fuzzer's own libFuzzer
+binary, which is where minimization comes from — the crashing input
+shrunk to what still reproduces it, written back to oss-fuzz's own
+`build/out/` for this checkout, the directory `reproduce` mounts as
+`/out`. Two things about the invocation are not obvious and both are
+`helper.py`'s: `fuzzer_args` is declared `nargs='*'` rather than
+`argparse.REMAINDER`, so a first token beginning with `-` is read as an
+option to `helper.py` itself and refused — `--` is what ends its own
+arguments; and `reproduce_impl` prepends `-runs=100`, which is the
+whole minimization budget unless a later `-runs` overrides it, libFuzzer
+taking the last occurrence of a flag:
+
+```shell
+python3 oss-fuzz/infra/helper.py reproduce \
+    --external "${btclib_checkout:?}" "${fuzzer:?}" "${crash_file:?}" \
+    -- -minimize_crash=1 -runs=100000
+```
+
+What to do with the minimized input from there is `fuzz.yml`'s own
+comment and `fuzz/fuzz_*.py`'s: a regression test naming it and the
+exception the parser is expected to raise on it.
+
+Not `fuzz/corpus/<name>/`, which is a seed corpus checked into the
+tree and asserted still valid by `tests/fuzz_corpus_test.py`; `fuzz.yml`'s
+own comment is where the reason a crash cannot live there is argued. The
+corpus
+a batch run accumulates lives the same way a crash does, a GitHub
+Actions artifact named `cifuzz-corpus-<fuzzer>`, `fuzz.yml` naming no
+`storage-repo` to keep it in a git branch instead. The prefix is the
+difference: `GithubActionsFilestore.upload_corpus` goes through
+`_upload_directory`, which prepends `cifuzz-`, where `upload_crashes`
+calls `_raw_upload_directory` and does not — so the two names are not
+the same shape, and a download asking for the wrong one answers
+`no artifact matches any of the names or patterns provided`.
+
 ## There is no `slow` marker, and that is a measurement
 
 `addopts` in pyproject.toml passes `--strict-markers`, so a marker has to


### PR DESCRIPTION
`tests/README.md` gains a section documenting how a ClusterFuzzLite
crash is replayed and minimized locally, which is what ISS 530's
decision comment names as the whole of what closes it.

The premise the issue was filed on — fuzzing on the machine writing the
code — is replaced by the one `fuzz.yml` actually answers: reproducible.
A crash found in CI is downloaded as a run artifact and replayed against
the same images, which is what makes Atheris' missing macOS and aarch64
wheels irrelevant to reproducing a finding rather than blocking it.

Every command is derived from this tree's `.clusterfuzzlite/` and
`.github/workflows/fuzz.yml` and from `google/oss-fuzz`'s and
`google/clusterfuzzlite`'s own sources, read at source and cited by
path. None was executed: no docker was run anywhere in producing this.

Two of them were wrong on the first draft and are the reason the section
is worth reviewing rather than skimming, both settled against upstream
source with a positive control:

- the crash artifact is `crashes-<fuzzer>`, **not**
  `cifuzz-crashes-<fuzzer>`. `GithubActionsFilestore.upload_corpus` goes
  through `_upload_directory`, which prepends `cifuzz-`, where
  `upload_crashes` calls `_raw_upload_directory` and does not. The
  control is this repository's own runs, whose artifacts are all
  `cifuzz-corpus-fuzz_*` — the corpus half of the same asymmetry;
- the minimize invocation needs `--` before the libFuzzer flag:
  `helper.py` declares `reproduce`'s `fuzzer_args` as `nargs='*'` rather
  than `argparse.REMAINDER`, so a first token beginning with `-` is
  refused as an option to `helper.py` itself. It also passes an explicit
  `-runs`, `reproduce_impl` prepending `-runs=100` that would otherwise
  be the entire minimization budget.

The fenced commands use an assignment block plus `${name:?}` rather than
a bare `<placeholder>` mid-command, so an unfilled paste is a parse
error rather than a redirection — which is not hypothetical: verifying
that very property is how a stray file got written during this work.

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Document a reproducible local workflow for replaying and minimizing ClusterFuzzLite crashes found by CI.

New Features:
- Document how to download, replay, and minimize ClusterFuzzLite crashes locally using the same OSS-Fuzz container workflow as CI.
- Explain the GitHub Actions artifact locations and naming for crashes and accumulated fuzzing corpora.

Enhancements:
- Clarify the distinction between ordinary test fuzzing and the separate coverage-guided ClusterFuzzLite job, including the implications of Atheris platform support.
- Document safe, reproducible command examples for building external fuzzers and forwarding libFuzzer minimization options.

Documentation:
- Add user-facing fuzzing guidance to tests/README.md, including local crash reproduction, minimization, artifact retrieval, and follow-up regression-test advice.