### PR TITLE
tests/fetch's prose names the questions rather than counting them (closes #1714)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -683,6 +683,36 @@ file of the test tree, and no caller acts on it.
   rather than a spelling rule over the tree: a capital-initial message
   elsewhere in `src/btclib` stays as it is.
 
+### `tests/fetch`'s prose names the questions rather than counting them
+
+- **No docstring, comment or test name under `tests/fetch/` states how
+  many questions `Fetcher` declares** (closes #1714). The number moves
+  when the interface grows, in files the growth does not otherwise
+  touch, and it is the same count `src/btclib/fetch/` no longer carries.
+  What replaces it is the property each sentence was about -- every
+  question `Fetcher` declares, the stub answering all of them, a fetch
+  verifying the chain like the others -- and the enumerations stay.
+- **A count in a test name is a rename**, so what a failure prints
+  changes with the prose: `test_the_stub_answers_every_question`,
+  `test_leaving_any_one_question_abstract_refuses_construction`,
+  `test_fallback_answers_every_question_from_the_first_backend`,
+  `test_get_block_header_verifies_the_chain_once_like_the_others` in
+  both Bitcoin Core test modules, and
+  `test_get_tx_merkle_and_verify_tx_are_refused_on_another_chain_too`,
+  which names the entry points it is about rather than their place in a
+  sequence.
+- **One count named a set the code it describes never reads**:
+  `EsploraFetcher`'s refusal of an unknown network was documented as a
+  name that "is none of the three known ones", where the deployments
+  `BLOCKSTREAM_INFO` names have nothing to do with that refusal --
+  `Fetcher.__init__` puts the name through
+  `network._validated_network_name`, which answers for the whole of
+  `NETWORKS`. The test now says the name is one btclib does not know.
+- **A number that indexes the test's own script stays**, a count of what
+  a test builds being no claim about the tree: the ids a cache test
+  inserts, the parameters a case is repeated over, and the members
+  JSON-RPC fixes on an error object.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/fetch/bitcoin_core_rest_test.py
+++ b/tests/fetch/bitcoin_core_rest_test.py
@@ -357,8 +357,8 @@ def test_verify_network_false_asks_the_node_nothing() -> None:
     assert urls(endpoint) == [f"{URL}/rest/tx/{TX_ID}.bin"]
 
 
-def test_get_block_header_verifies_the_chain_once_like_the_other_three() -> None:
-    """The fourth question asks first too, and before the height is mapped."""
+def test_get_block_header_verifies_the_chain_once_like_the_others() -> None:
+    """`get_block_header` asks first too, and before the height is mapped."""
     endpoint = client(
         (200, recorded_body("rest_chaininfo.json")),
         (200, recorded_body("rest_blockhashbyheight.bin")),
@@ -434,7 +434,7 @@ def test_a_challenge_is_refused_for_a_testnet_too(network: str) -> None:
     """The refusal is inequality with signet, not an ordering against it.
 
     `main` and `regtest` sort before `signet`, so a guard written as `<`
-    refuses them and would accept the two testnets, which sort after --
+    refuses them and would accept the testnets, which sort after --
     a challenge that could never be checked. The mainnet case above
     passes under that weakening and these two do not.
     """

--- a/tests/fetch/bitcoin_core_test.py
+++ b/tests/fetch/bitcoin_core_test.py
@@ -53,7 +53,7 @@ from tests.fetch import TIP_HEIGHT, TIP_ID, TX_ID, Recorded, recorded_body
 
 # the rpc credentials every test here passes. Named once rather than
 # written at each call, which is what keeps the string out of a
-# `password=` argument: the two secret scanners read a literal there as a
+# `password=` argument: the secret scanners read a literal there as a
 # credential, and they are right to -- a real one belongs in neither
 RPC_USER = "rpcuser"
 RPC_PASSWORD = "rpcpassword"  # noqa: S105  # pragma: allowlist secret
@@ -236,7 +236,7 @@ def blockchaininfo(**members: object) -> tuple[int, bytes]:
     """Return a 200 answer whose result is a getblockchaininfo of these members.
 
     Written here rather than recorded: the reply carries a dozen members
-    beyond the two this question reads, so a recording of it would be a
+    beyond the ones this question reads, so a recording of it would be a
     fixture to re-take whenever Core adds one, and every test below would
     then be edited to change the one member it is about.
     """
@@ -266,7 +266,7 @@ def test_every_network_btclib_ships_has_a_chain_name() -> None:
 def test_assert_network_accepts_the_chain_the_node_reports(
     network: str, chain: str
 ) -> None:
-    """The two names that differ, which are the two a mismatch hides behind."""
+    """The names that differ, which are what a mismatch hides behind."""
     fetcher(blockchaininfo(chain=chain), network=network).assert_network()
 
 
@@ -357,7 +357,7 @@ def test_a_challenge_is_refused_for_a_testnet_too(network: str) -> None:
 
     The chain names are compared as strings, and `main` and `regtest` both
     sort before `signet` where an ordering and an inequality agree. The
-    testnets sort after it, so they are the two networks a comparison
+    testnets sort after it, so they are the networks a comparison
     would accept a challenge for -- one that could never be checked,
     because there is no signet challenge in a testnet's genesis to hold it
     to.
@@ -580,8 +580,8 @@ def test_get_block_header_refuses_a_non_integer_height(height: object) -> None:
     assert asked(endpoint) == []
 
 
-def test_get_block_header_verifies_the_chain_once_like_the_other_three() -> None:
-    """The fourth fetch goes through `_verify_once`, as the first three do."""
+def test_get_block_header_verifies_the_chain_once_like_the_others() -> None:
+    """`get_block_header` goes through `_verify_once`, as the others do."""
     endpoint = client(
         blockchaininfo(chain="main"),
         (200, recorded_body("getblockhash.json")),
@@ -598,7 +598,7 @@ def test_a_small_reply_carries_a_small_limit() -> None:
     `call` defaults to the widest answer a fetcher asks for, a raw
     transaction as hex inside a json envelope, because it is public and
     takes any method -- `getblock` on a large block is a legitimate call.
-    The two answers that are a number and a hash say so instead.
+    The answers that are a number and a hash say so instead.
     """
     oversized = b'{"result":' + b"9" * 1100 + b',"error":null,"id":"x"}'
     with pytest.raises(FetchError, match="more than the max_body_size of 1024"):
@@ -642,8 +642,8 @@ def test_an_error_the_client_raises_without_a_status_is_a_fetch_error() -> None:
 
     The transport raises rather than answering, which is what a socket
     that never connected does; the client turns it into its own
-    `FetchError`, and this is the third branch of the translation -- the
-    one with no field to carry.
+    `FetchError`, and this is the branch of the translation with no field
+    to carry.
     """
     refused = rpc.FetchError("no answer from http://127.0.0.1:8332: refused")
     with pytest.raises(FetchError, match="refused") as exc:
@@ -752,7 +752,7 @@ def test_broadcast_verifies_the_network_before_sending_anything() -> None:
 
 
 def test_broadcast_verifies_the_network_once_like_the_other_methods() -> None:
-    """Agreeing once, the fifth call goes straight through like the fourth."""
+    """Agreeing once, `broadcast` goes straight through as the questions do."""
     tx = broadcast_tx()
     endpoint = client(
         blockchaininfo(chain="main"),

--- a/tests/fetch/decorators_test.py
+++ b/tests/fetch/decorators_test.py
@@ -206,7 +206,7 @@ def test_clear_forgets_every_cached_answer() -> None:
 # --- FallbackFetcher -----------------------------------------------------
 
 
-def test_fallback_answers_all_four_from_the_first_backend() -> None:
+def test_fallback_answers_every_question_from_the_first_backend() -> None:
     """A working primary answers every question; the secondary is unused."""
     tx = Tx.parse(RAW)
     header = BlockHeader.parse(TIP_HEADER_RAW)

--- a/tests/fetch/electrum_test.py
+++ b/tests/fetch/electrum_test.py
@@ -434,8 +434,8 @@ def test_a_server_on_another_chain_answers_no_fetch_at_all() -> None:
     assert len(transport.requests) == 1
 
 
-def test_the_fifth_question_is_refused_on_another_chain_too() -> None:
-    """`get_tx_merkle` asks first, as the four `Fetcher` questions do.
+def test_get_tx_merkle_and_verify_tx_are_refused_on_another_chain_too() -> None:
+    """`get_tx_merkle` asks first, as every question `Fetcher` declares does.
 
     The proof is the answer a caller is likeliest to trust, so a branch
     from a server on the wrong chain is the one worth never returning.

--- a/tests/fetch/esplora_test.py
+++ b/tests/fetch/esplora_test.py
@@ -94,7 +94,7 @@ def test_a_session_transport_can_drive_the_fetcher() -> None:
 
 
 def test_an_unknown_network_is_refused() -> None:
-    """Refuse a network name that is none of the three known ones."""
+    """Refuse a network name btclib does not know."""
     with pytest.raises(BTClibValueError, match="unknown network: 'liquid'"):
         EsploraFetcher(BASE, network="liquid")
 
@@ -348,7 +348,7 @@ def test_whitespace_around_an_answer_is_not_part_of_it() -> None:
 def test_each_answer_is_bounded_by_what_it_is() -> None:
     """A height is not megabytes, and the limit says so per endpoint.
 
-    One limit for all three would have to be the widest of them -- a raw
+    One limit for every answer would have to be the widest of them -- a raw
     transaction in hex -- so a host answering `blocks/tip/height` with a
     transaction's worth of digits would be held in memory and only then
     refused by `int`. The narrow answers carry narrow limits, with room
@@ -373,7 +373,7 @@ def test_each_answer_is_bounded_by_what_it_is() -> None:
 
 
 def test_the_header_answer_is_bounded_too() -> None:
-    """The fourth endpoint, bounded the same way the first three are.
+    """The header endpoint, bounded the same way the others are.
 
     Eighty bytes of hex is a hundred and sixty digits, so the limit
     leaves room for a proxy's newline and nothing past it.

--- a/tests/fetch/fetcher_test.py
+++ b/tests/fetch/fetcher_test.py
@@ -265,14 +265,14 @@ def test_the_interface_is_abstract() -> None:
     "missing",
     ["get_tx", "get_block_count", "get_best_block_id", "get_block_header"],
 )
-def test_leaving_any_one_of_the_four_abstract_refuses_construction(
+def test_leaving_any_one_question_abstract_refuses_construction(
     missing: str,
 ) -> None:
-    """Each of the four is `abstractmethod` on its own, not by inheriting one.
+    """Each question is `abstractmethod` on its own, not by inheriting one.
 
     `test_the_interface_is_abstract` covers `Fetcher` itself; a subclass
-    that overrides three of the four and forgets the last one is what a
-    decorator removed from only one of them would let through.
+    that overrides every question but one is what a decorator removed
+    from only one of them would let through.
     """
     methods = {
         "get_tx": lambda self, tx_id: Tx.parse(RAW),
@@ -287,7 +287,7 @@ def test_leaving_any_one_of_the_four_abstract_refuses_construction(
 
 
 def test_a_verifying_fetcher_without_assert_network_is_refused() -> None:
-    """The four questions answered and the chain question not declared.
+    """Every question answered and the chain question not declared.
 
     What a backend costs its caller when it is written without one is
     the check made never, on a class that compiles and passes its own
@@ -330,16 +330,16 @@ def test_a_network_name_is_taken_as_the_rest_of_the_library_takes_one() -> None:
 
 @pytest.mark.parametrize("network", ["mainnet", "testnet", "testnet4", "regtest"])
 def test_the_network_is_the_one_it_was_given(network: str) -> None:
-    """Expose the name the constructor resolved, for all four."""
+    """Expose the name the constructor resolved, for every name given."""
     assert StubFetcher(Tx.parse(RAW), network).network == network
 
 
-def test_the_stub_answers_all_four_questions() -> None:
-    """A Fetcher is the four or it is not one, so the stub must be one.
+def test_the_stub_answers_every_question() -> None:
+    """A Fetcher answers every question it declares, so the stub must.
 
     A subclass leaving one abstract could not be instantiated at all, and
     the tests below would then be testing nothing -- which is what this
-    says out loud rather than leaving to the two lines never called.
+    says out loud rather than leaving to the lines never called.
     """
     fetcher = StubFetcher(Tx.parse(RAW))
     assert fetcher.get_tx(TX_ID).id.hex() == TX_ID

--- a/tests/fetch/verify_network_test.py
+++ b/tests/fetch/verify_network_test.py
@@ -90,8 +90,8 @@ _BACKENDS = {
     "EsploraFetcher": _Backend(_esplora, TESTNET_GENESIS),
 }
 
-# `Fetcher`'s four, which every backend answers and every backend checks
-# the chain in front of
+# the questions `Fetcher` declares, which every backend answers and
+# every backend checks the chain in front of
 _QUESTIONS: dict[str, Callable[[Fetcher], object]] = {
     "get_best_block_id": lambda endpoint: endpoint.get_best_block_id(),
     "get_block_count": lambda endpoint: endpoint.get_block_count(),
@@ -103,7 +103,7 @@ _QUESTIONS: dict[str, Callable[[Fetcher], object]] = {
 # tested rather than a second time here:
 # `test_broadcast_verifies_the_network_before_sending_anything` in
 # `bitcoin_core_test.py` and in `esplora_test.py`, and
-# `test_the_fifth_question_is_refused_on_another_chain_too` in
+# `test_get_tx_merkle_and_verify_tx_are_refused_on_another_chain_too` in
 # `electrum_test.py`
 _ELSEWHERE = {
     ("BitcoinCoreFetcher", "broadcast"),


### PR DESCRIPTION
Closes #1714

No docstring, comment or test name under `tests/fetch/` states how many questions `Fetcher` declares. The number moves when the interface grows, in files the growth does not otherwise touch, and it is the same count [ISS 1708](https://github.com/btclib-org/btclib/issues/1708) took out of `src/btclib/fetch/`.

What replaces a count is the property the sentence was about — every question `Fetcher` declares, the stub answering all of them, a fetch verifying the chain like the others. The enumerations stay: a list naming each thing is not a count of them.

## A count in a test name is the harder half

Renaming a test changes what a failure prints, and that is the point: the name is the part a reader meets first. Five names took the property they were counting, and the one that numbered the fetcher's methods — `get_tx_merkle` and `verify_tx` as "the fifth question" — now names those entry points instead, a place in a sequence being exactly what moves when the interface gains a method.

## One count named a set the code it describes never reads

`EsploraFetcher`'s refusal of an unknown network was documented as a name that "is none of the three known ones". The three are `BLOCKSTREAM_INFO`'s deployments, and nothing in `EsploraFetcher` consults them for this: `Fetcher.__init__` puts the name through `network._validated_network_name`, which answers for the whole of `NETWORKS`. Measured in the branch's venv:

```text
sorted(NETWORKS)          ['mainnet', 'regtest', 'signet', 'testnet', 'testnet4']
sorted(BLOCKSTREAM_INFO)  ['mainnet', 'signet', 'testnet']
EsploraFetcher(BASE, network='regtest', verify_network=False).network -> 'regtest'
```

`regtest` is accepted and is in neither of the three. So this one was not merely a number that could go stale — it was already false.

## What stays

A number that indexes the test's own script: the ids a cache test inserts against the `max_size` it passes to the code under test, the cases a `parametrize` is repeated over where the sentence says which case does what, and the members JSON-RPC 2.0 fixes on an error object. A count of what a test builds is no claim about the tree.

The line between the two is where this branch was corrected in review. `fetcher_test.py:333` read "for all four" over a four-name `parametrize` and was first judged a stay on that ground. It is not one: it tallies the list rather than reasoning over its cases, so adding `signet` makes it false with nothing red, and it reads as "all four networks" where btclib has five — the same shape as the `esplora_test.py` defect above. It now reads "for every name given".

Every site is judged one at a time in [a comment on the issue](https://github.com/btclib-org/btclib/issues/1714#issuecomment-5552036771), including the ones left alone and why.

## The census

`\b` is the wrong boundary for this question — `_` is a word character, so a count living in a test name cannot match — and `git grep -E` drops `\b` silently anyway. A lookaround on letters alone makes `_` a boundary, and the pattern has to be case-insensitive:

```shell
git grep -nPi "(?<![a-z])(two|three|four|five|six|seven|eight|nine|ten|first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth)(?![a-z])" -- 'tests/fetch/*.py'
```

94 lines at the base, 69 here. Proved against a known positive before either number was believed: on `fetcher_test.py` the lookaround finds a test name that `-P "\b(four)\b"` does not, and that `-E "\b(four)\b"` cannot find at all.

Two widenings added nothing. Digits: every one in a comment or docstring under `tests/fetch/` is an HTTP status, a block height or index, a byte count, a JSON-RPC error code or an issue number — measured by extracting comments with `tokenize` and docstrings with `ast`, not by grepping source. And `both`, `dozen`, `pair`, `either`, `neither`: each refers to a thing the same sentence names, or to Core's reply shape, which is not this tree's to count.

Prose and test names only: no assertion changed, and nothing under `src/btclib/fetch/` is touched.

## Gates

- `uvx pre-commit run --all-files` → exit 0, tree clean afterwards
- `uv run --locked pytest -q` → exit 0, 100% floor held
- `uv run --locked sphinx-build -n -W -b html` → exit 0

All three on this sha, after the rebase rather than before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Make tests/fetch prose describe the behavior and interfaces under test instead of relying on counts that can become stale.

Bug Fixes:
- Remove inaccurate test prose that described a network as outside a fixed set of deployments, ensuring the documentation matches btclib's actual network validation behavior.

Enhancements:
- Replace brittle counts of Fetcher questions, endpoints, methods, and related items in tests/fetch prose and test names with descriptions of the properties or entry points under test.
- Retain numeric references that describe test-local data or protocol-defined structures rather than interface size.

Documentation:
- Document the removal of stale question-count references from tests/fetch and the distinction between interface counts and test-local enumerations.

Tests:
- Update tests/fetch test names, docstrings, and comments without changing assertions or test behavior.