### PR TITLE
The `uv` floor is raised to match Dependabot's ceiling (issue btclib-org/.github#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -428,6 +428,19 @@ and about a chain the caller did not mean. SECURITY.md's fetch-trust
 bullet names this backend beside the others, the genesis check and the
 signet limit alike now being one sentence for every one of them.
 
+### The `uv` floor is raised to match Dependabot's ceiling
+
+`[tool.uv] required-version` moves from `>=0.12.1` to `>=0.12.7` (issue
+btclib-org/.github#448), the uv version `dependabot/dependabot-core`'s
+`uv/Dockerfile` currently bundles (`ghcr.io/astral-sh/uv:0.12.7`,
+checked 2026-09-04). Section 1 of the organization standard sets the
+floor at that ceiling rather than below it: a floor below the ceiling
+admits a uv older than the one Dependabot's own lock updates are
+written with, which is the rewrite the key exists to guard against.
+Raising the floor as the ceiling moves is always safe, the ceiling only
+rising. `uv.lock` carries no `required-version` of its own and is
+unchanged.
+
 ## v2026.9.3
 
 ### Repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,7 @@ dev = [
 # update. Section 1 of the organization standard states that argument
 # once; section 15 carries the command that re-derives the ceiling
 # (btclib-org/.github#312)
-required-version = ">=0.12.1"
+required-version = ">=0.12.7"
 
 [tool.uv.build-backend]
 # what the sdist carries beyond what the backend puts there by itself --


### PR DESCRIPTION
The sixth of the seven trees that owe btclib-org/.github#448, and the
last before `btclib-org/.github` itself. The citation is `(issue …)` and
not a closing keyword deliberately: `.github` is the tree that answers
the issue, because it also has to delete a `BACKLOG` row keyed on 448
that lists all seven, and it lands last.

The ceiling was re-derived rather than taken from the issue body, whose
`0.12.5` is stale: `dependabot/dependabot-core`'s `uv/Dockerfile` names
`ghcr.io/astral-sh/uv:0.12.7`, read independently by the coder and again
by the reviewer on 2026-09-04.

The entry keeps this tree's paragraph shape rather than acquiring a
bullet, and carries its citation in the prose making the claim. Section
9's prohibition is against the *heading* citation, which the first draft
of this branch had and which was sent back. Whether the affirmative half
of that rule also fixes an entry's body shape is a question about the
standard rather than about this branch, and the reviewer filed it as
[ISS 802](https://github.com/btclib-org/.github/issues/802).

The `uv` floor is raised to match Dependabot's ceiling (issue btclib-org/.github#448)

`[tool.uv] required-version` moves from `>=0.12.1` to `>=0.12.7`, the uv
version `dependabot/dependabot-core`'s `uv/Dockerfile` currently bundles
(`ghcr.io/astral-sh/uv:0.12.7`, checked 2026-09-04). Section 1 of the
organization standard sets the floor at that ceiling rather than below
it: a floor below the ceiling admits a uv older than the one
Dependabot's own lock updates are written with, which is the rewrite
the key exists to guard against. Raising the floor as the ceiling moves
is always safe, the ceiling only rising. `uv.lock` carries no
`required-version` of its own and is unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CxwWEa8nRid69sZ81isSa1


Local review: CLEARED fe5ca7fb, which is this head. The reviewer re-derived the ceiling itself, traced all six clauses of the entry to sections 1 and 15 of the standard, and proved the union-seam invariant fires by deleting the blank line above the new heading in a scratch copy. Gates on that tree, each exit 0 and each checked by the reviewer against `CONTRIBUTING.md`'s own last section: `uv run pre-commit run --all-files` (the file calls this "the lint gate itself"); `uv run pytest` (32068 passed, 31 skipped, 1 xfailed, coverage 100.00%); `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html`; `grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'` exit 1, which is the pass, the file stating the job fails if this grep exits 0; and `uv run mypy src/btclib tests .github/scripts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxwWEa8nRid69sZ81isSa1

## Summary by Sourcery

Enhancements:
- Raise the project’s minimum supported uv version from 0.12.1 to 0.12.7 to align with Dependabot’s bundled uv version.