### PR TITLE
CLAUDE.md's worktree-removal fence takes the ${WT:?} guard (closes btclib-org/.github#790)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,16 @@ in this tree would leak its key through cache timing. `decrypt` returns
 a `key.PrvKeyData`, the shape a parsed private key takes everywhere else
 in this library since #1188's WIF row landed.
 
+### `CLAUDE.md`'s worktree-removal fence takes the `${WT:?}` guard
+
+- **`CLAUDE.md`'s worktree-removal fence closes with `${WT:?}` rather
+  than a bare `"$WT"`, and its paragraph gains the sentence explaining
+  why** (closes btclib-org/.github#790): the fence stands in a block of
+  its own precisely so that a paste of it alone still runs, and a bare
+  `"$WT"` there reaches `git worktree remove --force` with whatever
+  `$WT` the shell happens to hold; `${WT:?}` turns an unset `$WT` into a
+  shell refusal instead.
+
 ## v2026.9.3
 
 ### Repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,9 +138,11 @@ Removing the worktree is part of finishing, and it stands in a block of
 its own: the block above ends in a placeholder, and a shell that
 discards that line as a parse error reads the next as a fresh command —
 which, in one block, is this line against whatever `$WT` already held.
+Standing alone it is a second fence, so `${WT:?}` is what it writes:
+with no `$WT` set the expansion fails and the removal does not run.
 
 ```shell
-git worktree remove --force "$WT"
+git worktree remove --force "${WT:?}"
 ```
 
 The venv is the whole of the cost, and it buys the thing that matters: a


### PR DESCRIPTION
The last of the nine, so this landing closes ISS 790.

`CLAUDE.md`'s worktree-removal fence takes the `${WT:?}` guard, and the
paragraph above it gains the standard's clause saying what the `:?` is
for.

That fence stands in a block of its own, which is what makes it a
*second* fence — and a second fence pasted alone is a live command that
runs with whatever `$WT` the shell already holds. Section 9 has such a
fence write each value the reader was to set as `${name:?}`, and has the
prose beside it say what the `:?` is doing there, "since a reader who is
not told deletes it".

The clause is `btclib-org/.github`'s own, read live from that tree at
its tip rather than retyped, and byte-identical to it. Nothing here
asserts what `git worktree remove --force ""` does — it was not run, so
the prose stops at what the *shell* does with an unset variable. ISS
790's own body makes the stronger claim and none of the nine landings
repeated it.

Only the removal fence is touched. The `cd "$WT"` worktree fence is
[ISS 739](https://github.com/btclib-org/.github/issues/739)'s, open and
undecided, and this tree is also the subject of
[ISS 794](https://github.com/btclib-org/.github/issues/794), whose
doubled sentences sit above both fences and are left alone.

**`btclib-node`'s further sentence is not written here, or anywhere.**
It names what the guard does *not* catch — a `$WT` an earlier session
left set, which `${WT:?}` does nothing about — and
`btclib-org/.github` does not carry it. That divergence was filed as
[ISS 797](https://github.com/btclib-org/.github/issues/797) **before any
of these nine branches was dispatched**, precisely so that seven trees
would not each decide it in silence. It is still open, and the standard
still stops where it stopped.

The changelog entry gets a `###` of its own at the end of the open
section. It first went in as a fifth bullet under an existing heading,
which review caught: section 9 says *"A `###` names one entry, never a
theme several entries share"*, and *"Where an open section already
carries theme headings, the next entry goes after them, at the end of
the section, and nothing above it moves."* The heading it had been
appended to is back to its original four bullets, byte-identical to
`main`'s.

Closes btclib-org/.github#790

CLAUDE.md's worktree-removal fence takes the ${WT:?} guard (closes btclib-org/.github#790)

The worktree-removal fence closes with `${WT:?}` rather than a bare
`"$WT"`, and its paragraph gains the sentence explaining why: standing
alone it is a second fence, and an unset `$WT` now fails the expansion
and refuses the removal rather than running it against whatever the
shell happens to hold. CHANGELOG.md records the change under its own
heading, at the end of the open v2026.9 section.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CxwWEa8nRid69sZ81isSa1


Local review: round 1 CHANGES REQUESTED on the changelog heading, round 2 CLEARED 51806df, which is this head, by the same reviewer resumed rather than replaced. It ran no gates and says so; what it verified itself was that the heading the bullet left is byte-identical to `main`'s four original bullets, that the blank-line invariant passes on the real file while firing on a hand-damaged copy, and that the qualified citation is not orphaned from its verb. Gates on that tree, the coder's runs on this tip, each exit as intended: `uv run pre-commit run --all-files` exit 0 at load 3.09, its log captured whole rather than tailed; `uv run pytest --basetemp=<outside the worktree>` exit 0 at 4.13, `31924 passed, 30 skipped, 1 xfailed`, coverage 100.00%, the single xfail pre-existing and outside this diff; `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html` exit 0, run after polling a spike of 12.64 down to 5.78 — a changelog-only diff does not exempt it, `docs/source/changelog_link.md` pulling `../../CHANGELOG.md` under `-W`; and the cross-link grep exiting 1, which is what its job wants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpcKzs2UfKjjrgU6bj1b5i

## Summary by Sourcery

Guard the standalone worktree-removal fence against an unset worktree path and document the safety rationale.

Bug Fixes:
- Protect the standalone worktree-removal command from running when `$WT` is unset by requiring `${WT:?}` during expansion.

Enhancements:
- Clarify in `CLAUDE.md` why the worktree-removal fence requires the shell guard.

Documentation:
- Add a dedicated changelog entry documenting the guarded worktree-removal fence and its behavior.