### PR TITLE
ConsensusParams gains bip30_unspendable, beside bip30_exceptions (closes #1695)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -509,6 +509,25 @@ file of the test tree, and no caller acts on it.
   measurement is btclib-org/.github#739's material and stands as it is
   written.
 
+### `ConsensusParams.bip30_unspendable`, beside `bip30_exceptions`
+
+- **A row carries the `(height, hash)` pairs Bitcoin Core's
+  `IsBIP30Unspendable` names, mainnet's populated and every other
+  chain's empty** (closes #1695): the blocks whose coinbase a UTXO-set
+  accumulator leaves out, a later block's duplicate coinbase replacing
+  its outputs in the set before anything spends them. It sits beside
+  `bip30_exceptions`, the other BIP30 pair and the opposite one -- those
+  are the later blocks, whose repeat of an earlier coinbase the BIP30
+  check waives rather than rejects. `tests/consensus_test.py`
+  transcribes the row a second time off `src/validation.cpp` at
+  bitcoin/bitcoin@9be056a8a7 (v31.1), which is the blob the rest of the
+  table is read from.
+- **No predicate comes with it.** Nothing in this library asks the
+  question -- `btclib.coinstats` takes one output at a time and walks no
+  chain -- and `bip30_exceptions` carries none either, for the same
+  reason: the library holds the consensus fact, and whoever walks blocks
+  asks it of the row.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -94,6 +94,14 @@ full year, short month, short day (YYYY-M-D)
   or already knows which chain it is asking: `EsploraFetcher(base_url,
   verify_network=False)` is the previous behaviour.
 
+- **`ConsensusParams` takes a `bip30_unspendable` argument** (closes #1695),
+  the blocks Bitcoin Core's `IsBIP30Unspendable` names. It has no default,
+  as no field of the row has.
+
+  Act on it if you build a row of your own for a custom chain: pass
+  `bip30_unspendable=()`, which is what every chain but mainnet
+  carries.
+
 ### Worth knowing, though nothing raises
 
 - **`psbt_signer_contract.optional_protocols` returns `OptionalProtocols`,

--- a/src/btclib/consensus.py
+++ b/src/btclib/consensus.py
@@ -54,8 +54,9 @@ gone from it, buried the way `script_flags_at` below describes.
 
 What a row carries that `chainparams.cpp` does not hold is cited to
 `src/validation.cpp` at the same tag: `bip30_exceptions` is
-`IsBIP30Repeat` there. So is the rule that combines a row's heights into
-script flags, `GetBlockScriptFlags`, which `script_flags_at` names.
+`IsBIP30Repeat` there and `bip30_unspendable` is `IsBIP30Unspendable`.
+So is the rule that combines a row's heights into script flags,
+`GetBlockScriptFlags`, which `script_flags_at` names.
 
 Fields of `Consensus::Params` that are deliberately absent, so that a
 reader looking for one knows it was decided rather than missed:
@@ -247,6 +248,14 @@ class ConsensusParams:
     # heights has a different block there and is not exempt
     bip30_exceptions: tuple[tuple[int, bytes], ...]
 
+    # Core's IsBIP30Unspendable: the (height, hash) of every block whose
+    # coinbase a UTXO-set accumulator leaves out, a later block's
+    # duplicate coinbase replacing its outputs in the set before
+    # anything spends them. Not the pair above and not a subset of it:
+    # that one is the later blocks, whose repeat the BIP30 check waives,
+    # this one the earlier blocks whose outputs are never hashed
+    bip30_unspendable: tuple[tuple[int, bytes], ...]
+
     # Core's script_flag_exceptions: the blocks that are consensus-valid,
     # buried, and fail the flags every other block is checked with. The
     # value is the flag names `to_script_flags` accepts, replacing the
@@ -339,9 +348,9 @@ _POW_LIMIT_BITS_SIGNET = b"\x1e\x03\x77\xae"
 # afterwards would be in one table and in neither the other nor the
 # Network instances built from it
 _consensus_params: dict[str, ConsensusParams] = {
-    # read at lines 84 to 117 of chainparams.cpp, and at IsBIP30Repeat in
-    # validation.cpp for the blocks of 2010 whose coinbase repeats an earlier
-    # one
+    # read at lines 84 to 117 of chainparams.cpp, and in validation.cpp for
+    # the blocks of 2010 that a duplicate coinbase pairs: IsBIP30Repeat for
+    # the ones repeating, IsBIP30Unspendable for the ones repeated
     "mainnet": ConsensusParams(
         name="mainnet",
         subsidy_halving_interval=210_000,
@@ -368,6 +377,20 @@ _consensus_params: dict[str, ConsensusParams] = {
                 91_880,
                 bytes.fromhex(
                     "00000000000743f190a18c5577a3c2d2a1f610ae9601ac046a38084ccb7cd721"
+                ),
+            ),
+        ),
+        bip30_unspendable=(
+            (
+                91_722,
+                bytes.fromhex(
+                    "00000000000271a2dc26e7667f8419f2e15416dc6955e5a6c6cdf3f2574dd08e"
+                ),
+            ),
+            (
+                91_812,
+                bytes.fromhex(
+                    "00000000000af0aed4792b1acee3d966af36cf5def14935db8de83d6f9306f2f"
                 ),
             ),
         ),
@@ -409,6 +432,7 @@ _consensus_params: dict[str, ConsensusParams] = {
         pow_target_timespan=14 * 24 * 60 * 60,  # line 251, two weeks
         minimum_chain_work=0x0000000000000000000000000000000000000000000017DDE1C649F3708D14B6,
         bip30_exceptions=(),
+        bip30_unspendable=(),
         script_flag_exceptions=(
             # testnet3's own BIP16 exception, the mainnet one's twin
             (
@@ -450,6 +474,7 @@ _consensus_params: dict[str, ConsensusParams] = {
         pow_target_timespan=24 * 60 * 60,
         minimum_chain_work=0,
         bip30_exceptions=(),
+        bip30_unspendable=(),
         script_flag_exceptions=(),
     ),
     # read at lines 478 to 491 of chainparams.cpp for the heights and the
@@ -471,6 +496,7 @@ _consensus_params: dict[str, ConsensusParams] = {
         pow_target_timespan=14 * 24 * 60 * 60,  # line 495, two weeks
         minimum_chain_work=0x00000000000000000000000000000000000000000000000000000B463EA0A4B8,
         bip30_exceptions=(),
+        bip30_unspendable=(),
         script_flag_exceptions=(),
     ),
     # read at lines 326 to 356 of chainparams.cpp
@@ -491,6 +517,7 @@ _consensus_params: dict[str, ConsensusParams] = {
         pow_target_timespan=14 * 24 * 60 * 60,  # line 351, two weeks
         minimum_chain_work=0x0000000000000000000000000000000000000000000009A0FE15D0177D086304,
         bip30_exceptions=(),
+        bip30_unspendable=(),
         script_flag_exceptions=(),
     ),
 }

--- a/tests/consensus_test.py
+++ b/tests/consensus_test.py
@@ -51,8 +51,9 @@ _POW_LIMIT = {
 
 # src/kernel/chainparams.cpp, at the tag above: the class of each chain
 # type, read at the lines the module's own rows cite. `bip30_exceptions`
-# is src/validation.cpp's `IsBIP30Repeat` instead, which is where Core
-# hardcodes the pair rather than keeping it in the params struct
+# is src/validation.cpp's `IsBIP30Repeat` instead and `bip30_unspendable`
+# its `IsBIP30Unspendable`, which is where Core hardcodes both pairs
+# rather than keeping them in the params struct
 _CHAINPARAMS: dict[str, dict[str, Any]] = {
     "mainnet": {
         "subsidy_halving_interval": 210000,
@@ -80,6 +81,20 @@ _CHAINPARAMS: dict[str, dict[str, Any]] = {
                 91880,
                 bytes.fromhex(
                     "00000000000743f190a18c5577a3c2d2a1f610ae9601ac046a38084ccb7cd721"
+                ),
+            ),
+        ),
+        "bip30_unspendable": (
+            (
+                91722,
+                bytes.fromhex(
+                    "00000000000271a2dc26e7667f8419f2e15416dc6955e5a6c6cdf3f2574dd08e"
+                ),
+            ),
+            (
+                91812,
+                bytes.fromhex(
+                    "00000000000af0aed4792b1acee3d966af36cf5def14935db8de83d6f9306f2f"
                 ),
             ),
         ),
@@ -114,6 +129,7 @@ _CHAINPARAMS: dict[str, dict[str, Any]] = {
             "0000000000000000000000000000000000000000000017dde1c649f3708d14b6", 16
         ),
         "bip30_exceptions": (),
+        "bip30_unspendable": (),
         "script_flag_exceptions": (
             (
                 bytes.fromhex(
@@ -147,6 +163,7 @@ _CHAINPARAMS: dict[str, dict[str, Any]] = {
         # never leaves initial block download on this comparison
         "minimum_chain_work": 0,
         "bip30_exceptions": (),
+        "bip30_unspendable": (),
         "script_flag_exceptions": (),
     },
     "signet": {
@@ -167,6 +184,7 @@ _CHAINPARAMS: dict[str, dict[str, Any]] = {
             "00000000000000000000000000000000000000000000000000000b463ea0a4b8", 16
         ),
         "bip30_exceptions": (),
+        "bip30_unspendable": (),
         "script_flag_exceptions": (),
     },
     "testnet4": {
@@ -186,6 +204,7 @@ _CHAINPARAMS: dict[str, dict[str, Any]] = {
             "0000000000000000000000000000000000000000000009a0fe15d0177d086304", 16
         ),
         "bip30_exceptions": (),
+        "bip30_unspendable": (),
         "script_flag_exceptions": (),
     },
 }
@@ -392,6 +411,7 @@ def test_a_row_can_be_built_for_a_chain_this_library_does_not_ship() -> None:
         pow_target_timespan=14 * 24 * 60 * 60,
         minimum_chain_work=0,
         bip30_exceptions=(),
+        bip30_unspendable=(),
         script_flag_exceptions=(),
     )
     assert custom.script_flags_at(1) == CONSENSUS_PARAMS["signet"].script_flags_at(1)


### PR DESCRIPTION
Closes #1695

`ConsensusParams` gains `bip30_unspendable`, the `(height, hash)` pairs
Bitcoin Core's `IsBIP30Unspendable` names — the blocks whose coinbase
outputs a later duplicate coinbase overwrote in the UTXO set before
anything spent them, so a set accumulator must leave them out. Mainnet
carries the two of 2010; every other chain carries none.

It sits beside `bip30_exceptions`, which is the opposite pair and not a
subset of it: those are the later blocks, whose repeat of an earlier
coinbase the BIP30 check waives. The comment stating that contrast lives
once, on the new field.

No predicate comes with it. Nothing here walks blocks — `btclib.coinstats`
takes one output at a time — and `bip30_exceptions` carries none either,
for the same reason: the library holds the consensus fact and whoever
walks blocks asks it of the row.

`tests/consensus_test.py::_CHAINPARAMS` transcribes the row a second
time off `src/validation.cpp` at bitcoin/bitcoin@9be056a8a7 (v31.1), the
blob the rest of the table is read from.

**Breaking, and why it is in RELEASE_NOTES.md.** `ConsensusParams` is
public in the released `v2026.9.3` and no field of it has a default, so a
caller building a row of their own — which `tests/consensus_test.py`
documents as supported, already at that tag — gets a `TypeError` until
they pass `bip30_unspendable=()`. Measured against the released class
rather than remembered: the released-shape call raises on the new class
and succeeds once the argument is passed.

## Gates

Run in the worktree at `04b4948a`, exit codes read:

- `uv run --locked pytest -q --cov` → 0 (32088 passed, 31 skipped, 1 xfailed)
- `uv run --locked pre-commit run --all-files` → 0, tree clean

The docs build was not run: no `docs/source/` file and no cross-reference
target is touched.

## Review

Reviewed at fresh context, `CLEARED 0e3d756a`. The reviewer re-derived
Core's two literals from `src/validation.cpp` at that tag and AST-parsed
both branch files rather than eyeballing hex — same pairing, same byte
order, with `b == b[::-1]` false for each so a swap would have shown. It
re-ran the field mutations, including a control that names a *different*
field, and re-measured every link of the `RELEASE_NOTES.md` argument
above, any one of which failing would have made that bullet noise in a
breaking-changes list.

Since the clear, one line: the `(closes #1695)` citation in
`RELEASE_NOTES.md` was wrapped across a line break and is now on one
line, which is a rewrap and no change of claim. The reviewer called it
the only such wrap in the file; it is not — three landed entries there
and several in `CHANGELOG.md` wrap the same way — so this fixes the new
line rather than an anomaly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157LmcttGkdnQhLdCLkfVRR

## Summary by Sourcery

Expose Bitcoin Core’s BIP30-unspendable block data through consensus parameters and document the resulting API change.

New Features:
- Add `ConsensusParams.bip30_unspendable` to expose Bitcoin Core’s BIP30-unspendable block pairs for each supported chain.

Enhancements:
- Keep BIP30 unspendable blocks distinct from BIP30 exception blocks and populate the consensus data from Bitcoin Core.
- Update custom `ConsensusParams` construction requirements to include the new field.

Documentation:
- Document the new consensus field and its required value for custom chains in the changelog and release notes.

Tests:
- Extend consensus parameter fixtures and custom-chain construction coverage for `bip30_unspendable`.