### PR TITLE
`tests/fetch` holds each guard on the boundary to its own value (closes #1716)

### DIFF
--- a/.github/mutation/fetch.toml
+++ b/.github/mutation/fetch.toml
@@ -52,25 +52,25 @@ excluded-modules = []
 # itself rather than by the grep alone: `cosmic-ray init` over this file
 # enumerates the 474 mutants the session below did, and
 # `cosmic_ray.tools.filters.operators_filter` marks 110 of them SKIPPED
-# -- the same 110 the session below finds surviving on annotation lines,
-# and the "class fetch.toml documents" every other profile's own comment
-# points back to -- leaving 364 for a future session to have an opinion
-# about (issue #987).
+# -- the annotation lines the session below records as skipped, and the
+# "class fetch.toml documents" every other profile's own comment points
+# back to -- leaving the 364 that session executes (issue #987).
+#
+# That class is deferred evaluation, and this is what the other profiles
+# point back here for: an annotation is not evaluated where it is
+# written, so `str | bytes | None` rewritten `str + bytes + None` is
+# never built and no call changes. `bitcoin_core.py` has that from PEP
+# 649 and the 3.14 `.python-version` pins, `esplora.py` and
+# `bitcoin_core_rest.py` from `from __future__ import annotations` as
+# well. The filter is what keeps them out of a session that would
+# otherwise run them and find every one of them surviving.
 [cosmic-ray.filters.operators-filter]
 exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 
-# 474 mutants, complete: 314 killed, 160 survived. Four classes account
-# for 142 of the 160, and eighteen belong to none of them:
+# 474 mutants, complete: 332 killed, 32 survived, 110 skipped by the
+# filter above, for a survival rate of 8.79% over the 364 executed.
+# Three classes account for every survivor and nothing is left over:
 #
-# - 110 are `X | None` annotations, in `bitcoin_core.py`,
-#   `bitcoin_core_rest.py` and `esplora.py`. This is the class the other
-#   profiles' comments point back here for, and it is deferred
-#   evaluation: an annotation is not evaluated where it is written, so
-#   `str | bytes | None` rewritten `str + bytes + None` is never built
-#   and no call changes. `bitcoin_core.py` has that from PEP 649 and the
-#   3.14 `.python-version` pins, the other two from `from __future__
-#   import annotations` as well. The filter above is what keeps them out
-#   of a session that would otherwise run them.
 # - 5 in `fetcher.py` are equivalent by inspection: `==` against `is` on
 #   the very object `NETWORKS` holds, and four `check_validity=False`
 #   turned `True`, each on data the line beside it has already
@@ -90,20 +90,19 @@ exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 #   docstring saying so, and a private method's calling convention is
 #   nothing this library promises.
 #
-# The 18 left are what this boundary is held to on either side of a call --
-# what a reply is checked against, and what a request carries -- and
-# `tests/fetch` does not notice any of them weakened: the three `-rest` body
-# bounds moved by one, six comparisons turned into orderings -- issue #978's
-# shape, in `bitcoin_core_rest.py`'s and `esplora.py`'s `assert_network`, in
-# both broadcasts' txid check and at `esplora.py`'s `status != 200` --
-# `include_witness=True` turned `False` in both broadcasts, `esplora.py`'s
-# `Content-Type` condition read either way, and `ElectrumFetcher`'s
-# request-id counter, which `+= 0` makes the constant `_next_request_id`'s
-# own docstring rules out. Issue #1716 has each with its line and is where
-# they are answered.
+# What this boundary is held to on either side of a call -- what a reply
+# is checked against, and what a request carries -- is measured rather
+# than argued: each `-rest` body bound moved by one, the comparisons
+# turned into orderings in `bitcoin_core_rest.py`'s and `esplora.py`'s
+# `assert_network`, in both broadcasts' txid check and at `esplora.py`'s
+# `status != 200`, `include_witness=True` turned `False` in both
+# broadcasts, `esplora.py`'s `Content-Type` condition read either way,
+# and `ElectrumFetcher`'s request-id counter, which `+= 0` makes the
+# constant `_next_request_id`'s own docstring rules out -- each of them
+# is a failing test in `tests/fetch` (issue #1716).
 #
-# So the rate is not the reading here: those eighteen are, and a verdict
-# worth acting on is one that moves among them.
+# So the rate is not the reading here: a survivor outside those three
+# classes is, and it is a test nobody has written.
 
 [cosmic-ray.distributor]
 name = "local"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -851,6 +851,41 @@ file of the test tree, and no caller acts on it.
   has gained a file is another, the census holding the ledger to that
   transcription rather than to the directory.
 
+### `tests/fetch` holds each guard on the boundary to its own value
+
+- **A `-rest` body bound moved either way is a failing test** (closes
+  #1716). A reply one octet over the limit is refused with that limit in
+  the message, and the recorded answer inside it is accepted, so a
+  chaininfo reply, a block hash and a header are each held to the size
+  their endpoint answers rather than to something wider.
+- **A wrong value sorting each way is what tells an ordering from an
+  inequality**, and the checks on this boundary each get one on each
+  side: a node naming a chain that sorts before the fetcher's own, an
+  explorer serving a genesis that sorts before it, a broadcast answered
+  with a status below 200, and a host confirming a txid on either side
+  of the one it was handed.
+- **A signet challenge is asked for on signet and nowhere else**, which
+  the testnets pin: their chain names sort after `signet`, so a name
+  check weakened to an ordering would derive a magic for a testnet and
+  then read a member no node reports outside a signet.
+- **The broadcasts announce a transaction that has a witness.** The
+  witness separates the two serializations of one transaction and the id
+  is computed from the one without it, so a broadcast stripping it sends
+  bytes carrying none of the signatures under the id the host confirms
+  either way, which a witnessless vector cannot tell apart. The vector
+  is a spend out of the block already vendored under `tests/block/_data`.
+- **`POST /tx` carries the `Content-Type` and the reads carry none**,
+  the header describing a body a GET does not send.
+- **One `ElectrumFetcher` asked two questions sends two request ids.**
+  `decode_response` refuses a reply answering another id, which is a
+  check on a counter and no check at all on a constant.
+- **`.github/mutation/fetch.toml`'s header records what a session over
+  it measures**, every survivor of that session belonging to a class the
+  comment argues. The entry above that opened this scope says the
+  boundary's own guards go unnoticed when weakened, and names issue
+  #1716 as where they are answered; it stays as the record of what a
+  session found then, and this is that answer.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/fetch/__init__.py
+++ b/tests/fetch/__init__.py
@@ -47,6 +47,27 @@ TIP_HEADER_RAW = (
     "0040d1ca077fefe7fb797711baa0c063eca9b8ed9469ae0128982b44ad0c253864913"
     "29e59e93c011822ff5422"
 )
+# transaction 22 of block 481824, read out of
+# tests/block/_data/block_481824_complete.bin: a P2SH-P2WPKH spend, and
+# the transaction the broadcasts announce. A witness is what separates
+# the two serializations of one transaction, and the id is computed from
+# the one without it -- so a broadcast that stripped the witness sends
+# bytes carrying none of the signatures and still names this same id,
+# which is why a witnessless vector cannot tell the two apart
+SEGWIT_TX_RAW = (
+    "0200000000010140d43a99926d43eb0e619bf0b3d83b4a31f60c176beecfb9d3"
+    "5bf45e54d0f7420100000017160014a4b4ca48de0b3fffc15404a1acdc8dbaae"
+    "226955ffffffff0100e1f5050000000017a9144a1154d50b03292b3024370901"
+    "711946cb7cccc387024830450221008604ef8f6d8afa892dee0f31259b6ce02d"
+    "d70c545cfcfed8148179971876c54a022076d771d6e91bed212783c9b06e0de6"
+    "00fab2d518fad6f15a2b191d7fbd262a3e0121039d25ab79f41f75ceaf882411"
+    "fd41fa670a4c672c23ffaf0e361a969cde0692e800000000"
+)
+# another transaction of that block, and the wrong id that sorts *after*
+# the one above where block 170's coinbase sorts before it: a check that
+# a backend confirmed what it was handed is an inequality, and a fixture
+# offering one wrong value cannot say whether it is an ordering instead
+LATER_TX_ID = "dfcec48bb8491856c353306ab5febeb7e99e4d783eedf3de98f3ee0812b92bad"
 
 
 def recorded_body(name: str) -> bytes:

--- a/tests/fetch/bitcoin_core_rest_test.py
+++ b/tests/fetch/bitcoin_core_rest_test.py
@@ -25,6 +25,7 @@ from bitcoin_core_rpc import (
     DEFAULT_SIGNET_CHALLENGE,
     BitcoinCoreRestClient,
     SessionTransport,
+    chain_from_network,
 )
 
 from btclib.exceptions import BTClibTypeError, BTClibValueError, FetchError, HttpError
@@ -316,6 +317,19 @@ def test_a_node_on_another_chain_answers_no_fetch_at_all() -> None:
     assert urls(endpoint) == [f"{URL}/rest/chaininfo.json"]
 
 
+def test_a_node_on_a_chain_sorting_before_the_expected_one_is_refused() -> None:
+    """The refusal is inequality with the chain name, not an ordering on it.
+
+    Core names mainnet `main`, which sorts before `signet`: a signet
+    fetcher over a mainnet node is the case a guard written `>` accepts,
+    where the mainnet fetcher over a `test` node above refuses under that
+    same weakening.
+    """
+    endpoint = client((200, chaininfo(chain="main", blocks=TIP_HEIGHT)))
+    with pytest.raises(BTClibValueError, match="reports chain 'main'"):
+        BitcoinCoreRestFetcher(endpoint, "signet").assert_network()
+
+
 def test_a_node_that_could_not_be_asked_is_asked_again() -> None:
     """A node that did not answer said nothing about which chain it is on."""
     endpoint = client(
@@ -419,6 +433,21 @@ def test_a_signet_challenge_that_cannot_be_read_is_no_answer(body: bytes) -> Non
         BitcoinCoreRestFetcher(client((200, body)), "signet").assert_network()
 
 
+@pytest.mark.parametrize("network", ["testnet", "testnet4"])
+def test_a_testnet_node_is_not_asked_for_a_signet_challenge(network: str) -> None:
+    """A magic is signet's question, and the chain name is what asks it.
+
+    Core's names for the testnets sort after `signet`, so a check written
+    `>=` would derive a magic for a testnet and then read a member no
+    node reports outside one -- turning an agreement into a reply this
+    cannot read.
+    """
+    chain = chain_from_network(network)
+    BitcoinCoreRestFetcher(
+        client((200, chaininfo(chain=chain, blocks=TIP_HEIGHT))), network
+    ).assert_network()
+
+
 def test_a_challenge_is_refused_where_it_would_check_nothing() -> None:
     """Refused at construction, where the mistake was written."""
     with pytest.raises(BTClibValueError, match="challenge for mainnet"):
@@ -456,6 +485,43 @@ def test_the_body_bound_admits_a_maximal_signet_challenge() -> None:
     BitcoinCoreRestFetcher(
         client((200, answer)), "signet", signet_challenge=maximal
     ).assert_network()
+
+
+def test_each_answer_is_bounded_by_what_it_is() -> None:
+    """A chaininfo reply, a block hash and a header, each bounded by what it is.
+
+    The client's own default is wide enough for a block, which is the
+    bound a raw transaction wants and no other answer here does: a node
+    answering `/blockhashbyheight` with a block's worth of octets is
+    answering something that is not a hash, and there is no reason to
+    hold it in order to find that out. The hash and the header bounds
+    are the size their endpoint answers with; the chaininfo bound is
+    what a maximal signet challenge needs, which the constant's own
+    comment argues. Each refusal carries the number it was measured
+    against, which is what pins the bound to its value.
+    """
+    with pytest.raises(FetchError, match="more than the max_body_size of 32768"):
+        fetcher((200, b"x" * 32769)).get_block_count()
+
+    with pytest.raises(FetchError, match="more than the max_body_size of 32"):
+        fetcher((200, b"\x00" * 33)).get_block_header(TIP_HEIGHT)
+
+    oversized_header = fetcher(
+        (200, recorded_body("rest_blockhashbyheight.bin")), (200, b"\x00" * 81)
+    )
+    with pytest.raises(FetchError, match="more than the max_body_size of 80"):
+        oversized_header.get_block_header(TIP_HEIGHT)
+
+    # and the recorded answers are inside their limits, which is the
+    # other half of the claim
+    assert fetcher((200, recorded_body("rest_chaininfo.json"))).get_block_count() == (
+        TIP_HEIGHT
+    )
+    inside = fetcher(
+        (200, recorded_body("rest_blockhashbyheight.bin")),
+        (200, recorded_body("rest_headers.bin")),
+    )
+    assert inside.get_block_header(TIP_HEIGHT).hash.hex() == TIP_ID
 
 
 def test_a_challenge_that_is_no_script_fails_at_the_constructor() -> None:

--- a/tests/fetch/bitcoin_core_test.py
+++ b/tests/fetch/bitcoin_core_test.py
@@ -49,7 +49,15 @@ from btclib.fetch.bitcoin_core import BitcoinCoreFetcher
 from btclib.fetch.transport import DEFAULT_MAX_BODY_SIZE
 from btclib.network import NETWORKS
 from btclib.tx import OutPoint, Tx
-from tests.fetch import TIP_HEIGHT, TIP_ID, TX_ID, Recorded, recorded_body
+from tests.fetch import (
+    LATER_TX_ID,
+    SEGWIT_TX_RAW,
+    TIP_HEIGHT,
+    TIP_ID,
+    TX_ID,
+    Recorded,
+    recorded_body,
+)
 
 # the rpc credentials every test here passes. Named once rather than
 # written at each call, which is what keeps the string out of a
@@ -162,13 +170,14 @@ def asked(endpoint: BitcoinCoreRpcClient) -> list[str]:
 
 
 def broadcast_tx() -> Tx:
-    """Return the recorded transaction, parsed, as a signed Tx to announce.
+    """Return the transaction the broadcast tests announce, parsed.
 
-    The same transaction `getrawtransaction.json` answers `get_tx` with:
-    it exists already, so broadcasting it needs no new vector of its own.
+    A segwit spend and not the transaction `getrawtransaction.json`
+    answers `get_tx` with: what `sendrawtransaction` carries is the wire
+    serialization, and a transaction with no witness has one
+    serialization rather than two.
     """
-    body = json.loads(recorded_body("getrawtransaction.json"))
-    return Tx.parse(bytes.fromhex(body["result"]))
+    return Tx.parse(SEGWIT_TX_RAW)
 
 
 def test_get_tx_parses_the_serialization_the_node_sent() -> None:
@@ -680,6 +689,11 @@ def test_broadcast_sends_the_wire_serialization_and_returns_the_txid() -> None:
     has no null the way `sendrawtransaction`'s optional parameter reads
     it, so a caller who passed nothing gets a request with one parameter,
     not two.
+
+    The witness is in that serialization: the two serializations of this
+    transaction are different bytes under one id, so a broadcast
+    stripping it announces a transaction carrying none of the signatures
+    and the node confirms the same id either way.
     """
     tx = broadcast_tx()
     endpoint = client(
@@ -690,6 +704,9 @@ def test_broadcast_sends_the_wire_serialization_and_returns_the_txid() -> None:
     assert asked(endpoint) == ["sendrawtransaction"]
     body = sent(endpoint)
     assert body["params"] == [tx.serialize(include_witness=True).hex()]
+    # the vector tells the two serializations apart, which is the other
+    # half of the claim
+    assert tx.serialize(include_witness=False) != tx.serialize(include_witness=True)
 
 
 def test_broadcast_passes_maxfeerate_only_when_given() -> None:
@@ -703,14 +720,24 @@ def test_broadcast_passes_maxfeerate_only_when_given() -> None:
     assert body["params"] == [tx.serialize(include_witness=True).hex(), 0.02]
 
 
-def test_broadcast_refuses_a_success_naming_another_txid() -> None:
-    """The node answered for a transaction that is not the one it was sent."""
+@pytest.mark.parametrize(
+    "confirmed",
+    # the coinbase of block 170, whose id sorts before the transaction
+    # announced, and one of block 481824's, whose id sorts after it
+    ["b1fea52486ce0c62bb442b530a3f0132b826c74e473d1f2c220bfa78111c5082", LATER_TX_ID],
+)
+def test_broadcast_refuses_a_success_naming_another_txid(confirmed: str) -> None:
+    """The node answered for a transaction that is not the one it was sent.
+
+    One wrong id on each side of the one announced: the check is
+    inequality, and a guard written `<` hands the second back as the id
+    of a broadcast the node never confirmed.
+    """
     tx = broadcast_tx()
-    other = "b1fea52486ce0c62bb442b530a3f0132b826c74e473d1f2c220bfa78111c5082"
     endpoint = client(
-        (200, json.dumps({"jsonrpc": "2.0", "result": other, "id": "x"}).encode())
+        (200, json.dumps({"jsonrpc": "2.0", "result": confirmed, "id": "x"}).encode())
     )
-    with pytest.raises(FetchError, match=f"the node confirmed {other}"):
+    with pytest.raises(FetchError, match=f"the node confirmed {confirmed}"):
         BitcoinCoreFetcher(endpoint, verify_network=False).broadcast(tx)
 
 

--- a/tests/fetch/electrum_test.py
+++ b/tests/fetch/electrum_test.py
@@ -305,6 +305,22 @@ def test_a_response_whose_id_does_not_match_is_refused() -> None:
         fetcher(wrong_id).get_tx(MERKLE_TX_ID)
 
 
+def test_two_questions_carry_two_request_ids() -> None:
+    """A counter and not a constant, read off the wire rather than stated.
+
+    `decode_response` refuses a line answering a different id, so two
+    requests sharing one id could not be told apart by anything this
+    codec checks: what one fetcher asked, in order, is the whole of the
+    evidence for that.
+    """
+    tip = {"height": TIP_HEIGHT, "hex": TIP_HEADER_RAW}
+    endpoint = fetcher(tip)
+    endpoint.get_block_count()
+    endpoint.get_best_block_id()
+    ids = [json.loads(request)["id"] for request in transport_of(endpoint).requests]
+    assert ids == [1, 2]
+
+
 def test_a_line_that_is_not_json_is_refused() -> None:
     """A line a server never sends, refused rather than misread."""
     with pytest.raises(FetchError, match="not a JSON-RPC line"):

--- a/tests/fetch/esplora_test.py
+++ b/tests/fetch/esplora_test.py
@@ -19,6 +19,8 @@ from btclib.fetch.transport import SessionTransport
 from btclib.network import NETWORKS
 from btclib.tx import OutPoint, Tx
 from tests.fetch import (
+    LATER_TX_ID,
+    SEGWIT_TX_RAW,
     TIP_HEADER_RAW,
     TIP_HEIGHT,
     TIP_ID,
@@ -37,12 +39,13 @@ TESTNET_GENESIS = NETWORKS["testnet"].genesis_block.hex()
 
 
 def broadcast_tx() -> Tx:
-    """Return the recorded transaction, parsed, as a signed Tx to announce.
+    """Return the transaction the broadcast tests announce, parsed.
 
-    The same one `esplora_tx_hex.txt` answers `get_tx` with: it exists
-    already, so broadcasting it needs no new vector of its own.
+    A segwit spend and not the one `esplora_tx_hex.txt` answers `get_tx`
+    with: what `POST /tx` carries is the wire serialization, and a
+    transaction with no witness has one serialization rather than two.
     """
-    return Tx.parse(bytes.fromhex(recorded_body("esplora_tx_hex.txt").decode().strip()))
+    return Tx.parse(SEGWIT_TX_RAW)
 
 
 def fetcher(
@@ -223,6 +226,17 @@ def test_assert_network_refuses_a_different_genesis() -> None:
     """
     with pytest.raises(BTClibValueError, match=f"{TESTNET_GENESIS}.*{MAINNET_GENESIS}"):
         fetcher((200, TESTNET_GENESIS.encode())).assert_network()
+
+
+def test_assert_network_refuses_a_genesis_sorting_before_the_expected_one() -> None:
+    """The refusal is inequality with the genesis, not an ordering against it.
+
+    Mainnet's genesis sorts before testnet's, so a testnet fetcher over a
+    mainnet explorer is the case a guard written `>` accepts, where the
+    mainnet fetcher above refuses under the same weakening.
+    """
+    with pytest.raises(BTClibValueError, match=f"{MAINNET_GENESIS}.*{TESTNET_GENESIS}"):
+        fetcher((200, MAINNET_GENESIS.encode()), network="testnet").assert_network()
 
 
 def test_the_first_fetch_asks_the_explorer_which_chain_it_serves() -> None:
@@ -407,7 +421,13 @@ def test_the_body_of_a_failure_is_not_held_to_the_answer_limit() -> None:
 
 
 def test_broadcast_posts_the_wire_serialization_and_returns_the_txid() -> None:
-    """`POST /tx`, the hex body, the txid the server answers as text."""
+    """`POST /tx`, the hex body, the txid the server answers as text.
+
+    The witness is in the body: the two serializations of this
+    transaction are different bytes under one id, so what a broadcast
+    stripping it announces is a transaction carrying none of the
+    signatures, at the id the server confirms either way.
+    """
     tx = broadcast_tx()
     transport = Recorded((200, tx.id.hex().encode()))
     esplora = EsploraFetcher(BASE, transport=transport, verify_network=False)
@@ -416,13 +436,53 @@ def test_broadcast_posts_the_wire_serialization_and_returns_the_txid() -> None:
     assert transport.request.full_url == f"{BASE}/tx"
     assert transport.request.get_method() == "POST"
     assert transport.body == tx.serialize(include_witness=True).hex().encode("ascii")
+    # the vector tells the two serializations apart, which is the other
+    # half of the claim
+    assert tx.serialize(include_witness=False) != tx.serialize(include_witness=True)
 
 
-def test_broadcast_refuses_a_success_naming_another_txid() -> None:
-    """The server answered for a transaction that is not the one it was sent."""
+def test_a_content_type_rides_with_a_body_and_not_with_a_read() -> None:
+    """`Content-Type` rides with a body, and a GET has none to describe.
+
+    Esplora reads `POST /tx`'s body as the hex of a transaction, so the
+    header says what it is; a header on the reads would describe a
+    request that carries nothing.
+    """
     tx = broadcast_tx()
-    with pytest.raises(FetchError, match=f"the server confirmed {OTHER_ID}"):
-        fetcher((200, OTHER_ID.encode())).broadcast(tx)
+    posting = Recorded((200, tx.id.hex().encode()))
+    EsploraFetcher(BASE, transport=posting, verify_network=False).broadcast(tx)
+    assert posting.request.get_header("Content-type") == "text/plain"
+
+    getting = Recorded((200, recorded_body("esplora_blocks_tip_height.txt")))
+    EsploraFetcher(BASE, transport=getting, verify_network=False).get_block_count()
+    assert getting.request.get_header("Content-type") is None
+
+
+@pytest.mark.parametrize("confirmed", [OTHER_ID, LATER_TX_ID])
+def test_broadcast_refuses_a_success_naming_another_txid(confirmed: str) -> None:
+    """The server answered for a transaction that is not the one it was sent.
+
+    One wrong id sorting before the transaction announced and one after:
+    the check is inequality, and a guard written `<` hands the second
+    back as the id of a broadcast the server never confirmed.
+    """
+    tx = broadcast_tx()
+    with pytest.raises(FetchError, match=f"the server confirmed {confirmed}"):
+        fetcher((200, confirmed.encode())).broadcast(tx)
+
+
+@pytest.mark.parametrize("status", [100, 429, 503])
+def test_the_status_of_a_broadcast_failure_is_a_field(status: int) -> None:
+    """A broadcast reads its status the way a read does, and reports it.
+
+    100 is below 200, not above it: `!= 200` weakened to `> 200` refuses
+    every status above and accepts every status below, and what an
+    accepted one costs here is a body read as the id of a transaction
+    the server never took.
+    """
+    with pytest.raises(HttpError) as exc:
+        fetcher((status, b"no")).broadcast(broadcast_tx())
+    assert exc.value.status == status
 
 
 def test_broadcast_verifies_the_network_before_sending_anything() -> None:


### PR DESCRIPTION
Closes #1716

Eighteen mutants of `src/btclib/fetch/` survived a complete session over `.github/mutation/fetch.toml`, and each was a test `tests/fetch` did not have. Each now has one, and each test was proved to kill the mutant it is for.

## What was missing, by group

- **The `-rest` body bounds were unpinned**, where `esplora.py`'s three and `bitcoin_core.py`'s `_MAX_SMALL_REPLY` are killed in both directions. A reply one octet over the limit is now refused with that limit in the message, and the recorded answer inside it accepted.
- **Six comparisons leaked the one ordering their fixture's single wrong value happened to satisfy** — issue #978's shape, where an ordering cannot be told from an inequality by a fixture offering one wrong value. The fix is a second wrong value sorting the other way, and each of the six now has one on each side.
- **Both broadcasts serialized with `include_witness=True`, and nothing saw it turned `False`.** The old vector was witnessless, so the two serializations were the same bytes. The new one is a segwit spend out of the block already vendored under `tests/block/_data`, and an added assertion that `serialize(False) != serialize(True)` is what stops that vector silently regressing.
- **Esplora's `Content-Type` was not observed**, so nothing distinguished the request that carries it from the one that does not.
- **`ElectrumFetcher`'s request id could be a constant** — `+= 0` survived — which `_next_request_id`'s own docstring rules out in as many words. The test asks one fetcher two questions and reads the two *request* lines.

## How each was established

Red-then-green, one mutant at a time, with `__pycache__` cleared on both sides of every run and the source restored from bytes held in memory with its sha256 re-checked. Red exit 1 and green exit 0 for every one of the eighteen.

Two controls, because a harness that reports everything red measures nothing:

- **Negative**: `@override` removed from `BitcoinCoreFetcher.get_tx` — a documented survivor — exits 0 red. The harness reports a survivor as surviving.
- **The "before" measured rather than deduced**: this branch changes no file under `src/btclib/` (`git rev-parse <base>:src <tip>:src` is the same tree object), so `tests/fetch` was swapped back to `origin/main`'s blobs and all eighteen re-applied — **all eighteen exit 0**. They survive the suite as `main` has it.

## The session, re-run

`fetch: killed 332, survived 32, skipped 110; survival 8.79% over the 364 executed.` The 32 are 20 `@override` removals, 7 on the keyword-only `*` marker, 1 `Eq_Is` and 4 `ReplaceFalseWithTrue` — every one in a class the configuration's comment argues, nothing left over. `.github/mutation/fetch.toml`'s header states that measurement.

Two of its standing claims were false without being among the eighteen: a sentence calling the filtered annotation mutants "the same 110 the session below finds surviving", where the session below skips them, and the survivor bullet that *was* the tree-wide documentation of the deferred-annotation class ten other profiles point back here for. That paragraph moved beside the filter rather than being deleted with the bullet, and the pointers still resolve.

## Review

Cleared at fresh context. The reviewer re-derived every kill from source rather than from the report — including parsing `block_481824_complete.bin` to confirm the new vector is transaction 22 of that block, a P2SH-P2WPKH spend, and that `LATER_TX_ID` is transaction 532 and genuinely sorts the other way from it — and read the outcomes out of the session database rather than the summary. It also checked the provenance of the figures: the session ran against the tree between two of the branch's own commits, and the diff across that window is one docstring rewrite and one rename, nothing executable.

Its one substantive finding is applied. A landed bullet in the same open section says the boundary's guards go unnoticed when weakened and names this issue as where they are answered — true when it landed, false now. The remedy is the append-compatible one this tree already uses twice: the new entry names the one it supersedes rather than editing landed text.

## Gates

- `uvx pre-commit run --all-files` → exit 0, tree clean afterwards (`actionlint` and `zizmor` Passed)
- `uv run --locked pytest -q` → exit 0, 100% floor held
- `uv run --locked sphinx-build -n -W -b html` → exit 0

All three on this sha, after the rebase rather than before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Harden fetcher tests so boundary guards and request/response contracts are directly validated across all supported backends.

Enhancements:
- Strengthen fetch tests to pin response-size limits, exact network and transaction-id validation, witness-preserving broadcasts, request identifiers, HTTP status handling, and request headers.
- Update mutation-testing documentation to reflect current execution, survivor classifications, and the coverage provided by the fetch tests.

Documentation:
- Document the fetch boundary-guard coverage and mutation-testing results in the changelog.

Tests:
- Add boundary and mutation-killing coverage across Bitcoin Core REST, Bitcoin Core RPC, Esplora, and Electrum fetchers, including valid responses at limits and invalid responses just beyond them.