### PR TITLE
The chain check is one method on a NetworkVerifyingFetcher base (closes #1698)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -528,6 +528,37 @@ file of the test tree, and no caller acts on it.
   reason: the library holds the consensus fact, and whoever walks blocks
   asks it of the row.
 
+### The chain check is one method on a `NetworkVerifyingFetcher` base
+
+- **`btclib.fetch.fetcher` gains `NetworkVerifyingFetcher`, the `Fetcher`
+  of a backend that reaches a host and can therefore be asked which chain
+  it serves** (closes #1698). It carries `verify_network`, the memo
+  behind it -- ask once, remember a disagreement for ever, remember a
+  `FetchError` as nothing -- and declares `assert_network` abstract, so a
+  backend written without one does not construct rather than checking the
+  chain never. `BitcoinCoreFetcher`, `BitcoinCoreRestFetcher`,
+  `EsploraFetcher` and `ElectrumFetcher` derive from it and keep
+  `assert_network` alone, which is what differs between them: a chain
+  name and a signet challenge for the node backends, a genesis block for
+  the others. `CachingFetcher` and `FallbackFetcher` stay plain
+  `Fetcher`s -- each answers from another `Fetcher`, which is where the
+  host is and where the question belongs -- so neither carries a
+  `verify_network` with nothing to ask. Nothing a caller writes changes:
+  the argument keeps its name, its keyword-only position and its default
+  on every backend, and now has one declaration to keep them the same.
+
+- **`tests/fetch/verify_network_test.py` holds every entry point of every
+  backend to that check** (closes #1701). Each is called on a scripted
+  host serving another chain and must refuse with one request made, the
+  chain question having consumed it and the fetch behind it never having
+  gone out. The file also reads the call sites out of the source and
+  compares them with the cases, so a call site the cases do not pin, or
+  a pinned call site deleted, is a failing test rather than a fetcher
+  answering from a chain the caller did not mean. What it cannot see is
+  an entry point that never calls the check at all: that one leaves no
+  call site to compare, and the file's own docstring is where it is
+  stated.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/fetch/__init__.py
+++ b/src/btclib/fetch/__init__.py
@@ -66,12 +66,13 @@ call -- the node rewrites the cookie whenever it restarts -- so a caller
 who wants cookie authentication passes the path and never the credential,
 and a name for reading it is one way to hold a credential longer than the
 node does. `-rest` takes no credential to hold, `BitcoinCoreRestClient`
-declaring no equivalent at all. `fetcher.fetch_errors`,
-`tx_from_raw`, `tx_id_hex` and `tx_for_network` are not here either: they
-are what an implementation of the interface is built out of, and they are
-the answer to a caller writing their own rather than to a caller of the
-ones shipped here -- `from btclib.fetch.fetcher import fetch_errors` is
-that answer, and it says which layer it is reaching into.
+declaring no equivalent at all. `fetcher.NetworkVerifyingFetcher`,
+`fetch_errors`, `tx_from_raw`, `tx_id_hex` and `tx_for_network` are not
+here either: they are what an implementation of the interface is built
+out of, and they are the answer to a caller writing their own rather
+than to a caller of the ones shipped here --
+`from btclib.fetch.fetcher import fetch_errors` is that answer, and it
+says which layer it is reaching into.
 
 `FetchError`, `HttpError` and `RpcError` are not here because no exception
 is: `btclib.exceptions` holds every one of them together, which is what

--- a/src/btclib/fetch/bitcoin_core.py
+++ b/src/btclib/fetch/bitcoin_core.py
@@ -36,7 +36,7 @@ from btclib.alias import Octets
 from btclib.block.block_header import BlockHeader
 from btclib.exceptions import BTClibValueError, FetchError
 from btclib.fetch.fetcher import (
-    Fetcher,
+    NetworkVerifyingFetcher,
     block_header_from_raw,
     block_header_height,
     client_errors,
@@ -62,7 +62,7 @@ __all__ = [
 _MAX_SMALL_REPLY = 1024
 
 
-class BitcoinCoreFetcher(Fetcher):
+class BitcoinCoreFetcher(NetworkVerifyingFetcher):
     """The four fetcher questions, answered by a node over its RPC.
 
     Also a `Broadcaster`: `broadcast` sends `sendrawtransaction`, which
@@ -80,14 +80,6 @@ class BitcoinCoreFetcher(Fetcher):
     it is what the outputs of a fetched transaction are labelled with. The
     client knows a URL and no chain, so the label is a claim until the node
     is asked, and `assert_network` is the question.
-
-    `verify_network` is who asks it. On by default and before the first
-    fetch rather than in this constructor: the answer costs a round trip
-    that is worth paying where it is checked and wasted where a fetcher is
-    built and never used, and a node that is merely down should not be a
-    failure to *construct* anything. The answer is then kept -- a node
-    does not change chain under a client that goes on pointing at it --
-    and a caller that would rather not ask says `verify_network=False`.
 
     `signet_challenge` is which signet, for the one label that names more
     than one chain: Core answers `signet` for the default signet and for
@@ -108,7 +100,7 @@ class BitcoinCoreFetcher(Fetcher):
         verify_network: bool = True,
         signet_challenge: str | bytes | None = None,
     ) -> None:
-        super().__init__(network)
+        super().__init__(network, verify_network=verify_network)
         if signet_challenge is not None:
             if chain_from_network(self.network) != "signet":
                 err_msg = f"a signet_challenge for {self.network},"
@@ -125,36 +117,7 @@ class BitcoinCoreFetcher(Fetcher):
             with client_errors():
                 magic_from_signet_challenge(signet_challenge)
         self.client = client
-        self.verify_network = verify_network
         self.signet_challenge = signet_challenge
-        self._agreed = False
-        self._disagreement = ""
-
-    def _verify_once(self) -> None:
-        """Compare the node's chain with this fetcher's label, once.
-
-        Called by the four fetches and not by `_call`, which is what
-        `assert_network` itself goes through: a check in there would ask
-        the node about the node, from inside the question.
-
-        A disagreement is remembered and raised again for every later
-        fetch, because it is a settled fact about a configuration rather
-        than a request that failed -- and a fetcher that asked once,
-        refused once and then served an address would be the silent
-        failure this exists to stop. A `FetchError` is not an answer and
-        is remembered as nothing: the node was unreachable or spoke
-        nonsense, which the next fetch may well find otherwise.
-        """
-        if not self.verify_network or self._agreed:
-            return
-        if self._disagreement:
-            raise BTClibValueError(self._disagreement)
-        try:
-            self.assert_network()
-        except BTClibValueError as e:
-            self._disagreement = str(e)
-            raise
-        self._agreed = True
 
     def _call(
         self,
@@ -230,14 +193,9 @@ class BitcoinCoreFetcher(Fetcher):
         )
         return block_header_from_raw(raw, height)
 
+    @override
     def assert_network(self) -> None:
         """Raise unless the node serves the chain this fetcher labels with.
-
-        One round trip, asked once and not per fetch: the answer cannot
-        change under a client that goes on pointing at the same node.
-        `verify_network` is what asks it before the first fetch, and this
-        stays public for a caller that wants the question answered at a
-        moment of its own -- at startup, or after a client was repointed.
 
         Worth the call, because the failure it catches is silent.
         A client built for a testnet node -- an explicit url, no port
@@ -260,10 +218,6 @@ class BitcoinCoreFetcher(Fetcher):
         `chain_from_network` on the way in, `client_errors` on the way out.
         The check itself belongs beside the protocol it reads, and lived
         here only while `bitcoin_core_rpc` did not have it.
-
-        A malformed reply is a `FetchError`. A disagreement is a
-        `BTClibValueError`: the node is the authority on which chain it
-        serves, so the fetcher's label is the thing to fix.
         """
         # every network of NETWORKS is a chain of Core's -- the catalogue is
         # fixed at import and `tests/fetch/bitcoin_core_test.py` holds the

--- a/src/btclib/fetch/bitcoin_core_rest.py
+++ b/src/btclib/fetch/bitcoin_core_rest.py
@@ -50,7 +50,7 @@ from btclib.alias import Octets
 from btclib.block.block_header import BlockHeader
 from btclib.exceptions import BTClibValueError
 from btclib.fetch.fetcher import (
-    Fetcher,
+    NetworkVerifyingFetcher,
     block_header_from_raw,
     block_header_height,
     client_errors,
@@ -106,7 +106,7 @@ def _field(reply: Any, name: str) -> Any:
     return reply[name]
 
 
-class BitcoinCoreRestFetcher(Fetcher):
+class BitcoinCoreRestFetcher(NetworkVerifyingFetcher):
     """The four fetcher questions, answered by a node over `-rest`.
 
     The client is a constructor argument rather than connection
@@ -114,11 +114,8 @@ class BitcoinCoreRestFetcher(Fetcher):
     `BitcoinCoreRpcClient`: one class owns the endpoint, this one owns
     the mapping onto btclib types.
 
-    `network` labels the outputs `get_tx` returns, and `verify_network`
-    holds the node to it: on by default, asked before the first fetch and
-    not in this constructor, remembered once agreed and remembered once
-    refused -- `BitcoinCoreFetcher`'s reasons, unchanged, and its
-    `verify_network=False` for a caller that would rather not ask.
+    `network` labels the outputs `get_tx` returns, and `assert_network`
+    holds the node to it.
 
     `signet_challenge` is which signet, and means what it means on
     `BitcoinCoreFetcher`: Core answers `signet` for the default signet
@@ -142,7 +139,7 @@ class BitcoinCoreRestFetcher(Fetcher):
         verify_network: bool = True,
         signet_challenge: str | bytes | None = None,
     ) -> None:
-        super().__init__(network)
+        super().__init__(network, verify_network=verify_network)
         if signet_challenge is not None:
             if chain_from_network(self.network) != "signet":
                 err_msg = f"a signet_challenge for {self.network},"
@@ -158,11 +155,9 @@ class BitcoinCoreRestFetcher(Fetcher):
             with client_errors():
                 magic_from_signet_challenge(signet_challenge)
         self.client = client
-        self.verify_network = verify_network
         self.signet_challenge = signet_challenge
-        self._agreed = False
-        self._disagreement = ""
 
+    @override
     def assert_network(self) -> None:
         """Raise unless the node serves the chain, and the signet, this labels.
 
@@ -175,15 +170,9 @@ class BitcoinCoreRestFetcher(Fetcher):
         the magic `signet_challenge` derives, since Core answers `signet`
         for every signet and the name therefore separates none of them.
 
-        Public for the same reason `BitcoinCoreFetcher.assert_network`
-        is -- a caller that wants the question answered at a moment of its
-        own.
-
-        A reply that cannot be read is a `FetchError`, a node too old to
-        report its challenge included: that is one this cannot answer
-        for, and not a pass. A disagreement is a `BTClibValueError`, the
-        node being the authority on what it serves and the fetcher's
-        label therefore the thing to fix.
+        A node too old to report its challenge answers a reply this
+        cannot read, so a `FetchError`: one it cannot answer for, and not
+        a pass.
         """
         expected = chain_from_network(self.network)
         expected_magic: bytes | None = None
@@ -215,25 +204,6 @@ class BitcoinCoreRestFetcher(Fetcher):
             err_msg += f" {node_magic.hex()}, where {expected_magic.hex()}"
             err_msg += " was expected"
             raise BTClibValueError(err_msg)
-
-    def _verify_once(self) -> None:
-        """Compare the node's chain with this fetcher's label, once.
-
-        `BitcoinCoreFetcher._verify_once`, unchanged: a disagreement is a
-        settled fact about a configuration and is raised again for every
-        later fetch, where a `FetchError` is no answer and is remembered
-        as nothing, the next fetch asking again.
-        """
-        if not self.verify_network or self._agreed:
-            return
-        if self._disagreement:
-            raise BTClibValueError(self._disagreement)
-        try:
-            self.assert_network()
-        except BTClibValueError as e:
-            self._disagreement = str(e)
-            raise
-        self._agreed = True
 
     def _get_bin(self, path: str, *, max_body_size: int | None) -> bytes:
         """Return the raw body of one `-rest` request, translating its errors.

--- a/src/btclib/fetch/electrum.py
+++ b/src/btclib/fetch/electrum.py
@@ -52,7 +52,7 @@ from btclib.alias import Octets
 from btclib.block.block_header import BlockHeader
 from btclib.exceptions import BTClibValueError
 from btclib.fetch.fetcher import (
-    Fetcher,
+    NetworkVerifyingFetcher,
     block_header_from_raw,
     block_header_height,
     client_errors,
@@ -69,7 +69,7 @@ __all__ = [
 ]
 
 
-class ElectrumFetcher(Fetcher):
+class ElectrumFetcher(NetworkVerifyingFetcher):
     """The four fetcher questions, and a fifth, answered by an Electrum server.
 
     `get_tx` is `blockchain.transaction.get`, the raw hex decoded and
@@ -99,18 +99,6 @@ class ElectrumFetcher(Fetcher):
     history and its unspent outputs, `blockchain.scripthash.get_history`
     and `.listunspent`, but the interface does not ask those questions
     and this issue does not add them.
-
-    `verify_network` is who asks whether the server is on the chain this
-    fetcher labels with, and `assert_network` below is the question it
-    asks. On by default and before the first fetch rather than in this
-    constructor: the answer costs a round trip that is worth paying
-    where it is checked and wasted where a fetcher is built and never
-    used, and a server that is merely unreachable should not be a
-    failure to *construct* anything. The answer is then kept -- a server
-    does not change chain under a client that goes on pointing at it --
-    and a caller that would rather not ask says `verify_network=False`.
-    Same name, same keyword-only argument, same default, same opt-out as
-    `BitcoinCoreFetcher.verify_network`.
     """
 
     def __init__(
@@ -121,13 +109,10 @@ class ElectrumFetcher(Fetcher):
         verify_network: bool = True,
         timeout: float = DEFAULT_TIMEOUT,
     ) -> None:
-        super().__init__(network)
+        super().__init__(network, verify_network=verify_network)
         self.transport = transport
-        self.verify_network = verify_network
         self.timeout = timeout
         self._next_id = 0
-        self._agreed = False
-        self._disagreement = ""
 
     def _next_request_id(self) -> int:
         """Return a fresh request id, one higher than the last.
@@ -148,33 +133,6 @@ class ElectrumFetcher(Fetcher):
         """
         with client_errors():
             return self.transport(request, self.timeout)
-
-    def _verify_once(self) -> None:
-        """Compare the server's chain with this fetcher's label, once.
-
-        `BitcoinCoreFetcher._verify_once`, unchanged: called by the
-        fetches and not by `_round_trip` or `_header_at`, which is what
-        `assert_network` itself goes through -- a check in there would
-        ask the server about the server, from inside the question.
-
-        A disagreement is remembered and raised again for every later
-        call, because it is a settled fact about a configuration rather
-        than a request that failed -- and a fetcher that asked once,
-        refused once and then served an address would be the silent
-        failure this exists to stop. A `FetchError` is not an answer and
-        is remembered as nothing: the server was unreachable or spoke
-        nonsense, which the next call may well find otherwise.
-        """
-        if not self.verify_network or self._agreed:
-            return
-        if self._disagreement:
-            raise BTClibValueError(self._disagreement)
-        try:
-            self.assert_network()
-        except BTClibValueError as e:
-            self._disagreement = str(e)
-            raise
-        self._agreed = True
 
     def _tip(self) -> electrum.HeaderTip:
         """Return the chain tip `blockchain.headers.subscribe` answers."""
@@ -238,6 +196,7 @@ class ElectrumFetcher(Fetcher):
         self._verify_once()
         return self._header_at(block_header_height(height))
 
+    @override
     def assert_network(self) -> None:
         """Raise unless the server serves the chain this fetcher labels with.
 
@@ -255,10 +214,6 @@ class ElectrumFetcher(Fetcher):
         genesis rather than repeat a string, and because it needs no
         codec function `btclib.electrum` does not already have.
 
-        Public for the same reason `BitcoinCoreFetcher.assert_network` is
-        -- a caller that wants the question answered at a moment of its
-        own.
-
         Worth the call, because the failure it catches is silent, the
         same one `BitcoinCoreFetcher.assert_network`'s docstring names: a
         fetcher labelled `mainnet` over a server on another chain renders
@@ -274,11 +229,6 @@ class ElectrumFetcher(Fetcher):
         for the reason that class takes none: nothing among the methods
         `btclib.electrum` speaks is a signet's challenge to compare
         against.
-
-        A malformed reply is a `FetchError`. A disagreement is a
-        `BTClibValueError` naming both hashes: the server is the
-        authority on which chain it serves, so the fetcher's label is the
-        thing to fix.
         """
         reported = self._header_at(0).hash
         expected = NETWORKS[self.network].genesis_block

--- a/src/btclib/fetch/esplora.py
+++ b/src/btclib/fetch/esplora.py
@@ -27,14 +27,14 @@ the id check. The height and the tip hash have nothing here to check
 them against at all, and are taken on trust.
 
 Which chain the explorer serves is a separate question from those four,
-and `verify_network` is what asks it: on by default, the same name and
-the same opt-out `BitcoinCoreFetcher.verify_network` is, comparing
-`/block-height/0` against the genesis `NETWORKS` carries for the network
-this fetcher was built for. The failure it catches is the same silent
-one -- a fetcher labelled `mainnet` over a host serving another chain
-renders a mainnet address for every output it fetches -- and what a
-genesis hash cannot do is separate two signets; `assert_network`'s own
-docstring says why.
+and `verify_network` is what asks it: declared once on
+`NetworkVerifyingFetcher` rather than agreed among the backends, on by
+default, comparing `/block-height/0` against the genesis `NETWORKS`
+carries for the network this fetcher was built for. The failure it
+catches is the same silent one -- a fetcher labelled `mainnet` over a
+host serving another chain renders a mainnet address for every output it
+fetches -- and what a genesis hash cannot do is separate two signets;
+`assert_network`'s own docstring says why.
 
 Nor does anything here say a transaction is *confirmed*: the answer to
 that is a merkle branch checked against a header, which is what the
@@ -59,7 +59,7 @@ from btclib.alias import Octets
 from btclib.block.block_header import BlockHeader
 from btclib.exceptions import BTClibValueError, FetchError, HttpError
 from btclib.fetch.fetcher import (
-    Fetcher,
+    NetworkVerifyingFetcher,
     block_header_from_raw,
     block_header_height,
     client_errors,
@@ -112,7 +112,7 @@ _MAX_HEADER_BODY = 256
 _MAX_TX_BODY = DEFAULT_MAX_BODY_SIZE
 
 
-class EsploraFetcher(Fetcher):
+class EsploraFetcher(NetworkVerifyingFetcher):
     """The four questions, answered by an Esplora instance over HTTP.
 
     `base_url` is required and has no default, for the reason
@@ -122,17 +122,6 @@ class EsploraFetcher(Fetcher):
     this class that writes. Holding a fetcher is not broadcasting; a
     caller has to call the method, and `broadcast`'s own docstring is
     where its non-idempotence is stated, at the point a caller meets it.
-
-    `verify_network` is who asks whether the explorer is on the chain
-    this fetcher labels with. On by default and before the first fetch
-    rather than in this constructor: the answer costs a round trip that
-    is worth paying where it is checked and wasted where a fetcher is
-    built and never used, and an explorer that is merely unreachable
-    should not be a failure to *construct* anything. The answer is then
-    kept -- an explorer does not change chain under a client that goes on
-    pointing at it -- and a caller that would rather not ask says
-    `verify_network=False`. Same name, same keyword-only argument, same
-    default, same opt-out as `BitcoinCoreFetcher.verify_network`.
     """
 
     def __init__(
@@ -144,41 +133,10 @@ class EsploraFetcher(Fetcher):
         timeout: float = DEFAULT_TIMEOUT,
         transport: HttpTransport = urlopen_transport,
     ) -> None:
-        super().__init__(network)
+        super().__init__(network, verify_network=verify_network)
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
         self.transport = transport
-        self.verify_network = verify_network
-        self._agreed = False
-        self._disagreement = ""
-
-    def _verify_once(self) -> None:
-        """Compare the explorer's chain with this fetcher's label, once.
-
-        `BitcoinCoreFetcher._verify_once`, unchanged: called by the four
-        fetches and by `broadcast`, and not by `text` or `_request`,
-        which is what `assert_network` itself goes through -- a check in
-        there would ask the explorer about the explorer, from inside the
-        question.
-
-        A disagreement is remembered and raised again for every later
-        call, because it is a settled fact about a configuration rather
-        than a request that failed -- and a fetcher that asked once,
-        refused once and then served an address would be the silent
-        failure this exists to stop. A `FetchError` is not an answer and
-        is remembered as nothing: the explorer was unreachable or spoke
-        nonsense, which the next call may well find otherwise.
-        """
-        if not self.verify_network or self._agreed:
-            return
-        if self._disagreement:
-            raise BTClibValueError(self._disagreement)
-        try:
-            self.assert_network()
-        except BTClibValueError as e:
-            self._disagreement = str(e)
-            raise
-        self._agreed = True
 
     def _request(
         self, path: str, *, data: bytes | None, max_body_size: int
@@ -276,6 +234,7 @@ class EsploraFetcher(Fetcher):
         raw = self.text(f"/block/{block_hash}/header", _MAX_HEADER_BODY)
         return block_header_from_raw(raw, height)
 
+    @override
     def assert_network(self) -> None:
         """Raise unless the explorer serves the chain this fetcher labels with.
 
@@ -283,10 +242,6 @@ class EsploraFetcher(Fetcher):
         `get_block_header` reads for every other height, asked here for
         the block every chain starts from -- compared against
         `NETWORKS[self.network].genesis_block`.
-
-        Public for the same reason `BitcoinCoreFetcher.assert_network` is
-        -- a caller that wants the question answered at a moment of its
-        own.
 
         Worth the call, because the failure it catches is silent, the
         same one `BitcoinCoreFetcher.assert_network`'s docstring names: a
@@ -303,11 +258,6 @@ class EsploraFetcher(Fetcher):
         `signet_challenge` is given. This class takes no
         `signet_challenge` of its own: nothing Esplora's api publishes is
         a signet's challenge to compare it against.
-
-        A malformed reply is a `FetchError`. A disagreement is a
-        `BTClibValueError` naming both hashes: the explorer is the
-        authority on which chain it serves, so the fetcher's label is the
-        thing to fix.
         """
         with fetch_errors("block-height"):
             reply = self.text("/block-height/0", _MAX_HASH_BODY)

--- a/src/btclib/fetch/fetcher.py
+++ b/src/btclib/fetch/fetcher.py
@@ -41,6 +41,7 @@ from btclib.utils import bytes_from_octets, is_integer, is_octets
 
 __all__ = [
     "Fetcher",
+    "NetworkVerifyingFetcher",
     "block_header_from_raw",
     "block_header_height",
     "client_errors",
@@ -253,6 +254,84 @@ class Fetcher(ABC):
             err_msg += f" for a transaction with {len(tx.vout)} outputs"
             raise FetchError(err_msg)
         return tx.vout[out_point.vout]
+
+
+class NetworkVerifyingFetcher(Fetcher):
+    """A `Fetcher` that can ask its host which chain it serves.
+
+    Every backend reaching a host over a connection is one of these:
+    `network` is a label the caller chose, a host on another chain
+    answers every question just as readily, and asking is the only way
+    to tell. `CachingFetcher` and `FallbackFetcher` are `Fetcher`s and
+    not these -- each answers from another `Fetcher`, which is where the
+    host is and where the question belongs -- which is why the check is
+    declared here rather than on `Fetcher`, where those two would carry
+    a `verify_network` with nothing to ask.
+
+    `verify_network` is who asks. On by default and before the first
+    fetch rather than in the constructor: the answer costs a round trip
+    that is worth paying where it is checked and wasted where a fetcher
+    is built and never used, and a host that is merely unreachable
+    should not be a failure to *construct* anything. The answer is then
+    kept -- a host does not change chain under a client that goes on
+    pointing at it -- and a caller that would rather not ask says
+    `verify_network=False`.
+    """
+
+    verify_network: bool
+
+    def __init__(
+        self, network: str = "mainnet", *, verify_network: bool = True
+    ) -> None:
+        """Bind the fetcher to a network, and to whether its host is asked."""
+        super().__init__(network)
+        self.verify_network = verify_network
+        self._agreed = False
+        self._disagreement = ""
+
+    @abstractmethod
+    def assert_network(self) -> None:
+        """Raise unless the host serves the chain this fetcher labels with.
+
+        What settles it is the backend's: a chain name and a signet
+        challenge where the host is a node reporting both, a genesis
+        block where it is a host that only says it validated. Abstract
+        rather than a default, which could only pass: a backend
+        declaring none would check the chain never and compile.
+
+        Public, for a caller that wants the question answered at a moment
+        of its own -- at startup, or after a client was repointed.
+
+        A malformed reply is a `FetchError`. A disagreement is a
+        `BTClibValueError`: the host is the authority on which chain it
+        serves, so the fetcher's label is the thing to fix.
+        """
+
+    def _verify_once(self) -> None:
+        """Compare the host's chain with this fetcher's label, once.
+
+        Called by every question a backend answers, and by nothing
+        `assert_network` itself goes through -- a check there would ask
+        the host about the host, from inside the question.
+
+        A disagreement is remembered and raised again for every later
+        call, because it is a settled fact about a configuration rather
+        than a request that failed -- and a fetcher that asked once, was
+        refused once and then served an address would be the silent
+        failure this exists to stop. A `FetchError` is not an answer and
+        is remembered as nothing: the host was unreachable or spoke
+        nonsense, which the next call may well find otherwise.
+        """
+        if not self.verify_network or self._agreed:
+            return
+        if self._disagreement:
+            raise BTClibValueError(self._disagreement)
+        try:
+            self.assert_network()
+        except BTClibValueError as e:
+            self._disagreement = str(e)
+            raise
+        self._agreed = True
 
 
 def tx_id_hex(tx_id: Octets) -> str:

--- a/tests/bool_parameter_test.py
+++ b/tests/bool_parameter_test.py
@@ -1053,6 +1053,20 @@ _TRUTHS = (
         reason="whether the outputs are required to be worth no more than"
         " the inputs; the scripts run either way",
     ),
+    # the declaration the four below forward to, and the one that gives
+    # them the same name, the same keyword-only argument and the same
+    # default. Driven through a backend because the class it belongs to
+    # is abstract: `assert_network` is what a backend answers for itself,
+    # so there is no instance of the base to construct
+    _Case(
+        "btclib.fetch.fetcher.NetworkVerifyingFetcher.__init__",
+        "verify_network",
+        ElectrumFetcher,
+        {"transport": LineRecorded()},
+        reason="whether the host is asked which chain it serves before"
+        " the first answer leaves; a check, and the fetch is the same"
+        " fetch either way",
+    ),
     _Case(
         "btclib.fetch.bitcoin_core.BitcoinCoreFetcher.__init__",
         "verify_network",

--- a/tests/fetch/__init__.py
+++ b/tests/fetch/__init__.py
@@ -96,10 +96,10 @@ class Recorded:
 class StubFetcher(Fetcher):
     """A Fetcher over a fixed transaction, for testing the base class.
 
-    The concrete half of `Fetcher` -- the network check, `get_tx_out`
-    deriving an output from the transaction that made it -- is code no
-    backend re-implements, so testing it through one of them would test
-    it once for bitcoind and never for the interface.
+    The concrete half of `Fetcher` -- the network name it normalizes,
+    `get_tx_out` deriving an output from the transaction that made it --
+    is code no backend re-implements, so testing it through one of them
+    would test it once for bitcoind and never for the interface.
     """
 
     def __init__(self, tx: Tx, network: str = "mainnet") -> None:

--- a/tests/fetch/fetcher_test.py
+++ b/tests/fetch/fetcher_test.py
@@ -17,6 +17,7 @@ from btclib.exceptions import (
 )
 from btclib.fetch.fetcher import (
     Fetcher,
+    NetworkVerifyingFetcher,
     block_header_from_raw,
     block_header_height,
     fetch_errors,
@@ -283,6 +284,32 @@ def test_leaving_any_one_of_the_four_abstract_refuses_construction(
     incomplete = type("Incomplete", (Fetcher,), methods)
     with pytest.raises(TypeError, match="abstract"):
         incomplete("mainnet")
+
+
+def test_a_verifying_fetcher_without_assert_network_is_refused() -> None:
+    """The four questions answered and the chain question not declared.
+
+    What a backend costs its caller when it is written without one is
+    the check made never, on a class that compiles and passes its own
+    tests, so `NetworkVerifyingFetcher` declares `assert_network`
+    abstract and this is that refusal.
+    """
+    questions = {
+        "get_tx": lambda self, tx_id: Tx.parse(RAW),
+        "get_block_count": lambda self: TIP_HEIGHT,
+        "get_best_block_id": lambda self: bytes.fromhex(TIP_ID),
+        "get_block_header": lambda self, height: BlockHeader.parse(TIP_HEADER_RAW),
+    }
+    unasked = type("Unasked", (NetworkVerifyingFetcher,), questions)
+    with pytest.raises(TypeError, match="abstract"):
+        unasked("mainnet")
+
+    asking = type(
+        "Asking",
+        (NetworkVerifyingFetcher,),
+        {**questions, "assert_network": lambda self: None},
+    )
+    assert asking("mainnet").verify_network is True
 
 
 def test_a_network_name_is_taken_as_the_rest_of_the_library_takes_one() -> None:

--- a/tests/fetch/verify_network_test.py
+++ b/tests/fetch/verify_network_test.py
@@ -1,0 +1,186 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""No backend answers a question before the chain it is on is agreed.
+
+`NetworkVerifyingFetcher._verify_once` is the check, and what carries the
+property is the *set* of methods that call it: an entry point that does
+not is outside the guard, answering from a host on another chain with
+every other test green. The coverage floor cannot see it either -- the
+call is a statement every `verify_network=False` test executes and
+returns from at once -- which is what issue #1701 measured, and why the
+call sites here are read out of the source rather than listed by hand.
+
+Each case builds a fetcher whose scripted host serves testnet under a
+mainnet label, calls one entry point, and asserts both halves: the
+refusal, and that the host was asked once. One request is the chain
+question alone, so the fetch behind it never went out.
+
+The fixtures are each backend's own test module's, imported rather than
+repeated: what a recorded reply looks like is that module's business.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from btclib.exceptions import BTClibValueError
+from btclib.fetch.bitcoin_core import BitcoinCoreFetcher
+from btclib.fetch.bitcoin_core_rest import BitcoinCoreRestFetcher
+from btclib.fetch.electrum import ElectrumFetcher
+from btclib.fetch.esplora import EsploraFetcher
+from btclib.fetch.fetcher import Fetcher
+from tests.fetch import TIP_HEIGHT, TX_ID, Recorded
+from tests.fetch.bitcoin_core_rest_test import chaininfo
+from tests.fetch.bitcoin_core_rest_test import client as rest_client
+from tests.fetch.bitcoin_core_rest_test import recording as rest_recording
+from tests.fetch.bitcoin_core_test import blockchaininfo
+from tests.fetch.bitcoin_core_test import client as rpc_client
+from tests.fetch.bitcoin_core_test import recording as rpc_recording
+from tests.fetch.electrum_test import TESTNET_GENESIS_HEADER, LineRecorded
+from tests.fetch.esplora_test import BASE, TESTNET_GENESIS
+
+_FETCH = Path(__file__).parents[2] / "src" / "btclib" / "fetch"
+
+
+@dataclass(frozen=True)
+class _Backend:
+    """A fetcher on a host that serves another chain, and its refusal."""
+
+    build: Callable[[], tuple[Fetcher, Sequence[object]]]
+    refusal: str
+
+
+def _core() -> tuple[Fetcher, Sequence[object]]:
+    """Return a mainnet fetcher over a node reporting the chain `test`."""
+    endpoint = rpc_client(blockchaininfo(chain="test"))
+    return BitcoinCoreFetcher(endpoint, "mainnet"), rpc_recording(endpoint).requests
+
+
+def _rest() -> tuple[Fetcher, Sequence[object]]:
+    """Return a mainnet fetcher over `-rest` reporting the chain `test`."""
+    endpoint = rest_client((200, chaininfo(chain="test")))
+    return BitcoinCoreRestFetcher(endpoint, "mainnet"), rest_recording(
+        endpoint
+    ).requests
+
+
+def _esplora() -> tuple[Fetcher, Sequence[object]]:
+    """Return a mainnet fetcher over an explorer on testnet's genesis."""
+    transport = Recorded((200, TESTNET_GENESIS.encode()))
+    return EsploraFetcher(BASE, transport=transport), transport.requests
+
+
+def _electrum() -> tuple[Fetcher, Sequence[object]]:
+    """Return a mainnet fetcher over a server on testnet's genesis."""
+    transport = LineRecorded(TESTNET_GENESIS_HEADER)
+    return ElectrumFetcher("mainnet", transport=transport), transport.requests
+
+
+_BACKENDS = {
+    "BitcoinCoreFetcher": _Backend(_core, "reports chain 'test', not the 'main'"),
+    "BitcoinCoreRestFetcher": _Backend(_rest, "reports chain 'test', not the 'main'"),
+    "ElectrumFetcher": _Backend(_electrum, TESTNET_GENESIS),
+    "EsploraFetcher": _Backend(_esplora, TESTNET_GENESIS),
+}
+
+# `Fetcher`'s four, which every backend answers and every backend checks
+# the chain in front of
+_QUESTIONS: dict[str, Callable[[Fetcher], object]] = {
+    "get_best_block_id": lambda endpoint: endpoint.get_best_block_id(),
+    "get_block_count": lambda endpoint: endpoint.get_block_count(),
+    "get_block_header": lambda endpoint: endpoint.get_block_header(TIP_HEIGHT),
+    "get_tx": lambda endpoint: endpoint.get_tx(TX_ID),
+}
+
+# what `Fetcher` does not declare, each pinned where its own backend is
+# tested rather than a second time here:
+# `test_broadcast_verifies_the_network_before_sending_anything` in
+# `bitcoin_core_test.py` and in `esplora_test.py`, and
+# `test_the_fifth_question_is_refused_on_another_chain_too` in
+# `electrum_test.py`
+_ELSEWHERE = {
+    ("BitcoinCoreFetcher", "broadcast"),
+    ("ElectrumFetcher", "get_tx_merkle"),
+    ("EsploraFetcher", "broadcast"),
+}
+
+
+def _call_sites() -> set[tuple[str, str]]:
+    """Return every (class, method) of the package that calls the check."""
+    found: set[tuple[str, str]] = set()
+    for path in sorted(_FETCH.glob("*.py")):
+        module = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(module):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for method in node.body:
+                if isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)) and any(
+                    isinstance(call, ast.Call)
+                    and ast.unparse(call.func) == "self._verify_once"
+                    for call in ast.walk(method)
+                ):
+                    found.add((node.name, method.name))
+    return found
+
+
+@pytest.mark.parametrize("backend", sorted(_BACKENDS))
+@pytest.mark.parametrize("question", sorted(_QUESTIONS))
+def test_no_question_is_answered_by_a_host_on_another_chain(
+    backend: str, question: str
+) -> None:
+    """The chain is asked about first, whichever question was asked.
+
+    One request is the whole of what the host is allowed to see: the
+    check consumed it, and the request the question would have made was
+    never sent.
+    """
+    endpoint, asked = _BACKENDS[backend].build()
+    with pytest.raises(BTClibValueError, match=_BACKENDS[backend].refusal):
+        _QUESTIONS[question](endpoint)
+    assert len(asked) == 1
+
+
+def test_every_call_site_is_pinned() -> None:
+    """The census, and the reason this file is not a list kept by hand.
+
+    A call site the cases above do not pin fails here rather than
+    passing on a check no case exercises; a pinned call site deleted
+    fails both here and in the case that was covering it. An entry point
+    that never calls the check leaves no call site to compare, so it is
+    the gap this module's docstring names and not one this test closes.
+    """
+    pinned = {
+        (backend, question) for backend in _BACKENDS for question in _QUESTIONS
+    } | _ELSEWHERE
+    found = _call_sites()
+    assert found == pinned, (
+        f"not pinned by a test: {sorted(found - pinned)};"
+        f" gone from the tree: {sorted(pinned - found)}"
+    )
+
+
+def test_the_walk_reads_calls_and_not_names() -> None:
+    """The control: a walk finding nothing would pass the census silently.
+
+    `ElectrumFetcher._header_at` is the absence with the shape of the
+    defect: its docstring names `_verify_once` and its body does not call
+    it, so a walk reading names rather than calls invents it. The other
+    two mention the check nowhere and would be absent from a name walk
+    too; they say what the census must not invent for a different reason
+    -- `text` is the seam `EsploraFetcher.assert_network` itself goes
+    through, so a check in it would ask the explorer about the explorer,
+    and `ElectrumFetcher.verify_tx` reaches the chain through
+    `get_block_header` and asks nothing of its own.
+    """
+    found = _call_sites()
+    assert ("EsploraFetcher", "get_tx") in found
+    assert ("ElectrumFetcher", "_header_at") not in found
+    assert ("EsploraFetcher", "text") not in found
+    assert ("ElectrumFetcher", "verify_tx") not in found

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -201,6 +201,7 @@ KEYWORD_ONLY: dict[str, list[str]] = {
     "btclib.ecc.ssa:verify_": ["commit_hash", "receipt"],
     "btclib.fee:FeeRate.__init__": ["sats_per_kvbyte"],
     "btclib.fee:package_fee": ["ancestor_vsize", "ancestor_fee"],
+    "btclib.fetch.fetcher:NetworkVerifyingFetcher.__init__": ["verify_network"],
     "btclib.fetch.transport:http_request": [
         "data",
         "headers",


### PR DESCRIPTION
Closes #1698
Closes #1701

`btclib.fetch.fetcher` gains `NetworkVerifyingFetcher`: the `Fetcher` of a
backend that reaches a host and can therefore be asked which chain it
serves. It declares `verify_network`, the attributes the memo reads,
`_verify_once` itself — ask once, remember a disagreement for ever,
remember a `FetchError` as nothing — and `assert_network` as abstract,
which is what each backend answers for itself.

The flag rises with the memo rather than staying a constructor argument
each backend declares alone, because the sameness `SECURITY.md` states is
then one declaration rather than an agreement among four classes. It does
not rise as far as `Fetcher`: `CachingFetcher` and `FallbackFetcher`
answer from another `Fetcher`, so on them the flag would have no host to
ask.

Nothing a caller writes changes. Measured, not assumed: `inspect.signature`
and `dir()` over the four backends and `btclib.fetch.__all__`, taken on
`main` and on the branch, diff to nothing — which is why `RELEASE_NOTES.md`
does not move.

## The measurement that decided ISS 1701

`tests/fetch/verify_network_test.py` calls every entry point of every
backend on a scripted host serving another chain, and asserts both halves:
the refusal, and that the host was asked exactly once — one request being
the chain question alone, so the fetch behind it never went out.

The sweep, deleting `self._verify_once()` from each of the 19 call sites in
turn:

- before this branch, **7 of 19** deletions left the suite green —
  `get_best_block_id` on all four backends, `get_block_header` on the
  Electrum and Esplora ones, `get_block_count` over `-rest`
- after it, **0 of 19**

## What the census can and cannot see

The file also reads the call sites out of the source and compares them with
its cases, so a call site the cases do not pin, or a pinned call site
deleted, fails. It does **not** see an entry point that never calls the
check at all: that one leaves no call site to compare. The CHANGELOG entry
and the test's own docstring now say so, where an earlier draft of both
claimed the wider guarantee.

## Review, and what changed after the clear

Reviewed at fresh context: **CHANGES REQUESTED** on `521deb69`, one
blocking finding and four smaller ones, all fixed here. The reviewer
re-ran the 19-site sweep and the 7-site control on the pre-branch commit
independently rather than taking the coder's log.

- **blocking** — the CHANGELOG claimed the census catches "an entry point
  added without the check". It does not, and the reviewer demonstrated it:
  a fifth question on `EsploraFetcher` with no check, plus a test for it,
  left the whole suite green. Both prose sites now state the narrower,
  true guarantee and name the gap.
- the walk missed `async def`, so an async entry point would have been an
  unseen call site. Fixed, and measured: with an `async` call site added,
  `test_every_call_site_is_pinned` now fails and at `521deb69` it passed.
- `test_the_walk_reads_calls_and_not_names` asserted two absences that a
  name-based walk would also produce, so it did not have the shape of the
  defect it names. `ElectrumFetcher._header_at` — whose docstring names
  `_verify_once` and whose body does not call it — is now the third
  absence. Measured: degenerate the walk to read names, and the control
  fails at this sha where it passed at `521deb69`.
- two docstring nits, and `esplora.py`'s module docstring no longer frames
  the flag as an agreement between siblings, which is the framing this
  branch removes everywhere else.

## Gates

Run in the worktree at `7c67066e`, after the rebase, exit codes read:

- `uv run --locked pytest -q --cov` → 0 (32112 passed, 31 skipped, 1 xfailed)
- `uv run --locked pre-commit run --all-files` → 0, tree clean
- `uv run --locked sphinx-build -n -W docs/source` → 0

ISS 1708 is left as filed rather than folded in: nothing here adds or
removes a backend, so no count it names is falsified by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157LmcttGkdnQhLdCLkfVRR

## Summary by Sourcery

Centralize network verification for host-backed fetchers and enforce coverage of their protected entry points.

New Features:
- Introduce a shared NetworkVerifyingFetcher base for host-backed fetchers with consistent, opt-out network verification and abstract backend-specific chain checks.

Bug Fixes:
- Ensure all backend fetch and broadcast entry points verify the remote chain before proceeding, memoizing disagreements while allowing retries after fetch errors.

Enhancements:
- Centralize the verify_network interface across Bitcoin Core, Bitcoin Core REST, Esplora, and Electrum fetchers without changing caller-facing APIs.
- Add source-aware coverage checks that ensure every implemented network-verification call site is exercised and detect missing or altered checks.

Documentation:
- Document the shared network-verification behavior, its limitations, and the distinction between host-backed and wrapper fetchers.

Tests:
- Add comprehensive cross-backend tests confirming mismatched chains are rejected with only the verification request sent.
- Add tests ensuring network-verifying fetchers cannot be instantiated without an assert_network implementation and preserve keyword-only parameter conventions.