### PR TITLE
The numeral guard reads past a date, a specification number and an issue reference (closes #1684)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -441,6 +441,24 @@ Raising the floor as the ceiling moves is always safe, the ceiling only
 rising. `uv.lock` carries no `required-version` of its own and is
 unchanged.
 
+### The numeral guard reads past a date, a BIP number and an issue reference
+
+`tests/vendored_data_test.py` subtracts the numerals that name something
+before looking for one that counts something (closes #1684): an ISO
+date, a `bip-`/`slip-` or NIST `P-` number, an `issue #N` or an `ISS N`,
+a Wycheproof `tcId N`, and a dotted version. A line of
+`tests/_data/README.md` carrying nothing else needs no entry in
+`_EXEMPT`, and the entries such lines held are gone. A hyphen is what
+puts a specification number in front of the pattern at all: a digit run
+is matched between word boundaries, which `bip-0327` offers and a fused
+`BIP0327` does not. What stays enumerated is the one exception CLAUDE.md
+names -- a count of what upstream published, which has no shape -- and
+the lines stating such a count beside a date or an identifier, whose
+entry now records the count alone.
+
+`RELEASE_NOTES.md` does not carry this: the guard is a test's own, over a
+file of the test tree, and no caller acts on it.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/vendored_data_test.py
+++ b/tests/vendored_data_test.py
@@ -25,8 +25,8 @@ published -- `tests/_data/README.md`'s '121 vectors, Core's entire
 file' -- which pins a vendored file rather than measuring this tree".
 Everything below is an application of that sentence, not a paraphrase of
 it: a numeral -- a digit run, or a spelled-out numeral as a word -- is
-forbidden anywhere in this README unless the line it sits on is named in
-`_EXEMPT`, with the reason beside it.
+forbidden anywhere in this README unless `_NOT_A_COUNT` accounts for it,
+or the line it sits on is named in `_EXEMPT` with the reason beside it.
 
 The guard used to be a shape match: "N files." opening a line, and a
 bullet under `## Summary` opening with a digit. Both had a gap a widened
@@ -40,8 +40,8 @@ every line below was found by running the pattern above against this
 file as it stands and reading what it caught, not by predicting the
 shape a violation would take.
 
-Two carve-outs, both mechanical rather than semantic, and neither is the
-section-scoping this module used to do:
+The carve-outs are mechanical rather than semantic, and none of them is
+the section-scoping this module used to do:
 
 - **A fenced block is not scanned, whatever its language.** The
   ` ```text ` ones are the pin metadata -- `repo`, `path`, `commit`,
@@ -55,12 +55,22 @@ section-scoping this module used to do:
   one") far more often than counts in this file's prose, and a pattern
   that treated every "one" as a numeral would flag most of its sentences
   for no reason connected to this guard.
+- **A numeral naming something is subtracted before `_NUMERAL` runs.**
+  `_NOT_A_COUNT` takes out an ISO date, a `bip-`/`slip-` or NIST `P-`
+  number, an `issue #N` or an `ISS N`, a Wycheproof `tcId N` and a
+  dotted version, each of which names a thing rather than counting one.
+  A hyphen is what puts a specification number in front of the pattern
+  at all: a digit run is matched between word boundaries, which
+  `bip-0327` offers and a fused `BIP0327` does not, so such a number is
+  caught or missed according to how upstream spells its own path. Exempting
+  such a line records a decision nobody made, where an entry of
+  `_EXEMPT` is meant to record one (issue #1684).
 
 An exemption pins its line verbatim, so editing a line that carries one
 means editing its entry too. That cost is one line and not a paragraph:
 nothing here rewraps markdown -- `markdownlint`'s MD013 has no fixer and
 prettier's own hook does not take markdown -- so a correction is
-surgical, and the two tests below name the line they are unhappy about.
+surgical, and the guards below name the line they are unhappy about.
 
 A test rather than a hook, for the reasons `docs_test.py` gives: no
 environment the suite does not already have, every interpreter of the
@@ -82,46 +92,50 @@ _NUMERAL = re.compile(
     r"hundred|thousand)\b"
 )
 
-# the reasons an exempted line carries, named once and reused: CLAUDE.md's
-# exception is "a count of what upstream published", and each of these is
-# that exception's own shape rather than a new one
-_PIN_DATE = "the date of a pin or a refresh, not a count of this tree"
-_ISSUE_REF = "this repository's own issue number, an identifier rather than a count"
-_SPEC_NUMBER = (
-    "the number identifying a BIP, RFC, SLIP or NIST curve,"
-    " an identifier rather than a count"
+# the numerals that name something rather than count it, subtracted before
+# _NUMERAL runs: an ISO date at day or month precision, a specification
+# identifier as the bips and slips repositories spell one in a path and as
+# NIST names a curve, an issue of this tracker in either form the prose
+# uses, a Wycheproof test-case identifier, and a dotted version -- three
+# shapes rather than one, a version appearing here after a name, in three
+# components, and with a pre-release suffix. The first takes the version
+# and never the name in front of it, which is what keeps subtracting able
+# only to leave a numeral visible and never to hide one. A decimal is not
+# among them on purpose: a size in megabytes or a percentage is a
+# measurement, which is a count and wants a line of its own.
+# No `rfc-`: an RFC is cited here with a space rather than a hyphen, and
+# subtracting `RFC \d+` as well empties no line that the shapes below do
+# not already empty
+_NOT_A_COUNT = re.compile(
+    r"\b\d{4}-\d{2}(?:-\d{2})?\b"
+    r"|(?i:\b(?:bip|slip)-\d+)|\bP-\d+"
+    r"|(?i:\bissues?[ /]#?\d+)|\bISS \d+"
+    r"|\btcId \d+"
+    r"|(?<=[a-zA-Z]-)\b\d+(?:\.\d+)+"
+    r"|\b\d+\.\d+\.\d+\b"
+    r"|\b\d+(?:\.\d+)+(?=(?i:rc|a|b|dev|post)\d)"
 )
-_PIN_VERSION = "the version number of a pinned release, a fact of the pin"
-_TEST_CASE_ID = "Wycheproof's own test-case identifier, a fact of the upstream file"
+
+# the reason an exempted line carries, named once and reused: what reaches
+# _EXEMPT is CLAUDE.md's own exception, "a count of what upstream
+# published", and a numeral that is not one is a numeral the README drops
 _UPSTREAM_FACT = (
     "a fact of the upstream specification or vendored artefact,"
     " not a count of this tree"
 )
 
-# built by running _NUMERAL against tests/_data/README.md's prose (every
-# line outside a fenced ```text``` block, see _prose_lines) and classifying
-# every hit: each is named here with its reason, or the README no longer
-# states it (issue #1633)
+# built by running _NUMERAL against tests/_data/README.md's prose, past
+# _NOT_A_COUNT (every line outside a fenced ```text``` block, see
+# _prose_lines) and classifying every hit: each is named here with its
+# reason, or the README no longer states it (issue #1633)
 _EXEMPT: dict[str, str] = {
-    "nothing else pins: `src/btclib/mnemonic/_data/wordlist.txt`, SLIP-0039's word": _SPEC_NUMBER,
     "them, and `italian.txt` and the eleven other BIP39 lists nowhere, which": _UPSTREAM_FACT,
     "`BTCLIB_REGENERATE_GOLDEN=1 uv run pytest` rewrites them on purpose.": _UPSTREAM_FACT,
-    "`bips/blob/master/bip-0340/test-vectors.csv` names a file that changes": _SPEC_NUMBER,
     "citation is pinned to a commit and the two blobs are compared.": _UPSTREAM_FACT,
     "The two halves are kept in agreement in one direction only: a test module": _UPSTREAM_FACT,
-    "  directory, by SLIP-0039's own file of that name, which is a different": _SPEC_NUMBER,
     "one of the five that *is* a copy, upstream publishing a file of that very": _UPSTREAM_FACT,
-    "an upstream file each -- bip-0341's `wallet-test-vectors.json` and Core's": _SPEC_NUMBER,
     "citation is pinned to, the git blob SHA-1 that was compared, and a": _UPSTREAM_FACT,
-    "Every entry was last re-checked against its upstream on 2026-07-30, and": _PIN_DATE,
     "whatever had drifted was refreshed, so `behind` is 0 wherever a refresh": _UPSTREAM_FACT,
-    "alone, all of them taken at the tip of their path on 2026-08-02, which is": _PIN_DATE,
-    "csv files followed on 2026-08-03, at the tip of their paths too, the": _PIN_DATE,
-    "BIP322 files on 2026-08-08, and the Wycheproof files with the licence": _PIN_DATE,
-    "`bip375_test_vectors.json` on 2026-08-13, and Core's `siphash.json` on": _PIN_DATE,
-    "2026-08-20. BIP375's `bip375_test_vectors.json`, Core's": _PIN_DATE,
-    "on 2026-08-25, each at the tip of its path that day, and Core's": _PIN_DATE,
-    "`crypto_tests.cpp`, were pulled on 2026-09-03, at the tip of that path.": _PIN_DATE,
     "The comparison is on git blob SHA-1, not sha256: it is what a tree entry": _UPSTREAM_FACT,
     "alternative and caps out — `script_assets_test.json` is 9 MB.": _UPSTREAM_FACT,
     "The two hashes match for every file whose verdict is **identical**. Where": _UPSTREAM_FACT,
@@ -129,27 +143,20 @@ _EXEMPT: dict[str, str] = {
     "vectors, all eight columns.": _UPSTREAM_FACT,
     "Four of the 19 are messages of 0, 1, 17 and 100 bytes: BIP340 accepts a": _UPSTREAM_FACT,
     "take one, and the 32-byte gate that used to send these four down the": _UPSTREAM_FACT,
-    "Python path (issue 169) is gone. All four pass on either arithmetic:": _ISSUE_REF,
-    "The vectors of `bip-0327/vectors/`, vendored whole": _SPEC_NUMBER,
+    "Python path (issue 169) is gone. All four pass on either arithmetic:": _UPSTREAM_FACT,
     "them: six were untouched since the commit that added all eight,": _UPSTREAM_FACT,
-    '`87394eaeb436d02e0a68b38a1e94bc526d50056e` (2023-03-27, "Add BIP327:': _PIN_DATE,
-    '(2024-05-14, "Fix the four test vectors"); and `sig_agg_vectors.json`': _PIN_DATE,
-    '(2024-07-19, "bip327: minor fixes") -- the one commit the shared': _PIN_DATE,
+    '(2024-05-14, "Fix the four test vectors"); and `sig_agg_vectors.json`': _UPSTREAM_FACT,
     "placeholder cited as the tip of all eight paths, when it is the tip of": _UPSTREAM_FACT,
     "56 cases between them, and `tests/ecc/musig2_test.py` runs every one:": _UPSTREAM_FACT,
     "1 sorting, 4 + 5 aggregations valid and failing, 4 nonce derivations,": _UPSTREAM_FACT,
     "2 + 3 nonce aggregations, 6 + 6 + 3 + 2 signatures (valid, refused at": _UPSTREAM_FACT,
     "signing, false on verification, refused on verification), 5 + 1": _UPSTREAM_FACT,
     "tweaked, 4 + 5 deterministic, 4 + 1 aggregated. An error case carries": _UPSTREAM_FACT,
-    "What the files are measured against is `bip-0327/reference.py`, pinned": _SPEC_NUMBER,
-    "separately at `9297c12729670d09f9149ec6d8bad967d8161bfe` (2025-10-03,": _PIN_DATE,
     "function, and copies four of its error message strings verbatim": _UPSTREAM_FACT,
     "The files test the two halves of the map, and both halves are": _UPSTREAM_FACT,
     "eight `case` columns are eight assertions per row rather than one — an": _UPSTREAM_FACT,
     "`t>=p`, `info[v=0]`), which is what makes the files a branch": _UPSTREAM_FACT,
     "Neither file covers `create` or `encode`: those pick one of up to eight": _UPSTREAM_FACT,
-    "`bip-0324/packet_encoding_test_vectors.csv` is the third file of that": _SPEC_NUMBER,
-    "under upstream's own names, which is the whole of `bip-0374/`'s vector": _SPEC_NUMBER,
     "regenerated seven weeks after the generation file, and one pin would have": _UPSTREAM_FACT,
     "All 11 vectors, all eight columns: five over a generator that is not": _UPSTREAM_FACT,
     "secp256k1's, three over secp256k1's own, and three failure cases -- a zero": _UPSTREAM_FACT,
@@ -171,8 +178,7 @@ _EXEMPT: dict[str, str] = {
     "text, and the derivation counts match: 6, 6, 2, 3.": _UPSTREAM_FACT,
     "The original pin was the commit that *added* test vector 4 rather than": _UPSTREAM_FACT,
     "holding all 34 keys, the parent holding 28, which made that pin checkable": _UPSTREAM_FACT,
-    "rather than merely plausible. Re-checked against the tip on 2026-07-30": _PIN_DATE,
-    "and again on 2026-08-06 — both times still test vectors 1 to 5 and no": _PIN_DATE,
+    "and again on 2026-08-06 — both times still test vectors 1 to 5 and no": _UPSTREAM_FACT,
     "sixth, every extended key in it one of ours, 48 matching the key": _UPSTREAM_FACT,
     "pattern: our 34 valid plus 14 of the 16 invalid, the other 2 being the": _UPSTREAM_FACT,
     "zero-prefix keys of test vector 5, which serialize outside it — the pin": _UPSTREAM_FACT,
@@ -185,7 +191,7 @@ _EXEMPT: dict[str, str] = {
     "that these four psbts must fail the check, so that field is btclib's own": _UPSTREAM_FACT,
     "Verdict: **transcribed**, complete. All 17 psbts in the pinned text are": _UPSTREAM_FACT,
     "in our file and all 17 of ours are in the text — 11 invalid, 6 valid, the": _UPSTREAM_FACT,
-    "same 17 on 2026-07-30 and again on 2026-08-06 when re-checked against the": _PIN_DATE,
+    "same 17 on 2026-07-30 and again on 2026-08-06 when re-checked against the": _UPSTREAM_FACT,
     'tip. The two "PSBT_KEY_PATH_SIG" cases were renamed': _UPSTREAM_FACT,
     "section is here: 24 invalid, 14 valid, and the 10 of the timelock": _UPSTREAM_FACT,
     "compute beside them — `null` for the one whose two kinds of locktime": _UPSTREAM_FACT,
@@ -218,19 +224,14 @@ _EXEMPT: dict[str, str] = {
     'valid -- "two sp outputs - output 0 uses label=3 / output 1 uses label=1"': _UPSTREAM_FACT,
     "-- and its two spend keys are in descending order, so the two rules assign": _UPSTREAM_FACT,
     "the 66-byte info fields and sorting the bech32m address strings both order": _UPSTREAM_FACT,
-    "`bip-0375/validator/validate_psbt.py` walks index order too, so two of its": _SPEC_NUMBER,
+    "`bip-0375/validator/validate_psbt.py` walks index order too, so two of its": _UPSTREAM_FACT,
     "three artefacts agree and the prose is the outlier.": _UPSTREAM_FACT,
     "Verdict: **transcribed**, complete. All five groups — their 15 public keys": _UPSTREAM_FACT,
     "and their five p2sh addresses — appear verbatim in the pinned text, and": _UPSTREAM_FACT,
-    "re-checking against the tip on 2026-07-30 and again on 2026-08-06 found no": _PIN_DATE,
-    "The files of `bip-0322/`, vendored whole and under upstream's own": _SPEC_NUMBER,
-    '(2026-04-10, "BIP-0322: turn test vectors into JSON, add more") and': _PIN_DATE,
-    '`d77863fb` (2026-05-06, "BIP-0322: update test vectors"), which is the': _PIN_DATE,
     "Between them they are what `tests/bip322_test.py` runs: three": _UPSTREAM_FACT,
     "transaction hashes, eight *simple* signatures, ten *full*, three": _UPSTREAM_FACT,
     "*proof of funds*, and 36 error cases, with nothing left out and nothing": _UPSTREAM_FACT,
     "marked `xfail`. Two of the three proof-of-funds vectors were, until": _UPSTREAM_FACT,
-    "issue 513: their psbts carry a funding transaction whose input is a null": _ISSUE_REF,
     "tx_id with vout 0, which `OutPoint.assert_valid` refused and Bitcoin": _UPSTREAM_FACT,
     "The file is UTF-8 rather than ASCII, one of its three messages running": _UPSTREAM_FACT,
     "from Latin-1 accents through CJK to an astral-plane emoji, and": _UPSTREAM_FACT,
@@ -245,7 +246,6 @@ _EXEMPT: dict[str, str] = {
     "the name reads: the DERIVED ENTROPY of application 32' is the second half": _UPSTREAM_FACT,
     "of the 64 bytes, the private key of the xprv, and that of 39' is already": _UPSTREAM_FACT,
     "one with the message btclib refuses it with — two of those refusals": _UPSTREAM_FACT,
-    "pinned text on 2026-08-06.": _PIN_DATE,
     "six valid descriptors with the scripts they produce at each index listed,": _UPSTREAM_FACT,
     "and all fourteen invalid ones with the message each is refused with. Five": _UPSTREAM_FACT,
     "One of the fourteen is refused for a reason of btclib's own rather than": _UPSTREAM_FACT,
@@ -258,7 +258,6 @@ _EXEMPT: dict[str, str] = {
     '"use multipath_descriptors first" -- a coincidence of the raw `<0;1>`': _UPSTREAM_FACT,
     "Verdict: **transcribed**, complete: all three aggregate keys, the": _UPSTREAM_FACT,
     "BIP328's, and a `key_sort` applied here reaches none of the three": _UPSTREAM_FACT,
-    "published keys. Matched against the pinned text on 2026-08-06.": _PIN_DATE,
     "Verdict: **identical**. 1292 entries, 1237 vectors once the comment lines": _UPSTREAM_FACT,
     "are dropped: four cases added since the previous pin, one of them a": _UPSTREAM_FACT,
     "Five of the 1237 are TAPSCRIPT cases whose witness and output script are": _UPSTREAM_FACT,
@@ -266,7 +265,6 @@ _EXEMPT: dict[str, str] = {
     "five fail on `OP_#TAPROOTOUTPUT#`, and the two expecting a failure get": _UPSTREAM_FACT,
     "Verdict: **identical**, 121 vectors — Core's entire file, nothing": _UPSTREAM_FACT,
     "subsetted, and not only legacy: 2 of the 121 name WITNESS in their flags.": _UPSTREAM_FACT,
-    "which engine the vectors feed (issue 168).": _ISSUE_REF,
     "Verdict: **identical**, 93 vectors — Core's entire file, here too, with": _UPSTREAM_FACT,
     "14 of the 93 naming WITNESS in their flags.": _UPSTREAM_FACT,
     "Verdict: **identical**, 70 rows — 54 addresses and 16 WIFs, over the four": _UPSTREAM_FACT,
@@ -294,48 +292,38 @@ _EXEMPT: dict[str, str] = {
     "comparing them. The four below it commit nothing, which is what makes the": _UPSTREAM_FACT,
     "then the two answers, so every basic filter of the file is rebuilt from": _UPSTREAM_FACT,
     "The ten are testnet, where the four blocks of `tests/block/_data/` are": _UPSTREAM_FACT,
-    "Checked again on 2026-07-30, against the current document rather than the": _PIN_DATE,
     "Four of the calls are not here, being loops rather than literals: the": _UPSTREAM_FACT,
     "`multi_a()` of twenty-one keys, the three `and_b()` chains that pass the": _UPSTREAM_FACT,
     "p2wsh ops, stack and script-size limits, and the two nestings that reach a": _UPSTREAM_FACT,
     "thousand elements on the stack. `tests/descriptors/miniscript_test.py`": _UPSTREAM_FACT,
-    "is not implemented (issue #187), so there is nothing yet for those to": _ISSUE_REF,
     "of the four Core expands from the private form alone, and the two": _UPSTREAM_FACT,
-    "against the pinned file on 2026-08-06.": _PIN_DATE,
     "Not matched since: the commit above adds five cases -- a `musig()`": _UPSTREAM_FACT,
-    "[ISS 1334](https://github.com/btclib-org/btclib/issues/1334) tracks,": _ISSUE_REF,
-    "before. The two hold the same names, compared on 2026-09-03, and the": _PIN_DATE,
-    "[ISS 1120](https://github.com/btclib-org/btclib/issues/1120) is where": _ISSUE_REF,
+    "before. The two hold the same names, compared on 2026-09-03, and the": _UPSTREAM_FACT,
     "directions in `bitcoin/bitcoin#15437`. `src/btclib/p2p/reject.py` says": _UPSTREAM_FACT,
     "but an *interface*, and the two entries are the two halves of it: the": _UPSTREAM_FACT,
-    "`.github/workflows/integration-hwi.yml` installs release 3.2.0, so two": _PIN_VERSION,
-    "which issue #381 keeps out of the signing surface deliberately.": _ISSUE_REF,
-    '(`btclib.hwi`\'s module docstring, "Wallet policies", issue #1588), and': _ISSUE_REF,
+    "`.github/workflows/integration-hwi.yml` installs release 3.2.0, so two": _UPSTREAM_FACT,
     "`HWI_COMMAND_FLAGS` table above, `displayaddress`'s two modes taking": _UPSTREAM_FACT,
     "`--multipath-index 1` -- `HwiSigner.display_policy_address` always": _UPSTREAM_FACT,
-    "All of them entered upstream in 2026-08, after 3.2.0 shipped, so the": _PIN_VERSION,
     "whose `hwilib/_cli.py` adds them is what makes the two interfaces one.": _UPSTREAM_FACT,
     "The parser has only ever grown, and only additively, since 2021:": _UPSTREAM_FACT,
     "`--emulators` in 2024, `--chain` and `--expert` on enumerate in 2022,": _UPSTREAM_FACT,
-    "in 2026-08, and `--registration` on `signtx` in this pin. `signtx`": _UPSTREAM_FACT,
     "gained a second answer key, `signed`, in 2021 — which is how this pin": _UPSTREAM_FACT,
     "down, and now checks the two against each other.": _UPSTREAM_FACT,
     "`INVALID_POLICY` (-19) had already been checked in from ahead of, and the": _UPSTREAM_FACT,
     "the old name as a compat alias with the same code, -4 — is why": _UPSTREAM_FACT,
     "on — -14 is somebody pressing the button that says no, -3 is a cable, -9": _UPSTREAM_FACT,
     "Not in a release: `INVALID_POLICY` (-19). The rest of the table is in": _UPSTREAM_FACT,
-    "3.2.0, where -4 carries the misspelling this pin's commit corrects — a": _PIN_VERSION,
+    "3.2.0, where -4 carries the misspelling this pin's commit corrects — a": _UPSTREAM_FACT,
     "Verdict: **identical but for a trailing newline** — our 9,243,521 bytes": _UPSTREAM_FACT,
     "are that blob's 9,243,520 plus the `\\n` the `end-of-file-fixer` hook": _UPSTREAM_FACT,
     "added, so our blob is `601a40db`. 2244 vectors, in the same order.": _UPSTREAM_FACT,
     "Two caveats, and the second is the one that matters.": _UPSTREAM_FACT,
-    "`tests/script/sig_hash_taproot_test.py` (bip-0341) does not lead to it.": _SPEC_NUMBER,
     "The commit is a weak pin. The whole visible history of that path is three": _UPSTREAM_FACT,
     "commits, all stamped within a second of `2025-07-23T19:45:18Z`, which": _UPSTREAM_FACT,
     "cannot be when a 2021 dump was added: qa-assets prunes its history — the": _UPSTREAM_FACT,
     "survive the next prune. The blob SHA-1 above will, and it is what a": _UPSTREAM_FACT,
     "Verdict: **reformatted**. 349 vectors, JSON-equal to the upstream blob;": _UPSTREAM_FACT,
-    "ours is pretty-printed at four spaces. Re-checked on 2026-07-30: still": _PIN_DATE,
+    "ours is pretty-printed at four spaces. Re-checked on 2026-07-30: still": _UPSTREAM_FACT,
     "Verdict: **reformatted**. 199 vectors, JSON-equal.": _UPSTREAM_FACT,
     "Verdict: **reformatted**. 200 vectors, JSON-equal, and all 200 are": _UPSTREAM_FACT,
     "Verdict: **identical**. Four blocks — genesis twice, 99,960 and 99,993 —": _UPSTREAM_FACT,
@@ -348,59 +336,45 @@ _EXEMPT: dict[str, str] = {
     "One of the seven is misnamed, and the file is vendored with the name": _UPSTREAM_FACT,
     "three other findings as petertodd/python-bitcoinlib#323. Renaming it": _UPSTREAM_FACT,
     "Two blocks of values are cited inline instead, each small enough to read": _UPSTREAM_FACT,
-    "where it is used, both pinned to `fbbe9245` (2023-04-27), the tip of both": _PIN_DATE,
     "- the five secp256k1 RFC6979 vectors of `Test_RFC6979`, in": _UPSTREAM_FACT,
     "  ones, and four of the five differ from what RFC6979 arrives at before": _UPSTREAM_FACT,
     "- the six nBits-to-difficulty pairs of": _UPSTREAM_FACT,
     "Verdict: **identical**. All twelve language arrays, in order and value": _UPSTREAM_FACT,
     "Two `pulled` dates because the `english` array was here on its own for": _UPSTREAM_FACT,
     "the same file for it, and `behind 0 revisions` is now about the whole of": _UPSTREAM_FACT,
-    "very directory, by SLIP-0039's own file of that name, which is a": _SPEC_NUMBER,
     "Verdict: **reformatted**. 24 vectors, JSON-equal; upstream's indentation": _UPSTREAM_FACT,
     "wanders by a space or two and ours is what `json.dumps(indent=4)` writes.": _UPSTREAM_FACT,
-    "bip-0039 cites this file by URL in its own Test vectors section, beside": _SPEC_NUMBER,
     "The two Portuguese sentences beside them answer electrum's": _UPSTREAM_FACT,
     "`bip39_is_checksum_valid` yes and no, over its own 1626-word list.": _UPSTREAM_FACT,
     "lint gate's two spell checkers read a python source and skip `_data`, and": _UPSTREAM_FACT,
-    "Pulled 2026-08-02.": _PIN_DATE,
-    "Verdict: **identical**. SLIP-0039's 1024 words, ten bits each, and the": _SPEC_NUMBER,
+    "Verdict: **identical**. SLIP-0039's 1024 words, ten bits each, and the": _UPSTREAM_FACT,
     "for the list -- 1024 words, none shorter than four letters or longer": _UPSTREAM_FACT,
     "than eight, and all 1024 four-letter prefixes distinct -- which is what": _UPSTREAM_FACT,
-    "can read. Not the whole of `slip-0039/test_wordlist.sh`, which also": _SPEC_NUMBER,
     "Verdict: **identical but for a trailing newline** -- our 22,412 bytes": _UPSTREAM_FACT,
     "are that blob's 22,411 plus the `\\n` the `end-of-file-fixer` hook added,": _UPSTREAM_FACT,
     "so our blob is `2e6da291`. 45 quadruples -- description, mnemonics,": _UPSTREAM_FACT,
     "master secret, BIP32 root extended private key -- of which 15 are valid": _UPSTREAM_FACT,
     "and 30 have an empty master secret, meaning combining those mnemonics": _UPSTREAM_FACT,
     "must fail. All 45 are exercised, the 30 included: an invalid vector left": _UPSTREAM_FACT,
-    "The reference implementation rather than the SLIP: SLIP-0039's own \"Test": _SPEC_NUMBER,
     "commit that added the extendable backup flag and the four vectors for": _UPSTREAM_FACT,
     "Four of the 15 valid vectors are checked in both directions. They are": _UPSTREAM_FACT,
     "the 1-of-1 shares, whose value is the encrypted master secret itself and": _UPSTREAM_FACT,
     "regenerates each of the four mnemonics word for word from the master": _UPSTREAM_FACT,
     "secret. The other 11 are recovery only, a 2-of-3 share being random by": _UPSTREAM_FACT,
-    "licence that is not MIT: Apache-2.0, whose condition on redistribution": _PIN_VERSION,
-    "All are pinned to the same commit, `5722833c` of 2026-08-11, and all": _PIN_DATE,
-    "on 2025-09-02 and which no refresh can reach again. They are read by": _PIN_DATE,
     "the two ECDSA profiles is explained, and where the difference the files": _UPSTREAM_FACT,
     "measured, all files verify identically at 32 and at 64.": _UPSTREAM_FACT,
-    "the same commit. No longer frozen at `generatorVersion 0.9rc5` either:": _PIN_VERSION,
     "and its verifier no longer applies that rule, so two of these verdicts": _UPSTREAM_FACT,
     "are exempted rather than asserted — `wycheproof_test.py` reads which two": _UPSTREAM_FACT,
     "case is otherwise the same 463 cases, `numberOfTests` included.": _UPSTREAM_FACT,
     "above, without the bitcoin profile's two extra rules: what a": _UPSTREAM_FACT,
     "of the two the files above vary one at a time.": _UPSTREAM_FACT,
     "digests that report their own length and a SHAKE's is 0.": _UPSTREAM_FACT,
-    "a sponge of a different rate. Its tcId 425 is upstream's": _TEST_CASE_ID,
-    "`Untruncatedhash` case of the pair as tcId 190.": _TEST_CASE_ID,
     "Verdict: **identical**. Key agreement, with the public key X.509-encoded": _UPSTREAM_FACT,
     "above with the keys JWK-encoded (RFC 7517) rather than X.509: `WrongCurve`": _UPSTREAM_FACT,
-    "`d6456956`, which is the Apache-2.0 text as most repositories carry it.": _PIN_VERSION,
     "feature 100\" included: what refuses that one is `btclib.bolt9`'s": _UPSTREAM_FACT,
     "every run — so the first two entries verify themselves, and are the only": _UPSTREAM_FACT,
-    "Pulled 2020-06-08, except `block_200000.bin`, 2020-06-09.": _PIN_DATE,
     "`bitcoin-cli getblock <hash> 0` returns the first three and": _UPSTREAM_FACT,
-    "The twelve `scriptPubKey`s reported in issue #123, the five transactions": _ISSUE_REF,
+    "The twelve `scriptPubKey`s reported in issue #123, the five transactions": _UPSTREAM_FACT,
     "that carry them being the five the issue lists. Each entry holds the": _UPSTREAM_FACT,
     "`getrawtransaction_error.json` is Core's too, code `-5` with the message": _UPSTREAM_FACT,
     "`getrawtransaction.json` and in `esplora_tx_hex.txt` is transaction 1 of": _UPSTREAM_FACT,
@@ -413,23 +387,15 @@ _EXEMPT: dict[str, str] = {
     "`rest_headers.bin` the same eighty bytes as `getblockheader.json` and": _UPSTREAM_FACT,
     "Regenerating one of these is reading the two block files: the Core and": _UPSTREAM_FACT,
     "Appendix A.2 of RFC 6979, transcribed: 50 vectors, ten each for NIST": _UPSTREAM_FACT,
-    "P-192, P-224, P-256, P-384 and P-521, as `tests/ecc/rfc6979_test.py`": _SPEC_NUMBER,
-    "Pulled 2020-05-08.": _PIN_DATE,
     "**Unresolved, and probably unresolvable.** These 12-word mnemonics with": _UPSTREAM_FACT,
     "citation two lines above the values is one that gets checked.": _UPSTREAM_FACT,
     "`SEED_VECTORS`' five passphrase-bearing rows each carry the": _UPSTREAM_FACT,
-    "`300b986782c754be462788a30e0355301683c0ed` (2024-06-10, the tip of": _PIN_DATE,
-    "(2026-07-01, the tip of `tests/test_wallet_vertical.py`) — and": _PIN_DATE,
-    "The pre-2.0 scheme is the same arrangement and four more of upstream's": _PIN_VERSION,
-    "values, added for issue #208. The scheme has no specification — it": _ISSUE_REF,
-    "- the hex seed and `master_public_key` of the pre-2.0 wallet file in": _PIN_VERSION,
-    "Pulled 2018-06-11; the pre-2.0 values 2026-08-02.": _PIN_DATE,
+    "The pre-2.0 scheme is the same arrangement and four more of upstream's": _UPSTREAM_FACT,
     "`abandon`, deleted — 2047 words, so that `WORDLISTS.load_lang` raises": _UPSTREAM_FACT,
     "from `english.txt` if that ever changes, which it has not since 2014.": _UPSTREAM_FACT,
-    "Pulled 2018-06-01.": _PIN_DATE,
     "above deliberately leaves out. The starting psbts are five steps of the": _UPSTREAM_FACT,
     'BIP\'s "2-of-3 Multisig Workflow" walk-through — prose steps rather than': _UPSTREAM_FACT,
-    "`8c369ac8e60629ac6c032ffe21bb5ec5b35213d7` (2026-07-16), where all five": _PIN_DATE,
+    "`8c369ac8e60629ac6c032ffe21bb5ec5b35213d7` (2026-07-16), where all five": _UPSTREAM_FACT,
     "appear verbatim; the two version 2 cases start instead from the first": _UPSTREAM_FACT,
     "- the **creator**'s psbt with a `PSBT_GLOBAL_VERSION` of 1, and with the": _UPSTREAM_FACT,
     "  `0xff` of its magic bytes replaced — the two `invalid psbts`, which": _UPSTREAM_FACT,
@@ -438,12 +404,16 @@ _EXEMPT: dict[str, str] = {
     "- two version 2 psbts, BIP370's first valid one with its": _UPSTREAM_FACT,
     "  how a version 2 parse knows how many maps follow, so a wrong one is a": _UPSTREAM_FACT,
     "does not touch it — the five psbts are fixed bytes, and the edits are": _UPSTREAM_FACT,
-    "Composed 2026-08-02.": _PIN_DATE,
     "  in a repository that rewrites its history. The blob SHA-1 is the pin": _UPSTREAM_FACT,
     "  reach is an entry whose `behind` already reads other than 0, a gap": _UPSTREAM_FACT,
     "request vendoring a file is guaranteed to have -- and two branches moving": _UPSTREAM_FACT,
     "  chain data two of the entries above already hold.": _UPSTREAM_FACT,
 }
+
+
+def _countable(line: str) -> str:
+    """`line` with the numerals that name rather than count removed."""
+    return _NOT_A_COUNT.sub(" ", line)
 
 
 def _prose_lines() -> list[str]:
@@ -472,7 +442,7 @@ def test_every_numeral_outside_the_allowlist_is_a_count_of_this_tree() -> None:
         {
             line
             for line in _prose_lines()
-            if _NUMERAL.search(line) and line not in _EXEMPT
+            if _NUMERAL.search(_countable(line)) and line not in _EXEMPT
         }
     )
     assert not offenders, (
@@ -488,14 +458,15 @@ def test_every_exemption_is_still_a_line_that_needs_one() -> None:
     The discipline `tests/p2p/core_commands_test.py`'s
     `test_every_name_left_out_is_a_name_the_other_side_has` already
     applies to its own exemptions: each of `_EXEMPT`'s lines must still be
-    in the file, verbatim, and must still match `_NUMERAL` -- a line the
-    README no longer carries, or that no longer states a numeral, is an
-    exemption nothing needs and nothing here would otherwise notice.
+    in the file, verbatim, and must still match `_NUMERAL` once
+    `_NOT_A_COUNT` has run over it -- a line the README no longer carries,
+    or whose every numeral is a date or an identifier, is an exemption
+    nothing needs and nothing here would otherwise notice.
     """
     lines = set(_prose_lines())
     missing = sorted(line for line in _EXEMPT if line not in lines)
     assert not missing, f"exempted, and no longer in the README: {missing!r}"
-    stale = sorted(line for line in _EXEMPT if not _NUMERAL.search(line))
+    stale = sorted(line for line in _EXEMPT if not _NUMERAL.search(_countable(line)))
     assert not stale, f"exempted, and states no numeral any more: {stale!r}"
 
 
@@ -517,4 +488,35 @@ def test_the_pattern_still_matches() -> None:
         "49 files. Against a pinned blob:",
         "Fifty files. Against a pinned blob:",
     ):
-        assert _NUMERAL.search(text), text
+        assert _NUMERAL.search(_countable(text)), text
+
+
+def test_a_numeral_that_names_something_is_subtracted_and_a_count_is_not() -> None:
+    """`_NOT_A_COUNT` fails in two directions, and only one of them is loud.
+
+    A shape that stops matching puts its lines back in front of `_NUMERAL`,
+    and the guard above says which; a shape that reaches past what it names
+    swallows the count beside it and the guard goes quiet. The second group
+    is that half: each line states a count *and* carries a date, an
+    identifier or a version, and each is exempted for the count alone.
+    """
+    for named in (
+        "Pulled 2020-06-08, except `block_200000.bin`, 2020-06-09.",
+        "All of them entered upstream in 2026-08, after 3.2.0 shipped, so the",
+        "BIP322 files on 2026-08-08, and the Wycheproof files with the licence",
+        "The vectors of `bip-0327/vectors/`, vendored whole",
+        "P-192, P-224, P-256, P-384 and P-521, as `tests/ecc/rfc6979_test.py`",
+        "which engine the vectors feed (issue 168).",
+        "is not implemented (issue #187), so there is nothing yet for those to",
+        "[ISS 1120](https://github.com/btclib-org/btclib/issues/1120) is where",
+        "`Untruncatedhash` case of the pair as tcId 190.",
+        "licence that is not MIT: Apache-2.0, whose condition on redistribution",
+    ):
+        assert not _NUMERAL.search(_countable(named)), named
+    for counted in (
+        '(2024-05-14, "Fix the four test vectors"); and `sig_agg_vectors.json`',
+        "The twelve `scriptPubKey`s reported in issue #123, the five transactions",
+        "Verdict: **identical**. SLIP-0039's 1024 words, ten bits each, and the",
+        "`.github/workflows/integration-hwi.yml` installs release 3.2.0, so two",
+    ):
+        assert _NUMERAL.search(_countable(counted)), counted


### PR DESCRIPTION
Closes #1684

[ISS 1633](https://github.com/btclib-org/btclib/issues/1633) inverted the
numeral guard on `tests/_data/README.md`: a numeral is forbidden unless
an exemption list names its line. That stands. What it also produced is
an exemption list where most rows record a decision nobody made — a pin
date, a `bip-`/`slip-` path, an issue reference and a `tcId` are not
counts of anything, and they were listed only because the pattern cannot
tell a numeral from an identifier.

`_NOT_A_COUNT` subtracts those **shapes** before the numeral pattern
runs, and the entries they account for leave the list. A count of what
upstream published still has no shape and stays enumerated; that half of
1633's design is untouched, and so is the inversion.

## Review

Two rounds at fresh context, and the second is why this is worth reading.

The first re-derived every number by `ast.parse` at both shas rather than
by grep — the arithmetic closes exactly — read all thirteen re-tagged
lines in the README's context, audited every substring the subtraction
removes and found not one of them a count, and demonstrated that
subtraction can only ever make the guard *fire* where it otherwise would
not, never silence a line. It also re-ran the three controls.

It left one non-blocking finding: the last alternative was described in
three places as "a dotted version", but the shape was **any dotted
decimal** — so `9.5 MB`, `99.9%` and `1.5 seconds` were silent, and each
would enter this file with no exemption entry and no human deciding.
That is the very defect the issue exists to remove, reproduced by its own
fix. Rather than document it, the alternative became three shapes that
are actually versions.

The second round then refuted the reasoning behind that fix. The first
attempt let the version's *name* into the subtraction, and a name can
carry a numeral: `The seven-1.0 vectors are pinned.` went silent, where
the wide pattern had caught it. Zero occurrences in the tree, but the
property that makes this guard trustworthy — subtraction can only ever be
loud — no longer held. It now takes the version and never the name in
front of it, and the invariant is written down beside the pattern.

Measured after that, on 217001 non-empty lines of 486 tracked files:
**no line where the pattern hides a numeral either earlier version left
visible**, with a positive control proving the comparison can see one.
And the four controls: the guard silent at rest; a real count on a
non-exempt line caught and named; a line of nothing but shapes silent;
`script_assets_test.json is 9.5 MB.` caught and named, where before it
was silent.

Gates on `226946bb`: `uv run --locked pytest -q --cov` → 32069 passed, 31
skipped, 1 xfailed; `uv run --locked pre-commit run --all-files` → exit
0, tree clean. The two narrowings followed the second clearance and were
not themselves re-reviewed; both were that round's own suggested fixes,
and the measurements above are what stands behind them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157LmcttGkdnQhLdCLkfVRR

## Summary by Sourcery

Refine the vendored-data numeral guard to ignore numerals that identify referenced objects while continuing to flag genuine counts.

Bug Fixes:
- Prevent the numeral guard from treating dates, specification identifiers, issue references, test-case IDs, and version strings as counts.
- Ensure decimal measurements such as file sizes and percentages remain detectable as genuine counts or numerals requiring review.

Enhancements:
- Simplify the README exemption list by removing entries that only documented non-counting identifiers and metadata.
- Add focused checks confirming that subtracting named numerals cannot hide adjacent countable numerals.

Documentation:
- Document the numeral guard's distinction between identifiers and countable numerals in the changelog and guard documentation.

Tests:
- Update numeral guard validation and exemption checks to account for non-counting numeral patterns.
- Add regression coverage for dates, identifiers, versions, and adjacent countable numerals.