### PR TITLE
btclib.minikey reads Casascius minikeys, a module of its own (closes #653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,21 @@ is `wif_from_prv_key` and `b58.p2pkh` in the caller's own code now.
   this half; a second one adds the transport and the default that comes
   with it.
 
+### `btclib.minikey` reads Casascius minikeys (closes #653)
+
+`minikey.prv_key_data_from_minikey` turns a Casascius minikey into a
+`key.PrvKeyData`: `sha256(text)` is the private key, mainnet and
+uncompressed by the format's own convention, and `sha256(text + "?")`
+starting with a zero byte is its own typo check. A string of another
+shape refuses as NotAPrvKeyError -- too short, a first character other
+than `S`, a character outside the base58 alphabet -- and a well-shaped
+minikey whose typo check fails refuses as InvalidPrvKeyError. The format
+is neither Base58Check nor a `to_prv_key` spelling, so it lives in a
+module of its own rather than in `b58` or `to_prv_key`, and the module
+publishes no way to write one: Casascius physical coins stopped being
+made in 2013, and generating a key this short is not something to do
+today.
+
 ## v2026.9.3
 
 ### Repository

--- a/README.md
+++ b/README.md
@@ -311,7 +311,8 @@ The rest, roughly bottom-up. `alias` holds the types the public API
 accepts, much of it taking anything convertible rather than one type, and
 `exceptions` the errors it raises. `to_prv_key` and `to_pub_key` resolve
 the key spellings below them into one; a WIF is not among those, being
-`b58`'s own and read there. `bip32` and `mnemonic` derive keys.
+`b58`'s own and read there, and neither is a Casascius minikey, being
+`minikey`'s own and read-only there. `bip32` and `mnemonic` derive keys.
 `script`, `tx`, `block` and `psbt` build and validate what goes on
 the chain, and `script.engine` runs a transaction against the consensus
 rules. `p2p` is the wire format peers speak — the message envelope, its

--- a/docs/source/btclib.rst
+++ b/docs/source/btclib.rst
@@ -177,6 +177,13 @@ btclib.key module
    :members:
    :show-inheritance:
 
+btclib.minikey module
+---------------------
+
+.. automodule:: btclib.minikey
+   :members:
+   :show-inheritance:
+
 btclib.muhash module
 --------------------
 

--- a/src/btclib/__init__.py
+++ b/src/btclib/__init__.py
@@ -107,6 +107,7 @@ __all__ = [
     "hwi",
     "kdf",
     "key",
+    "minikey",
     "mnemonic",
     "muhash",
     "network",

--- a/src/btclib/minikey.py
+++ b/src/btclib/minikey.py
@@ -1,0 +1,106 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Casascius minikey support.
+
+A minikey is a short base58 string -- 20 characters or more, always
+starting with `S` -- that stands for a private key: `sha256(text)` is the
+key itself, and `sha256(text + "?")` beginning with a zero byte is the
+format's own typo check. Casascius physical bitcoins printed one on the
+paper disc under their security hologram, at 22 characters for the
+Series 1 coins and 30 for every series after -- neither length is
+enforced on its own here, matching
+`electrum/bitcoin.py:757-769` (`spesmilo/electrum`, pinned at
+`342bca3a`) exactly.
+
+**The string is never base58-decoded.** A minikey carries no version
+prefix and no Base58Check payload behind it -- the base58 alphabet is
+only the character set it happens to be drawn from -- so this module
+owns the format rather than `btclib.b58`, which decodes Base58Check and
+nothing else.
+
+**The format is dead, and read-only by design.** Casascius stopped
+making physical coins in 2013, after FinCEN classified them as money
+transmission; a 30-character minikey carries about 160 bits of entropy
+and a 22-character one about 128, well short of what a private key
+generated today should have. btclib reads a minikey because the coins
+already exist and their keys have to be swept out of them, and it
+publishes no way to build one.
+"""
+
+from __future__ import annotations
+
+from btclib.exceptions import InvalidPrvKeyError, NotAPrvKeyError
+from btclib.hashes import sha256
+from btclib.key import PrvKeyData
+from btclib.network import network_from_name
+from btclib.utils import assert_type
+
+__all__ = ["prv_key_data_from_minikey"]
+
+# base58's own alphabet, matched here as a plain character set rather than
+# imported from btclib.base58: that module's _ALPHABET is private to it,
+# and reaching for it would buy nothing a minikey needs -- this module
+# checks characters, never runs the base58 decoder that alphabet feeds
+_ALPHABET = frozenset("123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz")
+
+# electrum/bitcoin.py:758-759 (spesmilo/electrum, pinned at 342bca3a):
+# "Minikeys are typically 22 or 30 characters, but this routine permits
+# any length of 20 or more provided the minikey is valid." 22 is what
+# Casascius Series 1 holograms used and 30 what every later series and
+# every other generator uses; electrum enforces neither length on its
+# own, only the floor between the two, which is what this module matches
+_MIN_LENGTH = 20
+
+
+def prv_key_data_from_minikey(minikey: str) -> PrvKeyData:
+    """Return the private key a Casascius minikey encodes.
+
+    Two error classes, in refusal order, the same split
+    `b58.prv_key_data_from_wif` draws for a WIF. The first three checks
+    below -- the length, the leading `S`, the alphabet -- ask "is this
+    shape a minikey at all", and a no is a NotAPrvKeyError: nothing else
+    in this format could have produced such a string, so a caller trying
+    several key formats in turn is told to keep going rather than stop.
+    The `?`-suffix check asks "is this particular, well-shaped minikey
+    sound", and a no is an InvalidPrvKeyError: the shape is a minikey's,
+    the typo check is what failed, and it is what the check exists to
+    catch -- with probability 255/256 for one wrong character, never a
+    proof that no character is wrong, and no other format will read the
+    same string differently.
+
+    No message echoes the input or any part of it: unlike a WIF, whose
+    text is Base58Check encoding a payload distinct from it, a minikey's
+    text is the key material itself, `sha256(minikey)` being the private
+    key it stands for.
+
+    The key a minikey encodes carries no network of its own -- Casascius
+    coins are a mainnet artefact -- and, by the same physical-coin
+    convention, no compression flag beyond "uncompressed": both are
+    fixed rather than read from the string.
+    """
+    assert_type(minikey, str, "minikey")
+
+    if len(minikey) < _MIN_LENGTH:
+        err_msg = (
+            f"wrong minikey length: {len(minikey)}, at least {_MIN_LENGTH} required"
+        )
+        raise NotAPrvKeyError(err_msg)
+    if minikey[0] != "S":
+        raise NotAPrvKeyError("not a minikey: does not start with 'S'")
+    if not all(c in _ALPHABET for c in minikey):
+        raise NotAPrvKeyError("not a minikey: character outside the base58 alphabet")
+
+    if sha256((minikey + "?").encode("ascii"))[0] != 0x00:
+        raise InvalidPrvKeyError("invalid minikey: failed checksum")
+
+    q = int.from_bytes(sha256(minikey.encode("ascii")), byteorder="big")
+    ec = network_from_name("mainnet").curve
+    if not 0 < q < ec.n:
+        raise InvalidPrvKeyError("private key not in 1..n-1")
+
+    # every field has just been checked -- the shape, the checksum, the
+    # scalar ranged on the curve -- so the constructor is not asked to
+    # check them again
+    return PrvKeyData(q, "mainnet", False, check_validity=False)

--- a/tests/minikey_test.py
+++ b/tests/minikey_test.py
@@ -1,0 +1,113 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the `btclib.minikey` module."""
+
+from __future__ import annotations
+
+import pytest
+
+from btclib import minikey
+from btclib.curves import secp256k1
+from btclib.exceptions import BTClibTypeError, InvalidPrvKeyError, NotAPrvKeyError
+
+ec = secp256k1
+
+
+def test_prv_key_data_from_minikey() -> None:
+    """Casascius's own published example, and electrum's.
+
+    https://en.bitcoin.it/wiki/Mini_private_key_format (the 30-character
+    example, with its embedded "_SAMPLE_..._" placeholders stripped) and
+    tests/test_bitcoin.py (spesmilo/electrum, pinned at 342bca3a, the
+    22-character `priv_pub_addr` row with `minikey: True`).
+    Both keys are cross-checked independently against the WIF and the
+    address each source publishes beside its minikey, ahead of this
+    file: `sha256(minikey)` equals the WIF payload's key bytes, and
+    hashing the electrum row's own uncompressed public key to a p2pkh
+    address reproduces the address given there.
+    """
+    test_vectors = [
+        (
+            "S6c56bnXQiBjk9mqSYE7ykVQ7NzrRy",
+            34592368842595783461480169529335747692719505392594229791591388717055904041387,
+        ),
+        (
+            "SzavMBLoXU6kDrqtUVmffv",
+            105627842363267744400190144423808258002852957479547731009248450467191077417570,
+        ),
+    ]
+    for text, q in test_vectors:
+        data = minikey.prv_key_data_from_minikey(text)
+        assert (data.q, data.network, data.compressed) == (q, "mainnet", False)
+
+
+def test_wrong_length() -> None:
+    """Fewer than 20 characters: electrum's own floor, not a minikey shape."""
+    with pytest.raises(
+        NotAPrvKeyError, match="wrong minikey length: 19, at least 20 required"
+    ):
+        minikey.prv_key_data_from_minikey("SzavMBLoXU6kDrqtUVm")
+
+
+def test_empty_string() -> None:
+    """The same length check, at its most extreme."""
+    with pytest.raises(
+        NotAPrvKeyError, match="wrong minikey length: 0, at least 20 required"
+    ):
+        minikey.prv_key_data_from_minikey("")
+
+
+def test_wrong_first_character() -> None:
+    """Every minikey starts with 'S'; nothing else does."""
+    with pytest.raises(NotAPrvKeyError, match="does not start with 'S'"):
+        minikey.prv_key_data_from_minikey("TzavMBLoXU6kDrqtUVmffv")
+
+
+def test_character_outside_alphabet() -> None:
+    """'0' is one of the four look-alike characters base58 excludes."""
+    with pytest.raises(NotAPrvKeyError, match="character outside the base58 alphabet"):
+        minikey.prv_key_data_from_minikey("S0avMBLoXU6kDrqtUVmffv")
+
+
+def test_failed_checksum() -> None:
+    """Right shape, wrong typo check: a minikey with a fault in it.
+
+    The electrum vector with its last character changed from 'v' to '1',
+    still 22 base58 characters starting with 'S', but
+    `sha256(text + "?")` no longer starts with a zero byte.
+    """
+    with pytest.raises(InvalidPrvKeyError, match="invalid minikey: failed checksum"):
+        minikey.prv_key_data_from_minikey("SzavMBLoXU6kDrqtUVmff1")
+
+
+def test_wrong_type() -> None:
+    """A non-string input is the caller's own mistake, not a format guess."""
+    with pytest.raises(BTClibTypeError, match="invalid minikey type: int"):
+        minikey.prv_key_data_from_minikey(0)  # type: ignore[arg-type]
+
+
+def test_out_of_range_scalar(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A checksum-valid minikey whose derived scalar is out of range.
+
+    Unlike a WIF, whose scalar is the payload and can be set directly,
+    a minikey's scalar is `sha256(text)`: nothing in this module lets a
+    caller choose it, and no real text produces one equal to `ec.n`. The
+    branch is tripped by patching the hash rather than searched for:
+    CONTRIBUTING.md's coverage rule takes 100% literally, so a statement
+    no test reaches is either covered by patching what stands in the way
+    -- as the ripemd160 fallback and electrum's round-trip check are --
+    or marked `pragma: no cover` with the reason beside it.
+    """
+    good_minikey = "SzavMBLoXU6kDrqtUVmffv"
+    bad_q = ec.n.to_bytes(32, byteorder="big")
+
+    def fake_sha256(data: bytes) -> bytes:
+        if data.endswith(b"?"):
+            return b"\x00" * 32  # still passes the typo check
+        return bad_q
+
+    monkeypatch.setattr(minikey, "sha256", fake_sha256)
+    with pytest.raises(InvalidPrvKeyError, match="private key not in 1..n-1"):
+        minikey.prv_key_data_from_minikey(good_minikey)


### PR DESCRIPTION
Closes #653

A Casascius minikey is a short base58 string beginning with `S` whose
private key is `sha256(text)` over the characters, with
`sha256(text + "?")[0] == 0x00` as a typo check. This adds
`btclib.minikey`, a module of its own, with
`prv_key_data_from_minikey` returning a `key.PrvKeyData` — the shape
`b58.prv_key_data_from_wif` took when #1188's WIF row landed.

**Why a module and not `b58`.** A minikey is not Base58Check. It carries
no version prefix and no four-byte checksum, it is never `b58decode`d,
and the base58 alphabet is the character set the string is drawn from
and nothing more. Filing it under `b58` would file it under an encoding
it does not use. And not `to_prv_key` either, for the reason the WIF
left: a format with its own validity discipline is parsed by the module
that owns the format.

**The exception split is argued, not picked.** A wrong length, a first
character that is not `S`, and a character outside the alphabet are
`NotAPrvKeyError` — the string is not a minikey and another spelling may
read it. A failed `?`-check is `InvalidPrvKeyError`, because by then the
length, the prefix and the alphabet have already identified the format
uniquely; nothing else reads an `S…` of that shape. This is the opposite
of `b58.prv_key_data_from_wif`, where a failed Base58Check checksum is
`NotAPrvKeyError` — and deliberately so: there the checksum runs *before*
anything is identified, so a failure says only "this base58 text is not
sound", which several formats could still claim.

**The format is dead, and the module says so.** Casascius stopped in
2013 after FinCEN, and a minikey is not something to generate today.
btclib reads one because the coins exist and their keys have to be
swept; it publishes no constructor. Parsing what exists is not
recommending it.

Both vectors are Casascius's own published 30-character example and
electrum's 22-character one, each cross-checked against the WIF and the
address its source publishes beside it rather than against this code.
Every rejection path has its own test asserting the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTeFVfKekJi8DqL6MdYPb

## Summary by Sourcery

Add support for reading legacy Casascius minikeys without providing a way to generate them.

New Features:
- Add read-only Casascius minikey parsing that returns mainnet, uncompressed private-key data derived from the minikey text.

Enhancements:
- Expose minikey support as a dedicated module distinct from Base58Check and generic key parsing, with format-specific validation and error handling.

Documentation:
- Document the minikey module and its legacy, sweep-only purpose in the changelog, README, and API documentation.

Tests:
- Add published Casascius and Electrum vectors plus coverage for type, shape, checksum, and derived-key validation failures.