### PR TITLE
SECURITY.md's fetch-trust bullet accounts for each answer, and EsploraFetcher gains verify_network (closes #1673, closes #1674)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,6 +273,37 @@ in this library since #1188's WIF row landed.
   `$WT` the shell happens to hold; `${WT:?}` turns an unset `$WT` into a
   shell refusal instead.
 
+### SECURITY.md's fetch-trust bullet accounts for every answer (closes #1673)
+
+The `btclib.fetch` trust bullet stops saying only the transaction's id is
+checked. The block header is parsed and validated on arrival by every
+backend's `get_block_header` -- `assert_valid` and `assert_valid_pow` --
+and an output's amount is covered by the same txid check as the
+transaction it is read from: `Fetcher.get_tx_out` derives it from
+`get_tx`, and no shipped backend overrides it. The bullet also carries
+what the header check does not establish -- the height asked for, or the
+chain meant -- because a security document is read on its own and a
+pointer to a docstring is not an answer there. The height is still the
+backend's word alone, and so is the tip hash from every backend but
+`ElectrumFetcher`, which recomputes it from the header it was sent.
+
+### `EsploraFetcher` gains `verify_network` (closes #1674)
+
+`EsploraFetcher` takes `verify_network`, on by default, asked once before
+the first fetch and not in the constructor: `GET /block-height/0` --
+which `get_block_header` already reads for every other height -- compared
+against `NETWORKS[network].genesis_block`, refusing with both hashes in
+the message on a mismatch. Same name, same keyword-only argument, same
+default, same opt-out as `BitcoinCoreFetcher.verify_network` -- and a
+different question, since it compares one block rather than reading the
+host's own verdict on itself. A genesis hash tells mainnet, testnet,
+testnet4, signet and regtest apart, and no two signets from each other
+-- Core builds every signet's genesis from
+the same parameters, the challenge going into the message start and not
+the block -- which is the same limit the node backends have without a
+`signet_challenge`; SECURITY.md's bullet now says so once for all three
+backends instead of implying Esplora is worse.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -85,6 +85,15 @@ full year, short month, short day (YYYY-M-D)
   `btclib.b58.prv_key_data_from_wif(wif).pub.sec` reads the SEC octets
   `p2wpkh` still takes.
 
+- **`EsploraFetcher` asks which chain the explorer serves, before the
+  first fetch** (closes #1674). An explorer on another chain than the
+  label is now a `BTClibValueError` where it used to be addresses for
+  coins that are not there.
+
+  Act on it if a caller has checked the explorer's chain by other means,
+  or already knows which chain it is asking: `EsploraFetcher(base_url,
+  verify_network=False)` is the previous behaviour.
+
 ### Worth knowing, though nothing raises
 
 - **`psbt_signer_contract.optional_protocols` returns `OptionalProtocols`,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -355,20 +355,44 @@ used to teach and to prototype as much as to build:
     relies on to make that expensive per guess, not a MAC that would
     turn the guess away first
 - **a `btclib.fetch` backend is trusted, and they are not trusted
-    alike.** `BitcoinCoreFetcher` and `BitcoinCoreRestFetcher` talk to a
-    node that validated the chain it reports, and both ask it by default
-    which chain that is, and which signet: `rest_chaininfo` writes out
-    what `getblockchaininfo` answers and adds nothing, so `/chaininfo.json`
-    carries the members the JSON-RPC check reads and `verify_network` and
-    `signet_challenge` hold either backend to the fetcher's label through
-    the same two comparisons. What `-rest` adds is that it authenticates
-    nobody who reaches it, so the endpoint is trusted on whoever handed it
-    over. `EsploraFetcher` talks to a host that says it validated, and
-    asks it nothing about which chain.
-    Only one answer of the four is checked at all — the transaction, whose
-    id is recomputed from the bytes that came back — so a height, a tip
-    hash and the amount of an output all rest on the backend's word. An
-    explorer also learns every txid and outpoint you look up, which is a
+    alike.** `BitcoinCoreFetcher`, `BitcoinCoreRestFetcher` and
+    `EsploraFetcher` all ask by default which chain they are talking to,
+    and `verify_network` is the same name, the same keyword-only
+    argument, the same default and the same opt-out on all three -- not
+    the same question, which is the next sentence. `BitcoinCoreFetcher` and
+    `BitcoinCoreRestFetcher` talk to a node that validated the chain it
+    reports, and `signet_challenge` holds either to the fetcher's label
+    beside `verify_network`: `rest_chaininfo` writes out what
+    `getblockchaininfo` answers and adds nothing, so `/chaininfo.json`
+    carries the members the JSON-RPC check reads. What `-rest` adds is
+    that it authenticates nobody who reaches it, so the endpoint is
+    trusted on whoever handed it over. `EsploraFetcher` talks to a host
+    that says it validated, and its own `verify_network` compares one
+    block rather than reading the host's own verdict on itself:
+    `/block-height/0`, the genesis, against `NETWORKS[network].genesis_block`.
+    None of the three tells two signets apart on a genesis hash alone —
+    Core builds every signet's genesis from the same parameters, the
+    challenge going into the message start and not into the block — so
+    the node backends need `signet_challenge` for that half of the
+    question and `EsploraFetcher`, which takes none, cannot ask it.
+
+    Past that question, the answers a fetch itself makes are checked to
+    different degrees. The transaction: its id is recomputed
+    from the bytes that came back and refused unless it matches. An
+    output's amount: `get_tx_out` derives it from `get_tx`, so it is
+    covered by that same check — no shipped backend overrides it. The
+    block header: parsed and checked for a well-formed, real proof of
+    work by every backend alike, which says it is well-formed and cost
+    real work and not that it is the header at the height asked for or
+    on the chain meant — `Fetcher.get_block_header`'s own docstring is
+    where that caveat is written down. The height rests on the backend's
+    word. So does the tip hash, from every backend but one:
+    `ElectrumFetcher`'s `headers.subscribe` answers the tip's header
+    rather than a hash field, so what comes back is the hash of eighty
+    bytes that passed the same check, and not a string the server
+    chose.
+
+    An explorer also learns every txid and outpoint you look up, which is a
     good deal of what a wallet is; btclib names a public deployment as a
     constant and never as a default, so nothing here contacts anyone
     until a caller writes the endpoint down. `Broadcaster.broadcast` is a

--- a/src/btclib/fetch/esplora.py
+++ b/src/btclib/fetch/esplora.py
@@ -16,29 +16,39 @@ reason, and naming it here is the evidence for the sentence above rather
 than a recommendation.
 
 What the fallback promises is the same four answers behind the same
-interface. What it does not promise is that they are true. A node
-validated the chain it reports; an explorer is a host on the internet
-that says it did. `get_tx` is the one answer that checks itself
-completely, in `tx_from_raw` -- the serialization comes back and the id
-is recomputed from it, so a substituted transaction is caught.
-`get_block_header` checks less: `block_header_from_raw` only asks
-whether the eighty bytes are well-formed and cost a real hash to mine,
-which is cheap for a host to fabricate compared with the transaction it
-would have to forge to pass the id check. The height and the tip hash
-have nothing here to check them against at all, and are taken on trust.
+interface. What it does not promise is that they are all true. `get_tx`
+is the one answer that checks itself completely, in `tx_from_raw` -- the
+serialization comes back and the id is recomputed from it, so a
+substituted transaction is caught. `get_block_header` checks less:
+`block_header_from_raw` only asks whether the eighty bytes are
+well-formed and cost a real hash to mine, which is cheap for a host to
+fabricate compared with the transaction it would have to forge to pass
+the id check. The height and the tip hash have nothing here to check
+them against at all, and are taken on trust.
+
+Which chain the explorer serves is a separate question from those four,
+and `verify_network` is what asks it: on by default, the same name and
+the same opt-out `BitcoinCoreFetcher.verify_network` is, comparing
+`/block-height/0` against the genesis `NETWORKS` carries for the network
+this fetcher was built for. The failure it catches is the same silent
+one -- a fetcher labelled `mainnet` over a host serving another chain
+renders a mainnet address for every output it fetches -- and what a
+genesis hash cannot do is separate two signets; `assert_network`'s own
+docstring says why.
+
 Nor does anything here say a transaction is *confirmed*: the answer to
 that is a merkle branch checked against a header, which is what the
-Electrum backend of issue #204 would add and this one cannot. That is
-the trade the fallback exists to offer, and `SECURITY.md` states it.
+Electrum backend of issue #204 adds and this one cannot. That is the
+trade the fallback exists to offer, and `SECURITY.md` states it.
 
-Five endpoints, each answering in plain text rather than json:
+The endpoints reached here answer in plain text rather than json:
 `/tx/<txid>/hex`, `/blocks/tip/height`, `/blocks/tip/hash`,
-`/block-height/<height>` and `/block/<hash>/header`. The json renderings
-beside them carry the same values with more to disagree about -- and
-`/hex` is what makes the id check above possible at all. That those five
-are what a second deployment has to serve is why they are the thing to
-check before naming one: a host answering json where this expects text
-is not compatible in the way that matters.
+`/block-height/<height>` and `/block/<hash>/header`, read; `POST /tx`,
+written. The json renderings beside them carry the same values with more
+to disagree about -- and `/hex` is what makes the id check above possible
+at all. That these are what a second deployment has to serve is why they
+are the thing to check before naming one: a host answering json where
+this expects text is not compatible in the way that matters.
 """
 
 from __future__ import annotations
@@ -47,7 +57,7 @@ from typing_extensions import override
 
 from btclib.alias import Octets
 from btclib.block.block_header import BlockHeader
-from btclib.exceptions import FetchError, HttpError
+from btclib.exceptions import BTClibValueError, FetchError, HttpError
 from btclib.fetch.fetcher import (
     Fetcher,
     block_header_from_raw,
@@ -64,6 +74,7 @@ from btclib.fetch.transport import (
     http_request,
     urlopen_transport,
 )
+from btclib.network import NETWORKS
 from btclib.tx import Tx
 from btclib.utils import bytes_from_octets
 
@@ -111,6 +122,17 @@ class EsploraFetcher(Fetcher):
     this class that writes. Holding a fetcher is not broadcasting; a
     caller has to call the method, and `broadcast`'s own docstring is
     where its non-idempotence is stated, at the point a caller meets it.
+
+    `verify_network` is who asks whether the explorer is on the chain
+    this fetcher labels with. On by default and before the first fetch
+    rather than in this constructor: the answer costs a round trip that
+    is worth paying where it is checked and wasted where a fetcher is
+    built and never used, and an explorer that is merely unreachable
+    should not be a failure to *construct* anything. The answer is then
+    kept -- an explorer does not change chain under a client that goes on
+    pointing at it -- and a caller that would rather not ask says
+    `verify_network=False`. Same name, same keyword-only argument, same
+    default, same opt-out as `BitcoinCoreFetcher.verify_network`.
     """
 
     def __init__(
@@ -118,6 +140,7 @@ class EsploraFetcher(Fetcher):
         base_url: str,
         *,
         network: str = "mainnet",
+        verify_network: bool = True,
         timeout: float = DEFAULT_TIMEOUT,
         transport: HttpTransport = urlopen_transport,
     ) -> None:
@@ -125,6 +148,37 @@ class EsploraFetcher(Fetcher):
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
         self.transport = transport
+        self.verify_network = verify_network
+        self._agreed = False
+        self._disagreement = ""
+
+    def _verify_once(self) -> None:
+        """Compare the explorer's chain with this fetcher's label, once.
+
+        `BitcoinCoreFetcher._verify_once`, unchanged: called by the four
+        fetches and by `broadcast`, and not by `text` or `_request`,
+        which is what `assert_network` itself goes through -- a check in
+        there would ask the explorer about the explorer, from inside the
+        question.
+
+        A disagreement is remembered and raised again for every later
+        call, because it is a settled fact about a configuration rather
+        than a request that failed -- and a fetcher that asked once,
+        refused once and then served an address would be the silent
+        failure this exists to stop. A `FetchError` is not an answer and
+        is remembered as nothing: the explorer was unreachable or spoke
+        nonsense, which the next call may well find otherwise.
+        """
+        if not self.verify_network or self._agreed:
+            return
+        if self._disagreement:
+            raise BTClibValueError(self._disagreement)
+        try:
+            self.assert_network()
+        except BTClibValueError as e:
+            self._disagreement = str(e)
+            raise
+        self._agreed = True
 
     def _request(
         self, path: str, *, data: bytes | None, max_body_size: int
@@ -187,6 +241,7 @@ class EsploraFetcher(Fetcher):
     @override
     def get_tx(self, tx_id: Octets) -> Tx:
         """Return the transaction, parsed and checked against its txid."""
+        self._verify_once()
         hex_ = tx_id_hex(tx_id)
         raw = self.text(f"/tx/{hex_}/hex", _MAX_TX_BODY)
         return tx_from_raw(raw, hex_, self.network)
@@ -194,12 +249,14 @@ class EsploraFetcher(Fetcher):
     @override
     def get_block_count(self) -> int:
         """Return the height of the server's best chain tip."""
+        self._verify_once()
         with fetch_errors("blocks/tip/height"):
             return int(self.text("/blocks/tip/height", _MAX_HEIGHT_BODY))
 
     @override
     def get_best_block_id(self) -> bytes:
         """Return the hash of the server's best chain tip, display order."""
+        self._verify_once()
         with fetch_errors("blocks/tip/hash"):
             return bytes_from_octets(self.text("/blocks/tip/hash", _MAX_HASH_BODY), 32)
 
@@ -211,6 +268,7 @@ class EsploraFetcher(Fetcher):
         hash `/block/<hash>/header` takes, both plain text like the tip
         endpoints above.
         """
+        self._verify_once()
         height = block_header_height(height)
         with fetch_errors("block-height"):
             reply = self.text(f"/block-height/{height}", _MAX_HASH_BODY)
@@ -218,8 +276,58 @@ class EsploraFetcher(Fetcher):
         raw = self.text(f"/block/{block_hash}/header", _MAX_HEADER_BODY)
         return block_header_from_raw(raw, height)
 
+    def assert_network(self) -> None:
+        """Raise unless the explorer serves the chain this fetcher labels with.
+
+        One request, `/block-height/0` -- the same endpoint
+        `get_block_header` reads for every other height, asked here for
+        the block every chain starts from -- compared against
+        `NETWORKS[self.network].genesis_block`.
+
+        Public for the same reason `BitcoinCoreFetcher.assert_network` is
+        -- a caller that wants the question answered at a moment of its
+        own.
+
+        Worth the call, because the failure it catches is silent, the
+        same one `BitcoinCoreFetcher.assert_network`'s docstring names: a
+        fetcher labelled `mainnet` over an explorer serving another chain
+        renders a mainnet address for every output it fetches, for coins
+        that are not there.
+
+        Signet is the case a genesis hash cannot settle: Core builds
+        every signet's genesis from the same parameters
+        (`kernel/chainparams.cpp`), the challenge going into the message
+        start and not into the block, so this check separates mainnet,
+        testnet, testnet4, signet and regtest, and separates no two
+        signets -- the same limit the node backends have when no
+        `signet_challenge` is given. This class takes no
+        `signet_challenge` of its own: nothing Esplora's api publishes is
+        a signet's challenge to compare it against.
+
+        A malformed reply is a `FetchError`. A disagreement is a
+        `BTClibValueError` naming both hashes: the explorer is the
+        authority on which chain it serves, so the fetcher's label is the
+        thing to fix.
+        """
+        with fetch_errors("block-height"):
+            reply = self.text("/block-height/0", _MAX_HASH_BODY)
+            reported = bytes_from_octets(reply, 32)
+        expected = NETWORKS[self.network].genesis_block
+        if reported != expected:
+            err_msg = f"{self.base_url} serves a chain whose genesis is"
+            err_msg += f" {reported.hex()}, not the {expected.hex()}"
+            err_msg += f" {self.network} was built for"
+            raise BTClibValueError(err_msg)
+
     def broadcast(self, tx: Tx) -> bytes:
         """Announce `tx` to the server, and return the txid it confirmed.
+
+        `_verify_once` is called first, as every other method here calls
+        it -- but a broadcast to a server on the wrong chain is the worst
+        version of the silent failure `verify_network` exists to catch: a
+        fetch answering with the wrong data is corrected on the next
+        read, where a signed transaction fanned out to the wrong
+        network's peers cannot be called back.
 
         `POST /tx` with the wire serialization's hex, witness included, as
         the body -- what a peer relays and eventually mines, not the
@@ -243,6 +351,7 @@ class EsploraFetcher(Fetcher):
         `text` reports one for a GET: an Esplora deployment answers a
         rejected transaction with a 400 and the reason in plain text.
         """
+        self._verify_once()
         txid = tx.id
         hex_ = tx.serialize(include_witness=True).hex()
         status, answer = self._request(

--- a/src/btclib/fetch/fetcher.py
+++ b/src/btclib/fetch/fetcher.py
@@ -271,10 +271,10 @@ def tx_from_raw(raw: Octets, tx_id: str, network: str) -> Tx:
 
     Every backend answers `get_tx` with the serialization rather than with
     a rendering of it, and this is why: the id is a hash of those bytes,
-    so recomputing it says whether what arrived is what was asked for. No
-    other answer here can be checked at all -- a height and a tip hash
-    are taken on the backend's word -- and this one costs a hash of a few
-    hundred bytes.
+    so recomputing it says whether what arrived is what was asked for. A
+    height is taken on the backend's word and a block header answers for
+    itself, which `SECURITY.md` states per answer rather than here; this
+    one costs a hash of a few hundred bytes.
 
     It is not only the untrusted backend it guards. A node behind a
     caching proxy, a truncated response and a request that raced another

--- a/tests/bool_parameter_test.py
+++ b/tests/bool_parameter_test.py
@@ -130,6 +130,7 @@ from btclib.ecc import bms, dsa, musig2, ssa
 from btclib.exceptions import BTClibTypeError
 from btclib.fetch.bitcoin_core import BitcoinCoreFetcher
 from btclib.fetch.bitcoin_core_rest import BitcoinCoreRestClient, BitcoinCoreRestFetcher
+from btclib.fetch.esplora import EsploraFetcher
 from btclib.hwi import HwiSigner, enumerate_devices
 from btclib.key import PrvKeyData
 from btclib.mnemonic import bip39, slip39
@@ -1045,6 +1046,14 @@ _TRUTHS = (
         },
         reason="whether the node is asked which chain it serves, the same"
         " check over -rest, `/chaininfo.json` carrying the same `chain`",
+    ),
+    _Case(
+        "btclib.fetch.esplora.EsploraFetcher.__init__",
+        "verify_network",
+        EsploraFetcher,
+        {"base_url": "https://esplora.example/api", "transport": Recorded()},
+        reason="whether the explorer is asked which chain it serves; the"
+        " same check under the same name, made before its first fetch",
     ),
     _Case(
         "btclib.bip32.bip32.derive_from_account",

--- a/tests/fetch/esplora_test.py
+++ b/tests/fetch/esplora_test.py
@@ -16,6 +16,7 @@ import pytest
 from btclib.exceptions import BTClibTypeError, BTClibValueError, FetchError, HttpError
 from btclib.fetch.esplora import BLOCKSTREAM_INFO, EsploraFetcher
 from btclib.fetch.transport import SessionTransport
+from btclib.network import NETWORKS
 from btclib.tx import OutPoint, Tx
 from tests.fetch import (
     TIP_HEADER_RAW,
@@ -31,6 +32,9 @@ BASE = "https://esplora.example/api"
 # the recorded one, and not the one asked for
 OTHER_ID = "b1fea52486ce0c62bb442b530a3f0132b826c74e473d1f2c220bfa78111c5082"
 
+MAINNET_GENESIS = NETWORKS["mainnet"].genesis_block.hex()
+TESTNET_GENESIS = NETWORKS["testnet"].genesis_block.hex()
+
 
 def broadcast_tx() -> Tx:
     """Return the recorded transaction, parsed, as a signed Tx to announce.
@@ -44,10 +48,20 @@ def broadcast_tx() -> Tx:
 def fetcher(
     *answers: tuple[int, bytes] | Exception, **kwargs: object
 ) -> EsploraFetcher:
-    """Build an EsploraFetcher whose transport replays the answers."""
+    """Build an EsploraFetcher whose transport replays the answers.
+
+    `verify_network=False` unless a test says otherwise: the scripted
+    replies are consumed in order, so a fetcher that asked the explorer
+    which chain it serves would eat the reply the test wrote for the call
+    it is about. The tests that *are* about the question say so and
+    script the `/block-height/0` reply first.
+    """
+    verify_network = kwargs.pop("verify_network", False)
+    assert isinstance(verify_network, bool)
     return EsploraFetcher(
         BASE,
         transport=Recorded(*answers),
+        verify_network=verify_network,
         **kwargs,  # type: ignore[arg-type]
     )
 
@@ -88,14 +102,16 @@ def test_an_unknown_network_is_refused() -> None:
 def test_a_trailing_slash_does_not_double_up() -> None:
     """Verify a base URL with a trailing slash builds a clean request."""
     transport = Recorded((200, recorded_body("esplora_blocks_tip_height.txt")))
-    EsploraFetcher(BASE + "/", transport=transport).get_block_count()
+    esplora = EsploraFetcher(BASE + "/", transport=transport, verify_network=False)
+    esplora.get_block_count()
     assert transport.request.full_url == f"{BASE}/blocks/tip/height"
 
 
 def test_get_tx_asks_for_the_serialization_not_the_rendering() -> None:
     """`/hex`, which is what lets the id be recomputed from the answer."""
     transport = Recorded((200, recorded_body("esplora_tx_hex.txt")))
-    tx = EsploraFetcher(BASE, transport=transport).get_tx(TX_ID)
+    esplora = EsploraFetcher(BASE, transport=transport, verify_network=False)
+    tx = esplora.get_tx(TX_ID)
     assert transport.request.full_url == f"{BASE}/tx/{TX_ID}/hex"
     assert transport.request.get_method() == "GET"
     assert tx.id.hex() == TX_ID
@@ -136,11 +152,13 @@ def test_the_tip_is_two_endpoints_and_not_one() -> None:
     pair of round trips that a reorg can fall between.
     """
     height = Recorded((200, recorded_body("esplora_blocks_tip_height.txt")))
-    assert EsploraFetcher(BASE, transport=height).get_block_count() == TIP_HEIGHT
+    height_esplora = EsploraFetcher(BASE, transport=height, verify_network=False)
+    assert height_esplora.get_block_count() == TIP_HEIGHT
     assert height.request.full_url == f"{BASE}/blocks/tip/height"
 
     tip = Recorded((200, recorded_body("esplora_blocks_tip_hash.txt")))
-    assert EsploraFetcher(BASE, transport=tip).get_best_block_id().hex() == TIP_ID
+    tip_esplora = EsploraFetcher(BASE, transport=tip, verify_network=False)
+    assert tip_esplora.get_best_block_id().hex() == TIP_ID
     assert tip.request.full_url == f"{BASE}/blocks/tip/hash"
 
 
@@ -150,7 +168,8 @@ def test_get_block_header_asks_block_height_then_block_header() -> None:
         (200, recorded_body("esplora_block_height_hash.txt")),
         (200, recorded_body("esplora_block_header.txt")),
     )
-    header = EsploraFetcher(BASE, transport=transport).get_block_header(TIP_HEIGHT)
+    esplora = EsploraFetcher(BASE, transport=transport, verify_network=False)
+    header = esplora.get_block_header(TIP_HEIGHT)
     assert header.hash.hex() == TIP_ID
     assert transport.requests[0].full_url == f"{BASE}/block-height/{TIP_HEIGHT}"
     assert transport.requests[1].full_url == f"{BASE}/block/{TIP_ID}/header"
@@ -160,8 +179,9 @@ def test_get_block_header_asks_block_height_then_block_header() -> None:
 def test_get_block_header_refuses_a_negative_height(height: int) -> None:
     """Refused before any request, both requests mapping a height to a block."""
     transport = Recorded((200, b"unused"))
+    esplora = EsploraFetcher(BASE, transport=transport, verify_network=False)
     with pytest.raises(BTClibValueError, match="invalid height"):
-        EsploraFetcher(BASE, transport=transport).get_block_header(height)
+        esplora.get_block_header(height)
     assert transport.requests == []
 
 
@@ -169,10 +189,9 @@ def test_get_block_header_refuses_a_negative_height(height: int) -> None:
 def test_get_block_header_refuses_a_non_integer_height(height: object) -> None:
     """Refused before any request, the same as a negative one."""
     transport = Recorded((200, b"unused"))
+    esplora = EsploraFetcher(BASE, transport=transport, verify_network=False)
     with pytest.raises(BTClibTypeError, match="invalid height type"):
-        EsploraFetcher(BASE, transport=transport).get_block_header(
-            height  # type: ignore[arg-type]
-        )
+        esplora.get_block_header(height)  # type: ignore[arg-type]
     assert transport.requests == []
 
 
@@ -187,8 +206,91 @@ def test_a_header_that_did_not_mine_the_bits_it_claims_is_refused() -> None:
         (200, recorded_body("esplora_block_height_hash.txt")),
         (200, forged.encode()),
     )
+    esplora = EsploraFetcher(BASE, transport=transport, verify_network=False)
     with pytest.raises(FetchError, match=f"block header {TIP_HEIGHT}: invalid proof"):
-        EsploraFetcher(BASE, transport=transport).get_block_header(TIP_HEIGHT)
+        esplora.get_block_header(TIP_HEIGHT)
+
+
+def test_assert_network_accepts_the_genesis_of_the_network_given() -> None:
+    """The check that passes: the explorer answers the genesis expected."""
+    fetcher((200, MAINNET_GENESIS.encode())).assert_network()
+
+
+def test_assert_network_refuses_a_different_genesis() -> None:
+    """The silent failure this exists for: a testnet host under a mainnet label.
+
+    Both hashes are in the message, so the caller can see which is which.
+    """
+    with pytest.raises(BTClibValueError, match=f"{TESTNET_GENESIS}.*{MAINNET_GENESIS}"):
+        fetcher((200, TESTNET_GENESIS.encode())).assert_network()
+
+
+def test_the_first_fetch_asks_the_explorer_which_chain_it_serves() -> None:
+    """Which is what `verify_network` buys, and it is on by default."""
+    transport = Recorded(
+        (200, MAINNET_GENESIS.encode()), (200, recorded_body("esplora_tx_hex.txt"))
+    )
+    esplora = EsploraFetcher(BASE, transport=transport)
+    assert esplora.get_tx(TX_ID).id.hex() == TX_ID
+    assert transport.requests[0].full_url == f"{BASE}/block-height/0"
+    assert transport.requests[1].full_url == f"{BASE}/tx/{TX_ID}/hex"
+
+
+def test_the_chain_is_asked_for_once_and_not_per_fetch() -> None:
+    """An explorer does not change chain under a client pointing at it."""
+    transport = Recorded(
+        (200, MAINNET_GENESIS.encode()),
+        (200, recorded_body("esplora_blocks_tip_height.txt")),
+        (200, recorded_body("esplora_blocks_tip_hash.txt")),
+    )
+    esplora = EsploraFetcher(BASE, transport=transport)
+    assert esplora.get_block_count() == TIP_HEIGHT
+    assert esplora.get_best_block_id().hex() == TIP_ID
+    assert len(transport.requests) == 3
+    assert transport.requests[0].full_url == f"{BASE}/block-height/0"
+
+
+def test_an_explorer_on_another_chain_answers_no_fetch_at_all() -> None:
+    """The failure the option exists for, and it does not wear off.
+
+    A fetcher that asked once, was refused once and then served an
+    address on the next call would be the silent failure with an extra
+    step, so the disagreement is remembered -- and remembered rather than
+    re-asked, which is what the second call proves by adding no request.
+    """
+    transport = Recorded((200, TESTNET_GENESIS.encode()))
+    esplora = EsploraFetcher(BASE, transport=transport, verify_network=True)
+    for _ in range(2):
+        with pytest.raises(BTClibValueError, match=TESTNET_GENESIS):
+            esplora.get_block_count()
+    assert len(transport.requests) == 1
+
+
+def test_an_explorer_that_could_not_be_asked_is_asked_again() -> None:
+    """An explorer that did not answer said nothing about which chain it is on.
+
+    The distinction the remembering rests on: a chain that disagrees is a
+    fact about a configuration, where a request that did not answer is
+    one to make again.
+    """
+    transport = Recorded(
+        (500, b"internal error"),
+        (200, MAINNET_GENESIS.encode()),
+        (200, recorded_body("esplora_blocks_tip_height.txt")),
+    )
+    esplora = EsploraFetcher(BASE, transport=transport, verify_network=True)
+    with pytest.raises(FetchError, match="HTTP 500"):
+        esplora.get_block_count()
+    assert esplora.get_block_count() == TIP_HEIGHT
+    assert len(transport.requests) == 3
+
+
+def test_verify_network_false_asks_the_explorer_nothing() -> None:
+    """The opt-out is one round trip, and is what this class did before."""
+    transport = Recorded((200, recorded_body("esplora_blocks_tip_height.txt")))
+    esplora = EsploraFetcher(BASE, transport=transport, verify_network=False)
+    assert esplora.get_block_count() == TIP_HEIGHT
+    assert len(transport.requests) == 1
 
 
 def test_a_404_carries_what_the_explorer_said() -> None:
@@ -308,7 +410,8 @@ def test_broadcast_posts_the_wire_serialization_and_returns_the_txid() -> None:
     """`POST /tx`, the hex body, the txid the server answers as text."""
     tx = broadcast_tx()
     transport = Recorded((200, tx.id.hex().encode()))
-    txid = EsploraFetcher(BASE, transport=transport).broadcast(tx)
+    esplora = EsploraFetcher(BASE, transport=transport, verify_network=False)
+    txid = esplora.broadcast(tx)
     assert txid == tx.id
     assert transport.request.full_url == f"{BASE}/tx"
     assert transport.request.get_method() == "POST"
@@ -320,6 +423,34 @@ def test_broadcast_refuses_a_success_naming_another_txid() -> None:
     tx = broadcast_tx()
     with pytest.raises(FetchError, match=f"the server confirmed {OTHER_ID}"):
         fetcher((200, OTHER_ID.encode())).broadcast(tx)
+
+
+def test_broadcast_verifies_the_network_before_sending_anything() -> None:
+    """A wrong-chain explorer is refused before the transaction ever leaves.
+
+    The worst version of the silent failure `verify_network` exists to
+    catch, and the one case where being told late costs more than a wrong
+    address: `POST /tx` is never made at all, `assert_network` consuming
+    the one scripted reply.
+    """
+    transport = Recorded((200, TESTNET_GENESIS.encode()))
+    esplora = EsploraFetcher(BASE, transport=transport, verify_network=True)
+    with pytest.raises(BTClibValueError, match=f"{TESTNET_GENESIS}.*{MAINNET_GENESIS}"):
+        esplora.broadcast(broadcast_tx())
+    assert len(transport.requests) == 1
+    assert transport.requests[0].full_url == f"{BASE}/block-height/0"
+    assert transport.requests[0].get_method() == "GET"
+
+
+def test_broadcast_verifies_the_network_once_like_the_other_methods() -> None:
+    """Agreeing once, a second broadcast goes straight to `POST /tx`."""
+    tx = broadcast_tx()
+    transport = Recorded((200, MAINNET_GENESIS.encode()), (200, tx.id.hex().encode()))
+    esplora = EsploraFetcher(BASE, transport=transport)
+    assert esplora.broadcast(tx) == tx.id
+    assert esplora.broadcast(tx) == tx.id
+    assert transport.requests[0].full_url == f"{BASE}/block-height/0"
+    assert [r.get_method() for r in transport.requests] == ["GET", "POST", "POST"]
 
 
 def test_broadcast_reports_a_400_with_the_explorers_own_body() -> None:

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -251,7 +251,12 @@ KEYWORD_ONLY: dict[str, list[str]] = {
         "signet_challenge",
     ],
     "btclib.fetch:ElectrumFetcher.__init__": ["transport", "timeout"],
-    "btclib.fetch:EsploraFetcher.__init__": ["network", "timeout", "transport"],
+    "btclib.fetch:EsploraFetcher.__init__": [
+        "network",
+        "verify_network",
+        "timeout",
+        "transport",
+    ],
     "btclib.fetch:SessionTransport.__init__": ["max_body_size", "connection_factory"],
     "btclib.fetch:urlopen_transport": ["max_body_size"],
     "btclib.hwi:HwiSigner.__init__": [


### PR DESCRIPTION
Closes #1673
Closes #1674

`SECURITY.md`'s `btclib.fetch` trust bullet said only the transaction's
id was checked. Two of the other answers are checked too, and the bullet
now accounts for each one instead of collapsing them: the block header is
parsed and validated on arrival by every backend's `get_block_header`
(`assert_valid`, `assert_valid_pow`), and an output's amount is covered
by the same txid check as the transaction it is read from, since
`Fetcher.get_tx_out` derives it from `get_tx` and no shipped backend
overrides it. The height rests on the backend's word, and so does the tip
hash from every backend but `ElectrumFetcher`, which recomputes it from
the header `headers.subscribe` answered with.

`EsploraFetcher` gains `verify_network`: the same name, the same
keyword-only argument, the same default and the same opt-out
`BitcoinCoreFetcher` and `BitcoinCoreRestFetcher` already carry. It asks
`GET /block-height/0` once before the first fetch — never in the
constructor — and compares against `NETWORKS[network].genesis_block`,
refusing with both hashes in the message. A genesis hash separates
mainnet, testnet, testnet4, signet and regtest, and no two signets from
each other: Core builds every signet's genesis from the same fixed
parameters, the challenge going into the message start and not the block.

`ElectrumFetcher` asks no such question; that is #1691, filed against
this branch's own review and out of both issues' scope here.

## Review

Three local rounds at fresh context before this was opened. The second
found the defect worth naming: `verify_network=True` is the default
stated in the release note, `SECURITY.md`, `CHANGELOG.md` and two
docstrings, and every test constructed the fetcher passing the flag by
hand — so flipping the default left the suite green. Three tests now take
the default, and the control is that flipping it fails exactly those
three where before it failed nothing.

The same round found two sentences this branch's own correction had
falsified: `Fetcher.tx_from_raw`'s docstring still said no other answer
could be checked at all, and the bullet said "the four answers" over an
enumeration of five.

Gates green on `94b1f31c`: `uv run --locked pytest -q --cov` → 31938
passed, 30 skipped, 1 xfailed; `uv run --locked pre-commit run
--all-files` → exit 0, tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157LmcttGkdnQhLdCLkfVRR

## Summary by Sourcery

Protect Esplora fetches and broadcasts against wrong-network endpoints while documenting the actual trust guarantees of every fetched answer.

New Features:
- Add default-on network verification to EsploraFetcher, checking the explorer’s genesis block before the first fetch or broadcast with an opt-out for callers that have verified the network independently.

Bug Fixes:
- Prevent fetchers labeled for one Bitcoin network from silently retrieving data from an explorer serving another network.
- Correct the fetch trust documentation to accurately describe which transaction, output, header, height, and tip-hash answers are independently checked.

Enhancements:
- Align EsploraFetcher’s network-verification interface and behavior with the existing Bitcoin Core fetchers, including cached disagreement handling and retrying transient verification failures.

Documentation:
- Update the changelog, release notes, SECURITY.md, and fetcher documentation to explain network verification and the trust guarantees for each fetched answer.

Tests:
- Add coverage for Esplora network verification, caching, opt-out behavior, transient failures, and broadcast protection, and include the new boolean parameter in API signature checks.