### PR TITLE
A workflow-status badge's link filters the runs page to `main` (issue btclib-org/.github#762)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -960,6 +960,24 @@ file of the test tree, and no caller acts on it.
   transcribed is a reading of the same source either way and the pin is
   what changes.
 
+### A workflow-status badge's link filters the runs page to `main`
+
+- **Every workflow-status badge link in `README.md` carries
+  `?query=branch%3Amain`** (issue btclib-org/.github#762), where it
+  addressed the workflow's runs page with no filter on it. Section 2 of
+  the organization standard is where that is decided and why: the row is
+  an audit of `main`, so the page the reader arrives on lists the runs
+  the image answers for, and a feature branch's red run at the top of an
+  unfiltered list says nothing about `main`.
+- **The link's spelling is not the image's.** `?branch=main` is ignored
+  on a runs page, which then renders unfiltered, so copying the query
+  that qualifies the image onto the link leaves the click-through
+  answering for every branch. A badge that reports no workflow run --
+  `scorecard`, Read the Docs, pre-commit.ci -- is outside the rule and
+  its link is unchanged.
+- **The head comment gives both halves of the rule**, having named the
+  image's `?branch=main` alone.
+
 ## v2026.9.3
 
 ### Repository

--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ A badge that reports no state -- "we use ruff", "we use uv" -- reports a
 choice instead, and those are in CONTRIBUTING.md, beside the prose that
 says how the choice is enforced.
 
-Every workflow-status badge carries `?branch=main`: section 2 of the
-organization standard is where that is decided and why. The pre-commit.ci
-badge is outside it, being the service's own with its branch already in
-its path.
+Every workflow-status badge carries `?branch=main` on its image and
+`?query=branch%3Amain` on its link: section 2 of the organization
+standard is where that is decided and why. The two spellings are not
+interchangeable -- the runs page ignores the image's and renders
+unfiltered. The pre-commit.ci badge is outside it, being the service's
+own with its branch already in its path.
 -->
 [![PyPI version](https://img.shields.io/pypi/v/btclib.svg?logo=pypi)](https://pypi.python.org/pypi/btclib/)
 [![GitHub release](https://img.shields.io/github/v/release/btclib-org/btclib.svg)](https://github.com/btclib-org/btclib/releases)
@@ -34,23 +36,23 @@ its path.
 [![wheel](https://img.shields.io/pypi/wheel/btclib.svg)](https://pypi.python.org/pypi/btclib/)
 
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib/main.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib/main)
-[![lint workflow status](https://github.com/btclib-org/btclib/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/lint.yml)
-[![test workflow status](https://github.com/btclib-org/btclib/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/test.yml)
-[![docs workflow status](https://github.com/btclib-org/btclib/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/docs.yml)
+[![lint workflow status](https://github.com/btclib-org/btclib/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/lint.yml?query=branch%3Amain)
+[![test workflow status](https://github.com/btclib-org/btclib/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/test.yml?query=branch%3Amain)
+[![docs workflow status](https://github.com/btclib-org/btclib/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/docs.yml?query=branch%3Amain)
 [![documentation build](https://app.readthedocs.org/projects/btclib/badge/?version=latest)](https://btclib.readthedocs.io)
-[![vendored-vectors workflow status](https://github.com/btclib-org/btclib/actions/workflows/vendored-vectors.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/vendored-vectors.yml)
-[![mutation workflow status](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml)
-[![fuzz workflow status](https://github.com/btclib-org/btclib/actions/workflows/fuzz.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/fuzz.yml)
-[![integration-bitcoind workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml)
-[![integration-hwi workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-hwi.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/integration-hwi.yml)
-[![deps-latest workflow status](https://github.com/btclib-org/btclib/actions/workflows/deps-latest.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/deps-latest.yml)
-[![pypi-install workflow status](https://github.com/btclib-org/btclib/actions/workflows/pypi-install.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/pypi-install.yml)
-[![py-arm-authority workflow status](https://github.com/btclib-org/btclib/actions/workflows/py-arm-authority.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/py-arm-authority.yml)
-[![os-macos workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-macos.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/os-macos.yml)
-[![os-ubuntu workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-ubuntu.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/os-ubuntu.yml)
-[![os-windows workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-windows.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/os-windows.yml)
-[![links workflow status](https://github.com/btclib-org/btclib/actions/workflows/links.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/links.yml)
-[![codeql workflow status](https://github.com/btclib-org/btclib/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/codeql.yml)
+[![vendored-vectors workflow status](https://github.com/btclib-org/btclib/actions/workflows/vendored-vectors.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/vendored-vectors.yml?query=branch%3Amain)
+[![mutation workflow status](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/mutation.yml?query=branch%3Amain)
+[![fuzz workflow status](https://github.com/btclib-org/btclib/actions/workflows/fuzz.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/fuzz.yml?query=branch%3Amain)
+[![integration-bitcoind workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/integration-bitcoind.yml?query=branch%3Amain)
+[![integration-hwi workflow status](https://github.com/btclib-org/btclib/actions/workflows/integration-hwi.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/integration-hwi.yml?query=branch%3Amain)
+[![deps-latest workflow status](https://github.com/btclib-org/btclib/actions/workflows/deps-latest.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/deps-latest.yml?query=branch%3Amain)
+[![pypi-install workflow status](https://github.com/btclib-org/btclib/actions/workflows/pypi-install.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/pypi-install.yml?query=branch%3Amain)
+[![py-arm-authority workflow status](https://github.com/btclib-org/btclib/actions/workflows/py-arm-authority.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/py-arm-authority.yml?query=branch%3Amain)
+[![os-macos workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-macos.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/os-macos.yml?query=branch%3Amain)
+[![os-ubuntu workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-ubuntu.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/os-ubuntu.yml?query=branch%3Amain)
+[![os-windows workflow status](https://github.com/btclib-org/btclib/actions/workflows/os-windows.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/os-windows.yml?query=branch%3Amain)
+[![links workflow status](https://github.com/btclib-org/btclib/actions/workflows/links.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/links.yml?query=branch%3Amain)
+[![codeql workflow status](https://github.com/btclib-org/btclib/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/btclib-org/btclib/actions/workflows/codeql.yml?query=branch%3Amain)
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/btclib-org/btclib/badge)](https://scorecard.dev/viewer/?uri=github.com/btclib-org/btclib)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14253/badge)](https://www.bestpractices.dev/projects/14253)


### PR DESCRIPTION
Answers `btclib`'s share of
[btclib-org/.github#762](https://github.com/btclib-org/.github/issues/762);
the other eight repositories are other sessions', so this closes
nothing.

Section 2 of the organization standard says a workflow-status badge's
**link** carries `?query=branch%3Amain`, as its **image** carries
`?branch=main`. This tree's sixteen link halves carried neither.

The two spellings are not interchangeable, which is the whole reason
the rule needed a second half: `?branch=main` on a runs page is
**ignored** and the page renders unfiltered. Re-derived here rather
than taken from the issue, by fetching `actions/workflows/lint.yml`
three ways and counting in the served HTML:

| query | `branch:main` in the filter box | feature-branch names listed |
| --- | --- | --- |
| none | 0 | 38 |
| `?branch=main` | 0 | 38 |
| `?query=branch%3Amain` | 4 | 4 |

So copying the image's query onto the link — the obvious move — does
nothing.

### The head comment

`README.md`'s head comment stated the image's half as though it were
the whole rule. It now names both spellings and points at section 2 for
why, keeping the pre-commit.ci exemption it already carried.

The issue offered either stating the rule or ceasing to paraphrase it,
and the comment six lines above refuses to copy each sentinel's day and
hour from that same section — "a reader wanting the schedule reads it
there, where it is still true". The two are not in tension: a schedule
is a value this file does not embody, where the two spellings are
values sixteen of its own lines embody. And the clause that carries the
weight here — that the runs page ignores the image's query — is a fact
about GitHub rather than about the standard, so it does not go stale
when section 2 is edited.

### The census, and what was kept out of it

The issue's own commands, `/usr/bin/grep` because this machine's shell
`grep` is a function wrapping `ugrep` that answers a confident zero for
an anchor inside an alternation:

| | link halves | carrying a query |
| --- | --- | --- |
| before | 16 | 0 |
| after | 16 | 16 |
| `.github`, untouched, as the control | 3 | 3 |

`scorecard`, Read the Docs, pre-commit.ci and OpenSSF Best Practices
badges are not workflow-status badges and section 2 exempts them. Their
twelve lines are byte-identical to `origin/main`, with a positive
control proving that comparison can see a difference; and the reverse
question — a workflow badge the sweep missed — answers none under a
pattern deliberately wider than the edit's own. All sixteen rewritten
URLs answer `200`.

### Review

Cleared at this sha. One non-blocking nit, on the choice above rather
than on the diff, recorded in the paragraph that explains it.

Nothing gates this: no test reads the root `README.md`'s badge rows,
and `btclib-org/.github`'s `tests/grid_test.py` records that gap as a
deliberate limit — "the badge half is a reader's catch, no fixture here
holding a tree's `README.md`" — so it is not a defect found here.

### Gates

Read as exit codes:

| gate | exit |
|---|---|
| `uvx pre-commit run --all-files` | 0 |
| `uv run --locked pytest -q` | 0 — 32140 passed, 31 skipped, 1 xfailed, coverage 100.00% |
| `uv run --locked sphinx-build -n -W -b html docs/source` | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Make workflow-status badge links open runs filtered to `main` while documenting the distinct query syntax required for badge images and links.

Bug Fixes:
- Update all workflow-status badge links in `README.md` to open GitHub Actions runs filtered to the `main` branch.

Enhancements:
- Clarify in the README comment that workflow badge images and links require different branch-filter query parameters.

Documentation:
- Document the workflow badge link filtering rule and its exception for badges that do not report workflow status.