### PR TITLE
This tree's docs take section 9's comment and placeholder rules (issue btclib-org/.github#771) (issue btclib-org/.github#786) (issue btclib-org/.github#772) (issue btclib-org/.github#775)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,31 @@ documented at release-notes length in the first place, and are still in
 
 ## v2026.9 (work in progress, not released yet)
 
+### Section 9's comment and placeholder rules land in this tree's own docs
+
+- **A trailing `#` comment inside a `shell` fence of `CLAUDE.md`,
+  `REPOSITORY.md` or `tests/README.md` no longer sits on the command
+  line it followed** (issue btclib-org/.github#771): an interactive
+  `zsh` leaves `INTERACTIVE_COMMENTS` unset, so it hands the comment's
+  own words to the command as arguments rather than treating them as a
+  comment. What the comment said either became a sentence above the
+  fence or moved to a line of its own that opens with `#`, which the
+  same rule reads as harmless.
+- **`CLAUDE.md`'s `WT=` line loses its trailing worktree-name example**
+  (issue btclib-org/.github#786): the comment's own words followed the
+  line's final `>`, so an interactive `zsh` took them as that
+  redirection's target instead of finding nothing there and failing at
+  the parse before an unfilled paste ever reached the shell. The example
+  moves into a sentence above the fence.
+- **`REVIEWING.md`'s two placeholders — the `gh issue list --search` and
+  `gh issue create --title`/`--body` lines — go bare** (issue
+  btclib-org/.github#772): quoted, `gh issue create` takes both flags as
+  literal values and files an issue whose title is the placeholder
+  itself, rather than failing at the shell.
+- **`RELEASING.md`'s `--subject <title>` loses its quoting and moves
+  behind `--body-file <path>`, which keeps the bare placeholder at the
+  end of the command** (issue btclib-org/.github#775).
+
 ## v2026.9.3
 
 ### Repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ rather than merely readable, a fast-forward of a clean `main` brings it
 up:
 
 ```shell
-git fetch origin && git merge --ff-only origin/main   # clean main only
+git fetch origin && git merge --ff-only origin/main
 ```
 
 That writes no commit, switches no branch and runs no hook, so it is on
@@ -103,11 +103,15 @@ this way also sorts every worktree of one issue together. `role` covers
 the narrower case of a coder and its reviewer holding a worktree at
 once, which the ordinary sequence avoids by each removing its own.
 
+An issue of `btclib-org/.github`'s tracker worked in `btclib` by a coder
+names its worktree `wt-github-255-btclib-coder`. No `uv sync` follows
+the `cd`, the gate doing that itself, and the editing, the gates and the
+commits all happen in the worktree before the push.
+
 ```shell
-WT=<scratchpad>/wt-<tracker>-<issue>-<repo>-<role>  # wt-github-255-btclib-coder
+WT=<scratchpad>/wt-<tracker>-<issue>-<repo>-<role>
 git worktree add "$WT" origin/main -b <branch>
-cd "$WT"                              # no uv sync: the gate does it
-# edit, gate and commit here, then
+cd "$WT"
 git push origin HEAD:refs/heads/<branch>
 ```
 
@@ -292,7 +296,7 @@ Do not use Fable unless explicitly instructed.
   release wants it, and do not estimate:
 
   ```shell
-  grep -c '^- ' CHANGELOG.md   # the number, whenever it is wanted
+  grep -c '^- ' CHANGELOG.md
   git ls-files 'tests/_data/*' 'tests/*/_data/*' \
       src/btclib/mnemonic/_data/wordlist.txt | grep -cv 'README.md'
   ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -373,8 +373,8 @@ to `deps-latest`'s own result.
    landing from `BLOCKED` and `REVIEW_REQUIRED` with a verified
    signature, one of them (#1113) `BEHIND` as well and cleared the same
    way. Name the release commit's title and body explicitly when using
-   it — `gh pr merge <n> --squash --admin --subject "<title>"
-   --body-file <path>` — rather than leave them to
+   it — `gh pr merge <n> --squash --admin --body-file <path>
+   --subject <title>` — rather than leave them to
    `squash_merge_commit_message`'s repository default, recorded in
    REPOSITORY.md's *Merge methods*: this branch carries more than one
    commit every time (the paragraph below this one), and that default

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -791,7 +791,8 @@ at once. It is an attribute of the organization, shared by every
 repository in it, and the plan is what sets it.
 
 ```shell
-gh api orgs/btclib-org --jq .plan.name        # free
+gh api orgs/btclib-org --jq .plan.name
+# free
 ```
 
 [GitHub's own table](https://docs.github.com/en/actions/reference/limits)
@@ -883,11 +884,11 @@ std=$(gh api repos/btclib-org/.github/contents/README.md --jq .content \
   | base64 -d)
 for f in allow_forking allow_update_branch has_discussions has_downloads \
          is_template web_commit_signoff_required; do
-  printf '%s %s\n' "$f" "$(printf '%s' "$std" | grep -c "$f")"  # 0 each
+  printf '%s %s\n' "$f" "$(printf '%s' "$std" | grep -c "$f")"
 done
-printf '%s' "$std" | grep -c delete_branch_on_merge  # not 0, which is
-                                                     # what makes those
-                                                     # zeros absences
+# 0 each
+printf '%s' "$std" | grep -c delete_branch_on_merge
+# not 0, which is what makes those zeros absences
 ```
 
 Recording a field on no rule grows this file with GitHub's API rather
@@ -905,8 +906,10 @@ holds that token at the organization, in both stores, rather than in each
 repository:
 
 ```shell
-gh api repos/btclib-org/btclib/actions/secrets --jq '.total_count'     # 0
-gh api repos/btclib-org/btclib/dependabot/secrets --jq '.total_count'  # 0
+gh api repos/btclib-org/btclib/actions/secrets --jq '.total_count'
+# 0
+gh api repos/btclib-org/btclib/dependabot/secrets --jq '.total_count'
+# 0
 gh api orgs/btclib-org/actions/secrets \
   --jq '.secrets[] | "\(.name) \(.visibility)"'
 # CLAUDE_CODE_OAUTH_TOKEN all

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -138,7 +138,7 @@ line; it is whether this change is what put it there or made it worse.
 Look for the issue already open before filing another:
 
 ```shell
-gh issue list --state open --search "<the thing, in a word or two>"
+gh issue list --state open --search <the thing, in a word or two>
 ```
 
 The issue stands on its own, read by somebody who never sees this pull
@@ -147,9 +147,13 @@ it matters. No fix, and no reference to the pull request as a blocker,
 because it is not one.
 
 ```shell
-gh issue create --title "<the finding, as a claim>" \
-  --body "<what was noticed and where, how it is known, why it matters>"
+gh issue create --title <the finding, as a claim> \
+  --body <what was noticed and where, how it is known, why it matters>
 ```
+
+Both blocks leave their placeholders unquoted, which section 9 of the
+standard asks for: quoted, a paste of the second files an issue whose
+title is the placeholder.
 
 Name the issues filed at the foot of the summary comment, under a line
 saying they are **not** findings against this pull request. Without that

--- a/tests/README.md
+++ b/tests/README.md
@@ -156,11 +156,13 @@ What costs is `tests/script_engine/python_path_test.py`, which re-runs the
 same vector sets through the Python implementations of the two functions
 the engine takes from the bindings (issue #129). It holds most of the
 suite's slowest cases, the `tapscript-bigmulti` ones, and enough of a run
-to make the case for a marker a measurement rather than a shrug:
+to make the case for a marker a measurement rather than a shrug. The
+second run, serial with `-n0`, is the baseline a plain `uv run pytest`'s
+parallel workers are worth against:
 
 ```shell
 uv run pytest --ignore=tests/script_engine/python_path_test.py
-uv run pytest -n0                       # what the cores are worth
+uv run pytest -n0
 ```
 
 What it would cost is why none is registered: a plain `uv run pytest` is
@@ -184,10 +186,11 @@ That lopsidedness is also why `addopts` passes `--dist worksteal` instead
 of xdist's default `load`. `load` hands the queue out in chunks, so a
 worker that draws several `bigmulti` cases is still going when the others
 have nothing left; worksteal lets an idle worker take back what is queued
-behind a busy one. Worksteal wins that comparison, best of three runs each:
+behind a busy one. Worksteal wins that comparison against the default
+`load`, best of three runs each:
 
 ```shell
-uv run pytest -p no:randomly --dist load   # the default, to compare with
+uv run pytest -p no:randomly --dist load
 ```
 
 `-p no:randomly` is part of the comparison, not decoration: pytest-randomly
@@ -220,10 +223,13 @@ the number describes the machine rather than pytest.
 
 ## Profiling
 
+The second command's interactive browser takes `sort time`, `stats 30`
+and `callers add_jac` once it opens:
+
 ```shell
 uv run python -m cProfile -o btclib.prof -m pytest \
     -n0 --no-cov -p no:randomly
-uv run python -m pstats btclib.prof   # sort time, stats 30, callers add_jac
+uv run python -m pstats btclib.prof
 ```
 
 Every flag after `-m pytest` undoes something `addopts` asked for, and


### PR DESCRIPTION
The last of the eight trees, so this landing closes all four issues.

Twelve trailing `#` comments leave this tree's `shell` fences — moved to
an own-line comment where the file already had that idiom, and to prose
above the fence where it did not — with the `WT=` block brought to the
shape `btclib-org/.github`'s own `CLAUDE.md` converged on, and
`REVIEWING.md`'s two lines and their justification paragraph taken byte
for byte from the standard.

On `RELEASING.md`'s `--subject <title>`: it loses its quoting and moves
behind `--body-file <path>`, which keeps the bare placeholder at the end
of the command. What that does *not* do is make an unfilled paste safe —
the line already ended in a bare `<path>`, so such a paste was a parse
error before it reached `gh`, and the quoting is the whole of what this
fixes. Both forms were run under `zsh -f -i` and `bash -i` with a stub
`gh` and a control that invokes, seeded and unseeded; neither reaches
the command.

closes btclib-org/.github#771
closes btclib-org/.github#772
closes btclib-org/.github#775
closes btclib-org/.github#786

This tree's docs take section 9's comment and placeholder rules (issue btclib-org/.github#771) (issue btclib-org/.github#786) (issue btclib-org/.github#772) (issue btclib-org/.github#775)

A trailing `#` comment inside a `shell` fence hands its own words to the
command as arguments in an interactive `zsh`, which leaves
`INTERACTIVE_COMMENTS` unset. `CLAUDE.md`, `REPOSITORY.md` and
`tests/README.md` carried the shape: each comment either became a
sentence above its fence or moved to a line of its own that opens with
`#`, which the rule reads as harmless. This tree's `CHANGELOG.md` holds
no such instance, so nothing there is left carrying one.

`CLAUDE.md`'s `WT=<scratchpad>/wt-<tracker>-<issue>-<repo>-<role>` line
carried its worktree-name example as that same trailing comment: an
unfilled paste ends the line in a bare `>`, and the comment's words are
what an interactive `zsh` took as that redirection's target instead of
finding nothing there. The example is now a sentence above the fence,
naming `btclib-org/.github`'s tracker explicitly rather than "this
tracker", which is only true from inside that repository.

`REVIEWING.md`'s two placeholders -- `gh issue list --search` and
`gh issue create --title`/`--body` -- go bare, matching
`btclib-org/.github`'s own copy: quoted, `gh issue create` takes both
flags as literal text and files an issue whose title is the placeholder
itself.

`RELEASING.md`'s `--subject <title>` loses its quoting and moves behind
`--body-file <path>`, which keeps the bare placeholder at the end of the
command. The line already ended in a bare `<path>` before this change,
so an unfilled paste was already a parse error before it reached `gh`;
what this fixes is the quoting alone.

None of the four issues is answered in full by this branch: each is
owed by several repositories, and is done when the last of them lands.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WpcKzs2UfKjjrgU6bj1b5i


Local review: CLEARED eb45158, which is this head. Gates on that tree, each exit 0: `uv sync`, `uv run pytest` (31689 passed, 30 skipped, 1 xfailed, coverage 100.00%), `uv run pre-commit run --all-files`, `uv run --locked --only-group lint pre-commit run --all-files --show-diff-on-failure`, `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html`, and the docs job's own `href="#../"` grep at exit 1, its passing result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpcKzs2UfKjjrgU6bj1b5i

## Summary by Sourcery

Apply the organization's comment and placeholder conventions consistently across this repository's documentation.

Bug Fixes:
- Correct shell examples that could misinterpret trailing comments or quoted placeholders during interactive use.
- Make release and issue-management command examples preserve bare placeholders for safe manual substitution.

Enhancements:
- Align documentation examples and explanatory prose with the organization's section 9 comment and placeholder conventions across CLAUDE.md, REPOSITORY.md, REVIEWING.md, RELEASING.md, and tests/README.md.

Documentation:
- Document the rationale for moving shell comments out of command lines and leaving placeholders unquoted in issue and release workflows.

Chores:
- Record the documentation convention updates in the changelog.