### PR TITLE
The mutation dropdown is held to the matrix, and the curve session reported (closes #1734) (closes #1735)

### DIFF
--- a/.github/mutation/curve_group.toml
+++ b/.github/mutation/curve_group.toml
@@ -4,7 +4,7 @@
 # scope exists at all: `signatures.toml`'s own header names this pair as
 # invisible to it, because `curve.py`'s dispatch sends a default-curve
 # call to the libsecp256k1 bindings before either module's code ever
-# runs, and no other profile named them either.
+# runs, and no profile other than this one names them.
 #
 # Neither module goes through that dispatch here. Both test files below
 # import and call the underscore-prefixed algorithm functions directly
@@ -33,14 +33,15 @@ timeout = 300
 
 excluded-modules = []
 
-# no session has run yet. `cosmic-ray init` over this file enumerates
-# 5529 mutants today (5548 when this profile was written, both modules
-# having changed some since -- re-checked for issue #987, which is what
-# wires this profile into a job at last), nearly double
-# signatures.toml's dsa.py/ssa.py pair at 2980 -- sampled there rather
-# than finished, and likely sampled here too. The wall clock a sample
-# takes, and what it finds, are issue #822's follow-up rather than a
-# guess written down here in their place
+# The session is a sample and not a sweep: `cosmic-ray init` over this
+# file enumerates 5529 mutants today (5548 when this profile was
+# written, both modules having changed some since -- re-checked for
+# issue #987, which is what wires this profile into a job at last),
+# nearly double signatures.toml's dsa.py/ssa.py pair at 2980, and the
+# weekly job cuts the session at the budget mutation.yml's matrix gives
+# it. What it judged is in the run's own artifact; reading the survivors
+# back into a header here, the way signatures.toml's header reports its
+# own session, is issue #1745
 
 [cosmic-ray.distributor]
 name = "local"

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -233,14 +233,14 @@ jobs:
             sessions: |
               signatures.toml 90m
           # the pure-Python point arithmetic under the two signing modules
-          # above: 5529 mutants, nearly double their pair's 2980, and
-          # written for issue #822 -- which this scope answers and
-          # signatures.toml's own header still names as the profile with
-          # none of it yet -- but never added to a job of its own, so no
-          # session has run it. 90 minutes, matching signatures.toml's
-          # budget for a scope nearly double the size, is a first sample
-          # rather than a measured one; what it finds is #822's follow-up,
-          # the same note curve_group.toml itself makes
+          # above: 5529 mutants, nearly double their pair's 2980, and the
+          # scope issue #822 asks for -- why it is invisible to the
+          # signatures profile is curve_group.toml's own header. 90
+          # minutes, matching signatures.toml's budget for a scope nearly
+          # double the size, samples the scope rather than finishing it:
+          # the weekly job cuts the session there and reports what it
+          # judged, and triaging that is issue #1745, the same note
+          # curve_group.toml itself makes
           - profile: the pure-Python curve arithmetic
             slug: curves
             ceiling: 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -978,6 +978,37 @@ file of the test tree, and no caller acts on it.
 - **The head comment gives both halves of the rule**, having named the
   image's `?branch=main` alone.
 
+### `mutation.yml`'s dispatch options and its matrix slugs name one set
+
+- **`tests/mutation_sessions_test.py` asserts that
+  `.github/workflows/mutation.yml`'s `workflow_dispatch` options and the
+  matrix's own `slug` values are the same names**, `all` excepted
+  (closes #1734). An option no slug answers leaves the job's `SELECTED`
+  expression false in every entry of the matrix: each takes a runner and
+  gives it back in seconds, and the run is green having measured
+  nothing. A slug no option offers is the quieter direction, the
+  schedule running that profile whatever the dropdown holds.
+- **What that module reads is the dropdown as well as the block scalars
+  `sessions:` opens**, through one reader over the lines a key indents
+  under it, where the entry landing the session census named the block
+  scalars alone.
+- **`all` is asserted present before it is subtracted, and a repeated
+  name is asserted against on both sides.** Subtracting a member that is
+  not there removes nothing, so the equality would hold for a dropdown
+  that had lost the entry its own `default:` names; and two matrix
+  entries sharing a slug answer one option and upload their sessions
+  under one artifact name, which an equality of sets cannot see either.
+
+### `curve_group.toml` and `mutation.yml` report the curve session as sampled
+
+- **The `curves` matrix entry of `.github/workflows/mutation.yml` and
+  `.github/mutation/curve_group.toml` say what the weekly session does
+  with the scope** (closes #1735), where each said that none had run it.
+  The job cuts the session at the budget the matrix gives it and reports
+  what it judged, so the scope is sampled rather than unmeasured.
+- **Triaging those survivors is issue #1745**, which is what both files
+  defer to: the deferral named issue #822, and that one is closed.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/mutation_sessions_test.py
+++ b/tests/mutation_sessions_test.py
@@ -2,16 +2,27 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Every mutation profile has a session, and every session a profile.
+"""What `.github/workflows/mutation.yml`'s matrix is held to.
+
+Two correspondences, and each of them breaks in silence.
 
 `.github/mutation/` states what a scope mutates and what judges it, and
-`.github/workflows/mutation.yml`'s matrix is what spends a budget on it.
-Neither file names what the other holds, and both directions of the drift
-are quiet. A configuration no session names enumerates nothing, measures
-nothing and reports nothing, while the workflow stays green: a job that
-does not exist cannot fail. A session naming a configuration that is gone
-is a red `Check the baselines` step in a weekly run of a workflow that
-gates nothing, so it waits for whoever opens the Actions tab.
+the matrix is what spends a budget on it. Neither file names what the
+other holds. A configuration no session names enumerates nothing,
+measures nothing and reports nothing, while the workflow stays green: a
+job that does not exist cannot fail. A session naming a configuration
+that is gone is a red `Check the baselines` step in a weekly run of a
+workflow that gates nothing, so it waits for whoever opens the Actions
+tab.
+
+The dispatch dropdown and the matrix's own `slug` are the second pair,
+and `SELECTED` is what joins them: it compares `inputs.profile` with
+`matrix.slug`, so an option no slug answers leaves that expression false
+in every job. Each takes a runner and gives it back in seconds, and the
+run is green having measured nothing, which is a failure with nothing
+red in it. A slug no option offers is the quieter half: the schedule
+runs that profile whatever the dropdown holds, so nothing says the
+button is short of one.
 
 The workflow is read as text rather than parsed as yaml, the suite's own
 environment carrying no yaml parser: pyyaml reaches this tree through
@@ -22,14 +33,13 @@ collects on a contributor's own `uv sync`, which installs every group,
 and fails to collect in CI -- issue #1538's shape, and the reason
 `tests/copyright_test.py` reads a line of `docs/source/conf.py` rather
 than executing it. What is read here is narrow enough to defend without a
-parser: the block scalars introduced by `sessions:`, each line of which
-is a configuration and the budget `timeout` is given.
+parser: the lines a key indents under it, one at a time.
 
-Both censuses are asserted non-empty before either is compared, a set
-subtracted from an empty one being empty whatever it holds, and the
-reader is driven over a literal workflow of its own -- a `sessions:`
-reworded past what it matches would otherwise make every assertion below
-pass for free.
+Every census is asserted non-empty before anything is subtracted from
+it, a set subtracted from an empty one being empty whatever the other
+holds, and each reader is driven over a literal workflow of its own -- a
+key reworded past what a reader matches would otherwise make every
+assertion below pass for free.
 """
 
 from __future__ import annotations
@@ -52,23 +62,34 @@ _PROFILES = _ROOT / ".github" / "mutation"
 # of a budget this module does not otherwise read
 _SESSION = re.compile(r"(\S+\.toml) \d+(?:\.\d+)?[smhd]?")
 
+# an entry of the dispatch dropdown: a sequence item and nothing else
+# on the line. Held to the whole of it, so that a key indented into the
+# list is reported rather than read as an option
+_OPTION = re.compile(r"- (\S+)")
 
-def _sessions(text: str) -> tuple[list[str], list[str]]:
-    """Return the configurations the matrix runs, and what is no session.
+# the matrix column `SELECTED` compares `inputs.profile` against. Held
+# to its own indented, complete line, so that neither the `matrix.slug`
+# of that expression nor a comment writing the word is read as an entry
+_SLUG = re.compile(r"^ +slug: (\S+)$", re.MULTILINE)
 
-    A `sessions:` block scalar runs to the first line indented no deeper
-    than the key that opened it, blank lines belonging to the scalar
-    rather than closing it. That is the whole of the yaml this needs, the
-    value being literal text the `while read -r config budget` loops of
-    the workflow split on whitespace.
+# the one entry of the dropdown that is no profile: `inputs.profile ==
+# 'all'` is a branch of `SELECTED` rather than a matrix entry, so it is
+# subtracted from the dropdown's side instead of being looked for on the
+# matrix's
+_EVERY_PROFILE = "all"
 
-    The second list is what keeps a line from leaving the census in
-    silence: one the reader cannot parse is reported rather than dropped,
-    which is the difference between a census that is wrong and one that
-    is empty.
+
+def _block(text: str, key: str) -> list[str]:
+    """Return the stripped lines each `key` line indents under it.
+
+    A block runs to the first line indented no deeper than the key that
+    opened it, blank lines belonging to the block rather than closing
+    it. That is the whole of the yaml either reader below needs:
+    `sessions: |` opens a scalar whose value is literal text the
+    `while read -r config budget` loops of the workflow split on
+    whitespace, and `options:` a sequence the forge draws as a dropdown.
     """
-    configurations: list[str] = []
-    unparsed: list[str] = []
+    lines: list[str] = []
     depth: int | None = None
     for line in text.split("\n"):
         stripped = line.strip()
@@ -76,20 +97,57 @@ def _sessions(text: str) -> tuple[list[str], list[str]]:
             if not stripped:
                 continue
             if len(line) - len(line.lstrip(" ")) > depth:
-                session = _SESSION.fullmatch(stripped)
-                if session is None:
-                    unparsed.append(stripped)
-                else:
-                    configurations.append(session.group(1))
+                lines.append(stripped)
                 continue
             depth = None
-        if stripped == "sessions: |":
+        if stripped == key:
             depth = len(line) - len(line.lstrip(" "))
-    return configurations, unparsed
+    return lines
 
 
+def _entries(lines: list[str], entry: re.Pattern[str]) -> tuple[list[str], list[str]]:
+    """Return what `entry` captured line by line, and what it did not match.
+
+    The second list is what keeps a line from leaving a census in
+    silence: one the reader cannot parse is reported rather than
+    dropped, which is the difference between a census that is wrong and
+    one that is empty.
+    """
+    read: list[str] = []
+    unparsed: list[str] = []
+    for line in lines:
+        found = entry.fullmatch(line)
+        if found is None:
+            unparsed.append(line)
+        else:
+            read.append(found.group(1))
+    return read, unparsed
+
+
+def _sessions(text: str) -> tuple[list[str], list[str]]:
+    """Return the configurations the matrix runs, and what is no session."""
+    return _entries(_block(text, "sessions: |"), _SESSION)
+
+
+def _options(text: str) -> tuple[list[str], list[str]]:
+    """Return what the dropdown offers, and what is no option.
+
+    A comment is dropped here where the reader reports one under
+    `sessions: |`, and the asymmetry is the yaml: under `options:` a `#`
+    line is a comment, which this file's own matrix already writes
+    between the items of a sequence, while inside a block scalar the
+    same line is literal text the workflow would take for a
+    configuration of that name.
+    """
+    lines = [line for line in _block(text, "options:") if not line.startswith("#")]
+    return _entries(lines, _OPTION)
+
+
+_TEXT = _WORKFLOW.read_text(encoding="utf-8")
 _CONFIGURATIONS = frozenset(path.name for path in _PROFILES.glob("*.toml"))
-_RUN, _UNPARSED = _sessions(_WORKFLOW.read_text(encoding="utf-8"))
+_RUN, _UNPARSED = _sessions(_TEXT)
+_OFFERED, _UNOFFERED = _options(_TEXT)
+_SLUGS: list[str] = _SLUG.findall(_TEXT)
 
 
 def test_both_sides_of_the_census_were_read() -> None:
@@ -132,6 +190,54 @@ def test_every_session_names_a_configuration() -> None:
     assert not unaccounted, (
         f"a session names no file under .github/mutation: {unaccounted}"
     )
+
+
+def test_both_sides_of_the_dispatch_census_were_read() -> None:
+    """The same guard for the dropdown, and two the matrix needs beside it.
+
+    `all` is subtracted from the dropdown below, and subtracting a member
+    that is not there removes nothing: the equality would then hold for a
+    dropdown that had lost the entry its own `default:` names.
+
+    A repeated name is what an equality of sets cannot see either, and it
+    costs on both sides: two matrix entries sharing a slug answer one
+    option and name one artifact between them, which the upload step's
+    own comment calls an error, and an option offered twice is a
+    dropdown drawn with a duplicate in it.
+    """
+    assert _OFFERED, "no dispatch option was read out of mutation.yml at all"
+    assert _SLUGS, "no matrix slug was read out of mutation.yml at all"
+    assert not _UNOFFERED, f"a line under `options:` is no option: {_UNOFFERED}"
+    assert _EVERY_PROFILE in _OFFERED, (
+        f"the dropdown does not offer `{_EVERY_PROFILE}`, its own default"
+    )
+    assert len(set(_OFFERED)) == len(_OFFERED), (
+        f"the dropdown offers one profile twice: {sorted(_OFFERED)}"
+    )
+    assert len(set(_SLUGS)) == len(_SLUGS), (
+        f"two matrix entries share a slug: {sorted(_SLUGS)}"
+    )
+
+
+def test_every_option_names_a_profile() -> None:
+    """An option no slug answers asks for a run that measures nothing.
+
+    `SELECTED` is false in every job of the matrix, each of them takes a
+    runner and gives it back in seconds, and the run is green.
+    """
+    unmatched = sorted(set(_OFFERED) - {_EVERY_PROFILE} - set(_SLUGS))
+    assert not unmatched, f"the dropdown offers what no matrix entry runs: {unmatched}"
+
+
+def test_every_profile_is_offered_by_the_dropdown() -> None:
+    """The other direction: a profile the button cannot ask for.
+
+    The schedule runs it whatever the dropdown holds, so what is lost is
+    the escape hatch alone, and a scope reachable once a week is exactly
+    the one somebody wants to re-measure by hand.
+    """
+    unoffered = sorted(set(_SLUGS) - set(_OFFERED))
+    assert not unoffered, f"the dropdown cannot ask for: {unoffered}"
 
 
 def test_the_reader_finds_the_sessions_and_only_those() -> None:
@@ -179,3 +285,73 @@ def test_a_line_that_is_no_session_is_reported() -> None:
 
     assert configurations == ["a.toml"]
     assert unparsed == ["b.toml", "c.txt 30m"]
+
+
+def test_the_reader_finds_the_dropdown_and_only_it() -> None:
+    """The same guard for the other reader, over the same file's shapes.
+
+    The keys of the input above the list, a comment between two entries,
+    the dedent to the next top-level key, and the matrix's own sequence
+    below it, which is indented under a key of another name and is not
+    the dropdown.
+    """
+    offered, unparsed = _options(
+        "on:\n"
+        "  workflow_dispatch:\n"
+        "    inputs:\n"
+        "      profile:\n"
+        "        default: all\n"
+        "        type: choice\n"
+        "        options:\n"
+        "          - all\n"
+        "          # the escape hatch this file argues for\n"
+        "          - consensus\n"
+        "\n"
+        "permissions:\n"
+        "  contents: read\n"
+        "        include:\n"
+        "          - profile: one\n"
+    )
+
+    assert offered == ["all", "consensus"]
+    assert not unparsed
+
+
+def test_a_line_that_is_no_option_is_reported() -> None:
+    """A key indented into the list is named rather than read as an entry.
+
+    Dropping it instead is how the census goes quiet about the drift it
+    is here for: the dropdown would read as holding less than it does,
+    and the comparison would be against a set that is simply wrong.
+    """
+    offered, unparsed = _options(
+        "        options:\n"
+        "          - all\n"
+        "          - two words\n"
+        "          type: choice\n"
+    )
+
+    assert offered == ["all"]
+    assert unparsed == ["- two words", "type: choice"]
+
+
+def test_the_slug_reader_reads_the_column_and_not_a_mention_of_it() -> None:
+    """`slug` is a word the workflow writes about itself as well as a key.
+
+    The `SELECTED` expression that consumes the column names it, and so
+    does the comment on the step that uploads under it; neither is an
+    entry, and reading either as one would report a profile no job runs.
+    """
+    text = (
+        "    env:\n"
+        "      SELECTED: >-\n"
+        "        ${{ inputs.profile == matrix.slug }}\n"
+        "        include:\n"
+        "          # slug: the word, in a comment\n"
+        "          - profile: one\n"
+        "            slug: consensus\n"
+        "          - profile: two\n"
+        "            slug: parsers\n"
+    )
+
+    assert _SLUG.findall(text) == ["consensus", "parsers"]


### PR DESCRIPTION
Closes #1734.
Closes #1735.

**ISS 1734** — `mutation.yml`'s `workflow_dispatch` dropdown and its
matrix slugs are two hand-maintained lists that have to name one set,
and nothing held them together. `tests/mutation_sessions_test.py` now
reads both out of the workflow and asserts the correspondence in three
pieces: every option names a profile, every profile is offered by the
dropdown, and — the piece the two set differences cannot see — the
dropdown still offers `all`, its own default.

The reader gains no second block-walker: `_sessions` and `_options` are
one `_block(text, key)` plus one `_entries(lines, pattern)`, so the
existing session tests exercise the shared code and there is no
per-caller branch for the coverage floor to miss.

**ISS 1735** — `mutation.yml` said the curve arithmetic profile was
"never added to a job of its own, so no session has run" over it. Two
weekly runs on record say otherwise, and both were cut at the budget:
`33387231296` (2026-08-31) and `32618720233` (2026-08-23) each carry
`##[notice] .github/mutation/curve_group.toml: cut at 90m`. What that
establishes is that the session *samples* the scope, not what it
judged — the verdicts moved between the two runs, so either figure
written into a comment would be false again next Monday. The prose says
the weaker true thing:

> The session is a sample and not a sweep: … the weekly job cuts the
> session at the budget `mutation.yml`'s matrix gives it. What it judged
> is in the run's own artifact; reading the survivors back into a header
> here … is issue #1745

The issue named a third site, `signatures.toml`'s header, and that site
does not exist: the phrase belongs to `mutation.yml`'s *characterisation*
of `signatures.toml` rather than to `signatures.toml`, whose own text is
present-tense and still true. Verified with a positive control —
`none of it yet` answers `mutation.yml:239` at the base and nothing in
`signatures.toml` at either ref. That file is untouched, and the false
clause was removed where it actually lived.

One more past-tense clause went with it as collateral:
`curve_group.toml:7`'s "and no other profile named them either" became
"and no profile other than this one names them", measured against
`grep -n 'curve_group' .github/mutation/*.toml`.

### The claim this entry supersedes

`CHANGELOG.md`'s open section already carries, from PR #1738, "What is
read is the block scalars `sessions:` opens", which this change makes
non-exhaustive. That landed text is byte-identical at both refs; the new
entry names the gap in its own words rather than editing it, which is
the pattern this file already uses.

### Collateral filed

[ISS 1745](https://github.com/btclib-org/btclib/issues/1745) — both
files deferred the survivor triage to
[ISS 822](https://github.com/btclib-org/btclib/issues/822), which is
closed with nothing open naming that work, while two weekly sessions
have produced survivors that live only in run artifacts that expire. The
prose in both files now cites #1745. `CONTRIBUTING.md:897`'s claim that
every file under `.github/mutation/` states what its last session
measured is false of `curve_group.toml` and was false before this branch
too; it is quoted in #1745 rather than fixed here.

### Gates

Exit codes, read rather than filtered output:

| gate | exit |
|---|---|
| `uvx pre-commit run --all-files` | 0 |
| `uv run --locked pytest -q` | 0 (32146 passed, 31 skipped, 1 xfailed; coverage 100.00%, floor reached) |
| `uv run --locked sphinx-build -n -W -b html` | 0 |

Five red-then-green controls, each tamper proved by `git diff --numstat`
and restored: an option naming no slug, a slug the options do not offer,
the dropdown losing its own default (**both** set-difference tests stay
green — the case the third assertion exists for), two entries sharing a
slug, and the key reworded so the reader answers empty. `CHANGELOG.md`
is a pure append (31/0) reconstructed byte-for-byte from the base blob,
the glued-heading detector is silent against a control that fires, and
the falsification sweep's zeros each carry a positive control on the
base blob. Reviewed locally at fresh context before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Keep mutation workflow dispatch options aligned with matrix profiles and accurately describe the curve session as a budget-limited sample.

New Features:
- Add validation ensuring mutation workflow dispatch options and matrix slugs remain complete, unique, and mutually consistent.
- Document that the curve mutation profile runs as a budget-limited sample and defer survivor triage to issue #1745.

Bug Fixes:
- Correct inaccurate mutation workflow and profile commentary that claimed the curve session had not run.

Enhancements:
- Refactor mutation workflow parsing into shared block and entry readers and expand tests for dropdown, matrix, and malformed-input coverage.

Documentation:
- Update the changelog with the mutation configuration consistency checks and the curve session's sampled-run semantics.

Tests:
- Extend mutation session tests to verify dispatch options, matrix slugs, defaults, uniqueness, and both directions of correspondence.