### PR TITLE
`fetch/decorators.py` gets a mutation profile of its own (closes #1717)

### DIFF
--- a/.github/mutation/fetch.toml
+++ b/.github/mutation/fetch.toml
@@ -16,10 +16,10 @@
 # kind above to weaken. `CachingFetcher` and `FallbackFetcher` answer from
 # another `Fetcher` rather than from a host, which is the reason
 # `NetworkVerifyingFetcher`'s own docstring gives for their carrying no
-# chain check, and whether they are worth a scope of their own is issue
-# #1717. `broadcaster.py` needs no such decision: `cosmic-ray init` over a
-# configuration naming it enumerates nothing there, `Broadcaster` being a
-# `Protocol` whose method bodies are `...`.
+# chain check, and `fetch_decorators.toml` is the scope of their own that
+# follows from it. `broadcaster.py` needs no such decision: `cosmic-ray
+# init` over a configuration naming it enumerates nothing there,
+# `Broadcaster` being a `Protocol` whose method bodies are `...`.
 
 [cosmic-ray]
 module-path = [

--- a/.github/mutation/fetch_decorators.toml
+++ b/.github/mutation/fetch_decorators.toml
@@ -1,0 +1,76 @@
+# The composed fetchers, mutated: the cache in front of one backend and
+# the failover across several. `fetch.toml` beside it stops at the
+# network boundary -- what a reply is checked against, what a request
+# carries -- and neither `CachingFetcher` nor `FallbackFetcher` answers
+# from a host, so neither holds a guard of that kind to weaken. Naming
+# them there would leave that profile's name describing neither half,
+# which is the choice issue #1717 put and this file is the other side of.
+# What they hold instead is an eviction bound, a lookup that decides
+# whether the backend is reached at all, and a loop that swallows a
+# `FetchError` from one backend to ask the next -- so a mutant here has
+# its own shapes: a bound that never evicts, an answer handed back where
+# the backend should have been asked, a failover stopping at the first
+# backend or hiding the error it owed the caller.
+
+[cosmic-ray]
+module-path = "src/btclib/fetch/decorators.py"
+
+# one test file, where fetch.toml names a whole directory, and the reason
+# is that no other test names either class:
+#
+#   git grep -l 'CachingFetcher\|FallbackFetcher' -- tests
+#
+# answers `tests/fetch/decorators_test.py` alone. The rest of tests/fetch
+# adds 0.2 s to each mutant against that file's own 3.5 s, measured three
+# times apiece, for tests that reach none of this scope
+test-command = """python -m pytest -x -q -n0 -p no:randomly \
+  tests/fetch/decorators_test.py"""
+
+timeout = 300
+
+excluded-modules = []
+
+# The `BitOr` exclusion wallet.toml explains and parsers.toml argues.
+# Measured rather than assumed, as script.toml's own comment on this
+# exclusion asks:
+#
+#   grep -n ' | ' src/btclib/fetch/decorators.py
+#
+# answers `max_size: int | None` twice, as `CachingFetcher`'s attribute
+# annotation and as `__init__`'s parameter annotation, and `from __future__
+# import annotations` defers both: neither is evaluated where it is
+# written, so no mutation of either changes a call. Only the parameter's
+# annotation enumerates anything -- every mutant the filter marks SKIPPED
+# sits on that one line, a bare class-level annotation carrying none of
+# its own -- which is the class fetch.toml documents, in the smallest
+# form it takes here
+[cosmic-ray.filters.operators-filter]
+exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
+
+# 69 mutants, complete: 47 killed, 11 survived, 11 skipped by the filter
+# above. Two classes account for every survivor and nothing is left
+# over:
+#
+# - 8 are `@override` removed, which changes nothing at runtime --
+#   `typing_extensions.override` sets `__override__` and hands the method
+#   back -- and which `[tool.mypy] enable_error_code`'s
+#   `explicit-override` refuses: removing all eight and running `uv run
+#   --locked mypy src/btclib/fetch/decorators.py` exits 1 naming each of
+#   the eight methods, with the test command above still green.
+# - 3 are equivalent, and not all for the same reason.
+#   `len(fetchers) == 0` weakened to `<= 0` is the same test wherever it
+#   stands, a length being non-negative -- no guard is doing that.
+#   The other two are equivalent by a guard standing beside them in
+#   `FallbackFetcher.__init__`: `len(networks) > 1` read as `!= 1` is
+#   the same test on a set the refusal above keeps non-empty, and
+#   `fetchers[0].network` read as `fetchers[-1].network` is the same
+#   string, that set having exactly one element by the check three lines
+#   above it.
+#
+# So the reading here is not the rate but whether a verdict moves: a
+# survivor outside those two classes is a test nobody has written, and
+# the cache and the failover are where a wrong answer reaches a caller
+# with no error anywhere.
+
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -196,7 +196,7 @@ jobs:
             sessions: |
               block.toml 75m
           # the shared codec helpers and the numeric/network boundaries
-          # built on them: utils.toml is the slow one of the four -- a
+          # built on them: utils.toml is the slow one here -- a
           # weakened size bound turns into a near-timeout mutant the way
           # numeric.toml's own does -- so it carries the largest budget
           # here for the same reason, sampled rather than expected to
@@ -205,16 +205,23 @@ jobs:
           # per-mutant timeout that configuration argues for, 25 is what a
           # complete session costs: 602 mutants in 75 minutes of job, and a
           # profile that finishes states a survival rate where a sampled
-          # one can only be read for the verdicts that move in it. The four
-          # budgets sum to 85 against this ceiling, which is what leaves it
-          # unchanged
+          # one can only be read for the verdicts that move in it.
+          # fetch_decorators.toml sits beside fetch.toml rather than
+          # taking a runner of its own, a session this short buying
+          # nothing from one: 69 mutants, 11 of them skipped by the
+          # operator filter that configuration explains, and complete in
+          # 200 s of wall clock at a load average of 24 on the machine
+          # that timed it. 10 minutes is three times that, and the budgets
+          # sum to 95 against a ceiling raised by those same 10, which
+          # leaves the others the slack they were measured with
           - profile: shared helpers, numeric bounds and fetch
             slug: shared
-            ceiling: 95
+            ceiling: 105
             sessions: |
               utils.toml 30m
               numeric.toml 25m
               fetch.toml 15m
+              fetch_decorators.toml 10m
               mnemonic.toml 15m
           # Schnorr and ECDSA signing: 2475 mutants between the two
           # modules, nearly as large as the consensus job's own two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -713,6 +713,31 @@ file of the test tree, and no caller acts on it.
   inserts, the parameters a case is repeated over, and the members
   JSON-RPC fixes on an error object.
 
+### `.github/mutation/fetch_decorators.toml` mutates the cache and the failover
+
+- **`src/btclib/fetch/decorators.py` gets a mutation profile of its
+  own** (closes #1717). `CachingFetcher` and `FallbackFetcher` answer
+  from another `Fetcher` rather than from a host, so neither holds a
+  guard of the kind `fetch.toml` exists to weaken, and naming them there
+  would leave that profile's name describing neither half. What they
+  hold instead is an eviction bound, a lookup that decides whether the
+  backend is reached at all, and a failover loop, and
+  `tests/fetch/decorators_test.py` is what a mutant of those is held to.
+  `.github/workflows/mutation.yml` runs the session in the `shared` job,
+  whose ceiling rises by its budget.
+- **A complete session over the new scope is recorded in that
+  configuration's own comment**, every survivor belonging to one of the
+  two classes it argues: `@override` removed, which `[tool.mypy]`'s
+  `explicit-override` refuses, and a comparison or an index no test can
+  distinguish -- one of them because a length is never negative, the
+  other two because a guard above them has already narrowed what
+  reaches the line.
+- **`tests/fetch/decorators_test.py` builds a `FallbackFetcher` over one
+  backend**, which is the sequence where the constructor's `fetchers[0]`
+  is the only valid index: a mutant reading `fetchers[1]` there raises
+  `IndexError` on such a construction while passing every other test in
+  the file.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/fetch/decorators_test.py
+++ b/tests/fetch/decorators_test.py
@@ -292,3 +292,20 @@ def test_fallback_refuses_an_empty_sequence() -> None:
     """A FallbackFetcher with nothing to fall back to answers nothing."""
     with pytest.raises(BTClibValueError, match="no backends given"):
         FallbackFetcher([])
+
+
+def test_fallback_over_one_backend_answers_from_it() -> None:
+    """One backend is a legal sequence: only the empty one is refused.
+
+    `fetchers[0]` is what the constructor takes the network from, and a
+    sequence of one is where that index is the only valid one -- a
+    `FallbackFetcher` built over two backends answers the same whichever
+    of them the network came from.
+    """
+    tx = Tx.parse(RAW)
+    only = CountingFetcher(tx=tx)
+    fallback = FallbackFetcher([only])
+
+    assert fallback.network == only.network
+    assert fallback.get_tx(TX_ID) is tx
+    assert only.calls["get_tx"] == 1


### PR DESCRIPTION
Closes #1717

`src/btclib/fetch/decorators.py` gets a mutation profile of its own, `.github/mutation/fetch_decorators.toml`, rather than joining `fetch.toml`.

## Why a scope of its own

`fetch.toml`'s header states a network boundary — what a reply is checked against, and what a request carries. `CachingFetcher` and `FallbackFetcher` answer from another `Fetcher` rather than from a host, so neither holds a guard of that kind: what they hold is an eviction bound, a lookup that decides whether the backend is reached at all, and a failover loop. Naming them in `fetch.toml` would have left that profile's header describing neither half. The sentence in `fetch.toml` that reserved this question for this issue now points at the new file.

`tests/fetch/decorators_test.py` is what judges it, and it is the only test that names either class — `git grep -l 'CachingFetcher\|FallbackFetcher' -- tests` answers that file alone, against a positive control of 13 files for `Fetcher`.

## The session

69 mutants, complete: 47 killed, 11 survived, 11 skipped by the `BitOr` filter — every skipped one on `__init__`'s deferred `max_size: int | None`, which `from __future__ import annotations` never evaluates. Both survivor classes are measured rather than asserted:

- **8 are `@override` removed**, a runtime no-op that `[tool.mypy] enable_error_code`'s `explicit-override` refuses: removing all eight and running `mypy` on the file exits 1 naming each of the eight methods, with the profile's own test command still green. They are killed by a gate this profile does not run.
- **3 are equivalent, for two different reasons.** `len(fetchers) == 0` weakened to `<= 0` is the same test wherever it stands, a length being non-negative — no guard is doing that. The other two are equivalent because a guard above them has already narrowed what reaches the line: `len(networks) > 1` read as `!= 1` on a set the refusal above keeps non-empty, and `fetchers[0].network` read as `fetchers[-1].network` on a set the check three lines above holds to one element.

Nothing is left over, which is the reading the profile is for: a survivor outside those two classes is a test nobody has written.

## A twelfth survivor answered in the suite rather than filed

`fetchers[0]` read as `fetchers[1]` at the constructor survived, and that was a real gap: no test built a `FallbackFetcher` over a single backend, so the only sequence where that index is the only valid one was never constructed. `tests/fetch/decorators_test.py` now builds one. Under the mutation exactly that test fails and the other thirteen pass; on the tree all fourteen pass — both runs with the bytecode caches cleared, a stale `.pyc` having already produced one false measurement during this work.

## `mutation.yml`

The session joins the `shared` job. Budgets there now sum to 95 against `ceiling: 105`, which is `timeout-minutes` for the job and the same ten minutes of slack the other sessions were measured with. No `uses:` line is touched.

## Collateral

[ISS 1723](https://github.com/btclib-org/btclib/issues/1723) — nothing binds a `.github/mutation` profile to a session line in `mutation.yml`'s matrix. Every profile has exactly one session line today, so it is a gap in enforcement rather than a live orphan, and the workflow's own `curve_group.toml` comment records that failure having happened once.

## Gates

- `uvx pre-commit run --all-files` → exit 0, tree clean afterwards (`actionlint` and `zizmor` among them)
- `uv run --locked pytest -q` → exit 0, 100% floor held
- `uv run --locked sphinx-build -n -W -b html` → exit 0

All three on this sha, after the rebase rather than before it.

## Review

Cleared at `ba6ca0a3` by a fresh-context reviewer, which queried the session database rather than re-running the sweep and confirmed the survivor attribution row by row. Three non-blocking findings followed and all three are applied here: the equivalence class over-generalised "a guard beside them" over one member that rests on arithmetic instead (corrected in the configuration, in the changelog entry and in the commit message); line 114's `int | None` was called a parameter default where the `|` is in its annotation; and "two lines above" was three.

Those four edits and the rebase onto the ISS 1714 landing are mine rather than the coder's, and — disclosed rather than glossed — they did not get a second fresh-context round: the reviewer dispatched for them was killed by a session limit. What stands in its place is my own re-derivation of each claim from `src/btclib/fetch/decorators.py` and from the session database, the rebase checked for a collapsed hunk (`tests/fetch/decorators_test.py` carries both the ISS 1714 docstring and this branch's new test, with no duplicated `def`), and the three gates above re-run afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Give fetch decorators dedicated mutation coverage and strengthen single-backend failover testing.

New Features:
- Add a dedicated mutation-testing profile for fetch decorators covering CachingFetcher and FallbackFetcher.

Bug Fixes:
- Test single-backend FallbackFetcher construction to catch invalid backend indexing.

Enhancements:
- Document mutation survivors and scope the decorator tests to the dedicated profile.

CI:
- Run the new mutation profile in the shared workflow job and increase its time ceiling accordingly.

Documentation:
- Record the new fetch-decorator mutation coverage and rationale in the changelog.

Tests:
- Add coverage confirming a FallbackFetcher with one backend delegates successfully and exposes that backend's network.