### PR TITLE
`TF2.md`, one entry per file of Core's test framework (closes #1124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -825,6 +825,32 @@ file of the test tree, and no caller acts on it.
   operators than hosts; and a caller running their own server is on it
   nowhere.
 
+### `TF2.md`, one entry per file of Core's test framework
+
+- **The ledger [ISS 198](https://github.com/btclib-org/btclib/issues/198)
+  keeps asking for is a file at the root** (closes #1124). One entry per
+  Python file of `test/functional/test_framework/`, each naming what
+  covers it in btclib, what the covering module asserts, and the commit
+  of that path it was read at. "Strictly equivalent" is a claim about a
+  moving target, and an equivalence measured against a revision nobody
+  wrote down is one nobody can re-check.
+- **A pin is the tip of its own path, not a repository-wide revision.**
+  Both are honest ways to say which tree was read, and only the first
+  can ever read `behind 0`, so only the first is one a per-path
+  staleness check can clear. The entry grammar is
+  `tests/_data/README.md`'s for that reason: the same `repo`, `path`,
+  `commit` and `behind` fields, which
+  `.github/scripts/check_vendored_vectors.py` already parses.
+- **`tests/tf2_ledger_test.py` holds the file to its shape offline.**
+  Core's directory is transcribed and the census asserted in both
+  directions, every verdict is from the vocabulary the ledger defines
+  and every defined verdict is used, every btclib path an entry names is
+  a file of this tree, and no entry states a count. What it cannot see
+  is upstream, and in more than one way: whether a pin is still a tip is
+  a network question the re-checker will answer weekly, and whether Core
+  has gained a file is another, the census holding the ledger to that
+  transcription rather than to the directory.
+
 ## v2026.9.3
 
 ### Repository

--- a/TF2.md
+++ b/TF2.md
@@ -1,0 +1,682 @@
+# The tf2 ledger
+
+One entry per Python file of Bitcoin Core's
+`test/functional/test_framework/`, naming what covers it in btclib, what
+the covering module asserts, and the revision of that file the entry was
+read at.
+
+What it is for is
+[ISS 198](https://github.com/btclib-org/btclib/issues/198)'s "strictly
+equivalent", the phrase on which offering anything back to Core rests.
+That is a claim about a moving target: Core's framework changes, so an
+equivalence measured against a revision nobody wrote down is an
+equivalence nobody can re-check. An entry here turns "btclib covers
+`blocktools`" into a sentence with a truth value -- which `blocktools`,
+asserted by what, and what has moved upstream since.
+
+It makes the gap visible in the other direction too. Re-deriving what is
+left of Core's framework means reading the directory again, which is
+work that starts going stale the moment it is finished; this is that
+reading written down once, and moved by whatever moves it.
+
+The file is btclib's while tf2 has no repository of its own, and it is
+tf2's the day one exists. It sits at the root rather than inside
+`tests/_data/README.md` for that reason and for one more: that README is
+about `tests/**/_data/`, and a record of files this tree deliberately
+does *not* hold is a different subject, which appending it there would
+make both records harder to read.
+
+## Reading an entry
+
+An entry is a `###` heading naming the file's path in Core, a fenced
+block pinning it, and a verdict with what stands behind it.
+
+`repo`, `path` and `commit` are the pin, and `behind` is how many
+upstream revisions of that path have landed since. That is the grammar
+`tests/_data/README.md` uses, so an entry here can be read without
+learning a second shape -- by a person, and by
+`.github/scripts/check_vendored_vectors.py`, which parses exactly those
+fields. That script is not yet asked to read this file: it takes one
+README path and names one drift issue in a module constant, and
+btclib-secp256k1 carries a copy of it under the same name that a change
+to either would be owed. Wiring is therefore its own change, not this
+file's.
+
+An entry's `commit` is the tip of its own path, so `behind` reads zero
+and a re-check can clear it. A repository-wide revision is a perfectly
+good "this is the tree I read" pin, and `contents/<path>?ref=<sha>`
+resolves one; what it cannot be is the tip of any single path, so
+`behind` never reads zero for it and a per-path staleness check never
+clears it. A ledger whose whole purpose is re-checkability takes the pin
+that goes stale loudly.
+
+## The verdicts
+
+- **covered** -- btclib publishes the same thing, and a test asserts it.
+- **covered in part** -- some of the file's surface is btclib's and some
+  is not; the entry names both halves.
+- **vendored** -- btclib holds Core's own file, with the attribution.
+- **tf2's by decision** -- an issue decided it out of btclib, and the
+  entry names that issue.
+- **tf2's (harness)** -- it drives a node: a process, an RPC client, a
+  socket, an event loop. Nothing in btclib answers it, and nothing is
+  meant to.
+- **empty upstream** -- the file has no content at the pinned commit.
+  The entry is there so that content arriving in it moves the pin.
+
+## Re-checking a pin
+
+The path stands in a fence of its own, sitting inside the API argument
+rather than at the end of the command; the fence below reads it as
+`${entry_path:?}`, the shell's must-be-set form, so a paste of that
+fence alone fails naming the variable rather than asking about whatever
+the shell already held.
+
+The variable is `entry_path` and not `path`, which is the name the
+argument wants: in `zsh` -- the shell this is read in -- `path` is tied
+to `PATH` as an array, so assigning a file path to it replaces the
+reader's `PATH` with that one entry and the next command in their
+terminal is not found. The `:?` guard does not catch it either, `path`
+being always set there where `bash` refuses it. Measured both ways:
+`zsh -c 'path=a/b.py; git --version'` answers `command not found: git`,
+and `entry_path` leaves `PATH` alone.
+
+```shell
+entry_path=<the path the entry gives>
+```
+
+```shell
+gh api --method GET repos/bitcoin/bitcoin/commits \
+    -f "path=${entry_path:?}" -f per_page=1 \
+    --jq '.[0].sha + "  " + .[0].commit.committer.date[:10]'
+```
+
+The answer is the entry's own `commit` where nothing has moved.
+Any other commit means the file changed after it was read, and the
+entry's verdict is then a claim about a file that is no longer there.
+
+What no fence here catches is a file Core *gains*. The census in
+`tests/tf2_ledger_test.py` runs offline and holds this file to a
+transcription of Core's directory rather than to Core, so a new
+`test_framework/*.py` upstream is invisible to it and to a pin re-check,
+which only reads the entries a ledger already carries. Listing the
+directory at a fresh commit is the read that answers it.
+
+No entry carries a `blob`, and that is where this file parts from
+`tests/_data/README.md`: nothing in this tree is a copy of any file
+below but the RIPEMD-160 implementation, whose own entry names where
+that comparison lives instead of making one here.
+
+## bitcoin/bitcoin
+
+### `test/functional/test_framework/__init__.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/__init__.py
+commit  c28ee91db07ce82e134d500ddeb5600363c98048  2017-03-20
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **empty upstream**. The package marker, with no content at the
+pinned commit. The entry is here so that content arriving in it moves
+the pin rather than passing unnoticed.
+
+### `test/functional/test_framework/address.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/address.py
+commit  4dbaa7cc65b9546d07f1f9bfc8fb912b6fb20a5e  2026-06-16
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered**. `b58.address_from_h160` and `b58.h160_from_address`
+for the base58 addresses, `b32.address_from_witness` and
+`b32.witness_from_address` for the segwit ones, each over the codec
+below it -- `base58` and `bech32`, a split Core's file does not make.
+`script.script_pub_key`'s `address`, `addresses` and `type_and_payload`
+are the `address_to_scriptpubkey` direction.
+`create_deterministic_address_bcrt1_p2tr_op_true` composes
+`script.taproot.output_pubkey` over `tree_helper` with `b32.p2tr`, so it
+is a convenience of tf2's assembled from parts that are here.
+`tests/key_io_test.py` runs Core's own `key_io_valid.json` and
+`key_io_invalid.json`, both vendored and pinned in
+`tests/_data/README.md`.
+
+### `test/functional/test_framework/authproxy.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/authproxy.py
+commit  f42226d526ebb3eb9217e738108e4f8148a1b069  2026-06-04
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **tf2's (harness)**. Reaching a node over JSON-RPC is the
+`bitcoin-core-rpc` package, which this organization publishes and
+`btclib.fetch.bitcoin_core` builds on. Core's file is not a vendoring
+candidate either: its header puts it under the GNU Lesser General Public
+License, which is not this project's.
+
+### `test/functional/test_framework/blockfilter.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/blockfilter.py
+commit  fa5f29774872d18febc0df38831a6e45f3de69cc  2025-12-16
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered**. `block/block_filter.py` holds both halves.
+`BasicBlockFilter` maps an element into the filter's range as
+`bip158_basic_element_hash` does, keyed on the block hash, and its
+`from_block` selects what `bip158_relevant_scriptpubkeys` selects --
+the previous output script of every non-coinbase input, and every output
+script BIP158 does not exclude -- with the utxo set handed in through
+`prevout_scripts_from_utxos` rather than read off a node. Each draws the
+output rule from a different place, and btclib's is the one the BIP
+states: Core's Python asks whether the output type is `nulldata`, where
+btclib tests the first byte for `OP_RETURN` as Core's own C++ does, and
+says beside `_OP_RETURN` why a non-standard OP_RETURN output separates
+them.
+`p2p/block_filters.py` carries BIP157's messages over it, and
+`tests/block/blockfilters_test.py` runs Core's `blockfilters.json`,
+vendored and pinned.
+
+### `test/functional/test_framework/blocktools.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/blocktools.py
+commit  1966621b76885257b4b4e44aab4712e9f84313e6  2026-05-13
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered in part**. `block/build.py` is `create_coinbase`,
+`create_block` and `add_witness_commitment`:
+[ISS 1118](https://github.com/btclib-org/btclib/issues/1118) put
+`build_coinbase`, which pays `consensus.subsidy` at a height and commits
+to that height as BIP34 requires, beside `build_block`, which assembles
+the block over a list of transactions and its witness commitment.
+`block/proof_of_work`'s `target_from_bits` and `bits_from_target` are
+what `nbits_str` and `target_str` print, and `script.sig_ops`'s
+`sig_op_count` is what `get_legacy_sigopcount_tx` counts.
+`tests/block/build_test.py` asserts the first group against real
+mainnet blocks. `create_tx_with_script`, `create_witness_tx` and
+`send_to_witness` spend against a node's wallet, and are tf2's.
+
+### `test/functional/test_framework/compressor.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/compressor.py
+commit  b34fdb5ade0b48384636f8c7c9673554bf82cedf  2025-03-04
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **tf2's by decision**.
+[ISS 1123](https://github.com/btclib-org/btclib/issues/1123): the
+chainstate encoding is the format Core reserves for itself, where
+`fetch/` depends on the interface Core publishes for everyone else.
+`util.util_xor`, the obfuscation of Core's own block files, went to tf2
+with it.
+
+### `test/functional/test_framework/coverage.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/coverage.py
+commit  fa71c15f8610816a6ee0426cd396315da3d27c30  2025-11-26
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **tf2's (harness)**. It records which RPCs a run reached.
+Nothing in btclib answers it.
+
+### `test/functional/test_framework/crypto/bip324_cipher.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/crypto/bip324_cipher.py
+commit  fa5f29774872d18febc0df38831a6e45f3de69cc  2025-12-16
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **tf2's by decision**.
+[ISS 1066](https://github.com/btclib-org/btclib/issues/1066) drew the
+line: what btclib builds out of the standard library is in, and a
+hand-rolled cipher is not.
+
+### `test/functional/test_framework/crypto/chacha20.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/crypto/chacha20.py
+commit  fa5f29774872d18febc0df38831a6e45f3de69cc  2025-12-16
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **tf2's by decision**. ISS 1066, the same line.
+`muhash.py` carries a private `_chacha20_block` because `MuHash3072`'s
+element hash is a keyed ChaCha20 keystream and nothing else here needs
+one; its `__all__` publishes `MuHash3072` alone, which is
+[ISS 1122](https://github.com/btclib-org/btclib/issues/1122) reading
+that line rather than excepting itself from it.
+
+### `test/functional/test_framework/crypto/ellswift.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/crypto/ellswift.py
+commit  3fd68a95e68b4c6f3bb6c59d41dd196001110f3a  2026-04-07
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered**. `ecc/ellswift.py`: `create_var` for
+`ellswift_create`, `encode_var` for `xelligatorswift`, `decode_var` for
+`xswiftec`, and `xdh` for `ellswift_ecdh_xonly`, over `_xswiftec_var`
+and `_xswiftec_inv_var`. `tests/ecc/ellswift_test.py` runs BIP324's
+`ellswift_decode_test_vectors.csv` and `xswiftec_inv_test_vectors.csv`,
+vendored from bitcoin/bips and pinned.
+
+### `test/functional/test_framework/crypto/hkdf.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/crypto/hkdf.py
+commit  fa5f29774872d18febc0df38831a6e45f3de69cc  2025-12-16
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered**. `kdf.hkdf` is Core's `hkdf_sha256`, and
+`kdf.hkdf_extract` and `kdf.hkdf_expand` stand beside it where Core's
+file offers the one-shot alone
+([ISS 1080](https://github.com/btclib-org/btclib/issues/1080)).
+`tests/kdf_test.py` runs RFC 5869's own vectors.
+
+### `test/functional/test_framework/crypto/muhash.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/crypto/muhash.py
+commit  fec2ca6c9a8a8e44b6e4d51c4ef7fa6eaca6e446  2023-09-29
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered**. `muhash.MuHash3072` is Core's class operation for
+operation -- `insert`, `remove` and the digest are all the pinned file
+has -- and `coinstats.py` is what feeds a utxo set through one. btclib's
+`serialize` and `deserialize` answer Core's C++ class instead, which the
+module says where it implements them.
+`tests/muhash_test.py` runs `muhash_vectors.json` and
+`chacha20_vectors.json`, both transcribed from Core's `crypto_tests.cpp`
+and pinned in `tests/_data/README.md`.
+
+### `test/functional/test_framework/crypto/poly1305.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/crypto/poly1305.py
+commit  fa5f29774872d18febc0df38831a6e45f3de69cc  2025-12-16
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **tf2's by decision**. ISS 1066, the same line: an
+authenticator written out by hand is what that issue put on tf2's side.
+
+### `test/functional/test_framework/crypto/ripemd160.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/crypto/ripemd160.py
+commit  08a4a56cbcfa54366c2c0bb52bb147fc2740edc5  2023-09-10
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **vendored**. `src/btclib/_ripemd160.py` is Core's file, MIT
+and therefore this project's licence too, for an interpreter whose
+`hashlib` offers no RIPEMD-160; its docstring carries the attribution,
+the revision it was taken at, and every delta from upstream.
+`tests/ripemd160_test.py` holds the vectors that were in Core's own
+`unittest.TestCase`.
+
+### `test/functional/test_framework/crypto/secp256k1.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/crypto/secp256k1.py
+commit  3fd68a95e68b4c6f3bb6c59d41dd196001110f3a  2026-04-07
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered**, and wider than Core's file: `curves/curve.py`,
+`curves/curve_group.py`, `curves/curve_group_2.py`,
+`curves/curve_group_f.py` and `curves/sec_point.py` carry every curve
+this library has rather than secp256k1 alone. What the arithmetic is
+asserted against is not a vector file but the `btclib_secp256k1`
+bindings, which `curves.curve.mult` and its variants delegate to for
+secp256k1 and which the suite validates the Python arm against. Core's
+file warns that it is slow and side-channel vulnerable; `SECURITY.md`
+publishes the same about the Python arm here.
+
+### `test/functional/test_framework/crypto/siphash.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/crypto/siphash.py
+commit  af50ba8500a81e1a79cdf953d27bbf53ee6c979f  2026-07-18
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered**. `hashes.siphash` takes the key words in the order
+Core's own `siphash(k0, k1, data)` reads them out of a key
+([ISS 373](https://github.com/btclib-org/btclib/issues/373)). Core's
+second entry point, `siphash256`, is a little-endian `to_bytes` of a
+`uint256` ahead of that same call, and `hashes.siphash`'s docstring is
+where declining to restate that conversion is argued: a hash is already
+bytes in that order here. `tests/siphash_test.py` runs Core's
+`siphash.json`, vendored and pinned, and
+`tests/p2p/compact_blocks_test.py` reads Core's own Python as a second
+implementation.
+
+### `test/functional/test_framework/descriptors.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/descriptors.py
+commit  fab300b378941a233119805c0d62198596a57790  2025-12-26
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered in part**. `descriptors.checksum`,
+`descriptors.add_checksum` and `descriptors.strip_checksum` are
+`descsum_polymod`, `descsum_expand`, `descsum_create` and
+`descsum_check`, asserted in `tests/descriptors/descriptors_test.py`
+against `descriptor_checksums.json`. `drop_origins` has no equivalent:
+`descriptors.normalized` is Core's `ToNormalizedString`, which re-roots
+each key at its last hardened step, where dropping key origins is a
+different operation that nothing here publishes.
+
+### `test/functional/test_framework/extendedkey.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/extendedkey.py
+commit  d2a03d50acbf4bffc11048ef2cabb1b42ea78989  2026-06-19
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered**. `bip32/` is BIP32 whole, where Core's file says of
+itself that it provides "only basic functionality", and `slip132`,
+`bip44`, `bip85` and `bip32/key_origin.py` stand beside it. `tests/bip32/`
+runs BIP32's own vectors and its invalid extended keys, both pinned.
+
+### `test/functional/test_framework/ipc_util.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/ipc_util.py
+commit  3962138cc036578926d901e6ff4ff807243bbb4e  2026-05-26
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **tf2's (harness)**. Cap'n Proto IPC into a `bitcoin-node`
+process. `src/btclib` names it nowhere.
+
+### `test/functional/test_framework/key.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/key.py
+commit  3fd68a95e68b4c6f3bb6c59d41dd196001110f3a  2026-04-07
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered**. `ecc/dsa.py` and `ecc/ssa.py` sign and verify,
+`ecc/rfc6979_nonce.py` and `ecc/bip340_nonce.py` derive the nonces,
+`key.py`, `to_prv_key.py` and `to_pub_key.py` are the key objects Core's
+`ECKey` and `ECPubKey` are, `hashes.tagged_hash` is `TaggedHash`, and
+`script/taproot.py` holds the x-only tweak. What the signatures are
+asserted against is BIP340's own vectors and the `btclib_secp256k1`
+bindings, which are the authority on the answer.
+
+### `test/functional/test_framework/mempool_util.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/mempool_util.py
+commit  fa5f29774872d18febc0df38831a6e45f3de69cc  2025-12-16
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **tf2's (harness)**. It fills and reads a running node's
+mempool.
+
+### `test/functional/test_framework/messages.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/messages.py
+commit  e3b026bf56e66baa6e070a00c136da95f3a16ef8  2026-07-07
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered in part**. `p2p/` publishes one `Payload` subclass
+per command over `tx/`, `block/`, `var_int`, `var_bytes`, `hashes`,
+`block/partial_merkle_tree.py` and `p2p/merkleblock.py`
+([ISS 1083](https://github.com/btclib-org/btclib/issues/1083) and its
+children); the `C`-prefixed structures Core's file also carries are
+`tx/` and `block/` here. `tests/p2p/core_commands_test.py` asserts that
+census in both directions against Core's `src/protocol.h`, pinned in
+`tests/_data/README.md`. `filterload`, `filteradd` and `filterclear` are
+left out for good by
+[ISS 1120](https://github.com/btclib-org/btclib/issues/1120): a client
+constructs those to ask a node for the service that leaks its wallet to
+that node, and BIP157 is what replaced them.
+
+### `test/functional/test_framework/netutil.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/netutil.py
+commit  59ebf558f3458bbc9038c7bf2958f2f224485ee1  2026-09-02
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **tf2's (harness)**. Interfaces, sockets and kernel inode
+tables. `src/btclib` imports `socket` nowhere.
+
+### `test/functional/test_framework/p2p.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/p2p.py
+commit  e4d80e7001e9996a2836225f45a905dd16ffc777  2026-08-18
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered in part**. The envelope is `p2p/message.py`:
+`Message.parse` reads one message off a stream and answers "not enough
+bytes yet" as `IncompleteMessageError`, distinctly from a wrong
+checksum, rewinding the stream to where it started.
+`P2PConnection`, `P2PInterface`, `NetworkThread`, `P2PDataStore` and the
+listener are the socket, the event loop and the peer state machine, and
+are tf2's.
+
+### `test/functional/test_framework/psbt.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/psbt.py
+commit  a2a2b1745f0818364dd8149161e88cea1475d9b6  2026-05-27
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered**. `psbt/` -- `Psbt`, `PsbtIn`, `PsbtOut`,
+`psbt_view`, `psbt_size`, `musig2` and `silent_payments` -- where Core's
+file is a reader and a writer of the maps. `tests/psbt/` runs BIP174,
+BIP370, BIP371, BIP373 and BIP375 vectors, each pinned.
+
+### `test/functional/test_framework/script.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/script.py
+commit  3fd68a95e68b4c6f3bb6c59d41dd196001110f3a  2026-04-07
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered**. `script/script.py` is the codec,
+`script/engine/` the execution, `script/op_codes_tapscript.py` and
+`script/taproot.py` the taproot half, and `script/sig_hash.py` the
+signature hashes Core's file also carries. `tests/script/` and
+`tests/script_engine/` run Core's `script_tests.json`, `tx_valid.json`,
+`tx_invalid.json` and `sighash.json`, all vendored and pinned.
+
+### `test/functional/test_framework/script_util.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/script_util.py
+commit  3fd68a95e68b4c6f3bb6c59d41dd196001110f3a  2026-04-07
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered in part**. `script/script_pub_key.py` publishes the
+`ScriptPubKey` constructors Core's `*_script` functions are, with the
+`assert_*` and `is_*` pair beside them, `type_and_payload` and
+`address`; `tests/script/script_pub_key_test.py` asserts them.
+`bulk_vout` and `build_malleated_tx_package` build a transaction of a
+chosen size or a package of a chosen shape for a node to accept or
+refuse, and are tf2's.
+
+### `test/functional/test_framework/segwit_addr.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/segwit_addr.py
+commit  fe5e495c31de47b0ec732b943db11fe345d874af  2021-03-16
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered**. `bech32.py` is the codec with no bitcoin in it and
+`b32.py` the bitcoin semantics on top, which is the split this file does
+not make; `tests/bech32_test.py` and `tests/b32_test.py` assert each
+half.
+
+### `test/functional/test_framework/socks5.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/socks5.py
+commit  4e8c4bc794c045beb678854e6e326fc04322c7c3  2026-08-04
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **tf2's (harness)**. A SOCKS5 server for the Tor tests.
+`src/btclib` names SOCKS nowhere.
+
+### `test/functional/test_framework/test_framework.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/test_framework.py
+commit  fa7be0a8df9d99d4dd880afb4f48a9b197dca5b0  2026-08-27
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **tf2's (harness)**. The base class every functional test
+derives from.
+
+### `test/functional/test_framework/test_node.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/test_node.py
+commit  de2adc308a421ea57414c4e28f9a75350df54f25  2026-08-11
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **tf2's (harness)**. It starts, stops and drives a `bitcoind`,
+and wraps `bitcoin-cli`.
+
+### `test/functional/test_framework/test_shell.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/test_shell.py
+commit  fa5f29774872d18febc0df38831a6e45f3de69cc  2025-12-16
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **tf2's (harness)**. The framework driven from a python shell.
+
+### `test/functional/test_framework/util.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/util.py
+commit  6f4109b4489182bf5fa517630043df1829f00808  2026-08-25
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered in part**. `get_fee` is `fee.fee_from_vsize` over a
+`FeeRate`, and what `satoshi_round` quantizes to is what `amount.py`'s
+`valid_btc_amount`, `sats_from_btc` and `btc_from_sats` work in;
+`util_xor` went to tf2 with the compressor by ISS 1123. The rest is the
+harness: the assertions, the ports, the datadirs, the cookie files, the
+configuration files and the waits.
+
+### `test/functional/test_framework/v2_p2p.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/v2_p2p.py
+commit  6a129983c9bf8efa1081f9a8b462c3635d1cfb39  2026-06-04
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **tf2's by decision**. ISS 1066 put BIP324's transport on tf2's
+side. Its non-cipher halves are btclib's and are here:
+`ecc/ellswift.py` is the key exchange and `kdf.hkdf` the key schedule.
+
+### `test/functional/test_framework/wallet.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/wallet.py
+commit  91586f701e1ebb12d8147feda7e78169a05da36f  2026-06-30
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **tf2's (harness)**. `MiniWallet` spends against a node's
+chain. Its building blocks are btclib's -- `tx_builder.build_psbt`,
+`coin_selection`, `psbt_signer` and `script/script_pub_key.py` -- so it
+is tf2 written on btclib rather than a gap in btclib.
+
+### `test/functional/test_framework/wallet_util.py`
+
+```text
+repo    bitcoin/bitcoin
+path    test/functional/test_framework/wallet_util.py
+commit  42330922dd8d5f96dbc0cc6a8e4092500029f89d  2026-05-27
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **covered in part**. `tx.input_weight` is
+`calculate_input_weight`, with Core's own cases transcribed in
+`tests/tx/tx_in_test.py`
+([ISS 1067](https://github.com/btclib-org/btclib/issues/1067)), and
+`b58.wif_from_prv_key` is `bytes_to_wif`. `get_generate_key`,
+`test_address` and `WalletUnlock` need a node.
+
+## The files that are not Python
+
+The directory also carries `bip340_test_vectors.csv`,
+`crypto/ellswift_decode_test_vectors.csv` and
+`crypto/xswiftec_inv_test_vectors.csv`. Those are Core's copies of
+bitcoin/bips files, and btclib vendors the bips originals instead, each
+pinned against bitcoin/bips in `tests/_data/README.md`. No entry above
+pins Core's copy, on purpose: pinning a copy of an upstream makes a
+record drift for a reason that is not its subject's.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,6 +275,7 @@ source-exclude = [
     "/tests/generate_sbom_test.py",
     "/tests/mutation_counts_test.py",
     "/tests/normalize_sdist_test.py",
+    "/tests/tf2_ledger_test.py",
     "/tests/verify_dist_contents_test.py",
     "/tests/wait_for_hwi_device_test.py",
     "/tests/wait_for_pypi_release_test.py",

--- a/tests/tf2_ledger_test.py
+++ b/tests/tf2_ledger_test.py
@@ -1,0 +1,412 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""What `TF2.md` must say about Core's test framework, and must not.
+
+The ledger is one entry per Python file of Core's
+`test/functional/test_framework/`, and its whole value is that the
+entries can be re-checked. Two things rot such a record and neither is
+loud: an upstream file with no entry, and an entry whose btclib side has
+been renamed out from under it.
+
+The shape here is `tests/p2p/core_commands_test.py`'s, for the same
+reasons that module gives at length: Core's set is transcribed rather
+than fetched, so the verdict does not depend on somebody else's uptime,
+and the census is asserted in both directions, so a file gained upstream
+and an entry that has outlived its subject each land on a different
+assertion. `test_both_sides_of_the_census_were_read` is the guard
+against the failure that would otherwise make every comparison below
+pass for free -- a regex reworded past the text it reads answers with an
+empty set, and an empty set is a subset of everything.
+
+The entry's own grammar is not re-implemented here. It is
+`.github/scripts/check_vendored_vectors.py`'s, and that script is loaded
+by path and asked to parse `TF2.md`: a heading whose fenced block that
+parser skips is a heading the weekly re-check would silently never look
+at, which is exactly the drift the ledger exists to prevent. Loading it
+that way is `tests/check_vendored_vectors_test.py`'s idiom,
+`.github/scripts` being no package, and it is why `pyproject.toml`
+excludes this module from the sdist: the script is not shipped, so from
+an unpacked sdist this would be a fixture error rather than a test.
+
+What none of it can see is upstream. Whether the pinned commit is still
+the tip of its path is a network question, and the whole point of a pin
+is that answering it is somebody's weekly job rather than a condition of
+every test run. What is offline is that every upstream file has an
+entry, that every entry is one the re-checker can put that question to,
+that every btclib path an entry names is a file this tree has, and that
+no entry states a count.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_ROOT = Path(__file__).parents[1]
+_LEDGER = _ROOT / "TF2.md"
+_CHECKER = _ROOT / ".github" / "scripts" / "check_vendored_vectors.py"
+
+_UPSTREAM = "test/functional/test_framework"
+
+# every Python file of that directory at the commit the entries pin,
+# transcribed in the order `git/trees?recursive=1` lists them. A refresh
+# of the ledger is a diff over this tuple.
+_CORE_FILES = (
+    "__init__.py",
+    "address.py",
+    "authproxy.py",
+    "blockfilter.py",
+    "blocktools.py",
+    "compressor.py",
+    "coverage.py",
+    "crypto/bip324_cipher.py",
+    "crypto/chacha20.py",
+    "crypto/ellswift.py",
+    "crypto/hkdf.py",
+    "crypto/muhash.py",
+    "crypto/poly1305.py",
+    "crypto/ripemd160.py",
+    "crypto/secp256k1.py",
+    "crypto/siphash.py",
+    "descriptors.py",
+    "extendedkey.py",
+    "ipc_util.py",
+    "key.py",
+    "mempool_util.py",
+    "messages.py",
+    "netutil.py",
+    "p2p.py",
+    "psbt.py",
+    "script.py",
+    "script_util.py",
+    "segwit_addr.py",
+    "socks5.py",
+    "test_framework.py",
+    "test_node.py",
+    "test_shell.py",
+    "util.py",
+    "v2_p2p.py",
+    "wallet.py",
+    "wallet_util.py",
+)
+
+# the verdicts `TF2.md`'s own "The verdicts" section defines. A closed
+# vocabulary rather than free text: a verdict spelled some other way is
+# a row nobody can group with the rows it belongs with, and a verdict
+# defined and never used is a definition that has outlived its subject
+_VERDICTS = frozenset(
+    {
+        "covered",
+        "covered in part",
+        "vendored",
+        "tf2's by decision",
+        "tf2's (harness)",
+        "empty upstream",
+    }
+)
+
+# an entry's heading, which is the file's path in Core
+_HEADING = re.compile(rf"^### `({_UPSTREAM}/[^`]+)`$", re.MULTILINE)
+
+# the verdict opening the prose under a fenced block; what follows the
+# closing asterisks is the entry's own argument and is not read here
+_VERDICT = re.compile(r"^Verdict: \*\*([^*]+)\*\*", re.MULTILINE)
+
+# a path in a backtick span, which is how the prose names both Core's
+# files and this tree's. A trailing `.py` is what tells a path from the
+# module attributes and class names the same spans also carry
+_PATH = re.compile(r"`([\w./-]+\.py)`")
+
+# a digit run, or a spelled-out cardinal as a whole word. "one" and
+# "zero" are matched as digits only, never as words: in prose they are
+# articles and pronouns far more often than counts, which is
+# `tests/vendored_data_test.py`'s reading of the same rule
+_NUMERAL = re.compile(
+    r"(?i)\b(?:\d+|two|three|four|five|six|seven|eight|nine|ten|eleven|"
+    r"twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|"
+    r"nineteen|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety|"
+    r"hundred|thousand)\b"
+)
+
+# the numerals that name something rather than count it, subtracted
+# before `_NUMERAL` runs: an ISO date, a specification as the bips and
+# slips repositories spell one in a path, an RFC, an issue of this
+# tracker in either form the prose uses, and the variant number a
+# hyphen introduces after a name (RIPEMD-160). A specification spelled
+# without the hyphen needs no entry, `BIP340` offering no word boundary
+# in front of its digits
+_NOT_A_COUNT = re.compile(
+    r"\b\d{4}-\d{2}(?:-\d{2})?\b"
+    r"|(?i:\b(?:bip|slip)-\d+)"
+    r"|\bRFC \d+"
+    r"|(?i:\bissues?[ /]#?\d+)|\bISS \d+"
+    r"|(?<=[A-Za-z]-)\d+(?:-\d+)*"
+)
+
+_TEXT = _LEDGER.read_text(encoding="utf-8")
+_ENTRIES = tuple(_HEADING.findall(_TEXT))
+_VERDICTS_READ = tuple(_VERDICT.findall(_TEXT))
+
+
+def _prose_lines() -> list[str]:
+    """Every line of the ledger outside a fenced block.
+
+    A fence holds either the pin fields, whose `commit` and `behind` are
+    facts of a pin that "Reading an entry" already defines, or a shell
+    command, where a digit is an argument. Neither is prose stating a
+    count, and scanning them would say so once per entry.
+    """
+    lines = []
+    in_fence = False
+    for line in _TEXT.split("\n"):
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            lines.append(line)
+    return lines
+
+
+@pytest.fixture
+def checker(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Return the weekly re-checker, imported by path.
+
+    Registered in `sys.modules` before it runs, its `Entry` and `Drift`
+    dataclasses resolving their field types through the module name
+    under `from __future__ import annotations`. That is
+    `tests/check_vendored_vectors_test.py`'s own fixture, and the
+    duplication is deliberate: this module asks the script one question
+    about a different file, and importing a fixture out of a test module
+    of another subject would tie the two together for no other reason.
+    """
+    spec = importlib.util.spec_from_file_location("check_vendored_vectors", _CHECKER)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "check_vendored_vectors", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_both_sides_of_the_census_were_read() -> None:
+    """A comparison over a side that came up empty is true of nothing.
+
+    Every assertion below subtracts one set from another, and each of
+    them passes for free where the set being subtracted from is empty.
+    The ledger's side is read by a regex, which answers empty for a
+    heading spelled some other way; Core's side is a literal tuple,
+    which cannot be empty but can hold a path twice, in which case the
+    two censuses disagree about a file neither reports.
+    """
+    assert _ENTRIES, "no entry heading was found in TF2.md at all"
+    assert len(set(_ENTRIES)) == len(_ENTRIES), (
+        f"a file has more than one entry: {sorted(_ENTRIES)}"
+    )
+    assert len(set(_CORE_FILES)) == len(_CORE_FILES), (
+        f"a Core file is transcribed twice: {sorted(_CORE_FILES)}"
+    )
+    assert len(_VERDICTS_READ) == len(_ENTRIES), (
+        f"{len(_ENTRIES)} entries carry {len(_VERDICTS_READ)} verdicts"
+    )
+
+
+def test_every_core_file_has_an_entry() -> None:
+    """The census: a file of Core's directory is answered for."""
+    entries = {path.removeprefix(f"{_UPSTREAM}/") for path in _ENTRIES}
+    missing = sorted(set(_CORE_FILES) - entries)
+    assert not missing, f"no entry in TF2.md for: {missing}"
+
+
+def test_every_entry_names_a_core_file() -> None:
+    """The other direction, which is where a deleted file lands.
+
+    A file upstream renames or removes leaves an entry describing
+    something that is not there, and the entry goes on reading as a
+    statement about Core. The transcription above is what the entry is
+    held to; refreshing one means refreshing both.
+    """
+    entries = {path.removeprefix(f"{_UPSTREAM}/") for path in _ENTRIES}
+    unaccounted = sorted(entries - set(_CORE_FILES))
+    assert not unaccounted, f"an entry names no transcribed Core file: {unaccounted}"
+
+
+def test_every_verdict_is_one_of_the_defined_ones() -> None:
+    """A verdict is from the closed vocabulary the ledger defines."""
+    unknown = sorted({v for v in _VERDICTS_READ if v not in _VERDICTS})
+    assert not unknown, f"a verdict TF2.md does not define: {unknown}"
+
+
+def test_every_defined_verdict_is_used() -> None:
+    """A definition nothing uses is a definition nothing holds to.
+
+    The mirror of the assertion above, and the one that catches a
+    verdict whose last entry was rewritten: the definition survives, is
+    read as describing part of the ledger, and describes nothing.
+    """
+    unused = sorted(_VERDICTS - set(_VERDICTS_READ))
+    assert not unused, f"TF2.md defines a verdict no entry carries: {unused}"
+
+
+def _unresolved(paths: Iterable[str]) -> list[str]:
+    """Return the paths that name no file, in either of the two ways.
+
+    A path is written the way this tree writes one: relative to
+    `src/btclib` for the package's own modules, and from the root for
+    anything else. Core's own paths are recognized by their prefix and
+    held to the transcription above rather than to this checkout, there
+    being no checkout of Core here to hold them to.
+
+    A function rather than a loop inside the assertion below, so that
+    `test_the_resolution_reports_a_path_that_is_not_there` can drive
+    both of its answers: on a ledger that is right this reports nothing,
+    and a branch no green run crosses is a branch the coverage floor
+    fails on.
+    """
+    missing = []
+    for path in sorted(set(paths)):
+        if path.startswith(f"{_UPSTREAM}/"):
+            if path.removeprefix(f"{_UPSTREAM}/") not in _CORE_FILES:
+                missing.append(path)
+            continue
+        root = (
+            _ROOT
+            if path.split("/")[0] in {"tests", "src", ".github"}
+            else _ROOT / "src" / "btclib"
+        )
+        if not (root / path).is_file():
+            missing.append(path)
+    return missing
+
+
+def test_every_btclib_path_an_entry_names_exists() -> None:
+    """A module renamed out from under an entry is the quiet rot."""
+    missing = _unresolved(_PATH.findall(_TEXT))
+    assert not missing, f"TF2.md names a path this tree does not have: {missing}"
+
+
+def test_the_resolution_reports_a_path_that_is_not_there() -> None:
+    """The guard above passes for free if nothing can be unresolved.
+
+    One wrong path of each shape the ledger writes, beside the right one
+    it was made from: a package module, a path from the root, and a
+    Core path the transcription does not carry.
+    """
+    assert _unresolved(("block/build.py", "tests/block/build_test.py")) == []
+    assert _unresolved(("block/built.py",)) == ["block/built.py"]
+    assert _unresolved(("tests/block/built_test.py",)) == ["tests/block/built_test.py"]
+    gone = f"{_UPSTREAM}/blocktoolz.py"
+    assert _unresolved((gone,)) == [gone]
+
+
+def test_the_path_pattern_still_matches() -> None:
+    """The guard above passes for free if `_PATH` matches nothing.
+
+    Both shapes the ledger writes, and one that must not be read as a
+    path: a module attribute is a dotted name in a backtick span too,
+    and reading `kdf.hkdf` as a file would make the assertion above red
+    for a reason that is not a renamed module.
+    """
+    assert _PATH.findall("`block/build.py` and `tests/block/build_test.py`") == [
+        "block/build.py",
+        "tests/block/build_test.py",
+    ]
+    assert not _PATH.findall("`kdf.hkdf` and `hashes.siphash`")
+
+
+def test_no_entry_states_a_count() -> None:
+    """Enforces CLAUDE.md's "Never state how many of anything a file holds".
+
+    The rule `tests/vendored_data_test.py` enforces on
+    `tests/_data/README.md`, applied here with no allowlist beside it: a
+    count of the entries, of the covered files or of the uncovered ones
+    is exactly the number that is exact today, wrong after the next
+    upstream commit, and plausible throughout. Nothing in this ledger
+    needs one, the entries being the fact such a number would summarize.
+
+    CLAUDE.md's own exception -- a count of what upstream published --
+    has no instance here either, and that is a decision rather than an
+    accident: a line count or a function count of a Core file measures
+    upstream honestly and still has to be refreshed with the pin, so an
+    entry states what the file is instead of how big it is.
+    """
+    offenders = sorted(
+        {
+            line
+            for line in _prose_lines()
+            if _NUMERAL.search(_NOT_A_COUNT.sub(" ", line))
+        }
+    )
+    assert not offenders, f"TF2.md states a numeral that is not exempt: {offenders}"
+
+
+def test_the_numeral_pattern_still_matches() -> None:
+    """The guard above passes for free if `_NUMERAL` matches nothing.
+
+    The failure mode of every assertion written in the negative, and the
+    one the file it reads cannot reveal. The strings below are the
+    shapes a count of this ledger would take.
+    """
+    for text in (
+        "The ledger has 36 entries.",
+        "Thirty-six files, of which twelve are tf2's.",
+        "- 7 files here",
+        "Nine of them are the harness.",
+    ):
+        assert _NUMERAL.search(_NOT_A_COUNT.sub(" ", text)), text
+
+
+def test_a_numeral_that_names_something_is_subtracted() -> None:
+    """`_NOT_A_COUNT` fails in two directions and one of them is quiet.
+
+    A shape that stops matching puts its line back in front of
+    `_NUMERAL`, and the guard above says which line. A shape reaching
+    past what it names swallows a count beside it and nothing says so,
+    which is what the second group is for: each of those states a count
+    *and* carries something the subtraction takes out.
+    """
+    for named in (
+        "commit  0f206eed51e2d00aa78f709ecc427b484d04b4d5  2026-09-05",
+        "vectors of `bip-0327/vectors/`, vendored whole",
+        "`tests/kdf_test.py` runs RFC 5869's own vectors",
+        "[ISS 1120](https://github.com/btclib-org/btclib/issues/1120) is where",
+        "`hashlib` offers no RIPEMD-160; its docstring carries",
+        "secp256k1 alone, over BIP340's own vectors and MuHash3072",
+    ):
+        assert not _NUMERAL.search(_NOT_A_COUNT.sub(" ", named)), named
+    for counted in (
+        "Six entries were read at 2026-09-05.",
+        "ISS 1120 left three of them out.",
+    ):
+        assert _NUMERAL.search(_NOT_A_COUNT.sub(" ", counted)), counted
+
+
+def test_the_weekly_re_checker_reads_every_entry(checker: ModuleType) -> None:
+    """Every entry is one the re-checker can ask upstream about.
+
+    The grammar is that script's, so this is what says the ledger is in
+    it: an entry whose fenced block lacks `repo`, `path` or `commit`, or
+    whose `behind` does not read zero, is skipped by the script and
+    would be skipped in silence once the ledger is wired into the weekly
+    run. Wiring it is a change owed to btclib-secp256k1's copy of the
+    script as well, and is not this file's; being parseable is.
+    """
+    entries, skipped = checker._entries_at_tip(_TEXT)
+    assert not skipped, f"the re-checker would skip: {skipped}"
+    assert [entry.heading for entry in entries] == [f"`{path}`" for path in _ENTRIES], (
+        "the re-checker reads other headings than the ledger's own"
+    )
+    assert all(entry.repo == "bitcoin/bitcoin" for entry in entries)
+    assert all(entry.path == entry.heading.strip("`") for entry in entries), (
+        "an entry's `path` field and its heading name different files"
+    )
+    assert all(re.fullmatch(r"[0-9a-f]{40}", entry.commit) for entry in entries), (
+        "a pin is not a full commit sha"
+    )


### PR DESCRIPTION
Closes #1124

`TF2.md` at the repository root: one entry per file of Core's `test/functional/test_framework`, each pinned to the Core commit it was read at, each carrying a verdict about btclib's counterpart. `tests/tf2_ledger_test.py` holds the file to its shape.

The three decisions this answers were taken on the issue before the work started — the file's name and place, per-path *tip* pins in `check_vendored_vectors.py`'s grammar, and the weekly wiring split off into its own issue.

## Why a tip pin and not a "tree I read" commit

Two pin conventions exist and are not interchangeable. A repository-wide commit says *this is the tree I read* and is resolvable through `contents/<path>?ref=<sha>`; a per-path pin says *this is the tip of this path*, and only for the second can `behind 0` ever hold. Every entry here is the second kind, and the file says so where a reader would otherwise assume the first.

## What the test can and cannot see

It runs offline. It asserts the census in both directions against a transcription of Core's directory, a closed verdict vocabulary in both directions, that every btclib path an entry names is a file of this tree, that no entry states a count, and that the weekly re-checker's own parser reads every entry and skips none.

What it cannot see is upstream, in more than one way — and the file, the entry and the commit message all say both. Whether a pin is still the tip of its path is a network question, which the weekly job will answer. Whether Core has *gained* a file is another, since the census holds the ledger to that transcription rather than to the directory; listing the directory at a fresh commit is the read that answers it.

## What review corrected

Two blocking findings, both mine to fix and both about the file's own claims rather than its structure:

**The re-check procedure destroyed the reader's `PATH`.** It said `path=<the path the entry gives>`. In `zsh` — the shell this is read in — `path` is tied to `PATH` as an array, so that assignment replaces the reader's `PATH` with one file path and the next command in their terminal is not found. The stated guard fails open there too: `${path:?}` never fires, `path` being always set, where `bash` refuses it. Measured both ways before rewriting:

```text
zsh -c 'path=a/b.py; git --version'         -> command not found: git
bash -c 'path=a/b.py; git --version'        -> git version 2.50.1, PATH intact
zsh  -c 'printf "%s\n" "path=${path:?}"'    -> prints the whole PATH, exit 0
bash -c 'printf "%s\n" "path=${path:?}"'    -> path: parameter null or not set
zsh  -c 'printf "%s\n" "${entry_path:?}"'   -> entry_path: parameter not set
```

The variable is `entry_path` now, the API argument stays `path=` where it belongs, and the paragraph says why.

**The `muhash.py` entry credited Core's pinned Python file with a serialization it does not have.** Re-fetched at that entry's own pin `fec2ca6c`: `__init__`, `insert`, `remove`, `digest`, and the only `to_bytes` is inside `digest`. btclib's `serialize`/`deserialize` answer Core's **C++** class — `SERIALIZE_METHODS(MuHash3072, obj)`, numerator then denominator, which is the order `muhash.py` writes and what its docstring cites. The verdict **covered** was right; the clause about the pinned file was not, and the pinned file is the one side the pin exists to make re-checkable.

Two non-blocking findings applied as well. The `blockfilter.py` entry attributed to Core's Python the rule Core's C++ has: Core's Python asks `type != 'nulldata'`, where btclib tests the first byte for `OP_RETURN` as `BasicFilterElements` does and argues the difference beside `_OP_RETURN`. The verdict was right and btclib is the one following the BIP; the entry now names both. And the gained-file gap above was recorded in three places rather than left implicit.

## The guard caught the person applying the findings

Rewriting the `blockfilter.py` clause, I used the word "two" twice, and `test_no_entry_states_a_count` went red on exactly those lines:

```text
AssertionError: TF2.md states a numeral that is not exempt:
['`prevout_scripts_from_utxos` rather than read off a node. The two draw',
 'two differ.']
```

Worth recording for two reasons. It is stronger evidence that the guard has the shape of the defect than the seven deliberate tampers the coder ran, because it fired on prose nobody wrote to be caught. And the response was to reword rather than to widen `_NOT_A_COUNT` — the test blob is byte-identical across the fix — which is the right one: an exemption for "the two" as a pronoun is exactly the hole that pattern declines to open.

## Not in this branch

The wiring into `.github/workflows/vendored-vectors.yml`, deliberately, per the issue's third decision — that script takes one README path and `_ISSUE_TITLE` is a module constant, and the same change is owed to `btclib-secp256k1`'s copy. Its issue gets filed when this lands. [ISS 1726](https://github.com/btclib-org/btclib/issues/1726) is the other collateral: Core `test_framework` citations scattered through `src/` and `tests/` name no revision now that this file pins every path.

## Gates

- `uvx pre-commit run --all-files` → exit 0, tree clean afterwards
- `uv run --locked pytest -q` → exit 0, 100% floor held
- `uv run --locked sphinx-build -n -W -b html` → exit 0

All three on this sha, after the rebase. Reviewed at fresh context, `CHANGES REQUESTED` then `CLEARED` on the delta, with the pins re-derived against Core's current tip in the second round — Core's `master` moved between rounds and all 36 are still at tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Establish a pinned, validated ledger of Bitcoin Core’s functional test framework coverage in btclib.

New Features:
- Add a root-level TF2 ledger documenting coverage and non-coverage for every Bitcoin Core functional test framework Python file, with per-path upstream commit pins and explicit verdicts.

Enhancements:
- Add offline validation that the ledger census is complete in both directions, verdicts are valid and used, referenced btclib paths exist, counts are not stated, and all entries are parseable by the weekly re-checker.
- Document the ledger’s re-checking model, pin semantics, coverage boundaries, and treatment of non-Python upstream files.

Build:
- Exclude the ledger-specific test from source distributions because it depends on repository-only checker infrastructure.

Documentation:
- Record the TF2 coverage ledger and its maintenance and re-checking guidance in TF2.md and the changelog.

Tests:
- Add tests enforcing the TF2 ledger’s structure, coverage census, verdict vocabulary, path resolution, count-free prose, and compatibility with the vendored-vector checker.