### PR TITLE
A `test_framework` citation names the file, not a revision (closes #1726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -905,6 +905,25 @@ file of the test tree, and no caller acts on it.
   one from the other, an empty side being a subtraction that passes
   whatever the other holds.
 
+### A `test_framework` citation names the file and leaves the pin to `TF2.md`
+
+- **A module or a test citing Core's `test/functional/test_framework/`
+  names the framework file and carries no revision of its own** (closes
+  #1726). `TF2.md` is where that path's pin lives, so a refresh moves
+  the entry rather than every site that repeats it: a pin written beside
+  a citation is right the day it is written, and is the copy the next
+  refresh misses.
+- **`script/sig_hash.py`'s `segwit_v0` names Core's
+  `SegwitV0SignatureHash` of `test/functional/test_framework/script.py`,
+  where it carried a permalink with a line number in it.** A line number
+  into another repository is re-checked by nothing, and an edit upstream
+  moves it with nothing here going red.
+- **`TF2.md` says which form a citation takes**, and which shapes are
+  not it. It pins no C++ path, so a citation of Core's C++ has no entry
+  there to leave a revision to and stands as it is; the revision beside
+  `src/btclib/_ripemd160.py`'s vendored copy says which bytes were
+  taken, and belongs where the copy is.
+
 ## v2026.9.3
 
 ### Repository

--- a/TF2.md
+++ b/TF2.md
@@ -107,6 +107,33 @@ No entry carries a `blob`, and that is where this file parts from
 below but the RIPEMD-160 implementation, whose own entry names where
 that comparison lives instead of making one here.
 
+## Citing the framework from btclib
+
+A module or a test citing a file of this directory names the file and
+says that `TF2.md` pins the revision, carrying no revision of its own.
+That is `tests/_data/README.md`'s shape applied to a second ledger: the
+record is the single place a pin is refreshed, so a re-check reads one
+file rather than finding every site that repeats it. A pin written
+beside a citation is right on the day it is written, and it is the copy
+the next refresh misses.
+
+A citation carries no line number into another repository either.
+Nothing here re-checks such a line, and an edit upstream moves it with
+nothing going red, so what a citation names beside the file is the
+function: `script/sig_hash.py`'s `segwit_v0` cites
+`SegwitV0SignatureHash` of `test/functional/test_framework/script.py`.
+
+**A citation of Core's C++ is a different thing**, and none of the above
+reaches it. This file pins no C++ path, so such a citation has no entry
+here to leave a revision to, and *Reading an entry* above is about the
+entries below rather than about how Core's C++ is cited from this tree.
+Those citations stand as they are.
+
+**A vendoring line is not a citation.** `_ripemd160.py` is Core's own
+file, and the revision its docstring carries says which bytes were
+copied, beside the attribution the licence asks for. That pin belongs
+where the copy is, and moves when the copy does.
+
 ## bitcoin/bitcoin
 
 ### `test/functional/test_framework/__init__.py`

--- a/src/btclib/block/build.py
+++ b/src/btclib/block/build.py
@@ -23,9 +23,10 @@ candidate cannot pass, and which `mining.candidate_block_header` has
 already asked of the header the same way `BlockHeader` always does.
 `build_block`'s own docstring has why the two remaining rules are left
 to the caller. A caller wanting a block that is invalid on purpose, the
-way Bitcoin Core's own `test_framework.blocktools.create_block` is
-meant to be driven into invalid states, builds a `Tx` or a `Block` by
-hand with `check_validity=False` and mutates the result, exactly as a
+way Bitcoin Core's `create_block`
+(`test/functional/test_framework/blocktools.py`; `TF2.md` pins the
+revision) is meant to be driven into invalid states, builds a `Tx` or a
+`Block` by hand with `check_validity=False` and mutates the result, as a
 caller already does for a regtest block whose proof-of-work `mainnet`'s
 own default limit would refuse.
 """
@@ -73,9 +74,9 @@ def build_coinbase(
     """Return a coinbase transaction paying the subsidy at `height`, plus fees.
 
     Bitcoin Core's `create_coinbase`
-    (`test/functional/test_framework/blocktools.py`, at
-    bitcoin/bitcoin@9be056a8a7): a null-outpoint input committing to
-    `height` (BIP34, `bip34_commitment`) and one output paying
+    (`test/functional/test_framework/blocktools.py`; `TF2.md` pins the
+    revision): a null-outpoint input committing to `height` (BIP34,
+    `bip34_commitment`) and one output paying
     `consensus.subsidy(height, halving_interval) + fees` to
     `script_pub_key`. `halving_interval` defaults to mainnet's own;
     a caller building for another network passes that network's own row

--- a/src/btclib/hashes.py
+++ b/src/btclib/hashes.py
@@ -164,12 +164,12 @@ def siphash(k0: int, k1: int, octets: Octets) -> int:
     k0 and k1 are the two 64-bit words of the key, in the order Core's
     `CSipHasher(k0, k1)` takes them (`crypto/siphash.h`) and its Python
     mirror `siphash(k0, k1, data)`
-    (`test/functional/test_framework/crypto/siphash.py`) reads them out
-    of a key: two rounds of compression per eight-byte word of octets,
-    padded with a trailing byte counting the input length mod 256, and
-    four rounds of finalization. The result is an unsigned 64-bit
-    integer, `v0 ^ v1 ^ v2 ^ v3` of the finalized state, never negative
-    and never wider than 8 bytes.
+    (`test/functional/test_framework/crypto/siphash.py`; `TF2.md` pins
+    the revision) reads them out of a key: two rounds of compression
+    per eight-byte word of octets, padded with a trailing byte counting
+    the input length mod 256, and four rounds of finalization. The
+    result is an unsigned 64-bit integer, `v0 ^ v1 ^ v2 ^ v3` of the
+    finalized state, never negative and never wider than 8 bytes.
 
     A hash keyed on a peer- or block-derived secret and not a
     general-purpose digest: BIP158's filter and BIP152's short

--- a/src/btclib/p2p/block_filters.py
+++ b/src/btclib/p2p/block_filters.py
@@ -12,8 +12,9 @@ asks for every thousandth filter header and is answered by a `cfcheckpt`.
 BIP157 is the specification, and its field tables are the wire form; the
 layout Core writes is test/functional/test_framework/messages.py's
 `msg_getcfilters`, `msg_cfilter`, `msg_getcfheaders`, `msg_cfheaders`,
-`msg_getcfcheckpt` and `msg_cfcheckpt`, and the handlers reading them are
-`ProcessGetCFilters`, `ProcessGetCFHeaders` and `ProcessGetCFCheckPt` of
+`msg_getcfcheckpt` and `msg_cfcheckpt` -- `TF2.md` pins that file's
+revision -- and the handlers reading them are `ProcessGetCFilters`,
+`ProcessGetCFHeaders` and `ProcessGetCFCheckPt` of
 src/net_processing.cpp.
 
 **A `cfilter` holds the filter as octets, not as a `BasicBlockFilter`.**

--- a/src/btclib/p2p/compact_blocks.py
+++ b/src/btclib/p2p/compact_blocks.py
@@ -10,7 +10,8 @@ trip that fills what the receiver had not got. BIP152 is the
 specification and its field tables are the wire form; Core's
 src/blockencodings.h and .cpp are the implementation, and its
 test/functional/test_framework/messages.py's `msg_sendcmpct`,
-`msg_cmpctblock`, `msg_getblocktxn` and `msg_blocktxn` the layout.
+`msg_cmpctblock`, `msg_getblocktxn` and `msg_blocktxn` the layout;
+`TF2.md` pins that file's revision.
 
 **This is the one module of the package that carries an algorithm**, and
 the algorithm rather than the layout is where a compact block goes wrong:

--- a/src/btclib/p2p/data.py
+++ b/src/btclib/p2p/data.py
@@ -5,10 +5,11 @@
 """`tx` and `block`: the two messages that deliver what a `getdata` named.
 
 Bitcoin Core's `msg_tx` and `msg_block`, of
-test/functional/test_framework/messages.py: one transaction and one
-block, each serialized exactly as it is serialized anywhere else. So the
-wire format is `btclib.tx`'s and `btclib.block`'s, and what is left for
-this module is the one thing those two leave open.
+test/functional/test_framework/messages.py, whose revision `TF2.md`
+pins: one transaction and one block, each serialized exactly as it is
+serialized anywhere else. So the wire format is `btclib.tx`'s and
+`btclib.block`'s, and what is left for this module is the one thing
+those two leave open.
 
 **`include_witness` is a field of the payload, not an argument of
 `serialize`.** `Tx.serialize` and `Block.serialize` take it, and on the

--- a/src/btclib/p2p/handshake.py
+++ b/src/btclib/p2p/handshake.py
@@ -5,9 +5,10 @@
 """The two messages a connection opens with: `version` and `verack`.
 
 Bitcoin Core's `msg_version` and `msg_verack`, of
-test/functional/test_framework/messages.py, read against what
-`net_processing.cpp` actually does with the octets -- which is not the
-same thing, and the difference is this module's one hard decision.
+test/functional/test_framework/messages.py (`TF2.md` pins the
+revision), read against what `net_processing.cpp` actually does with the
+octets -- which is not the same thing, and the difference is this
+module's one hard decision.
 
 **`version`'s trailing fields are conditional, and the conditional is not
 the protocol version.** Core's test framework reads the relay flag `if

--- a/src/btclib/p2p/inventory.py
+++ b/src/btclib/p2p/inventory.py
@@ -11,8 +11,8 @@ what they do not, and the type code under them. `inv`, `getdata` and
 hash; `headers` is block headers. The layout is Core's
 test/functional/test_framework/messages.py -- `msg_inv`, `msg_getdata`,
 `msg_notfound`, `msg_getblocks`, `msg_getheaders`, `msg_headers` and the
-`CInv` and `CBlockLocator` under them -- and the type codes are
-src/protocol.h's `GetDataMsg`.
+`CInv` and `CBlockLocator` under them, at the revision `TF2.md` pins --
+and the type codes are src/protocol.h's `GetDataMsg`.
 
 **Three commands share one body, and so one class each over one private
 base**, which is `btclib.p2p.keepalive`'s shape for `ping` and `pong`:

--- a/src/btclib/p2p/message.py
+++ b/src/btclib/p2p/message.py
@@ -8,7 +8,7 @@ The layout is Bitcoin Core's `CMessageHeader`, of src/protocol.h: four
 octets of message start, twelve of message type, four of payload size
 little-endian and four of checksum, followed by the payload the last two
 describe. Core's own test framework writes the same header by hand, in
-`test/functional/test_framework/p2p.py`.
+`test/functional/test_framework/p2p.py`; `TF2.md` pins the revision.
 
 Core spells the second field `m_msg_type`, where the wire documentation,
 the BIPs and every other implementation say "command". The name here is

--- a/src/btclib/p2p/negotiation.py
+++ b/src/btclib/p2p/negotiation.py
@@ -81,17 +81,17 @@ octets hold, which is the field boundary rather than a judgement.
 **`sendtxrcncl` is BIP330's Erlay negotiation and none of Erlay's
 reconciliation.** The message itself is two unsigned fields, a `uint32`
 protocol version and a `uint64` salt; BIP330's own table and Core's
-`test/functional/test_framework/messages.py` `msg_sendtxrcncl` agree on
-that layout field for field. `node/txreconciliation.h` declares
-`TXRECONCILIATION_VERSION` 1, matching BIP330's "Sender must set this
-to 1 currently" -- so both sources name the same one value a peer
-sends today, and this codec fixes neither: a version below 1 is a
-protocol violation BIP330 states and Core enforces in
-`TxReconciliationTracker::RegisterPeer`, after the parse and against
-the *pair* of versions the two peers offered, which is a connection's
-state and not a fact the four octets of `version` carry alone; a salt
-is entropy, and every value its width holds is one a peer may have
-picked.
+`test/functional/test_framework/messages.py` `msg_sendtxrcncl`, at the
+revision `TF2.md` pins, agree on that layout field for field.
+`node/txreconciliation.h` declares `TXRECONCILIATION_VERSION` 1,
+matching BIP330's "Sender must set this to 1 currently" -- so both
+sources name the same one value a peer sends today, and this codec
+fixes neither: a version below 1 is a protocol violation BIP330 states
+and Core enforces in `TxReconciliationTracker::RegisterPeer`, after the
+parse and against the *pair* of versions the two peers offered, which
+is a connection's state and not a fact the four octets of `version`
+carry alone; a salt is entropy, and every value its width holds is one
+a peer may have picked.
 
 Erlay itself -- the sketches, the Minisketch library, the
 request-and-response round that follows a successful negotiation -- is

--- a/src/btclib/script/sig_hash.py
+++ b/src/btclib/script/sig_hash.py
@@ -557,7 +557,8 @@ class PrecomputedTxData:
         return sha256(self.sha_outputs)
 
 
-# https://github.com/bitcoin/bitcoin/blob/4b30c41b4ebf2eb70d8a3cd99cf4d05d405eec81/test/functional/test_framework/script.py#L673
+# Core's `SegwitV0SignatureHash`, of
+# test/functional/test_framework/script.py; `TF2.md` pins the revision
 def segwit_v0(
     script_code: Octets,
     tx: Tx,

--- a/src/btclib/tx/tx_in.py
+++ b/src/btclib/tx/tx_in.py
@@ -232,12 +232,13 @@ def input_weight(script_sig: Octets, witness: Witness | None = None) -> int:
     """Return the weight one input adds to a transaction, per BIP141.
 
     Bitcoin Core's `calculate_input_weight`, of
-    test/functional/test_framework/wallet_util.py: the non-witness bytes
-    weigh WITNESS_SCALE_FACTOR each -- the 36-byte outpoint, the
-    script_sig behind its var_int length, the 4-byte sequence -- and the
-    serialized witness stack weighs one each. Which output is spent and
-    what the sequence says do not enter the answer, both fields being
-    fixed-width, so neither is an argument.
+    test/functional/test_framework/wallet_util.py, whose revision
+    `TF2.md` pins: the non-witness bytes weigh WITNESS_SCALE_FACTOR each
+    -- the 36-byte outpoint, the script_sig behind its var_int length,
+    the 4-byte sequence -- and the serialized witness stack weighs one
+    each. Which output is spent and what the sequence says do not enter
+    the answer, both fields being fixed-width, so neither is an
+    argument.
 
     It is computable before the input exists, which is the point: a fee
     is chosen before the transaction is signed, so the weight the fee is

--- a/tests/p2p/block_filters_test.py
+++ b/tests/p2p/block_filters_test.py
@@ -10,8 +10,8 @@ annotates a `version`, a `verack` and an `addr` and none of these six,
 and Bitcoin Core has no vector file for them. The wire form here is
 BIP157's own field tables and the writer Core reads them back with,
 test/functional/test_framework/messages.py's `msg_cfilter` and its five
-neighbours, and the octets below were assembled from those tables rather
-than captured from anything.
+neighbours -- `TF2.md` pins that file's revision -- and the octets below
+were assembled from those tables rather than captured from anything.
 
 **What is vendored is the other half of the message, and it is real.**
 `tests/block/_data/blockfilters.json` is Core's BIP158 vector file, pinned

--- a/tests/p2p/compact_blocks_test.py
+++ b/tests/p2p/compact_blocks_test.py
@@ -16,11 +16,11 @@ The vectors are block 481,824 -- the first segwit block, already in the
 tree under tests/block/_data and authenticated by its own proof of work,
 which is what issue #1101 and issue #1103 leaned on -- and the short ids
 and the key below were computed with Bitcoin Core's own
-test/functional/test_framework/crypto/siphash.py, a second implementation
-of SipHash-2-4 and not `btclib.hashes.siphash` under another name. So a
-short id keyed on a txid, or on a hash the wrong way round, or under a
-digest of the header without the nonce, fails here rather than
-round-tripping.
+test/functional/test_framework/crypto/siphash.py, whose revision
+`TF2.md` pins: a second implementation of SipHash-2-4 and not
+`btclib.hashes.siphash` under another name. So a short id keyed on a
+txid, or on a hash the wrong way round, or under a digest of the header
+without the nonce, fails here rather than round-tripping.
 
 **The wire form has weaker authority, and saying so is better than
 dressing it up.** BIP152 publishes field tables and no test vectors, and
@@ -81,11 +81,12 @@ _BLOCK_1 = Block.parse((_DATA / "block_1.bin").read_bytes())
 _NONCE = 0x0123_4567_89AB_CDEF
 
 # what Bitcoin Core's test/functional/test_framework/crypto/siphash.py
-# answers for the block and the nonce above: the key is the first two
-# little-endian 64-bit words of the single-SHA256 of the eighty octets of
-# the header with the nonce appended, and each short id is that
-# implementation's `siphash(k0, k1, wtxid)` with the two most significant
-# octets dropped -- `calculate_shortid`, of that framework's messages.py.
+# answers for the block and the nonce above, at the revision `TF2.md`
+# pins: the key is the first two little-endian 64-bit words of the
+# single-SHA256 of the eighty octets of the header with the nonce
+# appended, and each short id is that implementation's
+# `siphash(k0, k1, wtxid)` with the two most significant octets dropped
+# -- `calculate_shortid`, of that framework's messages.py.
 #
 # The transactions are picked for carrying a witness, which few of that
 # block's do: a wtxid is a txid for a transaction that has none, and over

--- a/tests/p2p/data_test.py
+++ b/tests/p2p/data_test.py
@@ -29,8 +29,9 @@ own header, which anybody can recompute over anything; a mainnet header
 is pinned by its proof of work, so no other eighty octets hash below the
 target it declares. `assert_valid_pow` is that check, run here.
 
-Everything else is a round trip, a refusal, or a reading of BIP144 and of
-Core's test/functional/test_framework/messages.py.
+Everything else is a round trip, a refusal, or a reading of BIP144 and
+of Core's test/functional/test_framework/messages.py, whose revision
+`TF2.md` pins.
 """
 
 from __future__ import annotations

--- a/tests/p2p/inventory_test.py
+++ b/tests/p2p/inventory_test.py
@@ -42,7 +42,8 @@ records the height and hash of every block file this reads.
 
 Everything else is a round trip, a refusal, or a reading of Core's
 src/protocol.h, src/net_processing.h and
-test/functional/test_framework/messages.py.
+test/functional/test_framework/messages.py, whose revision `TF2.md`
+pins.
 """
 
 from __future__ import annotations

--- a/tests/p2p/message_test.py
+++ b/tests/p2p/message_test.py
@@ -8,9 +8,10 @@
 where that is said.** Bitcoin Core publishes no file of envelope vectors:
 there is no `message.json` to pin the way `tests/_data/README.md` pins
 `siphash.json` and `blockfilters.json`, the header being exercised in
-Core through `test/functional/test_framework/p2p.py`, which builds it in
-Python and reads it back -- a round trip, which is what these tests are
-too. So nothing here is vendored, and nothing is claimed to be.
+Core through `test/functional/test_framework/p2p.py` (`TF2.md` pins the
+revision), which builds it in Python and reads it back -- a round trip,
+which is what these tests are too. So nothing here is vendored, and
+nothing is claimed to be.
 
 What stands in for it are the two messages the Bitcoin Wiki's Protocol
 documentation publishes with their octets -- a `version` a

--- a/tests/ripemd160_test.py
+++ b/tests/ripemd160_test.py
@@ -6,8 +6,9 @@
 
 The vectors are the ones the authors of RIPEMD-160 publish at
 https://homes.esat.kuleuven.be/~bosselae/ripemd160.html, as the vendored
-upstream carries them in its own unittest -- bitcoin/bitcoin at 08a4a56c,
-test/functional/test_framework/crypto/ripemd160.py.
+upstream carries them in its own unittest -- Bitcoin Core's
+test/functional/test_framework/crypto/ripemd160.py, whose revision
+`TF2.md` pins.
 
 Eight of that upstream's nine. The ninth is 10^6 times "a", and in pure
 Python it takes 1.5 s, which would make it the slowest test in this suite

--- a/tests/tx/tx_in_test.py
+++ b/tests/tx/tx_in_test.py
@@ -214,13 +214,14 @@ def test_script_sig_is_not_validated_and_that_is_the_answer() -> None:
 def test_input_weight() -> None:
     """Match Core's TestFrameworkWalletUtil.test_calculate_input_weight.
 
-    Its cases transcribed from
-    test/functional/test_framework/wallet_util.py at bitcoin/bitcoin
-    42330922, with Core's `witness_stack_hex=None` spelled `None` and its
-    `[]` spelled `Witness()`. They are chosen for the two boundaries the
-    arithmetic can be wrong at: a length of 252 against one of 253, where
-    a var_int grows from one byte to three, on the script_sig and on the
-    witness item count alike; and no witness against an empty stack.
+    Its cases transcribed from Core's
+    test/functional/test_framework/wallet_util.py, whose revision
+    `TF2.md` pins, with Core's `witness_stack_hex=None` spelled `None`
+    and its `[]` spelled `Witness()`. They are chosen for the two
+    boundaries the arithmetic can be wrong at: a length of 252 against
+    one of 253, where a var_int grows from one byte to three, on the
+    script_sig and on the witness item count alike; and no witness
+    against an empty stack.
     """
     SKELETON_BYTES = 32 + 4 + 4  # prevout-txid, prevout-index, sequence
     SMALL_LEN_BYTES = 1  # a var_int announcing a length below 253


### PR DESCRIPTION
Closes #1726

`TF2.md` pins every file of Core's `test/functional/test_framework/` to
the tip of its own path, so a citation of that directory in `src/` or
`tests/` names the framework file and leaves the revision to the ledger.
That is one place a pin is refreshed: a pin repeated beside a citation
is right the day it is written, and is the copy the next refresh misses.

`script/sig_hash.py`'s `segwit_v0` names Core's `SegwitV0SignatureHash`
of `test/functional/test_framework/script.py`, where it carried a
permalink with a line number into another repository that nothing
re-checks. A citation names the function instead, which an edit upstream
does not move.

`TF2.md` gains a section saying which form a citation takes and which
shapes are not it: a module or a test citing a file of that directory
names the file and says `TF2.md` pins the revision; a citation carries
no line number into another repository; a vendoring line is not a
citation, the revision beside `src/btclib/_ripemd160.py`'s copy saying
which bytes were taken.

### The census, and the decision it changed

The issue body read the tree-wide `bitcoin/bitcoin@9be056a8a7` C++
convention as two odd exceptions. A census taken before any edit found
that spelling across `src/` and `tests/` and in `tests/_data/README.md`,
so it is a convention and the exceptions were the reading. Without that
measurement the sweep would have rewritten every one of those sites. The
branch leaves every C++ citation alone.

### Review

Four local review rounds at fresh context, each on its own sha. Three
found a false clause in prose this branch wrote itself, and the same
sentence was wrong three times:

1. `8b8b3e92` — one framework citation the path-spelling sweep could not
   see: `block/build.py`'s dotted `test_framework.blocktools.create_block`,
   in the same file whose other citation the branch had already fixed.
   And the C++ clause claimed `bitcoin/bitcoin@9be056a8a7` is used
   "throughout `src/` and `tests/`": of the nine files citing
   `src/protocol.h`, eight carry no revision at all.
2. `920f74c0` — the correction had generalised the quantifier while
   keeping the identification: the tree cites two repository-wide trees,
   `9be056a8a7` (27 sites) and `4ec6ff022a` (5), so neither is *the*
   tree that was read.
3. `ad3b3697` — the third spelling, "never the tip of a single path" and
   "no pin of the path it names", is refuted by
   `tests/p2p/addrv2_test.py:14-26`: two Core C++ files cited at
   permalinks that each *are* the tip of their own path. The remedy was
   not a fourth qualifier. The claim is gone from all three prose sites;
   the paragraph says only that `TF2.md` pins no C++ path, so such a
   citation has no entry there to leave a revision to.
4. `1f62c404` — cleared. One further sentence deleted on the reviewer's
   non-blocking note: "Neither is spelled the way a framework citation
   is" is false of `tests/p2p/core_commands_test.py:63-65`, which names
   `src/protocol.h`, carries no revision, and points at
   `tests/_data/README.md`.

The closing measurement, agreed by five independent runs: a
paragraph-level sweep over every `test_framework` mention in `src/` and
`tests/` reads 22 paragraphs at every sha, flags 22 on `main` and 2 on
this branch — `src/btclib/_ripemd160.py` (the vendoring line) and
`tests/_data/README.md` (ledger machinery), both carve-outs the
decision names.

### Gates

Read as exit codes, on this tree:

| gate | exit |
|---|---|
| `uvx pre-commit run --all-files` | 0 |
| `uv run --locked pytest -q` | 0 — 32140 passed, 31 skipped, 1 xfailed, coverage 100.00% |
| `uv run --locked sphinx-build -n -W -b html docs/source` | 0 |

Rebased onto `origin/main` after PR 1738 landed; the `merge=union`
driver ate the blank line before the new `###`, which the detector run
*after* the rebase caught and one inserted line repaired.

### Collateral filed, not fixed here

- [ISS 1737](https://github.com/btclib-org/btclib/issues/1737) —
  `tests/_data/README.md` pins `src/test/crypto_tests.cpp` to a
  repository-wide sha under a per-path `behind 0`, so a re-check run as
  documented reports drift forever.
- [ISS 1739](https://github.com/btclib-org/btclib/issues/1739) —
  `TF2.md`'s *Reading an entry* says a repository-wide revision cannot
  be the tip of any single path; `tests/p2p/addrv2_test.py`'s two pins
  are that shape and each is a tip. That sentence is what cost this
  branch three rounds, and it is landed text this branch does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Standardize Bitcoin Core test-framework citations around stable file or function names while centralizing revision tracking in TF2.md.

Bug Fixes:
- Replace fragile Bitcoin Core file revisions and line-number permalinks in test-framework citations with stable function or file references managed through TF2.md.

Enhancements:
- Document citation conventions and distinguish framework references, C++ citations, and vendored source pins.
- Update btclib source and test documentation to consistently identify the TF2.md-managed revision for referenced Bitcoin Core test-framework files.

Documentation:
- Add changelog and TF2.md guidance explaining how test-framework citations are formed and where their revisions are pinned.