### PR TITLE
`ssa.py`'s sign-to-contract tags switch to `s2c/schnorr/…` (closes #1680)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,19 @@ documented at release-notes length in the first place, and are still in
   `-minimize_crash=1` forwarded through `reproduce` to the fuzzer's own
   libFuzzer binary.
 
+### `ssa.py`'s sign-to-contract tags switch to `s2c/schnorr/…`
+
+- **`ssa._S2C_POINT_TAG` and `ssa._S2C_DATA_TAG` spell `s2c/schnorr/point`
+  and `s2c/schnorr/data`** (closes #1680), matching
+  bitcoin-core/secp256k1#1140 ("Schnorr sign-to-contract and
+  anti-exfil") byte for byte, at its head `49c31379`. #1140 is open and
+  unmerged, so this is a reference rather than an authority and its
+  spelling can still move — but the tags are frozen the moment they
+  ship, so the cost of aligning to it never falls below what it is
+  today. This is a breaking change: every BIP340 sign-to-contract
+  commitment already made stops opening, with no version byte to switch
+  on. RELEASE_NOTES.md has what to act on.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,17 @@ full year, short month, short day (YYYY-M-D)
 
 ## v2026.9 (work in progress, not released yet)
 
+### Breaking changes
+
+- **`ssa`'s sign-to-contract tags change** (closes #1680). They were
+  `s2c/bip340/point` and `s2c/bip340/data`; they are now
+  `s2c/schnorr/point` and `s2c/schnorr/data`, matching
+  bitcoin-core/secp256k1#1140's spelling.
+
+  Act on it if you hold a BIP340 sign-to-contract commitment made
+  before this release: it no longer opens, and there is no version
+  byte to switch on. Re-derive it with the new tags.
+
 ## v2026.9.3
 
 ### Breaking changes

--- a/src/btclib/ecc/ssa.py
+++ b/src/btclib/ecc/ssa.py
@@ -116,15 +116,18 @@ __all__ = [
     "verify_",
 ]
 
-# btclib's own sign-to-contract tags, and the only invented thing in the
-# scheme: libsecp256k1 has an ecdsa_s2c module and no schnorr one, and
-# BIP340 says nothing about commitments, so there is no upstream string
-# to copy and nothing to be interoperable with. Named for the standard
-# rather than for btclib's `ssa`, and not under BIP0340/, which would
-# claim the BIP defines this. Frozen all the same: a different string is
-# a different scheme, and every signature already made would stop opening
-_S2C_POINT_TAG = b"s2c/bip340/point"
-_S2C_DATA_TAG = b"s2c/bip340/data"
+# bitcoin-core/secp256k1#1140 ("Schnorr sign-to-contract and anti-exfil")
+# spells these `s2c/schnorr/point` and `s2c/schnorr/data`, in
+# src/modules/schnorrsig/main_impl.h at its head 49c31379, and this tree
+# matches it byte for byte: if it lands, a commitment made here opens
+# there. #1140 is open and unmerged, so it is a reference and not an
+# authority -- its spelling can still change, and the pull request may
+# never land at all. Named for the standard rather than for btclib's
+# `ssa`, and not under BIP0340/, which would claim the BIP defines this.
+# Frozen all the same: a different string is a different scheme, and
+# every signature already made would stop opening
+_S2C_POINT_TAG = b"s2c/schnorr/point"
+_S2C_DATA_TAG = b"s2c/schnorr/data"
 
 # BIP340 serializes a signature as thirty-two octets of r and thirty-two
 # of s, on secp256k1 and by that BIP alone: a Sig on another curve has no

--- a/tests/ecc/commit_nonce_test.py
+++ b/tests/ecc/commit_nonce_test.py
@@ -10,9 +10,11 @@ an ordinary one, opens against the value committed to, and opens against
 nothing else.
 
 The dsa construction is libsecp256k1-zkp's `ecdsa_s2c`, and the fixed
-vectors of that module's test suite are below. There is no upstream
-schnorr sign-to-contract, so the ssa side has no vector to match and is
-tested against itself and against the properties the scheme needs.
+vectors of that module's test suite are below. The ssa side matches
+bitcoin-core/secp256k1#1140's tags, an open and unmerged pull request
+whose `tests_impl.h` publishes no fixed vector of its own, so it has
+none to match and is tested against itself and against the properties
+the scheme needs.
 """
 
 import random


### PR DESCRIPTION
`src/btclib/ecc/ssa.py` chose its sign-to-contract tags under a comment
saying "libsecp256k1 has an ecdsa_s2c module and no schnorr one … so
there is no upstream string to copy and nothing to be interoperable
with." There is one: bitcoin-core/secp256k1#1140 spells
`s2c/schnorr/data` and `s2c/schnorr/point` in
`src/modules/schnorrsig/main_impl.h`. This tree now matches it byte for
byte, and the comment says what is true instead.

**This closes a question the issue reserved for the maintainer**, and he
took it today: of the two options btclib-org/btclib#1680 put — switch
now, or keep `s2c/bip340/…` and rewrite the comment — he chose to
switch. His reasoning, so it is on the record rather than reconstructed:
if #1140 never merges the two spellings are equally arbitrary, and if it
does merge only this one interoperates, while the cost of switching
never falls with time. The cut-back, if the answer is unwanted, is to
restore the two literals and keep the comment's correction, which is the
half the issue said had to happen either way.

#1140 is open and unmerged, so it is a **reference and not an
authority**, and nothing that lands here claims otherwise — no date and
no mergeability state is asserted anywhere in the prose, only that it is
open.

`tests/ecc/commit_nonce_test.py`'s module docstring carried the same
refuted premise. That is in this branch rather than filed, since this
diff is what falsifies it.

**Breaking**, and `RELEASE_NOTES.md` says so with an action: every BIP340
sign-to-contract commitment already made stops opening, and there is no
version byte to switch on.

## Verification

Gates are the coder's, run on this exact sha and attributed to them, not
re-run by the reviewer: lint, the full suite at 100% coverage, the
no-bindings suite, the coverage union, and the documentation build under
`-W`, each exit `0`.

Local review at fresh context answered `CLEARED
172bbfd6f618804b51e9872752c83ffd87b36197`, having re-derived the central
claim independently — it fetched benma/secp256k1 at `49c31379` and read
the two C arrays itself rather than taking the coder's word — and having
checked that `RELEASE_NOTES.md`'s `### Breaking changes` heading is this
file's own landed convention across five prior release sections rather
than the themed grouping the standard rejects.

**No rebase.** The branch's parent is `origin/main`'s current tip, so
the gate runs and the clearance both stand on the tree that lands, and
no union-driver reconstruction was owed.

Closes #1680

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015t5eo9hhNUxpM2XeG11Koj

## Summary by Sourcery

Switch SSA sign-to-contract tags to the Schnorr naming convention, documenting the resulting breaking change for existing commitments.

Enhancements:
- Align sign-to-contract tag strings with the Schnorr naming used by the referenced secp256k1 implementation.
- Correct comments and test documentation to reflect the upstream Schnorr sign-to-contract reference.

Documentation:
- Document the sign-to-contract tag change and its impact in the changelog and release notes.