### PR TITLE
btclib.coinstats reproduces gettxoutsetinfo, over a shared is_unspendable (closes #1623)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -170,9 +170,10 @@ repos:
         # check-json above still answers the question worth asking of
         # them, which is whether they parse. The lookahead names the
         # files in there with no pinned blob for a reformat to void --
-        # btclib's own, and one of chain data whose provenance is a txid
-        # rather than a blob -- because the default for anything else in
-        # that directory has to stay "not touched". (?x) is verbose mode,
+        # btclib's own, one of chain data whose provenance is a txid
+        # rather than a blob, and one recorded from a node this repository
+        # does not ship -- because the default for anything else in that
+        # directory has to stay "not touched". (?x) is verbose mode,
         # i.e. the newlines below are not part of the pattern
         # `.vscode` is the second name in the alternation and is there for
         # the reason check-json above is given the same exclude: those files
@@ -186,6 +187,7 @@ repos:
               |descriptor_checksums\.json
               |rfc6979\.json
               |electrum_test_vectors\.json
+              |gettxoutsetinfo_regtest\.json
               |unspendable_script_pub_keys\.json))
       - id: check-merge-conflict
       - id: check-vcs-permalinks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -361,6 +361,39 @@ validating one costs.
 issue's `xprv, xpub` row, and nothing a caller has to act on moves until
 the second half takes `BIP32KeyData` out of `PrvKey`, `PubKey` and `Key`.
 
+### `btclib.coinstats` reproduces `gettxoutsetinfo`
+
+`coinstats.CoinStats` is a MuHash commitment to a UTXO set and the
+counters Bitcoin Core's `CoinStatsIndex` keeps beside it, maintained
+the same way it maintains them: one output at a time, `insert` and
+`remove` exact inverses of each other (closes #1623).
+`coinstats.tx_out_ser` is what an output is committed to as -- Core's
+`TxOutSer`, whose packed `(height << 1) | coinbase` is a fixed 4-byte
+little-endian `uint32` and not the `var_int` a store is free to write
+the same number as -- and `coinstats.bogo_size` is Core's `GetBogoSize`,
+a fixed part plus the script's own length, which reproduces no wire
+size. Neither can be checked against this tree, so a regtest
+`bitcoind` running with `-coinstatsindex=1` is the oracle:
+`tests/integration/coinstats_test.py` puts the question to a live node,
+and `tests/coinstats_test.py` to a recorded reply,
+`tests/_data/gettxoutsetinfo_regtest.json`. A module of its own and not
+part of `btclib.muhash`, which is the general accumulator and imports no
+transaction; `CoinStats` carries no `serialize` and no `parse`, for the
+reason `btclib.tx.coin`'s `Coin` carries none.
+
+### `script.is_unspendable` is one predicate for Core's `IsUnspendable`
+
+A leading OP_RETURN, or a script over `MAX_SCRIPT_SIZE`: the test
+`fee.dust_threshold` spelled inline is a name of its own in
+`btclib.script.spendability`, which `coinstats.CoinStats` gates on too.
+Why it is not `is_nulldata` -- a bare OP_RETURN, and an OP_RETURN
+followed by several pushes, are unknown to that classifier and
+unspendable to a node (issue #211) -- is argued once, where the
+predicate is. A module of its own rather than a name in
+`script_pub_key`, which pairs an `assert_x` with every `is_x` it
+publishes: unspendable is not one of the standard shapes, and refusing
+a script for being spendable is not a question anybody asks.
+
 ## v2026.9.3
 
 ### Repository

--- a/docs/source/btclib.rst
+++ b/docs/source/btclib.rst
@@ -121,6 +121,13 @@ btclib.coin_selection module
    :members:
    :show-inheritance:
 
+btclib.coinstats module
+-----------------------
+
+.. automodule:: btclib.coinstats
+   :members:
+   :show-inheritance:
+
 btclib.consensus module
 -----------------------
 

--- a/docs/source/btclib.script.rst
+++ b/docs/source/btclib.script.rst
@@ -54,6 +54,13 @@ btclib.script.sig\_ops module
    :members:
    :show-inheritance:
 
+btclib.script.spendability module
+---------------------------------
+
+.. automodule:: btclib.script.spendability
+   :members:
+   :show-inheritance:
+
 btclib.script.taproot module
 ----------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -510,12 +510,12 @@ skip = "*/_data/*.json,*/_data/*.csv,*/_data/*.txt,*/_data/*.bin,*/_generated_fi
 # writing it differently -- unlike the rest of what this hook found,
 # which was corrected instead of listed here
 # "ser" and "unser" join them for a reason of this file's own rather than
-# of the prose: `[tool.typos.default.extend-identifiers]` below has to
-# carry Core's `Ser` and `Unser` as bare TOML keys, and a key cannot be
-# written in the backticks the rule below hides a deliberate misspelling
-# in. Every *prose* mention of either is backticked and already invisible
-# to this hook; what these two entries cover is the two lines that
-# configure the other one.
+# of the prose: `[tool.typos.default.extend-words]` below configures the
+# other spell checker with `ser = "ser"` and `unser = "unser"`, and a TOML
+# key cannot be written in the backticks the rule below hides a deliberate
+# misspelling in. Every *prose* mention of either is backticked and
+# already invisible to this hook; what these two entries cover is the two
+# lines that configure the other one.
 # "te" is what electrum's own NFD spelling of "término" tokenizes into:
 # base "e" and the combining acute accent on it are two codepoints, so
 # the word splits into "te" and "rmino" at the mark, and "te" alone is in
@@ -612,36 +612,6 @@ OP_SUCCESSx = "OP_SUCCESSx"
 # tests/hwi_test.py's transcription follows the rename, and CHANGELOG.md
 # still narrates the misspelling that was pinned before it
 UNKNWON_DEVICE_TYPE = "UNKNWON_DEVICE_TYPE"
-# Bitcoin Core's own name for the serialization parameters of an address,
-# `Ser` for serialize where the dictionary reads a misspelt `Set`
-# (src/protocol.h). src/btclib/p2p/address.py cites it, the hook runs
-# with --write-changes, and a citation a spell checker rewrote names a
-# symbol that is not in the source it points at -- which is worse than no
-# citation, being one a reader would go and fail to find
-SerParams = "SerParams"
-# Core's writer for a 256-bit hash, `Ser` for serialize again
-# (src/serialize.h). tests/p2p/block_filters_test.py cites it as the one
-# function every BIP157 hash field is written with, and a citation the
-# spell checker turned into `set_uint256` names nothing
-ser_uint256 = "ser_uint256"
-# Core's two halves of a serializer, `Ser` for serialize a third time and
-# `Unser` for the reverse (src/serialize.h, and src/blockencodings.h's
-# `DifferenceFormatter`, which is where BIP152's differential index
-# encoding is written and read). src/btclib/p2p/compact_blocks.py cites
-# both methods by name as the place each of its two overflow refusals is
-# spelled in Core; the hook runs with --write-changes and turns them into
-# `Set` and one of four guesses, and a citation a spell checker rewrote
-# names a symbol that is not in the source it points at
-Ser = "Ser"
-Unser = "Unser"
-# Core's own local variable holding a MuHash3072 serialization vector's
-# expected hex, `Ser` for serialize once more (src/test/crypto_tests.cpp).
-# tests/_data/README.md cites it as the vector under
-# tests/_data/muhash_vectors.json's own "serialization" entry; the hook
-# runs with --write-changes and turns it into `set_exp`, a citation a
-# spell checker rewrote naming a symbol that is not in the source it
-# points at
-ser_exp = "ser_exp"
 # BOLT9's own name for the feature at bits 8/9, `optin` for opt-in
 # (09-features.md). src/btclib/bolt9.py transcribes that table and the hook
 # runs with --write-changes, so without this line the name becomes
@@ -665,6 +635,26 @@ ful = "ful"
 # code; without this entry the hook splits it and rewrites the comment
 # into one naming COPY001, a rule that does not exist
 CPY = "CPY"
+# Bitcoin Core's abbreviation for serialize, which the dictionary reads
+# as a misspelt "set", and `unser` for the reverse. This tree cites Core's
+# names that carry one -- `SerParams` (src/protocol.h),
+# `Ser`/`Unser` (src/serialize.h, and src/blockencodings.h's
+# `DifferenceFormatter`), `ser_exp` (src/test/crypto_tests.cpp),
+# `ser_uint256` (test/functional/test_framework/messages.py, which is
+# where it is defined rather than in serialize.h) and `TxOutSer`
+# (src/kernel/coinstats.cpp) -- and carries the abbreviation in a name of
+# its own, `btclib.coinstats.tx_out_ser`, which is what that last one is
+# called here. The hook runs with --write-changes, so without these two
+# lines it rewrites a public function into `tx_out_set` and a citation
+# into a symbol the source it points at does not have, which is worse
+# than no citation: a reader would go and fail to find it.
+# A word rather than an entry per name in
+# [tool.typos.default.extend-identifiers] above, which matches a whole
+# identifier and so needs one line for every name Core spells this way;
+# [tool.codespell]'s own ignore-words-list states the same two as words
+# for the same reason
+ser = "ser"
+unser = "unser"
 
 [tool.typos.type.verbatim]
 # the three files that quote a word rather than use it: CHANGELOG.md names

--- a/src/btclib/__init__.py
+++ b/src/btclib/__init__.py
@@ -95,6 +95,7 @@ __all__ = [
     "bolt9",
     "bolt11",
     "coin_selection",
+    "coinstats",
     "consensus",
     "core_import",
     "curves",

--- a/src/btclib/coinstats.py
+++ b/src/btclib/coinstats.py
@@ -1,0 +1,200 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""What `gettxoutsetinfo` reports about a UTXO set, as arithmetic.
+
+Bitcoin Core's `CoinStatsIndex` (`src/index/coinstatsindex.cpp`, at
+bitcoin/bitcoin@9be056a8a7, tag v31.1) maintains a MuHash commitment
+to the unspent output set incrementally, and beside it the running
+counters `m_transaction_output_count`, `m_total_amount` and
+`m_bogo_size` the same way. `CoinStats` below is the commitment and
+those counters together, and each of `insert` and `remove` is one
+output's contribution to every one of them.
+
+`btclib.muhash` is the accumulator and knows nothing about outputs;
+what this module adds is the bitcoin on top of it -- which bytes an
+output is committed to as, which outputs are committed to at all, and
+what a counter counts. That split is why this is a module of its own:
+`btclib.muhash` is the general construction, RFC 8439's own ChaCha20
+block function included, and it would have to import the transaction
+package to carry any of what is here.
+
+The seam runs where `btclib.tx.coin` already put it for `Coin`: what is
+here is a function of its arguments alone, and how a node keeps a
+running total on disk is that node's own decision. So there is no
+`serialize` and no `parse` for `CoinStats`, no walk of a chain, and no
+undo log -- `insert` and `remove` are exact inverses on the same
+arguments, in either order and regardless of what else went through
+either meanwhile, which is what lets a caller undo a staged block
+without having recorded what the accumulator and the counters held
+before it.
+
+## Reading a digest against a node
+
+`gettxoutsetinfo`'s own `muhash` field is `digest` below with its bytes
+reversed. `FinalizeHash` (`kernel/coinstats.cpp`) writes what
+`MuHash3072::Finalize` gives into a `uint256`, and the rpc prints that
+through `uint256::GetHex`, which is `uint256`'s display order and the
+reverse of its serialization; `digest` is the serialization.
+
+## What is committed to, and what is not
+
+`btclib.script.is_unspendable` gates both `insert` and `remove`:
+`CCoinsViewCache::AddCoin` (`coins.cpp:91`) returns without adding such
+an output to Core's own set at all, so `ApplyCoinHash` never sees one
+and no counter here ever counts one. The gate is here rather than left
+to the caller because it is the difference between reproducing
+`gettxoutsetinfo` and not, and because a caller that skips such an
+output on the way in and not on the way out has an accumulator that no
+longer cancels.
+
+Two exclusions Core's own set makes are the caller's and not this
+module's, both being facts about a chain rather than about an output:
+the genesis block's coinbase, which is spendable-looking and
+unspendable, and the coinbase of either mainnet block
+`IsBIP30Unspendable` (`validation.cpp:6230-6234`) names by height and
+hash, each duplicated verbatim by a later one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from btclib.alias import Octets
+from btclib.exceptions import BTClibValueError
+from btclib.muhash import MuHash3072
+from btclib.script.spendability import is_unspendable
+from btclib.tx.coin import Coin
+from btclib.utils import assert_type, bytes_from_octets
+
+__all__ = [
+    "CoinStats",
+    "bogo_size",
+    "tx_out_ser",
+]
+
+# what OutPoint.serialize writes: a 32-byte tx id and a 4-byte vout
+_OUT_POINT_SIZE = 36
+
+# GetBogoSize's own fixed part (kernel/coinstats.cpp:36-44), with Core's
+# own labels: 32 txid, 4 vout index, 4 height and coinbase bit, 8 amount,
+# 2 scriptPubKey length
+_BOGO_FIXED = 32 + 4 + 4 + 8 + 2
+
+# TxOutSer packs the height and the coinbase bit into one uint32, so the
+# height it can carry stops one bit short of that width
+_MAX_PACKED_HEIGHT = (1 << 31) - 1
+
+
+def bogo_size(script_pub_key: Octets) -> int:
+    """Return Core's `GetBogoSize` for an output with such a script.
+
+    A fixed part plus the script's own length, and no output's actual
+    size: Core's own comment over it reads "Database-independent metric
+    indicating the UTXO set size". The fixed part allows a constant for
+    the script's length marker rather than measuring the `var_int` the
+    wire writes it behind, and allows nothing at all for what a store
+    compresses an output down to. It is what `gettxoutsetinfo` answers
+    as `bogosize`, and nothing else reproduces it.
+    """
+    return _bogo_size(bytes_from_octets(script_pub_key))
+
+
+def _bogo_size(script_pub_key: bytes) -> int:
+    """Return `GetBogoSize`, on a script already read as bytes."""
+    return _BOGO_FIXED + len(script_pub_key)
+
+
+def tx_out_ser(out_point_bytes: Octets, coin: Coin) -> bytes:
+    """Return the bytes a coin is committed to as -- Core's `TxOutSer`.
+
+    `TxOutSer` (`kernel/coinstats.cpp:46-52`) writes the outpoint, then
+    `(height << 1) | coinbase` as a fixed 4-byte little-endian `uint32`,
+    then the output. The fixed width is the whole of what a caller
+    cannot guess: an outpoint, that packed number and an output are
+    also what a UTXO store keeps, and a store is free to write the
+    packed number as a `var_int` for density -- the same number, a
+    different encoding, and a different digest.
+
+    `out_point_bytes` rather than an `OutPoint`, because a caller with a
+    UTXO set already holds the outpoint in exactly this form -- it is
+    what keys the set -- and `OutPoint.serialize` is what writes it.
+    """
+    return _tx_out_ser(_checked_out_point(out_point_bytes, coin), coin)
+
+
+def _tx_out_ser(out_point_bytes: bytes, coin: Coin) -> bytes:
+    """Return `TxOutSer`, on arguments already checked."""
+    packed = (coin.height << 1) | int(coin.is_coinbase)
+    return (
+        out_point_bytes
+        + packed.to_bytes(4, "little")
+        + coin.tx_out.serialize(check_validity=False)
+    )
+
+
+def _checked_out_point(out_point_bytes: Octets, coin: Coin) -> bytes:
+    """Return the outpoint as bytes, both arguments having been checked."""
+    out_point_bytes = bytes_from_octets(out_point_bytes, _OUT_POINT_SIZE)
+    assert_type(coin, Coin, "coin")
+    coin.assert_valid()
+    # a height the uint32 above cannot hold would leave as an
+    # OverflowError, from outside the library's exception contract
+    if coin.height > _MAX_PACKED_HEIGHT:
+        raise BTClibValueError(f"invalid height: {coin.height}")
+    return out_point_bytes
+
+
+@dataclass
+class CoinStats:
+    """The MuHash commitment to a UTXO set, and the counters beside it.
+
+    The defaults are the empty set, which is what a caller starting from
+    the genesis block wants; a caller resuming from a store hands back
+    what it kept.
+    """
+
+    muhash: MuHash3072 = field(default_factory=MuHash3072)
+    transaction_output_count: int = 0
+    total_amount: int = 0  # denominated in satoshi
+    bogo_size: int = 0
+
+    def insert(self, out_point_bytes: Octets, coin: Coin) -> None:
+        """Count one coin everywhere; skip an unspendable output.
+
+        Nothing is returned and nothing has to be kept: `remove` skips
+        exactly what this skips, so undoing a staged block is the same
+        walk the other way round, and a caller that wants to know asks
+        `btclib.script.is_unspendable` itself.
+        """
+        checked = _checked_out_point(out_point_bytes, coin)
+        script = coin.tx_out.script_pub_key.script
+        if is_unspendable(script):
+            return
+        self.muhash.insert(_tx_out_ser(checked, coin))
+        self.transaction_output_count += 1
+        self.total_amount += coin.tx_out.value
+        self.bogo_size += _bogo_size(script)
+
+    def remove(self, out_point_bytes: Octets, coin: Coin) -> None:
+        """Uncount one coin everywhere -- `insert`'s exact inverse."""
+        checked = _checked_out_point(out_point_bytes, coin)
+        script = coin.tx_out.script_pub_key.script
+        if is_unspendable(script):
+            return
+        self.muhash.remove(_tx_out_ser(checked, coin))
+        self.transaction_output_count -= 1
+        self.total_amount -= coin.tx_out.value
+        self.bogo_size -= _bogo_size(script)
+
+    @property
+    def digest(self) -> bytes:
+        """Return the 32-byte commitment, `MuHash3072.digest`'s own bytes.
+
+        A property and not a call, as on the accumulator it reads, and
+        in its byte order: the module docstring's "Reading a digest
+        against a node" is what a `gettxoutsetinfo` reply has to be
+        reversed against.
+        """
+        return self.muhash.digest

--- a/src/btclib/fee.py
+++ b/src/btclib/fee.py
@@ -40,9 +40,8 @@ from btclib import var_int
 from btclib.alias import Octets
 from btclib.amount import sats_from_btc, valid_sats_amount
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.script.limits import MAX_SCRIPT_SIZE
-from btclib.script.script import BYTE_FROM_OP_CODE_NAME
 from btclib.script.script_pub_key import is_segwit
+from btclib.script.spendability import is_unspendable
 from btclib.utils import bytes_from_octets, is_integer
 
 __all__ = [
@@ -348,17 +347,7 @@ def dust_threshold(
     """
     script_pub_key = bytes_from_octets(script_pub_key)
 
-    # Core's CScript::IsUnspendable, spelled out rather than read off
-    # btclib's is_nulldata, which is narrower on purpose (issue #211): a
-    # bare OP_RETURN, and an OP_RETURN followed by several pushes, are
-    # unknown to that classifier and unspendable to a node, and asking it
-    # would hand each of them a threshold it does not have.
-    # Sliced and not indexed, so that an empty script is a script with no
-    # leading OP_RETURN rather than an IndexError
-    if (
-        script_pub_key[:1] == BYTE_FROM_OP_CODE_NAME["OP_RETURN"]
-        or len(script_pub_key) > MAX_SCRIPT_SIZE
-    ):
+    if is_unspendable(script_pub_key):
         return 0
 
     size = (

--- a/src/btclib/script/__init__.py
+++ b/src/btclib/script/__init__.py
@@ -22,9 +22,10 @@ closes a cycle on a half-initialized `btclib.script`. That is issue #147's
 shape, and tests/imports_test.py is what reports it.
 
 The other submodules are not named: `script`, `script_pub_key`,
-`sig_ops` and `witness` are where the flat names above are defined, and
-`limits` and `op_codes_tapscript` are tables the engine reads. Each
-declares its own `__all__` and is importable; none is a group.
+`sig_ops`, `spendability` and `witness` are where the flat names above
+are defined, and `limits` and `op_codes_tapscript` are tables the engine
+reads. Each declares its own `__all__` and is importable; none is a
+group.
 """
 
 from importlib import import_module
@@ -68,6 +69,7 @@ from btclib.script.script_pub_key import (
     type_and_payload,
 )
 from btclib.script.sig_ops import sig_op_count
+from btclib.script.spendability import is_unspendable
 from btclib.script.taproot import (
     check_output_pubkey,
     input_script_sig,
@@ -110,6 +112,7 @@ __all__ = [
     "is_p2wpkh",
     "is_p2wsh",
     "is_segwit",
+    "is_unspendable",
     "op_int",
     "output_prvkey",
     "output_prvkey_from_merkle_root",

--- a/src/btclib/script/spendability.py
+++ b/src/btclib/script/spendability.py
@@ -1,0 +1,57 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Whether an output can ever be spent, from its script_pub_key alone.
+
+Bitcoin Core's `CScript::IsUnspendable` (`script/script.h:563-566`, at
+bitcoin/bitcoin@9be056a8a7, tag v31.1): a leading OP_RETURN, or a script
+longer than `MAX_SCRIPT_SIZE`. `CCoinsViewCache::AddCoin`
+(`coins.cpp:91`) returns without adding such an output to the UTXO set
+at all, so it is what a node's own set never carries and what an output
+worth anything at all still cannot be paid out of.
+
+A module of its own rather than part of `script_pub_key.py`, which is
+the classification of the standard shapes and pairs an `assert_x` with
+every `is_x` it publishes: unspendable is not a shape, and an
+`assert_unspendable` refusing a script for being spendable is not a
+question anybody asks. Beside `sig_ops.py` instead, which is here for
+the same reason -- a rule about a script that is neither its encoding
+nor its type -- and reads `limits.py` the same way.
+
+`is_nulldata` in `script_pub_key.py` answers a narrower question and is
+not this one (issue #211): a bare OP_RETURN, and an OP_RETURN followed
+by several pushes, are not the standard nulldata shape and are
+unspendable to a node all the same. `fee.dust_threshold` and
+`coinstats.CoinStats` are the two callers, and they would each be wrong
+in the same way if they asked the classifier instead -- one handing a
+dust threshold to an output nothing can spend, the other counting an
+output Core's own set never held.
+"""
+
+from __future__ import annotations
+
+from btclib.alias import Octets
+from btclib.script.limits import MAX_SCRIPT_SIZE
+from btclib.script.script import BYTE_FROM_OP_CODE_NAME
+from btclib.utils import bytes_from_octets
+
+__all__ = [
+    "is_unspendable",
+]
+
+# read out of the table rather than written as a byte, so that this stays
+# the op code that name stands for, as `sig_ops.py` reads its own
+_OP_RETURN = BYTE_FROM_OP_CODE_NAME["OP_RETURN"]
+
+
+def is_unspendable(script_pub_key: Octets) -> bool:
+    """Answer whether no transaction can ever spend such an output.
+
+    Sliced and not indexed, so that an empty script is a script with no
+    leading OP_RETURN rather than an IndexError; and the length is
+    compared with `>`, so a script of exactly `MAX_SCRIPT_SIZE` bytes is
+    spendable, as it is to a node.
+    """
+    script_pub_key = bytes_from_octets(script_pub_key)
+    return script_pub_key[:1] == _OP_RETURN or len(script_pub_key) > MAX_SCRIPT_SIZE

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -103,6 +103,11 @@ verdict. The verdicts used:
 - **transcribed** — the upstream is prose (a BIP, an RFC), so there is no
   file to compare; the check is that every value in our copy appears
   verbatim in the pinned text.
+- **composed locally**, **recorded** — there is nothing upstream to
+  compare, so the entry says what stands in for one. *composed locally*
+  is a case this tree wrote, naming the third implementation that
+  answered it; *recorded* is one reply a program gave, kept verbatim,
+  naming the program and the calls that ask it again.
 - **extended**, **edited** — characterised in the entry. No file here
   carries one, and that is the discipline rather than an accident: a case
   of btclib's own is written in the test module that reads the file,
@@ -2392,6 +2397,58 @@ btclib's.
 
 Composed 2026-08-02.
 
+### `tests/_data/gettxoutsetinfo_regtest.json`
+
+```text
+program   bitcoind v31.1, the tag at bitcoin/bitcoin@9be056a8a7
+chain     regtest, started with -coinstatsindex=1
+calls     getblockhash <height>
+          getblock <hash> 2
+          gettxout <txid> <n> false
+          gettxoutsetinfo muhash <height>
+recorded  2026-09-04
+```
+
+Verdict: **recorded**. There is no upstream file and no repository: this
+is one throwaway regtest chain, the outputs it left unspent, and what
+`gettxoutsetinfo` reported about the set they are. Nothing upstream will
+ever refresh it.
+
+It is here because nothing in this tree can say `btclib.coinstats` is
+right. `bogo_size` reproduces no wire size and `tx_out_ser` no storage
+format, so an assertion written from btclib's own answer would say only
+that the answer has not changed; a node's `gettxoutsetinfo` is the one
+thing that says more, and a wrong byte in either shows up there as a
+plausible number rather than as an error.
+
+**What the node was asked.** The `gettxoutsetinfo` key is that reply
+verbatim, taken at the tip height -- naming a height is what makes Core
+answer from `coinstatsindex`, which maintains those numbers
+incrementally, rather than by scanning the set. `utxos` is every output
+`gettxout` answered for, which is Core's own set: the value and the
+script are that reply's own, and the height and the coinbase bit come
+from the `getblock` the transaction sits in. `unspendable_outputs` is
+what `gettxout` answers null for and no transaction ever spent -- an
+OP_RETURN output, and each block's own witness commitment -- read from
+`getblock` alone, Core's set having never held either.
+
+**The amounts are strings** because json carries no exact decimal: the
+digits are the ones `bitcoin-cli` printed, and `tests/coinstats_test.py`
+reads them through `Decimal` and `btclib.amount.sats_from_btc`.
+
+**The genesis coinbase is in neither list**, Core excluding it from the
+set by hand -- the recorded reply reports its value as
+`total_unspendable_amount`.
+
+**Recording another** is `tests/integration/coinstats_test.py`, which
+builds a chain of this shape against a live `bitcoind`, walks it with
+the calls above and makes the comparison the unit test makes against
+this file: re-recording is that test writing down what it collected. So
+the procedure is a test rather than a note here. The chain is not
+reproducible byte for byte -- the addresses, and so the txids, are
+whatever the node's wallet minted -- so a re-recording is a new file
+rather than a refreshed one.
+
 ## What is not pinned, and why
 
 - **`tests/mnemonic/_data/electrum_test_vectors.json`** has no upstream.
@@ -2476,10 +2533,11 @@ No upstream blob exists for the rest:
   composed from Core's and Esplora's own source and whose payload is
   chain data two of the entries above already hold.
 - not vendored: `rfc6979.json` (an RFC), `electrum_test_vectors.json`,
-  `electrum_language_vectors.json`, `fakeenglish.txt` and
-  `btclib_test_vectors.json` (btclib's own). The last is the only one
-  composed rather than recorded: its cases were built here, out of psbts
-  BIP174 prints as prose.
+  `electrum_language_vectors.json`, `fakeenglish.txt`,
+  `gettxoutsetinfo_regtest.json` and `btclib_test_vectors.json`
+  (btclib's own). The last is the only one composed rather than
+  recorded: its cases were built here, out of psbts BIP174 prints as
+  prose.
 
 ### Left for a maintainer to decide
 

--- a/tests/_data/gettxoutsetinfo_regtest.json
+++ b/tests/_data/gettxoutsetinfo_regtest.json
@@ -1,0 +1,1755 @@
+{
+    "gettxoutsetinfo": {
+        "height": 104,
+        "bestblock": "2fde9bf6e5f8420e4ab576e8c652f2a822b0aa5c7e5299bfe8a9535d51a0a694",
+        "txouts": 111,
+        "bogosize": 8036,
+        "muhash": "806214624f6be48b41908cafae4778e3df5a8c2e4262b977c3fb1dded5a9c318",
+        "total_amount": "5200.00000000",
+        "total_unspendable_amount": "50.00000000",
+        "block_info": {
+            "prevout_spent": "195.26533736",
+            "coinbase": "50.00015020",
+            "new_outputs_ex_coinbase": "195.26518716",
+            "unspendable": "0.00000000",
+            "unspendables": {
+                "genesis_block": "0.00000000",
+                "bip30": "0.00000000",
+                "scripts": "0.00000000",
+                "unclaimed_rewards": "0.00000000"
+            }
+        }
+    },
+    "utxos": [
+        {
+            "txid": "f3b8c2a89c1be9e0c2a548c7c993f111cb81865343947230b0da3e1d7e11d054",
+            "vout": 0,
+            "height": 4,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "eefd29383bde9b4287804d6762b349924b1915802a4f846ac95c58490c087c55",
+            "vout": 0,
+            "height": 5,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "4b2d59e0149d34919d9c3fd535d058a2b82c1154db1fb1eee0c4824ecae8a77f",
+            "vout": 0,
+            "height": 6,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "da95c9dd959877f5d22d5f6f982e58ed116a8c0caaf1de5245fc27e7713d8f9c",
+            "vout": 0,
+            "height": 7,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "7095029e835e3e4352f51c10e629ec2b66965f4fb9edb5a7e834da7db8722072",
+            "vout": 0,
+            "height": 8,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "020864ae23e711c4de7d2e97af17b31b8fd1da8c8fe98420b4a915d7ef3aed2f",
+            "vout": 0,
+            "height": 9,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "7b298ae66f7abfe021824cc81f811fd60196705c08f92af61f10f6f8445d6c4e",
+            "vout": 0,
+            "height": 10,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "1a0e4c8ab0f1d29d01f8f22d91dfab5197b81273a4e9dee96b1198482bb49010",
+            "vout": 0,
+            "height": 11,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "fb69cd927306a5cafed42f353e6bf90f6f1365a227ffb4cab4687ec84f1d6d05",
+            "vout": 0,
+            "height": 12,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "d248eed86157748b800f68d54dff8edaace36f27d8ab9409f34f51e1c5e95b36",
+            "vout": 0,
+            "height": 13,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "8ed2a12ddc73a25cd1b65d9dcdf690ab66a4733d18a5df8e985616102f4c41ac",
+            "vout": 0,
+            "height": 14,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "11060758ad34916ede160baf7fd5d1c8cc4f38b4153ca99c3125288d8de4cabe",
+            "vout": 0,
+            "height": 15,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "796f803475e9327926b3fff6145e3f962f333ea876444d7728c8dda2eb2a57ba",
+            "vout": 0,
+            "height": 16,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "2a80e850530cc62fd4cb1d9b54b6e2c3120b4a238205c1ad05916ce15c8eb943",
+            "vout": 0,
+            "height": 17,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "2ff1ff96abc7421496526cc37161c7a727299bdcf08271cc260790996b040817",
+            "vout": 0,
+            "height": 18,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "5400428e6e1b60805005bdeb02ffe4b93e59cb1487bf65eb9a9bb0e0f9b895f1",
+            "vout": 0,
+            "height": 19,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "7440d3746e99765ae176bd85a71e8ead01da3e45c383fe9ffb0616fb62782fc9",
+            "vout": 0,
+            "height": 20,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "bdd92376311dede08ca00560b28923fb0cb990168befb4e61d62e0fd4a5b88b3",
+            "vout": 0,
+            "height": 21,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "6cf03bdc4153038aa82800357b3c71aff4b4b9c11f6d1220779f371c0f6c513d",
+            "vout": 0,
+            "height": 22,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "4d2b4599407c0013a3ebd9f491a285f2b2182ebe9b533870c846f45a77825ca8",
+            "vout": 0,
+            "height": 23,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "76fc1b7f91a0494fcdc29c0352ca179d2df07d35cc4e2ad17a740961cbd96d07",
+            "vout": 0,
+            "height": 24,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "55eb47e5c2348d9102cc073052a64c823f48a910f5156461a667ff4a00d8c29b",
+            "vout": 0,
+            "height": 25,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "3047e5fdc95dde49454ca35e17c55fb115dd1c24d7f869229074ff0dcd50c6aa",
+            "vout": 0,
+            "height": 26,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "b9a24f5c25ff13b3114cdbd0094a7d98fcdbfd04401f58f0a40c30c0ea7ca1be",
+            "vout": 0,
+            "height": 27,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "d17c68f32f99a83aaa02336406b3ebf3dc155a9f0716efa1f40cb6781e0448bb",
+            "vout": 0,
+            "height": 28,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "a906d432fcaa35454c5418d199d574f03d6573a55c24a3e1b55e290509172173",
+            "vout": 0,
+            "height": 29,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "e116ff75cbb6d36238d5e2c708e90f8d56626326180786da75ef0bb8a5858002",
+            "vout": 0,
+            "height": 30,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "2ed1fbcaa0f346f1694bc1229f8a8b2792842f6ddf6ace4b939ea5a85067a7f6",
+            "vout": 0,
+            "height": 31,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "088883c03c78a1f82f5271118a4c7f6dd2d81d5fe0965b4e7a9e1f1a23b1e2a9",
+            "vout": 0,
+            "height": 32,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "b76d5a871c25f22fca741db2e4a2c20fba34b8ca44e4de2c920a571f6bae136e",
+            "vout": 0,
+            "height": 33,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "9478e293e98c38016debd013cd4b33c92a9f665c4beef95e961f305ae076ff86",
+            "vout": 0,
+            "height": 34,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "3d18954a407a131b5a5c866285f8c74086e9d696808280e92c63aa1a45b44cbd",
+            "vout": 0,
+            "height": 35,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "c0eae5ae34c064fd21318dc412d26b62f6635e9a540ff346a1d9a381bb278d6a",
+            "vout": 0,
+            "height": 36,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "e0e95a0014b7671b030428fc077746f6eb1a2000bcf5408f23b831df4053bf83",
+            "vout": 0,
+            "height": 37,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "563a00d73bbc85c677bd6c285ed78cd9b5416e4a845dd9456a2bae0cf6627476",
+            "vout": 0,
+            "height": 38,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "02b1a614c551462f6dbba77f29d9dce799fe0dd7c08a05d69b6b3be03142ffa8",
+            "vout": 0,
+            "height": 39,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "16d1b11a4d22af96e8910cd129f21fc5b817b1980266a8a9846b55e9e520929b",
+            "vout": 0,
+            "height": 40,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "cef0151d9450075a700d7afce4e245dd3656e71d2ed3f77af457b8639bc1a85f",
+            "vout": 0,
+            "height": 41,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "c311a355eaf07ce5ba3a5784f927f7b94e55edb5886428f8b7105281cec8b8f4",
+            "vout": 0,
+            "height": 42,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "6b2e73559b0cbefb0c9f2e1cdb75f5cf21eef3e910a10938abc3d30e3050a04e",
+            "vout": 0,
+            "height": 43,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "d6ac174fe1166da5fe12836774a0a83e78f3512f2f9b310d0d3f90e3c161494b",
+            "vout": 0,
+            "height": 44,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "4c1d1a3bb62c7944355d185748a199cfb0274516bc0d763a7a53544b3a697ea7",
+            "vout": 0,
+            "height": 45,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "5545d037e8ebf1925fc50e0a564ad10aed58bca5399cec6e60078cf796bc588f",
+            "vout": 0,
+            "height": 46,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "cfb3b89209787a5cc117a231ab651c310f7b5740e65f42cc1c63104d21ac25f5",
+            "vout": 0,
+            "height": 47,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "f736278909a46fc1cd02d1aafef6a30410421857df36b9fa7cf0ad32a027e694",
+            "vout": 0,
+            "height": 48,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "748a352a36ff38588f5aede9c4a3bbba7cd3daca649edbc7a396ccdd26b7cffd",
+            "vout": 0,
+            "height": 49,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "6a9ceca605978482150c1ef5d10755c65d70972089b0901b0e8ed4c87bc611a7",
+            "vout": 0,
+            "height": 50,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "07037488858f388fdcf8ec505c8db303556011ca64e65f9cbca7a18657785fa1",
+            "vout": 0,
+            "height": 51,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "b92682b18a5cb494227252042ce9c14b0078f6e87508a6218a649040d59265fc",
+            "vout": 0,
+            "height": 52,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "83c7d7c064e97f09c32a7491dfb7ed9db7463729e8dc56900c4e218cd4240a36",
+            "vout": 0,
+            "height": 53,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "f87db0def46109fd46a6dcced686859e5c360ea9c1ecd2c5663193192c2a8c95",
+            "vout": 0,
+            "height": 54,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "bf9315cd2fc8941ccce14068460753d3ed7853fd39f1692784204e42810fa617",
+            "vout": 0,
+            "height": 55,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "5e4a7ec77b5d59599f099ef545b4b4b12bb60ab770b7b0fd81c21d139ce291df",
+            "vout": 0,
+            "height": 56,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "b8d75f2e83494b41847359aafcf526354e3fbb068fb1c346fb9a0c97d387f0e8",
+            "vout": 0,
+            "height": 57,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "3e14935f5debefaa57ac7ebe31411e61926221050a244c81605d21ab7bc5b688",
+            "vout": 0,
+            "height": 58,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "72c9bdd20dbd470a75a7bcddaeb22cdd7e395250e4c9f6097d8e8d87afbf42de",
+            "vout": 0,
+            "height": 59,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "a569aef8c49d26ffc2a0e656047826ef55582dd454ffd2c60a67600503a4a7ec",
+            "vout": 0,
+            "height": 60,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "22565e840c0fb053f266f09b4364578a096ad85481edbfe955e8277b42bf4704",
+            "vout": 0,
+            "height": 61,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "1384f73e5bf2409dfd4bb0019822d67a3ef1e09e0c160be7282e838102b81664",
+            "vout": 0,
+            "height": 62,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "b4e787c42ab9f248e85bac4e42a0c257a58fdf63c0c6a9abca39887182dc1cb9",
+            "vout": 0,
+            "height": 63,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "c5e150d3cd6db84534270685705f329fdf9095073fa858a5c924725dd50561aa",
+            "vout": 0,
+            "height": 64,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "6b0e4e5899c50e2868e7ad5effb6b653c215780103c96024a57b293207d0b66c",
+            "vout": 0,
+            "height": 65,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "ed35b20c373377565d9fdbfc82a81ad3d2d091a6076469d517669e23f2106e7a",
+            "vout": 0,
+            "height": 66,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "023831b79c70aa0553c03387c059351aac8bf0dddcbadd8be140f2785423855c",
+            "vout": 0,
+            "height": 67,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "7536090f1a9b408bd28852f348ea9266511ada02dca5383108807e198fe31361",
+            "vout": 0,
+            "height": 68,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "504cce6342f60f5ea37fa13c3369077e4dad5d2baa71036f2a4673216f9c961a",
+            "vout": 0,
+            "height": 69,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "59925d3bad3be13dd89b0ff87ce7e396224ffc249a6bfa94ed7d56cf84c315a0",
+            "vout": 0,
+            "height": 70,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "e9198ca936110bfe45343bdf76a3e8c0e1e3ff8f52147911a6390d9b0c9909df",
+            "vout": 0,
+            "height": 71,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "b39fe40d3901e2981dd65fe64613337b84c8182682edf6663e391746700a18fc",
+            "vout": 0,
+            "height": 72,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "29f466b9c5acd7887636b5d91badd52e0f5a99bf08a708ba316381df903344b2",
+            "vout": 0,
+            "height": 73,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "540e7539164420c9276581fd1dee51f52bd477f79c59dc6e0d04e1f672d2f695",
+            "vout": 0,
+            "height": 74,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "74bbe9975943bd04607513be5557276746dccf93a757cf334fedfa25a95d1d66",
+            "vout": 0,
+            "height": 75,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "61b16a9be592c984de9ca91d9c882b381ed14fb5c33b273dd8cf6a502004ff3d",
+            "vout": 0,
+            "height": 76,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "689befea6d1ffa2af20d61648eb6f0b0d1ad1b46742ec9b2c212f3329005c2a8",
+            "vout": 0,
+            "height": 77,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "9d60efacfe4161cc343bcfe47ca472810864771ed137caa6f975363723e7d97d",
+            "vout": 0,
+            "height": 78,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "41bf535274dbdec9f2820e7eff53acabff5c5feacbb4cf245cb6ddd439568c89",
+            "vout": 0,
+            "height": 79,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "dfba660958df8728d27a8a4be75bceb1abad29d4d97b9d44b7b5812026295c09",
+            "vout": 0,
+            "height": 80,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "00bc492c5445266186911fda9b77bf37943ea0959b171749dbe8cdf53fdb7d01",
+            "vout": 0,
+            "height": 81,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "8263c90c2b576e350bf3c35dc8b55008223753aab46f2384baacf2d1906730e9",
+            "vout": 0,
+            "height": 82,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "6b5974bccff74b2151db762c446a17e4f52527affd26b143cd77d44dd18a119e",
+            "vout": 0,
+            "height": 83,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "cd34a757872a405b2addca21e2168d26c610f6b60aeec326f391f2dd8c1807d3",
+            "vout": 0,
+            "height": 84,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "992cdeede0d09c4873b56558efeebbf6b69e549e575fa9f74c4f8049fca864ab",
+            "vout": 0,
+            "height": 85,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "1eecde7b755a443c257851a6fcba4c446b6583737166828b5b49345c87837b72",
+            "vout": 0,
+            "height": 86,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "0857880e7395046a2e4eac10ff867785a73e9486d678d7ffe01389955eaa9ed1",
+            "vout": 0,
+            "height": 87,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "9e563c63b8678b190ca91bab4740776c64efed8f65e5d2f66e95f6e7da61a683",
+            "vout": 0,
+            "height": 88,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "d7603b1bd07d025c3d5ea4288be6bf7ff99911961a6d7921df8933964b8ac131",
+            "vout": 0,
+            "height": 89,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "134418cc2eba3fcf2b10bbfe3594a373fb55739eab3262f63e217e5bebddc1e2",
+            "vout": 0,
+            "height": 90,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "81f8c6b596d9e209042514e51ce97dadfb5f5829dfff624c6a7c477bfc6b6ba9",
+            "vout": 0,
+            "height": 91,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "010bc4cdb89dad170dd52fd9630c81656a55defa2b8ec596e53a4b45ad259877",
+            "vout": 0,
+            "height": 92,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "b6b7957a797b8b711f844dd7235c7384cfc4aef684a175c0e12ae790e778e51a",
+            "vout": 0,
+            "height": 93,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "9412248b4b33013765d3d3f2bfe4be4624d14f00785124e7bdff5a9cc7375ddd",
+            "vout": 0,
+            "height": 94,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "d8c4f98179b9d70ee83b4d1ab7cc46d5407f9dfaf94f62eb2ece19d445a748dd",
+            "vout": 0,
+            "height": 95,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "0873dfa5058bb346530dac4d32d304ac54bfc75bdeec066c205f4470d312027f",
+            "vout": 0,
+            "height": 96,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "bb11ece7f985a5f07fba0c526b94bb035b6ad36aafa03f07db7df6a69b6007f6",
+            "vout": 0,
+            "height": 97,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "c68fd4a2d61d58e8c80381f561abaef29dd80624174cd6da98b08e67fa0e182c",
+            "vout": 0,
+            "height": 98,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "33224b907ec8b836eb2f005522dc169adf57dee1a74550450c2b19a665fa75a7",
+            "vout": 0,
+            "height": 99,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "727a2b9c3f97e02eab7d2468b8fdf1d936b3c28e3b3341a7ec41faf930a19e43",
+            "vout": 0,
+            "height": 100,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "0573515497a17463662db624d3c069567bf9733756e3e8e7e8e1f7896734b9a6",
+            "vout": 0,
+            "height": 101,
+            "coinbase": true,
+            "value": "50.00000000",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "f36e4c1a46102178fc32e41d01fbbf60237e5eadc91410abc59ee6b90868cbdd",
+            "vout": 0,
+            "height": 102,
+            "coinbase": true,
+            "value": "50.00002820",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "be0b9f906ec16b73bd5ce6c6410647868c56f736ca982164c95e57ed7cf98ee4",
+            "vout": 0,
+            "height": 103,
+            "coinbase": true,
+            "value": "50.00003360",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "389e7c5c35fb6d46ba824ced2d343f18b95209ef608093725bddc9d239db2f35",
+            "vout": 2,
+            "height": 103,
+            "coinbase": false,
+            "value": "0.50000000",
+            "script_pub_key": "0014edeec244961f4df0063656fa4c3de321bc4e811f"
+        },
+        {
+            "txid": "e310354f203b81bfe95721184bae370b581d18896333c2640670e577badf1407",
+            "vout": 0,
+            "height": 104,
+            "coinbase": true,
+            "value": "50.00015020",
+            "script_pub_key": "0014eec5927f2a27d3c3ac3e2bb4acee737d457399a9"
+        },
+        {
+            "txid": "92633937932665bc43a77a35d731fff29d587926abb28707c031bd8dc5ccfa07",
+            "vout": 1,
+            "height": 104,
+            "coinbase": false,
+            "value": "4.23456784",
+            "script_pub_key": "512047b39d8fcca6afedca7fd601650101b763be7bb4a6c9650702ada58482e3a87f"
+        },
+        {
+            "txid": "bf65cfc509c628ced44b1756d673a1c015f2ef2c0a6b845677e68dd8d3d74ae2",
+            "vout": 0,
+            "height": 104,
+            "coinbase": false,
+            "value": "40.53080031",
+            "script_pub_key": "512078a067b713394739a03da4e1d3394657a6fa08773b68364c424029e2e8ec6fd8"
+        },
+        {
+            "txid": "bf65cfc509c628ced44b1756d673a1c015f2ef2c0a6b845677e68dd8d3d74ae2",
+            "vout": 1,
+            "height": 104,
+            "coinbase": false,
+            "value": "5.23456785",
+            "script_pub_key": "00202cdef98ab71a2056158d1ea429a432b4d26abb1a9727c8473eb791b605976858"
+        },
+        {
+            "txid": "bd436a3ba8262154dd97389961df631842ba0d4988284e50f8f510a934af8a19",
+            "vout": 0,
+            "height": 104,
+            "coinbase": false,
+            "value": "3.23456783",
+            "script_pub_key": "0014bb90fe93c77f44f9a0954e4c1166457f11e9b98f"
+        },
+        {
+            "txid": "bd436a3ba8262154dd97389961df631842ba0d4988284e50f8f510a934af8a19",
+            "vout": 1,
+            "height": 104,
+            "coinbase": false,
+            "value": "46.76540397",
+            "script_pub_key": "0014a6534453dfbf5d6f48537907ea95f1ea8b3f9cec"
+        },
+        {
+            "txid": "d87131ad6db7eb9e9d1d4a5720a2f4396fe5c5a609d6cb233ae7eb7f79a44bd8",
+            "vout": 0,
+            "height": 104,
+            "coinbase": false,
+            "value": "37.76537538",
+            "script_pub_key": "a9142cc862af9201a721575c8426916f359e130cf8e887"
+        },
+        {
+            "txid": "d87131ad6db7eb9e9d1d4a5720a2f4396fe5c5a609d6cb233ae7eb7f79a44bd8",
+            "vout": 1,
+            "height": 104,
+            "coinbase": false,
+            "value": "2.23456782",
+            "script_pub_key": "a914f97946bc799917c3584f12ba494ea3b309c22ae987"
+        },
+        {
+            "txid": "d86415137e5abec77b875c50d120e9686520394c5bb17a56647c4509a737e338",
+            "vout": 0,
+            "height": 104,
+            "coinbase": false,
+            "value": "8.26536919",
+            "script_pub_key": "76a91493d80b28a6e159a645e0307b4e38bfccf24dc65188ac"
+        },
+        {
+            "txid": "d86415137e5abec77b875c50d120e9686520394c5bb17a56647c4509a737e338",
+            "vout": 1,
+            "height": 104,
+            "coinbase": false,
+            "value": "1.23456781",
+            "script_pub_key": "76a9143158300aa3db91e22669e0ccc4fdb02dfda134d788ac"
+        }
+    ],
+    "unspendable_outputs": [
+        {
+            "txid": "4fc92ddd18a2c281680439bfc7e236601b0e9cfac4ceae768ee58b2fbb865669",
+            "vout": 1,
+            "height": 1,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "55fb612115b1802d0d2490a4be3af0102cbb1c0ebafbce0fffec901123f96d5c",
+            "vout": 1,
+            "height": 2,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "7a40f651ba90ba80f4dd8b7689d12acd425fec711c21cf327200207372088b3a",
+            "vout": 1,
+            "height": 3,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "f3b8c2a89c1be9e0c2a548c7c993f111cb81865343947230b0da3e1d7e11d054",
+            "vout": 1,
+            "height": 4,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "eefd29383bde9b4287804d6762b349924b1915802a4f846ac95c58490c087c55",
+            "vout": 1,
+            "height": 5,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "4b2d59e0149d34919d9c3fd535d058a2b82c1154db1fb1eee0c4824ecae8a77f",
+            "vout": 1,
+            "height": 6,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "da95c9dd959877f5d22d5f6f982e58ed116a8c0caaf1de5245fc27e7713d8f9c",
+            "vout": 1,
+            "height": 7,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "7095029e835e3e4352f51c10e629ec2b66965f4fb9edb5a7e834da7db8722072",
+            "vout": 1,
+            "height": 8,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "020864ae23e711c4de7d2e97af17b31b8fd1da8c8fe98420b4a915d7ef3aed2f",
+            "vout": 1,
+            "height": 9,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "7b298ae66f7abfe021824cc81f811fd60196705c08f92af61f10f6f8445d6c4e",
+            "vout": 1,
+            "height": 10,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "1a0e4c8ab0f1d29d01f8f22d91dfab5197b81273a4e9dee96b1198482bb49010",
+            "vout": 1,
+            "height": 11,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "fb69cd927306a5cafed42f353e6bf90f6f1365a227ffb4cab4687ec84f1d6d05",
+            "vout": 1,
+            "height": 12,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "d248eed86157748b800f68d54dff8edaace36f27d8ab9409f34f51e1c5e95b36",
+            "vout": 1,
+            "height": 13,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "8ed2a12ddc73a25cd1b65d9dcdf690ab66a4733d18a5df8e985616102f4c41ac",
+            "vout": 1,
+            "height": 14,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "11060758ad34916ede160baf7fd5d1c8cc4f38b4153ca99c3125288d8de4cabe",
+            "vout": 1,
+            "height": 15,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "796f803475e9327926b3fff6145e3f962f333ea876444d7728c8dda2eb2a57ba",
+            "vout": 1,
+            "height": 16,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "2a80e850530cc62fd4cb1d9b54b6e2c3120b4a238205c1ad05916ce15c8eb943",
+            "vout": 1,
+            "height": 17,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "2ff1ff96abc7421496526cc37161c7a727299bdcf08271cc260790996b040817",
+            "vout": 1,
+            "height": 18,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "5400428e6e1b60805005bdeb02ffe4b93e59cb1487bf65eb9a9bb0e0f9b895f1",
+            "vout": 1,
+            "height": 19,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "7440d3746e99765ae176bd85a71e8ead01da3e45c383fe9ffb0616fb62782fc9",
+            "vout": 1,
+            "height": 20,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "bdd92376311dede08ca00560b28923fb0cb990168befb4e61d62e0fd4a5b88b3",
+            "vout": 1,
+            "height": 21,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "6cf03bdc4153038aa82800357b3c71aff4b4b9c11f6d1220779f371c0f6c513d",
+            "vout": 1,
+            "height": 22,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "4d2b4599407c0013a3ebd9f491a285f2b2182ebe9b533870c846f45a77825ca8",
+            "vout": 1,
+            "height": 23,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "76fc1b7f91a0494fcdc29c0352ca179d2df07d35cc4e2ad17a740961cbd96d07",
+            "vout": 1,
+            "height": 24,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "55eb47e5c2348d9102cc073052a64c823f48a910f5156461a667ff4a00d8c29b",
+            "vout": 1,
+            "height": 25,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "3047e5fdc95dde49454ca35e17c55fb115dd1c24d7f869229074ff0dcd50c6aa",
+            "vout": 1,
+            "height": 26,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "b9a24f5c25ff13b3114cdbd0094a7d98fcdbfd04401f58f0a40c30c0ea7ca1be",
+            "vout": 1,
+            "height": 27,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "d17c68f32f99a83aaa02336406b3ebf3dc155a9f0716efa1f40cb6781e0448bb",
+            "vout": 1,
+            "height": 28,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "a906d432fcaa35454c5418d199d574f03d6573a55c24a3e1b55e290509172173",
+            "vout": 1,
+            "height": 29,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "e116ff75cbb6d36238d5e2c708e90f8d56626326180786da75ef0bb8a5858002",
+            "vout": 1,
+            "height": 30,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "2ed1fbcaa0f346f1694bc1229f8a8b2792842f6ddf6ace4b939ea5a85067a7f6",
+            "vout": 1,
+            "height": 31,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "088883c03c78a1f82f5271118a4c7f6dd2d81d5fe0965b4e7a9e1f1a23b1e2a9",
+            "vout": 1,
+            "height": 32,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "b76d5a871c25f22fca741db2e4a2c20fba34b8ca44e4de2c920a571f6bae136e",
+            "vout": 1,
+            "height": 33,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "9478e293e98c38016debd013cd4b33c92a9f665c4beef95e961f305ae076ff86",
+            "vout": 1,
+            "height": 34,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "3d18954a407a131b5a5c866285f8c74086e9d696808280e92c63aa1a45b44cbd",
+            "vout": 1,
+            "height": 35,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "c0eae5ae34c064fd21318dc412d26b62f6635e9a540ff346a1d9a381bb278d6a",
+            "vout": 1,
+            "height": 36,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "e0e95a0014b7671b030428fc077746f6eb1a2000bcf5408f23b831df4053bf83",
+            "vout": 1,
+            "height": 37,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "563a00d73bbc85c677bd6c285ed78cd9b5416e4a845dd9456a2bae0cf6627476",
+            "vout": 1,
+            "height": 38,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "02b1a614c551462f6dbba77f29d9dce799fe0dd7c08a05d69b6b3be03142ffa8",
+            "vout": 1,
+            "height": 39,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "16d1b11a4d22af96e8910cd129f21fc5b817b1980266a8a9846b55e9e520929b",
+            "vout": 1,
+            "height": 40,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "cef0151d9450075a700d7afce4e245dd3656e71d2ed3f77af457b8639bc1a85f",
+            "vout": 1,
+            "height": 41,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "c311a355eaf07ce5ba3a5784f927f7b94e55edb5886428f8b7105281cec8b8f4",
+            "vout": 1,
+            "height": 42,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "6b2e73559b0cbefb0c9f2e1cdb75f5cf21eef3e910a10938abc3d30e3050a04e",
+            "vout": 1,
+            "height": 43,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "d6ac174fe1166da5fe12836774a0a83e78f3512f2f9b310d0d3f90e3c161494b",
+            "vout": 1,
+            "height": 44,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "4c1d1a3bb62c7944355d185748a199cfb0274516bc0d763a7a53544b3a697ea7",
+            "vout": 1,
+            "height": 45,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "5545d037e8ebf1925fc50e0a564ad10aed58bca5399cec6e60078cf796bc588f",
+            "vout": 1,
+            "height": 46,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "cfb3b89209787a5cc117a231ab651c310f7b5740e65f42cc1c63104d21ac25f5",
+            "vout": 1,
+            "height": 47,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "f736278909a46fc1cd02d1aafef6a30410421857df36b9fa7cf0ad32a027e694",
+            "vout": 1,
+            "height": 48,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "748a352a36ff38588f5aede9c4a3bbba7cd3daca649edbc7a396ccdd26b7cffd",
+            "vout": 1,
+            "height": 49,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "6a9ceca605978482150c1ef5d10755c65d70972089b0901b0e8ed4c87bc611a7",
+            "vout": 1,
+            "height": 50,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "07037488858f388fdcf8ec505c8db303556011ca64e65f9cbca7a18657785fa1",
+            "vout": 1,
+            "height": 51,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "b92682b18a5cb494227252042ce9c14b0078f6e87508a6218a649040d59265fc",
+            "vout": 1,
+            "height": 52,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "83c7d7c064e97f09c32a7491dfb7ed9db7463729e8dc56900c4e218cd4240a36",
+            "vout": 1,
+            "height": 53,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "f87db0def46109fd46a6dcced686859e5c360ea9c1ecd2c5663193192c2a8c95",
+            "vout": 1,
+            "height": 54,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "bf9315cd2fc8941ccce14068460753d3ed7853fd39f1692784204e42810fa617",
+            "vout": 1,
+            "height": 55,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "5e4a7ec77b5d59599f099ef545b4b4b12bb60ab770b7b0fd81c21d139ce291df",
+            "vout": 1,
+            "height": 56,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "b8d75f2e83494b41847359aafcf526354e3fbb068fb1c346fb9a0c97d387f0e8",
+            "vout": 1,
+            "height": 57,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "3e14935f5debefaa57ac7ebe31411e61926221050a244c81605d21ab7bc5b688",
+            "vout": 1,
+            "height": 58,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "72c9bdd20dbd470a75a7bcddaeb22cdd7e395250e4c9f6097d8e8d87afbf42de",
+            "vout": 1,
+            "height": 59,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "a569aef8c49d26ffc2a0e656047826ef55582dd454ffd2c60a67600503a4a7ec",
+            "vout": 1,
+            "height": 60,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "22565e840c0fb053f266f09b4364578a096ad85481edbfe955e8277b42bf4704",
+            "vout": 1,
+            "height": 61,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "1384f73e5bf2409dfd4bb0019822d67a3ef1e09e0c160be7282e838102b81664",
+            "vout": 1,
+            "height": 62,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "b4e787c42ab9f248e85bac4e42a0c257a58fdf63c0c6a9abca39887182dc1cb9",
+            "vout": 1,
+            "height": 63,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "c5e150d3cd6db84534270685705f329fdf9095073fa858a5c924725dd50561aa",
+            "vout": 1,
+            "height": 64,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "6b0e4e5899c50e2868e7ad5effb6b653c215780103c96024a57b293207d0b66c",
+            "vout": 1,
+            "height": 65,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "ed35b20c373377565d9fdbfc82a81ad3d2d091a6076469d517669e23f2106e7a",
+            "vout": 1,
+            "height": 66,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "023831b79c70aa0553c03387c059351aac8bf0dddcbadd8be140f2785423855c",
+            "vout": 1,
+            "height": 67,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "7536090f1a9b408bd28852f348ea9266511ada02dca5383108807e198fe31361",
+            "vout": 1,
+            "height": 68,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "504cce6342f60f5ea37fa13c3369077e4dad5d2baa71036f2a4673216f9c961a",
+            "vout": 1,
+            "height": 69,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "59925d3bad3be13dd89b0ff87ce7e396224ffc249a6bfa94ed7d56cf84c315a0",
+            "vout": 1,
+            "height": 70,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "e9198ca936110bfe45343bdf76a3e8c0e1e3ff8f52147911a6390d9b0c9909df",
+            "vout": 1,
+            "height": 71,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "b39fe40d3901e2981dd65fe64613337b84c8182682edf6663e391746700a18fc",
+            "vout": 1,
+            "height": 72,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "29f466b9c5acd7887636b5d91badd52e0f5a99bf08a708ba316381df903344b2",
+            "vout": 1,
+            "height": 73,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "540e7539164420c9276581fd1dee51f52bd477f79c59dc6e0d04e1f672d2f695",
+            "vout": 1,
+            "height": 74,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "74bbe9975943bd04607513be5557276746dccf93a757cf334fedfa25a95d1d66",
+            "vout": 1,
+            "height": 75,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "61b16a9be592c984de9ca91d9c882b381ed14fb5c33b273dd8cf6a502004ff3d",
+            "vout": 1,
+            "height": 76,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "689befea6d1ffa2af20d61648eb6f0b0d1ad1b46742ec9b2c212f3329005c2a8",
+            "vout": 1,
+            "height": 77,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "9d60efacfe4161cc343bcfe47ca472810864771ed137caa6f975363723e7d97d",
+            "vout": 1,
+            "height": 78,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "41bf535274dbdec9f2820e7eff53acabff5c5feacbb4cf245cb6ddd439568c89",
+            "vout": 1,
+            "height": 79,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "dfba660958df8728d27a8a4be75bceb1abad29d4d97b9d44b7b5812026295c09",
+            "vout": 1,
+            "height": 80,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "00bc492c5445266186911fda9b77bf37943ea0959b171749dbe8cdf53fdb7d01",
+            "vout": 1,
+            "height": 81,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "8263c90c2b576e350bf3c35dc8b55008223753aab46f2384baacf2d1906730e9",
+            "vout": 1,
+            "height": 82,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "6b5974bccff74b2151db762c446a17e4f52527affd26b143cd77d44dd18a119e",
+            "vout": 1,
+            "height": 83,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "cd34a757872a405b2addca21e2168d26c610f6b60aeec326f391f2dd8c1807d3",
+            "vout": 1,
+            "height": 84,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "992cdeede0d09c4873b56558efeebbf6b69e549e575fa9f74c4f8049fca864ab",
+            "vout": 1,
+            "height": 85,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "1eecde7b755a443c257851a6fcba4c446b6583737166828b5b49345c87837b72",
+            "vout": 1,
+            "height": 86,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "0857880e7395046a2e4eac10ff867785a73e9486d678d7ffe01389955eaa9ed1",
+            "vout": 1,
+            "height": 87,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "9e563c63b8678b190ca91bab4740776c64efed8f65e5d2f66e95f6e7da61a683",
+            "vout": 1,
+            "height": 88,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "d7603b1bd07d025c3d5ea4288be6bf7ff99911961a6d7921df8933964b8ac131",
+            "vout": 1,
+            "height": 89,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "134418cc2eba3fcf2b10bbfe3594a373fb55739eab3262f63e217e5bebddc1e2",
+            "vout": 1,
+            "height": 90,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "81f8c6b596d9e209042514e51ce97dadfb5f5829dfff624c6a7c477bfc6b6ba9",
+            "vout": 1,
+            "height": 91,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "010bc4cdb89dad170dd52fd9630c81656a55defa2b8ec596e53a4b45ad259877",
+            "vout": 1,
+            "height": 92,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "b6b7957a797b8b711f844dd7235c7384cfc4aef684a175c0e12ae790e778e51a",
+            "vout": 1,
+            "height": 93,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "9412248b4b33013765d3d3f2bfe4be4624d14f00785124e7bdff5a9cc7375ddd",
+            "vout": 1,
+            "height": 94,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "d8c4f98179b9d70ee83b4d1ab7cc46d5407f9dfaf94f62eb2ece19d445a748dd",
+            "vout": 1,
+            "height": 95,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "0873dfa5058bb346530dac4d32d304ac54bfc75bdeec066c205f4470d312027f",
+            "vout": 1,
+            "height": 96,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "bb11ece7f985a5f07fba0c526b94bb035b6ad36aafa03f07db7df6a69b6007f6",
+            "vout": 1,
+            "height": 97,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "c68fd4a2d61d58e8c80381f561abaef29dd80624174cd6da98b08e67fa0e182c",
+            "vout": 1,
+            "height": 98,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "33224b907ec8b836eb2f005522dc169adf57dee1a74550450c2b19a665fa75a7",
+            "vout": 1,
+            "height": 99,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "727a2b9c3f97e02eab7d2468b8fdf1d936b3c28e3b3341a7ec41faf930a19e43",
+            "vout": 1,
+            "height": 100,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "0573515497a17463662db624d3c069567bf9733756e3e8e7e8e1f7896734b9a6",
+            "vout": 1,
+            "height": 101,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9"
+        },
+        {
+            "txid": "f36e4c1a46102178fc32e41d01fbbf60237e5eadc91410abc59ee6b90868cbdd",
+            "vout": 1,
+            "height": 102,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9edd9d51733f9e8bbad0bdd25d28137c9f9a2cc8b8e428aae318c34f1ed408ed907"
+        },
+        {
+            "txid": "be0b9f906ec16b73bd5ce6c6410647868c56f736ca982164c95e57ed7cf98ee4",
+            "vout": 1,
+            "height": 103,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9edc99865cb0f28720a762c1fc823eff994c35c63f26642e56df37c14b05a1f1469"
+        },
+        {
+            "txid": "389e7c5c35fb6d46ba824ced2d343f18b95209ef608093725bddc9d239db2f35",
+            "vout": 1,
+            "height": 103,
+            "coinbase": false,
+            "value": "0.00000000",
+            "script_pub_key": "6a106274636c69622049535320313632330a"
+        },
+        {
+            "txid": "e310354f203b81bfe95721184bae370b581d18896333c2640670e577badf1407",
+            "vout": 1,
+            "height": 104,
+            "coinbase": true,
+            "value": "0.00000000",
+            "script_pub_key": "6a24aa21a9ed8bd9dd6677c58edaa375a4dafdfb44af0e6b9e1b522aebd1b58494251f417747"
+        }
+    ]
+}

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -271,6 +271,7 @@ CHILD_MODULES = {
             "script",
             "script_pub_key",
             "sig_ops",
+            "spendability",
             "witness",
         ],
     },

--- a/tests/coinstats_test.py
+++ b/tests/coinstats_test.py
@@ -1,0 +1,244 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the `btclib.coinstats` module.
+
+The oracle is a Bitcoin Core node and nothing else: `bogo_size` and
+`tx_out_ser` reproduce no wire size and no storage format, so an
+assertion written from this tree's own answer would say only that the
+answer has not changed. `tests/_data/gettxoutsetinfo_regtest.json` is
+one regtest chain's unspent outputs beside what `gettxoutsetinfo`
+reported about it, and that file's entry in `tests/_data/README.md` says
+which call each field came from and how to record another.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from btclib import var_int
+from btclib.amount import sats_from_btc
+from btclib.coinstats import CoinStats, bogo_size, tx_out_ser
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.muhash import MuHash3072
+from btclib.script import is_unspendable
+from btclib.tx.coin import Coin
+from btclib.tx.out_point import OutPoint
+from btclib.tx.tx_out import TxOut
+from tests import load
+
+_RECORDED = load("_data", "gettxoutsetinfo_regtest.json")
+
+
+def _out_point_and_coin(recorded: dict[str, Any]) -> tuple[bytes, Coin]:
+    """Return the outpoint bytes and the `Coin` one recorded output is."""
+    out_point = OutPoint(bytes.fromhex(recorded["txid"]), recorded["vout"])
+    tx_out = TxOut(
+        sats_from_btc(Decimal(recorded["value"])), recorded["script_pub_key"]
+    )
+    return out_point.serialize(), Coin(tx_out, recorded["height"], recorded["coinbase"])
+
+
+def _counters(stats: CoinStats) -> tuple[int, int, int]:
+    """Return the three running counters, the accumulator left aside."""
+    return (stats.transaction_output_count, stats.total_amount, stats.bogo_size)
+
+
+def _every_recorded_output() -> list[tuple[bytes, Coin]]:
+    """Return every unspent output of the recorded chain, in block order."""
+    return [
+        _out_point_and_coin(recorded)
+        for recorded in _RECORDED["utxos"] + _RECORDED["unspendable_outputs"]
+    ]
+
+
+def test_the_recorded_chain_reproduces_what_the_node_reported() -> None:
+    """Every number `gettxoutsetinfo` answered, from the outputs alone.
+
+    The one assertion that says `tx_out_ser` and `bogo_size` are Core's:
+    a wrong byte anywhere in what is committed to gives a digest that is
+    a plausible 32 bytes, and a wrong fixed part gives a plausible
+    integer.
+
+    The digest is compared reversed, `gettxoutsetinfo` printing a
+    `uint256` in display order -- `btclib.coinstats`' own "Reading a
+    digest against a node" is where that is argued.
+    """
+    stats = CoinStats()
+    for out_point_bytes, coin in _every_recorded_output():
+        stats.insert(out_point_bytes, coin)
+
+    reported = _RECORDED["gettxoutsetinfo"]
+    assert stats.digest[::-1].hex() == reported["muhash"]
+    assert stats.transaction_output_count == reported["txouts"]
+    assert stats.bogo_size == reported["bogosize"]
+    assert stats.total_amount == sats_from_btc(Decimal(reported["total_amount"]))
+
+
+def test_the_recorded_chain_carries_what_it_is_read_for() -> None:
+    """Guard the oracle above against passing on a file that lost its point.
+
+    It reads a file, and a file that had lost its unspendable outputs, or
+    every script but one shape, would still make every assertion up
+    there true -- of a chain that no longer exercises the gate or the
+    script-length term of the bogo size.
+    """
+    assert _RECORDED["unspendable_outputs"]
+    scripts = {utxo["script_pub_key"][:4] for utxo in _RECORDED["utxos"]}
+    assert scripts == {"0014", "0020", "5120", "76a9", "a914"}
+    coinbase_bits = {utxo["coinbase"] for utxo in _RECORDED["utxos"]}
+    assert coinbase_bits == {True, False}
+
+
+def test_remove_undoes_insert_whatever_the_order() -> None:
+    """`insert` and `remove` are exact inverses, as the accumulator is.
+
+    Removed in the reverse of the order they went in, and the counters
+    come back to the empty set as well as the digest does -- which is
+    what lets a caller undo a staged block without recording what any of
+    them held before it.
+    """
+    empty = CoinStats()
+    stats = CoinStats()
+    outputs = _every_recorded_output()
+    for out_point_bytes, coin in outputs:
+        stats.insert(out_point_bytes, coin)
+    for out_point_bytes, coin in reversed(outputs):
+        stats.remove(out_point_bytes, coin)
+
+    assert stats.digest == empty.digest
+    assert stats.transaction_output_count == 0
+    assert stats.total_amount == 0
+    assert stats.bogo_size == 0
+
+
+def test_an_unspendable_output_moves_nothing() -> None:
+    """What Core's own UTXO set never carries, this never counts.
+
+    `CCoinsViewCache::AddCoin` returns before adding such an output, so
+    the answer is not that the arithmetic cancels: nothing is asked of
+    the accumulator at all, which is what the assertion after the
+    `insert` alone says. `remove` is checked beside it because a gate on
+    one of the two and not the other is an accumulator that stops
+    cancelling.
+    """
+    empty = CoinStats()
+    stats = CoinStats()
+    op_return = _RECORDED["unspendable_outputs"][0]
+    out_point_bytes, coin = _out_point_and_coin(op_return)
+    assert is_unspendable(coin.tx_out.script_pub_key.script)
+
+    # the accumulator is compared by digest and not by identity, two
+    # MuHash3072 of the same multiset being different objects
+    stats.insert(out_point_bytes, coin)
+    assert _counters(stats) == _counters(empty)
+    assert stats.digest == empty.digest
+    stats.remove(out_point_bytes, coin)
+    assert _counters(stats) == _counters(empty)
+    assert stats.digest == empty.digest
+
+
+def test_the_packed_height_is_four_bytes_wide_and_not_a_var_int() -> None:
+    """The fixed width is what a storage format is free to disagree on.
+
+    A height under 253 is one byte as a `var_int` and four here, so the
+    two encodings of the same number are not interchangeable and the
+    digests they lead to are different.
+    """
+    out_point = OutPoint(bytes.fromhex(f"{7:064x}"), 3)
+    tx_out = TxOut(1000, "0014" + "11" * 20)
+    coin = Coin(tx_out, 12, is_coinbase=True)
+
+    serialized = tx_out_ser(out_point.serialize(), coin)
+    packed = serialized[36:40]
+    assert packed == b"\x19\x00\x00\x00"  # (12 << 1) | 1
+    assert serialized == out_point.serialize() + packed + tx_out.serialize()
+    assert len(var_int.serialize((12 << 1) | 1)) == 1
+
+
+def test_the_coinbase_bit_is_the_low_bit_of_the_packed_field() -> None:
+    """The same height with and without it differ in one bit, and only there."""
+    out_point_bytes = OutPoint(bytes.fromhex(f"{7:064x}"), 3).serialize()
+    tx_out = TxOut(1000, "0014" + "11" * 20)
+
+    mined = tx_out_ser(out_point_bytes, Coin(tx_out, 12, is_coinbase=True))
+    spent_from = tx_out_ser(out_point_bytes, Coin(tx_out, 12, is_coinbase=False))
+    assert int.from_bytes(mined[36:40], "little") ^ 1 == int.from_bytes(
+        spent_from[36:40], "little"
+    )
+
+
+def test_a_height_wider_than_the_packed_field_is_refused() -> None:
+    """The `uint32` Core packs into is what bounds the height.
+
+    One bit is the coinbase flag, so the highest height the field holds
+    is one below 2**31 -- and a height above it would otherwise leave as
+    an OverflowError, from outside the library's exception contract.
+    """
+    out_point_bytes = OutPoint(bytes.fromhex(f"{7:064x}"), 3).serialize()
+    tx_out = TxOut(1000, "0014" + "11" * 20)
+
+    highest = (1 << 31) - 1
+    at_the_bound = tx_out_ser(out_point_bytes, Coin(tx_out, highest, True))
+    assert len(at_the_bound) == 36 + 4 + len(tx_out.serialize())
+    assert at_the_bound[36:40] == b"\xff\xff\xff\xff"
+
+    coin = Coin(tx_out, highest + 1, is_coinbase=True)
+    with pytest.raises(BTClibValueError, match="invalid height"):
+        tx_out_ser(out_point_bytes, coin)
+    with pytest.raises(BTClibValueError, match="invalid height"):
+        CoinStats().insert(out_point_bytes, coin)
+
+
+def test_a_wrong_argument_is_refused_as_btclib_refuses_one() -> None:
+    """Both arguments are checked, the outpoint by its size."""
+    out_point_bytes = OutPoint(bytes.fromhex(f"{7:064x}"), 3).serialize()
+    coin = Coin(TxOut(1000, "0014" + "11" * 20), 12, is_coinbase=False)
+
+    with pytest.raises(BTClibValueError, match="invalid size"):
+        tx_out_ser(out_point_bytes[:-1], coin)
+    with pytest.raises(BTClibTypeError, match="invalid coin type"):
+        tx_out_ser(out_point_bytes, coin.tx_out)  # type: ignore[arg-type]
+    with pytest.raises(BTClibTypeError, match="invalid coin type"):
+        CoinStats().remove(out_point_bytes, "not a coin")  # type: ignore[arg-type]
+
+
+def test_the_bogo_size_is_not_a_serialized_size() -> None:
+    """Core's own "database-independent metric", and what it is not.
+
+    A script long enough to need a three-byte `var_int` length prefix
+    still counts two for it, so the bogo size of an output and the bytes
+    a transaction writes it as move apart as the script grows.
+    """
+    short = bytes.fromhex("0014" + "11" * 20)
+    long = b"\x51" * 300
+
+    assert bogo_size(short) == 50 + len(short)
+    assert bogo_size(long) == 50 + len(long)
+    assert bogo_size(short.hex()) == bogo_size(short)
+
+    wire = TxOut(1000, long).serialize()
+    assert len(wire) == 8 + 3 + len(long)
+    assert bogo_size(long) != len(wire) + 32 + 4 + 4
+
+
+def test_the_accumulator_is_the_module_it_comes_from() -> None:
+    """`CoinStats` wraps `MuHash3072` and adds no arithmetic of its own.
+
+    A caller resuming from a store hands back an accumulator that module
+    deserialized, and the digest read here is that module's own bytes.
+    """
+    stats = CoinStats()
+    out_point_bytes, coin = _out_point_and_coin(_RECORDED["utxos"][0])
+    stats.insert(out_point_bytes, coin)
+
+    expected = MuHash3072()
+    expected.insert(tx_out_ser(out_point_bytes, coin))
+    assert stats.digest == expected.digest
+    assert CoinStats(MuHash3072.deserialize(stats.muhash.serialize)).digest == (
+        stats.digest
+    )

--- a/tests/integration/coinstats_test.py
+++ b/tests/integration/coinstats_test.py
@@ -1,0 +1,136 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""`btclib.coinstats` against `gettxoutsetinfo`, on a live regtest node.
+
+`bogo_size` and `tx_out_ser` reproduce no wire size and no storage
+format, so nothing in this tree can say either is right: a node's own
+`gettxoutsetinfo` can, and it is the only thing that can.
+`tests/coinstats_test.py` reads a recorded reply for the same reason,
+and this is the same question put to a node of the day rather than to
+the one `tests/_data/gettxoutsetinfo_regtest.json` was recorded from:
+the walk below is the walk that file holds the output of, so re-recording
+it is this test writing down what it collected.
+
+The node is the session's, `-coinstatsindex=1` among its options: asking
+`gettxoutsetinfo` at a named height is what makes it answer from the
+index, which maintains those numbers incrementally as `CoinStats` does
+rather than scanning the set once.
+
+Skipped unless `BTCLIB_INTEGRATION=1` and a `bitcoind` is available; the
+conftest beside this says which switch was off.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from bitcoin_core_rpc import BitcoinCoreRpcClient
+
+from btclib.amount import sats_from_btc
+from btclib.coinstats import CoinStats
+from btclib.script import is_unspendable
+from btclib.tx.coin import Coin
+from btclib.tx.out_point import OutPoint
+from btclib.tx.tx_out import TxOut
+
+pytestmark = pytest.mark.integration
+
+# the payload of the OP_RETURN output below, which is what puts an output
+# Core's own UTXO set refuses into the chain this walks
+_MESSAGE = b"btclib ISS 1623".hex()
+
+
+def _unspent_outputs(
+    node: BitcoinCoreRpcClient, height: int
+) -> list[tuple[bytes, Coin]]:
+    """Return every unspent output of the chain, the genesis one excepted.
+
+    Read from the node and not from a wallet: `getblock` at verbosity 2
+    carries every output of every transaction with the height beside it,
+    and `gettxout` answers for exactly the ones Core's own set holds --
+    null for one that was spent and null for one it never added, which
+    is why an OP_RETURN output is picked up from the block rather than
+    from that call.
+
+    Core excludes the genesis coinbase from the set by hand and reports
+    its value as `total_unspendable_amount`, so it is left out here the
+    way `CoinStatsIndex` leaves it out.
+    """
+    outputs = []
+    for block_height in range(1, height + 1):
+        block = node.call("getblock", [node.call("getblockhash", [block_height]), 2])
+        for position, tx in enumerate(block["tx"]):
+            for out in tx["vout"]:
+                script = str(out["scriptPubKey"]["hex"])
+                spent = node.call("gettxout", [tx["txid"], out["n"], False]) is None
+                if spent and not script.startswith("6a"):
+                    continue
+                value = sats_from_btc(Decimal(str(out["value"])))
+                out_point = OutPoint(bytes.fromhex(str(tx["txid"])), int(out["n"]))
+                coin = Coin(TxOut(value, script), int(block["height"]), position == 0)
+                outputs.append((out_point.serialize(), coin))
+    return outputs
+
+
+def _op_return_output(node: BitcoinCoreRpcClient, wallet: Any) -> None:
+    """Put an output into the chain that Core's own UTXO set will refuse."""
+    raw = wallet.call(
+        "createrawtransaction",
+        [[], [{"data": _MESSAGE}, {wallet.call("getnewaddress"): "0.5"}]],
+    )
+    funded = wallet.call("fundrawtransaction", [raw])
+    signed = wallet.call("signrawtransactionwithwallet", [funded["hex"]])
+    node.call("sendrawtransaction", [signed["hex"]])
+
+
+def test_core_reports_what_coinstats_computes(
+    node: BitcoinCoreRpcClient,
+    wallets: tuple[BitcoinCoreRpcClient, BitcoinCoreRpcClient],
+) -> None:
+    """Build a chain, walk its unspent outputs, and match all four numbers.
+
+    A wrong byte in `tx_out_ser` gives a digest that is a plausible 32
+    bytes and a wrong fixed part in `bogo_size` a plausible integer, so
+    the node answering the same numbers is the whole of the evidence
+    that either is Core's.
+
+    The digest is compared reversed: `gettxoutsetinfo` prints it through
+    `uint256::GetHex`, which is display order, where `digest` is
+    `MuHash3072::Finalize`'s own serialization.
+    """
+    miner, _ = wallets
+    address = miner.call("getnewaddress")
+    # 101, so that the first coinbase is mature and can be spent below
+    miner.call("generatetoaddress", [101, address])
+    miner.call("sendtoaddress", [miner.call("getnewaddress"), "10.0"])
+    miner.call("generatetoaddress", [1, address])
+    _op_return_output(node, miner)
+    # every address type the node writes, so that the script-length term
+    # of the bogo size is more than one script long
+    for amount, address_type in enumerate(
+        ("legacy", "p2sh-segwit", "bech32", "bech32m"), start=1
+    ):
+        target = miner.call("getnewaddress", ["", address_type])
+        miner.call("sendtoaddress", [target, f"{amount}.2345678{amount}"])
+    miner.call("generatetoaddress", [1, address])
+
+    height = int(node.call("getblockcount"))
+    reported = node.call("gettxoutsetinfo", ["muhash", height])
+
+    stats = CoinStats()
+    unspendable = 0
+    for out_point_bytes, coin in _unspent_outputs(node, height):
+        unspendable += is_unspendable(coin.tx_out.script_pub_key.script)
+        stats.insert(out_point_bytes, coin)
+
+    # the walk fed the accumulator what Core's own set refuses, so the
+    # gate is what the agreement below rests on and not an empty branch
+    assert unspendable
+    assert stats.digest[::-1].hex() == reported["muhash"]
+    assert stats.transaction_output_count == reported["txouts"]
+    assert stats.bogo_size == reported["bogosize"]
+    assert stats.total_amount == sats_from_btc(Decimal(str(reported["total_amount"])))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -128,6 +128,12 @@ def node(
             # transaction whole, and a node without the index answers only
             # for what is still in its mempool
             "-txindex=1",
+            # so that `gettxoutsetinfo` answers at a named height, which
+            # is what makes it read the index's own incrementally
+            # maintained numbers rather than scan the set: the two are
+            # the same answer where they agree and only the index says
+            # anything about how it was kept
+            "-coinstatsindex=1",
             "-printtoconsole=0",
         ],
     )

--- a/tests/script/spendability_test.py
+++ b/tests/script/spendability_test.py
@@ -1,0 +1,66 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the `btclib.script.spendability` module."""
+
+from __future__ import annotations
+
+import pytest
+
+from btclib.script import is_nulldata, is_unspendable, serialize
+from btclib.script.limits import MAX_SCRIPT_SIZE
+
+
+@pytest.mark.parametrize(
+    "script_pub_key",
+    [
+        pytest.param(serialize(["OP_RETURN", b"\xde\xad\xbe\xef"]), id="nulldata"),
+        pytest.param(b"\x6a", id="bare OP_RETURN"),
+        pytest.param(b"\x6a\x51", id="OP_RETURN OP_1"),
+        pytest.param(b"\x6a" + bytes(MAX_SCRIPT_SIZE), id="huge OP_RETURN"),
+        pytest.param(b"\x51" * (MAX_SCRIPT_SIZE + 1), id="over MAX_SCRIPT_SIZE"),
+    ],
+)
+def test_an_unspendable_script(script_pub_key: bytes) -> None:
+    """Verify each shape Core's IsUnspendable answers True for."""
+    assert is_unspendable(script_pub_key)
+
+
+@pytest.mark.parametrize(
+    "script_pub_key",
+    [
+        pytest.param(b"", id="empty"),
+        pytest.param(b"\x51" * MAX_SCRIPT_SIZE, id="at MAX_SCRIPT_SIZE"),
+        pytest.param(b"\x6b\x01\x00", id="OP_RESERVED, one past OP_RETURN"),
+    ],
+)
+def test_a_spendable_script(script_pub_key: bytes) -> None:
+    """Verify the boundary on either side of both conditions.
+
+    The empty script has no leading op code to read, the comparison on
+    the length is `>` so the bound itself passes, and the byte above
+    OP_RETURN is a different op code -- weakened to an inequality, the
+    first condition would answer True for every one of these.
+    """
+    assert not is_unspendable(script_pub_key)
+
+
+def test_unspendable_is_wider_than_the_nulldata_classifier() -> None:
+    """`is_nulldata` answers a narrower question, on purpose (issue #211).
+
+    A bare OP_RETURN and an OP_RETURN followed by several pushes are not
+    the standard nulldata shape, and a node will never let either be
+    spent: reading spendability off the classifier would call both
+    spendable.
+    """
+    assert not is_nulldata(b"\x6a")
+    assert not is_nulldata(b"\x6a\x51")
+    assert is_unspendable(b"\x6a")
+    assert is_unspendable(b"\x6a\x51")
+
+
+def test_a_hex_string_is_read_as_octets() -> None:
+    """An Octets parameter takes hex, as every other one here does."""
+    assert is_unspendable("6a0100")
+    assert not is_unspendable("0014" + "00" * 20)


### PR DESCRIPTION
Closes #1623

`btclib.coinstats` — `CoinStats`, `tx_out_ser` and the bogo size — is the
second step [ISS 1122](https://github.com/btclib-org/btclib/issues/1122)
deferred to itself and then closed on, leaving it with no open home. Its
precondition is met: the `Coin` value type landed with
[ISS 1580](https://github.com/btclib-org/btclib/issues/1580).

A module of its own rather than inside `btclib.muhash`: that module is
the general accumulator, RFC 8439's ChaCha20 block function and Core's
`muhash_tests`, and knows nothing about outputs. Putting bitcoin's
application of it there would make the accumulator import the transaction
package.

`CoinStats.serialize` and `deserialize` **stay in btclib-node**. They are
a storage layout chosen by the store that holds them, round-tripping
nothing anybody outside node can check — the same arrangement `Coin`
already has, and the reason `Coin` carries no `parse`. The maintenance
loop stays there too: iteration over live chain state is what node is.

`is_unspendable` rises into `btclib.script`, and it is a deduplication
rather than a move: `fee.dust_threshold` already spelled `CScript::
IsUnspendable` inline. One predicate, two callers, and the issue-211
argument — a bare `OP_RETURN`, and an `OP_RETURN` followed by several
pushes, are unknown to `is_nulldata` and unspendable to a node — stated
once, where the predicate is.

## The oracle, and what it caught

The issue asked for Core's own answers rather than btclib-node's, and it
got them: a regtest `bitcoind` with `-coinstatsindex=1`, asked at a named
height so the reply comes from the index rather than a scan. `muhash`,
`txouts`, `bogosize` and `total_amount` all reproduce.

**`gettxoutsetinfo`'s `muhash` field is byte-reversed.** `FinalizeHash`
puts `MuHash3072::Finalize`'s output in a `uint256` and
`rpc/blockchain.cpp` prints it through `GetHex()`. The first prototype run
mismatched on that alone — and no self-consistent vector could have said
so, which is exactly why the issue demanded a node.

## Review

One local round at fresh context. It did not read the arithmetic a second
time: it **reimplemented Core's** from source with no btclib in it —
ChaCha20, `Num3072` mod 2^3072−1103717, `Finalize`, `TxOutSer`,
`GetBogoSize`, `CTxOut` — and ran it over the recorded reply. All four
fields matched, and three mutations of that independent oracle each
refuted it as they should: packing the height as a `var_int`, not
reversing the digest, and a 49-byte bogo fixed part.

It also checked the three places this branch departed from what the issue
prescribed, and found each of them the tree refusing rather than a
preference — `all_test.py` demands an `assert_x` for every `is_x` a
module publishes, and `assert_unspendable` is not a question anybody
asks; `name_contract_test.py` refuses a public bool whose name promises
nothing, and requires `digest` to be a property.

What it found wrong was prose this diff had falsified: `[tool.codespell]`'s
comment still pointed at the `typos` table that used to carry Core's
`Ser`, and the census justifying the widened entry called every name
carrying the abbreviation Core's — where the largest consumer is now
`tx_out_ser`, which this tree defines and exports. Both say what is true
now. `tests/_data/README.md`'s verdict vocabulary also gained the two
verdicts it was missing.

Gates on `5994409c`, the tip: `uv run --locked pytest -q --cov` → 32052
passed, 31 skipped, 1 xfailed; `uv run --locked pre-commit run
--all-files` → exit 0, tree clean. The `-n -W` docs build and
`BTCLIB_INTEGRATION=1 pytest tests/integration` (5 passed, 3 skipped for
want of an HWI device) ran on `44cdee5f`, before the three prose
corrections and the rebase, and are stated as of that sha rather than
this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157LmcttGkdnQhLdCLkfVRR
