### PR TITLE
CLAUDE.md and release_notes_test.py stop offering a broken entry count (issue btclib-org/.github#829)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1020,6 +1020,20 @@ file of the test tree, and no caller acts on it.
   environments and `RELEASING.md`'s prose move with it, `RELEASING.md`
   naming the range rather than restating the number.
 
+### Counting `CHANGELOG.md`'s entries is a reading, not a command
+
+- **`CLAUDE.md` and `tests/release_notes_test.py` no longer offer
+  `grep -c '^- ' CHANGELOG.md` as what counts this file's entries**
+  (issue btclib-org/.github#829): a `###` heading names one entry or a
+  theme several entries share, and an entry making a single claim can be
+  a paragraph with no bullet at all, so no bullet-anchored pattern
+  reaches every entry and only entries. Counting them is a reading of
+  the file. `CLAUDE.md`'s own rule against stating a count is unchanged;
+  the places in `## v2026.8.7` making the same claim -- that section's
+  own opening prose and a bullet of its `### Repository` entry -- are
+  landed text and stand as written, this entry being where the
+  correction is read instead.
+
 ## v2026.9.3
 
 ### Repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,10 +310,15 @@ Do not use Fable unless explicitly instructed.
   release wants it, and do not estimate:
 
   ```shell
-  grep -c '^- ' CHANGELOG.md
   git ls-files 'tests/_data/*' 'tests/*/_data/*' \
       src/btclib/mnemonic/_data/wordlist.txt | grep -cv 'README.md'
   ```
+
+  CHANGELOG.md has no command of this kind: a `###` heading names one
+  entry or a theme several entries share, and an entry's own claims sit
+  in a bullet or, where it makes a single claim, in a paragraph with no
+  bullet at all — so counting its entries is a reading of the file, not
+  a pattern any command matches.
 
   The why is section 9 of the organization standard, which
   `CONTRIBUTING.md` points at; what this file adds is that nothing states

--- a/tests/release_notes_test.py
+++ b/tests/release_notes_test.py
@@ -15,8 +15,8 @@ Checking the number against the bullets is one answer, and it costs what
 it fixes: the count is then a line every open branch has to edit, so it
 becomes the one conflict a pull request is guaranteed to have -- and two
 branches moving it to the same new number merge without a conflict into a
-number that is wrong. So neither file states it, and
-`grep -c '^- ' CHANGELOG.md` derives it whenever a release wants it.
+number that is wrong. So neither file states it, and counting the
+entries is a reading of the file, not a command.
 
 Which is what this module guards, the assertions running the other way
 round: a count anywhere in either file is a failure. Not only because one
@@ -74,15 +74,15 @@ def test_neither_file_states_a_count(path: Path) -> None:
 
     Written by hand or put back by a `union` merge that had nothing to
     decide: either way the number is a claim nothing derives, and the
-    command in the header derives it instead.
+    header explains why -- counting the entries is a reading of the
+    file, not a command.
     """
     text = path.read_text(encoding="utf-8")
     for pattern in _FORBIDDEN:
         match = re.search(pattern, text)
         assert match is None, (
             f"{path.name} states a count again: {match[0]!r}."
-            " Remove it -- `grep -c '^- ' CHANGELOG.md` answers on demand,"
-            " and a rebase restores such a paragraph in silence."
+            " Remove it -- a rebase restores such a paragraph in silence."
         )
 
 


### PR DESCRIPTION
btclib's share of btclib-org/.github#829. It does **not** close that
issue — four other trees still owe their own share.

`grep -c '^- ' CHANGELOG.md` does not count this file's entries, and
four live sites offered it as the way to. A `-` bullet at the margin is
one of an entry's separate claims where the `###` heading above it names
an entry, and a whole entry where that heading names a theme several
entries share; and section 9 lets an entry making a single claim have a
paragraph body with no bullet at all. Counting the headings fails too,
both kinds sitting in one file.

The four:

| site | what it said |
|---|---|
| `CLAUDE.md:313` | the command block under *Never state how many of anything a file holds* |
| `tests/release_notes_test.py:19` | "`grep -c '^- ' CHANGELOG.md` derives it whenever a release wants it" |
| `tests/release_notes_test.py:77` | "the command in the header derives it instead" |
| `tests/release_notes_test.py:84` | the assertion's failure message |

The last is the one that mattered most: the guard that **enforces** the
no-count rule handed the contributor who had just tripped it a command
that does not answer — advice at the moment of maximum trust, to
somebody who by construction is looking for the right thing to do
instead. The third carried no command and so was not a site of the
claim, but it pointed at the second and would have gone dangling; that
is a repair the same commit owes.

**No replacement command is named**, deliberately: a second command that
also cannot count would be this issue landed twice, and worse than
twice, since the second would arrive with a landing behind it and read
as settled.

### What is untouched, and why

The `git ls-files` command beside the removed one counts vendored data
*files*, which `git ls-files` does answer. `tests/release_notes_test.py`'s
assertions and `_FORBIDDEN` patterns are byte-identical — this is prose
and one message string, not a behaviour change.

The places in the released `## v2026.8.7` making the same claim — that
section's own opening prose and a bullet of its `### Repository`
entry — are landed text and stand as written. Fixing the live sites
leaves no live *instruction* wrong: `CLAUDE.md` and a failing assertion
are read to decide what to do, where a released changelog section is
read to learn what happened. This entry is where the correction is met.

### Measured rather than assumed

`git grep -n -F "grep -c '^- '"` at the tip answers three — this entry's
own body, and the two landed sites. The sibling `bitcoin-core-rpc` entry
reads the same way, so the family's post-fix census is one live
occurrence per fixed tree rather than zero.

The organization standard itself prescribes no counting command: its
three `grep -c` hits are a security-policy readback, the note that a
diff's deletions are `--numstat`'s, and a commit count. So there is no
root sentence upstream to fix and no port issue owed — only per-tree
work.

### Gates

Exit codes, read rather than filtered output:

| gate | exit |
|---|---|
| `pre-commit run --all-files` | 0, zero `Failed` lines |
| `uv run --locked pytest` | 0 — 32146 passed, 31 skipped, 1 xfailed, coverage 100.00% |
| `sphinx-build -n -W -b html` | 0 |

`CHANGELOG.md` is a pure append; base current, two-dot and three-dot
`--numstat` identical; glued-heading detector silent against a control
that fires. Reviewed locally at fresh context over two rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Stop presenting an unreliable command as a way to count CHANGELOG.md entries and clarify the resulting guidance across contributor documentation and release-note checks.

Bug Fixes:
- Remove misleading commands that claim to derive the number of entries in CHANGELOG.md.

Enhancements:
- Clarify that CHANGELOG.md entry counts must be determined by reading the file rather than by a reliable counting pattern.
- Document the correction in the changelog while preserving the existing no-count enforcement behavior.

Tests:
- Update release-note guidance and assertion messaging to reflect that changelog entry counts cannot be derived by command.