### PR TITLE
ElectrumFetcher asks which chain the server serves (closes #1691)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,8 +301,8 @@ testnet4, signet and regtest apart, and no two signets from each other
 -- Core builds every signet's genesis from
 the same parameters, the challenge going into the message start and not
 the block -- which is the same limit the node backends have without a
-`signet_challenge`; SECURITY.md's bullet now says so once for all three
-backends instead of implying Esplora is worse.
+`signet_challenge`; SECURITY.md's bullet now says so once for every
+backend instead of implying Esplora is worse.
 
 ### `merkleblock` joins `btclib.p2p`, over a new `PartialMerkleTree`
 
@@ -405,6 +405,28 @@ a script for being spendable is not a question anybody asks.
   `gh api repos/btclib-org/btclib --jq .fork` answers `false`, so `full_name`
   and `.fork` decide alike here and the swap the old example warned against
   would show up in no run.
+
+### `ElectrumFetcher` gains `verify_network` (closes #1691)
+
+`ElectrumFetcher` takes `verify_network`, on by default, asked once
+before the first fetch and not in the constructor: `blockchain.block.header`
+at height 0 -- which `get_block_header` already reads for every other
+height -- with `BlockHeader.hash` of the eighty bytes it answers compared
+against `NETWORKS[network].genesis_block`, refusing with both hashes in
+the message on a mismatch. Same name, same keyword-only argument, same
+default, same opt-out as `BitcoinCoreFetcher.verify_network`. The header
+and not `server.features`, which carries the `genesis_hash` member
+Electrum's own client compares: `btclib.electrum` already carries this
+request and the reply, where that one would want a codec function it
+does not have. The header is also what this backend can check rather
+than take, the eighty bytes going through `block_header_from_raw` before
+their hash is compared, the same way `get_best_block_id` recomputes the
+tip. `get_tx_merkle` asks as the `Fetcher` questions do, and `verify_tx`
+through it: a branch checked
+against a header from a server on another chain is a proof that is valid
+and about a chain the caller did not mean. SECURITY.md's fetch-trust
+bullet names this backend beside the others, the genesis check and the
+signet limit alike now being one sentence for every one of them.
 
 ## v2026.9.3
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -354,27 +354,29 @@ used to teach and to prototype as much as to build:
     password still runs the cipher once; `scrypt`'s cost is what BIP38
     relies on to make that expensive per guess, not a MAC that would
     turn the guess away first
-- **a `btclib.fetch` backend is trusted, and they are not trusted
-    alike.** `BitcoinCoreFetcher`, `BitcoinCoreRestFetcher` and
-    `EsploraFetcher` all ask by default which chain they are talking to,
-    and `verify_network` is the same name, the same keyword-only
-    argument, the same default and the same opt-out on all three -- not
-    the same question, which is the next sentence. `BitcoinCoreFetcher` and
+- **a `btclib.fetch` backend is trusted, and they are not trusted alike.**
+    `BitcoinCoreFetcher`, `BitcoinCoreRestFetcher`, `EsploraFetcher` and
+    `ElectrumFetcher` each ask by default which chain they are talking to,
+    and `verify_network` is the same name, the same keyword-only argument,
+    the same default and the same opt-out on every one of them -- not the
+    same question, which is the next sentence. `BitcoinCoreFetcher` and
     `BitcoinCoreRestFetcher` talk to a node that validated the chain it
     reports, and `signet_challenge` holds either to the fetcher's label
     beside `verify_network`: `rest_chaininfo` writes out what
     `getblockchaininfo` answers and adds nothing, so `/chaininfo.json`
-    carries the members the JSON-RPC check reads. What `-rest` adds is
-    that it authenticates nobody who reaches it, so the endpoint is
-    trusted on whoever handed it over. `EsploraFetcher` talks to a host
-    that says it validated, and its own `verify_network` compares one
-    block rather than reading the host's own verdict on itself:
-    `/block-height/0`, the genesis, against `NETWORKS[network].genesis_block`.
-    None of the three tells two signets apart on a genesis hash alone —
+    carries the members the JSON-RPC check reads. What `-rest` adds is that
+    it authenticates nobody who reaches it, so the endpoint is trusted on
+    whoever handed it over. `EsploraFetcher` and `ElectrumFetcher` talk to a
+    host that says it validated, and their own `verify_network` compares one
+    block rather than reading the host's own verdict on itself: the genesis,
+    against `NETWORKS[network].genesis_block` — `/block-height/0` for the
+    one, `blockchain.block.header` at height 0 for the other, whose answer
+    is the eighty bytes rather than a hash, so what is compared there is
+    their hash. No backend tells two signets apart on a genesis hash alone —
     Core builds every signet's genesis from the same parameters, the
-    challenge going into the message start and not into the block — so
-    the node backends need `signet_challenge` for that half of the
-    question and `EsploraFetcher`, which takes none, cannot ask it.
+    challenge going into the message start and not into the block — so the
+    node backends need `signet_challenge` for that half of the question, and
+    `EsploraFetcher` and `ElectrumFetcher`, which take none, cannot ask it.
 
     Past that question, the answers a fetch itself makes are checked to
     different degrees. The transaction: its id is recomputed

--- a/src/btclib/fetch/electrum.py
+++ b/src/btclib/fetch/electrum.py
@@ -40,7 +40,7 @@ issue and issue #1193 hold the interface itself unchanged. What
 `Fetcher`'s own class docstring calls "evidence beside the data" is what
 these two are -- a merkle branch checked against a header this fetcher
 fetched on its own, which is a different kind of answer from the other
-three backends' word for it, and the reason this backend exists.
+backends' word for it, and the reason this backend exists.
 """
 
 from __future__ import annotations
@@ -50,6 +50,7 @@ from typing_extensions import override
 from btclib import electrum
 from btclib.alias import Octets
 from btclib.block.block_header import BlockHeader
+from btclib.exceptions import BTClibValueError
 from btclib.fetch.fetcher import (
     Fetcher,
     block_header_from_raw,
@@ -60,6 +61,7 @@ from btclib.fetch.fetcher import (
     tx_id_hex,
 )
 from btclib.fetch.transport import DEFAULT_TIMEOUT, LineTransport
+from btclib.network import NETWORKS
 from btclib.tx import Tx
 
 __all__ = [
@@ -97,6 +99,18 @@ class ElectrumFetcher(Fetcher):
     history and its unspent outputs, `blockchain.scripthash.get_history`
     and `.listunspent`, but the interface does not ask those questions
     and this issue does not add them.
+
+    `verify_network` is who asks whether the server is on the chain this
+    fetcher labels with, and `assert_network` below is the question it
+    asks. On by default and before the first fetch rather than in this
+    constructor: the answer costs a round trip that is worth paying
+    where it is checked and wasted where a fetcher is built and never
+    used, and a server that is merely unreachable should not be a
+    failure to *construct* anything. The answer is then kept -- a server
+    does not change chain under a client that goes on pointing at it --
+    and a caller that would rather not ask says `verify_network=False`.
+    Same name, same keyword-only argument, same default, same opt-out as
+    `BitcoinCoreFetcher.verify_network`.
     """
 
     def __init__(
@@ -104,12 +118,16 @@ class ElectrumFetcher(Fetcher):
         network: str = "mainnet",
         *,
         transport: LineTransport,
+        verify_network: bool = True,
         timeout: float = DEFAULT_TIMEOUT,
     ) -> None:
         super().__init__(network)
         self.transport = transport
+        self.verify_network = verify_network
         self.timeout = timeout
         self._next_id = 0
+        self._agreed = False
+        self._disagreement = ""
 
     def _next_request_id(self) -> int:
         """Return a fresh request id, one higher than the last.
@@ -131,6 +149,33 @@ class ElectrumFetcher(Fetcher):
         with client_errors():
             return self.transport(request, self.timeout)
 
+    def _verify_once(self) -> None:
+        """Compare the server's chain with this fetcher's label, once.
+
+        `BitcoinCoreFetcher._verify_once`, unchanged: called by the
+        fetches and not by `_round_trip` or `_header_at`, which is what
+        `assert_network` itself goes through -- a check in there would
+        ask the server about the server, from inside the question.
+
+        A disagreement is remembered and raised again for every later
+        call, because it is a settled fact about a configuration rather
+        than a request that failed -- and a fetcher that asked once,
+        refused once and then served an address would be the silent
+        failure this exists to stop. A `FetchError` is not an answer and
+        is remembered as nothing: the server was unreachable or spoke
+        nonsense, which the next call may well find otherwise.
+        """
+        if not self.verify_network or self._agreed:
+            return
+        if self._disagreement:
+            raise BTClibValueError(self._disagreement)
+        try:
+            self.assert_network()
+        except BTClibValueError as e:
+            self._disagreement = str(e)
+            raise
+        self._agreed = True
+
     def _tip(self) -> electrum.HeaderTip:
         """Return the chain tip `blockchain.headers.subscribe` answers."""
         request_id = self._next_request_id()
@@ -138,9 +183,28 @@ class ElectrumFetcher(Fetcher):
         with fetch_errors("headers.subscribe"):
             return electrum.headers_subscribe_response(line, request_id)
 
+    def _header_at(self, height: int) -> BlockHeader:
+        """Return the header at this height, checked, asking nothing else.
+
+        The seam `get_block_header` and `assert_network` share, the way
+        `_tip` is the one `get_block_count` and `get_best_block_id`
+        share: `assert_network` reaches the genesis header through this
+        and not through `get_block_header`, which calls `_verify_once`.
+
+        `block_header_from_raw` is what checks the eighty bytes, so the
+        header a caller compares or hashes is one that is well-formed and
+        cost real work to find, and not the server's word for either.
+        """
+        request_id = self._next_request_id()
+        line = self._round_trip(electrum.block_header_request(request_id, height))
+        with fetch_errors(f"block header {height}"):
+            raw = electrum.block_header_response(line, request_id)
+        return block_header_from_raw(raw, height)
+
     @override
     def get_tx(self, tx_id: Octets) -> Tx:
         """Return the transaction with this id, via `transaction.get`."""
+        self._verify_once()
         hex_ = tx_id_hex(tx_id)
         request_id = self._next_request_id()
         line = self._round_trip(electrum.transaction_get_request(request_id, hex_))
@@ -151,6 +215,7 @@ class ElectrumFetcher(Fetcher):
     @override
     def get_block_count(self) -> int:
         """Return the height of the chain tip, via `headers.subscribe`."""
+        self._verify_once()
         return self._tip().height
 
     @override
@@ -162,6 +227,7 @@ class ElectrumFetcher(Fetcher):
         `block_header_from_raw`'s check on the bytes it sent, and then
         the hash of the header that passed it.
         """
+        self._verify_once()
         tip = self._tip()
         header = block_header_from_raw(tip.header, tip.height)
         return header.hash
@@ -169,19 +235,66 @@ class ElectrumFetcher(Fetcher):
     @override
     def get_block_header(self, height: int) -> BlockHeader:
         """Return the header at this height, via `blockchain.block.header`."""
-        height = block_header_height(height)
-        request_id = self._next_request_id()
-        line = self._round_trip(electrum.block_header_request(request_id, height))
-        with fetch_errors(f"block header {height}"):
-            raw = electrum.block_header_response(line, request_id)
-        return block_header_from_raw(raw, height)
+        self._verify_once()
+        return self._header_at(block_header_height(height))
+
+    def assert_network(self) -> None:
+        """Raise unless the server serves the chain this fetcher labels with.
+
+        One request and one comparison: `blockchain.block.header` at
+        height 0 -- the same method `get_block_header` asks for every
+        other height, asked here for the block every chain starts from --
+        against `NETWORKS[self.network].genesis_block`. What is compared
+        is `BlockHeader.hash` of the eighty bytes `_header_at` has
+        checked, so this backend answers the question the way it answers
+        `get_best_block_id`: by hashing a header rather than by reading a
+        hash the server chose. `server.features` carries a `genesis_hash`
+        member and is what Electrum's own client compares
+        (`electrum/interface.py`); the header is asked for instead
+        because it makes the server produce eighty bytes that hash to the
+        genesis rather than repeat a string, and because it needs no
+        codec function `btclib.electrum` does not already have.
+
+        Public for the same reason `BitcoinCoreFetcher.assert_network` is
+        -- a caller that wants the question answered at a moment of its
+        own.
+
+        Worth the call, because the failure it catches is silent, the
+        same one `BitcoinCoreFetcher.assert_network`'s docstring names: a
+        fetcher labelled `mainnet` over a server on another chain renders
+        a mainnet address for every output it fetches, for coins that are
+        not there. It is sharper here than elsewhere, because `verify_tx`
+        checks a branch against a header fetched from that same server:
+        a caller on the wrong chain is otherwise handed a proof that is
+        valid and about a chain they did not mean.
+
+        What a genesis hash cannot separate is two signets, and
+        `EsploraFetcher.assert_network`'s docstring is where that is
+        written down. This class takes no `signet_challenge` of its own,
+        for the reason that class takes none: nothing among the methods
+        `btclib.electrum` speaks is a signet's challenge to compare
+        against.
+
+        A malformed reply is a `FetchError`. A disagreement is a
+        `BTClibValueError` naming both hashes: the server is the
+        authority on which chain it serves, so the fetcher's label is the
+        thing to fix.
+        """
+        reported = self._header_at(0).hash
+        expected = NETWORKS[self.network].genesis_block
+        if reported != expected:
+            err_msg = "the server serves a chain whose genesis is"
+            err_msg += f" {reported.hex()}, not the {expected.hex()}"
+            err_msg += f" this {self.network} fetcher was built for"
+            raise BTClibValueError(err_msg)
 
     def get_tx_merkle(self, tx_id: Octets, height: int) -> electrum.MerkleProof:
         """Return the branch proving `tx_id` confirmed at `height`.
 
-        `blockchain.transaction.get_merkle`, the one question the other
-        two backends cannot answer at all.
+        `blockchain.transaction.get_merkle`, the one question no other
+        backend here can answer at all.
         """
+        self._verify_once()
         hex_ = tx_id_hex(tx_id)
         height = block_header_height(height)
         request_id = self._next_request_id()

--- a/tests/bool_parameter_test.py
+++ b/tests/bool_parameter_test.py
@@ -132,6 +132,7 @@ from btclib.ecc import bms, dsa, musig2, ssa
 from btclib.exceptions import BTClibTypeError
 from btclib.fetch.bitcoin_core import BitcoinCoreFetcher
 from btclib.fetch.bitcoin_core_rest import BitcoinCoreRestClient, BitcoinCoreRestFetcher
+from btclib.fetch.electrum import ElectrumFetcher
 from btclib.fetch.esplora import EsploraFetcher
 from btclib.hwi import HwiSigner, enumerate_devices
 from btclib.key import PrvKeyData
@@ -173,6 +174,7 @@ from btclib.tx.tx_out import TxOut
 from btclib.wallet.script_wallet import KeyGroup
 from tests.fetch import Recorded
 from tests.fetch.bitcoin_core_test import client
+from tests.fetch.electrum_test import LineRecorded
 from tests.psbt import psbt_cases
 
 
@@ -1078,6 +1080,15 @@ _TRUTHS = (
         {"base_url": "https://esplora.example/api", "transport": Recorded()},
         reason="whether the explorer is asked which chain it serves; the"
         " same check under the same name, made before its first fetch",
+    ),
+    _Case(
+        "btclib.fetch.electrum.ElectrumFetcher.__init__",
+        "verify_network",
+        ElectrumFetcher,
+        {"transport": LineRecorded()},
+        reason="whether the server is asked which chain it serves; the"
+        " same check again, over the header at height 0 this backend"
+        " hashes rather than a chain name it would be told",
     ),
     _Case(
         "btclib.bip32.bip32.derive_from_account",

--- a/tests/fetch/electrum_test.py
+++ b/tests/fetch/electrum_test.py
@@ -23,6 +23,7 @@ from bitcoin_core_rpc import FetchError as RpcFetchError
 from btclib.block.block_header import BlockHeader
 from btclib.exceptions import BTClibValueError, FetchError, RpcError
 from btclib.fetch.electrum import ElectrumFetcher
+from btclib.network import NETWORKS
 from btclib.tx import OutPoint
 from tests.fetch import TIP_HEADER_RAW, TIP_HEIGHT, TIP_ID, TX_ID
 
@@ -53,6 +54,26 @@ MERKLE_BRANCH = [
     "b3c8b80f3aca397fba2062b35cc042ff806655d0e593c5ef50d6df48d7360836",
     "66532296fd04814bf47c9b0bbe2760262d5e452a77671c5cac90624d6d8c8554",
 ]
+
+# the eighty bytes `blockchain.block.header` answers for height 0 on each
+# chain: the first eighty of the genesis block serializations this tree
+# already carries, mainnet's in tests/block/_data/checkblock_valid.json and
+# testnet's in tests/block/_data/blockfilters.json. What makes them vectors
+# rather than literals to trust is that their hashes are the ones
+# `NETWORKS[network].genesis_block` holds, which is what the first test of
+# the network check asserts before any of the others rests on it
+MAINNET_GENESIS_HEADER = (
+    "010000000000000000000000000000000000000000000000000000000000000000000000"
+    "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49"
+    "ffff001d1dac2b7c"
+)
+TESTNET_GENESIS_HEADER = (
+    "010000000000000000000000000000000000000000000000000000000000000000000000"
+    "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4adae5494d"
+    "ffff001d1aa4ae18"
+)
+MAINNET_GENESIS = NETWORKS["mainnet"].genesis_block.hex()
+TESTNET_GENESIS = NETWORKS["testnet"].genesis_block.hex()
 
 
 class RpcErrorAnswer:
@@ -108,11 +129,26 @@ class LineRecorded:
 
 
 def fetcher(*answers: object, **kwargs: object) -> ElectrumFetcher:
-    """Return an ElectrumFetcher over a scripted LineTransport."""
+    """Return an ElectrumFetcher over a scripted LineTransport.
+
+    `verify_network=False` unless a test says otherwise: the scripted
+    answers are consumed in order, so a fetcher that asked the server
+    which chain it serves would eat the answer the test wrote for the
+    call it is about. The tests that *are* about the question build the
+    fetcher themselves -- one of them passing no `verify_network` at all,
+    which is what pins the default.
+    """
     network = kwargs.pop("network", "mainnet")
     assert isinstance(network, str)
+    verify_network = kwargs.pop("verify_network", False)
+    assert isinstance(verify_network, bool)
     transport = LineRecorded(*answers)
-    return ElectrumFetcher(network, transport=transport, **kwargs)  # type: ignore[arg-type]
+    return ElectrumFetcher(
+        network,
+        transport=transport,
+        verify_network=verify_network,
+        **kwargs,  # type: ignore[arg-type]
+    )
 
 
 def transport_of(endpoint: ElectrumFetcher) -> LineRecorded:
@@ -218,7 +254,7 @@ def test_get_block_header_refuses_a_negative_height(height: int) -> None:
 
 
 def test_get_tx_merkle_round_trips_the_proof() -> None:
-    """`get_tx_merkle` is the question the other two backends cannot answer."""
+    """`get_tx_merkle` is the question no other backend can answer."""
     endpoint = fetcher(
         {"block_height": TIP_HEIGHT, "merkle": MERKLE_BRANCH, "pos": MERKLE_TX_POS}
     )
@@ -302,3 +338,138 @@ def test_a_transport_failure_is_translated() -> None:
     """`LineTransport`'s exception contract, translated by `client_errors`."""
     with pytest.raises(FetchError, match="connection refused"):
         fetcher(RpcFetchError("connection refused")).get_tx(MERKLE_TX_ID)
+
+
+@pytest.mark.parametrize(
+    "network, raw",
+    [("mainnet", MAINNET_GENESIS_HEADER), ("testnet", TESTNET_GENESIS_HEADER)],
+)
+def test_the_genesis_headers_hash_to_what_networks_carries(
+    network: str, raw: str
+) -> None:
+    """The control the two vectors above rest on, for both chains.
+
+    `assert_network` compares the hash of the eighty bytes the server
+    sent, so a header vector that hashed to something else would make
+    every test below agree about the wrong thing.
+    """
+    assert BlockHeader.parse(raw).hash == NETWORKS[network].genesis_block
+
+
+def test_assert_network_accepts_the_genesis_of_the_network_given() -> None:
+    """The check that passes: the server answers the genesis expected."""
+    endpoint = fetcher(MAINNET_GENESIS_HEADER)
+    endpoint.assert_network()
+    request = json.loads(transport_of(endpoint).requests[0])
+    assert request["method"] == "blockchain.block.header"
+    assert request["params"] == [0]
+
+
+def test_assert_network_refuses_a_different_genesis() -> None:
+    """The silent failure this exists for: a testnet server, a mainnet label.
+
+    Both hashes are in the message, so the caller can see which is which.
+    """
+    with pytest.raises(BTClibValueError, match=f"{TESTNET_GENESIS}.*{MAINNET_GENESIS}"):
+        fetcher(TESTNET_GENESIS_HEADER).assert_network()
+
+
+def test_a_header_that_is_not_the_genesis_of_any_chain_is_refused() -> None:
+    """A server answering height 0 with some other block it mined is refused.
+
+    The tip header is well-formed and cost real work, so
+    `block_header_from_raw` passes it: what refuses it is the comparison.
+    """
+    with pytest.raises(BTClibValueError, match=f"{TIP_ID}.*{MAINNET_GENESIS}"):
+        fetcher(TIP_HEADER_RAW).assert_network()
+
+
+def test_the_first_fetch_asks_the_server_which_chain_it_serves() -> None:
+    """Which is what `verify_network` buys, and it is on by default.
+
+    No `verify_network` argument here on purpose: this is the test that
+    would fail if the default were flipped.
+    """
+    transport = LineRecorded(MAINNET_GENESIS_HEADER, MERKLE_TX_RAW)
+    endpoint = ElectrumFetcher("mainnet", transport=transport)
+    assert endpoint.get_tx(MERKLE_TX_ID).id.hex() == MERKLE_TX_ID
+    assert transport.methods == [
+        "blockchain.block.header",
+        "blockchain.transaction.get",
+    ]
+    assert json.loads(transport.requests[0])["params"] == [0]
+
+
+def test_the_chain_is_asked_for_once_and_not_per_fetch() -> None:
+    """A server does not change chain under a client pointing at it.
+
+    Built with no `verify_network` argument, like the test above: the
+    default is what these two pin.
+    """
+    tip = {"height": TIP_HEIGHT, "hex": TIP_HEADER_RAW}
+    transport = LineRecorded(MAINNET_GENESIS_HEADER, tip)
+    endpoint = ElectrumFetcher("mainnet", transport=transport)
+    assert endpoint.get_block_count() == TIP_HEIGHT
+    assert endpoint.get_best_block_id().hex() == TIP_ID
+    assert transport.methods == [
+        "blockchain.block.header",
+        "blockchain.headers.subscribe",
+        "blockchain.headers.subscribe",
+    ]
+
+
+def test_a_server_on_another_chain_answers_no_fetch_at_all() -> None:
+    """The failure the option exists for, and it does not wear off.
+
+    A fetcher that asked once, was refused once and then served an
+    address on the next call would be the silent failure with an extra
+    step, so the disagreement is remembered -- and remembered rather than
+    re-asked, which is what the second call proves by adding no request.
+    """
+    transport = LineRecorded(TESTNET_GENESIS_HEADER)
+    endpoint = ElectrumFetcher("mainnet", transport=transport, verify_network=True)
+    for _ in range(2):
+        with pytest.raises(BTClibValueError, match=TESTNET_GENESIS):
+            endpoint.get_block_count()
+    assert len(transport.requests) == 1
+
+
+def test_the_fifth_question_is_refused_on_another_chain_too() -> None:
+    """`get_tx_merkle` asks first, as the four `Fetcher` questions do.
+
+    The proof is the answer a caller is likeliest to trust, so a branch
+    from a server on the wrong chain is the one worth never returning.
+    """
+    transport = LineRecorded(TESTNET_GENESIS_HEADER)
+    endpoint = ElectrumFetcher("mainnet", transport=transport, verify_network=True)
+    with pytest.raises(BTClibValueError, match=TESTNET_GENESIS):
+        endpoint.get_tx_merkle(MERKLE_TX_ID, TIP_HEIGHT)
+    with pytest.raises(BTClibValueError, match=TESTNET_GENESIS):
+        endpoint.verify_tx(MERKLE_TX_ID, TIP_HEIGHT)
+
+
+def test_a_server_that_could_not_be_asked_is_asked_again() -> None:
+    """A server that did not answer said nothing about which chain it is on.
+
+    The distinction the remembering rests on: a chain that disagrees is a
+    fact about a configuration, where a request that did not answer is
+    one to make again.
+    """
+    tip = {"height": TIP_HEIGHT, "hex": TIP_HEADER_RAW}
+    transport = LineRecorded(
+        RpcFetchError("connection refused"), MAINNET_GENESIS_HEADER, tip
+    )
+    endpoint = ElectrumFetcher("mainnet", transport=transport, verify_network=True)
+    with pytest.raises(FetchError, match="connection refused"):
+        endpoint.get_block_count()
+    assert endpoint.get_block_count() == TIP_HEIGHT
+    assert len(transport.requests) == 3
+
+
+def test_verify_network_false_asks_the_server_nothing() -> None:
+    """With the opt-out taken, the fetch is the only request made."""
+    tip = {"height": TIP_HEIGHT, "hex": TIP_HEADER_RAW}
+    transport = LineRecorded(tip)
+    endpoint = ElectrumFetcher("mainnet", transport=transport, verify_network=False)
+    assert endpoint.get_block_count() == TIP_HEIGHT
+    assert transport.methods == ["blockchain.headers.subscribe"]

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -254,7 +254,11 @@ KEYWORD_ONLY: dict[str, list[str]] = {
         "verify_network",
         "signet_challenge",
     ],
-    "btclib.fetch:ElectrumFetcher.__init__": ["transport", "timeout"],
+    "btclib.fetch:ElectrumFetcher.__init__": [
+        "transport",
+        "verify_network",
+        "timeout",
+    ],
     "btclib.fetch:EsploraFetcher.__init__": [
         "network",
         "verify_network",


### PR DESCRIPTION
Closes #1691
Closes #1702

`ElectrumFetcher` labelled every output with the network it was built for
and never asked the server which chain it is on. It asks now, in the
shape the other backends carry — same name, keyword-only, on by default,
same opt-out — through `blockchain.block.header` at height 0, compared
against `NETWORKS[network].genesis_block`, once before the first fetch
and never in the constructor.

The header route rather than `server.features`, whose reply carries a
`genesis_hash` member and which Electrum's own client uses
(`spesmilo/electrum`'s `interface.py`): a header makes the server produce
eighty bytes that hash to the genesis, where the feature member is a
string it can simply repeat. It also needs no codec `btclib.electrum`
lacks — `block_header_request` is already there, and the reply comes back
through `block_header_from_raw`, so it is checked before it is compared.

A private `_header_at` is the seam `get_block_header` and `assert_network`
share: reaching through the public method would recurse into
`_verify_once`.

**No `RELEASE_NOTES.md` entry**, and that is the one thing separating
this from #1674: `git show v2026.9.3:src/btclib/fetch/electrum.py` fails,
so `ElectrumFetcher` has never shipped and there is no previous behaviour
for anyone to act on.

## Review

One local round at fresh context, which ran the branch rather than read
it.

The precedent's blocking finding was reproduced first, since it is the
gap this could most easily repeat: flipping the default to `False` fails
exactly the two tests that construct with no flag, and no others. Six
more load-bearing lines were broken one at a time against the whole
suite, each caught by the test that claims to pin it — including the
recursion the `_header_at` seam exists to avoid, which is a
`RecursionError` and not an argument.

Its strongest finding it then refused to charge to this branch: two
`_verify_once` calls can be deleted with the suite green — and the same
sweep against the backends already on `main` shows `EsploraFetcher` has
the same two gaps in the same two methods. Existing practice, filed as
[ISS 1701](https://github.com/btclib-org/btclib/issues/1701).

`SECURITY.md`'s bullet names the backends instead of counting them:
`CachingFetcher` and `FallbackFetcher` are `Fetcher` subclasses that take
no `verify_network`, so a universal would have been false. The same
change falsified a sentence in #1674's own `CHANGELOG.md` entry, which is
this diff's to fix rather than to file, and three more sentences counted
the backends — `get_tx_merkle`'s docstring, the module docstring, and the
test driving it. They name the property now, which closes #1702.

Gates on `6b2483e9`: `uv run --locked pytest -q --cov` → 32068 passed, 31
skipped, 1 xfailed; `uv run --locked pre-commit run --all-files` → exit
0, tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157LmcttGkdnQhLdCLkfVRR

## Summary by Sourcery

Verify Electrum servers against the configured network before serving fetched blockchain data.

New Features:
- Add opt-in-compatible-by-default network verification to ElectrumFetcher, checking the server’s genesis header before the first fetch and caching the result.
- Expose ElectrumFetcher network verification with the same keyword-only interface, default, and opt-out behavior as the other verified fetchers.

Bug Fixes:
- Prevent ElectrumFetcher from returning data or transaction proofs from a server serving a different blockchain.

Enhancements:
- Consolidate Electrum header retrieval for normal requests and network validation while preserving retry behavior for failed verification requests.

Documentation:
- Update the changelog and security guidance to include ElectrumFetcher among the backends that verify their configured network.

Tests:
- Add coverage for matching and mismatched genesis headers, default verification, one-time checks, persistent mismatches, retryable transport failures, and the verification opt-out.