### PR TITLE
Add btclib.electrum, an Electrum protocol codec, and ElectrumFetcher over it (issue #1127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,42 @@ is `wif_from_prv_key` and `b58.p2pkh` in the caller's own code now.
   stated a count of this tree's own vendored files drops the numeral
   instead of being spared.
 
+### `btclib.electrum`, the Electrum protocol codec, and `ElectrumFetcher`
+
+- **`btclib.electrum` adds the Electrum protocol codec: newline-delimited
+  JSON-RPC framing, the shapes of `blockchain.transaction.get`,
+  `blockchain.headers.subscribe`, `blockchain.block.header` and
+  `blockchain.transaction.get_merkle`, and the merkle-branch check of a
+  `get_merkle` answer against a `BlockHeader`, built on
+  `btclib.block.merkle_proof`** (issue #1127). It sits beside
+  `btclib.p2p` and outside `btclib.fetch`, on the same pattern and for
+  the same reason: `btclib.fetch.__init__` imports every fetcher it
+  ships, so a module that only ever speaks or serves this protocol reads
+  and writes lines without loading `urllib`, `ssl` or `socket` through
+  it. No socket anywhere in it, which
+  `tests/imports_test.py::test_electrum_codec_does_not_import_fetch`
+  checks in a subprocess.
+- **`btclib.fetch.electrum` adds `ElectrumFetcher`, a `Fetcher` over the
+  codec above and a `transport: LineTransport`.** It answers the four
+  interface questions the way `btclib.electrum`'s shapes carry them, and
+  a fifth `get_tx_merkle`/`verify_tx` pair the interface itself does not
+  gain: the one answer among the four other backends cannot check at
+  all, a transaction proven confirmed by checking its branch against a
+  header this fetcher fetched on its own rather than taking either on
+  the server's word. No default server, `EsploraFetcher`'s
+  `base_url`'s own reason: naming any one of the handful of hosts that
+  pass strict certificate verification would repeat the mistake
+  `BLOCKSTREAM_INFO` already refuses.
+- **`LineTransport` is declared in `btclib.fetch.transport`, beside
+  `HttpTransport`, and ships with no implementation in this half.**
+  `ElectrumFetcher.transport` is therefore required and keyword-only,
+  with no default: a lax placeholder would hand every caller the
+  self-signed certificate a private Electrum server presents by
+  construction, and this half cannot yet build the strict one the
+  measurement behind this issue argues for. Issue #1127 stays open on
+  this half; a second one adds the transport and the default that comes
+  with it.
+
 ## v2026.9.3
 
 ### Repository

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -367,6 +367,20 @@ used to teach and to prototype as much as to build:
     the txid this code computed from the transaction handed to it, and
     nothing checks that the transaction went on to propagate beyond
     whichever peer or node answered
+- **`ElectrumFetcher` is the one backend that can prove an answer rather
+    than take it on trust.** `get_tx_merkle`/`verify_tx` check a
+    transaction's branch against a header this fetcher fetched with
+    `get_block_header` itself, `btclib.block.merkle_proof` doing the
+    arithmetic — a caller who runs the check learns that the transaction
+    is in the block that header names, not merely that some server said
+    so. It establishes nothing about that header being the right chain's
+    or the right height's, `Fetcher.get_block_header`'s own caveat and
+    unaffected by the branch matching underneath it. `transport:
+    LineTransport` is required and carries no default in this half — its
+    own docstring in `btclib.fetch.transport` says why — so nothing here
+    contacts a server until a caller supplies both a transport and, once
+    one exists, a host: the same refusal to name one `BLOCKSTREAM_INFO`
+    already carries
 - **rpc credentials.** They are passed as arguments and refused in the
     url, so that a password is not carried in a string that ends up in
     config files, tracebacks and logs. bitcoind's `.cookie` needs none at

--- a/docs/source/btclib.fetch.rst
+++ b/docs/source/btclib.fetch.rst
@@ -48,6 +48,13 @@ btclib.fetch.decorators module
    :members:
    :show-inheritance:
 
+btclib.fetch.electrum module
+-----------------------------
+
+.. automodule:: btclib.fetch.electrum
+   :members:
+   :show-inheritance:
+
 btclib.fetch.esplora module
 ---------------------------
 

--- a/docs/source/btclib.rst
+++ b/docs/source/btclib.rst
@@ -128,6 +128,13 @@ btclib.core_import module
    :members:
    :show-inheritance:
 
+btclib.electrum module
+-----------------------
+
+.. automodule:: btclib.electrum
+   :members:
+   :show-inheritance:
+
 btclib.exceptions module
 ------------------------
 

--- a/src/btclib/__init__.py
+++ b/src/btclib/__init__.py
@@ -99,6 +99,7 @@ __all__ = [
     "curves",
     "descriptors",
     "ecc",
+    "electrum",
     "exceptions",
     "fee",
     "fetch",

--- a/src/btclib/electrum.py
+++ b/src/btclib/electrum.py
@@ -1,0 +1,278 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The Electrum server protocol: newline-delimited JSON-RPC, no socket.
+
+Not to be confused with `btclib.mnemonic.electrum`, Electrum's seed
+scheme: this module is the wire protocol an Electrum *server* speaks,
+unrelated beyond sharing the project's name.
+
+Beside `btclib.p2p`, outside `btclib.fetch`, on the same pattern and for
+the same reason `btclib.p2p`'s own docstring states: `btclib.fetch.electrum`
+is the one place that goes and asks a server anything, and this module is
+what turns a question into a request line and a line into an answer,
+opening nothing. `btclib.fetch.__init__` imports every fetcher it ships,
+so a module that only ever *serves* this protocol -- an electrs-shaped
+index over its own chainstate, should one ever exist -- imports this and
+not `urllib`, `ssl` or `socket` through that package's `__init__`.
+Nothing here imports `btclib.fetch`, and nothing there imports this;
+`tests/electrum_test.py` asserts the first half by importing this module
+in a subprocess and checking `btclib.fetch` never enters `sys.modules` --
+a static AST walk would answer for an import statement and not for one
+reached through `importlib`, and the question that actually matters is
+what a process that only imports this module ends up with loaded.
+
+**Framing.** `encode_request` writes one JSON-RPC request, an id and a
+newline the server splits messages on; `decode_response` reads one reply
+line back, matched to the id of the request it answers, and refuses a
+line that is not a well-formed answer to it -- not JSON, not an object,
+answering the wrong id, or carrying neither a `result` nor an `error`.
+Protocol-basics.rst encourages JSON-RPC 2.0 without requiring it, so no
+`jsonrpc` member is sent and both an object `error` and a bare one are
+read back, which is the one place this module still meets the elder
+convention.
+
+**Four methods, the ones a fetcher over this protocol needs.**
+`blockchain.transaction.get` for a raw transaction,
+`blockchain.headers.subscribe` for the chain tip's height and header,
+`blockchain.block.header` for the header at a height, and
+`blockchain.transaction.get_merkle` for the branch and position that
+proves a transaction confirmed. Each is a pair of functions, one to
+build the request and one to read the matching response -- shapes, not
+a client: nothing here keeps a connection, retries, or knows which
+request line answers which of several outstanding ones, since a codec
+with no socket cannot have more than one line outstanding.
+
+**The merkle proof.** `assert_merkle_proof` and `verify_merkle_proof`
+check what `transaction_get_merkle_response` returns against a
+`BlockHeader` the caller already holds, and are what `Fetcher`'s own
+class docstring means by "returns evidence beside the data": the branch
+and position are not evidence until they are checked against a root, and
+that check is `btclib.block.merkle_proof.assert_as_valid`, unmodified --
+this module supplies the shapes either side of it and reimplements
+neither the arithmetic nor CVE-2017-12842's hardening.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, cast
+
+from btclib.alias import Octets
+from btclib.block.block_header import BlockHeader
+from btclib.block.merkle_proof import assert_as_valid
+from btclib.block.merkle_proof import verify as verify_merkle_branch
+from btclib.exceptions import BTClibTypeError, BTClibValueError, RpcError
+from btclib.utils import bytes_from_octets, is_integer
+
+__all__ = [
+    "HeaderTip",
+    "MerkleProof",
+    "assert_merkle_proof",
+    "block_header_request",
+    "block_header_response",
+    "decode_response",
+    "encode_request",
+    "headers_subscribe_request",
+    "headers_subscribe_response",
+    "transaction_get_merkle_request",
+    "transaction_get_merkle_response",
+    "transaction_get_request",
+    "transaction_get_response",
+    "verify_merkle_proof",
+]
+
+
+def encode_request(request_id: int, method: str, params: Any = ()) -> bytes:
+    """Return one JSON-RPC request line, newline-terminated.
+
+    The newline is part of the wire shape and not a transport's to add:
+    `LineTransport` (`btclib.fetch.transport`) takes and returns exactly
+    one such line, so a caller building one by hand -- outside the
+    per-method helpers below -- still gets the framing right.
+    """
+    request = {"id": request_id, "method": method, "params": list(params)}
+    return json.dumps(request).encode("utf-8") + b"\n"
+
+
+def decode_response(line: bytes, request_id: int) -> Any:
+    """Return the `result` of one response line, matched to `request_id`.
+
+    Refuses a line that is not one: not JSON, not an object, an id that
+    is not this request's, or neither a `result` nor an `error` member.
+    An `error` member is raised as `RpcError` rather than returned -- a
+    JSON-RPC error object, `{"code", "message"}` and an optional `data`,
+    every field this module's own caller in `btclib.fetch.electrum` asks
+    for the way it asks a bitcoind JSON-RPC error's fields. A server that
+    still answers the elder, non-object form of an error -- a bare string
+    result under protocol 1.0 -- is read the same way, with code 0: the
+    protocol carries no code for that shape, and 0 is no code Core or
+    Electrum ever assigns one of their own.
+    """
+    try:
+        reply: Any = json.loads(line)
+    except (TypeError, ValueError) as e:
+        raise BTClibValueError(f"not a JSON-RPC line: {line!r}") from e
+    if not isinstance(reply, dict):
+        raise BTClibTypeError(f"not a JSON-RPC response object: {reply!r}")
+    if reply.get("id") != request_id:
+        err_msg = f"response id {reply.get('id')!r}"
+        err_msg += f" does not answer request {request_id}"
+        raise BTClibValueError(err_msg)
+    error = reply.get("error")
+    if error is not None:
+        if isinstance(error, dict):
+            message = str(error.get("message", error))
+            code = error.get("code", 0)
+            raise RpcError(message, code if is_integer(code) else 0, error.get("data"))
+        raise RpcError(str(error), 0)
+    if "result" not in reply:
+        raise BTClibValueError(f"neither a result nor an error: {reply!r}")
+    return reply["result"]
+
+
+def transaction_get_request(request_id: int, tx_id: str) -> bytes:
+    """Return the `blockchain.transaction.get` request for `tx_id`."""
+    return encode_request(request_id, "blockchain.transaction.get", [tx_id])
+
+
+def transaction_get_response(line: bytes, request_id: int) -> bytes:
+    """Return the raw transaction `blockchain.transaction.get` answered.
+
+    The result is the serialization as a hex string, `verbose` left at
+    its default `false`; decoded to bytes here so a caller -- and
+    `btclib.fetch.fetcher.tx_from_raw`, which every other backend hands
+    the same octets to -- reads the transaction and not a string it has
+    to already know is hex.
+    """
+    result = decode_response(line, request_id)
+    if not isinstance(result, str):
+        raise BTClibTypeError(f"transaction.get: not a hex string: {result!r}")
+    return bytes_from_octets(result)
+
+
+@dataclass(frozen=True)
+class HeaderTip:
+    """The chain tip `blockchain.headers.subscribe` answered.
+
+    `header` is the raw eighty-byte serialization, decoded here so a
+    caller checks it with `BlockHeader.parse` rather than hex-decoding it
+    a second time.
+    """
+
+    height: int
+    header: bytes
+
+
+def headers_subscribe_request(request_id: int) -> bytes:
+    """Return the `blockchain.headers.subscribe` request.
+
+    A subscription in the protocol's own vocabulary, but this codec
+    speaks one request and one response: the notifications a live
+    subscription goes on to deliver are a connection's to read off the
+    wire, which nothing here holds, and are no part of what
+    `decode_response` matches by id.
+    """
+    return encode_request(request_id, "blockchain.headers.subscribe")
+
+
+def headers_subscribe_response(line: bytes, request_id: int) -> HeaderTip:
+    """Return the chain tip `blockchain.headers.subscribe` answered."""
+    result = decode_response(line, request_id)
+    if not isinstance(result, dict):
+        raise BTClibTypeError(f"headers.subscribe: not an object: {result!r}")
+    height = result.get("height")
+    header = result.get("hex")
+    if not is_integer(height):
+        raise BTClibTypeError(f"headers.subscribe: invalid height: {height!r}")
+    if not isinstance(header, str):
+        raise BTClibTypeError(f"headers.subscribe: invalid hex: {header!r}")
+    return HeaderTip(cast(int, height), bytes_from_octets(header))
+
+
+def block_header_request(request_id: int, height: int) -> bytes:
+    """Return the `blockchain.block.header` request for `height`.
+
+    `cp_height` left unsent, at its protocol default of zero: with it,
+    the answer is the raw header hex alone, rather than a second, unasked
+    merkle proof -- the `{"branch", "header", "root"}` checkpoint shape --
+    this codec has no method for and `Fetcher.get_block_header`'s own
+    checks, run on the header this returns, have no use for.
+    """
+    return encode_request(request_id, "blockchain.block.header", [height])
+
+
+def block_header_response(line: bytes, request_id: int) -> bytes:
+    """Return the raw header `blockchain.block.header` answered."""
+    result = decode_response(line, request_id)
+    if not isinstance(result, str):
+        raise BTClibTypeError(f"block.header: not a hex string: {result!r}")
+    return bytes_from_octets(result)
+
+
+@dataclass(frozen=True)
+class MerkleProof:
+    """The branch `blockchain.transaction.get_merkle` answered.
+
+    `branch` and the transaction id it is checked against are both in
+    display order -- the order `assert_merkle_proof` below, `Tx.id` and a
+    block explorer all already use. `block_height` is the server's own
+    claim of which block, unchecked here: it is what a caller passes to
+    `Fetcher.get_block_header` to fetch the header this proof is checked
+    against, so a wrong claim there is a wrong header fetched, and the
+    branch check below is what refuses it.
+    """
+
+    block_height: int
+    branch: tuple[bytes, ...]
+    pos: int
+
+
+def transaction_get_merkle_request(request_id: int, tx_id: str, height: int) -> bytes:
+    """Return the `blockchain.transaction.get_merkle` request."""
+    return encode_request(
+        request_id, "blockchain.transaction.get_merkle", [tx_id, height]
+    )
+
+
+def transaction_get_merkle_response(line: bytes, request_id: int) -> MerkleProof:
+    """Return the merkle proof `blockchain.transaction.get_merkle` answered."""
+    result = decode_response(line, request_id)
+    if not isinstance(result, dict):
+        raise BTClibTypeError(f"transaction.get_merkle: not an object: {result!r}")
+    block_height = result.get("block_height")
+    branch = result.get("merkle")
+    pos = result.get("pos")
+    if not is_integer(block_height):
+        err_msg = f"transaction.get_merkle: invalid block_height: {block_height!r}"
+        raise BTClibTypeError(err_msg)
+    if not isinstance(branch, list):
+        raise BTClibTypeError(f"transaction.get_merkle: invalid merkle: {branch!r}")
+    if not is_integer(pos):
+        raise BTClibTypeError(f"transaction.get_merkle: invalid pos: {pos!r}")
+    return MerkleProof(
+        cast(int, block_height),
+        tuple(bytes_from_octets(sibling, 32) for sibling in branch),
+        cast(int, pos),
+    )
+
+
+def assert_merkle_proof(tx_id: Octets, proof: MerkleProof, header: BlockHeader) -> None:
+    """Raise unless `proof` proves `tx_id` is in the tree `header` commits to.
+
+    `btclib.block.merkle_proof.assert_as_valid`, unmodified: this is the
+    shape the answer arrives in, checked against the header a caller
+    fetched on its own, not a second implementation of the arithmetic.
+    """
+    assert_as_valid(tx_id, proof.branch, proof.pos, header.merkle_root)
+
+
+def verify_merkle_proof(tx_id: Octets, proof: MerkleProof, header: BlockHeader) -> bool:
+    """Return True if `proof` proves `tx_id` is in the tree `header` commits to.
+
+    See `assert_merkle_proof`, which this wraps the same way
+    `btclib.block.merkle_proof.verify` wraps `assert_as_valid`.
+    """
+    return verify_merkle_branch(tx_id, proof.branch, proof.pos, header.merkle_root)

--- a/src/btclib/exceptions.py
+++ b/src/btclib/exceptions.py
@@ -154,15 +154,17 @@ class HttpError(FetchError):
 
 
 class RpcError(FetchError):
-    """bitcoind answered with a JSON-RPC error object, and this is it.
+    """A backend answered with a JSON-RPC error object, and this is it.
 
-    `code` is the node's, from `src/rpc/protocol.h`: -5 is
-    RPC_INVALID_ADDRESS_OR_KEY, which is what `getrawtransaction` returns
-    for a transaction it cannot find -- including every non-wallet
-    transaction on a node running without `-txindex`. A caller that means
-    to tell "no such transaction" from "the node is unreachable" needs the
-    number, and parsing it back out of the message is what having a field
-    avoids.
+    `code` is the backend's own. From bitcoind, `src/rpc/protocol.h`: -5
+    is RPC_INVALID_ADDRESS_OR_KEY, which is what `getrawtransaction`
+    returns for a transaction it cannot find -- including every
+    non-wallet transaction on a node running without `-txindex`. From an
+    Electrum server (`btclib.electrum`), the field carries that server's
+    own JSON-RPC 2.0 code instead, nothing here asking anything
+    bitcoind-specific of it. A caller that means to tell "no such
+    transaction" from "the backend is unreachable" needs the number, and
+    parsing it back out of the message is what having a field avoids.
 
     `data` is JSON-RPC's optional third member of an error object, kept as
     it arrived. Core leaves it out today, so it is None for every error a

--- a/src/btclib/fetch/__init__.py
+++ b/src/btclib/fetch/__init__.py
@@ -7,11 +7,12 @@
 **Where the chain is.** Everything else in btclib works on bytes it was
 handed. This package is the one place that goes and asks: what
 transaction has this id, what output does this outpoint name, where is
-the chain tip. `Fetcher` is the interface, and it is implemented three
+the chain tip. `Fetcher` is the interface, and it is implemented four
 times -- `BitcoinCoreFetcher` over a full node's JSON-RPC,
 `BitcoinCoreRestFetcher` over the same node's unauthenticated `-rest`
-interface, `EsploraFetcher` over a block explorer's HTTP api -- so that
-calling code takes a `Fetcher` and never branches on which one it got.
+interface, `EsploraFetcher` over a block explorer's HTTP api,
+`ElectrumFetcher` over an Electrum server -- so that calling code takes a
+`Fetcher` and never branches on which one it got.
 
 **`Broadcaster` is the one place that announces a transaction rather than
 asking about one**, and is a `typing.Protocol` rather than a fourth
@@ -51,11 +52,13 @@ what raises if there is nothing to connect to.
 they implement, `Broadcaster` beside it, the two clients a Bitcoin Core
 node is reached through -- `BitcoinCoreRpcClient` for the JSON-RPC
 server, `BitcoinCoreRestClient` for `-rest` -- and the transport seam:
-the timeout, the protocol a substitute has to satisfy and the two
-implementations of it that open a socket -- one connection per call, and
-one kept open across calls. That last group is here because the seam is
-the supported way to test calling code without a node, which is not a
-detail of the fetcher implementations.
+the timeout, the two protocols a substitute has to satisfy and the two
+HTTP implementations of one of them that open a socket -- one connection
+per call, and one kept open across calls. `LineTransport`,
+`ElectrumFetcher`'s own protocol, has no implementation here yet; its
+own docstring in `btclib.fetch.transport` says why. That last group is
+here because the seam is the supported way to test calling code without
+a node, which is not a detail of the fetcher implementations.
 
 `bitcoin_core.cookie_auth` is deliberately not here:
 `BitcoinCoreRpcClient` takes a `cookie_path` and reads that file at every
@@ -88,11 +91,13 @@ from btclib.fetch.bitcoin_core import BitcoinCoreFetcher
 from btclib.fetch.bitcoin_core_rest import BitcoinCoreRestFetcher
 from btclib.fetch.broadcaster import Broadcaster
 from btclib.fetch.decorators import CachingFetcher, FallbackFetcher
+from btclib.fetch.electrum import ElectrumFetcher
 from btclib.fetch.esplora import BLOCKSTREAM_INFO, EsploraFetcher
 from btclib.fetch.fetcher import Fetcher
 from btclib.fetch.transport import (
     DEFAULT_TIMEOUT,
     HttpTransport,
+    LineTransport,
     SessionTransport,
     urlopen_transport,
 )
@@ -106,10 +111,12 @@ __all__ = [
     "BitcoinCoreRpcClient",
     "Broadcaster",
     "CachingFetcher",
+    "ElectrumFetcher",
     "EsploraFetcher",
     "FallbackFetcher",
     "Fetcher",
     "HttpTransport",
+    "LineTransport",
     "SessionTransport",
     "urlopen_transport",
 ]

--- a/src/btclib/fetch/electrum.py
+++ b/src/btclib/fetch/electrum.py
@@ -1,0 +1,204 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The btclib fetcher backed by an Electrum server.
+
+`btclib.electrum` is the codec -- the JSON-RPC framing, the shapes of the
+four methods this fetcher asks, and the merkle-branch check -- and holds
+no socket; this module is the `Fetcher` over it, taking a `transport` and
+turning each question into a request line and a line back into a btclib
+type, the way `EsploraFetcher` and `BitcoinCoreRestFetcher` do over their
+own transports.
+
+**`transport` is required, keyword-only, and has no default in this
+half.** `LineTransport` (`btclib.fetch.transport`) is declared and not
+implemented yet -- its own docstring says why -- so a default here would
+either be a lax placeholder, which the trust measurement behind this
+issue argues against, or a strict one this half cannot yet build. Every
+caller supplies a transport of its own until issue #1127's second half
+ships one.
+
+**No `base_url` and no default server.** Unlike `EsploraFetcher`, which
+takes a required url with no default, this fetcher takes none at all:
+`transport` is the whole of how it reaches a server, and which server
+that is is `transport`'s own business. `EsploraFetcher.base_url`'s
+reasoning -- `BLOCKSTREAM_INFO` is offered as a value to pass and never
+as a default, because which host sees every address a caller looks up is
+not btclib's decision to make on anyone's behalf -- applies here with
+even less room: measured against Electrum's own shipped server list,
+strict certificate verification reaches four hosts, two of them one
+operator, and a caller running their own server is invisible to that
+list entirely. Naming any one of the four as a constant would repeat the
+mistake `BLOCKSTREAM_INFO` already refuses.
+
+**A fifth question, answered by nothing else in this package.**
+`get_tx_merkle` and `verify_tx` are not on `Fetcher`: adding a return type
+only one backend can honor is what the interface's four abstract methods,
+each with a return type of its own, already exist to avoid, and both the
+issue and issue #1193 hold the interface itself unchanged. What
+`Fetcher`'s own class docstring calls "evidence beside the data" is what
+these two are -- a merkle branch checked against a header this fetcher
+fetched on its own, which is a different kind of answer from the other
+three backends' word for it, and the reason this backend exists.
+"""
+
+from __future__ import annotations
+
+from typing_extensions import override
+
+from btclib import electrum
+from btclib.alias import Octets
+from btclib.block.block_header import BlockHeader
+from btclib.fetch.fetcher import (
+    Fetcher,
+    block_header_from_raw,
+    block_header_height,
+    client_errors,
+    fetch_errors,
+    tx_from_raw,
+    tx_id_hex,
+)
+from btclib.fetch.transport import DEFAULT_TIMEOUT, LineTransport
+from btclib.tx import Tx
+
+__all__ = [
+    "ElectrumFetcher",
+]
+
+
+class ElectrumFetcher(Fetcher):
+    """The four fetcher questions, and a fifth, answered by an Electrum server.
+
+    `get_tx` is `blockchain.transaction.get`, the raw hex decoded and
+    handed to `tx_from_raw`, which recomputes the id the same way every
+    other backend does. `get_block_count` and `get_best_block_id` are
+    both `blockchain.headers.subscribe`, asked once each: the protocol
+    answers the tip's height together with its header rather than a
+    separate hash field, so the id `get_best_block_id` returns is not the
+    server's word -- it is `BlockHeader.hash` of the header
+    `block_header_from_raw` has already checked is well-formed and cost
+    real work to find, the same check `get_block_header` runs.
+    `get_block_header` is `blockchain.block.header`, `cp_height` left
+    unsent.
+
+    `get_tx_merkle` is `blockchain.transaction.get_merkle`, returning the
+    branch and position `btclib.electrum.MerkleProof` carries.
+    `verify_tx` fetches the header at the height asked for with
+    `get_block_header` -- the caller's own height, not the proof's
+    unchecked `block_height` -- and checks the branch against it with
+    `btclib.electrum.verify_merkle_proof`, answering `False` for a
+    malformed branch or a wrong position the way
+    `btclib.block.merkle_proof.verify` does, and still raising for
+    anything `get_block_header` itself refuses.
+
+    `get_tx_out` is not overridden, and stays the `Fetcher` base's
+    derivation from `get_tx`: the protocol answers a script hash's
+    history and its unspent outputs, `blockchain.scripthash.get_history`
+    and `.listunspent`, but the interface does not ask those questions
+    and this issue does not add them.
+    """
+
+    def __init__(
+        self,
+        network: str = "mainnet",
+        *,
+        transport: LineTransport,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        super().__init__(network)
+        self.transport = transport
+        self.timeout = timeout
+        self._next_id = 0
+
+    def _next_request_id(self) -> int:
+        """Return a fresh request id, one higher than the last.
+
+        A counter and not a constant: `decode_response` refuses a reply
+        that answers a different id, so two requests sharing one id could
+        not be told apart by anything this codec checks.
+        """
+        self._next_id += 1
+        return self._next_id
+
+    def _round_trip(self, request: bytes) -> bytes:
+        """Send one request line and return the line answering it.
+
+        The one call site that reaches `self.transport`, so a translation
+        of what it raises is written once. `LineTransport`'s own
+        docstring is where the exception contract this wraps is stated.
+        """
+        with client_errors():
+            return self.transport(request, self.timeout)
+
+    def _tip(self) -> electrum.HeaderTip:
+        """Return the chain tip `blockchain.headers.subscribe` answers."""
+        request_id = self._next_request_id()
+        line = self._round_trip(electrum.headers_subscribe_request(request_id))
+        with fetch_errors("headers.subscribe"):
+            return electrum.headers_subscribe_response(line, request_id)
+
+    @override
+    def get_tx(self, tx_id: Octets) -> Tx:
+        """Return the transaction with this id, via `transaction.get`."""
+        hex_ = tx_id_hex(tx_id)
+        request_id = self._next_request_id()
+        line = self._round_trip(electrum.transaction_get_request(request_id, hex_))
+        with fetch_errors(f"transaction {hex_}"):
+            raw = electrum.transaction_get_response(line, request_id)
+        return tx_from_raw(raw, hex_, self.network)
+
+    @override
+    def get_block_count(self) -> int:
+        """Return the height of the chain tip, via `headers.subscribe`."""
+        return self._tip().height
+
+    @override
+    def get_best_block_id(self) -> bytes:
+        """Return the id of the chain tip, recomputed from its own header.
+
+        `headers.subscribe` answers the header itself rather than a
+        separate hash field, so this is not the server's word: it is
+        `block_header_from_raw`'s check on the bytes it sent, and then
+        the hash of the header that passed it.
+        """
+        tip = self._tip()
+        header = block_header_from_raw(tip.header, tip.height)
+        return header.hash
+
+    @override
+    def get_block_header(self, height: int) -> BlockHeader:
+        """Return the header at this height, via `blockchain.block.header`."""
+        height = block_header_height(height)
+        request_id = self._next_request_id()
+        line = self._round_trip(electrum.block_header_request(request_id, height))
+        with fetch_errors(f"block header {height}"):
+            raw = electrum.block_header_response(line, request_id)
+        return block_header_from_raw(raw, height)
+
+    def get_tx_merkle(self, tx_id: Octets, height: int) -> electrum.MerkleProof:
+        """Return the branch proving `tx_id` confirmed at `height`.
+
+        `blockchain.transaction.get_merkle`, the one question the other
+        two backends cannot answer at all.
+        """
+        hex_ = tx_id_hex(tx_id)
+        height = block_header_height(height)
+        request_id = self._next_request_id()
+        line = self._round_trip(
+            electrum.transaction_get_merkle_request(request_id, hex_, height)
+        )
+        with fetch_errors(f"transaction {hex_} merkle"):
+            return electrum.transaction_get_merkle_response(line, request_id)
+
+    def verify_tx(self, tx_id: Octets, height: int) -> bool:
+        """Return whether `tx_id` is proven confirmed at `height`.
+
+        Fetches the header at `height` and the branch separately, then
+        checks the second against the first's merkle root -- see this
+        class's own docstring for what each half already checks on its
+        own.
+        """
+        header = self.get_block_header(height)
+        proof = self.get_tx_merkle(tx_id, height)
+        return electrum.verify_merkle_proof(tx_id, proof, header)

--- a/src/btclib/fetch/fetcher.py
+++ b/src/btclib/fetch/fetcher.py
@@ -71,6 +71,12 @@ def client_errors() -> Iterator[None]:
     directly where its `-rest` twin asks the same question through
     `_get_json` and is covered by the first group.
 
+    `ElectrumFetcher._round_trip` is the same wrap over a caller-supplied
+    `transport` rather than a call into this package directly: a
+    `LineTransport` that cannot answer raises this same vocabulary, its
+    own docstring says so, and this is where that translation happens
+    for every one of that fetcher's calls.
+
     The fields are what make this a translation rather than a blanket
     wrap: `status` and `code` are the whole reason those two classes
     exist, and losing them would leave a caller matching on the text of a
@@ -160,8 +166,8 @@ def tx_for_network(tx: Tx, network: str) -> Tx:
 class Fetcher(ABC):
     """What a backend must answer, and what btclib does with the answers.
 
-    Four abstract methods, one per question, each with a return type of
-    its own. That is the shape on purpose rather than one `get(kind, id)`
+    One abstract method per question, each with a return type of its
+    own. That is the shape on purpose rather than one `get(kind, id)`
     returning whatever: a backend able to *prove* what it says -- the
     Electrum protocol serves a merkle branch, which a client checks
     against a header it already holds (issues #188, #204 and #1132) --

--- a/src/btclib/fetch/transport.py
+++ b/src/btclib/fetch/transport.py
@@ -4,9 +4,12 @@
 
 """The standard-library HTTP transport, re-exported under btclib's name.
 
-The implementation is `bitcoin_core_rpc`'s: a bounded read, no redirect
-followed and no proxy taken from the environment, in a package that
-depends on nothing beyond the standard library. btclib depends on it
+`LineTransport` is declared here too, beside it, and not yet implemented
+-- the paragraphs below the exceptions one say why and what that costs.
+
+The HTTP half's implementation is `bitcoin_core_rpc`'s: a bounded read, no
+redirect followed and no proxy taken from the environment, in a package
+that depends on nothing beyond the standard library. btclib depends on it
 for the rpc client and reaches the same transport through it, rather than
 keeping a second copy of that bounded-read and redirect policy in step
 with the first.
@@ -30,7 +33,30 @@ raises the package's `FetchError` and `HttpError`, which are not the
 classes `btclib.exceptions` declares;
 `btclib.fetch.fetcher.client_errors` is what translates them, and every
 call into this module from inside btclib is wrapped in it.
+
+**`LineTransport` is not an alias of anything.** `bitcoin_core_rpc`'s own
+transport is HTTP, and the Electrum protocol `btclib.electrum` speaks is
+newline-delimited JSON-RPC over a raw TCP or TLS socket, which that
+package does not carry. `ElectrumFetcher` (`btclib.fetch.electrum`) takes
+one request line, already terminated by `btclib.electrum.encode_request`'s
+own newline, and a timeout in seconds, and returns the answering line
+with its delimiter consumed rather than included -- bytes on both sides,
+the shape `btclib.electrum`'s own framing already produces and reads, so
+the boundary needs no encoding step of its own, the same reason
+`HttpTransport` is bytes in and bytes out. A transport that cannot
+answer raises `bitcoin_core_rpc`'s own `FetchError` or a subclass of it,
+the vocabulary `HttpTransport` already raises through this same package;
+`btclib.fetch.fetcher.client_errors` is what translates it, at every
+`ElectrumFetcher` call the way it is at every other backend's.
+
+**No implementation ships in this half.** issue #1127's second half is
+what adds a strict-verifying one and gives `ElectrumFetcher` a default
+transport; until then this is a declared seam and every caller -- and
+every test in this tree -- supplies a transport of its own, opening no
+socket.
 """
+
+from collections.abc import Callable
 
 from bitcoin_core_rpc import (
     DEFAULT_MAX_BODY_SIZE,
@@ -42,11 +68,14 @@ from bitcoin_core_rpc import (
     urlopen_transport,
 )
 
+LineTransport = Callable[[bytes, float], bytes]
+
 __all__ = [
     "DEFAULT_MAX_BODY_SIZE",
     "DEFAULT_TIMEOUT",
     "MAX_ERROR_BODY_SIZE",
     "HttpTransport",
+    "LineTransport",
     "SessionTransport",
     "http_request",
     "urlopen_transport",

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -214,6 +214,7 @@ CHILD_MODULES = {
             "bitcoin_core_rest",
             "broadcaster",
             "decorators",
+            "electrum",
             "esplora",
             "fetcher",
             "transport",

--- a/tests/electrum_test.py
+++ b/tests/electrum_test.py
@@ -1,0 +1,294 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for `btclib.electrum`, the Electrum protocol codec.
+
+No transport anywhere here -- there is none in this module to test, by
+design -- so every case is a line built or read by hand. The transaction
+and header vectors are `tests/fetch/__init__.py`'s TX_ID and
+TIP_HEADER_RAW, block 481824; the merkle branch is a second vector from
+the same block, `tests/block/_data/block_481824_complete.bin`'s
+transaction at index 1, computed with the sibling-walk
+`tests/block/merkle_proof_test.py` already uses and checked here against
+`btclib.block.merkle_proof.assert_as_valid` directly rather than
+recomputed at collection time -- `tests/fetch/electrum_test.py` shares
+the same four literals so that a fetcher test and a codec test agree on
+what a real server would have answered without importing one another.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from btclib.block.block_header import BlockHeader
+from btclib.electrum import (
+    HeaderTip,
+    MerkleProof,
+    assert_merkle_proof,
+    block_header_request,
+    block_header_response,
+    decode_response,
+    encode_request,
+    headers_subscribe_request,
+    headers_subscribe_response,
+    transaction_get_merkle_request,
+    transaction_get_merkle_response,
+    transaction_get_request,
+    transaction_get_response,
+    verify_merkle_proof,
+)
+from btclib.exceptions import BTClibTypeError, BTClibValueError, RpcError
+from tests.fetch import TIP_HEADER_RAW, TIP_HEIGHT, TIP_ID, TX_ID
+
+# block 481824's transaction at index 1: 225 bytes, no witness, so its
+# hash and its id are the same value. The branch is the eleven siblings
+# met climbing to the header's merkle_root, deepest first -- computed
+# once from tests/block/_data/block_481824_complete.bin with the same
+# construction tests/block/merkle_proof_test.py's `_branch` performs, and
+# checked below against the real header rather than trusted on arrival
+MERKLE_TX_ID = "c2bfb6f1bf791308c6b8f73f5d4181be9aa490da6e73c188f9ebd0723e8531b6"
+MERKLE_TX_RAW = bytes.fromhex(
+    "0200000001d40c5407d03e50fdfbdaa1ec97b3ce0cc29d72e7ca360c18221cf903d8b5f51b"
+    "010000006a47304402203dad2ca83215b123c8c89bfd161b519033eb1c049935e06358"
+    "9f265e05640371022064e64c030368b78ac842d4dd6a2b9959afc2e46ea78f011dcb9d"
+    "b3bbdae23651012103d20c7990a9cccd9d1346d2d1bfa7270030209e73810edd9a33fe"
+    "d28ad1409b50feffffff02400d0300000000001976a9145f8c60ce58c1791c2df2040e"
+    "f8a086e948f2f22588ac0c7cb132000000001976a914f3f79e50b1556826355864c4da"
+    "ca603e52e50b4888ac1f5a0700"
+)
+MERKLE_TX_POS = 1
+MERKLE_BRANCH = (
+    "da917699942e4a96272401b534381a75512eeebe8403084500bd637bd47168b3",
+    "392b569a882bc6252cc5fef0c2b420fcbad0c568ba70df3d6cff11b2ea1d3351",
+    "9aec6f7d8292ddbc922e608a2be69b2ab74675c1e1d1d4156339f831ab8a1458",
+    "015365e7ce124037203a131573c77c1d54f5fef5fb77baba2ab202ccd4e133f8",
+    "af310a3344d96e14141142e334552ad1fa75a4a365cd895c1cfbd0961de6cd41",
+    "2812b22e24414bae49286160a78ef765848b375bde5b67f2fd7209f07a24902d",
+    "d0da4f69356c1c7739a1971f76384829ebe1517635778d4ce0b0a91b56d282cc",
+    "0cfa885934de2d374d14ecdcf1f2a03dba36fbe6ca034202ca17a0a58aefa9bf",
+    "6632f3c95dcf284f86569018d081853473c1f8416009856103384e218e412df5",
+    "b3c8b80f3aca397fba2062b35cc042ff806655d0e593c5ef50d6df48d7360836",
+    "66532296fd04814bf47c9b0bbe2760262d5e452a77671c5cac90624d6d8c8554",
+)
+
+
+def reply(**members: object) -> bytes:
+    """Return a JSON-RPC response line carrying these members."""
+    return json.dumps(members).encode() + b"\n"
+
+
+def test_the_merkle_vector_proves_against_the_real_header() -> None:
+    """The literals above are consistent with each other, not asserted blind.
+
+    `assert_as_valid` is `btclib.block.merkle_proof`'s own, not this
+    module's -- this is the positive control the branch below is
+    measured against, so a typo in either literal fails here first.
+    """
+    header = BlockHeader.parse(TIP_HEADER_RAW)
+    proof = MerkleProof(
+        TIP_HEIGHT, tuple(bytes.fromhex(h) for h in MERKLE_BRANCH), MERKLE_TX_POS
+    )
+    assert_merkle_proof(MERKLE_TX_ID, proof, header)
+
+
+def test_encode_request_is_one_newline_terminated_json_object() -> None:
+    """The wire shape: an id, a method and a params list, one line."""
+    line = encode_request(7, "server.version", ["btclib", "1.4"])
+    assert line.endswith(b"\n")
+    assert json.loads(line) == {
+        "id": 7,
+        "method": "server.version",
+        "params": ["btclib", "1.4"],
+    }
+
+
+def test_decode_response_returns_the_result() -> None:
+    """A well-formed reply answers with its own `result`."""
+    assert decode_response(reply(id=3, result="ok"), 3) == "ok"
+
+
+def test_decode_response_refuses_a_line_that_is_not_json() -> None:
+    """A line a server never sends, refused rather than misread."""
+    with pytest.raises(BTClibValueError, match="not a JSON-RPC line"):
+        decode_response(b"not json at all\n", 1)
+
+
+def test_decode_response_refuses_a_json_value_that_is_not_an_object() -> None:
+    """Valid JSON, the wrong shape: a JSON-RPC reply is an object."""
+    with pytest.raises(BTClibTypeError, match="not a JSON-RPC response object"):
+        decode_response(b"[1, 2, 3]\n", 1)
+
+
+def test_decode_response_refuses_a_mismatched_id() -> None:
+    """A reply answering a different request is refused, not returned."""
+    with pytest.raises(BTClibValueError, match="does not answer request 1"):
+        decode_response(reply(id=2, result="ok"), 1)
+
+
+def test_decode_response_refuses_a_reply_with_neither_result_nor_error() -> None:
+    """A JSON-RPC object with neither member is not an answer to anything."""
+    with pytest.raises(BTClibValueError, match="neither a result nor an error"):
+        decode_response(reply(id=1), 1)
+
+
+def test_decode_response_raises_rpc_error_for_an_error_object() -> None:
+    """A JSON-RPC 2.0 error object: `code` and `message`, both kept."""
+    line = reply(id=1, error={"code": -32601, "message": "unknown method"})
+    with pytest.raises(RpcError, match="unknown method") as exc_info:
+        decode_response(line, 1)
+    assert exc_info.value.code == -32601
+
+
+def test_decode_response_raises_rpc_error_for_a_bare_error() -> None:
+    """Protocol 1.0's shape: `error` is a string, not an object."""
+    line = reply(id=1, error="no such transaction")
+    with pytest.raises(RpcError, match="no such transaction") as exc_info:
+        decode_response(line, 1)
+    assert exc_info.value.code == 0
+
+
+def test_transaction_get_round_trips_the_raw_transaction() -> None:
+    """The request names the id; the response decodes the hex it answers."""
+    tx_hex = "aabbcc"
+    request = transaction_get_request(1, TX_ID)
+    assert json.loads(request)["params"] == [TX_ID]
+
+    raw = transaction_get_response(reply(id=1, result=tx_hex), 1)
+    assert raw == bytes.fromhex(tx_hex)
+
+
+def test_transaction_get_response_refuses_a_non_string_result() -> None:
+    """The wire answer is hex text; anything else is not a transaction."""
+    with pytest.raises(BTClibTypeError, match="not a hex string"):
+        transaction_get_response(reply(id=1, result=1234), 1)
+
+
+def test_headers_subscribe_round_trips_height_and_header() -> None:
+    """The request needs no argument; the response carries height and header."""
+    request = headers_subscribe_request(9)
+    assert json.loads(request)["method"] == "blockchain.headers.subscribe"
+
+    line = reply(id=9, result={"height": TIP_HEIGHT, "hex": TIP_HEADER_RAW})
+    tip = headers_subscribe_response(line, 9)
+    assert tip == HeaderTip(TIP_HEIGHT, bytes.fromhex(TIP_HEADER_RAW))
+    assert BlockHeader.parse(tip.header).hash.hex() == TIP_ID
+
+
+@pytest.mark.parametrize(
+    "members",
+    [
+        {"height": "not an int", "hex": TIP_HEADER_RAW},
+        {"height": TIP_HEIGHT, "hex": 12345},
+        {"height": True, "hex": TIP_HEADER_RAW},
+    ],
+)
+def test_headers_subscribe_response_refuses_a_malformed_object(
+    members: dict[str, object],
+) -> None:
+    """A missing or wrongly typed member is refused, `bool` height included."""
+    with pytest.raises(BTClibTypeError):
+        headers_subscribe_response(reply(id=1, result=members), 1)
+
+
+def test_block_header_round_trips_the_raw_header() -> None:
+    """No `cp_height` sent; the answer is the raw header hex alone."""
+    request = block_header_request(4, TIP_HEIGHT)
+    assert json.loads(request)["params"] == [TIP_HEIGHT]
+
+    raw = block_header_response(reply(id=4, result=TIP_HEADER_RAW), 4)
+    assert raw == bytes.fromhex(TIP_HEADER_RAW)
+    assert BlockHeader.parse(raw).hash.hex() == TIP_ID
+
+
+def test_block_header_response_refuses_a_non_string_result() -> None:
+    """The wire answer, with no `cp_height`, is hex text and nothing else."""
+    with pytest.raises(BTClibTypeError, match="not a hex string"):
+        block_header_response(reply(id=4, result=None), 4)
+
+
+def test_transaction_get_merkle_round_trips_the_proof() -> None:
+    """The request names the height too; the response is branch, pos, height."""
+    request = transaction_get_merkle_request(2, MERKLE_TX_ID, TIP_HEIGHT)
+    assert json.loads(request)["params"] == [MERKLE_TX_ID, TIP_HEIGHT]
+
+    line = reply(
+        id=2,
+        result={
+            "block_height": TIP_HEIGHT,
+            "merkle": list(MERKLE_BRANCH),
+            "pos": MERKLE_TX_POS,
+        },
+    )
+    proof = transaction_get_merkle_response(line, 2)
+    assert proof.block_height == TIP_HEIGHT
+    assert proof.pos == MERKLE_TX_POS
+    assert proof.branch == tuple(bytes.fromhex(h) for h in MERKLE_BRANCH)
+
+
+def test_transaction_get_merkle_response_refuses_a_non_object() -> None:
+    """A `get_merkle` reply has three members, not a bare list or scalar."""
+    with pytest.raises(BTClibTypeError, match="not an object"):
+        transaction_get_merkle_response(reply(id=1, result=[1, 2, 3]), 1)
+
+
+@pytest.mark.parametrize(
+    "members",
+    [
+        {"merkle": list(MERKLE_BRANCH), "pos": MERKLE_TX_POS},  # no block_height
+        {"block_height": "not an int", "merkle": list(MERKLE_BRANCH), "pos": 0},
+        {"block_height": TIP_HEIGHT, "pos": MERKLE_TX_POS},  # no merkle
+        {"block_height": TIP_HEIGHT, "merkle": "not a list", "pos": 0},
+        {"block_height": TIP_HEIGHT, "merkle": list(MERKLE_BRANCH)},  # no pos
+        {"block_height": TIP_HEIGHT, "merkle": list(MERKLE_BRANCH), "pos": "0"},
+    ],
+)
+def test_transaction_get_merkle_response_refuses_a_malformed_object(
+    members: dict[str, object],
+) -> None:
+    """A missing or wrongly typed member is refused before a branch is built."""
+    with pytest.raises(BTClibTypeError):
+        transaction_get_merkle_response(reply(id=1, result=members), 1)
+
+
+def test_the_accepted_proof_verifies_against_the_real_header() -> None:
+    """`verify_merkle_proof`, not `assert_as_valid`, over the real branch."""
+    header = BlockHeader.parse(TIP_HEADER_RAW)
+    proof = MerkleProof(
+        TIP_HEIGHT, tuple(bytes.fromhex(h) for h in MERKLE_BRANCH), MERKLE_TX_POS
+    )
+    assert verify_merkle_proof(MERKLE_TX_ID, proof, header)
+
+
+def test_a_wrong_branch_is_refused() -> None:
+    """A substituted sibling fails the check, `verify` and `assert` alike."""
+    header = BlockHeader.parse(TIP_HEADER_RAW)
+    wrong_branch = (b"\x00" * 32, *(bytes.fromhex(h) for h in MERKLE_BRANCH[1:]))
+    proof = MerkleProof(TIP_HEIGHT, wrong_branch, MERKLE_TX_POS)
+    assert not verify_merkle_proof(MERKLE_TX_ID, proof, header)
+    with pytest.raises(BTClibValueError, match="invalid merkle branch"):
+        assert_merkle_proof(MERKLE_TX_ID, proof, header)
+
+
+def test_a_wrong_position_is_refused() -> None:
+    """The real branch at the wrong position does not recompute the root."""
+    header = BlockHeader.parse(TIP_HEADER_RAW)
+    proof = MerkleProof(
+        TIP_HEIGHT,
+        tuple(bytes.fromhex(h) for h in MERKLE_BRANCH),
+        MERKLE_TX_POS ^ 1,
+    )
+    assert not verify_merkle_proof(MERKLE_TX_ID, proof, header)
+
+
+def test_a_truncated_transaction_decodes_to_short_octets() -> None:
+    """The codec decodes the hex; a whole transaction is not its question.
+
+    `Tx.parse`, reached through `btclib.fetch.fetcher.tx_from_raw`, is
+    what refuses a serialization that stops early -- exercised in
+    `tests/fetch/electrum_test.py`, over the fetcher that calls it.
+    """
+    raw = transaction_get_response(reply(id=1, result=MERKLE_TX_RAW.hex()[:20]), 1)
+    assert raw == MERKLE_TX_RAW[:10]

--- a/tests/fetch/electrum_test.py
+++ b/tests/fetch/electrum_test.py
@@ -1,0 +1,304 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for `ElectrumFetcher`, against a scripted `LineTransport`.
+
+No socket anywhere here, `LineRecorded` below being the whole of what
+answers: this half ships no implementation of `LineTransport`, so a test
+reaching a real server is not merely undesirable, it is not possible.
+`tests/electrum_test.py` is the codec these calls are built on; the
+literals below are that module's own, repeated rather than imported, so
+that the two suites agree on what a real server would answer without one
+importing the other.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from bitcoin_core_rpc import FetchError as RpcFetchError
+
+from btclib.block.block_header import BlockHeader
+from btclib.exceptions import BTClibValueError, FetchError, RpcError
+from btclib.fetch.electrum import ElectrumFetcher
+from btclib.tx import OutPoint
+from tests.fetch import TIP_HEADER_RAW, TIP_HEIGHT, TIP_ID, TX_ID
+
+# block 481824's transaction at index 1 -- see tests/electrum_test.py for
+# how the branch below was derived and its own positive control against
+# the real header
+MERKLE_TX_ID = "c2bfb6f1bf791308c6b8f73f5d4181be9aa490da6e73c188f9ebd0723e8531b6"
+MERKLE_TX_RAW = (
+    "0200000001d40c5407d03e50fdfbdaa1ec97b3ce0cc29d72e7ca360c18221cf903d8b5f51b"
+    "010000006a47304402203dad2ca83215b123c8c89bfd161b519033eb1c049935e06358"
+    "9f265e05640371022064e64c030368b78ac842d4dd6a2b9959afc2e46ea78f011dcb9d"
+    "b3bbdae23651012103d20c7990a9cccd9d1346d2d1bfa7270030209e73810edd9a33fe"
+    "d28ad1409b50feffffff02400d0300000000001976a9145f8c60ce58c1791c2df2040e"
+    "f8a086e948f2f22588ac0c7cb132000000001976a914f3f79e50b1556826355864c4da"
+    "ca603e52e50b4888ac1f5a0700"
+)
+MERKLE_TX_POS = 1
+MERKLE_BRANCH = [
+    "da917699942e4a96272401b534381a75512eeebe8403084500bd637bd47168b3",
+    "392b569a882bc6252cc5fef0c2b420fcbad0c568ba70df3d6cff11b2ea1d3351",
+    "9aec6f7d8292ddbc922e608a2be69b2ab74675c1e1d1d4156339f831ab8a1458",
+    "015365e7ce124037203a131573c77c1d54f5fef5fb77baba2ab202ccd4e133f8",
+    "af310a3344d96e14141142e334552ad1fa75a4a365cd895c1cfbd0961de6cd41",
+    "2812b22e24414bae49286160a78ef765848b375bde5b67f2fd7209f07a24902d",
+    "d0da4f69356c1c7739a1971f76384829ebe1517635778d4ce0b0a91b56d282cc",
+    "0cfa885934de2d374d14ecdcf1f2a03dba36fbe6ca034202ca17a0a58aefa9bf",
+    "6632f3c95dcf284f86569018d081853473c1f8416009856103384e218e412df5",
+    "b3c8b80f3aca397fba2062b35cc042ff806655d0e593c5ef50d6df48d7360836",
+    "66532296fd04814bf47c9b0bbe2760262d5e452a77671c5cac90624d6d8c8554",
+]
+
+
+class RpcErrorAnswer:
+    """A scripted JSON-RPC error object, for `LineRecorded` to answer with."""
+
+    def __init__(self, message: str, code: int, data: object = None) -> None:
+        self.message = message
+        self.code = code
+        self.data = data
+
+
+class LineRecorded:
+    """A LineTransport answering from a script, remembering the requests.
+
+    Each answer is a `result` value, an `RpcErrorAnswer`, raw `bytes`, or
+    an `Exception`, consumed in order; the last one repeats. A `result`
+    or `RpcErrorAnswer` answer has this request's own id spliced in
+    before it is returned, the way a real server's reply carries the id
+    it was asked with -- so a test scripts a result and never a rendered
+    one. Raw `bytes` is returned exactly as scripted, unmodified id
+    included or not, which is how a test reaches "the line does not
+    decode" and "the id does not match" without this class fixing either.
+    """
+
+    def __init__(self, *answers: object) -> None:
+        self.answers = list(answers)
+        self.requests: list[bytes] = []
+        self.timeouts: list[float] = []
+
+    def __call__(self, request: bytes, timeout: float) -> bytes:
+        """Record the request and answer with the next scripted answer."""
+        self.requests.append(request)
+        self.timeouts.append(timeout)
+        answer = self.answers.pop(0) if len(self.answers) > 1 else self.answers[0]
+        if isinstance(answer, Exception):
+            raise answer
+        if isinstance(answer, bytes):
+            return answer
+        request_id = json.loads(request)["id"]
+        if isinstance(answer, RpcErrorAnswer):
+            error: dict[str, object] = {"code": answer.code, "message": answer.message}
+            if answer.data is not None:
+                error["data"] = answer.data
+            body: dict[str, object] = {"id": request_id, "error": error}
+        else:
+            body = {"id": request_id, "result": answer}
+        return json.dumps(body).encode()
+
+    @property
+    def methods(self) -> list[str]:
+        """The `method` field of every request made, in order."""
+        return [json.loads(request)["method"] for request in self.requests]
+
+
+def fetcher(*answers: object, **kwargs: object) -> ElectrumFetcher:
+    """Return an ElectrumFetcher over a scripted LineTransport."""
+    network = kwargs.pop("network", "mainnet")
+    assert isinstance(network, str)
+    transport = LineRecorded(*answers)
+    return ElectrumFetcher(network, transport=transport, **kwargs)  # type: ignore[arg-type]
+
+
+def transport_of(endpoint: ElectrumFetcher) -> LineRecorded:
+    """Return the transport a fetcher was built with, as one."""
+    assert isinstance(endpoint.transport, LineRecorded)
+    return endpoint.transport
+
+
+def test_transport_is_required() -> None:
+    """No default in this half: no transport is a `TypeError`, no fallback."""
+    with pytest.raises(TypeError, match="transport"):
+        ElectrumFetcher()  # type: ignore[call-arg]
+
+
+def test_get_tx_parses_the_serialization_the_server_sent() -> None:
+    """`transaction.get`'s hex, decoded and checked against the id asked for."""
+    endpoint = fetcher(MERKLE_TX_RAW)
+    tx = endpoint.get_tx(MERKLE_TX_ID)
+    assert tx.id.hex() == MERKLE_TX_ID
+    assert transport_of(endpoint).methods == ["blockchain.transaction.get"]
+
+
+def test_get_tx_asks_the_display_order_id() -> None:
+    """`get_tx` accepts bytes and sends the display-order hex on the wire."""
+    endpoint = fetcher(MERKLE_TX_RAW)
+    endpoint.get_tx(bytes.fromhex(MERKLE_TX_ID))
+    request = json.loads(transport_of(endpoint).requests[0])
+    assert request["params"] == [MERKLE_TX_ID]
+
+
+def test_get_tx_refuses_the_answer_to_another_question() -> None:
+    """The id is recomputed from the serialization and checked against it."""
+    with pytest.raises(FetchError, match="the answer is"):
+        fetcher(MERKLE_TX_RAW).get_tx(TX_ID)
+
+
+def test_get_tx_out_derives_the_output() -> None:
+    """`get_tx_out` is not overridden: it reads off the fetched transaction."""
+    out = fetcher(MERKLE_TX_RAW).get_tx_out(OutPoint(MERKLE_TX_ID, 0))
+    assert out.value == 200_000
+
+
+def test_a_truncated_transaction_is_refused() -> None:
+    """A body cut off in transit is caught by `Tx.parse`, not by the codec."""
+    truncated = MERKLE_TX_RAW[:20]
+    with pytest.raises(FetchError, match=f"transaction {MERKLE_TX_ID}:"):
+        fetcher(truncated).get_tx(MERKLE_TX_ID)
+
+
+def test_get_block_count_and_get_best_block_id() -> None:
+    """Both answers are read from the same `headers.subscribe` reply."""
+    tip = {"height": TIP_HEIGHT, "hex": TIP_HEADER_RAW}
+    assert fetcher(tip).get_block_count() == TIP_HEIGHT
+    assert fetcher(tip).get_best_block_id().hex() == TIP_ID
+
+
+def test_get_block_count_asks_headers_subscribe() -> None:
+    """`get_block_count` asks `blockchain.headers.subscribe`, nothing else."""
+    endpoint = fetcher({"height": TIP_HEIGHT, "hex": TIP_HEADER_RAW})
+    endpoint.get_block_count()
+    assert transport_of(endpoint).methods == ["blockchain.headers.subscribe"]
+
+
+def test_get_best_block_id_is_not_the_servers_word() -> None:
+    """The id is recomputed from the header bytes, not read off a field."""
+    tip = {"height": TIP_HEIGHT, "hex": TIP_HEADER_RAW}
+    header = BlockHeader.parse(TIP_HEADER_RAW)
+    assert fetcher(tip).get_best_block_id() == header.hash
+
+
+@pytest.mark.parametrize(
+    "tip",
+    [
+        {"height": "not an int", "hex": TIP_HEADER_RAW},
+        {"height": TIP_HEIGHT},  # no "hex" member at all
+        {"height": TIP_HEIGHT, "hex": "not hex at all!!"},
+        "not an object",
+    ],
+)
+def test_a_headers_subscribe_answer_that_is_not_one(tip: object) -> None:
+    """A missing or wrongly typed member, or no object at all, is refused."""
+    with pytest.raises(FetchError, match="headers.subscribe:"):
+        fetcher(tip).get_block_count()
+
+
+def test_get_block_header_asks_block_header() -> None:
+    """`blockchain.block.header`, the height alone, no `cp_height`."""
+    endpoint = fetcher(TIP_HEADER_RAW)
+    header = endpoint.get_block_header(TIP_HEIGHT)
+    assert header.hash.hex() == TIP_ID
+    request = json.loads(transport_of(endpoint).requests[0])
+    assert request["method"] == "blockchain.block.header"
+    assert request["params"] == [TIP_HEIGHT]
+
+
+@pytest.mark.parametrize("height", [-1, -481824])
+def test_get_block_header_refuses_a_negative_height(height: int) -> None:
+    """Refused before any request, the same guard every backend shares."""
+    endpoint = fetcher()
+    with pytest.raises(BTClibValueError, match="invalid height"):
+        endpoint.get_block_header(height)
+    assert transport_of(endpoint).requests == []
+
+
+def test_get_tx_merkle_round_trips_the_proof() -> None:
+    """`get_tx_merkle` is the question the other two backends cannot answer."""
+    endpoint = fetcher(
+        {"block_height": TIP_HEIGHT, "merkle": MERKLE_BRANCH, "pos": MERKLE_TX_POS}
+    )
+    proof = endpoint.get_tx_merkle(MERKLE_TX_ID, TIP_HEIGHT)
+    assert proof.pos == MERKLE_TX_POS
+    assert proof.branch == tuple(bytes.fromhex(h) for h in MERKLE_BRANCH)
+    request = json.loads(transport_of(endpoint).requests[0])
+    assert request["method"] == "blockchain.transaction.get_merkle"
+    assert request["params"] == [MERKLE_TX_ID, TIP_HEIGHT]
+
+
+def test_verify_tx_accepts_the_real_proof() -> None:
+    """The header and the branch, fetched separately, agree on the vector."""
+    endpoint = fetcher(
+        TIP_HEADER_RAW,
+        {"block_height": TIP_HEIGHT, "merkle": MERKLE_BRANCH, "pos": MERKLE_TX_POS},
+    )
+    assert endpoint.verify_tx(MERKLE_TX_ID, TIP_HEIGHT) is True
+
+
+def test_verify_tx_refuses_a_wrong_branch() -> None:
+    """A substituted sibling answers False, not an exception."""
+    wrong_branch = ["00" * 32, *MERKLE_BRANCH[1:]]
+    endpoint = fetcher(
+        TIP_HEADER_RAW,
+        {"block_height": TIP_HEIGHT, "merkle": wrong_branch, "pos": MERKLE_TX_POS},
+    )
+    assert endpoint.verify_tx(MERKLE_TX_ID, TIP_HEIGHT) is False
+
+
+def test_verify_tx_refuses_a_wrong_position() -> None:
+    """The real branch at the wrong position answers False too."""
+    endpoint = fetcher(
+        TIP_HEADER_RAW,
+        {
+            "block_height": TIP_HEIGHT,
+            "merkle": MERKLE_BRANCH,
+            "pos": MERKLE_TX_POS ^ 1,
+        },
+    )
+    assert endpoint.verify_tx(MERKLE_TX_ID, TIP_HEIGHT) is False
+
+
+def test_a_response_whose_id_does_not_match_is_refused() -> None:
+    """A line answering a different request is refused, not returned."""
+    wrong_id = json.dumps({"id": 999999, "result": MERKLE_TX_RAW}).encode()
+    with pytest.raises(FetchError, match="does not answer request"):
+        fetcher(wrong_id).get_tx(MERKLE_TX_ID)
+
+
+def test_a_line_that_is_not_json_is_refused() -> None:
+    """A line a server never sends, refused rather than misread."""
+    with pytest.raises(FetchError, match="not a JSON-RPC line"):
+        fetcher(b"this is not json\n").get_tx(MERKLE_TX_ID)
+
+
+def test_a_json_rpc_error_object_is_refused() -> None:
+    """A JSON-RPC error object reaches the caller as `RpcError`, code kept."""
+    endpoint = fetcher(RpcErrorAnswer("no such transaction", -32000))
+    with pytest.raises(RpcError, match="no such transaction") as exc_info:
+        endpoint.get_tx(MERKLE_TX_ID)
+    assert exc_info.value.code == -32000
+
+
+def test_a_json_rpc_error_objects_data_member_is_kept() -> None:
+    """`data` is JSON-RPC's optional third member, carried across when sent."""
+    endpoint = fetcher(RpcErrorAnswer("busy", -32001, data={"retry_after": 5}))
+    with pytest.raises(RpcError) as exc_info:
+        endpoint.get_tx(MERKLE_TX_ID)
+    assert exc_info.value.data == {"retry_after": 5}
+
+
+def test_the_timeout_is_passed_to_the_transport() -> None:
+    """The fetcher's own `timeout`, not `LineTransport`'s default."""
+    endpoint = fetcher(TIP_HEADER_RAW, timeout=12.5)
+    endpoint.get_block_header(TIP_HEIGHT)
+    assert transport_of(endpoint).timeouts == [12.5]
+
+
+def test_a_transport_failure_is_translated() -> None:
+    """`LineTransport`'s exception contract, translated by `client_errors`."""
+    with pytest.raises(FetchError, match="connection refused"):
+        fetcher(RpcFetchError("connection refused")).get_tx(MERKLE_TX_ID)

--- a/tests/imports_test.py
+++ b/tests/imports_test.py
@@ -193,6 +193,28 @@ def test_the_codec_does_not_pay_for_the_rpc_package() -> None:
     assert transport_cost not in loaded
 
 
+def test_electrum_codec_does_not_import_fetch() -> None:
+    """`btclib.electrum` is the codec `btclib.fetch.electrum` is built on.
+
+    Not the reverse: `btclib.fetch.__init__` imports every fetcher, so an
+    importer of this module alone -- node, should it ever serve the
+    protocol rather than only speak it -- does not pay for `urllib`,
+    `ssl` and `socket` through that package. `btclib.p2p`'s own docstring
+    states the same rule for the same reason.
+
+    A subprocess and not `unimported_btclib`: that fixture takes btclib
+    out of `sys.modules` and leaves `bitcoin_core_rpc` wherever an
+    earlier test in this process put it, so `btclib.fetch`'s absence
+    needs a fresh interpreter to mean anything -- the same reason the
+    p2p test above uses one.
+    """
+    probe = "import btclib.electrum, sys; print(sorted(sys.modules))"
+    loaded = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", probe], check=True, capture_output=True, encoding="utf-8"
+    ).stdout
+    assert "btclib.fetch" not in loaded
+
+
 def test_address_encodings_stay_below_script(unimported_btclib: None) -> None:
     """b58 and b32 must not import btclib.script.
 

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -247,6 +247,7 @@ KEYWORD_ONLY: dict[str, list[str]] = {
         "verify_network",
         "signet_challenge",
     ],
+    "btclib.fetch:ElectrumFetcher.__init__": ["transport", "timeout"],
     "btclib.fetch:EsploraFetcher.__init__": ["network", "timeout", "transport"],
     "btclib.fetch:SessionTransport.__init__": ["max_body_size", "connection_factory"],
     "btclib.fetch:urlopen_transport": ["max_body_size"],


### PR DESCRIPTION
The first half of #1127 — **not** a closing pull request. The commit says
`(issue #1127)`; the issue stays open until the second half ships a
transport.

`btclib.electrum` is a pure codec, and it sits **beside** `btclib.p2p`,
outside `btclib.fetch`, opening no socket: newline-delimited JSON-RPC
framing, the request and response shapes of the methods a fetcher needs,
and merkle-branch verification of a `get_merkle` answer against a
`BlockHeader` the caller already holds — built on
`btclib.block.merkle_proof`'s `assert_as_valid`/`verify`, not
reimplemented. That the module imports nothing from `btclib.fetch` is
the whole reason it lives where it does, so a test asserts it in a
subprocess rather than leaving it to a convention.

`ElectrumFetcher` answers `Fetcher`'s questions over a **required**
`transport: LineTransport`, keyword-only, **with no default** — the
default arrives with the transport and not before. `LineTransport` is a
type alias in `btclib.fetch.transport` and nothing implements it on this
branch. That is the constraint #1127's decision calls binding, so that
the first half does not quietly become the "declared seam, no
implementation" shape that was rejected: the docstrings say so in plain
words and name the issue that will ship it.

**No default server, ever.** The docstring carries the measurement
instead of an assurance — the reachable servers found under strict
verification on 2026-08-21, two of them run by one operator — because a
default here would be btclib choosing whose node reads a user's
addresses.

Beyond the interface, this backend gets `get_tx_merkle` and `verify_tx`,
which nothing else in the package can answer: a merkle branch checked
against a header this fetcher fetched itself. They are deliberately
**not** on `Fetcher` — adding a return type only one backend can honor is
what an interface of one-method-per-question exists to avoid, and both
this issue and #1193 hold the interface unchanged.

Errors cross into btclib's vocabulary through `client_errors` /
`fetch_errors` as the other backends do, and `client_errors`'s docstring
names its call sites, so this one joined the list. `SECURITY.md`'s
fetch-trust bullet gains this backend: it is the one that can *prove* a
transaction is in a block, which is a different claim from the others'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Add Electrum protocol support and an injectable Electrum-backed fetcher without introducing a default server or socket transport.

New Features:
- Add a pure Electrum JSON-RPC codec for request/response framing, fetcher method payloads, and merkle-proof validation.
- Add ElectrumFetcher support for retrieving transactions and block data, plus optional transaction merkle proofs and verification.

Enhancements:
- Introduce the required keyword-only LineTransport seam without selecting a default server or transport implementation.
- Integrate Electrum errors with btclib's existing fetch and RPC error handling conventions.

Documentation:
- Document Electrum fetching behavior, trust considerations, transport constraints, and the new public modules.

Tests:
- Add codec, fetcher, merkle-proof, error-handling, transport-seam, and import-isolation coverage using scripted transports.