### PR TITLE
Add Broadcaster, a typed announce over the two fetchers that can (closes #1584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,35 @@ documented at release-notes length in the first place, and are still in
   commitment already made stops opening, with no version byte to switch
   on. RELEASE_NOTES.md has what to act on.
 
+### `Broadcaster`, a typed announce over the two fetchers that can
+
+- **`btclib.fetch.broadcaster` adds `Broadcaster`, a `typing.Protocol`
+  with one method, `broadcast(tx: Tx) -> bytes`** (closes #1584).
+  `Fetcher` only reads the chain; this is the write, and a separate
+  protocol rather than a fifth abstract method because not every backend
+  that answers `Fetcher`'s four questions can announce a transaction --
+  Core's `-rest` interface is read-only, so `BitcoinCoreRestFetcher`
+  does not satisfy it, where `BitcoinCoreFetcher` and `EsploraFetcher`
+  do.
+- **The txid is computed from the transaction before the request, and a
+  success naming any other txid is refused as a `FetchError`.** One
+  request and no retry: after a timeout, neither implementation can tell
+  a transaction that never arrived from one that did and whose
+  acknowledgement was merely lost, so retrying is left to the caller.
+- **`BitcoinCoreFetcher.broadcast` sends `sendrawtransaction`, checking
+  the chain first through `_verify_once`** the way every other method on
+  this class does, and takes `maxfeerate` as an optional keyword-only
+  argument, forwarded exactly as given rather than defaulted: Core's own
+  default refuses a fee a caller may have deliberately chosen.
+- **`EsploraFetcher.broadcast` sends `POST /tx`, the wire serialization
+  as the body, the txid as the text answer** -- the fetcher's first POST,
+  sharing the bounded read, the `transport` seam and the `client_errors`
+  translation with the GET requests its other four methods make.
+- **A refusal keeps its reason.** Core's `RpcError` code and message, an
+  Esplora deployment's 400 body, both reach the caller through
+  `fetcher.client_errors` unchanged, neither reshaped into a code common
+  to both backends.
+
 ## v2026.9.3
 
 ### Repository

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -362,7 +362,11 @@ used to teach and to prototype as much as to build:
     explorer also learns every txid and outpoint you look up, which is a
     good deal of what a wallet is; btclib names a public deployment as a
     constant and never as a default, so nothing here contacts anyone
-    until a caller writes the endpoint down
+    until a caller writes the endpoint down. `Broadcaster.broadcast` is a
+    write and not idempotent: what it checks is that the backend named
+    the txid this code computed from the transaction handed to it, and
+    nothing checks that the transaction went on to propagate beyond
+    whichever peer or node answered
 - **rpc credentials.** They are passed as arguments and refused in the
     url, so that a password is not carried in a string that ends up in
     config files, tracebacks and logs. bitcoind's `.cookie` needs none at

--- a/docs/source/btclib.fetch.rst
+++ b/docs/source/btclib.fetch.rst
@@ -34,6 +34,13 @@ btclib.fetch.bitcoin_core_rest integration module
    :show-inheritance:
    :exclude-members: BitcoinCoreRestClient
 
+btclib.fetch.broadcaster module
+-------------------------------
+
+.. automodule:: btclib.fetch.broadcaster
+   :members:
+   :show-inheritance:
+
 btclib.fetch.decorators module
 ------------------------------
 

--- a/src/btclib/fetch/__init__.py
+++ b/src/btclib/fetch/__init__.py
@@ -13,6 +13,14 @@ times -- `BitcoinCoreFetcher` over a full node's JSON-RPC,
 interface, `EsploraFetcher` over a block explorer's HTTP api -- so that
 calling code takes a `Fetcher` and never branches on which one it got.
 
+**`Broadcaster` is the one place that announces a transaction rather than
+asking about one**, and is a `typing.Protocol` rather than a fourth
+`Fetcher` method: `BitcoinCoreFetcher` and `EsploraFetcher` satisfy it,
+`BitcoinCoreRestFetcher` does not -- Core's `-rest` interface is
+read-only, and a protocol lets that asymmetry be a fact of the type
+rather than a `NotImplementedError` written into a class that never
+promised the capability.
+
 **It adds no dependency.** `urllib.request`, `json` and `base64` from the
 standard library are the whole of the client. Its canonical implementation is
 the `bitcoin-core-rpc` package, which btclib depends on and does not
@@ -40,14 +48,14 @@ fetcher does not either: the first call is what opens a connection, and
 what raises if there is nothing to connect to.
 
 **What is exported, and what is not.** The fetchers, the interface
-they implement, the two clients a Bitcoin Core node is reached through --
-`BitcoinCoreRpcClient` for the JSON-RPC server, `BitcoinCoreRestClient`
-for `-rest` -- and the transport seam: the timeout, the protocol a
-substitute has to satisfy and the two implementations of it that open a
-socket -- one connection per call, and one kept open across calls. That
-last group is here because the seam is the supported way to test calling
-code without a node, which is not a detail of the fetcher
-implementations.
+they implement, `Broadcaster` beside it, the two clients a Bitcoin Core
+node is reached through -- `BitcoinCoreRpcClient` for the JSON-RPC
+server, `BitcoinCoreRestClient` for `-rest` -- and the transport seam:
+the timeout, the protocol a substitute has to satisfy and the two
+implementations of it that open a socket -- one connection per call, and
+one kept open across calls. That last group is here because the seam is
+the supported way to test calling code without a node, which is not a
+detail of the fetcher implementations.
 
 `bitcoin_core.cookie_auth` is deliberately not here:
 `BitcoinCoreRpcClient` takes a `cookie_path` and reads that file at every
@@ -78,6 +86,7 @@ from bitcoin_core_rpc import BitcoinCoreRestClient, BitcoinCoreRpcClient
 
 from btclib.fetch.bitcoin_core import BitcoinCoreFetcher
 from btclib.fetch.bitcoin_core_rest import BitcoinCoreRestFetcher
+from btclib.fetch.broadcaster import Broadcaster
 from btclib.fetch.decorators import CachingFetcher, FallbackFetcher
 from btclib.fetch.esplora import BLOCKSTREAM_INFO, EsploraFetcher
 from btclib.fetch.fetcher import Fetcher
@@ -95,6 +104,7 @@ __all__ = [
     "BitcoinCoreRestClient",
     "BitcoinCoreRestFetcher",
     "BitcoinCoreRpcClient",
+    "Broadcaster",
     "CachingFetcher",
     "EsploraFetcher",
     "FallbackFetcher",

--- a/src/btclib/fetch/bitcoin_core.py
+++ b/src/btclib/fetch/bitcoin_core.py
@@ -34,7 +34,7 @@ from typing_extensions import override
 
 from btclib.alias import Octets
 from btclib.block.block_header import BlockHeader
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibValueError, FetchError
 from btclib.fetch.fetcher import (
     Fetcher,
     block_header_from_raw,
@@ -64,6 +64,12 @@ _MAX_SMALL_REPLY = 1024
 
 class BitcoinCoreFetcher(Fetcher):
     """The four fetcher questions, answered by a node over its RPC.
+
+    Also a `Broadcaster`: `broadcast` sends `sendrawtransaction`, which
+    `-rest` -- and so `BitcoinCoreRestFetcher` -- has no equivalent of.
+    Holding a fetcher is not broadcasting; a caller has to call the
+    method, and `broadcast`'s own docstring is where its non-idempotence
+    is stated, at the point a caller meets it.
 
     The client is a constructor argument rather than a set of connection
     arguments repeated here: one class owns the endpoint and credentials,
@@ -268,3 +274,45 @@ class BitcoinCoreFetcher(Fetcher):
                 chain_from_network(self.network),
                 signet_challenge=self.signet_challenge,
             )
+
+    def broadcast(self, tx: Tx, *, maxfeerate: float | None = None) -> bytes:
+        """Announce `tx` to the node, and return the txid it confirmed.
+
+        `_verify_once` is called first, as every other method here calls
+        it -- but a broadcast to a node on the wrong chain is the worst
+        version of the silent failure `verify_network` exists to catch: a
+        fetch answering with the wrong data is corrected on the next
+        read, where a signed transaction fanned out to the wrong network's
+        peers cannot be called back.
+
+        `sendrawtransaction` with the wire serialization, witness
+        included -- what a peer relays and eventually mines, not the
+        stripped form `Tx.id` hashes. `maxfeerate` is forwarded exactly as
+        given, an absent one leaving the parameter out of the call rather
+        than substituting a value of this method's choosing: Core's own
+        default (`DEFAULT_MAX_RAW_TX_FEE_RATE`) refuses a fee a caller may
+        have deliberately chosen, so a default written here would refuse
+        it on the caller's behalf.
+
+        The id is computed from `tx` before the request, the way
+        `tx_from_raw` recomputes one from a fetched serialization: a
+        success naming a different txid is a `FetchError`, the node
+        having confirmed some other transaction. One request and no
+        retry -- after a timeout this method cannot tell a transaction
+        that never reached the mempool from one that did and whose
+        acknowledgement was merely lost on the way back, so trying again
+        could announce the same signed spend twice for no information
+        gained. That decision is the caller's, made with whatever else it
+        can ask the node.
+        """
+        self._verify_once()
+        txid = tx.id
+        hex_ = tx.serialize(include_witness=True).hex()
+        params: list[Any] = [hex_] if maxfeerate is None else [hex_, maxfeerate]
+        reply = self._call("sendrawtransaction", params, max_body_size=_MAX_SMALL_REPLY)
+        with fetch_errors("sendrawtransaction"):
+            answered = bytes_from_octets(reply, 32)
+        if answered != txid:
+            err_msg = f"broadcast {txid.hex()}: the node confirmed {answered.hex()}"
+            raise FetchError(err_msg)
+        return answered

--- a/src/btclib/fetch/broadcaster.py
+++ b/src/btclib/fetch/broadcaster.py
@@ -1,0 +1,58 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The interface a chain backend answers to announce a transaction.
+
+Kept apart from `Fetcher`: broadcasting is a write and not every backend
+that answers `Fetcher`'s four questions can perform one --
+`BitcoinCoreRestFetcher`, over Core's read-only `-rest` interface, is
+exactly that backend, `bitcoin-core-rpc`'s `BitcoinCoreRestClient`
+declaring no method that writes. An ABC method here would force a choice
+between a `NotImplementedError` on a class that never promised the
+capability and a signature every backend has to carry whether or not it
+can honour it; a `Protocol` lets `BitcoinCoreFetcher` and `EsploraFetcher`
+satisfy `Broadcaster` structurally, with nothing to say about
+`BitcoinCoreRestFetcher` at all.
+
+Not `runtime_checkable`. The contract below -- the txid check, the single
+request -- is not what `isinstance(x, Broadcaster)` would verify, only
+whether something named `broadcast` exists; marking the protocol checkable
+would invite exactly that shortcut in place of reading the contract.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from btclib.tx import Tx
+
+__all__ = ["Broadcaster"]
+
+
+class Broadcaster(Protocol):
+    """A backend able to announce a signed transaction to the network.
+
+    One method and one contract, binding on every implementation of it:
+
+    - the txid is computed from `tx` before the request is sent, and a
+      success naming any other txid is refused as a `FetchError` -- the
+      backend answered for a transaction that is not the one it was
+      asked to broadcast;
+    - one request, no retry. After a timeout there is no way to tell a
+      transaction that never reached the backend from one that did and
+      whose acknowledgement was merely lost in transit, so retrying could
+      announce the same signed spend twice for no information gained;
+      whether to try again, and how, is the caller's decision, made with
+      whatever else it can ask the backend -- this is
+      `bitcoin-core-rpc`'s own one-call contract, carried across;
+    - a refusal keeps its reason. Whatever the backend answered --
+      Core's `RpcError` code and message, an explorer's error body -- it
+      reaches the caller through `client_errors`, text intact and not
+      reshaped into a code common to every backend, because the two
+      refuse for different reasons and a caller acts on the one it got.
+    """
+
+    def broadcast(self, tx: Tx) -> bytes:
+        """Announce `tx`, and return the txid the backend confirmed."""
+        ...

--- a/src/btclib/fetch/esplora.py
+++ b/src/btclib/fetch/esplora.py
@@ -47,7 +47,7 @@ from typing_extensions import override
 
 from btclib.alias import Octets
 from btclib.block.block_header import BlockHeader
-from btclib.exceptions import HttpError
+from btclib.exceptions import FetchError, HttpError
 from btclib.fetch.fetcher import (
     Fetcher,
     block_header_from_raw,
@@ -106,6 +106,11 @@ class EsploraFetcher(Fetcher):
 
     `base_url` is required and has no default, for the reason
     `BLOCKSTREAM_INFO` is a constant and not one.
+
+    Also a `Broadcaster`: `broadcast` is `POST /tx`, the one endpoint of
+    this class that writes. Holding a fetcher is not broadcasting; a
+    caller has to call the method, and `broadcast`'s own docstring is
+    where its non-idempotence is stated, at the point a caller meets it.
     """
 
     def __init__(
@@ -121,14 +126,47 @@ class EsploraFetcher(Fetcher):
         self.timeout = timeout
         self.transport = transport
 
-    def text(self, path: str, max_body_size: int = DEFAULT_MAX_BODY_SIZE) -> str:
-        """Return the body of a GET on `path`, as stripped text.
+    def _request(
+        self, path: str, *, data: bytes | None, max_body_size: int
+    ) -> tuple[int, str]:
+        """Return the status and stripped text body of one exchange on `path`.
+
+        `data` is what decides the verb, the way `http_request` itself
+        decides it: `None` is the GET every read here is, and bytes are a
+        POST body -- `broadcast`'s only caller today.
 
         Stripped because a deployment behind a proxy may add a newline
-        and none of the three answers can contain whitespace. Decoded
-        with `replace` rather than strictly: the body of a failure is an
-        error page from whatever is in the way, and it is more use
-        rendered imperfectly than swallowed by a UnicodeDecodeError.
+        and none of the answers this seam carries can contain whitespace.
+        Decoded with `replace` rather than strictly: the body of a
+        failure is an error page from whatever is in the way, and it is
+        more use rendered imperfectly than swallowed by a
+        UnicodeDecodeError.
+
+        `client_errors` because `http_request` is `bitcoin_core_rpc`'s and
+        raises that package's exceptions: a refused connection reaching a
+        caller as something no `except FetchError` of btclib's catches is
+        what it is there to prevent.
+        """
+        url = f"{self.base_url}{path}"
+        headers = None if data is None else {"Content-Type": "text/plain"}
+        with client_errors():
+            status, payload = http_request(
+                url,
+                data=data,
+                headers=headers,
+                timeout=self.timeout,
+                max_body_size=max_body_size,
+                transport=self.transport,
+            )
+        return status, payload.decode("utf-8", errors="replace").strip()
+
+    def _http_error(self, path: str, status: int, text: str) -> HttpError:
+        """Return the `HttpError` a non-200 status on `path` reports."""
+        url = f"{self.base_url}{path}"
+        return HttpError(f"HTTP {status} from {url}: {text}", status)
+
+    def text(self, path: str, max_body_size: int = DEFAULT_MAX_BODY_SIZE) -> str:
+        """Return the body of a GET on `path`, as stripped text.
 
         `max_body_size` is what this particular answer may weigh; the
         default is the widest of the three, so a caller asking for
@@ -140,23 +178,10 @@ class EsploraFetcher(Fetcher):
         attempt, and telling it from a 404 without reading a message is
         what the field is for. btclib retries nothing itself -- an
         explorer's rate limit is the caller's budget to spend.
-
-        `client_errors` because `http_request` is `bitcoin_core_rpc`'s and
-        raises that package's exceptions: a refused connection reaching a
-        caller as something no `except FetchError` of btclib's catches is
-        what it is there to prevent.
         """
-        url = f"{self.base_url}{path}"
-        with client_errors():
-            status, payload = http_request(
-                url,
-                timeout=self.timeout,
-                max_body_size=max_body_size,
-                transport=self.transport,
-            )
-        text = payload.decode("utf-8", errors="replace").strip()
+        status, text = self._request(path, data=None, max_body_size=max_body_size)
         if status != 200:
-            raise HttpError(f"HTTP {status} from {url}: {text}", status)
+            raise self._http_error(path, status, text)
         return text
 
     @override
@@ -192,3 +217,42 @@ class EsploraFetcher(Fetcher):
             block_hash = bytes_from_octets(reply, 32).hex()
         raw = self.text(f"/block/{block_hash}/header", _MAX_HEADER_BODY)
         return block_header_from_raw(raw, height)
+
+    def broadcast(self, tx: Tx) -> bytes:
+        """Announce `tx` to the server, and return the txid it confirmed.
+
+        `POST /tx` with the wire serialization's hex, witness included, as
+        the body -- what a peer relays and eventually mines, not the
+        stripped form `Tx.id` hashes. The server answers the same way its
+        GET endpoints do, plain text and not json, which is why this
+        shares `_request` with `text` rather than opening a second seam:
+        the bounded read, the `transport` argument and the `client_errors`
+        translation are the same regardless of which verb sent the body.
+
+        The id is computed from `tx` before the request, the way
+        `tx_from_raw` recomputes one from a fetched serialization: a
+        success naming a different txid is a `FetchError`, the server
+        having confirmed some other transaction. One request and no
+        retry, for the reason `BitcoinCoreFetcher.broadcast`'s docstring
+        gives: after a timeout this method cannot tell a transaction that
+        never reached the server from one that did and whose
+        acknowledgement was merely lost on the way back, and that is the
+        caller's decision to make, not this one's.
+
+        A non-200 status is an `HttpError` carrying the body, the way
+        `text` reports one for a GET: an Esplora deployment answers a
+        rejected transaction with a 400 and the reason in plain text.
+        """
+        txid = tx.id
+        hex_ = tx.serialize(include_witness=True).hex()
+        status, answer = self._request(
+            "/tx", data=hex_.encode("ascii"), max_body_size=_MAX_HASH_BODY
+        )
+        if status != 200:
+            raise self._http_error("/tx", status, answer)
+        with fetch_errors("POST /tx"):
+            answered = bytes_from_octets(answer, 32)
+        if answered != txid:
+            err_msg = f"broadcast {txid.hex()}: the server confirmed {answered.hex()}"
+            raise FetchError(err_msg)
+        return answered

--- a/src/btclib/fetch/fetcher.py
+++ b/src/btclib/fetch/fetcher.py
@@ -61,8 +61,10 @@ def client_errors() -> Iterator[None]:
     `btclib.exceptions` declares, and an `except FetchError` written
     against btclib does not catch them. This is the one place the
     two meet, and every call that crosses into the package goes through
-    it: the fetches, by way of `EsploraFetcher.text`,
-    `BitcoinCoreFetcher._call` and
+    it: the fetches and the broadcasts alike, by way of
+    `EsploraFetcher._request` -- `text` and `broadcast` both going
+    through it -- `BitcoinCoreFetcher._call`, which `broadcast` uses the
+    same as every other method there, and
     `BitcoinCoreRestFetcher._get_bin`/`_get_json`; the constructors that
     derive a signet challenge before any fetch; and
     `BitcoinCoreFetcher.assert_network`, which reaches `assert_chain`

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -212,6 +212,7 @@ CHILD_MODULES = {
         "unpublished": [
             "bitcoin_core",
             "bitcoin_core_rest",
+            "broadcaster",
             "decorators",
             "esplora",
             "fetcher",

--- a/tests/fetch/bitcoin_core_rest_test.py
+++ b/tests/fetch/bitcoin_core_rest_test.py
@@ -29,6 +29,7 @@ from bitcoin_core_rpc import (
 
 from btclib.exceptions import BTClibTypeError, BTClibValueError, FetchError, HttpError
 from btclib.fetch.bitcoin_core_rest import BitcoinCoreRestFetcher
+from btclib.fetch.broadcaster import Broadcaster
 from btclib.tx import OutPoint
 from tests.fetch import TIP_HEIGHT, TIP_ID, TX_ID, Recorded, recorded_body
 
@@ -461,3 +462,19 @@ def test_a_challenge_that_is_no_script_fails_at_the_constructor() -> None:
     """Derived and thrown away there, so it fails where it was written."""
     with pytest.raises((BTClibValueError, FetchError)):
         BitcoinCoreRestFetcher(client(), "signet", signet_challenge="not hex")
+
+
+def test_bitcoin_core_rest_fetcher_does_not_satisfy_broadcaster() -> None:
+    """A mypy fact and not a runtime one: `-rest` has no write method.
+
+    `Broadcaster` is not `runtime_checkable`, so an `isinstance` check
+    would either raise or, marked checkable, pass on the method name
+    `broadcast` alone without asking about the contract behind it --
+    neither is the question. What actually says this class is not one is
+    the assignment below failing under `strict = true`'s
+    `warn_unused_ignores`: the `# type: ignore[assignment]` is only valid
+    while `BitcoinCoreRestFetcher` really has no `broadcast`, and mypy
+    fails the line the day that stops being true.
+    """
+    rest = BitcoinCoreRestFetcher(client(), verify_network=False)
+    _not_a_broadcaster: Broadcaster = rest  # type: ignore[assignment]

--- a/tests/fetch/bitcoin_core_test.py
+++ b/tests/fetch/bitcoin_core_test.py
@@ -31,6 +31,7 @@ import pytest
 from bitcoin_core_rpc import (
     DEFAULT_SIGNET_CHALLENGE,
     BitcoinCoreRpcClient,
+    RPCErrorCode,
     SessionTransport,
     chain_from_network,
     network_from_chain,
@@ -47,7 +48,7 @@ from btclib.exceptions import (
 from btclib.fetch.bitcoin_core import BitcoinCoreFetcher
 from btclib.fetch.transport import DEFAULT_MAX_BODY_SIZE
 from btclib.network import NETWORKS
-from btclib.tx import OutPoint
+from btclib.tx import OutPoint, Tx
 from tests.fetch import TIP_HEIGHT, TIP_ID, TX_ID, Recorded, recorded_body
 
 # the rpc credentials every test here passes. Named once rather than
@@ -158,6 +159,16 @@ def asked(endpoint: BitcoinCoreRpcClient) -> list[str]:
         assert isinstance(body, dict)
         methods.append(str(body["method"]))
     return methods
+
+
+def broadcast_tx() -> Tx:
+    """Return the recorded transaction, parsed, as a signed Tx to announce.
+
+    The same transaction `getrawtransaction.json` answers `get_tx` with:
+    it exists already, so broadcasting it needs no new vector of its own.
+    """
+    body = json.loads(recorded_body("getrawtransaction.json"))
+    return Tx.parse(bytes.fromhex(body["result"]))
 
 
 def test_get_tx_parses_the_serialization_the_node_sent() -> None:
@@ -660,3 +671,96 @@ def test_an_rpc_error_keeps_its_code_and_its_data_across_the_translation() -> No
     # the message itself, and not the code or the data carried beside it
     # under the same positional index once `args` holds all three
     assert "No such mempool transaction" in str(exc.value)
+
+
+def test_broadcast_sends_the_wire_serialization_and_returns_the_txid() -> None:
+    """`sendrawtransaction` with the hex serialization, and no maxfeerate.
+
+    `maxfeerate` absent from `params` and not defaulted to `None`: json
+    has no null the way `sendrawtransaction`'s optional parameter reads
+    it, so a caller who passed nothing gets a request with one parameter,
+    not two.
+    """
+    tx = broadcast_tx()
+    endpoint = client(
+        (200, json.dumps({"jsonrpc": "2.0", "result": tx.id.hex(), "id": "x"}).encode())
+    )
+    txid = BitcoinCoreFetcher(endpoint, verify_network=False).broadcast(tx)
+    assert txid == tx.id
+    assert asked(endpoint) == ["sendrawtransaction"]
+    body = sent(endpoint)
+    assert body["params"] == [tx.serialize(include_witness=True).hex()]
+
+
+def test_broadcast_passes_maxfeerate_only_when_given() -> None:
+    """`maxfeerate` rides as a second positional parameter, never a default."""
+    tx = broadcast_tx()
+    endpoint = client(
+        (200, json.dumps({"jsonrpc": "2.0", "result": tx.id.hex(), "id": "x"}).encode())
+    )
+    BitcoinCoreFetcher(endpoint, verify_network=False).broadcast(tx, maxfeerate=0.02)
+    body = sent(endpoint)
+    assert body["params"] == [tx.serialize(include_witness=True).hex(), 0.02]
+
+
+def test_broadcast_refuses_a_success_naming_another_txid() -> None:
+    """The node answered for a transaction that is not the one it was sent."""
+    tx = broadcast_tx()
+    other = "b1fea52486ce0c62bb442b530a3f0132b826c74e473d1f2c220bfa78111c5082"
+    endpoint = client(
+        (200, json.dumps({"jsonrpc": "2.0", "result": other, "id": "x"}).encode())
+    )
+    with pytest.raises(FetchError, match=f"the node confirmed {other}"):
+        BitcoinCoreFetcher(endpoint, verify_network=False).broadcast(tx)
+
+
+@pytest.mark.parametrize(
+    "code", [RPCErrorCode.VERIFY_REJECTED, RPCErrorCode.VERIFY_ALREADY_IN_UTXO_SET]
+)
+def test_broadcast_reports_the_nodes_refusal_with_its_own_reason(
+    code: RPCErrorCode,
+) -> None:
+    """A refusal keeps Core's code and message, through `client_errors`.
+
+    `-26` is a policy rejection and `-27` a transaction already
+    confirmed: two different refusals, and the message is what a caller
+    tells them apart with, not a code flattened to "broadcast failed".
+    """
+    tx = broadcast_tx()
+    message = (
+        "min relay fee not met" if code == -26 else "Transaction already in block chain"
+    )
+    error = {"code": int(code), "message": message}
+    body = json.dumps({"jsonrpc": "2.0", "error": error, "id": "x"}).encode()
+    with pytest.raises(RpcError) as exc:
+        BitcoinCoreFetcher(client((200, body)), verify_network=False).broadcast(tx)
+    assert exc.value.code == code
+    assert message in str(exc.value)
+
+
+def test_broadcast_verifies_the_network_before_sending_anything() -> None:
+    """A wrong-chain node is refused before the transaction ever leaves.
+
+    The worst version of the silent failure `verify_network` exists to
+    catch: `sendrawtransaction` is never called at all, `assert_network`
+    consuming the one scripted reply.
+    """
+    endpoint = client(blockchaininfo(chain="test"))
+    with pytest.raises(BTClibValueError, match="reports chain 'test', not the 'main'"):
+        BitcoinCoreFetcher(endpoint, network="mainnet").broadcast(broadcast_tx())
+    assert asked(endpoint) == ["getblockchaininfo"]
+
+
+def test_broadcast_verifies_the_network_once_like_the_other_methods() -> None:
+    """Agreeing once, the fifth call goes straight through like the fourth."""
+    tx = broadcast_tx()
+    endpoint = client(
+        blockchaininfo(chain="main"),
+        (
+            200,
+            json.dumps({"jsonrpc": "2.0", "result": tx.id.hex(), "id": "x"}).encode(),
+        ),
+    )
+    core = BitcoinCoreFetcher(endpoint)
+    assert core.broadcast(tx) == tx.id
+    assert asked(endpoint) == ["getblockchaininfo", "sendrawtransaction"]

--- a/tests/fetch/esplora_test.py
+++ b/tests/fetch/esplora_test.py
@@ -16,7 +16,7 @@ import pytest
 from btclib.exceptions import BTClibTypeError, BTClibValueError, FetchError, HttpError
 from btclib.fetch.esplora import BLOCKSTREAM_INFO, EsploraFetcher
 from btclib.fetch.transport import SessionTransport
-from btclib.tx import OutPoint
+from btclib.tx import OutPoint, Tx
 from tests.fetch import (
     TIP_HEADER_RAW,
     TIP_HEIGHT,
@@ -30,6 +30,15 @@ BASE = "https://esplora.example/api"
 # the coinbase of block 170: a transaction with the same provenance as
 # the recorded one, and not the one asked for
 OTHER_ID = "b1fea52486ce0c62bb442b530a3f0132b826c74e473d1f2c220bfa78111c5082"
+
+
+def broadcast_tx() -> Tx:
+    """Return the recorded transaction, parsed, as a signed Tx to announce.
+
+    The same one `esplora_tx_hex.txt` answers `get_tx` with: it exists
+    already, so broadcasting it needs no new vector of its own.
+    """
+    return Tx.parse(bytes.fromhex(recorded_body("esplora_tx_hex.txt").decode().strip()))
 
 
 def fetcher(
@@ -293,3 +302,28 @@ def test_the_body_of_a_failure_is_not_held_to_the_answer_limit() -> None:
     page = b"<html><body>Block not found, and here is why: " + b"x" * 200 + b"</body>"
     with pytest.raises(FetchError, match="HTTP 404"):
         fetcher((404, page)).get_block_count()
+
+
+def test_broadcast_posts_the_wire_serialization_and_returns_the_txid() -> None:
+    """`POST /tx`, the hex body, the txid the server answers as text."""
+    tx = broadcast_tx()
+    transport = Recorded((200, tx.id.hex().encode()))
+    txid = EsploraFetcher(BASE, transport=transport).broadcast(tx)
+    assert txid == tx.id
+    assert transport.request.full_url == f"{BASE}/tx"
+    assert transport.request.get_method() == "POST"
+    assert transport.body == tx.serialize(include_witness=True).hex().encode("ascii")
+
+
+def test_broadcast_refuses_a_success_naming_another_txid() -> None:
+    """The server answered for a transaction that is not the one it was sent."""
+    tx = broadcast_tx()
+    with pytest.raises(FetchError, match=f"the server confirmed {OTHER_ID}"):
+        fetcher((200, OTHER_ID.encode())).broadcast(tx)
+
+
+def test_broadcast_reports_a_400_with_the_explorers_own_body() -> None:
+    """A refusal keeps Esplora's reason, the way a 404 on `get_tx` does."""
+    tx = broadcast_tx()
+    with pytest.raises(FetchError, match="HTTP 400 .*: min relay fee not met"):
+        fetcher((400, b"min relay fee not met")).broadcast(tx)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -38,6 +38,7 @@ from bitcoin_core_rpc import BitcoinCoreRpcClient
 
 from btclib.amount import sats_from_btc
 from btclib.descriptors import Descriptor, add_checksum, parse
+from btclib.fetch.bitcoin_core import BitcoinCoreFetcher
 from btclib.psbt.psbt import Psbt, extract_tx, finalize
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 
@@ -244,12 +245,13 @@ def broadcast(node: BitcoinCoreRpcClient, psbt: Psbt) -> str:
 
     Which is the oracle these tests are here for: a signature that does
     not verify, a witness assembled wrong or a fee that is not there are
-    all this call failing.
+    all this call failing. `BitcoinCoreFetcher.broadcast` is what makes
+    the call, `verify_network=True` and `regtest` its label -- the one
+    chain this suite's node ever serves -- so a fixture pointed at the
+    wrong node fails here rather than mining a transaction nobody meant
+    to send it.
     """
     final = extract_tx(finalize(psbt), check_validity=True)
-    # with the witness, which is the whole point of what was just signed:
-    # `serialize` asks rather than assuming, a txid being the other one
-    raw = final.serialize(include_witness=True).hex()
-    tx_id = str(node.call("sendrawtransaction", [raw]))
-    assert tx_id == final.id.hex()
-    return tx_id
+    tx_id = BitcoinCoreFetcher(node, "regtest").broadcast(final)
+    assert tx_id == final.id
+    return tx_id.hex()

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -205,6 +205,7 @@ KEYWORD_ONLY: dict[str, list[str]] = {
         "verify_network",
         "signet_challenge",
     ],
+    "btclib.fetch:BitcoinCoreFetcher.broadcast": ["maxfeerate"],
     "btclib.fetch:BitcoinCoreRpcClient.__init__": [
         "user",
         "password",


### PR DESCRIPTION
Closes #1584

`Fetcher` only reads. This adds the one write a caller needs beside it:
`Broadcaster`, a `typing.Protocol` with a single method
`broadcast(tx: Tx) -> bytes`, implemented by the two backends that can
write and by neither of the others.

The `Protocol` is the shape rather than an ABC because the asymmetry is
real and permanent: Core's `-rest` interface is read-only, so
`BitcoinCoreRestFetcher` has no `broadcast` to write, and a base class
would have to hand it one that raises. A protocol lets the type system
say which fetchers can announce a transaction without any of them
inheriting a method they cannot answer. That `BitcoinCoreRestFetcher`
does not satisfy it is asserted as a mypy fact, which is the only place
the claim has meaning — the protocol is deliberately not
`runtime_checkable`.

What the contract buys, and what it does not:

- The txid is computed here, from the transaction, **before** the
  request. A success naming any other txid is refused as a `FetchError`:
  the backend answered for a transaction that is not this one.
- **One call, no retry.** After a timeout a caller cannot know whether
  the transaction reached the mempool, so whether to send it again is
  the caller's decision and not this code's. The docstrings say so.
- `maxfeerate` is passed through as an optional keyword argument and
  never defaulted away, Core's own default refusing a fee a caller may
  have chosen deliberately.
- A refusal keeps its reason. Core's `RpcError` code and message and
  Esplora's 400 body reach the caller through `client_errors` with the
  text intact, rather than being reshaped into a common code.
- Nothing here checks that the transaction propagated. `SECURITY.md`
  says that, beside the note that a broadcast is a write and is not
  idempotent.

`EsploraFetcher` gained a POST path for `/tx` under the same bounded
read, the same `transport` seam and the same error translation its GET
path already used; no existing refusal changed its class or its message.
`tests/integration/regtest_test.py` now broadcasts through this
interface instead of the raw client, which is the call the issue said
becomes the broadcaster's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Add a typed transaction-broadcasting interface and use it to submit transactions through the writable Bitcoin Core and Esplora fetchers.

New Features:
- Add the typed `Broadcaster` protocol for announcing transactions through writable fetch backends.
- Implement transaction broadcasting for Bitcoin Core RPC and Esplora backends with transaction-ID validation and backend-specific refusal details.

Enhancements:
- Keep read-only Bitcoin Core REST fetchers separate from the broadcasting capability and document broadcasting’s non-idempotent behavior and propagation limitations.

Documentation:
- Document the new broadcaster API, its transaction submission guarantees, and associated security considerations.

Tests:
- Add unit coverage for Core and Esplora broadcasting, fee handling, network validation, txid mismatches, and preserved refusal errors.
- Update regtest integration tests to broadcast through the fetcher interface and assert that the REST fetcher does not satisfy the broadcaster protocol.