### PR TITLE
`claude-review.yml`'s fork-condition comment drops its stale `bbt` example (closes btclib-org/.github#456)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -61,9 +61,15 @@ jobs:
     # mention job below is the path that still works there: issue_comment
     # is a base-repository event, so it is handed the secret.
     #
-    # Compared by full_name rather than by `.fork`, which asks whether the
-    # head repository is a fork of anything and is true of a branch of
-    # btclib-org/bbt, itself a fork.
+    # Compared by full_name rather than by `.fork`: what withholds the
+    # secret is the head repository not being this one, and `.fork` asks
+    # instead whether the head repository has a parent. The two part on a
+    # repository that is itself a fork -- one the organization has taken
+    # over, say -- whose own branches are handed the secret and answer
+    # `.fork` true, so there `.fork` skips the review this condition means
+    # to run. `gh api repos/btclib-org/btclib --jq .fork` answers `false`,
+    # so the two decide alike here and a swap between them would show up
+    # in no run.
     #
     # CLAUDE_REVIEW_ENABLED is the switch, an *organization* variable,
     # and section 11's *Review* is where what it does is stated rather

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -394,6 +394,18 @@ predicate is. A module of its own rather than a name in
 publishes: unspendable is not one of the standard shapes, and refusing
 a script for being spendable is not a question anybody asks.
 
+### `claude-review.yml`'s fork-condition comment drops its stale `bbt` example
+
+- **The fork-condition comment stops illustrating `.fork` with `btclib-org/bbt`,
+  which is not a fork** (closes btclib-org/.github#456): the argument for
+  comparing by `full_name` instead of `.fork` stands on its own -- `.fork` asks
+  whether the head repository has a parent, not whether it is this one -- and
+  the example now names the case that still trips it, a repository the
+  organization has taken over, whose own branches would be handed the secret.
+  `gh api repos/btclib-org/btclib --jq .fork` answers `false`, so `full_name`
+  and `.fork` decide alike here and the swap the old example warned against
+  would show up in no run.
+
 ## v2026.9.3
 
 ### Repository


### PR DESCRIPTION
`claude-review.yml`'s job header explains why the fork condition is
compared by `full_name` rather than by `.fork`, and its example was
`btclib-org/bbt`, "itself a fork". `bbt` is not a fork and nothing in
the organization is, so the sentence had stopped instancing the case it
argued from. The argument is sound and was never at issue — `.fork` is a
property of the head repository rather than of the pull request — and it
is only the example that expired.

**This is the last of the eight**, which is why it closes rather than
advances. `btclib-org/.github` and `btclib-org/bbt` already carried the
replacement; `bitcoin-core-rpc`, `btclib-secp256k1`, `btclib-node`,
`portanode` and `btclib-benchmarks` landed it earlier today.

The replacement is not this branch's composition. `bbt` landed the
wording in its own tree ([PR 8](https://github.com/btclib-org/bbt/pull/8),
`6ccfd3a`, closing [ISS 3](https://github.com/btclib-org/bbt/issues/3)
there); two landed copies agreed before this wave began, so every
receiving tree is a receiver rather than a decider. The words here are
identical to `bbt`'s after folding whitespace — checked with a negative
control, the comparison without the repository-name substitution
answering false — and the one adaptation is that name, in a sentence
this tree asserts about itself: `gh api repos/btclib-org/btclib --jq
.fork` answers `false`, with `gitster/git` answering `true` as the
control that makes the reading able to say either.

The line wrapping is this file's own: 70-74 columns against its
pre-existing maximum of 75.

The paragraph below, opening `# CLAUDE_REVIEW_ENABLED is the switch`, is
spelled three different ways across the receiving trees. That divergence
is [ISS 267](https://github.com/btclib-org/.github/issues/267)'s and is
explicitly open, so it is left exactly as this tree has it: the diff
shows no `+`/`-` line touching it. No `EXPECTED_DRIFT` entry is added
either — section 14 does not list `claude-review.yml`, this repository
having no receiving copy of it.

The branch was rebased three times, `main` moving under it each time,
and the union merge driver ate the blank line above the changelog
entry's heading on every one — exit 0 and a clean tree each time.
Repaired from the pre-rebase blob before any fixer ran, so the
subsequent `--fix` run is independent confirmation rather than the cause
of the state it approves. What carried the review's clear across those
rebases is the non-`CHANGELOG.md` diff hash,
`ef117263bd0432dffab11782a172a359534eb387` over 12 lines, derived
independently by the coder, by the reviewer and again before this merge.

The bot review does not run on this branch, and that is expected rather
than a failure: the action validates its own workflow against the
default branch and declines where they differ.

`claude-review.yml`'s fork-condition comment drops its stale `bbt` example (closes btclib-org/.github#456)

`btclib-org/bbt` stopped being a fork, so the comment's example no
longer instances the case it illustrates. The replacement wording is
the one already landed in `btclib-org/bbt` (PR 8, `6ccfd3a`) and in
`btclib-org/.github`, with only the repository name in the `gh api`
readback adapted to this tree; `gh api repos/btclib-org/btclib --jq
.fork` answers `false`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CxwWEa8nRid69sZ81isSa1


Local review: CLEARED dedecfd3, and the branch was then rebased onto 5daff97 with the diff unchanged — the non-CHANGELOG.md hash ef117263 holding over 12 lines, re-derived by the reviewer and again before this merge — so nothing went back for a further round, per the process file's rule that a rebase moving only the base owes the gates rather than a new review. Gates on that tree, all exit 0 on the final tip: `uv run pre-commit run --all-files`, `uv run pytest` (32052 passed, coverage 100.00%), `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html` with its dead-link grep, and `uv run mypy src/btclib tests .github/scripts`. They ran at one-minute loads of 30 to 87 on a ten-core machine shared with other sessions; load produces timeouts and flakes, which surface as failures, so a green under it is not weakened by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxwWEa8nRid69sZ81isSa1

## Summary by Sourcery

Correct the Claude review workflow documentation to accurately explain fork-condition handling and replace its outdated repository example.

Bug Fixes:
- Update the fork-condition documentation to remove the stale `btclib-org/bbt` fork example and clarify why repository identity must be checked with `full_name` rather than `.fork`.
- Record the workflow-comment correction in the changelog and close btclib-org/.github#456.