### PR TITLE
btclib.fetch's prose names what it holds rather than counting it (closes #1708)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -559,6 +559,26 @@ file of the test tree, and no caller acts on it.
   call site to compare, and the file's own docstring is where it is
   stated.
 
+### `btclib.fetch`'s prose names what it holds rather than counting it
+
+- **No docstring or comment under `src/btclib/fetch/` states how many
+  backends implement `Fetcher`, nor how many questions `Fetcher`
+  declares** (closes #1708). Either number moves when the package grows,
+  in files the growth does not otherwise touch, and one had never been
+  true: the package docstring called `Broadcaster` a `typing.Protocol`
+  "rather than a fourth `Fetcher` method", where `Fetcher` already
+  declared four abstract methods when that sentence was written -- the
+  number was counting against a list of questions in the prose above it
+  and not against the class it names. What replaces a
+  count is the property the sentence was about -- each backend's class
+  docstring opens on every question `Fetcher` declares -- and the
+  enumerations stay, `BitcoinCoreFetcher`, `BitcoinCoreRestFetcher`,
+  `EsploraFetcher` and `ElectrumFetcher` still named where naming them
+  helps.
+- **The same rule reaches the rest of the package's prose**, where the
+  exported clients, the transport implementations and the fetchers that
+  compose another `Fetcher` were counted too.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/fetch/__init__.py
+++ b/src/btclib/fetch/__init__.py
@@ -7,15 +7,15 @@
 **Where the chain is.** Everything else in btclib works on bytes it was
 handed. This package is the one place that goes and asks: what
 transaction has this id, what output does this outpoint name, where is
-the chain tip. `Fetcher` is the interface, and it is implemented four
-times -- `BitcoinCoreFetcher` over a full node's JSON-RPC,
+the chain tip. `Fetcher` is the interface, implemented once per
+backend -- `BitcoinCoreFetcher` over a full node's JSON-RPC,
 `BitcoinCoreRestFetcher` over the same node's unauthenticated `-rest`
 interface, `EsploraFetcher` over a block explorer's HTTP api,
 `ElectrumFetcher` over an Electrum server -- so that calling code takes a
 `Fetcher` and never branches on which one it got.
 
 **`Broadcaster` is the one place that announces a transaction rather than
-asking about one**, and is a `typing.Protocol` rather than a fourth
+asking about one**, and is a `typing.Protocol` rather than another
 `Fetcher` method: `BitcoinCoreFetcher` and `EsploraFetcher` satisfy it,
 `BitcoinCoreRestFetcher` does not -- Core's `-rest` interface is
 read-only, and a protocol lets that asymmetry be a fact of the type
@@ -49,12 +49,12 @@ fetcher does not either: the first call is what opens a connection, and
 what raises if there is nothing to connect to.
 
 **What is exported, and what is not.** The fetchers, the interface
-they implement, `Broadcaster` beside it, the two clients a Bitcoin Core
+they implement, `Broadcaster` beside it, the clients a Bitcoin Core
 node is reached through -- `BitcoinCoreRpcClient` for the JSON-RPC
 server, `BitcoinCoreRestClient` for `-rest` -- and the transport seam:
-the timeout, the two protocols a substitute has to satisfy and the two
-HTTP implementations of one of them that open a socket -- one connection
-per call, and one kept open across calls. `LineTransport`,
+the timeout, the protocols a substitute has to satisfy and the HTTP
+implementations of one of them that open a socket -- one connection per
+call, and one kept open across calls. `LineTransport`,
 `ElectrumFetcher`'s own protocol, has no implementation here yet; its
 own docstring in `btclib.fetch.transport` says why. That last group is
 here because the seam is the supported way to test calling code without

--- a/src/btclib/fetch/bitcoin_core.py
+++ b/src/btclib/fetch/bitcoin_core.py
@@ -63,7 +63,7 @@ _MAX_SMALL_REPLY = 1024
 
 
 class BitcoinCoreFetcher(NetworkVerifyingFetcher):
-    """The four fetcher questions, answered by a node over its RPC.
+    """Every `Fetcher` question, answered by a node over its RPC.
 
     Also a `Broadcaster`: `broadcast` sends `sendrawtransaction`, which
     `-rest` -- and so `BitcoinCoreRestFetcher` -- has no equivalent of.

--- a/src/btclib/fetch/bitcoin_core_rest.py
+++ b/src/btclib/fetch/bitcoin_core_rest.py
@@ -15,7 +15,7 @@ to a block explorer rather than to a node.
 The client's own surface is two methods, `get_bin` and `get_json`, and no
 method per resource -- `path` is the caller's own, built from Core's
 `doc/REST-interface.md` and appended after `/rest` unread. That is why
-this is a third class rather than `EsploraFetcher` with a second
+this is a class of its own rather than `EsploraFetcher` with a second
 `base_url`: `EsploraFetcher` speaks HTTP itself and takes a `base_url`
 with no client in front of it, where this fetcher takes a *client*, the
 same shape `BitcoinCoreFetcher` takes a `BitcoinCoreRpcClient` in. One
@@ -29,9 +29,11 @@ unmodified, so `chain` and `signet_challenge` are both members of it and
 `verify_network` and `signet_challenge` mean here exactly what they mean
 there. What differs is authentication -- `-rest` needs no cookie and
 refuses nobody, which is what this class is for -- and the endpoints the
-four questions are asked at, none of which is shared with
-`EsploraFetcher` either: `.bin` answers octets where Esplora answers text,
-hex for three of its four and a decimal height for the fourth.
+questions are asked at, none of which is shared with `EsploraFetcher`
+either: a transaction and a header are read as octets from a `.bin`
+endpoint, where Esplora answers text -- hex, save for the chain tip's
+height, which is a decimal number -- and the tip's height and hash are
+members of a `/chaininfo.json` reply rather than endpoints of their own.
 """
 
 from __future__ import annotations
@@ -107,7 +109,7 @@ def _field(reply: Any, name: str) -> Any:
 
 
 class BitcoinCoreRestFetcher(NetworkVerifyingFetcher):
-    """The four fetcher questions, answered by a node over `-rest`.
+    """Every `Fetcher` question, answered by a node over `-rest`.
 
     The client is a constructor argument rather than connection
     arguments repeated here, the same reason `BitcoinCoreFetcher` takes a

--- a/src/btclib/fetch/broadcaster.py
+++ b/src/btclib/fetch/broadcaster.py
@@ -5,7 +5,7 @@
 """The interface a chain backend answers to announce a transaction.
 
 Kept apart from `Fetcher`: broadcasting is a write and not every backend
-that answers `Fetcher`'s four questions can perform one --
+that answers `Fetcher`'s questions can perform one --
 `BitcoinCoreRestFetcher`, over Core's read-only `-rest` interface, is
 exactly that backend, `bitcoin-core-rpc`'s `BitcoinCoreRestClient`
 declaring no method that writes. An ABC method here would force a choice

--- a/src/btclib/fetch/decorators.py
+++ b/src/btclib/fetch/decorators.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Two `Fetcher`s that answer from another `Fetcher`, not from a network.
+"""Fetchers that answer from another `Fetcher`, not from a network.
 
 `CachingFetcher` composes one backend and remembers what it answered;
 `FallbackFetcher` composes several and tries them in order. Both are

--- a/src/btclib/fetch/electrum.py
+++ b/src/btclib/fetch/electrum.py
@@ -5,7 +5,7 @@
 """The btclib fetcher backed by an Electrum server.
 
 `btclib.electrum` is the codec -- the JSON-RPC framing, the shapes of the
-four methods this fetcher asks, and the merkle-branch check -- and holds
+methods this fetcher asks, and the merkle-branch check -- and holds
 no socket; this module is the `Fetcher` over it, taking a `transport` and
 turning each question into a request line and a line back into a btclib
 type, the way `EsploraFetcher` and `BitcoinCoreRestFetcher` do over their
@@ -32,15 +32,16 @@ operator, and a caller running their own server is invisible to that
 list entirely. Naming any one of the four as a constant would repeat the
 mistake `BLOCKSTREAM_INFO` already refuses.
 
-**A fifth question, answered by nothing else in this package.**
-`get_tx_merkle` and `verify_tx` are not on `Fetcher`: adding a return type
-only one backend can honor is what the interface's four abstract methods,
-each with a return type of its own, already exist to avoid, and both the
-issue and issue #1193 hold the interface itself unchanged. What
-`Fetcher`'s own class docstring calls "evidence beside the data" is what
-these two are -- a merkle branch checked against a header this fetcher
-fetched on its own, which is a different kind of answer from the other
-backends' word for it, and the reason this backend exists.
+**A question the interface does not declare, answered by nothing else in
+this package.** `get_tx_merkle` and `verify_tx` are not on `Fetcher`:
+adding a return type no other backend can honor is what the interface's
+abstract methods, each with a return type of its own, already exist to
+avoid, and both the issue and issue #1193 hold the interface itself
+unchanged. What `Fetcher`'s own class docstring calls "evidence beside
+the data" is what these two are -- a merkle branch checked against a
+header this fetcher fetched on its own, which is a different kind of
+answer from the other backends' word for it, and the reason this backend
+exists.
 """
 
 from __future__ import annotations
@@ -70,7 +71,7 @@ __all__ = [
 
 
 class ElectrumFetcher(NetworkVerifyingFetcher):
-    """The four fetcher questions, and a fifth, answered by an Electrum server.
+    """Every `Fetcher` question, and a merkle branch, from an Electrum server.
 
     `get_tx` is `blockchain.transaction.get`, the raw hex decoded and
     handed to `tx_from_raw`, which recomputes the id the same way every

--- a/src/btclib/fetch/esplora.py
+++ b/src/btclib/fetch/esplora.py
@@ -15,7 +15,7 @@ look up. mempool.space is not offered as a second constant for the same
 reason, and naming it here is the evidence for the sentence above rather
 than a recommendation.
 
-What the fallback promises is the same four answers behind the same
+What the fallback promises is the same answers behind the same
 interface. What it does not promise is that they are all true. `get_tx`
 is the one answer that checks itself completely, in `tx_from_raw` -- the
 serialization comes back and the id is recomputed from it, so a
@@ -26,8 +26,8 @@ fabricate compared with the transaction it would have to forge to pass
 the id check. The height and the tip hash have nothing here to check
 them against at all, and are taken on trust.
 
-Which chain the explorer serves is a separate question from those four,
-and `verify_network` is what asks it: declared once on
+Which chain the explorer serves is a separate question from the answers
+above, and `verify_network` is what asks it: declared once on
 `NetworkVerifyingFetcher` rather than agreed among the backends, on by
 default, comparing `/block-height/0` against the genesis `NETWORKS`
 carries for the network this fetcher was built for. The failure it
@@ -94,14 +94,14 @@ BLOCKSTREAM_INFO = {
 }
 
 
-# What each answer may weigh, because each of the four is bounded by
-# what it is: a height is a decimal number, a tip hash is sixty-four hex
-# digits, a header is eighty bytes of hex, and a raw transaction is hex of
-# a transaction that fits in a block -- DEFAULT_MAX_BODY_SIZE, which is
-# that bound. The three small ones leave room for the whitespace a
-# deployment behind a proxy adds and for nothing else: a host answering a
-# height with a megabyte is answering something that is not a height, and
-# there is no reason to hold it in order to find that out.
+# What each answer may weigh, because each is bounded by what it is: a
+# height is a decimal number, a tip hash is sixty-four hex digits, a
+# header is eighty bytes of hex, and a raw transaction is hex of a
+# transaction that fits in a block -- DEFAULT_MAX_BODY_SIZE, which is
+# that bound. The small ones leave room for the whitespace a deployment
+# behind a proxy adds and for nothing else: a host answering a height
+# with a megabyte is answering something that is not a height, and there
+# is no reason to hold it in order to find that out.
 #
 # The body of a *failure* is not bounded by these -- see
 # `MAX_ERROR_BODY_SIZE` -- so a 404 whose error page is longer than a
@@ -113,7 +113,7 @@ _MAX_TX_BODY = DEFAULT_MAX_BODY_SIZE
 
 
 class EsploraFetcher(NetworkVerifyingFetcher):
-    """The four questions, answered by an Esplora instance over HTTP.
+    """Every `Fetcher` question, answered by an Esplora instance over HTTP.
 
     `base_url` is required and has no default, for the reason
     `BLOCKSTREAM_INFO` is a constant and not one.
@@ -181,8 +181,8 @@ class EsploraFetcher(NetworkVerifyingFetcher):
         """Return the body of a GET on `path`, as stripped text.
 
         `max_body_size` is what this particular answer may weigh; the
-        default is the widest of the three, so a caller asking for
-        something narrow says so.
+        default is the widest of the bounds above, so a caller asking
+        for something narrow says so.
 
         A status that is not 200 is an `HttpError`, which carries it:
         every answer here is a GET of an immutable value, so a 429 or a

--- a/src/btclib/fetch/fetcher.py
+++ b/src/btclib/fetch/fetcher.py
@@ -4,7 +4,7 @@
 
 """The interface a chain backend answers, whichever backend it is.
 
-Four questions btclib cannot answer from bytes it was handed: what
+The questions btclib cannot answer from bytes it was handed: what
 transaction has this id, what output does this outpoint name, where is
 the chain tip, and what header does a given height carry. `Fetcher` is
 those questions and nothing else, so that calling code takes a `Fetcher`
@@ -58,7 +58,7 @@ def client_errors() -> Iterator[None]:
 
     `bitcoin_core_rpc` declares a `FetchError`, an `HttpError` and an
     `RpcError` of its own -- it declares zero dependencies and imports
-    nothing of btclib's -- so those three are not the classes
+    nothing of btclib's -- so those are not the classes
     `btclib.exceptions` declares, and an `except FetchError` written
     against btclib does not catch them. This is the one place the
     two meet, and every call that crosses into the package goes through
@@ -115,7 +115,7 @@ def fetch_errors(source: str) -> Iterator[None]:
     `bytes_from_octets`, and as BTClibRuntimeError from the stream
     readers under `Tx.parse` -- "not enough binary data" is what a
     transaction truncated in transit looks like from inside `var_bytes`.
-    All three name the converter and not the host, and the host is what
+    All of them name the converter and not the host, and the host is what
     has to be fixed.
     """
     try:
@@ -216,12 +216,12 @@ class Fetcher(ABC):
         but the Electrum protocol's `blockchain.block.header` takes a
         height and publishes no call that takes a hash at all. A hash-only
         signature would be one an Electrum backend could never answer, which is
-        the `NotImplementedError`-in-an-ABC outcome the three questions
-        above already avoid.
+        the `NotImplementedError`-in-an-ABC outcome the questions above
+        already avoid.
 
         Checked on arrival: `assert_valid` and `assert_valid_pow`, so a
         well-formed header answers for eighty bytes that took a real hash
-        to produce. `assert_valid_time` is not one of the two -- it
+        to produce. `assert_valid_time` is not among them -- it
         compares against the local clock, and a header that is genuinely
         on the chain should not start failing this because the machine
         running it has drifted.
@@ -403,10 +403,10 @@ def block_header_from_raw(raw: Octets, height: int) -> BlockHeader:
     rendering of it, the way `get_tx` does -- but a header names no
     height and no chain of its own, so there is nothing here to recompute
     it against the way `tx_from_raw` recomputes a txid. What is checked
-    instead is `Fetcher.get_block_header`'s two: `BlockHeader.assert_valid`,
-    for eighty well-formed bytes, and `assert_valid_pow`, for a hash that
-    took real work to find. Its docstring is where what neither check
-    establishes is written down.
+    instead is what `Fetcher.get_block_header` promises:
+    `BlockHeader.assert_valid`, for eighty well-formed bytes, and
+    `assert_valid_pow`, for a hash that took real work to find. Its
+    docstring is where what neither check establishes is written down.
     """
     with fetch_errors(f"block header {height}"):
         header = BlockHeader.parse(raw, check_validity=False)

--- a/src/btclib/fetch/transport.py
+++ b/src/btclib/fetch/transport.py
@@ -19,9 +19,10 @@ through to `http_request`, and a caller substituting one for a test needs
 the object those two agree on. `HttpTransport` is that seam, and this is
 btclib's name for it.
 
-Two implementations satisfy it. `urlopen_transport` is the default: one
-connection per call, opened and handed to the node to close.
-`SessionTransport` keeps one connection per `(scheme, host, port)` open
+The implementations here differ in how they hold the connection.
+`urlopen_transport` is the default: one connection per call, opened and
+handed to the node to close. `SessionTransport` keeps one connection per
+`(scheme, host, port)` open
 across calls instead, which is worth choosing over many calls against one
 node -- a walker fetching many transactions, a client polling one --
 where the reused connection, and on `https` the reused TLS handshake, is


### PR DESCRIPTION
Closes #1708

No docstring or comment under `src/btclib/fetch/` states how many backends
implement `Fetcher`, nor how many questions `Fetcher` declares. Both
numbers move when the package grows, in files the growth does not
otherwise touch, which is what CLAUDE.md's *Conventions to match*
forbids.

What replaces a count is the property the sentence was about: each
backend's class docstring now opens on **every question `Fetcher`
declares**. The enumerations stay — a list is not a count — so the four
backends are still named where naming them helps.

Electrum was the hard case, and it is the one that shows the rule paying
for itself. "The four fetcher questions, and a fifth" is two numbers kept
in step, and "a fifth" implied `get_tx_merkle` was a peer of the other
four. It now reads "Every `Fetcher` question, and a merkle branch", with
the module docstring saying in words what the arithmetic used to imply:
a question the interface does not declare, answered by nothing else in
this package.

## Two counts that were already false

- `__init__.py` called `Broadcaster` a `typing.Protocol` "rather than a
  fourth `Fetcher` method" — but `Fetcher` already declared four abstract
  methods when that sentence was written, so a broadcast would have been
  a fifth. The number was counting against a list of questions in the
  prose above it, not against the class it names.
- `esplora.text`'s default was "the widest of the three". There are four
  `_MAX_*` bounds and the default is none of the three narrow ones; it is
  `DEFAULT_MAX_BODY_SIZE`, the widest of all four.

Neither was caught by anything. That is the argument for the rule: a
count stays grammatical and plausible after it stops being true.

## Collateral fixed here rather than filed

`bitcoin_core_rest.py`'s module docstring said "`.bin` answers octets
where Esplora answers text", which characterises half of what it claims:
`get_block_count` and `get_best_block_id` both read members of a
`/chaininfo.json` reply, and only `get_tx` and `get_block_header` use a
`.bin` endpoint. Pre-existing, in a sentence this diff already had open.

## Gates

Run in the worktree at `2c4e9704`, exit codes read:

- `uv run --locked pytest -q --cov` → 0 (32112 passed, 31 skipped, 1 xfailed)
- `uv run --locked pre-commit run --all-files` → 0, tree clean
- `uv run --locked sphinx-build -n -W docs/source` → 0, and its second
  step, the `href="#../"` grep over the built HTML, finds nothing

The diff is prose only, verified rather than asserted: for each of the
nine modules, stripping every docstring and comparing `ast.dump` of base
against branch gives an identical tree.

## Review

Reviewed at fresh context: **CHANGES REQUESTED** on `710aca6c`, one
blocking finding, fixed here.

The changelog said the `Broadcaster` count was one "which the interface's
abstract methods have since outgrown". The reviewer found it with
`git log -S` on the phrase: at the commit that wrote the sentence,
`Fetcher` already declared four abstract methods, and its abstract set
has not grown since. So the count had never been true rather than gone
stale — and the two stories argue differently. "The interface grew past
the number" says counts go stale; "the number never matched the class"
says a count is not a measurement of what it sits next to, which is the
case the rule is actually about. The changelog and the commit message
both now say the second.

The reviewer also re-derived the sweep's zero with patterns of its own —
`ast`+`tokenize` to extract prose, folded to one line, cardinals,
**ordinals** and bare digits separately, counted with `grep -o | wc -l`
and with a positive control that fired at 27 hits on the base.

[ISS 1714](https://github.com/btclib-org/btclib/issues/1714), filed for
the same counts in `tests/fetch/`, has had its census corrected since:
its first pattern was word-bounded and case-sensitive, so it missed eight
sites — `_` is a word character, and every count living in a test *name*
was invisible to it. None of the twenty-two belongs in this branch; the
diff falsifies no test's count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157LmcttGkdnQhLdCLkfVRR

## Summary by Sourcery

Make `btclib.fetch` documentation describe its interfaces and implementations without fragile counts, while correcting related inaccuracies.

Bug Fixes:
- Correct inaccurate count-based prose in `btclib.fetch`, including the Broadcaster description and Esplora body-size default documentation.
- Clarify Bitcoin Core REST response descriptions to accurately distinguish binary endpoints from values returned by `/chaininfo.json`.

Enhancements:
- Replace fragile numeric references with wording that describes Fetcher questions, backend relationships, transport implementations, and Electrum’s additional merkle-branch capability without relying on counts.

Documentation:
- Update fetch package and backend documentation to remain accurate as interfaces and implementations evolve.