### PR TITLE
The `uv_build` floor is bounded rather than copied (closes #1743)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -733,7 +733,7 @@ repos:
     hooks:
       - id: check-sdist
         args: [--inject-junk, --installer=pip]
-        additional_dependencies: ["uv_build>=0.12.6,<0.13"]
+        additional_dependencies: ["uv_build>=0.12.9,<0.13"]
   - repo: https://github.com/regebro/pyroma
     # the newest *stable* tag: 5.1b1 and 5.1b2 sit above it, and
     # `pre-commit autoupdate` offers a prerelease as readily as a release,
@@ -761,4 +761,4 @@ repos:
         # dependencies elsewhere in this file: what this has to match is
         # a range rather than a release, and the isolated build it
         # replaces would have resolved the same range itself
-        additional_dependencies: ["uv_build>=0.12.6,<0.13"]
+        additional_dependencies: ["uv_build>=0.12.9,<0.13"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1009,6 +1009,17 @@ file of the test tree, and no caller acts on it.
 - **Triaging those survivors is issue #1745**, which is what both files
   defer to: the deferral named issue #822, and that one is closed.
 
+### `[build-system] requires`'s `uv_build` floor is a range, not a rev copy
+
+- **The floor sits above the `0.12.0` boundary and no higher than the rev
+  `.pre-commit-config.yaml` pins for `uv-pre-commit`, rather than at
+  that rev** (closes #1743): pre-commit.ci moves the rev on this
+  repository's own weekly schedule with nothing moving the floor, so a
+  floor written equal to it stops being equal at the next bump where a
+  floor under it stays right. The `check-sdist` and `pyroma` hook
+  environments and `RELEASING.md`'s prose move with it, `RELEASING.md`
+  naming the range rather than restating the number.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -683,11 +683,11 @@ Two things bound that guarantee, and both are worth knowing before reading
 a mismatch as tampering:
 
 - **the build backend is bounded, not pinned.** `[build-system] requires`
-  asks for `uv_build>=0.12.5,<0.13`, and a build takes whichever version
-  in that range the uv running it carries, so a rebuild months later runs
-  a backend the release never saw. A mismatch dates the rebuild before it
-  accuses anyone; pinning the backend to a version is the fix, and the
-  cost is a bound that ages.
+  names a range rather than a version, and a build takes whichever
+  version in that range the uv running it carries, so a rebuild months
+  later runs a backend the release never saw. A mismatch dates the
+  rebuild before it accuses anyone; pinning the backend to a version is
+  the fix, and the cost is a bound that ages.
 - **the rehearsal is a different version, by construction.** A TestPyPI
   dispatch appends `.dev<run*100+attempt>` to the version, so its files
   are not a second build of the release's — they are their own artifact,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,21 @@
 # language of a MANIFEST.in. The sdist's own pyproject.toml becomes a
 # normalized copy of this file at 0.12.0, with the verbatim source kept
 # beside it as pyproject.toml.orig; below it, pyproject.toml is that
-# verbatim file itself, with no .orig. This floor sits above the boundary
-# on purpose, at the rev .pre-commit-config.yaml's uv-pre-commit hook
-# pins, so the backend building the sdist matches the uv whose lock
-# format that hook's uv-lock writes. The ceiling is the next minor, which
-# is where uv's versioning policy puts a breaking change, this backend
-# releasing with uv and versioned by it
-requires = ["uv_build>=0.12.6,<0.13"]
+# verbatim file itself, with no .orig. The floor sits above that boundary
+# and no higher than the rev .pre-commit-config.yaml pins for
+# uv-pre-commit -- a range and not an equality on purpose: pre-commit.ci
+# moves that rev upward on this repository's own weekly schedule with
+# nothing moving this number, so a floor written equal to it stops being
+# equal at the next bump where a floor under it stays right. The upper
+# bound, and the number to lower first if a resolver ever wants this one
+# lower:
+#
+#     grep -A1 'astral-sh/uv-pre-commit' .pre-commit-config.yaml
+#
+# The ceiling is the next minor, which is where uv's versioning policy
+# puts a breaking change, this backend releasing with uv and versioned by
+# it
+requires = ["uv_build>=0.12.9,<0.13"]
 build-backend = "uv_build"
 
 [project]


### PR DESCRIPTION
Closes #1743.

`[build-system] requires` gave one reason for its `uv_build` floor and
the rev it named had moved past it: the comment said the floor sits *at*
the rev `.pre-commit-config.yaml` pins for `uv-pre-commit`, and at the
branch point those were `0.12.6` and `0.12.9`. pre-commit.ci bumps that
rev weekly, so the number was right or wrong by accident from one week
to the next while the comment read as a rule being followed.

The comment now states a range — above the `0.12.0` boundary and no
higher than this tree's own pinned rev — with the mechanism beside it
and the command that re-derives the upper bound
(`grep -A1 'astral-sh/uv-pre-commit' .pre-commit-config.yaml`). The
relation survives the bump in a way the equality does not: the rev only
ever moves upward, so `floor <= rev` holds at every future bump wherever
in the range the floor sits.

This is the same defect `bitcoin-core-rpc` closed today in
btclib-org/bitcoin-core-rpc#379, and what carried across is the
reasoning and not the number — that commit's own argument is that a
sibling's floor is no second reason for one, since pre-commit.ci moves
each tree's revs on that tree's own schedule. This floor is derived from
btclib's rev, and nothing here gives the sibling as a reason.

Two things the sibling's fix did that this one does **not**, because the
defects are not here: btclib's comment never carried the refuted
`uv build`-under-a-pinned-`requires` re-derivation (confirmed with a
positive control, not a bare zero), so nothing was imported for it; and
there was no "this pin included" provenance clause to strike.

### What the sweep found that the issue did not

`RELEASING.md` carried a *third* restatement of the specifier, at
`uv_build>=0.12.5,<0.13` — already stale against the pre-fix floor of
`0.12.6`, so wrong before this branch touched anything. It now names the
range rather than repeating it, which is the point: the number is
declared where it is enforced. `check-sdist` and `pyroma`'s
`additional_dependencies` move with `[build-system]`, those hook
environments being where `build` finds the backend when it does not
isolate.

Left alone, each checked rather than assumed to state no number:
`CONTRIBUTING.md`, `docs/source/package-content-policy.md`,
`.github/workflows/deps-latest.yml`, and `CHANGELOG.md`'s landed
entries.

### Out of scope, and tracked

`[tool.uv] required-version` is untouched — it answers a different
question, the uv that reads `uv.lock` rather than the backend that
builds the archive. That it now sits below the `uv_build` floor, and
that section 3 of the organization standard names two alignment targets
that cannot both hold, are btclib-org/.github#834 and
btclib-org/.github#835, both open. Neither blocks this.

### Gates

Exit codes, read rather than filtered output:

| gate | exit |
|---|---|
| `uv sync --locked` | 0 |
| `uv run pytest` | 0 (32146 passed, 31 skipped, 1 xfailed; coverage 100.00%, floor reached) |
| `uv run pre-commit run --all-files` | 0 |
| `uv run sphinx-build -n -W -b html` | 0 |

Base current, with two-dot and three-dot `--numstat` identical;
`CHANGELOG.md` a pure append (11/0); glued-heading detector silent.
Reviewed locally at fresh context, which traced the one judgement call —
raising the floor to the rev pinned today rather than leaving it lower —
and found it consistent with both the comment's own words and the
sibling's practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Bound the uv_build floor to the repository’s pinned uv-pre-commit revision while keeping the requirement resilient to future automated revision updates.

Bug Fixes:
- Keep the uv_build minimum version bounded by the repository’s uv-pre-commit revision instead of treating it as an exact revision copy.

Enhancements:
- Update release guidance to describe the uv_build requirement as a version range rather than a repeated version number.
- Synchronize pre-commit hook build dependencies with the updated uv_build floor.

Documentation:
- Clarify how the uv_build range is derived and maintained, including the command for checking the pinned uv-pre-commit revision.