### PR TITLE
WIF parsing and building move to b58, taking a WIF and not the key union (issue #1188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,37 @@ documented at release-notes length in the first place, and are still in
   `fetcher.client_errors` unchanged, neither reshaped into a code common
   to both backends.
 
+### WIF parsing and building move to `b58`, taking a WIF and not the key union
+
+`b58.wif_from_prv_key` and the new `b58.prv_key_data_from_wif` are where
+a WIF is read and written now (issue #1188), and `to_prv_key.PrvKey`
+drops it: a WIF is Base58Check with a version prefix and a compression
+flag, which is `b58`'s own idea and not a spelling `to_prv_key` has any
+business resolving, `b58` sitting below it and having no way back up to
+a parser living above it. `to_prv_key.int_from_prv_key` and
+`prv_keyinfo_from_prv_key` keep the rest -- an int, an octets scalar, a
+BIP32 xprv, a `BIP32KeyData` -- and refuse a WIF as the octets it is
+not, on the same `bytes_from_octets` "invalid hex string" terms as any
+other non-hex text.
+
+`b58.p2pkh` and `b58.p2wpkh_p2sh` still take a WIF: each tries one
+first, ahead of `to_pub_key.pub_keyinfo_from_key`, since a WIF is
+disjoint from every other spelling `Key` carries and costs nothing to
+try. `b32.p2wpkh` does not: `b32` imports `to_pub_key` and `b58` imports
+`b32`, so resolving a WIF there would need the import the other way
+round. A caller holding a WIF for `b32.p2wpkh` now derives the SEC
+octets first, with `b58.prv_key_data_from_wif(wif).pub.sec`.
+
+`ecc.bms.sign`, `ecc.bms.gen_keys` and `bip322.sign` take the parsed
+`btclib.key.PrvKeyData` and not a `PrvKey` union: message signing wants
+the network and the compression flag beside the scalar, which is what a
+WIF carries and `PrvKeyData` now states explicitly --
+`b58.prv_key_data_from_wif(wif)` for the one,
+`btclib.key.PrvKeyData(q, network, compressed)` for a bare scalar.
+`bms.gen_keys` drops its `prv_key` parameter with it: drawing a key and
+handing one in were two different calls behind one name, and the second
+is `wif_from_prv_key` and `b58.p2pkh` in the caller's own code now.
+
 ## v2026.9.3
 
 ### Repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,12 +43,17 @@ which is the single most important thing to know before touching
 Layers, roughly bottom-up: `curves/` (curve arithmetic) → `ecc/` (dsa, ssa,
 bms, borromean, pedersen, rfc6979/bip340 nonces). At the key boundary,
 `base58` and `bech32` are the low-level codecs; `bip32/` depends on
-`base58`; `to_prv_key` and `to_pub_key` depend on `bip32/`; and `b58`
-and `b32` depend on those converters. `slip132` therefore sits above the
-address encodings, beside `bip44`. `mnemonic/`, `script/`, `tx/`,
-`block/`, `psbt/` and `descriptors` build on those layers. `alias.py`
-holds the type aliases the public API accepts, and much of the surface
-takes "anything convertible" rather than one type.
+`base58`; `to_prv_key` and `to_pub_key` depend on `bip32/`; `b32` depends
+on `to_pub_key`. `b58` depends on `to_pub_key` too, but not on
+`to_prv_key`: a WIF is Base58Check with a prefix and a flag, so it is
+`b58`'s own object, read by `b58.prv_key_data_from_wif` and written by
+`b58.wif_from_prv_key`, and `to_prv_key` -- which sits below `b58`
+through `to_pub_key` -- has no way back up to a parser living above it
+(issue #1188). `slip132` therefore sits above the address encodings,
+beside `bip44`. `mnemonic/`, `script/`, `tx/`, `block/`, `psbt/` and
+`descriptors` build on those layers. `alias.py` holds the type aliases
+the public API accepts, and much of the surface takes "anything
+convertible" rather than one type.
 
 Each of those pairs is one idea split in two, and each split runs one
 way only: `curves/` is arithmetic and `ecc/` is what is built on it;

--- a/README.md
+++ b/README.md
@@ -309,9 +309,10 @@ these modules says the same in its own docstring.
 
 The rest, roughly bottom-up. `alias` holds the types the public API
 accepts, much of it taking anything convertible rather than one type, and
-`exceptions` the errors it raises. `to_prv_key` and `to_pub_key` accept
-any key representation and hand back one. `bip32` and `mnemonic` derive
-keys. `script`, `tx`, `block` and `psbt` build and validate what goes on
+`exceptions` the errors it raises. `to_prv_key` and `to_pub_key` resolve
+the key spellings below them into one; a WIF is not among those, being
+`b58`'s own and read there. `bip32` and `mnemonic` derive keys.
+`script`, `tx`, `block` and `psbt` build and validate what goes on
 the chain, and `script.engine` runs a transaction against the consensus
 rules. `p2p` is the wire format peers speak — the message envelope, its
 framing, the message start each network begins with, and the payloads a

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,6 +31,59 @@ full year, short month, short day (YYYY-M-D)
   Act on it if you hold a BIP340 sign-to-contract commitment made
   before this release: it no longer opens, and there is no version
   byte to switch on. Re-derive it with the new tags.
+- **A WIF is `btclib.b58`'s object now, not `btclib.to_prv_key`'s**
+  (issue #1188). `btclib.b58.wif_from_prv_key(prv_key: PrvKey, network:
+  str | None = None, compressed: bool | None = None)` took the wide
+  `PrvKey` union -- an int, an octets scalar, a WIF, a BIP32 xprv, or a
+  `BIP32KeyData` -- and narrows to `wif_from_prv_key(prv_key: Integer,
+  network: str = "mainnet", compressed: bool = True)`, an int, its
+  octets or their hex only. Reading a WIF back is a new function,
+  `btclib.b58.prv_key_data_from_wif`, answering a `btclib.key.PrvKeyData`
+  rather than the `(int, str, bool)` tuple `to_prv_key.prv_keyinfo_from_prv_key`
+  used to for one. `to_prv_key.PrvKey`, `int_from_prv_key` and
+  `prv_keyinfo_from_prv_key` no longer accept a WIF at all: a WIF handed
+  to any of them is refused as the octets it is not.
+
+  Act on it if you called `wif_from_prv_key` with a WIF, an xprv or a
+  `BIP32KeyData` to re-encode it under a different network or compression,
+  or if you passed a WIF to `to_prv_key.int_from_prv_key` or
+  `prv_keyinfo_from_prv_key`. `btclib.b58.prv_key_data_from_wif(wif,
+  network, compressed).q` reads the scalar out of a WIF; an xprv or a
+  `BIP32KeyData` still goes through `to_prv_key`, unaffected.
+
+- **`btclib.ecc.bms.sign` and `btclib.bip322.sign` take a
+  `btclib.key.PrvKeyData`, not a `PrvKey`** (issue #1188). Both took
+  `prv_key: PrvKey` -- `bms.sign(msg: Octets, prv_key: PrvKey, addr:
+  String | None = None)` at v2023.7.12, unchanged since -- and answered
+  the network and the compression flag by parsing whatever spelling was
+  handed in; both now take the already-parsed `PrvKeyData` and raise
+  `BTClibTypeError` for anything else, a WIF and a bare scalar included.
+
+  Act on it if you called either with a WIF, an xprv, a `BIP32KeyData` or
+  a bare scalar. `btclib.b58.prv_key_data_from_wif(wif)` reads a WIF into
+  the object both now want; a bare scalar is
+  `btclib.key.PrvKeyData(q, network, compressed)`.
+
+- **`btclib.ecc.bms.gen_keys` no longer takes a `prv_key` argument**
+  (issue #1188). It was `gen_keys(prv_key: PrvKey | None = None, network:
+  str | None = None, compressed: bool | None = None)` at v2023.7.12,
+  drawing a random key when `prv_key` was `None` and re-deriving the pair
+  from it otherwise; it is `gen_keys(network: str = "mainnet", compressed:
+  bool = True)` now, drawing only.
+
+  Act on it if you called `gen_keys` with an explicit `prv_key`.
+  `btclib.b58.wif_from_prv_key(prv_key, network, compressed)` and
+  `btclib.b58.p2pkh` on the WIF it returns are the pair `gen_keys` used
+  to hand back for one.
+
+- **`btclib.b32.p2wpkh` no longer resolves a WIF** (issue #1188). It took
+  `key: Key` at v2023.7.12 and resolved a WIF among the spellings `Key`
+  covers; `b32` sits below `b58`, which is where a WIF is read now, and
+  has no way to reach it.
+
+  Act on it if you called `b32.p2wpkh` with a WIF.
+  `btclib.b58.prv_key_data_from_wif(wif).pub.sec` reads the SEC octets
+  `p2wpkh` still takes.
 
 ## v2026.9.3
 

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -139,20 +139,28 @@ The four aliases:
     function names tells you which reading applies.
 
 ``PrvKey``
-    An ``int``, an ``Octets`` scalar, a WIF, a BIP32 ``xprv``, or a
-    ``BIP32KeyData``. **Prefer the WIF or the extended key.** They carry
-    the network and the compressed-public-key flag with them, so
-    ``b58.p2pkh(wif)`` knows which address to build; a bare integer
+    An ``int``, an ``Octets`` scalar, a BIP32 ``xprv``, or a
+    ``BIP32KeyData``. **Prefer the extended key.** It carries the
+    network and the compressed-public-key flag with it; a bare integer
     carries neither and everything downstream has to assume mainnet and
     compressed.
 
+    A WIF is not among them: it is ``b58``'s own object, read with
+    ``b58.prv_key_data_from_wif`` and built with ``b58.wif_from_prv_key``
+    — ``to_prv_key``, which is what this type belongs to, has no way
+    back up to a parser living above it (issue #1188). ``b58.p2pkh(wif)``
+    still knows which address to build: it tries a WIF itself, ahead of
+    anything this type covers.
+
     **This is the bitcoin layer's type, not** ``ecc``\ **'s.** The
     signature schemes take a scalar — an ``int``, its ``n_size`` octets,
-    or their hex — because a WIF and an extended key are ``b58``'s and
-    ``bip32``'s objects, and converting one is a call you make. So
-    ``b58.p2pkh(wif)`` works and ``dsa.sign(msg, wif)`` does not; pass
-    ``prv_keyinfo_from_prv_key(wif)[0]``. ``ecc.bms`` is the exception,
-    message signing being bitcoin: it still takes the lot.
+    or their hex — because an extended key is ``bip32``'s object and
+    converting one is a call you make. So ``dsa.sign(msg, xprv)`` does
+    not work; pass ``prv_keyinfo_from_prv_key(xprv)[0]``. ``ecc.bms`` is
+    narrower still: message signing wants the network and the
+    compression too, so it takes the ``btclib.key.PrvKeyData`` a WIF and
+    a scalar both resolve to — ``b58.prv_key_data_from_wif(wif)`` for the
+    one, ``btclib.key.PrvKeyData(q)`` for the other.
 
 ``Key``
     A public key in any of its spellings — SEC bytes compressed or not,
@@ -740,7 +748,9 @@ byte for byte, with no trimming of your own.
 >>> address = b58.p2pkh(wif)
 >>> address
 '13eeg4y5wYGxNTxBEuWLPFauoMJQLxdoip'
->>> signature = bms.sign(b"paid invoice 42 on 2026-01-01", wif)
+>>> signature = bms.sign(
+...     b"paid invoice 42 on 2026-01-01", b58.prv_key_data_from_wif(wif)
+... )
 >>> signature.b64encode()
 'IPn1BZ4xi86uCS5NrSrX+2g+RSsHgm94QX5+krikMl4Fd25te6nrF53iI9amQ5XtAcM4fMggHPybYOxufoR8MVA='
 >>> bms.verify(b"paid invoice 42 on 2026-01-01", address, signature)

--- a/src/btclib/b58.py
+++ b/src/btclib/b58.py
@@ -12,6 +12,13 @@ The encoding itself is btclib.base58, which knows nothing about bitcoin, and
 the rule between the two is that direction: this module imports base58, never
 the other way round. `bech32` and `b32` are the same pair for the segwit
 address encoding.
+
+A WIF is this module's object in both directions. `wif_from_prv_key` writes
+one from a scalar, a network and a compression flag, and
+`prv_key_data_from_wif` reads one back into a `key.PrvKeyData`. Nothing
+above this module parses the format, and `to_prv_key` does not spell it:
+that converter sits below this module and has no way to reach a parser
+living here (issue #1188).
 """
 
 from __future__ import annotations
@@ -19,13 +26,14 @@ from __future__ import annotations
 from typing import Literal
 
 from btclib import b32
-from btclib.alias import Octets, ScriptType, String
+from btclib.alias import Integer, Octets, ScriptType, String
 from btclib.base58 import decode as b58decode
 from btclib.base58 import encode as b58encode
-from btclib.exceptions import BTClibValueError
+from btclib.curves import scalar_from_prv_key
+from btclib.exceptions import BTClibValueError, InvalidPrvKeyError, NotAPrvKeyError
 from btclib.hashes import hash160, sha256
+from btclib.key import PrvKeyData
 from btclib.network import network_from_key_value, network_from_name
-from btclib.to_prv_key import PrvKey, prv_keyinfo_from_prv_key
 from btclib.to_pub_key import Key, pub_keyinfo_from_key
 from btclib.utils import assert_type, bytes_from_octets
 
@@ -36,35 +44,134 @@ __all__ = [
     "p2sh",
     "p2wpkh_p2sh",
     "p2wsh_p2sh",
+    "prv_key_data_from_wif",
     "wif_from_prv_key",
 ]
 
 
 def wif_from_prv_key(
-    prv_key: PrvKey, network: str | None = None, compressed: bool | None = None
+    prv_key: Integer, network: str = "mainnet", compressed: bool = True
 ) -> str:
-    """Return the WIF encoding of a private key."""
-    # asked here rather than passed down: `prv_keyinfo_from_prv_key` is
-    # called without it, so what the key says is what comes back and this
-    # is where a caller's own choice is read
-    if compressed is not None:
-        assert_type(compressed, bool, "compressed")
-    q, net, compr = prv_keyinfo_from_prv_key(prv_key)
+    """Return the WIF encoding of a private key.
 
-    # the private key might provide network and compressed information
-    # e.g., wif or xprv
-    network = net if network is None else network
-    compressed = compr if compressed is None else compressed
-
-    ec = network_from_name(network).curve
+    A scalar, a network and whether the public key is compressed are the
+    three things a WIF encodes, and they are the three arguments. A
+    spelling that carries the other two with it is parsed first -- a WIF
+    by `prv_key_data_from_wif` below, an xprv by `to_prv_key` -- and the
+    fields of what comes back are handed here.
+    """
+    assert_type(compressed, bool, "compressed")
+    net = network_from_name(network)
+    q = scalar_from_prv_key(prv_key, net.curve)
     payload = b"".join(
         [
-            network_from_name(network).wif,
-            q.to_bytes(ec.n_size, byteorder="big", signed=False),
+            net.wif,
+            q.to_bytes(net.curve.n_size, byteorder="big", signed=False),
             b"\x01" if compressed else b"",
         ]
     )
     return b58encode(payload).decode("ascii")
+
+
+def _wif_network(prefix: bytes, network: str | None) -> str:
+    """Return the network a WIF version prefix belongs to.
+
+    NotAPrvKeyError for a prefix no network claims: the text is not a
+    WIF. InvalidPrvKeyError once a network has claimed it and the caller
+    asked for another one: that is a WIF, and the wrong one.
+    """
+    net = network_from_key_value("wif", prefix)
+    if net is None:
+        raise NotAPrvKeyError(f"not a WIF (invalid prefix 0x{prefix.hex()})")
+
+    if network is None:
+        return net
+
+    # the forward check, and not a `net != network` name comparison:
+    # the reverse lookup answers "testnet" for the 0xef that testnet,
+    # regtest, signet and testnet4 all use, so comparing names would
+    # reject a signet WIF as "not a signet wif: prefix 0xef" --
+    # naming the very prefix signet asks for (issue #207).
+    # `to_prv_key._prv_keyinfo_from_xprv` makes the same membership check
+    if prefix != network_from_name(network).wif:
+        raise InvalidPrvKeyError(f"not a {network} wif: prefix 0x{prefix.hex()}")
+    # the declared network, not the lookup's guess: for a caller who
+    # said "signet" the answer is signet, and it is the one that ends
+    # up in the returned key
+    return network
+
+
+def _wif_prv_key_and_compression(
+    payload: bytes, n_size: int, compressed: bool | None
+) -> tuple[bytes, bool]:
+    """Return the key bytes of a WIF payload, and whether it is compressed.
+
+    The size is what says which of the two it is, the compressed
+    spelling carrying one byte more; the caller's `compressed`, if it
+    said anything, then has to agree with the answer.
+    """
+    if len(payload) == n_size + 2:  # compressed WIF
+        compr = True
+        if payload[-1] != 0x01:  # must have a trailing 0x01
+            raise InvalidPrvKeyError("not a compressed WIF: missing trailing 0x01")
+        prv_key = payload[1:-1]
+    elif len(payload) == n_size + 1:  # uncompressed WIF
+        compr = False
+        prv_key = payload[1:]
+    else:
+        raise InvalidPrvKeyError(f"wrong WIF size: {len(payload)}")
+
+    if compressed is not None and compr != compressed:
+        raise InvalidPrvKeyError("compression requirement mismatch")
+
+    return prv_key, compr
+
+
+def prv_key_data_from_wif(
+    wif: String, network: str | None = None, compressed: bool | None = None
+) -> PrvKeyData:
+    """Return the private key a WIF encodes, with its network and compression.
+
+    A WIF carries both, so `network` and `compressed` are consistency
+    checks and not overrides: `None` takes what the WIF says, and a value
+    the WIF contradicts is refused. `network` is also what names a
+    network sharing its prefix with others -- the 0xef that testnet,
+    regtest, signet and testnet4 all use answers "testnet" on its own,
+    and a caller who said "signet" gets signet (issue #207).
+
+    Two error classes, in refusal order. Everything up to and including
+    the version prefix answers "is this a WIF at all", and a no is a
+    NotAPrvKeyError; everything after it answers "is this WIF sound", and
+    a no is an InvalidPrvKeyError. Both are BTClibValueError. No message
+    echoes the input, which is candidate key material: a checksum, a
+    prefix and a size are not secret.
+    """
+    # None is a declared value here and means "whatever the WIF says", so
+    # it is the one non-bool this position takes
+    if compressed is not None:
+        assert_type(compressed, bool, "compressed")
+    if isinstance(wif, str):
+        wif = wif.strip()
+
+    # only a value no WIF has is re-classed: a wrong type leaves b58decode
+    # as the BTClibTypeError it is, that being the caller's own mistake
+    try:
+        payload = b58decode(wif)
+    except BTClibValueError as e:
+        raise NotAPrvKeyError(f"not a WIF ({e})") from e
+
+    net = _wif_network(payload[:1], network)
+    ec = network_from_name(net).curve
+    prv_key, compr = _wif_prv_key_and_compression(payload, ec.n_size, compressed)
+
+    q = int.from_bytes(prv_key, byteorder="big")
+    if not 0 < q < ec.n:
+        raise InvalidPrvKeyError("private key not in 1..n-1")
+
+    # every field has just been checked -- the name resolved to a network,
+    # the scalar ranged on that network's curve, the flag read off the
+    # size -- so the constructor is not asked to check them again
+    return PrvKeyData(q, net, compr, check_validity=False)
 
 
 # 1. Hash/WitnessProgram from pub_key/script_pub_key
@@ -118,9 +225,42 @@ def h160_from_address(b58addr: String) -> tuple[ScriptType, bytes, str]:
 # 1.+2. = 3. base58 address from pub_key/script_pub_key
 
 
+def _pub_keyinfo_from_key(
+    key: Key, network: str | None, compressed: bool | None
+) -> tuple[bytes, str]:
+    """Return (SEC octets, network) from a `Key`, a WIF included.
+
+    A WIF is tried first: it is this module's own object, and disjoint
+    from every other spelling `Key` carries -- 51 or 52 base58
+    characters, where the shortest of the others is 64 hex digits, so
+    trying it ahead of `to_pub_key.pub_keyinfo_from_key` costs nothing an
+    ambiguous input could exploit. `to_pub_key` resolves everything else,
+    and cannot resolve a WIF itself: it sits below this module and has no
+    way back up to `prv_key_data_from_wif` (issue #1188).
+
+    What falls through to `pub_keyinfo_from_key` is text that is no WIF
+    at all -- a checksum that does not verify, a version prefix no
+    network claims -- because there is another spelling left to try it
+    as, and that call fails on the same text with the message callers
+    already see. A WIF a network has claimed and that is then faulty --
+    the wrong compression, a network other than the one asked for --
+    raises here: `InvalidPrvKeyError` is what says the format was
+    recognised, and swallowing it would answer "not a key" about
+    something that is one.
+    """
+    if isinstance(key, (str, bytes, bytearray, memoryview)):
+        try:
+            data = prv_key_data_from_wif(key, network, compressed)
+        except NotAPrvKeyError:
+            pass
+        else:
+            return data.pub.sec, data.network
+    return pub_keyinfo_from_key(key, network, compressed=compressed)
+
+
 def p2pkh(key: Key, network: str | None = None, compressed: bool | None = None) -> str:
     """Return the p2pkh base58 address corresponding to a public key."""
-    pub_key, network = pub_keyinfo_from_key(key, network, compressed=compressed)
+    pub_key, network = _pub_keyinfo_from_key(key, network, compressed)
     return address_from_h160("p2pkh", hash160(pub_key), network)
 
 
@@ -155,7 +295,7 @@ def _address_from_v0_witness(wit_prg: Octets, network: str) -> str:
 
 def p2wpkh_p2sh(key: Key, network: str | None = None) -> str:
     """Return the base58 p2sh-wrapped address of a p2wpkh."""
-    pub_key, network = pub_keyinfo_from_key(key, network, compressed=True)
+    pub_key, network = _pub_keyinfo_from_key(key, network, True)
     witness_program = hash160(pub_key)
     return _address_from_v0_witness(witness_program, network)
 

--- a/src/btclib/bip322.py
+++ b/src/btclib/bip322.py
@@ -101,6 +101,7 @@ from btclib.exceptions import (
     InconclusiveError,
 )
 from btclib.hashes import hash160, tagged_hash
+from btclib.key import PrvKeyData
 from btclib.psbt import Psbt, extract_tx
 from btclib.script import serialize
 from btclib.script.engine import ALL_FLAGS, ScriptFlag, verify_transaction
@@ -109,7 +110,6 @@ from btclib.script.sig_hash import ALL, DEFAULT, from_tx
 from btclib.script.sig_hash import taproot as taproot_sig_hash
 from btclib.script.taproot import output_prvkey_from_merkle_root, output_pubkey
 from btclib.script.witness import Witness
-from btclib.to_prv_key import PrvKey, prv_keyinfo_from_prv_key
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from btclib.utils import assert_type, bytes_from_octets, str_from_string
 
@@ -659,12 +659,18 @@ def _assert_key_owns(script_type: str, payload: bytes, pub_key: bytes) -> None:
         raise BTClibValueError("mismatch between private key and address")
 
 
-def sign(msg: Octets, prv_key: PrvKey, addr: String) -> Sig:
+def sign(msg: Octets, prv_key: PrvKeyData, addr: String) -> Sig:
     """Return the BIP322 signature of a message for a single-key address.
 
     The address is the argument and not something worked out from the
     key, one key owning an address of each type: it is the challenge
     being signed, and BIP322 has no default for it.
+
+    The key is the parsed form, as `ecc.bms.sign` takes it: the scalar
+    signs and the compression flag beside it says which SEC octets the
+    address was built from. A WIF is read once by
+    `b58.prv_key_data_from_wif`, and a scalar is stated with
+    `PrvKeyData(q, network, compressed)`.
 
     p2pkh, p2wpkh, p2sh-p2wpkh and p2tr are what one private key
     satisfies on its own, so they are what this signs; the taproot case
@@ -678,9 +684,13 @@ def sign(msg: Octets, prv_key: PrvKey, addr: String) -> Sig:
     `Descriptor.satisfy` over the signatures it needs, and then a `Sig`
     of what comes out. This function is the case that needs neither.
     """
+    # asked here whatever `check_validity` the object was built with: a
+    # key the constructor was told not to check is one a caller may hold
+    assert_type(prv_key, PrvKeyData, "prv_key")
+    prv_key.assert_valid()
     script_pub_key = ScriptPubKey.from_address(addr).script
     script_type, payload = type_and_payload(script_pub_key)
-    q, _, compressed = prv_keyinfo_from_prv_key(prv_key)
+    q, compressed = prv_key.q, prv_key.compressed
     pub_key = bytes_from_prv_key_int(q, compressed=compressed)
     _assert_key_owns(script_type, payload, pub_key)
 

--- a/src/btclib/descriptors/key_expression.py
+++ b/src/btclib/descriptors/key_expression.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass
 
 from typing_extensions import override
 
+from btclib import b58
 from btclib.bip32.bip32 import (
     BIP328_CHAIN_CODE,
     BIP32KeyData,
@@ -518,10 +519,11 @@ def _fixed_pub_key(key: str, *, x_only: bool) -> tuple[bytes, bool]:
     """
     if _HEX.fullmatch(key):
         return _pub_key_from_hex(key, x_only=x_only)
-    # what is left is a WIF, and pub_keyinfo_from_key answers both for it
-    # and for characters that are no key expression at all
+    # what is left is a WIF, which is b58's object and not to_pub_key's
+    # (issue #1188); prv_key_data_from_wif answers both for it and for
+    # characters that are no key expression at all
     try:
-        return pub_keyinfo_from_key(key)[0], x_only
+        return b58.prv_key_data_from_wif(key).pub.sec, x_only
     except (TypeError, ValueError) as e:
         raise BTClibValueError("invalid key expression") from e
 

--- a/src/btclib/ecc/bms.py
+++ b/src/btclib/ecc/bms.py
@@ -76,11 +76,11 @@ where:
 +----------+---------+-----------------------------------------------------+
 
 This implementation endorses the Electrum approach: a signature
-generated with a compressed WIF (i.e. without explicit address or
+generated with a compressed key (i.e. without explicit address or
 with a compressed p2pkh address) is valid also for the
-p2wpkh-p2sh and p2wpkh addresses derived from the same WIF.
+p2wpkh-p2sh and p2wpkh addresses derived from the same key.
 
-The BIP137 behaviour is available all the same: a compressed WIF
+The BIP137 behaviour is available all the same: a compressed key
 supplemented at signing time with a p2wpkh-p2sh or p2wpkh address
 yields a signature valid for that address alone.
 
@@ -124,9 +124,14 @@ from btclib.ecc import dsa
 from btclib.ecc.dsa import _libsecp256k1_recover_sec_
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.hashes import hash160, magic_message, reduce_to_hlen
+from btclib.key import PrvKeyData
 from btclib.network import network_from_name
-from btclib.to_prv_key import PrvKey, prv_keyinfo_from_prv_key
-from btclib.utils import assert_no_trailing, bytesio_from_binarydata, str_from_string
+from btclib.utils import (
+    assert_no_trailing,
+    assert_type,
+    bytesio_from_binarydata,
+    str_from_string,
+)
 
 __all__ = [
     "Sig",
@@ -258,30 +263,35 @@ class Sig:
         return cls.parse(data_decoded, check_validity=check_validity)
 
 
-def gen_keys(
-    prv_key: PrvKey | None = None,
-    network: str | None = None,
-    compressed: bool | None = None,
-) -> tuple[str, str]:
-    """Return a private/public key pair.
+def gen_keys(network: str = "mainnet", compressed: bool = True) -> tuple[str, str]:
+    """Return a private/public key pair, drawn on the network's curve.
 
     The private key is a WIF, the public key is a base58 p2pkh address.
     """
-    if prv_key is None:
-        if network is None:
-            network = "mainnet"
-        ec = network_from_name(network).curve
-        # q in the range [1, ec.n-1]
-        prv_key = 1 + secrets.randbelow(ec.n - 1)
-
-    wif = wif_from_prv_key(prv_key, network, compressed)
-    return wif, p2pkh(wif)
+    ec = network_from_name(network).curve
+    # q in the range [1, ec.n-1]
+    q = 1 + secrets.randbelow(ec.n - 1)
+    # `wif_from_prv_key` is what refuses a `compressed` that is no bool,
+    # ahead of the derivation below reading it
+    wif = wif_from_prv_key(q, network, compressed)
+    return wif, p2pkh(bytes_from_prv_key_int(q, ec, compressed), network)
 
 
-def sign(msg: Octets, prv_key: PrvKey, addr: String | None = None) -> Sig:
-    """Generate address-based compact signature for the provided message."""
+def sign(msg: Octets, prv_key: PrvKeyData, addr: String | None = None) -> Sig:
+    """Generate address-based compact signature for the provided message.
+
+    The key is the parsed form and not a spelling of one. What signs is
+    the scalar, and what names the address is the network and the
+    compression flag beside it -- the three a WIF carries, which
+    `b58.prv_key_data_from_wif` reads once, and which a caller holding a
+    scalar states with `PrvKeyData(q, network, compressed)`.
+    """
+    # asked here whatever `check_validity` the object was built with: a
+    # key the constructor was told not to check is one a caller may hold
+    assert_type(prv_key, PrvKeyData, "prv_key")
+    prv_key.assert_valid()
     magic_msg = magic_message(msg)
-    q, network, compressed = prv_keyinfo_from_prv_key(prv_key)
+    q, network, compressed = prv_key.q, prv_key.network, prv_key.compressed
 
     # signing and naming the key_id are one call, not two, and this module
     # has no dispatch of its own for it: `dsa.sign_recoverable` answers the

--- a/src/btclib/exceptions.py
+++ b/src/btclib/exceptions.py
@@ -305,10 +305,12 @@ class ScriptError(BTClibValueError):
 class NotAPrvKeyError(BTClibValueError):
     """The input is not in this private key format at all: try the next one.
 
-    The library accepts a private key as a WIF, a BIP32 xprv, octets, or an
-    int, and works out which by trying them in turn. That only reads well
-    when a failed attempt says which kind of failure it was, and this is
-    the kind that means "wrong format, keep going".
+    `to_prv_key` accepts a private key as a BIP32 xprv, octets, or an int,
+    and works out which by trying them in turn. That only reads well when
+    a failed attempt says which kind of failure it was, and this is the
+    kind that means "wrong format, keep going". `b58.prv_key_data_from_wif`
+    raises it for text that is no WIF, the same question asked of the one
+    format it reads.
 
     A BTClibValueError, so code catching that keeps catching this.
     """
@@ -317,10 +319,13 @@ class NotAPrvKeyError(BTClibValueError):
 class InvalidPrvKeyError(BTClibValueError):
     """The format was recognised and the content is wrong: stop here.
 
-    The counterpart of NotAPrvKeyError. A WIF whose version prefix says
-    mainnet but whose payload is the wrong size is not something another
-    format might accept: reporting it is more use than trying the input as
-    a hex string and telling the caller it was not a private key.
+    The counterpart of NotAPrvKeyError. An xprv whose version bytes name a
+    network and whose key prefix is not the private one is not something
+    another format might accept: reporting it is more use than trying the
+    input as a hex string and telling the caller it was not a private key.
+    A WIF whose version prefix says mainnet but whose payload is the wrong
+    size is the same answer from `b58.prv_key_data_from_wif`: a WIF, with
+    a fault in it.
 
     A BTClibValueError, so code catching that keeps catching this.
     """

--- a/src/btclib/psbt_signer.py
+++ b/src/btclib/psbt_signer.py
@@ -77,6 +77,7 @@ from btclib.descriptors import (
 )
 from btclib.ecc import bms, dsa, ssa
 from btclib.exceptions import BTClibValueError, SignerError
+from btclib.key import PrvKeyData
 from btclib.psbt.psbt import Psbt, assert_signatures_only, combine, sign
 from btclib.script.taproot import output_prvkey_from_merkle_root
 from btclib.to_prv_key import prv_keyinfo_from_prv_key
@@ -833,7 +834,10 @@ class SoftwareSigner:
         self._assert_open()
         if self.is_watch_only:
             raise BTClibValueError("watch-only signer: it holds no key that signs")
-        prv_key = self._at(der_path)
+        # `_at` answers an xprv, `to_prv_key`'s object and not `bms.sign`'s
+        # (issue #1188): resolve it to a `PrvKeyData` before handing it over.
+        q, network, compressed = prv_keyinfo_from_prv_key(self._at(der_path))
+        prv_key = PrvKeyData(q, network, compressed)
         return b64encode(bms.sign(message, prv_key).serialize()).decode("ascii")
 
     def _prv_key(self, pub_key: bytes, origin: BIP32KeyOrigin | None) -> int | None:

--- a/src/btclib/to_prv_key.py
+++ b/src/btclib/to_prv_key.py
@@ -2,12 +2,17 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Functions for conversions between different private key formats."""
+"""Functions for conversions between different private key formats.
+
+A WIF is not among the formats: it is `b58`'s object, read by
+`b58.prv_key_data_from_wif` and written by `b58.wif_from_prv_key`, and
+this module -- which `b58` imports through `to_pub_key` -- has no way to
+reach a parser living there (issue #1188).
+"""
 
 from __future__ import annotations
 
-from btclib.alias import Octets, String
-from btclib.base58 import decode as b58decode
+from btclib.alias import Octets
 from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, _key_data_from_bip32_key
 from btclib.curves import Curve, secp256k1
 from btclib.curves.curve import _assert_valid_ec
@@ -18,7 +23,6 @@ from btclib.exceptions import (
     NotAPrvKeyError,
 )
 from btclib.network import (
-    network_from_key_value,
     network_from_name,
     network_from_xkeyversion,
     xprvversions_from_network,
@@ -35,9 +39,8 @@ __all__ = [
 # private key inputs:
 # integer as Union[int, Octets]
 # BIP32key as BIP32Key
-# WIF as String
 #
-# BIP32key and WIF also provide extra info about
+# BIP32key also provides extra info about
 # network and (un)compressed-pub_key-derivation
 PrvKey = int | Octets | BIP32KeyData
 
@@ -54,10 +57,10 @@ def _assert_prv_key_type(prv_key: PrvKey) -> None:
     reason: a type the union does not declare is the caller's own
     mistake, where a value of a declared type that is no key is a
     NotAPrvKeyError -- "wrong format, try the next one", which is what
-    the guessing below is for. Without this the two were one class: a
-    float was reported as "not a private key: not a WIF (...); not a
-    BIP32 xkey (...); not octets (...)", three formats tried against a
-    value no format could have held.
+    the guessing below is for. Without this the two would be one class:
+    a float reported as "not a private key: not a BIP32 xkey (...); not
+    octets (...)", every format tried against a value no format could
+    have held.
 
     A bool is refused here rather than answered as the number one.
     `utils.is_integer` is where that rule is stated -- issue #326 gave it
@@ -82,7 +85,6 @@ def int_from_prv_key(prv_key: PrvKey, ec: Curve = secp256k1) -> int:
 
     It supports:
 
-    - WIF (bytes or string)
     - BIP32 extended keys (bytes, string, or BIP32KeyData)
     - SEC Octets (bytes or hex-string, with 02, 03, or 04 prefix)
     - integer (native int or hex-string)
@@ -91,9 +93,9 @@ def int_from_prv_key(prv_key: PrvKey, ec: Curve = secp256k1) -> int:
     are not used.
     """
     # before the key, because every branch below reaches the curve: an
-    # xprv or a WIF is compared against it rather than parsed with it, and
-    # an ec of no curve type compares unequal to every network's -- which
-    # is "ec / network mismatch" for what is a caller's own mistake
+    # xprv is compared against it rather than parsed with it, and an ec
+    # of no curve type compares unequal to every network's -- which is
+    # "ec / network mismatch" for what is a caller's own mistake
     _assert_valid_ec(ec)
     _assert_prv_key_type(prv_key)
 
@@ -101,19 +103,19 @@ def int_from_prv_key(prv_key: PrvKey, ec: Curve = secp256k1) -> int:
         q = prv_key
     elif isinstance(prv_key, BIP32KeyData):
         q, network, _ = _prv_keyinfo_from_xprv(prv_key, None, None)
-        # q has been validated on the xprv/wif network
+        # q has been validated on the xprv network
         return _q_if_network_and_ec_match(q, network, ec)
     else:
         reasons = []
         try:
-            q, network, _ = _prv_keyinfo_from_xprvwif(prv_key, None, None)
+            q, network, _ = _prv_keyinfo_from_xprv(prv_key, None, None)
         except NotAPrvKeyError as e:
             # an InvalidPrvKeyError is not caught: the format was
             # recognised, so trying the input as octets and reporting "not
             # a private key" would replace the answer with a worse one
             reasons.append(str(e))
         else:
-            # q has been validated on the xprv/wif network
+            # q has been validated on the xprv network
             return _q_if_network_and_ec_match(q, network, ec)
         # it must be octets
         try:
@@ -144,7 +146,7 @@ def int_from_prv_key(prv_key: PrvKey, ec: Curve = secp256k1) -> int:
 
 
 def _q_if_network_and_ec_match(q: int, network: str, ec: Curve) -> int:
-    # q has been validated on the xprv/wif network
+    # q has been validated on the xprv network
     ec2 = network_from_name(network).curve
     if ec != ec2:
         raise BTClibValueError(f"ec / network ({network}) mismatch")
@@ -152,108 +154,6 @@ def _q_if_network_and_ec_match(q: int, network: str, ec: Curve) -> int:
 
 
 PrvkeyInfo = tuple[int, str, bool]
-
-
-def _wif_network(prefix: bytes, network: str | None) -> str:
-    """Return the network a WIF version prefix belongs to.
-
-    NotAPrvKeyError for a prefix no network claims: the input is not a
-    WIF, and the format-guessing caller is free to try it as octets or
-    as an int. InvalidPrvKeyError once a network has claimed it and the
-    caller asked for another one: that is a WIF, and the wrong one.
-    """
-    net = network_from_key_value("wif", prefix)
-    if net is None:
-        raise NotAPrvKeyError(f"not a WIF (invalid prefix 0x{prefix.hex()})")
-
-    if network is None:
-        return net
-
-    # the forward check, and not a `net != network` name comparison:
-    # the reverse lookup answers "testnet" for the 0xef that testnet,
-    # regtest, signet and testnet4 all use, so comparing names would
-    # reject a signet WIF as "not a signet wif: prefix 0xef" --
-    # naming the very prefix signet asks for (issue #207).
-    # _prv_keyinfo_from_xprv below makes the same membership check
-    if prefix != network_from_name(network).wif:
-        raise InvalidPrvKeyError(f"not a {network} wif: prefix 0x{prefix.hex()}")
-    # the declared network, not the lookup's guess: for a caller who
-    # said "signet" the answer is signet, and it is the one that ends
-    # up in the returned tuple
-    return network
-
-
-def _wif_prv_key_and_compression(
-    payload: bytes, n_size: int, compressed: bool | None
-) -> tuple[bytes, bool]:
-    """Return the key bytes of a WIF payload, and whether it is compressed.
-
-    The size is what says which of the two it is, the compressed
-    spelling carrying one byte more; the caller's `compressed`, if it
-    said anything, then has to agree with the answer.
-    """
-    if len(payload) == n_size + 2:  # compressed WIF
-        compr = True
-        if payload[-1] != 0x01:  # must have a trailing 0x01
-            raise InvalidPrvKeyError("not a compressed WIF: missing trailing 0x01")
-        prv_key = payload[1:-1]
-    elif len(payload) == n_size + 1:  # uncompressed WIF
-        compr = False
-        prv_key = payload[1:]
-    else:
-        raise InvalidPrvKeyError(f"wrong WIF size: {len(payload)}")
-
-    if compressed is not None and compr != compressed:
-        raise InvalidPrvKeyError("compression requirement mismatch")
-
-    return prv_key, compr
-
-
-def _prv_keyinfo_from_wif(
-    wif: String, network: str | None, compressed: bool | None
-) -> PrvkeyInfo:
-    """Return private key tuple(int, compressed, network) from a WIF.
-
-    WIF is always compressed and includes network information: here the
-    'network, compressed' input parameters are passed only to allow
-    consistency checks.
-
-    The two helpers below are the two questions in refusal order, and
-    the order is what the error types are about: everything up to and
-    including the version prefix answers "is this a WIF at all", and
-    everything after it answers "is this WIF sound".
-    """
-    if isinstance(wif, str):
-        wif = wif.strip()
-
-    # base58 or not is the first question, and a negative answer leaves the
-    # input free to be octets or an int: NotAPrvKeyError, carrying the
-    # reason, so a mistyped WIF is reported as the bad checksum it is
-    # instead of being swallowed. None of the messages in this function
-    # echoes the input, which is candidate key material -- a checksum, a
-    # prefix and a size are not secret.
-    #
-    # both classes, as the octets branch of the two public converters
-    # catches both: what is neither a base58 string nor bytes is a
-    # TypeError, and it means here what a bad checksum means -- this input
-    # is not a WIF, and the caller is free to try it as something else
-    try:
-        payload = b58decode(wif)
-    except (TypeError, ValueError) as e:
-        raise NotAPrvKeyError(f"not a WIF ({e})") from e
-
-    # from here on the version prefix says WIF, so a fault in what follows
-    # is a fault in a WIF: InvalidPrvKeyError, which the format-guessing
-    # callers let through instead of trying the input as something else
-    net = _wif_network(payload[:1], network)
-    ec = network_from_name(net).curve
-    prv_key, compr = _wif_prv_key_and_compression(payload, ec.n_size, compressed)
-
-    q = int.from_bytes(prv_key, byteorder="big")
-    if not 0 < q < ec.n:
-        raise InvalidPrvKeyError("private key not in 1..n-1")
-
-    return q, net, compr
 
 
 def _prv_keyinfo_from_xprv(
@@ -310,40 +210,15 @@ def _prv_keyinfo_from_xprv(
     return q, network, True
 
 
-def _prv_keyinfo_from_xprvwif(
-    xprvwif: BIP32Key, network: str | None, compressed: bool | None
-) -> PrvkeyInfo:
-    """Return prv_key tuple (int, compressed, network) from WIF/BIP32.
-
-    Support WIF or BIP32 xprv.
-    """
-    reasons = []
-    if not isinstance(xprvwif, BIP32KeyData):
-        # NotAPrvKeyError only, letting an InvalidPrvKeyError through: a
-        # WIF whose prefix and checksum are right and whose payload is the
-        # wrong size is not something the xprv branch might accept
-        try:
-            return _prv_keyinfo_from_wif(xprvwif, network, compressed)
-        except NotAPrvKeyError as e:
-            reasons.append(str(e))
-    try:
-        return _prv_keyinfo_from_xprv(xprvwif, network, compressed)
-    except NotAPrvKeyError as e:
-        # both reasons, not the last one: which format the caller meant is
-        # exactly what is unknown here, so guessing would drop the answer
-        reasons.append(str(e))
-        raise NotAPrvKeyError("; ".join(reasons)) from e
-
-
 def prv_keyinfo_from_prv_key(
     prv_key: PrvKey, network: str | None = None, compressed: bool | None = None
 ) -> PrvkeyInfo:
-    """Return (int key, network, compressed) from any private key spelling.
+    """Return (int key, network, compressed) from a private key spelling.
 
-    A WIF or an xprv carries its own network and compression, and a
-    contradicting argument is refused rather than overridden; an int
-    or octets carry neither, so the arguments -- mainnet, compressed
-    -- fill in.
+    An xprv carries its own network and compression, and a contradicting
+    argument is refused rather than overridden; an int or octets carry
+    neither, so the arguments -- mainnet, compressed -- fill in. A WIF
+    carries both too, and is `b58.prv_key_data_from_wif`'s to read.
     """
     _assert_prv_key_type(prv_key)
     # None is a declared value here and means "whatever the key says", so
@@ -363,7 +238,7 @@ def prv_keyinfo_from_prv_key(
         reasons = []
         # NotAPrvKeyError only, letting an InvalidPrvKeyError through
         try:
-            return _prv_keyinfo_from_xprvwif(prv_key, network, compressed)
+            return _prv_keyinfo_from_xprv(prv_key, network, compressed)
         except NotAPrvKeyError as e:
             reasons.append(str(e))
         # it must be octets

--- a/src/btclib/to_pub_key.py
+++ b/src/btclib/to_pub_key.py
@@ -147,9 +147,9 @@ def point_from_key(key: Key, ec: Curve = secp256k1) -> Point:
     - native tuple
     """
     # as in `point_from_pub_key` below and `to_prv_key.int_from_prv_key`:
-    # a WIF is compared against the curve rather than parsed with it, and
-    # an ec of no curve type compares unequal to every network's, which is
-    # "Curve mismatch" for what is a caller's own mistake
+    # an xkey is compared against the curve rather than parsed with it,
+    # and an ec of no curve type compares unequal to every network's,
+    # which is "Curve mismatch" for what is a caller's own mistake
     _assert_valid_ec(ec)
     _assert_key_type(key)
     if isinstance(key, PreparedPoint):
@@ -289,7 +289,7 @@ def _sec_from_key(key: Key) -> bytes:
 
 def _err_msg(key: Key, network: str | None, compressed: bool | None) -> str:
     # never echo the key: it may well be private material
-    # (e.g. an xprv or WIF on the wrong network)
+    # (e.g. an xprv on the wrong network)
     err_msg = "not a private or"
     if compressed is not None:
         err_msg += " compressed" if compressed else " uncompressed"

--- a/src/btclib/wallet/key_wallet.py
+++ b/src/btclib/wallet/key_wallet.py
@@ -64,7 +64,7 @@ from btclib.bip32.der_path import (
 from btclib.bip44 import _ADDRESS_FROM_SCRIPT_TYPE, _script_type_from_purpose
 from btclib.curves import PreparedPoint
 from btclib.ecc import bms
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibValueError, NotAPrvKeyError
 from btclib.key import PrvKeyData, PubKeyData
 from btclib.network import network_from_xkeyversion
 from btclib.script.script_pub_key import ScriptPubKey
@@ -120,8 +120,7 @@ def _key_data(key: Key, network: str) -> PrvKeyData | PubKeyData:
     being a point and a caller's word about how often it will be
     multiplied, which says nothing about who can sign.
 
-    The rest -- octets, a WIF or an extended key -- are told apart in the
-    order `to_pub_key.pub_keyinfo_from_key` tells them apart, public
+    The rest -- octets, a WIF or an extended key -- are told apart public
     first: a public key is a complete answer here, the wallet watching
     that address and unable to sign for it, while anything that is not
     one has to be a private key, and the error raised for a malformed one
@@ -131,6 +130,11 @@ def _key_data(key: Key, network: str) -> PrvKeyData | PubKeyData:
     through to the private branch and come back as "not a private key",
     its own diagnosis lost. Nothing reaches that today, and the narrow
     `try` is so that nothing can rather than that nothing does.
+
+    A WIF is tried ahead of `to_prv_key.prv_keyinfo_from_prv_key`, which
+    cannot resolve one itself: `b58` is where a WIF is read, and this
+    module already imports it for the direction `add` below writes
+    (issue #1188).
 
     Both types re-check what the converter that fed them has already
     guaranteed, which looks redundant and is not: `to_prv_key` admits a
@@ -145,8 +149,16 @@ def _key_data(key: Key, network: str) -> PrvKeyData | PubKeyData:
     try:
         pub_key_info = pub_keyinfo_from_pub_key(key, network)
     except BTClibValueError:
-        return PrvKeyData(*prv_keyinfo_from_prv_key(key, network))
-    return PubKeyData(*pub_key_info)
+        pass
+    else:
+        return PubKeyData(*pub_key_info)
+
+    if isinstance(key, (str, bytes, bytearray, memoryview)):
+        try:
+            return b58.prv_key_data_from_wif(key, network)
+        except NotAPrvKeyError:
+            pass
+    return PrvKeyData(*prv_keyinfo_from_prv_key(key, network))
 
 
 class KeyWallet(Wallet):
@@ -256,7 +268,8 @@ class KeyWallet(Wallet):
             err_msg = f"BMS cannot sign for a p2tr address: {info.address};"
             err_msg += " message signing for taproot is btclib.bip322"
             raise BTClibValueError(err_msg)
-        return bms.sign(msg, self.prv_key(info.address), info.address)
+        prv_key = b58.prv_key_data_from_wif(self.prv_key(info.address))
+        return bms.sign(msg, prv_key, info.address)
 
 
 class BIP32KeyWallet(KeyWallet, RangedWallet):
@@ -369,12 +382,15 @@ class BIP32KeyWallet(KeyWallet, RangedWallet):
         `bip32.derive_from_account_` is what imposes them -- branch 0 or 1,
         index at most 65535 -- and the message on a violation is its own.
 
-        The key and not its xprv/xpub text: all three callers hand it to
+        The key and not its xprv/xpub text: both other callers hand it to
         something that decodes it -- an address builder,
-        `ScriptPubKey.p2wpkh`, `b58.wif_from_prv_key` -- and a
-        `BIP32KeyData` is in the `Key` and `PrvKey` unions those take.
-        Answering text instead would make each of them build it and read
-        it back inside one line (issue 886)
+        `ScriptPubKey.p2wpkh` -- and a `BIP32KeyData` is in the `Key`
+        union those take. Answering text instead would make each of them
+        build it and read it back inside one line (issue 886). `prv_key`
+        below is the one caller that cannot take it directly any more:
+        `b58.wif_from_prv_key` wants the scalar an xprv resolves to, not
+        the xprv itself (issue #1188), so it goes through
+        `to_prv_key.prv_keyinfo_from_prv_key` first.
         """
         return derive_from_account_(self._xkey, branch, index)
 
@@ -437,4 +453,6 @@ class BIP32KeyWallet(KeyWallet, RangedWallet):
         # wallet holding one private key, the account one, however many
         # addresses it has handed out
         branch, index = indexes_from_der_path(info.der_path)[-2:]
-        return b58.wif_from_prv_key(self._derived_xkey(branch, index))
+        xkey = self._derived_xkey(branch, index)
+        q, network, compressed = prv_keyinfo_from_prv_key(xkey)
+        return b58.wif_from_prv_key(q, network, compressed)

--- a/tests/b58_test.py
+++ b/tests/b58_test.py
@@ -23,58 +23,57 @@ from btclib.exceptions import (
 from btclib.hashes import hash160, sha256
 from btclib.script.script import serialize
 from btclib.to_prv_key import prv_keyinfo_from_prv_key
-from btclib.to_pub_key import pub_keyinfo_from_key, pub_keyinfo_from_prv_key
+from btclib.to_pub_key import pub_keyinfo_from_key
 
 ec = secp256k1
 
 
 def test_wif_from_prv_key() -> None:
-    """Verify WIF encoding from any key spelling, and the malformed WIFs."""
+    """Verify WIF encoding from a scalar, and the malformed scalars.
+
+    A WIF is not among `wif_from_prv_key`'s own inputs any more: it is
+    what the function writes, and what `prv_key_data_from_wif` below
+    reads back, never what either takes as the other's spelling
+    (issue #1188).
+    """
     q_prv_key = "0C28FCA386C7A227600B2FE50B7CAE11EC86D3BF1FBE471BE89827E19D72AA1D"
-    wif_prv_keys = [
-        "KwdMAjGmerYanjeui5SHS7JkmpZvVipYvB2LJGU1ZxJwYvP98617",
-        "cMzLdeGd5vEqxB8B6VFQoRopQ3sLAAvEzDAoQgvX54xwofSWj1fx",
-        "5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ",
-        "91gGn1HgSap6CbU12F6z3pJri26xzp7Ay1VW6NHCoEayNXwRpu2",
-        " KwdMAjGmerYanjeui5SHS7JkmpZvVipYvB2LJGU1ZxJwYvP98617",
-        "KwdMAjGmerYanjeui5SHS7JkmpZvVipYvB2LJGU1ZxJwYvP98617 ",
-    ]
-    for alt_prv_key in wif_prv_keys:
-        assert alt_prv_key.strip() == b58.wif_from_prv_key(alt_prv_key)
+    q_int = int(q_prv_key, 16)
 
     test_vectors = [
         ("KwdMAjGmerYanjeui5SHS7JkmpZvVipYvB2LJGU1ZxJwYvP98617", "mainnet", True),
         ("cMzLdeGd5vEqxB8B6VFQoRopQ3sLAAvEzDAoQgvX54xwofSWj1fx", "testnet", True),
         ("5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ", "mainnet", False),
         ("91gGn1HgSap6CbU12F6z3pJri26xzp7Ay1VW6NHCoEayNXwRpu2", "testnet", False),
-        (" KwdMAjGmerYanjeui5SHS7JkmpZvVipYvB2LJGU1ZxJwYvP98617", "mainnet", True),
-        ("KwdMAjGmerYanjeui5SHS7JkmpZvVipYvB2LJGU1ZxJwYvP98617 ", "mainnet", True),
     ]
-    for v in test_vectors:
-        for prv_key in [q_prv_key, *wif_prv_keys]:
-            assert v[0].strip() == b58.wif_from_prv_key(prv_key, v[1], v[2])
-            q, network, compressed = prv_keyinfo_from_prv_key(v[0])
-            assert q == int(q_prv_key, 16)
-            assert network == v[1]
-            assert compressed == v[2]
+    for wif, network, compressed in test_vectors:
+        assert wif == b58.wif_from_prv_key(q_prv_key, network, compressed)
+        assert wif == b58.wif_from_prv_key(q_int, network, compressed)
+        data = b58.prv_key_data_from_wif(wif)
+        assert (data.q, data.network, data.compressed) == (q_int, network, compressed)
 
     bad_q = ec.n.to_bytes(ec.n_size, byteorder="big", signed=False)
     with pytest.raises(BTClibValueError, match="private key not in 1..n-1"):
         b58.wif_from_prv_key(bad_q, "mainnet", True)
 
+    # not a private key: 33 bytes, not the 32 a scalar's octets are
+    bad_q = 33 * b"\x02"
+    with pytest.raises(BTClibValueError, match="invalid size: 33 bytes"):
+        b58.wif_from_prv_key(bad_q, "mainnet", True)
+
+
+def test_prv_key_data_from_wif() -> None:
+    """The malformed WIFs, and the two error classes they fall into."""
+    bad_q = ec.n.to_bytes(ec.n_size, byteorder="big", signed=False)
     payload = b"\x80" + bad_q
     badwif = b58encode(payload)
     # a well-formed WIF -- base58, checksum, 0x80 prefix, right size --
     # carrying a scalar equal to n. The format is recognised, so the
-    # fault in it is reported rather than swallowed, the string retried
-    # as a hex-string, and the caller told "not a private key"
+    # fault in it is reported rather than swallowed as "not a WIF"
     with pytest.raises(InvalidPrvKeyError, match="private key not in 1..n-1"):
-        prv_keyinfo_from_prv_key(badwif)
+        b58.prv_key_data_from_wif(badwif)
 
-    # not a private key: 33 bytes
+    # not a WIF at all: 33 bytes wrapped as if it were a scalar's payload
     bad_q = 33 * b"\x02"
-    with pytest.raises(BTClibValueError, match="not a private key"):
-        b58.wif_from_prv_key(bad_q, "mainnet", True)
     payload = b"\x80" + bad_q
     badwif = b58encode(payload)
     # 34 bytes is the compressed-WIF size, so the trailing byte is what is
@@ -82,31 +81,82 @@ def test_wif_from_prv_key() -> None:
     # reason to try the string as something else
     err_msg = "not a compressed WIF: missing trailing 0x01"
     with pytest.raises(InvalidPrvKeyError, match=err_msg):
-        prv_keyinfo_from_prv_key(badwif)
+        b58.prv_key_data_from_wif(badwif)
 
-    # Not a WIF: missing leading 0x80. Nothing says WIF about it, so the
-    # guessing goes on, and what the caller gets is every reason together
+    # Not a WIF: missing leading 0x80
     good_q = 32 * b"\x02"
     payload = b"\x81" + good_q
     badwif = b58encode(payload)
-    with pytest.raises(NotAPrvKeyError, match="not a private key") as exc_info:
-        prv_keyinfo_from_prv_key(badwif)
-    message = str(exc_info.value)
-    assert "not a WIF (invalid prefix 0x81)" in message
-    assert "not a BIP32 xkey" in message
-    assert "not octets" in message
+    with pytest.raises(NotAPrvKeyError, match="not a WIF") as exc_info:
+        b58.prv_key_data_from_wif(badwif)
+    assert "invalid prefix 0x81" in str(exc_info.value)
 
     # Not a compressed WIF: missing trailing 0x01
     payload = b"\x80" + good_q + b"\x00"
     badwif = b58encode(payload)
     with pytest.raises(InvalidPrvKeyError, match=err_msg):
-        prv_keyinfo_from_prv_key(badwif)
+        b58.prv_key_data_from_wif(badwif)
 
     # Not a WIF: wrong size (35)
     payload = b"\x80" + good_q + b"\x01\x00"
     badwif = b58encode(payload)
     with pytest.raises(InvalidPrvKeyError, match="wrong WIF size: 35"):
-        prv_keyinfo_from_prv_key(badwif)
+        b58.prv_key_data_from_wif(badwif)
+
+    # leading/trailing spaces in a str are stripped; a WIF is also read
+    # from bytes, base58's own alphabet excluding the space either way
+    wif = "KwdMAjGmerYanjeui5SHS7JkmpZvVipYvB2LJGU1ZxJwYvP98617"
+    for alt in (f" {wif}", f"{wif} ", wif.encode("ascii")):
+        assert b58.prv_key_data_from_wif(alt) == b58.prv_key_data_from_wif(wif)
+
+    # a mainnet WIF asked for as a testnet one: the prefix is recognised,
+    # so the fault is reported as the wrong network rather than "not a
+    # WIF"
+    with pytest.raises(InvalidPrvKeyError, match="not a testnet wif: prefix 0x80"):
+        b58.prv_key_data_from_wif(wif, "testnet")
+
+
+def test_a_mistyped_wif_is_reported_as_one() -> None:
+    """The headline case: one wrong character in a WIF.
+
+    The checksum failure must not be swallowed, and never as "not a
+    private key": a WIF is the one format `prv_key_data_from_wif` reads,
+    so there is nothing else left to try it as.
+    """
+    good = "KwdMAjGmerYanjeui5SHS7JkmpZvVipYvB2LJGU1ZxJwYvP98617"
+    assert b58.prv_key_data_from_wif(good).network == "mainnet"
+
+    mistyped = f"{good[:-1]}8"
+    with pytest.raises(NotAPrvKeyError, match="not a WIF") as exc_info:
+        b58.prv_key_data_from_wif(mistyped)
+    message = str(exc_info.value)
+    assert "invalid checksum" in message
+    # never the input itself, which is candidate key material
+    assert mistyped not in message
+
+    # the address functions answer otherwise, and that is the contract
+    # rather than a gap: the checksum is verified before any prefix is
+    # read, so nothing there knows a WIF was meant, and there are other
+    # spellings left to try the text as
+    with pytest.raises(BTClibValueError, match="not a private or public key"):
+        b58.p2pkh(mistyped)
+
+
+def test_a_faulty_wif_keeps_its_diagnosis_through_an_address() -> None:
+    """A WIF a network has claimed does not degrade to "not a key".
+
+    `NotAPrvKeyError` says another spelling is worth trying and
+    `_pub_keyinfo_from_key` tries it. `InvalidPrvKeyError` says the
+    format was recognised, so there is nothing left to try and the
+    diagnosis already computed is the answer.
+    """
+    uncompressed = "5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf"
+    with pytest.raises(InvalidPrvKeyError, match="compression requirement mismatch"):
+        b58.p2wpkh_p2sh(uncompressed)
+
+    testnet_wif = "cMahea7zqjxrtgAbB7LSGbcQUr1uX1ojuat9jZodMN87JcbXMTcA"
+    with pytest.raises(InvalidPrvKeyError, match="not a mainnet wif"):
+        b58.p2pkh(testnet_wif, network="mainnet")
 
 
 def test_address_from_h160() -> None:
@@ -125,21 +175,27 @@ def test_address_from_h160() -> None:
 
 
 def test_p2pkh_from_wif() -> None:
-    """Verify the p2pkh of a derived WIF, and refuse an xpub as a key."""
+    """Verify the p2pkh of a derived WIF, and refuse an xpub as a key.
+
+    `wif_from_prv_key` takes the scalar an xprv resolves to, not the
+    xprv itself: `to_prv_key` is what still resolves one, `b58` having
+    no way to reach `bip32` for it (issue #1188).
+    """
     seed = b"\x00" * 32  # better be a documented test case
     rxprv = bip32.rootxprv_from_seed(seed)
     path = "m/0h/0h/12"
     xprv = bip32.derive(rxprv, path)
-    wif = b58.wif_from_prv_key(xprv)
+    q, network, compressed = prv_keyinfo_from_prv_key(xprv)
+    wif = b58.wif_from_prv_key(q, network, compressed)
     assert wif == "L2L1dqRmkmVtwStNf5wg8nnGaRn3buoQr721XShM4VwDbTcn9bpm"
-    pub_key, _ = pub_keyinfo_from_prv_key(wif)
+    pub_key = b58.prv_key_data_from_wif(wif).pub.sec
     address = b58.p2pkh(pub_key)
     xpub = bip32.xpub_from_xprv(xprv)
     assert address == slip132.address_from_xpub(xpub)
 
     err_msg = "not a private key"
     with pytest.raises(BTClibValueError, match=err_msg):
-        b58.wif_from_prv_key(xpub)
+        prv_keyinfo_from_prv_key(xpub)
 
 
 def test_p2pkh_from_pub_key() -> None:
@@ -272,14 +328,18 @@ def test_address_from_wif() -> None:
     ]
     for compressed, network, wif, address in test_cases:
         assert wif == b58.wif_from_prv_key(q, network, compressed)
-        assert prv_keyinfo_from_prv_key(wif) == (q, network, compressed)
+        data = b58.prv_key_data_from_wif(wif)
+        assert (data.q, data.network, data.compressed) == (q, network, compressed)
         assert address == b58.p2pkh(wif)
         script_type, payload, net = b58.h160_from_address(address)
         assert net == network
         assert script_type == "p2pkh"
 
         if compressed:
-            b32_address = b32.p2wpkh(wif)
+            # b58 reads the WIF itself; b32 sits below it and cannot, so
+            # the pub key it derives is handed over instead (issue #1188)
+            pub_key = data.pub.sec
+            b32_address = b32.p2wpkh(pub_key, network)
             assert (0, payload, net) == b32.witness_from_address(b32_address)
 
             b58_address = b58.p2wpkh_p2sh(wif)
@@ -287,10 +347,14 @@ def test_address_from_wif() -> None:
             assert ("p2sh", script_bin, net) == b58.h160_from_address(b58_address)
 
         else:
+            # b32 cannot read a WIF, so an uncompressed one reaches it as
+            # text no spelling resolves; b58 reads it, finds a WIF that a
+            # p2wpkh cannot use, and says which of the two it is
             err_msg = "not a private or compressed public key"
             with pytest.raises(BTClibValueError, match=err_msg):
                 b32.p2wpkh(wif)
-            with pytest.raises(BTClibValueError, match=err_msg):
+            err_msg = "compression requirement mismatch"
+            with pytest.raises(InvalidPrvKeyError, match=err_msg):
                 b58.p2wpkh_p2sh(wif)
 
 
@@ -328,4 +392,5 @@ def test_round_trip_address(script_type: ScriptType, h160: bytes, network: str) 
 def test_round_trip_wif(prv_key: int, compressed: bool) -> None:
     """A WIF decodes to the key it was made from, and to its compression."""
     wif = b58.wif_from_prv_key(prv_key, "mainnet", compressed)
-    assert prv_keyinfo_from_prv_key(wif) == (prv_key, "mainnet", compressed)
+    data = b58.prv_key_data_from_wif(wif)
+    assert (data.q, data.network, data.compressed) == (prv_key, "mainnet", compressed)

--- a/tests/bip322_test.py
+++ b/tests/bip322_test.py
@@ -23,7 +23,7 @@ from typing import Any
 
 import pytest
 
-from btclib import bip322
+from btclib import b58, bip322
 from btclib.b32 import p2tr, p2wpkh, p2wsh
 from btclib.b58 import p2pkh, p2wpkh_p2sh, wif_from_prv_key
 from btclib.ecc import bms, dsa, ssa
@@ -48,8 +48,6 @@ from btclib.script.sig_hash import (
 from btclib.script.sig_hash import taproot as taproot_sig_hash
 from btclib.script.taproot import output_prvkey, output_pubkey
 from btclib.script.witness import Witness
-from btclib.to_prv_key import prv_keyinfo_from_prv_key
-from btclib.to_pub_key import pub_keyinfo_from_key
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from tests import load, vector_id
 
@@ -68,12 +66,17 @@ _NATIVE_SEGWIT = frozenset({"p2wpkh", "p2wsh", "p2tr"})
 
 
 def _address(wif: str, script_type: str) -> str:
-    """Return the address of one of the four types a single key owns."""
+    """Return the address of one of the four types a single key owns.
+
+    The pub key and not the WIF: `b32.p2wpkh` sits below `b58` and has
+    no way to read one, where `b58.p2pkh` and `b58.p2wpkh_p2sh` would
+    (issue #1188) -- the octets work for all four alike.
+    """
+    pub_key = b58.prv_key_data_from_wif(wif, compressed=True).pub.sec
     if script_type == "p2tr":
-        pub_key = pub_keyinfo_from_key(wif, compressed=True)[0]
         return p2tr(output_pubkey(pub_key)[0])
     return {"p2pkh": p2pkh, "p2wpkh": p2wpkh, "p2sh-p2wpkh": p2wpkh_p2sh}[script_type](
-        wif
+        pub_key
     )
 
 
@@ -223,7 +226,7 @@ def test_sign_and_verify(script_type: str, msg: bytes) -> None:
     everything passes the first assertion too.
     """
     addr = _address(WIF, script_type)
-    sig = bip322.sign(msg, WIF, addr)
+    sig = bip322.sign(msg, b58.prv_key_data_from_wif(WIF), addr)
     assert sig.variant == (
         bip322.SIMPLE if script_type in _NATIVE_SEGWIT else bip322.FULL
     )
@@ -234,7 +237,9 @@ def test_sign_and_verify(script_type: str, msg: bytes) -> None:
     assert not bip322.verify(msg + b"!", addr, text)
     assert not bip322.verify(msg, _address(OTHER_WIF, script_type), text)
     other = _address(OTHER_WIF, script_type)
-    assert not bip322.verify(msg, addr, bip322.sign(msg, OTHER_WIF, other))
+    assert not bip322.verify(
+        msg, addr, bip322.sign(msg, b58.prv_key_data_from_wif(OTHER_WIF), other)
+    )
 
 
 @pytest.mark.parametrize(
@@ -251,7 +256,9 @@ def test_signing_reproduces_the_ecdsa_vectors(case: dict[str, Any]) -> None:
     vector sets a version and a lock time that `sign` does not.
     """
     sig = bip322.sign(
-        case["message"].encode(), case["private_keys"][0], case["address"]
+        case["message"].encode(),
+        b58.prv_key_data_from_wif(case["private_keys"][0]),
+        case["address"],
     )
     assert sig.b64encode() in case["bip322_signatures"]
 
@@ -260,16 +267,18 @@ def test_sign_refuses_an_address_the_key_does_not_own() -> None:
     """A key that does not open the address is refused before it signs."""
     for script_type in ("p2pkh", "p2wpkh", "p2sh-p2wpkh", "p2tr"):
         with pytest.raises(BTClibValueError, match="mismatch between private key"):
-            bip322.sign(b"", OTHER_WIF, _address(WIF, script_type))
+            bip322.sign(
+                b"", b58.prv_key_data_from_wif(OTHER_WIF), _address(WIF, script_type)
+            )
 
 
 def test_sign_refuses_a_script_no_single_key_satisfies() -> None:
     """p2wsh is not one of the four, and says so rather than signing."""
     script = serialize(
-        ["OP_1", pub_keyinfo_from_key(WIF)[0], "OP_1", "OP_CHECKMULTISIG"]
+        ["OP_1", b58.prv_key_data_from_wif(WIF).pub.sec, "OP_1", "OP_CHECKMULTISIG"]
     )
     with pytest.raises(BTClibValueError, match="mismatch between private key"):
-        bip322.sign(b"", WIF, p2wsh(script))
+        bip322.sign(b"", b58.prv_key_data_from_wif(WIF), p2wsh(script))
 
 
 def test_sign_refuses_an_uncompressed_key_for_segwit() -> None:
@@ -279,12 +288,14 @@ def test_sign_refuses_an_uncompressed_key_for_segwit() -> None:
     mismatch rather than a signature nobody can verify.
     """
     wif = wif_from_prv_key(
-        prv_keyinfo_from_prv_key(WIF)[0], "mainnet", compressed=False
+        b58.prv_key_data_from_wif(WIF).q, "mainnet", compressed=False
     )
-    assert bip322.verify(b"", p2pkh(wif), bip322.sign(b"", wif, p2pkh(wif)))
+    assert bip322.verify(
+        b"", p2pkh(wif), bip322.sign(b"", b58.prv_key_data_from_wif(wif), p2pkh(wif))
+    )
     for script_type in ("p2wpkh", "p2sh-p2wpkh", "p2tr"):
         with pytest.raises(BTClibValueError, match="mismatch between private key"):
-            bip322.sign(b"", wif, _address(WIF, script_type))
+            bip322.sign(b"", b58.prv_key_data_from_wif(wif), _address(WIF, script_type))
 
 
 def test_multisig_is_signed_through_the_witness_it_needs() -> None:
@@ -296,7 +307,10 @@ def test_multisig_is_signed_through_the_witness_it_needs() -> None:
     the simple variant. Which is the shape the vectors verify, arrived
     at from the other side.
     """
-    keys = [pub_keyinfo_from_key(wif, compressed=True)[0] for wif in (WIF, OTHER_WIF)]
+    keys = [
+        b58.prv_key_data_from_wif(wif, compressed=True).pub.sec
+        for wif in (WIF, OTHER_WIF)
+    ]
     witness_script = serialize(["OP_2", *keys, "OP_2", "OP_CHECKMULTISIG"])
     addr = p2wsh(witness_script)
     msg = b"two keys, one message"
@@ -317,7 +331,7 @@ def test_multisig_is_signed_through_the_witness_it_needs() -> None:
 
 def dsa_sign(msg_hash: bytes, wif: str) -> bytes:
     """Return the DER signature of the hash, SIGHASH_ALL appended."""
-    q = prv_keyinfo_from_prv_key(wif)[0]
+    q = b58.prv_key_data_from_wif(wif).q
     return dsa.sign_(msg_hash, q).serialize() + ALL.to_bytes(1, "big")
 
 
@@ -330,11 +344,13 @@ def test_legacy_signature_is_accepted_for_p2pkh_alone() -> None:
     whatever `ecc.bms` would say of it.
     """
     msg = b"legacy"
-    legacy = bms.sign(msg, WIF).b64encode()
-    assert bms.verify(msg, p2wpkh(WIF), legacy)
+    # b32.p2wpkh sits below b58 and cannot read a WIF (issue #1188)
+    wif_pub_key = b58.prv_key_data_from_wif(WIF).pub.sec
+    legacy = bms.sign(msg, b58.prv_key_data_from_wif(WIF)).b64encode()
+    assert bms.verify(msg, p2wpkh(wif_pub_key), legacy)
 
     assert bip322.verify(msg, p2pkh(WIF), legacy)
-    assert not bip322.verify(msg, p2wpkh(WIF), legacy)
+    assert not bip322.verify(msg, p2wpkh(wif_pub_key), legacy)
     assert not bip322.verify(msg, p2pkh(WIF), legacy, legacy=False)
     assert not bip322.verify(b"another", p2pkh(WIF), legacy)
 
@@ -352,7 +368,7 @@ def test_legacy_signature_is_accepted_for_p2pkh_alone() -> None:
     octets = legacy.encode("ascii")
     for spelling in (octets, bytearray(octets), memoryview(octets)):
         assert bip322.verify(msg, p2pkh(WIF), spelling)
-        assert not bip322.verify(msg, p2wpkh(WIF), spelling)
+        assert not bip322.verify(msg, p2wpkh(wif_pub_key), spelling)
 
 
 def test_a_simple_signature_is_not_65_octets() -> None:
@@ -364,7 +380,7 @@ def test_a_simple_signature_is_not_65_octets() -> None:
     the prefixless case decidable.
     """
     addr = _address(WIF, "p2tr")
-    shortest = bip322.sign(b"", WIF, addr)
+    shortest = bip322.sign(b"", b58.prv_key_data_from_wif(WIF), addr)
     assert len(shortest.serialize()) == 66
 
 
@@ -372,7 +388,9 @@ def test_sig_round_trip() -> None:
     """Each variant survives b64encode and b64decode, and keeps its name."""
     msg = b"round trip"
     for script_type, variant in (("p2wpkh", bip322.SIMPLE), ("p2pkh", bip322.FULL)):
-        sig = bip322.sign(msg, WIF, _address(WIF, script_type))
+        sig = bip322.sign(
+            msg, b58.prv_key_data_from_wif(WIF), _address(WIF, script_type)
+        )
         text = sig.b64encode()
         assert text[:3] == variant
         assert bip322.Sig.b64decode(text) == sig
@@ -394,7 +412,7 @@ def test_sig_is_frozen_and_check_validity_defaults_to_true() -> None:
     instead of passing the keyword explicitly.
     """
     msg, addr = b"frozen", _address(WIF, "p2pkh")
-    sig = bip322.sign(msg, WIF, addr)
+    sig = bip322.sign(msg, b58.prv_key_data_from_wif(WIF), addr)
     with pytest.raises(dataclasses.FrozenInstanceError):
         sig.payload = sig.payload  # type: ignore[misc]
 
@@ -428,7 +446,7 @@ def test_b64decode_refuses_what_is_not_base64() -> None:
     # and `☃` above fail regardless of `validate`, where a stray
     # newline is stripped and silently decoded under `validate=False`
     # and is what `validate=True` is actually for
-    sig = bip322.sign(b"x", WIF, _address(WIF, "p2pkh"))
+    sig = bip322.sign(b"x", b58.prv_key_data_from_wif(WIF), _address(WIF, "p2pkh"))
     text = sig.b64encode()
     smuggled = text[:10] + "\n" + text[10:]
     with pytest.raises(BTClibValueError, match="invalid base64 encoding"):
@@ -461,7 +479,7 @@ def _to_sign_of(msg: bytes, addr: str, **kwargs: Any) -> tuple[Tx, Tx]:
 def test_shape_of_to_sign_is_checked() -> None:
     """Every field BIP322 fixes is a refusal when it is something else."""
     msg, addr = b"shape", _address(WIF, "p2wpkh")
-    signed = bip322.sign(msg, WIF, addr)
+    signed = bip322.sign(msg, b58.prv_key_data_from_wif(WIF), addr)
     spend, tx = _to_sign_of(msg, addr, witness=signed.payload)
 
     other = bip322.to_spend(b"other", ScriptPubKey.from_address(addr).script)
@@ -534,7 +552,7 @@ def test_a_version_that_is_not_0_or_2_is_inconclusive() -> None:
     False for both, an inconclusive signature not being a valid one.
     """
     msg, addr = b"version", _address(WIF, "p2wpkh")
-    signed = bip322.sign(msg, WIF, addr)
+    signed = bip322.sign(msg, b58.prv_key_data_from_wif(WIF), addr)
     _, tx = _to_sign_of(msg, addr, witness=signed.payload, version=1)
 
     with pytest.raises(InconclusiveError, match="BIP322 allows 0 and 2"):
@@ -612,7 +630,7 @@ def _sign_with(msg: bytes, script_type: str, hash_type: int) -> tuple[str, bip32
     addr = _address(WIF, script_type)
     spend = bip322.to_spend(msg, ScriptPubKey.from_address(addr).script)
     tx = bip322.to_sign(spend)
-    q = prv_keyinfo_from_prv_key(WIF)[0]
+    q = b58.prv_key_data_from_wif(WIF).q
 
     if script_type == "p2tr":
         msg_hash = taproot_sig_hash(tx, 0, spend.vout, hash_type, 0, b"", b"")
@@ -625,7 +643,7 @@ def _sign_with(msg: bytes, script_type: str, hash_type: int) -> tuple[str, bip32
 
     msg_hash = from_tx(spend.vout, tx, 0, hash_type)
     signature = dsa.sign_(msg_hash, q).serialize() + hash_type.to_bytes(1, "big")
-    pub_key = pub_keyinfo_from_key(WIF, compressed=True)[0]
+    pub_key = b58.prv_key_data_from_wif(WIF, compressed=True).pub.sec
     if script_type == "p2pkh":
         tx.vin[0].script_sig = serialize([signature, pub_key])
         return addr, bip322.Sig(tx)
@@ -711,8 +729,8 @@ def test_proof_of_funds_refuses_anyonecanpay_on_a_further_input(
     prevouts = [spend.vout[0], funded]
 
     psbt = Psbt.from_tx(tx)
-    pub_key = pub_keyinfo_from_key(WIF, compressed=True)[0]
-    q = prv_keyinfo_from_prv_key(WIF)[0]
+    pub_key = b58.prv_key_data_from_wif(WIF, compressed=True).pub.sec
+    q = b58.prv_key_data_from_wif(WIF).q
     for i, one_type in enumerate((ALL, hash_type)):
         signature = dsa.sign_(from_tx(prevouts, tx, i, one_type), q).serialize()
         psbt.inputs[i].witness_utxo = prevouts[i]
@@ -746,14 +764,14 @@ def test_a_broken_required_rule_answers_before_an_upgradeable_one(
     because the first run never reaches the end of the script: it is
     the case for the second run collecting at all.
     """
-    keys = pub_keyinfo_from_key(WIF, compressed=True)[0]
+    keys = b58.prv_key_data_from_wif(WIF, compressed=True).pub.sec
     witness_script = serialize([keys, "OP_CHECKSIGVERIFY", "OP_NOP4", "OP_1"])
     msg, addr = b"two rules at once", p2wsh(witness_script)
 
     spend = bip322.to_spend(msg, ScriptPubKey.from_address(addr).script)
     tx = bip322.to_sign(spend)
     msg_hash = segwit_v0(witness_script, tx, 0, hash_type, 0)
-    q = prv_keyinfo_from_prv_key(WIF)[0]
+    q = b58.prv_key_data_from_wif(WIF).q
     signature = dsa.sign_(msg_hash, q).serialize() + hash_type.to_bytes(1, "big")
     sig = bip322.Sig(Witness([signature, witness_script]))
 
@@ -890,7 +908,10 @@ def test_a_created_psbt_is_signed_and_finalized_into_a_proof() -> None:
     coordination flow -- the psbt is how the two signatures meet, and
     the field is how the second signer knows what it is signing.
     """
-    keys = [pub_keyinfo_from_key(wif, compressed=True)[0] for wif in (WIF, OTHER_WIF)]
+    keys = [
+        b58.prv_key_data_from_wif(wif, compressed=True).pub.sec
+        for wif in (WIF, OTHER_WIF)
+    ]
     witness_script = serialize(["OP_2", *keys, "OP_2", "OP_CHECKMULTISIG"])
     addr = p2wsh(witness_script)
     msg = b"two keys, one psbt"

--- a/tests/bip85_test.py
+++ b/tests/bip85_test.py
@@ -32,6 +32,7 @@ from typing import Any
 
 import pytest
 
+from btclib import b58
 from btclib.bip32 import BIP32KeyData, derive, rootxprv_from_seed, xpub_from_xprv
 from btclib.bip85 import (
     _HMAC_KEY,
@@ -53,7 +54,6 @@ from btclib.curves import secp256k1 as ec
 from btclib.exceptions import BTClibValueError
 from btclib.mnemonic.bip39 import entropy_from_mnemonic
 from btclib.network import NETWORKS
-from btclib.to_prv_key import prv_keyinfo_from_prv_key
 from tests import load, vector_id
 
 _VECTORS = load("_data", "bip85_test_vectors.json")
@@ -107,8 +107,8 @@ def test_hd_seed_wif_application(vector: dict[str, Any]) -> None:
 
     wif = wif_from_root_key(_ROOT)
     assert wif == vector["derived_wif"]
-    _, network, compressed = prv_keyinfo_from_prv_key(wif)
-    assert (network, compressed) == ("mainnet", True)
+    data = b58.prv_key_data_from_wif(wif)
+    assert (data.network, data.compressed) == ("mainnet", True)
 
 
 @pytest.mark.parametrize("vector", **_ids("xprv"))
@@ -200,8 +200,7 @@ def test_a_testnet_root_emits_testnet_keys() -> None:
     seed = "000102030405060708090a0b0c0d0e0f"
     tprv = rootxprv_from_seed(seed, NETWORKS["testnet"].bip32_prv)
     assert xprv_from_root_key(tprv).startswith("tprv")
-    _, network, _ = prv_keyinfo_from_prv_key(wif_from_root_key(tprv))
-    assert network == "testnet"
+    assert b58.prv_key_data_from_wif(wif_from_root_key(tprv)).network == "testnet"
 
 
 def test_a_slip132_root_still_emits_an_xprv() -> None:

--- a/tests/bool_contract_test.py
+++ b/tests/bool_contract_test.py
@@ -65,6 +65,7 @@ from btclib import b58, bip322
 from btclib.block import merkle_proof
 from btclib.ecc import bms, dleq, dsa, pedersen, ssa
 from btclib.hashes import reduce_to_hlen
+from btclib.key import PrvKeyData
 from btclib.script.engine import script as engine_script
 from btclib.script.engine import tapscript as engine_tapscript
 from btclib.to_pub_key import pub_keyinfo_from_prv_key
@@ -78,10 +79,10 @@ _MSG_HASH = reduce_to_hlen(_MSG)
 _ADDR = b58.p2pkh(_PUB)
 _DSA_SIG = dsa.sign(_MSG, _Q)
 _SSA_SIG = ssa.sign(_MSG, _Q)
-_BMS_SIG = bms.sign(_MSG, _Q)
+_BMS_SIG = bms.sign(_MSG, PrvKeyData(_Q))
 # BIP322 declares a `Sig` of its own, and it is not bms's: the two are
 # distinct classes, so each case is given the one its function takes
-_BIP322_SIG = bip322.sign(_MSG, _Q, _ADDR)
+_BIP322_SIG = bip322.sign(_MSG, PrvKeyData(_Q), _ADDR)
 _TX_ID = bytes.fromhex("01" * 32)
 # a DLEQ triple: A = a*G and C = a*B, so the proof holds for (A, B, C)
 _DLEQ_B = pub_keyinfo_from_prv_key(2)[0]

--- a/tests/bool_parameter_test.py
+++ b/tests/bool_parameter_test.py
@@ -218,7 +218,7 @@ _SMALL_CURVE = dict(
 _XPUB = xpub_from_xprv(_ROOT_XPRV)
 _DESCRIPTOR = descriptor_from_string(f"wpkh({_XPUB}/0/*)")
 _ADDRESS = b58.p2pkh(_PUB_KEY)
-_BIP322_SIG = bip322.sign(_MSG, _PRV_KEY, _ADDRESS)
+_BIP322_SIG = bip322.sign(_MSG, PrvKeyData(_PRV_KEY), _ADDRESS)
 
 # a transaction with an input, which is what the engine and the psbt
 # boundary both refuse to work without
@@ -278,8 +278,8 @@ class _Case:
 
 _KINDS = (
     # `compressed` chooses which public key is computed, and therefore
-    # which address: eleven parameters, four checks, the rest reaching one
-    # of those four
+    # which address: a handful of checks, the rest of the `compressed`
+    # parameters reaching one of them
     _Case(
         "btclib.curves.sec_point.bytes_from_point",
         "compressed",
@@ -331,6 +331,12 @@ _KINDS = (
         "compressed",
         b58.wif_from_prv_key,
         {"prv_key": _PRV_KEY},
+    ),
+    _Case(
+        "btclib.b58.prv_key_data_from_wif",
+        "compressed",
+        b58.prv_key_data_from_wif,
+        {"wif": b58.wif_from_prv_key(_PRV_KEY)},
         optional=True,
     ),
     _Case("btclib.b58.p2pkh", "compressed", b58.p2pkh, {"key": _SEC}, optional=True),
@@ -348,8 +354,6 @@ _KINDS = (
         "btclib.ecc.bms.gen_keys",
         "compressed",
         bms.gen_keys,
-        {"prv_key": _PRV_KEY},
-        optional=True,
     ),
     _Case(
         "btclib.script.script_pub_key.ScriptPubKey.p2pkh",

--- a/tests/curve_parameter_test.py
+++ b/tests/curve_parameter_test.py
@@ -78,7 +78,6 @@ from typing import Any
 
 import pytest
 
-from btclib.b58 import wif_from_prv_key
 from btclib.bip32.bip32 import BIP32KeyData, rootxprv_from_seed, xpub_from_xprv
 from btclib.consensus import CONSENSUS_PARAMS
 from btclib.curves import CurveGroup, secp256k1
@@ -536,13 +535,15 @@ def test_the_curve_a_key_names_is_still_a_value() -> None:
     """
     ec = low_card_curves["ec23_31"]
 
-    # derived rather than written out: what makes it a mainnet WIF is the
-    # network, which is the whole of what this test is about
-    wif = wif_from_prv_key(_PRV_KEY)
+    # an xprv and not a WIF: `to_prv_key` still resolves an xprv, WIF
+    # resolution having moved to `b58` (issue #1188); what makes it a
+    # mainnet key is the network, which is the whole of what this test
+    # is about
+    xprv = rootxprv_from_seed("00" * 32)
     with pytest.raises(BTClibValueError, match="ec / network"):
-        int_from_prv_key(wif, ec)
+        int_from_prv_key(xprv, ec)
     with pytest.raises(BTClibValueError, match="Curve mismatch"):
-        point_from_key(wif, ec)
+        point_from_key(xprv, ec)
 
     # the parsed form, and not the string it b58decodes from: a spelling
     # this converter has to guess at is tried as octets after the xkey

--- a/tests/descriptors/descriptors_test.py
+++ b/tests/descriptors/descriptors_test.py
@@ -38,6 +38,7 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
+from btclib import b58
 from btclib.alias import BIP44ScriptType, Octets
 from btclib.bip32 import BIP32KeyOrigin, fingerprint
 from btclib.bip32.bip32 import BIP32KeyData, derive, xpub_from_xprv
@@ -1137,7 +1138,7 @@ def test_no_private_key_survives_the_parse() -> None:
     assert prv_keys == {xpub: xprv}
     assert parsed.key_expressions[0].xkey == xpub
 
-    for secret in (xprv, wif, str(prv_keyinfo_from_prv_key(wif)[0])):
+    for secret in (xprv, wif, str(b58.prv_key_data_from_wif(wif).q)):
         assert secret not in repr(parsed)
         assert secret not in str(vars(parsed))
 
@@ -1147,7 +1148,7 @@ def test_no_private_key_survives_the_parse() -> None:
     # the WIF was already public before this: no derivation is made from
     # it and nothing here signs, so it is reduced and not filed
     assert wif not in prv_keys.values()
-    assert parsed.key_expressions[1].pub_key == pub_keyinfo_from_key(wif)[0]
+    assert parsed.key_expressions[1].pub_key == b58.prv_key_data_from_wif(wif).pub.sec
 
 
 def test_a_hardened_step_takes_the_keys_back() -> None:
@@ -2833,7 +2834,7 @@ def test_what_writing_a_descriptor_normalizes() -> None:
     the one whose two spellings are two checksums.
     """
     wif = "L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1"
-    pub_key = pub_keyinfo_from_key(wif)[0].hex()
+    pub_key = b58.prv_key_data_from_wif(wif).pub.sec.hex()
     assert str(parse(f"pkh({wif})")) == f"pkh({pub_key})"
     assert str(parse(f"pkh({pub_key.upper()})")) == f"pkh({pub_key})"
 

--- a/tests/ecc/bms_test.py
+++ b/tests/ecc/bms_test.py
@@ -33,6 +33,7 @@ from btclib.curves.curve import CURVES
 from btclib.ecc import bms, dsa
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.hashes import magic_message
+from btclib.key import PrvKeyData
 from btclib.mnemonic import bip39
 from btclib.to_prv_key import prv_keyinfo_from_prv_key
 from tests import load, needs_bindings, vector_id
@@ -71,7 +72,7 @@ def test_signature() -> None:
     msg = b"test message"
 
     wif, addr = bms.gen_keys()
-    bms_sig = bms.sign(msg, wif)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))
     bms.assert_as_valid(msg, addr, bms_sig)
     assert bms.verify(msg, addr, bms_sig)
     assert bms_sig == bms.Sig.parse(bms_sig.serialize())
@@ -79,7 +80,7 @@ def test_signature() -> None:
     assert bms_sig == bms.Sig.b64decode(bms_sig.b64encode())
     assert bms_sig == bms.Sig.b64decode(bms_sig.b64encode().encode("ascii"))
 
-    assert bms_sig == bms.sign(msg, wif.encode("ascii"))
+    assert bms_sig == bms.sign(msg, b58.prv_key_data_from_wif(wif.encode("ascii")))
 
     # frozen: `__init__` sets both fields through `object.__setattr__`
     # for exactly this reason, and nothing after construction reaches
@@ -106,8 +107,9 @@ def test_signature() -> None:
     assert bms.verify(msg, addr, bms_sig)
 
     # bms_sig taken from (Electrum and) Bitcoin Core
-    wif, addr = bms.gen_keys("5KMWWy2d3Mjc8LojNoj8Lcz9B1aWu8bRofUgGwQk959Dw5h2iyw")
-    bms_sig = bms.sign(msg, wif)
+    wif = "5KMWWy2d3Mjc8LojNoj8Lcz9B1aWu8bRofUgGwQk959Dw5h2iyw"
+    addr = b58.p2pkh(wif)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))
     bms.assert_as_valid(msg, addr, bms_sig)
     assert bms.verify(msg, addr, bms_sig)
     exp_sig = "G/iew/NhHV9V9MdUEn/LFOftaTy1ivGPKPKyMlr8OSokNC755fAxpSThNRivwTNsyY9vPUDTRYBPc2cmGd5d4y4="
@@ -132,7 +134,7 @@ def test_long_message() -> None:
     wif, addr = bms.gen_keys()
     for length in (252, 253, 255, 256, 0x10000):
         msg = b"a" * length
-        bms_sig = bms.sign(msg, wif)
+        bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))
         bms.assert_as_valid(msg, addr, bms_sig)
         assert bms.verify(msg, addr, bms_sig)
 
@@ -202,7 +204,7 @@ def test_exceptions() -> None:
     address = "19f7adDYqhHSJm2v7igFWZAqxXHj1vUa3T"
     err_msg = "mismatch between private key and address"
     with pytest.raises(BTClibValueError, match=err_msg):
-        bms.sign(msg, wif, address)
+        bms.sign(msg, b58.prv_key_data_from_wif(wif), address)
 
     # uncompressed wif, compressed address: the mismatch the case above
     # reports, reported the same way -- not as "not a private or
@@ -212,22 +214,22 @@ def test_exceptions() -> None:
     address = "1DAag8qiPLHh6hMFVu9qJQm9ro1HtwuyK5"
     err_msg = "mismatch between private key and address"
     with pytest.raises(BTClibValueError, match=err_msg):
-        bms.sign(msg, wif, address)
+        bms.sign(msg, b58.prv_key_data_from_wif(wif), address)
 
     msg = b"test"
     wif = "L4xAvhKR35zFcamyHME2ZHfhw5DEyeJvEMovQHQ7DttPTM8NLWCK"
     b58_p2pkh = b58.p2pkh(wif)
-    b32_p2wpkh = b32.p2wpkh(wif)
+    b32_p2wpkh = b32.p2wpkh(b58.prv_key_data_from_wif(wif).pub.sec)
     b58_p2wpkh_p2sh = b58.p2wpkh_p2sh(wif)
 
     wif = "Ky1XfDK2v6wHPazA6ECaD8UctEoShXdchgABjpU9GWGZDxVRDBMJ"
     err_msg = "mismatch between private key and address"
     with pytest.raises(BTClibValueError, match=err_msg):
-        bms.sign(msg, wif, b58_p2pkh)
+        bms.sign(msg, b58.prv_key_data_from_wif(wif), b58_p2pkh)
     with pytest.raises(BTClibValueError, match=err_msg):
-        bms.sign(msg, wif, b32_p2wpkh)
+        bms.sign(msg, b58.prv_key_data_from_wif(wif), b32_p2wpkh)
     with pytest.raises(BTClibValueError, match=err_msg):
-        bms.sign(msg, wif, b58_p2wpkh_p2sh)
+        bms.sign(msg, b58.prv_key_data_from_wif(wif), b58_p2wpkh_p2sh)
 
     # Invalid recovery flag (39) for base58 p2pkh address
     exp_sig = "IHdKsFF1bUrapA8GMoQUbgI+Ad0ZXyX1c/yAZHmJn5hSNBi7J+TrI1615FG3g9JEOPGVvcfDWIFWrg2exLNtoVc="
@@ -270,7 +272,7 @@ def test_every_recovery_flag_is_ruled_on_by_range_alone() -> None:
     dummy_pub_key = b"\x02" + 32 * b"\x00"
     b58_p2pkh = b58.p2pkh(wif)
     _, h160_p2pkh, _ = h160_from_address(b58_p2pkh)
-    b32_p2wpkh = b32.p2wpkh(wif)
+    b32_p2wpkh = b32.p2wpkh(b58.prv_key_data_from_wif(wif).pub.sec)
     b58_p2wpkh_p2sh = b58.p2wpkh_p2sh(wif)
     _, h160_p2sh, _ = h160_from_address(b58_p2wpkh_p2sh)
 
@@ -318,7 +320,7 @@ def test_the_address_is_read_the_same_however_it_is_held() -> None:
     msg = b"however it is held"
     wif = "Kx45GeUBSMPReYQwgXiKhG9FzNXrnCeutJp4yjTd5kKxCitadm3C"
     address = b58.p2pkh(wif)
-    expected = bms.sign(msg, wif, address)
+    expected = bms.sign(msg, b58.prv_key_data_from_wif(wif), address)
 
     padded = f"  {address}  "
     for spelling in (
@@ -328,12 +330,12 @@ def test_the_address_is_read_the_same_however_it_is_held() -> None:
         bytearray(address.encode("ascii")),
         memoryview(address.encode("ascii")),
     ):
-        assert bms.sign(msg, wif, spelling).rf == expected.rf
+        assert bms.sign(msg, b58.prv_key_data_from_wif(wif), spelling).rf == expected.rf
 
     # and a byte outside ascii is this library's complaint about the
     # address, where the hand-rolled decode let Python's own out
     with pytest.raises(BTClibValueError, match="non-ascii character in address"):
-        bms.sign(msg, wif, address.encode("ascii") + b"\xc3")
+        bms.sign(msg, b58.prv_key_data_from_wif(wif), address.encode("ascii") + b"\xc3")
 
 
 def test_one_prv_key_multiple_addresses() -> None:
@@ -344,10 +346,10 @@ def test_one_prv_key_multiple_addresses() -> None:
     wif = "Kx45GeUBSMPReYQwgXiKhG9FzNXrnCeutJp4yjTd5kKxCitadm3C"
     b58_p2pkh_compressed = b58.p2pkh(wif)
     b58_p2wpkh_p2sh = b58.p2wpkh_p2sh(wif)
-    b32_p2wpkh = b32.p2wpkh(wif)
+    b32_p2wpkh = b32.p2wpkh(b58.prv_key_data_from_wif(wif).pub.sec)
 
     # sign with no address
-    sig1 = bms.sign(msg, wif)
+    sig1 = bms.sign(msg, b58.prv_key_data_from_wif(wif))
     # True for Bitcoin Core
     bms.assert_as_valid(msg, b58_p2pkh_compressed, sig1)
     assert bms.verify(msg, b58_p2pkh_compressed, sig1)
@@ -359,7 +361,7 @@ def test_one_prv_key_multiple_addresses() -> None:
     assert bms.verify(msg, b32_p2wpkh, sig1)
 
     # sign with p2pkh address
-    sig1 = bms.sign(msg, wif, b58_p2pkh_compressed)
+    sig1 = bms.sign(msg, b58.prv_key_data_from_wif(wif), b58_p2pkh_compressed)
     # True for Bitcoin Core
     bms.assert_as_valid(msg, b58_p2pkh_compressed, sig1)
     assert bms.verify(msg, b58_p2pkh_compressed, sig1)
@@ -369,10 +371,12 @@ def test_one_prv_key_multiple_addresses() -> None:
     # True for Electrum p2wpkh
     bms.assert_as_valid(msg, b32_p2wpkh, sig1)
     assert bms.verify(msg, b32_p2wpkh, sig1)
-    assert sig1 == bms.sign(msg, wif, b58_p2pkh_compressed.encode("ascii"))
+    assert sig1 == bms.sign(
+        msg, b58.prv_key_data_from_wif(wif), b58_p2pkh_compressed.encode("ascii")
+    )
 
     # sign with p2wpkh_p2sh address (BIP137)
-    sig2 = bms.sign(msg, wif, b58_p2wpkh_p2sh)
+    sig2 = bms.sign(msg, b58.prv_key_data_from_wif(wif), b58_p2wpkh_p2sh)
     # False for Bitcoin Core
     err_msg = "invalid p2pkh address recovery flag: "
     with pytest.raises(BTClibValueError, match=err_msg):
@@ -386,10 +390,12 @@ def test_one_prv_key_multiple_addresses() -> None:
     with pytest.raises(BTClibValueError, match=err_msg):
         bms.assert_as_valid(msg, b32_p2wpkh, sig2)
     assert not bms.verify(msg, b32_p2wpkh, sig2)
-    assert sig2 == bms.sign(msg, wif, b58_p2wpkh_p2sh.encode("ascii"))
+    assert sig2 == bms.sign(
+        msg, b58.prv_key_data_from_wif(wif), b58_p2wpkh_p2sh.encode("ascii")
+    )
 
     # sign with p2wpkh address (BIP137)
-    sig3 = bms.sign(msg, wif, b32_p2wpkh)
+    sig3 = bms.sign(msg, b58.prv_key_data_from_wif(wif), b32_p2wpkh)
     # False for Bitcoin Core
     err_msg = "invalid p2pkh address recovery flag: "
     with pytest.raises(BTClibValueError, match=err_msg):
@@ -403,15 +409,17 @@ def test_one_prv_key_multiple_addresses() -> None:
     # True for BIP137 p2wpkh
     bms.assert_as_valid(msg, b32_p2wpkh, sig3)
     assert bms.verify(msg, b32_p2wpkh, sig3)
-    assert sig3 == bms.sign(msg, wif, b32_p2wpkh.encode("ascii"))
+    assert sig3 == bms.sign(
+        msg, b58.prv_key_data_from_wif(wif), b32_p2wpkh.encode("ascii")
+    )
 
     # uncompressed WIF / p2pkh address
-    q, network, _ = prv_keyinfo_from_prv_key(wif)
-    wif2 = b58.wif_from_prv_key(q, network, False)
+    data = b58.prv_key_data_from_wif(wif)
+    wif2 = b58.wif_from_prv_key(data.q, data.network, False)
     b58_p2pkh_uncompressed = b58.p2pkh(wif2)
 
     # sign with uncompressed p2pkh
-    sig4 = bms.sign(msg, wif2, b58_p2pkh_uncompressed)
+    sig4 = bms.sign(msg, b58.prv_key_data_from_wif(wif2), b58_p2pkh_uncompressed)
     # False for Bitcoin Core compressed p2pkh
     with pytest.raises(BTClibValueError, match="invalid p2pkh address: "):
         bms.assert_as_valid(msg, b58_p2pkh_compressed, sig4)
@@ -429,13 +437,15 @@ def test_one_prv_key_multiple_addresses() -> None:
     # True for Bitcoin Core uncompressed p2pkh
     bms.assert_as_valid(msg, b58_p2pkh_uncompressed, sig4)
     assert bms.verify(msg, b58_p2pkh_uncompressed, sig4)
-    assert sig4 == bms.sign(msg, wif2, b58_p2pkh_uncompressed.encode("ascii"))
+    assert sig4 == bms.sign(
+        msg, b58.prv_key_data_from_wif(wif2), b58_p2pkh_uncompressed.encode("ascii")
+    )
 
     # unrelated different wif
     wif3 = "KwdMAjGmerYanjeui5SHS7JkmpZvVipYvB2LJGU1ZxJwYvP98617"
     b58_p2pkh_compressed = b58.p2pkh(wif3)
     b58_p2wpkh_p2sh = b58.p2wpkh_p2sh(wif3)
-    b32_p2wpkh = b32.p2wpkh(wif3)
+    b32_p2wpkh = b32.p2wpkh(b58.prv_key_data_from_wif(wif3).pub.sec)
 
     # False for Bitcoin Core compressed p2pkh
     with pytest.raises(BTClibValueError, match="invalid p2pkh address: "):
@@ -456,10 +466,10 @@ def test_one_prv_key_multiple_addresses() -> None:
     # raised out of the p2wpkh_p2sh BIP137 tries before giving up
     err_msg = "mismatch between private key and address"
     with pytest.raises(BTClibValueError, match=err_msg):
-        bms.sign(msg, wif2, b58_p2pkh_compressed)
+        bms.sign(msg, b58.prv_key_data_from_wif(wif2), b58_p2pkh_compressed)
 
     with pytest.raises(BTClibValueError, match=err_msg):
-        bms.sign(msg, wif, b58_p2pkh_uncompressed)
+        bms.sign(msg, b58.prv_key_data_from_wif(wif), b58_p2pkh_uncompressed)
 
 
 def test_msgsign_p2pkh() -> None:
@@ -474,7 +484,7 @@ def test_msgsign_p2pkh() -> None:
     assert wif1u == "5KMWWy2d3Mjc8LojNoj8Lcz9B1aWu8bRofUgGwQk959Dw5h2iyw"
     add1u = b58.p2pkh(wif1u)
     assert add1u == "1HUBHMij46Hae75JPdWjeZ5Q7KaL7EFRSD"
-    bms_sig1u = bms.sign(msg, wif1u)
+    bms_sig1u = bms.sign(msg, b58.prv_key_data_from_wif(wif1u))
     assert bms.verify(msg, add1u, bms_sig1u)
     assert bms_sig1u.rf == 27
     exp_sig1u = "G/iew/NhHV9V9MdUEn/LFOftaTy1ivGPKPKyMlr8OSokNC755fAxpSThNRivwTNsyY9vPUDTRYBPc2cmGd5d4y4="
@@ -485,7 +495,7 @@ def test_msgsign_p2pkh() -> None:
     assert wif1c == "L41XHGJA5QX43QRG3FEwPbqD5BYvy6WxUxqAMM9oQdHJ5FcRHcGk"
     add1c = b58.p2pkh(wif1c)
     assert add1c == "14dD6ygPi5WXdwwBTt1FBZK3aD8uDem1FY"
-    bms_sig1c = bms.sign(msg, wif1c)
+    bms_sig1c = bms.sign(msg, b58.prv_key_data_from_wif(wif1c))
     assert bms.verify(msg, add1c, bms_sig1c)
     assert bms_sig1c.rf == 31
     exp_sig1c = "H/iew/NhHV9V9MdUEn/LFOftaTy1ivGPKPKyMlr8OSokNC755fAxpSThNRivwTNsyY9vPUDTRYBPc2cmGd5d4y4="
@@ -520,10 +530,10 @@ def test_msgsign_p2pkh_2() -> None:
     address = "1DAag8qiPLHh6hMFVu9qJQm9ro1HtwuyK5"
     exp_sig = "IFqUo4/sxBEFkfK8mZeeN56V13BqOc0D90oPBChF3gTqMXtNSCTN79UxC33kZ8Mi0cHy4zYCnQfCxTyLpMVXKeA="
     assert bms.verify(msg, address, exp_sig)
-    bms_sig = bms.sign(msg, wif, address)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif), address)
     assert bms.verify(msg, address, bms_sig)
     assert bms_sig.b64encode() == exp_sig
-    bms_sig = bms.sign(msg, wif)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))
     assert bms.verify(msg, address, bms_sig)
     assert bms_sig.b64encode() == exp_sig
 
@@ -532,10 +542,10 @@ def test_msgsign_p2pkh_2() -> None:
     address = "19f7adDYqhHSJm2v7igFWZAqxXHj1vUa3T"
     exp_sig = "HFqUo4/sxBEFkfK8mZeeN56V13BqOc0D90oPBChF3gTqMXtNSCTN79UxC33kZ8Mi0cHy4zYCnQfCxTyLpMVXKeA="
     assert bms.verify(msg, address, exp_sig)
-    bms_sig = bms.sign(msg, wif, address)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif), address)
     assert bms.verify(msg, address, bms_sig)
     assert bms_sig.b64encode() == exp_sig
-    bms_sig = bms.sign(msg, wif)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))
     assert bms.verify(msg, address, bms_sig)
     assert bms_sig.b64encode() == exp_sig
 
@@ -612,13 +622,13 @@ def test_segwit() -> None:
     msg = b"test"
     wif = "L4xAvhKR35zFcamyHME2ZHfhw5DEyeJvEMovQHQ7DttPTM8NLWCK"
     b58_p2pkh = b58.p2pkh(wif)
-    b32_p2wpkh = b32.p2wpkh(wif)
+    b32_p2wpkh = b32.p2wpkh(b58.prv_key_data_from_wif(wif).pub.sec)
     b58_p2wpkh_p2sh = b58.p2wpkh_p2sh(wif)
 
     # p2pkh base58 address (Core, Electrum, BIP137)
     exp_sig = "IBFyn+h9m3pWYbB4fBFKlRzBD4eJKojgCIZSNdhLKKHPSV2/WkeV7R7IOI0dpo3uGAEpCz9eepXLrA5kF35MXuU="
     assert bms.verify(msg, b58_p2pkh, exp_sig)
-    bms_sig = bms.sign(msg, wif)  # no address: p2pkh assumed
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))  # no address: p2pkh assumed
     assert bms.verify(msg, b58_p2pkh, bms_sig)
     assert bms_sig.b64encode() == exp_sig
 
@@ -632,7 +642,7 @@ def test_segwit() -> None:
     # different first letter in bms_sig because of different rf
     exp_sig = "JBFyn+h9m3pWYbB4fBFKlRzBD4eJKojgCIZSNdhLKKHPSV2/WkeV7R7IOI0dpo3uGAEpCz9eepXLrA5kF35MXuU="
     assert bms.verify(msg, b58_p2wpkh_p2sh, exp_sig)
-    bms_sig = bms.sign(msg, wif, b58_p2wpkh_p2sh)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif), b58_p2wpkh_p2sh)
     assert bms.verify(msg, b58_p2wpkh_p2sh, bms_sig)
     assert bms_sig.b64encode() == exp_sig
 
@@ -640,7 +650,7 @@ def test_segwit() -> None:
     # different first letter in bms_sig because of different rf
     exp_sig = "KBFyn+h9m3pWYbB4fBFKlRzBD4eJKojgCIZSNdhLKKHPSV2/WkeV7R7IOI0dpo3uGAEpCz9eepXLrA5kF35MXuU="
     assert bms.verify(msg, b32_p2wpkh, exp_sig)
-    bms_sig = bms.sign(msg, wif, b32_p2wpkh)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif), b32_p2wpkh)
     assert bms.verify(msg, b32_p2wpkh, bms_sig)
     assert bms_sig.b64encode() == exp_sig
 
@@ -653,7 +663,7 @@ def test_sign_strippable_message() -> None:
     msg = b""
     exp_sig = "IFh0InGTy8lLCs03yoUIpJU6MUbi0La/4abhVxyKcCsoUiF3RM7lg51rCqyoOZ8Yt43h8LZrmj7nwwO3HIfesiw="
     assert bms.verify(msg, address, exp_sig)
-    bms_sig = bms.sign(msg, wif)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))
     assert bms.verify(msg, address, bms_sig)
     assert bms_sig.b64encode() == exp_sig
 
@@ -661,7 +671,7 @@ def test_sign_strippable_message() -> None:
     msg = b" "
     exp_sig = "IEveV6CMmOk5lFP+oDbw8cir/OkhJn4S767wt+YwhzHnEYcFOb/uC6rrVmTtG3M43mzfObA0Nn1n9CRcv5IGyak="
     assert bms.verify(msg, address, exp_sig)
-    bms_sig = bms.sign(msg, wif)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))
     assert bms.verify(msg, address, bms_sig)
     assert bms_sig.b64encode() == exp_sig
 
@@ -669,14 +679,14 @@ def test_sign_strippable_message() -> None:
     msg = b"  "
     exp_sig = "H/QjF1V4fVI8IHX8ko0SIypmb0yxfaZLF0o56Cif9z8CX24n4petTxolH59pYVMvbTKQkGKpznSiPiQVn83eJF0="
     assert bms.verify(msg, address, exp_sig)
-    bms_sig = bms.sign(msg, wif)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))
     assert bms.verify(msg, address, bms_sig)
     assert bms_sig.b64encode() == exp_sig
 
     msg = b"test"
     exp_sig = "IJUtN/2LZjh1Vx8Ekj9opnIKA6ohKhWB95PLT/3EFgLnOu9hTuYX4+tJJ60ZyddFMd6dgAYx15oP+jLw2NzgNUo="
     assert bms.verify(msg, address, exp_sig)
-    bms_sig = bms.sign(msg, wif)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))
     assert bms.verify(msg, address, bms_sig)
     assert bms_sig.b64encode() == exp_sig
 
@@ -684,7 +694,7 @@ def test_sign_strippable_message() -> None:
     msg = b" test "
     exp_sig = "IA59z13/HBhvMMJtNwT6K7vJByE40lQUdqEMYhX2tnZSD+IGQIoBGE+1IYGCHCyqHvTvyGeqJTUx5ywb4StuX0s="
     assert bms.verify(msg, address, exp_sig)
-    bms_sig = bms.sign(msg, wif)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))
     assert bms.verify(msg, address, bms_sig)
     assert bms_sig.b64encode() == exp_sig
 
@@ -692,7 +702,7 @@ def test_sign_strippable_message() -> None:
     msg = b"test "
     exp_sig = "IPp9l2w0LVYB4FYKBahs+k1/Oa08j+NTuzriDpPWnWQmfU0+UsJNLIPI8Q/gekrWPv6sDeYsFSG9VybUKDPGMuo="
     assert bms.verify(msg, address, exp_sig)
-    bms_sig = bms.sign(msg, wif)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))
     assert bms.verify(msg, address, bms_sig)
     assert bms_sig.b64encode() == exp_sig
 
@@ -700,7 +710,7 @@ def test_sign_strippable_message() -> None:
     msg = b" test"
     exp_sig = "H1nGwD/kcMSmsYU6qihV2l2+Pa+7SPP9zyViZ59VER+QL9cJsIAtu1CuxfYDAVt3kgr4t3a/Es3PV82M6z0eQAo="
     assert bms.verify(msg, address, exp_sig)
-    bms_sig = bms.sign(msg, wif)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))
     assert bms.verify(msg, address, bms_sig)
     assert bms_sig.b64encode() == exp_sig
 
@@ -726,7 +736,7 @@ def test_vector_python_bitcoinlib(vector: dict[str, Any]) -> None:
     msg = vector["address"].encode()
 
     # btclib self-consistency check
-    bms_sig = bms.sign(msg, vector["wif"])
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(vector["wif"]))
     assert bms.verify(msg, vector["address"], bms_sig)
     bms_sig_encoded = bms_sig.b64encode()
     assert bms.verify(msg, vector["address"], bms_sig_encoded)
@@ -826,7 +836,7 @@ def test_ledger() -> None:
     assert bms.verify(msg, addr, bms_sig)
     assert not bms.verify(magic_msg, addr, bms_sig)
 
-    bms.sign(msg, xprv)
+    bms.sign(msg, PrvKeyData(*prv_keyinfo_from_prv_key(xprv)))
 
     # standard leading 30 in DER serialization
     derivation_path = "m/0/0"
@@ -868,7 +878,7 @@ def test_recover_pub_key_input_type() -> None:
     """Verify recovery takes a Sig object or its serialization alike."""
     msg = b"test message"
     wif, _ = bms.gen_keys()
-    bms_sig = bms.sign(msg, wif)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))
 
     key_id = bms_sig.rf - 27 & 0b11
     magic_msg = magic_message(msg)
@@ -889,7 +899,7 @@ def test_the_recovery_flag_carries_a_key_id_not_a_list_index() -> None:
     for i in range(8):
         msg = f"message {i}".encode()
         prv_key, pub_key = dsa.gen_keys()
-        bms_sig = bms.sign(msg, prv_key)
+        bms_sig = bms.sign(msg, PrvKeyData(prv_key))
         magic_msg = magic_message(msg)
         key_id = bms_sig.rf - 27 & 0b11
         assert dsa.recover_pub_key(key_id, magic_msg, bms_sig.dsa_sig) == pub_key
@@ -941,13 +951,13 @@ def test_the_key_id_search_reports_a_key_it_cannot_reach() -> None:
     """
     msg = b"a message"
     wif, _addr = bms.gen_keys()
-    bms_sig = bms.sign(msg, wif)
+    bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))
     magic_msg = magic_message(msg)
 
     # somebody else's private key: the signature is valid, and none of its
     # candidates recovers this q's public key
     other_wif, _other_addr = bms.gen_keys()
-    other_q = prv_keyinfo_from_prv_key(other_wif)[0]
+    other_q = b58.prv_key_data_from_wif(other_wif).q
 
     err_msg = "no key_id recovers the public key"
     with pytest.raises(AssertionError, match=err_msg):
@@ -965,7 +975,7 @@ def test_a_key_id_that_recovers_nothing() -> None:
     """
     msg = b"a message"
     prv_key, pub_key = dsa.gen_keys()
-    bms_sig = bms.sign(msg, prv_key)
+    bms_sig = bms.sign(msg, PrvKeyData(prv_key))
     magic_msg = magic_message(msg)
 
     assert _recovers(bms_sig.rf - 27 & 0b11, magic_msg, bms_sig.dsa_sig) == pub_key
@@ -1000,10 +1010,10 @@ def test_recoverable_signing_answers_the_key_id_the_search_finds(
     for i in range(20):
         msg = f"message {i}".encode()
         wif, addr = bms.gen_keys()
-        bms_sig = bms.sign(msg, wif)
+        bms_sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))
 
         magic_msg = magic_message(msg)
-        q = prv_keyinfo_from_prv_key(wif)[0]
+        q = b58.prv_key_data_from_wif(wif).q
         # grind=False is what `sign_recoverable` does and cannot do
         # otherwise: a message signature is the fixed 65-byte compact form,
         # where a low r saves no DER pad, so there is nothing to grind for
@@ -1089,7 +1099,7 @@ def test_the_py_arm_reaches_no_bindings(monkeypatch: pytest.MonkeyPatch) -> None
     """
     wif, addr = bms.gen_keys()
     msg = b"a message signed once and recovered from twice"
-    sig = bms.sign(msg, wif)
+    sig = bms.sign(msg, b58.prv_key_data_from_wif(wif))
     # what the bindings answer, taken while they are still in reach
     delegated = bms.verify(msg, addr, sig)
     assert delegated
@@ -1112,7 +1122,7 @@ def test_parse_length_is_not_a_validity_opinion() -> None:
     and every input sharing a prefix collapses onto the same signature.
     """
     wif, _ = bms.gen_keys()
-    sig_bin = bms.sign(b"test", wif).serialize()
+    sig_bin = bms.sign(b"test", b58.prv_key_data_from_wif(wif)).serialize()
 
     for length in (0, 1, 33, 64):
         err_msg = f"invalid decoded length: {length} instead of 65"
@@ -1135,7 +1145,7 @@ def test_b64decode_rejects_what_is_not_base64() -> None:
     the one thing a signature encoding must not allow.
     """
     wif, _ = bms.gen_keys()
-    b64_sig = bms.sign(b"test", wif).b64encode()
+    b64_sig = bms.sign(b"test", b58.prv_key_data_from_wif(wif)).b64encode()
     assert bms.Sig.b64decode(b64_sig).b64encode() == b64_sig
 
     # surrounding whitespace stays tolerated, being what a copied and
@@ -1164,7 +1174,7 @@ def test_b64decode_requires_the_canonical_encoding() -> None:
     """
     alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
     wif, _ = bms.gen_keys()
-    b64_sig = bms.sign(b"test", wif).b64encode()
+    b64_sig = bms.sign(b"test", b58.prv_key_data_from_wif(wif)).b64encode()
     assert len(b64_sig) == 88
 
     err_msg = "invalid base64 encoding: not canonical"
@@ -1179,18 +1189,18 @@ def test_b64decode_requires_the_canonical_encoding() -> None:
 
 
 def test_a_drawn_key_takes_the_network_it_is_asked_for() -> None:
-    """`gen_keys(None, network)` draws on that network's curve.
+    """`gen_keys(network)` draws on that network's curve.
 
-    Every other call above leaves both arguments out, so the `network is
-    None` default was the only way through the draw and the branch that
-    keeps the caller's name never ran. What the name decides is the WIF
-    prefix and the address version, which is what is checked here: the
-    curve is secp256k1 on either network, so nothing else would say the
-    argument had been read.
+    Every other call above leaves the argument out, so `"mainnet"` was
+    the only default through the draw and the branch that keeps the
+    caller's own name never ran. What the name decides is the WIF prefix
+    and the address version, which is what is checked here: the curve is
+    secp256k1 on either network, so nothing else would say the argument
+    had been read.
     """
-    wif, addr = bms.gen_keys(None, "testnet")
+    wif, addr = bms.gen_keys("testnet")
 
-    assert prv_keyinfo_from_prv_key(wif)[1] == "testnet"
+    assert b58.prv_key_data_from_wif(wif).network == "testnet"
     assert addr == b58.p2pkh(wif)
     # and the default, which is the same call with the name left out
-    assert prv_keyinfo_from_prv_key(bms.gen_keys()[0])[1] == "mainnet"
+    assert b58.prv_key_data_from_wif(bms.gen_keys()[0]).network == "mainnet"

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -52,7 +52,6 @@ from btclib.curves import (
     scalar_from_prv_key,
     secp256k1,
 )
-from btclib.ecc.bms import sign as bms_sign
 from btclib.ecc.dsa import recover_pub_key_
 from btclib.ecc.dsa import sign as dsa_sign
 from btclib.ecc.ssa import challenge_ as ssa_challenge_
@@ -210,14 +209,17 @@ _CASES: list[tuple[str, Callable[[Any], object]]] = [
     # the key path, which this census did not reach until issue #1206.
     # Two lines of the library stand behind all of it: `int_from_integer`,
     # and `to_prv_key`'s type gate for the int branch that does not reach
-    # the coercion. Neither is alone everywhere -- `bms.sign` is behind
-    # both, and `point_from_key`, `p2pkh` and `p2wpkh` meet `to_pub_key`'s
-    # gate before either -- so dropping one line lets a bool back through
-    # only where nothing else stands behind it, and these cases are here
-    # for the reach of the policy and not as a test apiece. `to_pub_key`'s
-    # gate is a third line and not a third refusal: drop it and
-    # `to_prv_key`'s answers those three one frame down, which is why the
-    # wordings below are what pin it
+    # the coercion. Neither is alone everywhere -- `point_from_key`,
+    # `p2pkh` and `p2wpkh` meet `to_pub_key`'s gate before either -- so
+    # dropping one line lets a bool back through only where nothing else
+    # stands behind it, and these cases are here for the reach of the
+    # policy and not as a test apiece. `to_pub_key`'s gate is a third line
+    # and not a third refusal: drop it and `to_prv_key`'s answers those
+    # three one frame down, which is why the wordings below are what pin
+    # it. `bms.sign` is not among them any more: it takes a `PrvKeyData`
+    # and nothing else, so a bool is refused by `assert_type` before
+    # either line runs, on the same terms as any other wrong type
+    # (issue #1188) -- a refusal `key_test.py` holds, not this census
     ("integer coercion", int_from_integer),
     ("hex string", hex_string),
     ("curve multiplier", mult),
@@ -227,7 +229,6 @@ _CASES: list[tuple[str, Callable[[Any], object]]] = [
     ("WIF private key", wif_from_prv_key),
     ("base58 address key", p2pkh),
     ("bech32 address key", p2wpkh),
-    ("message signing key", lambda v: bms_sign(b"msg", v)),
     ("BIP340 x-only key", point_from_bip340pub_key),
     # not the converter twice: `verify` answers False where it cannot
     # verify, so what this pins is that the refusal is not one of those
@@ -330,9 +331,8 @@ _WORDINGS = [
     ("curve multiplier", mult, "non-integer: True"),
     ("curve scalar", scalar_from_prv_key, "non-integer: True"),
     ("dsa signing key", lambda v: dsa_sign(b"msg", v), "non-integer: True"),
+    ("WIF private key", wif_from_prv_key, "non-integer: True"),
     ("private key converter", int_from_prv_key, "not a private key"),
-    ("WIF private key", wif_from_prv_key, "not a private key"),
-    ("message signing key", lambda v: bms_sign(b"msg", v), "not a private key"),
     ("public key converter", point_from_key, "not a private or public key"),
     ("base58 address key", p2pkh, "not a private or public key"),
     ("bech32 address key", p2wpkh, "not a private or public key"),
@@ -451,7 +451,6 @@ def test_the_integers_a_bool_refusal_must_not_take_with_it() -> None:
     assert wif_from_prv_key(1).startswith("Kw")
     assert p2pkh(1).startswith("1")
     assert p2wpkh(1).startswith("bc1")
-    assert bms_sign(b"msg", 1).dsa_sig.r
     assert point_from_bip340pub_key(secp256k1.G[0]) == secp256k1.G
     assert ssa_verify(b"msg", secp256k1.G[0], _SSA_SIG)
     assert ssa_challenge_(b"msg", 1, 1, secp256k1, hashlib.sha256)

--- a/tests/key_io_test.py
+++ b/tests/key_io_test.py
@@ -15,12 +15,13 @@ scriptPubKey of an address, and the key behind a WIF, are Core's answer.
 
 One module for the two files, rather than one per entry point they
 reach. A row is a bare string with no field saying which encoding it
-uses, so the reader that decides is the same reader `b58`, `b32`,
-`ScriptPubKey.from_address` and `to_prv_key` would each need, and
-splitting the files would write it four times while leaving no module
-able to say what the whole of either file covers. The invalid half makes
-that plain: what it asserts is that *all four* refuse the string, which
-is not a claim any one of those modules could hold.
+uses, so the reader that decides is the same reader `b58` (twice over,
+an address and a WIF being two of its own functions), `b32` and
+`ScriptPubKey.from_address` would each need, and splitting the files
+would write it four times while leaving no module able to say what the
+whole of either file covers. The invalid half makes that plain: what it
+asserts is that *all four* refuse the string, which is not a claim any
+one of those modules could hold.
 """
 
 from __future__ import annotations
@@ -32,7 +33,6 @@ from btclib import b32, b58
 from btclib.exceptions import BTClibValueError
 from btclib.network import network_type_from_network
 from btclib.script import ScriptPubKey
-from btclib.to_prv_key import prv_keyinfo_from_prv_key
 from tests import load, vector_id
 
 # the `chain` of each vector is Core's name for it, as its `-chain=`
@@ -154,11 +154,11 @@ def test_address_case_flip(address: str, script_pub_key: str) -> None:
 @pytest.mark.parametrize("wif, prv_key, network, compressed", WIF_VECTORS)
 def test_wif(wif: str, prv_key: str, network: str, compressed: bool) -> None:
     """The key Core encoded, its compression flag, and the WIF written back."""
-    q, net, compr = prv_keyinfo_from_prv_key(wif, network)
-    assert f"{q:064x}" == prv_key
-    assert compr == compressed
-    assert net == network
-    assert b58.wif_from_prv_key(q, network, compressed) == wif
+    data = b58.prv_key_data_from_wif(wif, network)
+    assert f"{data.q:064x}" == prv_key
+    assert data.compressed == compressed
+    assert data.network == network
+    assert b58.wif_from_prv_key(data.q, network, compressed) == wif
 
 
 @pytest.mark.parametrize("wif, prv_key, network, compressed", WIF_VECTORS)
@@ -177,10 +177,10 @@ def test_wif_without_a_network(
     Nothing else moves -- the key and the compression flag are the
     payload, and the payload is unambiguous.
     """
-    q, net, compr = prv_keyinfo_from_prv_key(wif)
-    assert f"{q:064x}" == prv_key
-    assert compr == compressed
-    assert net == ("mainnet" if network == "mainnet" else "testnet")
+    data = b58.prv_key_data_from_wif(wif)
+    assert f"{data.q:064x}" == prv_key
+    assert data.compressed == compressed
+    assert data.network == ("mainnet" if network == "mainnet" else "testnet")
 
 
 @pytest.mark.parametrize("string", REFUSED_VECTORS)
@@ -190,8 +190,8 @@ def test_refused(string: str) -> None:
     Four and not one, because a string arrives without a label: an
     application handed one of these has no way to know it was meant as
     an address rather than as a key, and tries what it has. A refusal
-    from `ScriptPubKey.from_address` is worth nothing if `to_prv_key`
-    then accepts the same bytes as a WIF.
+    from `ScriptPubKey.from_address` is worth nothing if `b58` then
+    accepts the same bytes as a WIF.
 
     BTClibValueError covers `NotAPrvKeyError` and `InvalidPrvKeyError`,
     which is the whole of the contract here: the string is refused, and
@@ -205,4 +205,4 @@ def test_refused(string: str) -> None:
     with pytest.raises(BTClibValueError):
         b32.witness_from_address(string)
     with pytest.raises(BTClibValueError):
-        prv_keyinfo_from_prv_key(string)
+        b58.prv_key_data_from_wif(string)

--- a/tests/parse_contract_test.py
+++ b/tests/parse_contract_test.py
@@ -31,6 +31,7 @@ from btclib.bip32 import BIP32KeyData, BIP32KeyOrigin
 from btclib.block import Block, BlockHeader
 from btclib.ecc import bms, ssa
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
+from btclib.key import PrvKeyData
 from btclib.p2p import (
     Addr,
     AddrV2,
@@ -143,7 +144,7 @@ _CASES: list[tuple[str, type[Any], bytes]] = [
     ("block", Block, _block_1()),
     ("bip32_key", BIP32KeyData, BIP32KeyData.b58decode(_XPRV).serialize()),
     ("ssa_sig", ssa.Sig, ssa.sign(b"parse contract", 1).serialize()),
-    ("bms_sig", bms.Sig, bms.sign(b"parse contract", 1).serialize()),
+    ("bms_sig", bms.Sig, bms.sign(b"parse contract", PrvKeyData(1)).serialize()),
     ("witness", Witness, Witness([b"\x51", b"\x52\x53"]).serialize()),
     ("psbt", Psbt, _psbt().serialize()),
     ("psbt_in", PsbtIn, PsbtIn(redeem_script=b"\x51").serialize()),

--- a/tests/psbt_signer_test.py
+++ b/tests/psbt_signer_test.py
@@ -37,6 +37,7 @@ from btclib.descriptors import (
 from btclib.ecc import bms, dsa
 from btclib.exceptions import BTClibValueError, SignerError
 from btclib.hwi import HwiDevice
+from btclib.key import PrvKeyData
 from btclib.psbt.psbt import Psbt, sign
 from btclib.psbt_signer import (
     AddressDisplay,
@@ -444,7 +445,8 @@ class _MessageSigner(_Signer):
         back: the serialization is 65 bytes and no encoding of its own.
         """
         path = self.der_path if self.der_path is not None else der_path
-        prv_key = derive(self.xprv, path)
+        q, network, compressed = prv_keyinfo_from_prv_key(derive(self.xprv, path))
+        prv_key = PrvKeyData(q, network, compressed)
         return b64encode(bms.sign(message, prv_key).serialize()).decode("ascii")
 
 

--- a/tests/to_key_test.py
+++ b/tests/to_key_test.py
@@ -47,16 +47,16 @@ xprv_data = BIP32KeyData(
 xprv_string = xprv_data.b58encode(check_validity=False)
 xprv_string2 = " " + xprv_string + " "
 
+# a WIF is `b58`'s object, not `to_prv_key`'s or `to_pub_key`'s, so it is
+# not among the private-key spellings the two `*_prv_keys` families below
+# feed to their converters (issue #1188); `wif_compressed_string` and
+# `wif_uncompressed_string` above stay for the modules that still take a
+# WIF directly -- `b58`'s own tests among them
 net_aware_compressed_prv_keys: list[bytes | str] = [
-    wif_compressed_string,
-    wif_compressed_string2,
     xprv_string,
     xprv_string2,
 ]
-net_aware_uncompressed_prv_keys: list[bytes | str] = [
-    wif_uncompressed_string,
-    wif_uncompressed_string2,
-]
+net_aware_uncompressed_prv_keys: list[bytes | str] = []
 net_unaware_compressed_prv_keys: list[bytes | str] = []
 net_unaware_uncompressed_prv_keys: list[bytes | str] = []
 

--- a/tests/to_prv_key_test.py
+++ b/tests/to_prv_key_test.py
@@ -9,23 +9,9 @@ import pytest
 
 # Library imports
 from btclib.alias import INF
-from btclib.b58 import wif_from_prv_key
-from btclib.base58 import encode as b58encode
-from btclib.bip32 import BIP32KeyData
-from btclib.bip32.bip32 import rootxprv_from_seed
 from btclib.curves.curve import CURVES
-from btclib.exceptions import (
-    BTClibTypeError,
-    BTClibValueError,
-    InvalidPrvKeyError,
-    NotAPrvKeyError,
-)
-from btclib.to_prv_key import (
-    _prv_keyinfo_from_wif,
-    _prv_keyinfo_from_xprvwif,
-    int_from_prv_key,
-    prv_keyinfo_from_prv_key,
-)
+from btclib.exceptions import BTClibTypeError, BTClibValueError, InvalidPrvKeyError
+from btclib.to_prv_key import int_from_prv_key, prv_keyinfo_from_prv_key
 from tests.to_key_test import (
     INF_xpub_data,
     Q,
@@ -40,9 +26,7 @@ from tests.to_key_test import (
     q,
     q0,
     qn,
-    uncompressed_prv_keys,
     uncompressed_pub_keys,
-    wif_compressed_string,
     xprv0_data,
     xprv_data,
     xprv_string,
@@ -52,7 +36,13 @@ from tests.to_key_test import (
 
 
 def test_from_prv_key() -> None:
-    """Check every private-key form against network and compression."""
+    """Check every private-key form against network and compression.
+
+    A WIF is not one of the forms: `to_prv_key` cannot spell it, so
+    `compressed_prv_keys` and `net_aware_prv_keys` below hold only an
+    xprv, which is always compressed -- there is no uncompressed
+    net-aware form left for this module to resolve (issue #1188).
+    """
     secp256r1 = CURVES["secp256r1"]
     m_c = (q, "mainnet", True)
     m_unc = (q, "mainnet", False)
@@ -90,31 +80,12 @@ def test_from_prv_key() -> None:
         with pytest.raises(BTClibValueError):
             prv_keyinfo_from_prv_key(prv_key2, "testnet", compressed=False)
 
-    for prv_key3 in uncompressed_prv_keys:
-        assert q == int_from_prv_key(prv_key3)
-        with pytest.raises(BTClibValueError):
-            int_from_prv_key(prv_key3, secp256r1)
-        assert m_unc == prv_keyinfo_from_prv_key(prv_key3)
-        assert m_unc == prv_keyinfo_from_prv_key(prv_key3, "mainnet")
-        with pytest.raises(BTClibValueError):
-            prv_keyinfo_from_prv_key(prv_key3, "mainnet", compressed=True)
-        with pytest.raises(BTClibValueError):
-            prv_keyinfo_from_prv_key(prv_key3, compressed=True)
-        assert m_unc == prv_keyinfo_from_prv_key(prv_key3, "mainnet", compressed=False)
-        assert m_unc == prv_keyinfo_from_prv_key(prv_key3, compressed=False)
-        with pytest.raises(BTClibValueError):
-            prv_keyinfo_from_prv_key(prv_key3, "testnet")
-        with pytest.raises(BTClibValueError):
-            prv_keyinfo_from_prv_key(prv_key3, "testnet", compressed=True)
-        with pytest.raises(BTClibValueError):
-            prv_keyinfo_from_prv_key(prv_key3, "testnet", compressed=False)
-
     for prv_key4 in [xprv_data, *net_aware_prv_keys]:
         assert q == int_from_prv_key(prv_key4)
         with pytest.raises(BTClibValueError):
             int_from_prv_key(prv_key4, secp256r1)
-        assert prv_keyinfo_from_prv_key(prv_key4) in {m_c, m_unc}
-        assert prv_keyinfo_from_prv_key(prv_key4, "mainnet") in {m_c, m_unc}
+        assert prv_keyinfo_from_prv_key(prv_key4) == m_c
+        assert prv_keyinfo_from_prv_key(prv_key4, "mainnet") == m_c
         with pytest.raises(BTClibValueError):
             prv_keyinfo_from_prv_key(prv_key4, "testnet")
 
@@ -169,11 +140,6 @@ def test_no_key_material_in_exceptions() -> None:
         prv_keyinfo_from_prv_key(xprv_data, "testnet")
     assert xprv_string not in str(excinfo.value)
 
-    # network mismatch on a valid WIF
-    with pytest.raises(BTClibValueError, match="not a testnet wif: ") as excinfo:
-        _prv_keyinfo_from_wif(wif_compressed_string, "testnet", None)
-    assert wif_compressed_string not in str(excinfo.value)
-
     # out-of-range scalar
     with pytest.raises(BTClibValueError, match="not in 1..n-1") as excinfo:
         int_from_prv_key(qn)
@@ -185,54 +151,20 @@ def test_no_key_material_in_exceptions() -> None:
     assert "0202" not in str(excinfo.value)
 
 
-def test_a_mistyped_wif_is_reported_as_one() -> None:
-    """The headline case: one wrong character in a WIF.
-
-    The checksum failure must not be swallowed -- the string retried as
-    a hex-string, and the caller told "not a private key", which is true
-    and useless. Every reason travels with the exception.
-    """
-    good = "KwdMAjGmerYanjeui5SHS7JkmpZvVipYvB2LJGU1ZxJwYvP98617"
-    assert prv_keyinfo_from_prv_key(good)[1] == "mainnet"
-
-    mistyped = f"{good[:-1]}8"
-    for func in (int_from_prv_key, prv_keyinfo_from_prv_key):
-        with pytest.raises(NotAPrvKeyError, match="not a private key") as exc_info:
-            func(mistyped)
-        message = str(exc_info.value)
-        assert "invalid checksum" in message
-        assert "not a WIF" in message
-        assert "not a BIP32 xkey" in message
-        assert "not octets" in message
-        # never the input itself, which is candidate key material
-        assert mistyped not in message
-
-
 def test_a_recognised_format_stops_the_guessing() -> None:
-    """InvalidPrvKeyError propagates; NotAPrvKeyError moves on.
+    """InvalidPrvKeyError propagates; a format neither recognises moves on.
 
-    Which is the whole of the split. A WIF whose prefix and checksum are
-    right is a WIF: what is wrong with it is worth more than the news that
-    it is not a hex-string either.
+    An xpub is a BIP32 xkey, so "not a private key" is the answer and not
+    a step on the way to one -- the format is recognised, and what is
+    wrong with it is worth more than the news that it is not octets
+    either. The WIF half of this question is now `b58`'s (issue #1188).
     """
-    # 0x80, right checksum, right size, trailing byte 0x00 instead of 0x01
-    payload = b"\x80" + 32 * b"\x02" + b"\x00"
-    with pytest.raises(InvalidPrvKeyError, match="missing trailing 0x01") as info:
-        prv_keyinfo_from_prv_key(b58encode(payload))
-    # the reason, not an accumulation: the guessing stopped
-    assert "not octets" not in str(info.value)
-    assert "not a BIP32 xkey" not in str(info.value)
-
-    # an xpub is an xkey, so "not a private key" is the answer and not a
-    # step on the way to one
     xpub = "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8"
     with pytest.raises(InvalidPrvKeyError, match="not a private key: prefix 0x03"):
         prv_keyinfo_from_prv_key(xpub)
 
-    # both are BTClibValueError, so code catching that is unaffected
-    for bad in (b58encode(payload), xpub):
-        with pytest.raises(BTClibValueError):
-            prv_keyinfo_from_prv_key(bad)
+    with pytest.raises(BTClibValueError):
+        prv_keyinfo_from_prv_key(xpub)
 
 
 def test_an_uncompressed_sec_key_still_resolves() -> None:
@@ -256,53 +188,3 @@ def test_an_uncompressed_sec_key_still_resolves() -> None:
     err_msg = "uncompressed SEC / compressed BIP32 mismatch"
     with pytest.raises(InvalidPrvKeyError, match=err_msg):
         prv_keyinfo_from_prv_key(xprv, compressed=False)
-
-
-def test_a_wif_on_a_network_sharing_its_prefix() -> None:
-    """A signet WIF declared as signet is accepted (issue #207).
-
-    A name comparison against the reverse lookup cannot do it: the lookup
-    answers "testnet" for the 0xef prefix the four test networks share,
-    so a signet WIF asked for as signet would be refused as "not a signet
-    wif: prefix 0xef" -- naming the very prefix signet asks for. The
-    check is the forward one the xprv path uses, i.e. membership.
-    """
-    for network in ("testnet", "regtest", "signet", "testnet4"):
-        wif = wif_from_prv_key(q, network)
-        # the declared network is the one returned, not the lookup's guess
-        assert prv_keyinfo_from_prv_key(wif, network) == (q, network, True)
-        assert _prv_keyinfo_from_wif(wif, network, None) == (q, network, True)
-
-    # undeclared, the canonical name of the shared prefix is what it is
-    assert prv_keyinfo_from_prv_key(wif_from_prv_key(q, "signet")) == (
-        q,
-        "testnet",
-        True,
-    )
-
-    # and the check still refuses what it should: mainnet is a different
-    # prefix, so it is a different network type
-    with pytest.raises(InvalidPrvKeyError, match="not a signet wif: prefix 0x80"):
-        prv_keyinfo_from_prv_key(wif_from_prv_key(q, "mainnet"), "signet")
-    with pytest.raises(InvalidPrvKeyError, match="not a mainnet wif: prefix 0xef"):
-        prv_keyinfo_from_prv_key(wif_from_prv_key(q, "signet"), "mainnet")
-
-
-def test_the_xprvwif_helper_takes_a_bip32_key_data_too() -> None:
-    """`_prv_keyinfo_from_xprvwif` answers for a parsed xprv, not only a str.
-
-    Both public callers dispatch a `BIP32KeyData` to `_prv_keyinfo_from_xprv`
-    before they reach this helper, so its `isinstance` guard is never False
-    through them and the WIF attempt it skips is what nothing else measures.
-    The guard is the helper's own contract rather than a duplicate of theirs:
-    a parsed xprv is not a string the WIF decoder could be asked about, and
-    handing it to `_prv_keyinfo_from_wif` would be a `NotAPrvKeyError` added
-    to the reasons of a key that is in good order.
-    """
-    xprv = rootxprv_from_seed(b"\x01" * 32)
-    data = BIP32KeyData.b58decode(xprv)
-
-    assert _prv_keyinfo_from_xprvwif(data, None, None) == _prv_keyinfo_from_xprvwif(
-        xprv, None, None
-    )
-    assert _prv_keyinfo_from_xprvwif(data, "mainnet", None)[1] == "mainnet"

--- a/tests/to_pub_key_test.py
+++ b/tests/to_pub_key_test.py
@@ -9,7 +9,6 @@ from collections.abc import Callable, Sequence
 import pytest
 
 from btclib.alias import INF, Point
-from btclib.b58 import wif_from_prv_key
 from btclib.curves import (
     PreparedPoint,
     bytes_from_point,
@@ -264,8 +263,9 @@ def test_from_key() -> None:
 
     The private forms answer with the public key they derive, so each
     check is the one its public counterpart above gets: an int and its
-    hex-string carry neither network nor compression, a compressed WIF
-    carries both.
+    hex-string carry neither network nor compression, an xprv carries
+    both. A WIF is not among the forms: it is `b58`'s spelling, and
+    `to_pub_key` has no way to reach it (issue #1188).
     """
     api: Conversions = point_from_key, pub_keyinfo_from_key
     _check_plain(api, [Q, *plain_pub_keys, q, *plain_prv_keys])
@@ -365,7 +365,8 @@ def test_the_unproven_conversion_takes_every_spelling_a_key_has() -> None:
     cheap one for the call this feeds, and compressed from the public
     spelling, which answers "whatever the key says" and a point says
     nothing -- so the two are compared as the points they name. A private
-    key as an int and as a WIF, a point, a prepared point, an xpub.
+    key as an int, a point, a prepared point, an xpub. A WIF is not among
+    them: it is `b58`'s spelling, not `Key`'s (issue #1188).
 
     What this one does not do is prove octets a point: it leaves that to
     the call it feeds, `script.taproot`'s tweak.
@@ -376,11 +377,10 @@ def test_the_unproven_conversion_takes_every_spelling_a_key_has() -> None:
     neither kind of key.
     """
     q = 0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF
-    wif = wif_from_prv_key(q)
     xpub = "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy"
     point = mult(q)
 
-    for key in (q, wif, point, PreparedPoint(point), xpub):
+    for key in (q, point, PreparedPoint(point), xpub):
         assert point_from_octets(_sec_from_key(key)) == point_from_key(key)
 
     # what is no key in any spelling is refused in the same words, the

--- a/tests/wallet/key_wallet_test.py
+++ b/tests/wallet/key_wallet_test.py
@@ -257,8 +257,11 @@ def test_sign_by_address_verifies_with_bms(purpose: int) -> None:
     address = wallet.next_address()
     sig = wallet.sign(address, _MSG)
     assert bms.verify(_MSG, address, sig)
-    # and the signature is bms's own, reachable the long way round
-    assert sig == bms.sign(_MSG, wallet.prv_key(address), address)
+    # and the signature is bms's own, reachable the long way round: the
+    # WIF `prv_key` answers is `b58`'s object, not `bms.sign`'s (issue
+    # #1188)
+    prv_key = b58.prv_key_data_from_wif(wallet.prv_key(address))
+    assert sig == bms.sign(_MSG, prv_key, address)
 
 
 def test_the_recovery_flag_names_the_address_type() -> None:
@@ -419,6 +422,35 @@ def test_add_takes_a_script_type_of_its_own() -> None:
     assert wallet.addresses == (p2pkh, p2wpkh)
     assert wallet.address_info(p2wpkh).script_type == "p2wpkh"
     assert not wallet.is_watch_only
+
+
+def test_add_takes_an_xprv_too() -> None:
+    """An added key that is not a WIF still resolves to a private one.
+
+    `_key_data` tries a WIF first and falls through to `to_prv_key` for
+    everything that is not one, an xprv string among it -- the
+    fallthrough this exercises, where the WIF-only cases above do not
+    (issue #1188).
+    """
+    wallet = KeyWallet()
+    address = wallet.add(_ACCOUNT_44_XPRV)
+    assert not wallet.is_watch_only
+    assert bms.verify(_MSG, address, wallet.sign(address, _MSG))
+
+
+def test_add_takes_a_bip32keydata_too() -> None:
+    """A decoded `BIP32KeyData` skips the WIF attempt outright.
+
+    It is neither `str` nor `bytes`, so `_key_data` never tries
+    `b58.prv_key_data_from_wif` on it -- the one `Key` spelling that
+    reaches `to_prv_key` without going through that attempt first
+    (issue #1188).
+    """
+    xkey = bip32.BIP32KeyData.b58decode(_ACCOUNT_44_XPRV)
+    wallet = KeyWallet()
+    address = wallet.add(xkey)
+    assert not wallet.is_watch_only
+    assert bms.verify(_MSG, address, wallet.sign(address, _MSG))
 
 
 def test_a_key_added_to_a_bip32_wallet_is_not_derived() -> None:


### PR DESCRIPTION
The WIF row of #1188 — **not** a closing pull request: the issue's table
has further rows and stays open.

A WIF is Base58Check with a version prefix and a compression flag, which
is `b58`'s own idea and nothing else's. `to_prv_key` sits *below* `b58`,
through `to_pub_key`, so it has no way back up to a parser living above
it — and it was reading WIFs anyway. This moves the parsing to where the
format belongs: `b58.wif_from_prv_key` narrows from the wide `PrvKey`
union to a scalar, the new `b58.prv_key_data_from_wif` reads one back
into a `key.PrvKeyData`, and `to_prv_key.PrvKey` drops WIF, keeping an
int, an octets scalar, a BIP32 xprv and a `BIP32KeyData`.

`b58.p2pkh` and `b58.p2wpkh_p2sh` still take a WIF directly, trying one
ahead of `to_pub_key.pub_keyinfo_from_key`. **`b32.p2wpkh` cannot**, and
the asymmetry is a real import cycle rather than an oversight: `b32`
imports `to_pub_key` and `b58` imports `b32`. Callers that held a WIF for
it derive the SEC octets first.

Only a `NotAPrvKeyError` falls through to `pub_keyinfo_from_key`. Text
whose checksum does not verify is no WIF — the checksum is verified
before any version prefix is read, so nothing at that point knows a WIF
was meant, and another spelling may yet read it. A WIF a network *has*
claimed and that is then faulty — the wrong compression, a network other
than the one asked for — keeps the diagnosis `prv_key_data_from_wif`
already computed instead of degrading to "not a key" about something
that is one.

`ecc.bms.sign`, `ecc.bms.gen_keys` and `bip322.sign` take the parsed
`PrvKeyData` and not the wide union, matching the narrowing this issue
already gave `dsa.sign` and `ssa.sign`; `bms.gen_keys` drops its
`prv_key` argument entirely, drawing a key being the one thing left to
it. Four source-breaking spellings are in `RELEASE_NOTES.md`, each
checked against the `v2023.7.12` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Move WIF encoding and parsing into `b58` and make private-key consumers use explicitly parsed key data.

New Features:
- Add Base58Check WIF parsing that returns `PrvKeyData` with scalar, network, and compression metadata.
- Keep WIF-aware address generation in `b58` while requiring callers to provide public-key bytes to `b32.p2wpkh`.

Bug Fixes:
- Preserve meaningful errors for malformed or network-incompatible WIFs instead of degrading recognized WIF failures to generic key errors.

Enhancements:
- Narrow `to_prv_key` to integers, octet scalars, extended private keys, and `BIP32KeyData`, leaving WIF handling to `b58`.
- Require `ecc.bms.sign` and `bip322.sign` to receive parsed `PrvKeyData`, and simplify `bms.gen_keys` to generate keys only.
- Update wallet, descriptor, PSBT, and related integrations to use the new explicit key-data flow.

Documentation:
- Document the WIF API ownership changes, source-breaking signing and key-generation APIs, and migration guidance in the changelog, release notes, README, and contributor documentation.

Tests:
- Update WIF, signing, address, wallet, descriptor, and parser tests for explicit WIF parsing and `PrvKeyData` inputs, including malformed-WIF error classification.