### PR TITLE
`CLAUDE.md` states the worktree block's absent `uv sync` in one place (closes btclib-org/.github#794)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -500,6 +500,15 @@ file of the test tree, and no caller acts on it.
   most recent lines -- which is the failure the standard's rule is for,
   and which had already spread to a branch in another repository.
 
+### `CLAUDE.md` states the worktree block's absent `uv sync` in one place
+
+- **The paragraph below the worktree fence gives only what the sentence
+  above it does not** (closes btclib-org/.github#794): the sentence gives
+  the absence of `uv sync` and the gate as its reason, and the paragraph
+  says the `&&` that used to carry the sync is no guard. That `cd ""`
+  measurement is btclib-org/.github#739's material and stands as it is
+  written.
+
 ## v2026.9.3
 
 ### Repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,9 +129,8 @@ standard's rule. With the placeholder ahead of `"$WT"` the `>` closing it
 takes that path as its target, and a path with no directory at it is a
 file the paste creates.
 
-No line in the block writes. `uv sync` is absent because `uv run` syncs
-before every gate, and because the `&&` that used to carry it is no
-guard: with `WT` unset, `cd "$WT"` is `cd ""`, which `zsh` and the
+No line in the block writes. The `&&` that used to carry `uv sync` is
+no guard: with `WT` unset, `cd "$WT"` is `cd ""`, which `zsh` and the
 `bash` 3.2 macOS ships answer 0, where `bash` 5 refuses it. So the reach
 is the reader's shell rather than every reader's, and where the chain
 does proceed a sync line here runs in the reader's own directory, which


### PR DESCRIPTION
`CLAUDE.md` stated the absence of `uv sync` from the worktree block
twice, seventeen lines apart, once on each side of the fence — the
sentence section 9's sweep brings over from `btclib-org/.github`, and
this tree's own longer paragraph. Section 9's *One fact in one place*
refuses that, and it reads the same way inside one file as between two.

**The local half is what goes.** The above-fence sentence is byte-
identical to `btclib-org/.github`'s at `9867b746`, and seven of the nine
trees fill that same slot with a sentence of their own; the below-fence
paragraph exists in this tree alone. Deleting the shared half would make
this the one tree with the slot empty and would diverge from the tree
that is the standard. Deleting the local clause diverges from nothing.

**The `&&` material is untouched, by rule.** The `bash` 3.2 / `bash` 5
`cd ""` measurement and the sentence after it are byte-identical to the
base — that half is
[btclib-org/.github#739](https://github.com/btclib-org/.github/issues/739)'s
and is open. Nothing was added to it either, so 739 can still land
either answer over this paragraph.

The rejected alternative is section 9's own *the second points at the
first*: that remedy earns its keep across files, where deletion is
unavailable because each file needs the fact. Inside one file the second
location needs the fact for nothing, so deletion leaves one sentence to
keep true where a pointer leaves two — and the pointer would have added
prose to the paragraph 739 reserves.

`CLAUDE.md` states the worktree block's absent `uv sync` in one place (closes btclib-org/.github#794)

The sentence above the worktree fence gives the absence of `uv sync`
from the block and the gate as its reason. The paragraph below the
fence says the `&&` that used to carry the sync is no guard, and gives
the reason no second time.

Which of the two keeps the reason was the decision. The sentence above
is shared text rather than this tree's: at `origin/main`
`btclib-org/.github` carries it word for word and `bbt` carries the
same shape with a reason of its own, while the paragraph below the
fence is this tree's alone. The `cd ""` measurement in it is
btclib-org/.github#739's material and stands as it is written.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CxwWEa8nRid69sZ81isSa1


Local review: CLEARED c190e8ad. Rather than accept the seam checks, the reviewer rebuilt the entry block from the pre-rebase blobs alone and swept it over rotation x anchor — twelve cells, exactly two matching, and those two the same splice written two ways — with the duplicated-block and moved-block damage controls both failing as they must. It also settled the branch's sharpest question, that the edit does not foreclose ISS 739, by finding 739's own table to be a photograph taken before `12f8b17a` removed this fence's write. Gates on that tree, each on this sha, and they are `CONTRIBUTING.md`'s *These requirements are easily checked … or, in one go* plus *The documentation*: `uv run pre-commit run --all-files` exit 0; `uv run pytest` exit 0 at `32088 passed, 31 skipped, 1 xfailed`, coverage 100.00%; `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html` exit 0; and `grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'` exit 1, which is the pass, that file stating the job fails if this grep exits 0. The documentation gate was owed on a `CHANGELOG.md` diff and the reviewer confirmed the mechanism rather than the absence: `docs/source/changelog_link.md` pulls `../../CHANGELOG.md` through a MyST include under `-W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxwWEa8nRid69sZ81isSa1

## Summary by Sourcery

Consolidate the worktree documentation so the absence of `uv sync` is explained in one place without changing the existing shell-safety guidance.

Enhancements:
- Remove the duplicated explanation of the absent `uv sync` from `CLAUDE.md` while retaining the shared statement and the existing worktree safety rationale.

Documentation:
- Document the consolidated `CLAUDE.md` guidance in the changelog.