### PR TITLE
`bip32`'s xpub refusals take the words of their xprv twins (closes #1719)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -651,7 +651,7 @@ file of the test tree, and no caller acts on it.
   `bip32` call and pass the octets on, where they used to hand the key
   itself to a converter that decoded it again. An extended key on the
   wrong network is refused by `bip32` as a result, with the version bytes
-  that mismatched -- `Not a mainnet key: version 0x...` -- where a
+  that mismatched -- `not a mainnet key: version 0x...` -- where a
   `contextlib.suppress` around the BIP32 parse used to leave
   `to_pub_key`'s "not a private or public key for mainnet" behind. A
   caller matching on the old text has to change; the new text names the
@@ -669,6 +669,19 @@ file of the test tree, and no caller acts on it.
   `docs/source/guide.rst`'s alias descriptions and
   `docs/proposals/cli.md`'s account of the `bip32.slip132` cycle each
   carried the old arrow and are corrected.
+
+### `bip32`'s public-half refusals take the words of their private twins
+
+- **`pub_keyinfo_from_xpub` answers `uncompressed SEC / compressed BIP32
+  mismatch`, and both it and `pub_keyinfo_from_xkey` answer `not a
+  <network> key: version 0x...`** (closes #1719), which is word for word
+  what `prv_keyinfo_from_xprv` beside them answers for the same two
+  faults. The capital spelling of the second gave one key two wordings:
+  `pub_keyinfo_from_xkey` neuters an xprv through `_xpub_from_xprv`, so
+  an xprv on a network other than the one asked for is refused both
+  there and by `prv_keyinfo_from_xprv`. The pair is what decides this
+  rather than a spelling rule over the tree: a capital-initial message
+  elsewhere in `src/btclib` stays as it is.
 
 ## v2026.9.3
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -122,7 +122,7 @@ full year, short month, short day (YYYY-M-D)
   extended key and are unaffected: each performs that call for you.
 
   Act on it too if you match on the text of the refusal. An extended key
-  on the wrong network now leaves `bip32` as `Not a mainnet key: version
+  on the wrong network now leaves `bip32` as `not a mainnet key: version
   0x...`, where the `contextlib.suppress` around the BIP32 parse used to
   let `to_pub_key`'s "not a private or public key for mainnet" out
   instead.
@@ -134,6 +134,18 @@ full year, short month, short day (YYYY-M-D)
   Act on it if you build a row of your own for a custom chain: pass
   `bip30_unspendable=()`, which is what every chain but mainnet
   carries.
+
+- **`bip32`'s refusals of an extended key's public half are lower case**
+  (closes #1719). `pub_keyinfo_from_xpub` raises `uncompressed SEC /
+  compressed BIP32 mismatch` where it raised `Uncompressed SEC /
+  compressed BIP32 mismatch`, and both it and `pub_keyinfo_from_xkey`
+  raise `not a <network> key: version 0x...` where they raised `Not a
+  <network> key: version 0x...`. Each is the wording
+  `prv_keyinfo_from_xprv` uses for the same fault on the private half.
+
+  Act on it if you match on the text of either refusal. One pattern
+  serves both halves of a pair, so a match written for the private half
+  needs no second spelling for the public one.
 
 ### Worth knowing, though nothing raises
 

--- a/src/btclib/bip32/bip32.py
+++ b/src/btclib/bip32/bip32.py
@@ -645,7 +645,7 @@ def pub_keyinfo_from_xpub(
         # a BIP32 key is always compressed, so a caller asking for
         # uncompressed is asking about another format
         if not compressed:
-            raise BTClibValueError("Uncompressed SEC / compressed BIP32 mismatch")
+            raise BTClibValueError("uncompressed SEC / compressed BIP32 mismatch")
 
     return _pub_keyinfo_from_xpub(_key_data_from_bip32_key(xpub), network)
 
@@ -678,7 +678,7 @@ def _pub_keyinfo_from_xpub(
     if xpub_data.version not in allowed_versions:
         # an xpub is not funds-critical, but it derives all child pub
         # keys: keep it out of exception messages (and logs) too
-        err_msg = f"Not a {network} key: version 0x{xpub_data.version.hex()}"
+        err_msg = f"not a {network} key: version 0x{xpub_data.version.hex()}"
         raise BTClibValueError(err_msg)
 
     return xpub_data.key, network

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -104,14 +104,15 @@ def test_the_three_key_reads_answer_for_one_half_each() -> None:
     err_msg = "uncompressed SEC / compressed BIP32 mismatch"
     with pytest.raises(BTClibValueError, match=err_msg):
         prv_keyinfo_from_xprv(xprv, compressed=False)
-    with pytest.raises(BTClibValueError, match="ompressed SEC / compressed BIP32"):
+    with pytest.raises(BTClibValueError, match=err_msg):
         pub_keyinfo_from_xpub(xpub, compressed=False)
 
     # the version bytes say which network claims the key, so a network
     # the caller names has to be that one
-    with pytest.raises(BTClibValueError, match="not a testnet key: version "):
+    err_msg = "not a testnet key: version "
+    with pytest.raises(BTClibValueError, match=err_msg):
         prv_keyinfo_from_xprv(xprv, "testnet")
-    with pytest.raises(BTClibValueError, match="Not a testnet key: version "):
+    with pytest.raises(BTClibValueError, match=err_msg):
         pub_keyinfo_from_xpub(xpub, "testnet")
 
     # and each public read refuses the private half by its prefix

--- a/tests/descriptors/descriptors_test.py
+++ b/tests/descriptors/descriptors_test.py
@@ -1051,7 +1051,7 @@ def test_network() -> None:
     assert script_pub_key.network == "testnet"
     assert script_pub_key.address.startswith("tb1")
     assert ScriptPubKey.from_address(script_pub_key.address) == script_pub_key
-    with pytest.raises(BTClibValueError, match="Not a mainnet key: version "):
+    with pytest.raises(BTClibValueError, match="not a mainnet key: version "):
         parse(descriptor).script_pub_key()
 
 

--- a/tests/wallet/script_wallet_test.py
+++ b/tests/wallet/script_wallet_test.py
@@ -384,7 +384,7 @@ def test_a_script_too_long_for_the_output_it_would_pay() -> None:
 
 def test_a_key_of_another_network_cannot_be_in_the_quorum() -> None:
     """The template is built at construction, which is where this shows."""
-    with pytest.raises(BTClibValueError, match="Not a testnet key: version "):
+    with pytest.raises(BTClibValueError, match="not a testnet key: version "):
         ScriptWallet([KeyGroup(1, _XPUBS[:1])], "p2wsh", network="testnet")
 
 


### PR DESCRIPTION
Closes #1719

`pub_keyinfo_from_xpub` answers `uncompressed SEC / compressed BIP32 mismatch`, and it and `pub_keyinfo_from_xkey` answer `not a <network> key: version 0x...`: word for word what `prv_keyinfo_from_xprv` beside them answers for the same two faults.

## What decides it

The pairing, not a convention over the tree. `pub_keyinfo_from_xkey` neuters an xprv through `_xpub_from_xprv`, so an xprv on a network other than the one asked for is refused by that entry point *and* by `prv_keyinfo_from_xprv` — one fault, one sentence, and the capital spelling gave it two wordings.

A sweep was considered and rejected on measurement rather than taste. `src/btclib` carries 48 capital-initial exception messages against 1252 lowercase, and the 48 split 23 identifier-initial (a name that is capital in the code) against 25 ordinary words, across nine modules. So no tree-wide convention is being broken here and normalising all of them would be a decision this issue does not make. Each of the other 25 is its own question; what this closes is the pair.

## The assertion that could not have caught it

`tests/bip32/bip32_test.py:107` asserted `match="ompressed SEC / compressed BIP32"` — a substring blind to the first letter, which matches both spellings and is structurally unable to fail on the defect it names. It now matches the message whole. Run rather than read, `re.search` (which is what `pytest.raises(match=)` uses) answers `False` for each new string against its old capital spelling and `True` against the new one.

## What moved with it

`CHANGELOG.md` and `RELEASE_NOTES.md` quote the network refusal in the open section, and a quote of a message is wrong the moment the message changes, so both quotes move. `RELEASE_NOTES.md` carries it as a breaking change as well: a caller matching on the text of a refusal has to act.

## Collateral

[ISS 1721](https://github.com/btclib-org/btclib/issues/1721) — `pub_keyinfo_from_xpub` tests `compressed` *before* the decode where `prv_keyinfo_from_xprv` tests it after, so the same bad input leaves by two different faults depending on which spelling of the key it is given. Moving the check is a behaviour change with its own decision and its own changelog cost, so it is an issue rather than part of this diff.

## Gates

- `uvx pre-commit run --all-files` → exit 0, tree clean afterwards
- `uv run --locked pytest -q` → exit 0, 100% floor held

Both on this sha. The documentation build is the one gate not run locally, and this diff does reach it through `docs/source/changelog_link.md` and `docs/source/release_notes_link.md`; the edited blocks were inspected instead — backticks balanced, every `<network>` inside an inline code span, no new link or directive — and the `Build the documentation` job settles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Normalize BIP32 public-key refusal messages so paired public and private key APIs report the same errors.

Bug Fixes:
- Align public extended-key validation errors with the corresponding private-key errors by using consistent lowercase wording for compression mismatches and network-version refusals.

Documentation:
- Update the changelog and release notes to document the error-message changes and their impact on callers matching refusal text.

Tests:
- Strengthen BIP32 error-message assertions and update affected descriptor and wallet tests for the normalized network error wording.