### PR TITLE
`ElectrumFetcher`'s no-default-server reason stops counting hosts (closes #1722)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -805,6 +805,26 @@ file of the test tree, and no caller acts on it.
   the account it gave of a check made before there is a key to make it
   against.
 
+### `ElectrumFetcher`'s reason for no default server stops counting hosts
+
+- **`src/btclib/fetch/electrum.py` no longer says how many of the hosts
+  on Electrum's shipped server list pass strict certificate
+  verification** (closes #1722). The list moves with every Electrum
+  release and is vendored nowhere here, so nothing re-derives the
+  number; and the list cannot answer for it in any case, an entry
+  carrying a host's ports, its pruning and the protocol version it
+  speaks and nothing about the certificate that host presents.
+- **What stands in its place is what the list does answer for**, the
+  argument for naming no host as a constant being what the number
+  carried. Electrum's own client pins the certificate a server presents
+  and connects with `check_hostname` off wherever the CA-signed
+  handshake fails (`electrum/interface.py`,
+  `Interface._get_ssl_context`), so being listed says what protocol
+  version a server speaks rather than that a strict transport would
+  accept it; entries share registrable domains, so the list names fewer
+  operators than hosts; and a caller running their own server is on it
+  nowhere.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/fetch/electrum.py
+++ b/src/btclib/fetch/electrum.py
@@ -26,11 +26,19 @@ that is is `transport`'s own business. `EsploraFetcher.base_url`'s
 reasoning -- `BLOCKSTREAM_INFO` is offered as a value to pass and never
 as a default, because which host sees every address a caller looks up is
 not btclib's decision to make on anyone's behalf -- applies here with
-even less room: measured against Electrum's own shipped server list,
-strict certificate verification reaches four hosts, two of them one
-operator, and a caller running their own server is invisible to that
-list entirely. Naming any one of the four as a constant would repeat the
-mistake `BLOCKSTREAM_INFO` already refuses.
+even less room. Electrum's own shipped server list carries each host's
+ports, its pruning and the protocol version it speaks, and nothing about
+the certificate it presents, so which of its entries a transport
+verifying against a public CA store reaches is not a question the list
+answers. Electrum's own client does not ask it either: where the
+CA-signed handshake fails it pins the certificate that server presented
+and connects with `check_hostname` off (`electrum/interface.py`,
+`Interface._get_ssl_context`), so being listed says what protocol
+version a server speaks and not that its certificate is one a strict
+transport accepts. Entries share registrable domains, so the list names
+fewer operators than hosts, and a caller running their own server is
+invisible to it entirely. Naming any one entry as a constant would
+repeat the mistake `BLOCKSTREAM_INFO` already refuses.
 
 **A question the interface does not declare, answered by nothing else in
 this package.** `get_tx_merkle` and `verify_tx` are not on `Fetcher`:


### PR DESCRIPTION
Closes #1722

`src/btclib/fetch/electrum.py`'s module docstring no longer says how many of the hosts on Electrum's shipped server list pass strict certificate verification. It said it twice, and the second was the sentence the argument turned on.

## Why not a deletion, and not a vaguer sentence

The number was load-bearing: it was the reason `ElectrumFetcher` names no default server. "Very few hosts" would have kept the shape of a measurement while giving up the thing that made it checkable, which is a worse comment rather than a shorter one. What replaces it is what the list *does* answer for.

## Why the count could not be re-derived, measured rather than assumed

Two reasons, and only the first is the one `CLAUDE.md` is usually about.

The list is not vendored here, so `tests/vendored_data_test.py`'s exemption for a count of what upstream published does not reach it, and nothing in this tree re-derives the figure.

But the list cannot answer the question at all. An entry carries a host's ports, its pruning and the protocol version it speaks — and nothing about the certificate that host presents. Nor does Electrum's own client treat the list that way: `Interface._get_ssl_context` (`electrum/interface.py`) tries a CA context first and, where the server is not CA-signed, saves that server's own certificate and builds a context pinned to it with `check_hostname = False`. So being listed says what protocol version a server speaks, not that a CA-strict transport would accept it. Read at `spesmilo/electrum` `b8ae9a55`.

Deciding it properly would mean connecting to each host and reading the certificate it presents. **No socket was opened to any of them.**

## A stale path, worth recording

[ISS 1722](https://github.com/btclib-org/btclib/issues/1722) proposed the command

```shell
gh api repos/spesmilo/electrum/contents/electrum/servers.json -H 'Accept: application/vnd.github.raw'
```

which **404s**: upstream moved the file to `electrum/chains/mainnet/servers.json`, one per chain. Worth naming because of how the 404 behaves — piped to a file it writes the error body, which is valid JSON and parses as a three-key object, so a measurement over it runs cleanly and answers a plausible-looking number about nothing. That is what a positive control on the fetched file is for, and it is what caught this one.

## Gates

- `uvx pre-commit run --all-files` → exit 0, tree clean afterwards
- `uv run --locked pytest -q` → exit 0, 100% floor held
- `uv run --locked sphinx-build -n -W -b html` → exit 0 — a module docstring is rendered, so this one is not decorative here

All three on this sha, after the rebase. `RELEASE_NOTES.md` is untouched: a module docstring is not something a caller acts on.

Disclosed: this branch had no fresh-context review round — its coder was killed by a session limit mid-gate, and every reviewer dispatched afterwards was killed the same way. What stands in place of one is that both upstream claims in the new prose were verified by me against `spesmilo/electrum` at a named commit, the shared-domain claim was measured over the real list, and the three gates were re-run after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Replace the unverifiable Electrum host certificate count with an accurate explanation of why ElectrumFetcher does not choose a default server.

Bug Fixes:
- Remove the unsupported host-count claim from the ElectrumFetcher documentation so its rationale for having no default server remains accurate.

Enhancements:
- Clarify that Electrum's server list describes protocol and pruning metadata, not strict certificate validity, and document the remaining reasons against selecting a default server.

Documentation:
- Update the ElectrumFetcher module documentation and changelog to replace the unverifiable certificate-verification count with evidence-based limitations of the server list.