### PR TITLE
Every mutation profile is held to a session of the matrix (closes #1723)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -886,6 +886,25 @@ file of the test tree, and no caller acts on it.
   #1716 as where they are answered; it stays as the record of what a
   session found then, and this is that answer.
 
+### Every `.github/mutation` profile is held to a session of `mutation.yml`
+
+- **`tests/mutation_sessions_test.py` asserts that the configurations
+  under `.github/mutation/` and the sessions of
+  `.github/workflows/mutation.yml`'s matrix are the same set** (closes
+  #1723). A configuration no session names enumerates nothing and
+  reports nothing while the workflow stays green, a job that does not
+  exist being unable to fail; a session naming a configuration that is
+  not there is a red `Check the baselines` step in a weekly run of a
+  workflow that gates nothing. Each is a failure of the ordinary suite
+  instead.
+- **The workflow is read as text and not parsed as yaml**: the suite's
+  own dependency group carries no yaml parser, so a module importing one
+  collects on a contributor's `uv sync`, which installs every group, and
+  fails to collect in CI. What is read is the block scalars `sessions:`
+  opens, and the census asserts what each side found before subtracting
+  one from the other, an empty side being a subtraction that passes
+  whatever the other holds.
+
 ## v2026.9.3
 
 ### Repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,17 +263,21 @@ source-include = [
 # pattern here takes out is not reported as one the sdist is missing,
 # and does not have to be named again in [tool.check-sdist] below
 source-exclude = [
-    # tests whose subject the sdist does not carry: what
-    # .github/scripts holds is not shipped, so each of these loads a
-    # path that is not there -- a fixture error rather than a test.
+    # tests whose subject the sdist does not carry: what .github holds
+    # is not shipped, so each of these loads a path that is not there --
+    # a fixture error rather than a test for the ones that load a script
+    # of .github/scripts, and a collection error for
+    # mutation_sessions_test.py, which reads the workflow as it is
+    # imported and so does not reach a test at all.
     # Anchored, because a name this specific matching at some other
     # depth would be an accident rather than a decision.
-    # tests/build_system_test.py checks that every test reaching
-    # .github/scripts or fuzz/ this way is named here
+    # tests/build_system_test.py checks that every test its own reader
+    # recognizes as reaching .github or fuzz/ is named here
     "/tests/check_py_arm_authority_test.py",
     "/tests/check_vendored_vectors_test.py",
     "/tests/generate_sbom_test.py",
     "/tests/mutation_counts_test.py",
+    "/tests/mutation_sessions_test.py",
     "/tests/normalize_sdist_test.py",
     "/tests/tf2_ledger_test.py",
     "/tests/verify_dist_contents_test.py",

--- a/tests/build_system_test.py
+++ b/tests/build_system_test.py
@@ -136,10 +136,10 @@ def test_the_bindings_extra_and_group_ask_for_the_same_thing() -> None:
 
 
 # `[tool.uv.build-backend] source-exclude` carries its own reasoning in
-# pyproject.toml for why a test loading `.github/scripts` or `fuzz/` off
-# disk belongs in it: each such test is unrunnable from an unpacked
-# sdist, neither directory being shipped. What no comment there can show
-# is that the list still names every test with that shape -- ISS 1509
+# pyproject.toml for why a test loading `.github` or `fuzz/` off disk
+# belongs in it: each such test is unrunnable from an unpacked sdist,
+# neither directory being shipped. What no comment there can show is
+# that the list still names the tests of the shape below -- ISS 1509
 # found one it did not, and nothing failed
 _SOURCE_EXCLUDE = re.compile(
     r"^source-exclude\s*=\s*\[(.*?)^\]", re.MULTILINE | re.DOTALL
@@ -199,11 +199,19 @@ def _reaches_outside_the_sdist(tree: ast.Module) -> bool:
 
 
 def test_every_test_reaching_outside_the_sdist_is_source_excluded() -> None:
-    """A `tests/*.py` built on `.github/scripts` or `fuzz/` is in the list.
+    """A `tests/*.py` the reader above recognizes is named in the list.
 
     Not the other direction: `source-exclude` also names entries no test
     file could match -- `docs/build`, the linter caches -- so only this
     direction closes what ISS 1509 found open.
+
+    And not every test that reaches outside the sdist: what the reader
+    sees of a directory is a `/` join on its own name, so a path with
+    the whole of it in one literal -- `_ROOT / ".github/workflows"` --
+    is outside its reach and outside this assertion's, which is issue
+    #1736. Widening the sentence here without widening the reader is
+    what would put the guarantee ISS 1509 asked for on a green run that
+    does not give it.
     """
     excluded = set(_source_exclude())
     missing = [

--- a/tests/mutation_sessions_test.py
+++ b/tests/mutation_sessions_test.py
@@ -1,0 +1,181 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Every mutation profile has a session, and every session a profile.
+
+`.github/mutation/` states what a scope mutates and what judges it, and
+`.github/workflows/mutation.yml`'s matrix is what spends a budget on it.
+Neither file names what the other holds, and both directions of the drift
+are quiet. A configuration no session names enumerates nothing, measures
+nothing and reports nothing, while the workflow stays green: a job that
+does not exist cannot fail. A session naming a configuration that is gone
+is a red `Check the baselines` step in a weekly run of a workflow that
+gates nothing, so it waits for whoever opens the Actions tab.
+
+The workflow is read as text rather than parsed as yaml, the suite's own
+environment carrying no yaml parser: pyyaml reaches this tree through
+`myst-parser` and `pre-commit`, which are the `docs` and `lint` groups,
+and the suite runs under `--group harness` and under `--group test`,
+which is that group and the bindings. A module importing one
+collects on a contributor's own `uv sync`, which installs every group,
+and fails to collect in CI -- issue #1538's shape, and the reason
+`tests/copyright_test.py` reads a line of `docs/source/conf.py` rather
+than executing it. What is read here is narrow enough to defend without a
+parser: the block scalars introduced by `sessions:`, each line of which
+is a configuration and the budget `timeout` is given.
+
+Both censuses are asserted non-empty before either is compared, a set
+subtracted from an empty one being empty whatever it holds, and the
+reader is driven over a literal workflow of its own -- a `sessions:`
+reworded past what it matches would otherwise make every assertion below
+pass for free.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).parents[1]
+_WORKFLOW = _ROOT / ".github" / "workflows" / "mutation.yml"
+_PROFILES = _ROOT / ".github" / "mutation"
+
+# a session as the workflow's own steps read one: the configuration
+# under `.github/mutation/`, and the budget `timeout --signal=INT` is
+# given. The budget is matched and not captured -- what it has to do
+# here is tell a session from a line that is something else, so what
+# it matches is `timeout`'s own duration -- a number with an optional
+# `s`, `m`, `h` or `d` -- rather than the minutes every budget happens
+# to be spelled in today. Held to minutes, a legitimate `2h` would be
+# reported as no session at all and turn the census red on the spelling
+# of a budget this module does not otherwise read
+_SESSION = re.compile(r"(\S+\.toml) \d+(?:\.\d+)?[smhd]?")
+
+
+def _sessions(text: str) -> tuple[list[str], list[str]]:
+    """Return the configurations the matrix runs, and what is no session.
+
+    A `sessions:` block scalar runs to the first line indented no deeper
+    than the key that opened it, blank lines belonging to the scalar
+    rather than closing it. That is the whole of the yaml this needs, the
+    value being literal text the `while read -r config budget` loops of
+    the workflow split on whitespace.
+
+    The second list is what keeps a line from leaving the census in
+    silence: one the reader cannot parse is reported rather than dropped,
+    which is the difference between a census that is wrong and one that
+    is empty.
+    """
+    configurations: list[str] = []
+    unparsed: list[str] = []
+    depth: int | None = None
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if depth is not None:
+            if not stripped:
+                continue
+            if len(line) - len(line.lstrip(" ")) > depth:
+                session = _SESSION.fullmatch(stripped)
+                if session is None:
+                    unparsed.append(stripped)
+                else:
+                    configurations.append(session.group(1))
+                continue
+            depth = None
+        if stripped == "sessions: |":
+            depth = len(line) - len(line.lstrip(" "))
+    return configurations, unparsed
+
+
+_CONFIGURATIONS = frozenset(path.name for path in _PROFILES.glob("*.toml"))
+_RUN, _UNPARSED = _sessions(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_both_sides_of_the_census_were_read() -> None:
+    """A comparison over a side that came up empty is true of nothing.
+
+    The assertions below subtract one set from the other, and each of
+    them passes for free on an empty one. The workflow's side is read by
+    the function above, which answers empty for a key spelled some other
+    way; the directory's side is a glob, which answers empty for a
+    directory renamed or emptied out, which is the same drift this module
+    is about arriving where it cannot be seen.
+
+    A configuration named twice is the third way the comparison holds
+    while the matrix does not: `run_session` derives the session file
+    from the configuration's own name, so a second session of one
+    configuration in the same job re-initializes over the first's
+    verdicts, and in two jobs it pays twice for one answer.
+    """
+    assert _CONFIGURATIONS, "no configuration under .github/mutation at all"
+    assert _RUN, "no session was read out of mutation.yml at all"
+    assert not _UNPARSED, f"a line under `sessions:` is no session: {_UNPARSED}"
+    assert len(set(_RUN)) == len(_RUN), (
+        f"a configuration is given more than one session: {sorted(_RUN)}"
+    )
+
+
+def test_every_configuration_has_a_session() -> None:
+    """A profile the matrix does not name is a scope nothing mutates."""
+    missing = sorted(_CONFIGURATIONS - set(_RUN))
+    assert not missing, f"no session in mutation.yml for: {missing}"
+
+
+def test_every_session_names_a_configuration() -> None:
+    """The other direction, where a renamed configuration lands.
+
+    `cosmic-ray baseline` is what refuses it, in the step that runs
+    before any mutant, and the job it fails is one nothing gates on.
+    """
+    unaccounted = sorted(set(_RUN) - _CONFIGURATIONS)
+    assert not unaccounted, (
+        f"a session names no file under .github/mutation: {unaccounted}"
+    )
+
+
+def test_the_reader_finds_the_sessions_and_only_those() -> None:
+    """The guard above passes for free if the reader answers empty.
+
+    The shapes mutation.yml puts around a block scalar: a second entry's
+    key at the same depth, a blank line inside a block, the dedent to the
+    job's own keys, and the environment key that carries the same value
+    under a spelling this must not read as a block of its own.
+    """
+    configurations, unparsed = _sessions(
+        "    strategy:\n"
+        "      matrix:\n"
+        "        include:\n"
+        "          - profile: one\n"
+        "            sessions: |\n"
+        "              a.toml 90m\n"
+        "\n"
+        "              b.toml 30m\n"
+        "          - profile: two\n"
+        "            sessions: |\n"
+        "              c.toml 5m\n"
+        "    steps:\n"
+        "      - env:\n"
+        "          SESSIONS: ${{ matrix.sessions }}\n"
+    )
+
+    assert configurations == ["a.toml", "b.toml", "c.toml"]
+    assert not unparsed
+
+
+def test_a_line_that_is_no_session_is_reported() -> None:
+    """A line the reader cannot parse is named rather than skipped.
+
+    Skipping it is how a session leaves the census while the matrix goes
+    on spending its budget: the configuration would then read as one no
+    job runs, and the census would be red about the wrong thing.
+    """
+    configurations, unparsed = _sessions(
+        "            sessions: |\n"
+        "              a.toml 90m\n"
+        "              b.toml\n"
+        "              c.txt 30m\n"
+    )
+
+    assert configurations == ["a.toml"]
+    assert unparsed == ["b.toml", "c.txt 30m"]


### PR DESCRIPTION
Closes #1723

`.github/mutation/` states what a scope mutates and what judges it, and
`.github/workflows/mutation.yml`'s matrix is what spends a budget on it.
Neither file names what the other holds, and both directions of the
drift are quiet: a configuration no session names enumerates nothing
while the workflow stays green, and a session naming a configuration
that is gone is a red step in a weekly run of a workflow that gates
nothing. `tests/mutation_sessions_test.py` asserts the two are the same
set, in the ordinary suite.

The workflow is read as text rather than parsed as yaml. The suite runs
under `--group harness` and `--group test`, and neither carries a yaml
parser — pyyaml reaches this tree only through `myst-parser` and
`pre-commit`, which are `docs` and `lint` — so a module importing one
collects on a contributor's own `uv sync`, which installs every group,
and fails to collect in CI. That is [ISS
1538](https://github.com/btclib-org/btclib/issues/1538)'s shape, and the
reason `tests/copyright_test.py` reads a line of `docs/source/conf.py`
rather than executing it. What is read here is narrow enough to defend
without a parser: the block scalars `sessions:` opens. Both censuses are
asserted non-empty before either is compared, a set subtracted from an
empty one being empty whatever it holds, and the reader is driven over a
literal workflow of its own.

The module reads `.github`, which no sdist carries, so `pyproject.toml`
names it in `[tool.uv.build-backend] source-exclude`, and
`tests/build_system_test.py`'s own comment and that list's are widened
from `.github/scripts` to `.github` — the entries there load a script,
this one a workflow and a directory of configurations. The two
exclusions fail differently and the comment now says so: a fixture error
for the ten that load a script, a collection error for this one, which
reads the workflow as it is imported and does not reach a test at all.

### Review

Three local review rounds at fresh context, each on its own sha, and
each found a false clause in prose this branch wrote itself:

1. `0422f1b3` — the `source-exclude` comment claimed this module's
   absence from an sdist gives "a census of a directory that answers
   empty"; it raises at import. Reproduced from a tree with no
   `.github`: `ERROR collecting … FileNotFoundError`, zero tests run.
2. `0a0de325` — widening the summary line to `.github` asserted a
   guarantee the reader does not give:
   `tests/interpreters_test.py:34,76` and
   `tests/docs_commands_test.py:68,73` read `.github/workflows` through
   a single-literal join the AST walk cannot see, and neither is in
   `source-exclude`. That hole is [ISS
   1736](https://github.com/btclib-org/btclib/issues/1736), which this
   branch does not close: the docstring stops claiming the guarantee and
   names the limit instead.
3. `66861c26` — cleared, with the paragraph scoped to "what the reader
   sees **of a directory**", since the reader also matches a
   `subprocess` call to `git`. `283f4bd9` confirmed.

Also fixed on the way: `_SESSION` was `(\S+\.toml) \d+m`, which reports
a legitimate `2h` as no session and turns the census red on a budget
spelling it does not read; it is now `timeout`'s own duration. The
census over the real workflow is identical under both patterns, and
every non-session line still lands in `unparsed`.

### Gates

Read as exit codes, on the tree of `283f4bd9`:

| gate | exit |
|---|---|
| `uvx pre-commit run --all-files` | 0 |
| `uv run --locked pytest -q` | 0 — 32140 passed, 31 skipped, 1 xfailed, coverage 100.00% |
| `uv run --locked sphinx-build -n -W -b html docs/source` | 0 |

Rebased onto `origin/main`, the glued-heading detector run after the
rebase rather than before it.

### Collateral filed, not fixed here

- [ISS 1734](https://github.com/btclib-org/btclib/issues/1734) — nothing
  binds `mutation.yml`'s `workflow_dispatch` options to its matrix
  slugs.
- [ISS 1735](https://github.com/btclib-org/btclib/issues/1735) —
  `mutation.yml` and `curve_group.toml` still say no session has run the
  curve arithmetic, where a run of 2026-08-31 succeeded.
- [ISS 1736](https://github.com/btclib-org/btclib/issues/1736) — the
  reader is blind to a `.github` path spelled in one literal, and two
  modules are written that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Keep mutation profiles and workflow sessions synchronized by enforcing a bidirectional consistency check in the test suite.

Bug Fixes:
- Add regression coverage that detects mutation profiles missing from the workflow matrix and workflow sessions referring to missing profiles.

Enhancements:
- Validate mutation workflow sessions using a dependency-free text reader, including non-empty and duplicate-entry checks.
- Recognize session budgets expressed in seconds, minutes, hours, or days.
- Update source-distribution coverage checks and exclusions for tests that read the unshipped .github directory.

Documentation:
- Document the new consistency checks and their dependency-free workflow parsing approach in the changelog.

Tests:
- Add tests covering session extraction, malformed entries, block boundaries, and two-way profile/session consistency.