### PR TITLE
fetch.toml mutates every backend that reaches a host (closes #1675)

### DIFF
--- a/.github/mutation/fetch.toml
+++ b/.github/mutation/fetch.toml
@@ -1,19 +1,33 @@
-# The fetch boundary, mutated: the transport, the JSON-RPC and Esplora
-# backends, and the fetcher module they call into -- `module-path` below
-# is the whole of the scope, and the REST backend is outside it. Issue
-# #327 proposed this scope
-# directly -- a response-size limit weakened, a status check turned into
-# an acceptance, a tx-id verification skipped -- as the same class of gap
-# #219 found in the consensus code, on a boundary that is network input
-# rather than a parsed byte string. The test transport seam already keeps
-# these runs offline and deterministic, which is what makes a mutation
-# session over this scope no slower than any other local one.
+# The fetch boundary, mutated: every backend that reaches a host over the
+# transport, and the fetcher module they all call into. `transport.py` is
+# in `module-path` and enumerates nothing -- it is imports, a `Callable`
+# alias and `__all__`, no expression a mutation operator can reach -- so it
+# is named there for a body it may grow rather than for anything measured
+# below. Issue #327 proposed this scope directly -- a response-size limit
+# weakened, a status check turned into an acceptance, a tx-id verification
+# skipped -- as the same class of gap #219 found in the consensus code, on a
+# boundary that is network input rather than a parsed byte string. The test
+# transport seam already keeps these runs offline and deterministic, which is
+# what makes a mutation session over this scope no slower than any other
+# local one.
+#
+# `decorators.py` and `broadcaster.py` are outside `module-path`, and the
+# boundary is why: neither judges a reply, so neither holds a guard of the
+# kind above to weaken. `CachingFetcher` and `FallbackFetcher` answer from
+# another `Fetcher` rather than from a host, which is the reason
+# `NetworkVerifyingFetcher`'s own docstring gives for their carrying no
+# chain check, and whether they are worth a scope of their own is issue
+# #1717. `broadcaster.py` needs no such decision: `cosmic-ray init` over a
+# configuration naming it enumerates nothing there, `Broadcaster` being a
+# `Protocol` whose method bodies are `...`.
 
 [cosmic-ray]
 module-path = [
     "src/btclib/fetch/transport.py",
     "src/btclib/fetch/esplora.py",
     "src/btclib/fetch/bitcoin_core.py",
+    "src/btclib/fetch/bitcoin_core_rest.py",
+    "src/btclib/fetch/electrum.py",
     "src/btclib/fetch/fetcher.py",
 ]
 
@@ -27,44 +41,69 @@ excluded-modules = []
 # Measured rather than assumed, as script.toml's own comment on this
 # exclusion asks:
 #
-#   grep -n ' | ' src/btclib/fetch/transport.py src/btclib/fetch/esplora.py \
-#       src/btclib/fetch/bitcoin_core.py src/btclib/fetch/fetcher.py
+#   grep -n ' | ' src/btclib/fetch/transport.py \
+#       src/btclib/fetch/esplora.py src/btclib/fetch/bitcoin_core.py \
+#       src/btclib/fetch/bitcoin_core_rest.py src/btclib/fetch/electrum.py \
+#       src/btclib/fetch/fetcher.py
 #
-# Every hit is an annotation. Confirmed by running the filter itself
-# rather than by the grep alone: `cosmic-ray init` over this file still
-# enumerates the 177 mutants the session below did, and
-# `cosmic_ray.tools.filters.operators_filter` marks 55 of them SKIPPED
-# -- the same 55 the session below already found equivalent by
-# inspection, and the "class fetch.toml documents" every other
-# profile's own comment points back to -- leaving 122 for a future
-# session to have an opinion about (issue #987).
+# Every hit is an annotation but one, `bitcoin_core_rest.py`'s docstring
+# on why `_get_json`'s bound is an `int` where `_get_bin`'s is not, which
+# is text rather than an expression. Confirmed by running the filter
+# itself rather than by the grep alone: `cosmic-ray init` over this file
+# enumerates the 474 mutants the session below did, and
+# `cosmic_ray.tools.filters.operators_filter` marks 110 of them SKIPPED
+# -- the same 110 the session below finds surviving on annotation lines,
+# and the "class fetch.toml documents" every other profile's own comment
+# points back to -- leaving 364 for a future session to have an opinion
+# about (issue #987).
 [cosmic-ray.filters.operators-filter]
 exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 
-# 177 mutants, complete: 114 killed, 63 survived. One of the 63 is killed
-# now -- `chain_from_network(self.network) != "signet"` weakened to `<`,
-# which accepted a challenge for the two testnets whose chain names sort
-# after `signet`, where mainnet's and regtest's sort before it and an
-# ordering cannot be told from an inequality (issue #978). The 62 left are
-# three classes and no missing test among them:
+# 474 mutants, complete: 314 killed, 160 survived. Four classes account
+# for 142 of the 160, and eighteen belong to none of them:
 #
-# - 55 are three `X | None` annotations in `bitcoin_core.py`, mutated
-#   eleven ways on one and twenty-two on each of the others: the class
-#   under Python 3.14's deferred annotation evaluation (PEP 649) that
-#   numeric.toml documents at length. Nine tenths of this profile's
-#   survivors are those three lines, which is what its rate is, and no
-#   test can reach any of them.
-# - 4 in `fetcher.py` are equivalent by inspection: `==` against `is` on
-#   the very object `NETWORKS` holds, and three `check_validity=False`
-#   turned `True`, which validates data already valid.
-# - 3 are the keyword-only `*` marker turned `/`, in `bitcoin_core.py`
-#   and `esplora.py`. Nothing in the library asserts a keyword-only one is
-#   one -- 89 public callables take 132 of them -- so these three survive
-#   for a reason that is neither this profile's nor a test to write here.
-#   Issue #980 is where that is decided.
+# - 110 are `X | None` annotations, in `bitcoin_core.py`,
+#   `bitcoin_core_rest.py` and `esplora.py`. This is the class the other
+#   profiles' comments point back here for, and it is deferred
+#   evaluation: an annotation is not evaluated where it is written, so
+#   `str | bytes | None` rewritten `str + bytes + None` is never built
+#   and no call changes. `bitcoin_core.py` has that from PEP 649 and the
+#   3.14 `.python-version` pins, the other two from `from __future__
+#   import annotations` as well. The filter above is what keeps them out
+#   of a session that would otherwise run them.
+# - 5 in `fetcher.py` are equivalent by inspection: `==` against `is` on
+#   the very object `NETWORKS` holds, and four `check_validity=False`
+#   turned `True`, each on data the line beside it has already
+#   validated.
+# - 23 are killed by a gate this profile's test command does not run.
+#   Twenty are `@override` removed, which changes nothing at runtime --
+#   `typing_extensions.override` sets `__override__` and hands the method
+#   back -- and which `[tool.mypy] enable_error_code`'s
+#   `explicit-override` refuses: deleting the one on
+#   `BitcoinCoreFetcher.get_tx` and running `mypy` on that file exits 1,
+#   naming the method. The other three are the keyword-only `*` marker
+#   turned `/` on a public signature, which `tests/keyword_only_test.py`
+#   pins: making those three mutations at once leaves `tests/fetch`
+#   passing and fails that file at each of the three sites.
+# - 4 are the same marker on `_call`, `_get_bin`, `_get_json` and
+#   `_request`. That walk stops at a class's public names, its own
+#   docstring saying so, and a private method's calling convention is
+#   nothing this library promises.
 #
-# So the rate to read from this profile is the annotations', and a verdict
-# that moves in it is a verdict outside those three lines.
+# The 18 left are what this boundary is held to on either side of a call --
+# what a reply is checked against, and what a request carries -- and
+# `tests/fetch` does not notice any of them weakened: the three `-rest` body
+# bounds moved by one, six comparisons turned into orderings -- issue #978's
+# shape, in `bitcoin_core_rest.py`'s and `esplora.py`'s `assert_network`, in
+# both broadcasts' txid check and at `esplora.py`'s `status != 200` --
+# `include_witness=True` turned `False` in both broadcasts, `esplora.py`'s
+# `Content-Type` condition read either way, and `ElectrumFetcher`'s
+# request-id counter, which `+= 0` makes the constant `_next_request_id`'s
+# own docstring rules out. Issue #1716 has each with its line and is where
+# they are answered.
+#
+# So the rate is not the reading here: those eighteen are, and a verdict
+# worth acting on is one that moves among them.
 
 [cosmic-ray.distributor]
 name = "local"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -579,6 +579,25 @@ file of the test tree, and no caller acts on it.
   exported clients, the transport implementations and the fetchers that
   compose another `Fetcher` were counted too.
 
+### `.github/mutation/fetch.toml` mutates every backend that reaches a host
+
+- **`bitcoin_core_rest.py` and `electrum.py` join the profile's
+  `module-path`** (closes #1675). Both recompute a transaction id from
+  the bytes that arrived and refuse a host serving another chain, and
+  `bitcoin_core_rest.py` bounds each reply whose shape it knows -- a
+  hash, a header, a `chaininfo` reply -- leaving a raw transaction to
+  the client's own default, unbounded in the way those are not. Those
+  are the guards this scope exists to measure, and a backend outside the
+  profile is one whose weakened guard the suite is not known to notice.
+  `decorators.py` and `broadcaster.py` stay out, and the configuration
+  says why: neither judges a reply.
+- **A complete session over the new scope is recorded in that
+  configuration's own comment**, with its survivors read against the
+  classes the comment argues. The survivors belonging to no class are
+  what the boundary is held to on either side of a call, and
+  `tests/fetch` does not notice any of them weakened; issue #1716 names
+  each with its line.
+
 ## v2026.9.3
 
 ### Repository


### PR DESCRIPTION
Closes #1675

`.github/mutation/fetch.toml` mutated `transport.py`, `esplora.py`,
`bitcoin_core.py` and `fetcher.py`. `bitcoin_core_rest.py` and
`electrum.py` reach a host over the same transport and carry guards of
exactly the shapes [ISS 327](https://github.com/btclib-org/btclib/issues/327)
named when it proposed this profile — a response-size limit weakened, a
status check turned into an acceptance, a tx-id verification skipped — so
a list naming some of the backends left the rest unmeasured. Both join
`module-path`.

`decorators.py` and `broadcaster.py` stay out, and the header now says
why rather than leaving it to be inferred. `CachingFetcher` and
`FallbackFetcher` answer from another `Fetcher` rather than from a host;
whether they are worth a scope of their own is
[ISS 1717](https://github.com/btclib-org/btclib/issues/1717).
`broadcaster.py` needs no such decision — `cosmic-ray init` over a
configuration naming it enumerates nothing there, `Broadcaster` being a
`Protocol` whose method bodies are `...`.

## The comment records a session, so widening the scope required running one

Every figure below `module-path` describes a scope, so extending the list
without a session would leave each of them describing one the profile no
longer has. The session is `cosmic-ray baseline`, `init` and `exec` as
CONTRIBUTING.md documents them, with `.github/scripts/mutation_counts.py`
for the counts, complete on CPython 3.14.6: 474 mutants, 314 killed, 160
survived.

The comment reads the 160 against the classes it argued, each restated
where the tree moved under it, and both attributions are measured rather
than reasoned: deleting the `@override` on `BitcoinCoreFetcher.get_tx`
and running mypy on that file exits 1 naming the method; making the three
public `*`-to-`/` mutations at once leaves `tests/fetch` green while
`tests/keyword_only_test.py` fails at each of the three sites.

Eighteen survivors fall into no class, and they are what the session
found. [ISS 1716](https://github.com/btclib-org/btclib/issues/1716) has
each with its line.

## Re-derived at this base rather than carried over

The session ran at `3a0e70b8`;
[PR 1715](https://github.com/btclib-org/btclib/pull/1715) has since
landed, changing docstrings in every `fetch` module and no executable
line. Re-run at `87e02702`, `cosmic-ray init` over this configuration
enumerates 474 and `cr-filter-operators` marks 110 SKIPPED, leaving 364 —
the same seven annotation sites, shifted by two lines in
`bitcoin_core_rest.py`. Nothing in the comment cites a line, so nothing
in it drifted; ISS 1716 does cite lines and states the sha they were read
at, and gets a comment recording the shift once this lands.

## Review

Reviewed at fresh context: **CHANGES REQUESTED** on `cf17225a`, one
blocking finding and three others, all fixed here.

- **Blocking.** The CHANGELOG entry said `bitcoin_core_rest.py` "bounds
  every reply it reads by the shape it expects". `get_tx` passes
  `max_body_size=None` on purpose, the module saying so two methods
  above: a raw transaction is unbounded in the way a `chaininfo` reply is
  not. The bullet now names the replies whose shape the module does know
  and says what the transaction is left to.
- The comment's "The 18 left are guards against what a host answered"
  over-generalised: the `Content-Type` condition, the request-id counter
  and the two `include_witness` flags are request-side, and only ten of
  the eighteen judge a reply. Both the comment and the CHANGELOG entry
  now say "on either side of a call".
- The commit message claimed ISS 1716 carries "each with its line and its
  diff"; the issue carries lines, a SURVIVED/KILLED table and a
  blockquoted docstring, and no diff. Corrected.
- The commit message described the five `fetcher.py` equivalences by one
  of them. Corrected to what the configuration's own comment already said.

The review also found, and did not file, that `transport.py` is in
`module-path` and enumerates zero mutants in every session — imports, a
`Callable` alias and `__all__`, no expression an operator can reach —
while the header's first clause named it as something mutated. That
clause is inside this diff, so it is fixed here rather than filed: the
header now says what the module is doing in the list.

## Gates

Run in the worktree at `2309024e`, exit codes read:

- `uvx pre-commit run --all-files` → 0, tree clean afterwards
- `uv run --locked pytest -q` → 0 (32112 passed, 31 skipped, 1 xfailed)

No source file changes, so nothing here can move a test; the gates are
run for the `taplo`, toml-comment-width and markdownlint hooks and for
`tests/release_notes_test.py`, which is what a CHANGELOG entry has to
pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Broaden the fetch mutation profile to cover every backend that reaches a host and document the resulting mutation analysis.

Bug Fixes:
- Expand the fetch mutation profile to include Bitcoin Core REST and Electrum backends, ensuring host-facing response and request guards are measured consistently.

Enhancements:
- Document the mutation profile boundaries, excluded modules, and complete mutation-session results, including categorized survivors and deferred follow-up issues.

Documentation:
- Add changelog coverage for the expanded fetch mutation scope and its recorded mutation-session findings.