### PR TITLE
A pin's `behind` reads the default branch (closes #1739) (closes #1737)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -924,6 +924,42 @@ file of the test tree, and no caller acts on it.
   `src/btclib/_ripemd160.py`'s vendored copy says which bytes were
   taken, and belongs where the copy is.
 
+### `TF2.md` says what a repository-wide revision settles
+
+- **A commit chosen to name a tree is the tip of a path only where
+  nothing on the default branch has touched that path since**
+  (closes #1739). *Reading an entry* said such a revision cannot be the
+  tip of any single path, so that `behind` never reads zero for it and
+  no per-path check can clear it; `tests/p2p/addrv2_test.py` cites
+  Core's C++ at two such commits, and one of them is the tip of the
+  path it names. What the passage says now is that being a tip is a
+  fact about the default branch's history rather than about the pin, so
+  a per-path `behind` cannot be counted on to read zero for such a
+  revision -- which is what makes the per-path pin the one a ledger
+  built for re-checking takes.
+- **The entry *`TF2.md`, one entry per file of Core's test framework*
+  above carries that universal too**, as "only the first can ever read
+  `behind 0`". It is landed text and stands as written; the bullet above
+  is where the corrected sentence is.
+
+### `crypto_tests.cpp`'s pins name the tip of that path
+
+- **`tests/_data/chacha20_vectors.json` and
+  `tests/_data/muhash_vectors.json` pin `src/test/crypto_tests.cpp` to
+  `bitcoin/bitcoin@dbbb780af0`** (closes #1737), where they pinned
+  `9be056a8a7`, Core's v31.1 release merge. That merge is the tree this
+  repository reads for Core's consensus rules and is no ancestor of
+  Core's default branch, so the entries claimed `behind 0` under a
+  commit the weekly `.github/scripts/check_vendored_vectors.py` reports
+  as drift instead. *Re-checking a pin* in that file compares blobs and
+  answers at either commit; where a pin goes stale is the weekly
+  check's to say.
+- **No vendored byte moves.** `src/test/crypto_tests.cpp` is blob
+  `b348793bfb` at the release merge and at the tip of its path alike,
+  which is the `blob` both entries already carried, so what was
+  transcribed is a reading of the same source either way and the pin is
+  what changes.
+
 ## v2026.9.3
 
 ### Repository

--- a/TF2.md
+++ b/TF2.md
@@ -42,13 +42,18 @@ btclib-secp256k1 carries a copy of it under the same name that a change
 to either would be owed. Wiring is therefore its own change, not this
 file's.
 
-An entry's `commit` is the tip of its own path, so `behind` reads zero
-and a re-check can clear it. A repository-wide revision is a perfectly
-good "this is the tree I read" pin, and `contents/<path>?ref=<sha>`
-resolves one; what it cannot be is the tip of any single path, so
-`behind` never reads zero for it and a per-path staleness check never
-clears it. A ledger whose whole purpose is re-checkability takes the pin
-that goes stale loudly.
+An entry's `commit` is the tip of the path the entry names, so `behind`
+reads zero and a re-check can clear it. A repository-wide revision is a
+perfectly good "this is the tree I read" pin, and
+`contents/<path>?ref=<sha>` resolves one; what it settles is the tree
+and not the path. It is the tip of a path only where nothing on the
+default branch has touched that path since, which is a fact about that
+history rather than about the pin:
+`.github/scripts/check_vendored_vectors.py` records BIP327's files
+sharing a commit that was the tip of only one of the paths it stood
+for. So a per-path `behind` cannot be counted on to read zero for such
+a revision, and a ledger whose whole purpose is re-checkability takes
+the per-path pin, which is the one that goes stale loudly.
 
 ## The verdicts
 

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -1132,7 +1132,7 @@ implements no jumbo-block hasher.
 ```text
 repo    bitcoin/bitcoin
 path    src/test/crypto_tests.cpp
-commit  9be056a8a72b624dae9623b2f7bded92c2a21c91  2026-07-06
+commit  dbbb780af02d850a1f9257f18610cfb9de9cb828  2026-02-26
 blob    b348793bfb6397ebde806961b6783b1540a33804
 pulled  2026-09-03
 behind  0 revisions; that commit is the tip of the path
@@ -1158,7 +1158,7 @@ that source file, and the weekly re-check reports a case added to it.
 ```text
 repo    bitcoin/bitcoin
 path    src/test/crypto_tests.cpp
-commit  9be056a8a72b624dae9623b2f7bded92c2a21c91  2026-07-06
+commit  dbbb780af02d850a1f9257f18610cfb9de9cb828  2026-02-26
 blob    b348793bfb6397ebde806961b6783b1540a33804
 pulled  2026-09-03
 behind  0 revisions; that commit is the tip of the path


### PR DESCRIPTION
Closes #1739
Closes #1737

One decision in both ledgers: what a pin's `behind` is a fact about.

`TF2.md`'s *Reading an entry* said a repository-wide revision "cannot be
the tip of any single path", so `behind` never reads zero for it. It
can: `tests/p2p/addrv2_test.py` cites Core's C++ at two such commits,
and one of them is the tip of the path it names as the ledgers' own
re-check computes one — the latest commit of the **default branch**
touching that path.

The converse is false too, and it is the trap this branch fell into
twice before landing: such a commit is *not* the tip of every path it
touched. `dbbb780af02d…` touched fifty-three paths and is the tip of
thirteen, and `.github/scripts/check_vendored_vectors.py` already
records the shape — BIP327's files shared a commit that was the tip of
only one of the paths it stood for. What the passage says now is
narrower than either universal: such a revision is the tip of a path
only where nothing on the default branch has touched that path since,
which is a fact about that history rather than about the pin, so a
per-path `behind` cannot be counted on to read zero for it — which is
why a ledger built for re-checking pins per path.

`tests/_data/README.md`'s `chacha20_vectors.json` and
`muhash_vectors.json` pinned `src/test/crypto_tests.cpp` at
`9be056a8a7`, Core's v31.1 release merge, under `behind 0 revisions;
that commit is the tip of the path` — the same shape wearing a per-path
claim. That merge is no ancestor of Core's default branch, so the weekly
`.github/scripts/check_vendored_vectors.py` reads both entries as behind
forever. The pin moves to `dbbb780af0`, the real tip of that path, and
the `behind` line and `blob` stay: `src/test/crypto_tests.cpp` is blob
`b348793bfb` at both commits, so no vendored byte moves, and that blob
holds the two `BOOST_AUTO_TEST_CASE`s the entries transcribe. Declaring
the pin repository-wide instead would put a second grammar into a file
whose re-check is per path, and would drop both entries out of the
weekly check's scope.

`CHANGELOG.md`'s landed entry under *`TF2.md`, one entry per file of
Core's test framework* carries the same universal as "only the first can
ever read `behind 0`". Landed text is not rewritten, so the new entry
names it and carries the corrected sentence.

### Review

Two rounds. The first found that the replacement sentence had respelled
the defect rather than removed it — `cannot` had become `is`, and "the
tip of every path that commit touched" is false under the meaning of
*tip* both ledgers' re-checks use. It also found the second entry
blaming the wrong procedure: `tests/_data/README.md`'s *Re-checking a
pin* compares **blobs**, and the blob is identical at both commits, so
it answers and matches; the commits-by-path query lives in `TF2.md`'s
section of the same name. Both corrections went into all three prose
sites, the commit message rewritten rather than amended over, since its
evidence block measured the wrong relation too.

`tests/tf2_ledger_test.py::test_no_entry_states_a_count` caught the
first replacement stating "BIP327's eight files" — the ledger's own
count rule reaches a citation of another file's docstring.

### Gates

Read as exit codes, on this tree:

| gate | exit |
|---|---|
| `uvx pre-commit run --all-files` | 0 |
| `uv run --locked pytest -q` | 0 — 32140 passed, 31 skipped, 1 xfailed, coverage 100.00% |
| `uv run --locked sphinx-build -n -W -b html docs/source` | 0 |

### Collateral filed, not fixed here

- [ISS 1741](https://github.com/btclib-org/btclib/issues/1741) —
  `check_vendored_vectors.py` skips an entry carrying *no* `behind` line
  under the label "already documented as behind", so a pin whose
  `behind` an edit deleted reads as a deliberate gap. Its twin in
  `btclib-secp256k1` is owed the same fix.

ISS 1739's own body measures the wrong relation in its evidence
(`git log -1 <sha> -- <path>` walks history *from* that commit, so it
answers for any commit that touched the path); a comment on the issue
corrects it, since the conclusion stands on the half that holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Correct pin staleness semantics and refresh crypto test vector references without changing vendored source content.

Bug Fixes:
- Correct the documented semantics of repository-wide revisions and per-path `behind` checks so pins are evaluated against the default branch history.
- Update the crypto test vector pins to the current tip of `src/test/crypto_tests.cpp`, eliminating false staleness while preserving the vendored blob.

Enhancements:
- Clarify TF2 guidance on when a revision can represent the tip of an individual path and when per-path re-checking is appropriate.

Documentation:
- Document the corrected repository-wide revision and path-tip semantics in TF2.md and the changelog.