### PR TITLE
`pub_keyinfo_from_xpub` tests `compressed` after the decode (closes #1721)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -788,6 +788,23 @@ file of the test tree, and no caller acts on it.
   produce their scalar with, which neither has done since either took
   `curves.scalar_from_prv_key`.
 
+### `pub_keyinfo_from_xpub` answers about `compressed` once the key has decoded
+
+- **`bip32.pub_keyinfo_from_xpub` tests `compressed` after the decode**
+  (closes #1721), which is the order `prv_keyinfo_from_xprv` beside it
+  reads in and states the reason for: what the check answers is then a
+  fault in a key that did decode, where text that is no extended key has
+  already left as the decode's own refusal.
+  `pub_keyinfo_from_xpub("not an xkey", compressed=False)` raises
+  `Base58 string contains invalid characters` where it raised
+  `uncompressed SEC / compressed BIP32 mismatch`, so a caller handed a
+  garbled key is told about the key rather than about the argument it
+  also passed.
+- **`_pub_keyinfo_from_xpub`'s docstring names `compressed` as the check
+  `pub_keyinfo_from_xpub` makes on the key it has decoded**, in place of
+  the account it gave of a check made before there is a key to make it
+  against.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -174,6 +174,19 @@ full year, short month, short day (YYYY-M-D)
   still a `BTClibTypeError` or a `BTClibValueError`, so an `except` on
   either class is unaffected.
 
+- **`bip32.pub_keyinfo_from_xpub` answers about `compressed` once the
+  key has decoded** (closes #1721). `pub_keyinfo_from_xpub("not an
+  xkey", compressed=False)` raises `Base58 string contains invalid
+  characters`, the decode's own refusal, where the compression mismatch
+  answered first; `prv_keyinfo_from_xprv` beside it reads in that order.
+
+  Act on it if you match on the text of that mismatch to catch a bad
+  key: it answers for a key that decoded, so text that is no extended
+  key wants the decode's own refusal matched instead. The mismatch reads
+  `uncompressed SEC / compressed BIP32 mismatch` in this release, and
+  `Uncompressed SEC / compressed BIP32 mismatch` at v2026.9.3 and at
+  v2023.7.12, where reading an extended key was `to_pub_key`'s.
+
 ### Worth knowing, though nothing raises
 
 - **`psbt_signer_contract.optional_protocols` returns `OptionalProtocols`,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -144,7 +144,7 @@ used to teach and to prototype as much as to build:
     `ssa.nonce_bip340`. btclib passes none of them, and that is a
     decision, not an oversight. These call sites read one of those
     straight into a Python `int`: `bip32.__prv_key_derivation`
-    (`src/btclib/bip32/bip32.py:838`), `commit_nonce.commit_nonce_`
+    (`src/btclib/bip32/bip32.py:842`), `commit_nonce.commit_nonce_`
     (`src/btclib/ecc/commit_nonce.py:155`) and `taproot._tweaked_prvkey`
     (`src/btclib/script/taproot.py:479`). A caller-owned buffer can be
     wiped once the call that filled it returns; the `int` it is read

--- a/src/btclib/bip32/bip32.py
+++ b/src/btclib/bip32/bip32.py
@@ -600,8 +600,8 @@ def prv_keyinfo_from_xprv(
     # a BIP32 key is always compressed, so a caller asking for
     # uncompressed is asking about another format. This follows the
     # decode rather than preceding it, so that what it answers is a fault
-    # in a key that did decode -- an `InvalidPrvKeyError` -- where text
-    # that is no xkey has already left as the decode's own refusal
+    # in a key that did decode, where text that is no xkey has already
+    # left as the decode's own refusal
     if compressed is not None and not compressed:
         raise InvalidPrvKeyError("uncompressed SEC / compressed BIP32 mismatch")
 
@@ -642,12 +642,15 @@ def pub_keyinfo_from_xpub(
     """
     if compressed is not None:
         assert_type(compressed, bool, "compressed")
-        # a BIP32 key is always compressed, so a caller asking for
-        # uncompressed is asking about another format
-        if not compressed:
-            raise BTClibValueError("uncompressed SEC / compressed BIP32 mismatch")
 
-    return _pub_keyinfo_from_xpub(_key_data_from_bip32_key(xpub), network)
+    xpub_data = _key_data_from_bip32_key(xpub)
+
+    # `prv_keyinfo_from_xprv`'s refusal above, on the public half, and
+    # after the decode for the reason stated there
+    if compressed is not None and not compressed:
+        raise BTClibValueError("uncompressed SEC / compressed BIP32 mismatch")
+
+    return _pub_keyinfo_from_xpub(xpub_data, network)
 
 
 def _pub_keyinfo_from_xpub(
@@ -662,8 +665,9 @@ def _pub_keyinfo_from_xpub(
     validating an extended public key costs. `prv_keyinfo_from_xprv`
     above has no such second caller and is one function.
 
-    No `compressed`: the argument is a consistency check the public
-    spelling makes before there is a key to make it against.
+    No `compressed`: the argument is a consistency check
+    `pub_keyinfo_from_xpub` makes on the key it has decoded, before
+    calling here.
     """
     if xpub_data.key[0] not in {2, 3}:
         # this branch is reached with an xprv: never echo it,

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -107,6 +107,14 @@ def test_the_three_key_reads_answer_for_one_half_each() -> None:
     with pytest.raises(BTClibValueError, match=err_msg):
         pub_keyinfo_from_xpub(xpub, compressed=False)
 
+    # and each answers about `compressed` on a key that decoded, so text
+    # that is no extended key leaves as the decode's own refusal
+    err_msg = "Base58 string contains invalid characters"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        prv_keyinfo_from_xprv("not an xkey", compressed=False)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        pub_keyinfo_from_xpub("not an xkey", compressed=False)
+
     # the version bytes say which network claims the key, so a network
     # the caller names has to be that one
     err_msg = "not a testnet key: version "


### PR DESCRIPTION
Closes #1721

`bip32.pub_keyinfo_from_xpub` tests `compressed` after the decode, which is the order `prv_keyinfo_from_xprv` beside it already reads in.

## What decided it

Not the cost of the check — the argument test is cheaper than the decode, and that is not the criterion. Two things decided it, and the second is the one that made this worth closing rather than documenting.

**The private half's reason is not a private half's reason.** Its comment says the check "follows the decode rather than preceding it, so that what it answers is a fault in a key that did decode, where text that is no xkey has already left as the decode's own refusal". Nothing in that is about a key being private: it is a statement about what a caller handed garbage should be told.

**The tree already argued both sides.** `_pub_keyinfo_from_xpub`'s docstring stated the opposite reason for the opposite order, as settled, about the same argument — "the argument is a consistency check the public spelling makes before there is a key to make it against" — and neither paragraph knew the other existed. Whichever way this went, one of the two had to be rewritten. The reason is now carried once, by the private half, and the public half points at it.

## What a caller sees

`pub_keyinfo_from_xpub("not an xkey", compressed=False)` raises `Base58 string contains invalid characters` where it raised `uncompressed SEC / compressed BIP32 mismatch`. The exception class is `BTClibValueError` either way, so what a caller has to act on is the text — which is what the `RELEASE_NOTES.md` breaking-changes bullet says, naming the release each spelling belongs to: the message reads lowercase in this release and `Uncompressed SEC / compressed BIP32 mismatch` at `v2026.9.3` and at `v2023.7.12`, where reading an extended key was `to_pub_key`'s. Both checked against the tags.

The exception *type* stays `BTClibValueError`. `prv_keyinfo_from_xprv` raises `InvalidPrvKeyError`, `src/btclib/exceptions.py` has no public twin of it, and inventing one is a different question — the asymmetry a previous review already judged deliberate, `InvalidPrvKeyError` being about a private key whose format was recognised.

## The test

`tests/bip32/bip32_test.py` now asserts the decode's own refusal for both halves against the same garbled text. That assertion is red before this change, and by reading rather than by running: at the base, `pub_keyinfo_from_xpub` raises the mismatch at its line 648 and never reaches `_key_data_from_bip32_key` at 650, so `pytest.raises(..., match="Base58 string contains invalid characters")` cannot match. Disclosed: the command that would have *run* the counterfactual was denied by this session's permission classifier, and I did not retry it in another spelling — what stands instead is the reading above, from the object store.

## `SECURITY.md`

Its citation of the line `bip32.__prv_key_derivation` reads a tweaked key into a Python `int` on moves with the lines added above it. All six of that file's `file:line` citations were re-read against their claimed content after the rebase, not against which function they land in.

## Gates

- `uvx pre-commit run --all-files` → exit 0, tree clean afterwards
- `uv run --locked pytest -q` → exit 0, 100% floor held
- `uv run --locked sphinx-build -n -W -b html` → exit 0

All three on this sha, after the rebase rather than before it.

Disclosed: this branch had no fresh-context review round. Its coder was killed by a session limit mid-gate, and every reviewer dispatched afterwards was killed the same way. The branch it left was checkpointed, signed and clean; what stands in place of a review is my own reading of the diff against the source, the tag checks above, the `SECURITY.md` re-derivation and the three gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Evaluate the compression consistency check only after an extended public key has successfully decoded.

Bug Fixes:
- Make `pub_keyinfo_from_xpub` report malformed extended-key input using the decoder’s error before evaluating the compression argument.

Enhancements:
- Align public extended-key validation behavior and documentation with the corresponding private-key path.
- Add regression coverage for malformed inputs and update the security citation affected by line changes.

Documentation:
- Document the changed exception message behavior and its impact on callers matching error text.

Tests:
- Add tests confirming both public and private key readers return the decoder error for malformed extended keys.