### PR TITLE
psbt_signer_contract.optional_protocols returns a NamedTuple, OptionalProtocols (closes #1624)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,16 @@ WIF carries and `PrvKeyData` now states explicitly --
 handing one in were two different calls behind one name, and the second
 is `wif_from_prv_key` and `b58.p2pkh` in the caller's own code now.
 
+### `optional_protocols` returns a `NamedTuple`, not a plain tuple
+
+- **`psbt_signer_contract.optional_protocols` returns `OptionalProtocols`,
+  a `NamedTuple` of `displays_address`, `displays_policy_address` and
+  `signs_message`, in that order** (closes #1624). #1588 inserted a
+  protocol between the two that were already there, so `[1]` meant "signs
+  messages" in `v2026.8.29` and means "displays a wallet-policy address"
+  now; unpacking the old shape raises, and indexing it does not. The
+  class docstring is where the return type argues what it is.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -85,6 +85,20 @@ full year, short month, short day (YYYY-M-D)
   `btclib.b58.prv_key_data_from_wif(wif).pub.sec` reads the SEC octets
   `p2wpkh` still takes.
 
+### Worth knowing, though nothing raises
+
+- **`psbt_signer_contract.optional_protocols` returns `OptionalProtocols`,
+  a `NamedTuple`, in place of a plain tuple** (closes #1624). Act on it
+  if you read the result by index rather than by name: a field read by
+  name keeps answering the same question after the next optional
+  protocol is inserted, where an index answers whatever question now
+  sits at that position.
+
+  Unpacking, indexing, `isinstance` against `tuple` and comparing
+  against a plain tuple of `bool` all answer as before, so this is no
+  breaking change; `type(...) is tuple` and `repr(...)` do not, which is
+  what to check if either is what you read.
+
 ## v2026.9.3
 
 ### Breaking changes

--- a/src/btclib/psbt_signer_contract.py
+++ b/src/btclib/psbt_signer_contract.py
@@ -47,7 +47,7 @@ check into an end-to-end one.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NoReturn
+from typing import TYPE_CHECKING, NamedTuple, NoReturn
 
 from btclib.bip32.bip32 import BIP32KeyData
 from btclib.bip32.key_origin import BIP32KeyOrigin
@@ -70,6 +70,7 @@ if TYPE_CHECKING:
     from btclib.bip32.der_path import DerPath
 
 __all__ = [
+    "OptionalProtocols",
     "assert_psbt_signer",
     "optional_protocols",
     "unsignable_psbt",
@@ -236,7 +237,29 @@ def assert_psbt_signer(
     signer.close()
 
 
-def optional_protocols(signer: object) -> tuple[bool, bool, bool]:
+class OptionalProtocols(NamedTuple):
+    """Answers to unrelated questions, which is a record and no sequence.
+
+    A plain tuple is right for a sequence -- things of one kind whose
+    count is the point, where an index is a position and means it.
+    `displays_address`, `displays_policy_address` and `signs_message`
+    answer questions that have nothing to do with each other, and how
+    many of them there are is an accident of which optional protocols
+    exist today. An index into a record is a position standing in for a
+    name, and the name is what a caller reading `[1]` meant.
+
+    The field names are an escape from that for a caller who reads them,
+    not a guard: a caller who indexes rather than names a field reads
+    the wrong answer the moment a protocol is inserted rather than
+    appended.
+    """
+
+    displays_address: bool
+    displays_policy_address: bool
+    signs_message: bool
+
+
+def optional_protocols(signer: object) -> OptionalProtocols:
     """Return which optional protocols the signer offers, as a caller asks.
 
     `isinstance` against the three runtime-checkable protocols, which is
@@ -246,7 +269,7 @@ def optional_protocols(signer: object) -> tuple[bool, bool, bool]:
     caller says the answer must match, and a conformance pass has none of
     that material.
     """
-    return (
+    return OptionalProtocols(
         isinstance(signer, AddressDisplay),
         isinstance(signer, WalletPolicyAddressDisplay),
         isinstance(signer, MessageSigner),

--- a/tests/psbt_signer_contract_test.py
+++ b/tests/psbt_signer_contract_test.py
@@ -121,6 +121,46 @@ def test_the_optional_protocols_are_reported() -> None:
     assert policy_display.display_policy_address("registration") == "unused"
 
 
+def test_optional_protocols_answers_by_name_and_by_unpacking() -> None:
+    """A field read by name, not only a position, is what the record adds."""
+    reference = optional_protocols(_signer())
+    assert reference.displays_address is True
+    assert reference.displays_policy_address is False
+    assert reference.signs_message is True
+    displays_address, displays_policy_address, signs_message = reference
+    assert displays_address is True
+    assert displays_policy_address is False
+    assert signs_message is True
+
+    wrapped = optional_protocols(_Wrapper())
+    assert wrapped.displays_address is False
+    assert wrapped.displays_policy_address is False
+    assert wrapped.signs_message is False
+    displays_address, displays_policy_address, signs_message = wrapped
+    assert displays_address is False
+    assert displays_policy_address is False
+    assert signs_message is False
+
+    class _PolicyDisplay(_Wrapper):
+        """A signer whose only optional operation is the policy one."""
+
+        def display_policy_address(
+            self, registration: str, index: int = 0, multipath_index: int = 0
+        ) -> str:
+            return "unused"
+
+    policy_display = _PolicyDisplay()
+    policy = optional_protocols(policy_display)
+    assert policy.displays_address is False
+    assert policy.displays_policy_address is True
+    assert policy.signs_message is False
+    displays_address, displays_policy_address, signs_message = policy
+    assert displays_address is False
+    assert displays_policy_address is True
+    assert signs_message is False
+    assert policy_display.display_policy_address("registration") == "unused"
+
+
 def test_something_that_is_not_a_signer_is_refused() -> None:
     """The one check a caller cannot make with a type annotation."""
     with pytest.raises(BTClibValueError, match="does not implement PsbtSigner"):


### PR DESCRIPTION
Closes #1624

`optional_protocols` returned a plain tuple of `bool`. #1588 inserted
`WalletPolicyAddressDisplay` between the two protocols that were already
there — correctly, since it is a second mode of the address display it
sits beside — and the cost showed up where nothing could catch it:
`optional_protocols(signer)[1]` meant "signs messages" in `v2026.8.29`
and means "displays a wallet-policy address" now. Unpacking the old
shape raises, which is loud. Indexing returns a `bool` of the wrong
question, and no exception, no type error and no test outside this
repository sees it.

The return type is now a `NamedTuple`, `OptionalProtocols`, with the
fields in the order the tuple already had. This issue reorders nothing.

The argument for leaving it alone was that this library's convention
elsewhere is the plain tuple. That convention is about a different
object: a plain tuple is right for a *sequence*, things of one kind
whose count is the point, where an index is a position and means it.
This is a *record* — answers to questions that have nothing to do with
each other, whose number is an accident of which optional protocols
exist today. An index into a record is a position standing in for a
name, and the name is what the caller meant. That is also why the
failure was silent: reordering a sequence is loud because a reader knows
positions carry meaning, where inserting into a record is not.

Nothing that works today stops working — unpacking, indexing,
`isinstance` against `tuple` and `==` against a plain tuple of `bool` all
answer as before, which is why the conformance test's three assertions
are untouched. `type(...) is tuple` and `repr(...)` do change, and
`RELEASE_NOTES.md` says so rather than claiming more than was measured.
It is not a breaking-changes entry: nothing that compiles today stops
compiling.

What this does **not** fix, said here rather than discovered later: a
caller who indexes still reads the wrong question after the next
insertion. Field names are an escape offered to callers who take them,
not a guard, and no return type can be one for a caller who insists on
`[1]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Return named optional-protocol results from PSBT signer inspection to make capability checks resilient to protocol changes.

New Features:
- Expose `OptionalProtocols`, a named tuple with explicit fields for the optional signer capabilities returned by `optional_protocols`.
- Enable callers to access optional protocol results by descriptive field names while retaining tuple-compatible behavior.

Bug Fixes:
- Prevent silent misinterpretation of indexed optional-protocol results when protocols are inserted or reordered.

Documentation:
- Document the named-tuple return type, compatibility behavior, and implications for callers that rely on exact tuple types or representations.

Tests:
- Add coverage for named-field access, unpacking, and capability detection across different signer implementations.