### PR TITLE
Every pragma: no cover names its case inline (issue btclib-org/.github#838)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1034,6 +1034,27 @@ file of the test tree, and no caller acts on it.
   landed text and stand as written, this entry being where the
   correction is read instead.
 
+### Every `pragma: no cover` names its case on the pragma's own line
+
+- **Every `# pragma: no cover` in this tree carries its case after
+  ` -- ` on the pragma's own line** (issue btclib-org/.github#838):
+  `git grep -nE 'pragma: no cover$' -- '*.py'` answers empty, matching
+  section 8's current rule, and the fuller reason a site already
+  carried off the line stays where it was. `CONTRIBUTING.md`,
+  `pyproject.toml` and `tests/minikey_test.py` carry the same rule in
+  prose, worded to match.
+
+### `bms` no longer stands as an example of a pragma it does not carry
+
+- **`pyproject.toml`, `src/btclib/curves/curve.py` and
+  `tests/curves/curve_test.py` name `dleq` where they named `bms`**:
+  `git grep -n pragma -- src/btclib/ecc/bms.py` answers nothing here
+  and at the commit this branch is built on alike, where
+  `borromean.py`, `dleq.py` and `musig2.py` each carry one for a branch
+  the arithmetic rules out. The released entry repeating the claim is
+  landed text and stands as written, this entry being where the
+  correction is read instead.
+
 ## v2026.9.3
 
 ### Repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -396,8 +396,10 @@ special-cases the value, so 99.999% is a red build where the 99.99 this
 replaces passed everything above 99.985%, and the 99.9 before it ten
 times as much again. No slack, so a statement no test reaches is either
 covered by patching what stands in the way, as the ripemd160 fallback
-and electrum's round-trip check are, or marked `pragma: no cover` with
-the reason beside it. `--cov` is in pyproject.toml's addopts, so `uv run
+and electrum's round-trip check are, or marked `pragma: no cover --`
+with the reason on that same line, and a reason too long for the line
+above it as well, the inline half naming the case. `--cov` is in
+pyproject.toml's addopts, so `uv run
 pytest` prints the total and enforces the ratchet on every whole run, on
 the 3.14 the gate is checked on — a run that selects a subset with paths,
 `-k` or `-m` reports without gating, since `fail_under` would otherwise

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -116,7 +116,7 @@ used to teach and to prototype as much as to build:
     measured rather than assumed: the point-multiplication side has
     been regular since #254, and `sign`'s own line, `s = (k_1_ +
     values.b * k_2_ + values.e * a * d) % secp256k1.n`
-    (`src/btclib/ecc/musig2.py:838`), spreads 1.016x over uniform scalars
+    (`src/btclib/ecc/musig2.py:840`), spreads 1.016x over uniform scalars
     in `[1, n-1]` -- the magnitude leak that remains shows only for
     scalars with zero high bits, keys already lost for other reasons.
     The gain left is narrower than that figure suggests: delegating
@@ -154,7 +154,7 @@ used to teach and to prototype as much as to build:
     a public signature and buy nothing, short of btclib no longer
     holding a private key as a Python `int`, which is a change to that
     representation and not to a call site. `ellswift.xdh`
-    (`src/btclib/ecc/ellswift.py:363`) is the one of them that returns
+    (`src/btclib/ecc/ellswift.py:365`) is the one of them that returns
     octets rather than an `int`, so a caller-owned buffer there would
     hold what it wiped: taking it means growing `xdh`'s public
     signature with `into=` and owning the contract that comes with
@@ -165,7 +165,7 @@ used to teach and to prototype as much as to build:
     `dsa.Signer.__init__` crosses the same boundary the other way,
     once, at construction: the plain `int` `scalar_from_prv_key` already
     produced becomes a transient `bytes` via
-    `self._q.to_bytes(32, "big")` (`src/btclib/ecc/dsa.py:1350`) on the
+    `self._q.to_bytes(32, "big")` (`src/btclib/ecc/dsa.py:1354`) on the
     way into the owned buffer `wipe` overwrites afterwards. That
     `bytes` is dropped rather than erased, same as the `int` it
     replaces — one call rather than the buffer's whole lifetime, which

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -765,9 +765,9 @@ precision = 2
 # library that is installed, a guard the shipped data cannot trip --
 # no longer disappears into a rounding step. It is covered by patching
 # what stands in the way, which is what hashes_test and electrum_test
-# already do and say, or it carries a `pragma: no cover` with the reason
-# beside it, as borromean, bms and musig2 do for a branch arithmetic
-# rules out. Neither of those is a build left red.
+# already do and say, or it carries a `pragma: no cover --` whose reason
+# names the case on that same line, as borromean, dleq and musig2 do for
+# a branch arithmetic rules out. Neither of those is a build left red.
 # Measured on one interpreter, 3.14, and that is still enough at 100:
 # btclib has no sys.version_info and no sys.platform branch, so every
 # job walks the same lines and a tree at 100.00% there is at 100.00%

--- a/src/btclib/_libsecp256k1.py
+++ b/src/btclib/_libsecp256k1.py
@@ -129,7 +129,7 @@ try:
 # coverage that job does not collect. So this branch is a structural
 # miss in that report regardless of the union, and removing the pragma
 # would fail the one gate this issue chose to leave unchanged
-except ImportError:  # pragma: no cover
+except ImportError:  # pragma: no cover -- only the no-bindings job reaches this
     # None and not a callable that raises: what would raise is never
     # called, so the object would be a second thing to keep true. The
     # ignore is on the assignment and not on the module: every other

--- a/src/btclib/curves/curve.py
+++ b/src/btclib/curves/curve.py
@@ -724,9 +724,9 @@ def _multi_mult_x_only_var(
                 _y_even_var(x, ec)
             # the loop above raises, every ValueError from the bindings
             # here being a term they could not read: the pragma is the
-            # one borromean and bms carry, for a line the arithmetic
+            # one borromean and dleq carry, for a line the arithmetic
             # rules out
-            raise  # pragma: no cover
+            raise  # pragma: no cover -- the loop above always raises first
         return INF if total is None else _point_from_sec(total)
 
     points = [(x, _y_even_var(x, ec)) for x in x_coords]

--- a/src/btclib/ecc/borromean.py
+++ b/src/btclib/ecc/borromean.py
@@ -515,8 +515,10 @@ def sign(
             # low-cardinality curve makes it a one-in-n *accident* rather
             # than something a chosen message can arrange
             if not 0 < e[i][j] < ec.n:
-                err_msg = "implausible signature failure"  # pragma: no cover
-                raise BorromeanRingError(err_msg, i, j)  # pragma: no cover
+                err_msg = "implausible signature failure"  # pragma: no cover -- e is zero only by a one-in-n accident
+                raise BorromeanRingError(
+                    err_msg, i, j
+                )  # pragma: no cover -- e is zero only by a one-in-n accident
         # reduced mod n, like every forged value above: unreduced, this
         # is about twice the bit length of the others -- k and
         # q_ints[i] * e[i][j_star] are each near n, so their sum is

--- a/src/btclib/ecc/dleq.py
+++ b/src/btclib/ecc/dleq.py
@@ -159,7 +159,7 @@ def generate_proof(
         t + bytes_from_point(A, secp256k1) + bytes_from_point(C, secp256k1) + m,
     )
     k = int.from_bytes(rand, "big") % secp256k1.n
-    if k == 0:  # pragma: no cover
+    if k == 0:  # pragma: no cover -- k is zero only by an unreachable hash preimage
         # a preimage of a multiple of n for the nonce tagged hash: not
         # reachable by choosing arguments, and BIP374 fails rather than
         # signs with it
@@ -175,7 +175,9 @@ def generate_proof(
     # rather than in its reference harness: a proof that does not verify
     # is a fault in the arithmetic that produced it, and handing it out
     # is what the protocol above was going to use it to rule out
-    if not verify_proof(A, B_point, C, proof, G_point, msg):  # pragma: no cover
+    if not verify_proof(
+        A, B_point, C, proof, G_point, msg
+    ):  # pragma: no cover -- the proof just computed cannot fail to verify
         raise BTClibRuntimeError("implausible proof failure")
     return proof
 

--- a/src/btclib/ecc/dsa.py
+++ b/src/btclib/ecc/dsa.py
@@ -771,7 +771,9 @@ def _libsecp256k1_sign_(
             except BTClibValueError:
                 raise BTClibValueError("not a public key") from e
         raise BTClibValueError(str(e)) from e
-    except RuntimeError as e:  # pragma: no cover
+    except (
+        RuntimeError
+    ) as e:  # pragma: no cover -- libsecp256k1_dsa.sign's own RuntimeError, no argument
         # unreachable from an argument, as the Python arm's own is: what
         # it reports is the computation having gone wrong
         raise BTClibRuntimeError(str(e)) from e
@@ -1251,7 +1253,9 @@ def _delegated_sign_(
             verify=verify,
             pubkey=pubkey_sec if verify else None,
         )
-    except RuntimeError as e:  # pragma: no cover
+    except (
+        RuntimeError
+    ) as e:  # pragma: no cover -- libsecp256k1_dsa.sign's own RuntimeError, no argument
         # unreachable from an argument, as `_libsecp256k1_sign_`'s own is:
         # what it reports is the computation having gone wrong
         raise BTClibRuntimeError(str(e)) from e

--- a/src/btclib/ecc/ellswift.py
+++ b/src/btclib/ecc/ellswift.py
@@ -168,8 +168,10 @@ def _xswiftec_var(u: int, t: int, ec: Curve) -> int:
     # the map is total -- the SwiftEC paper's result is that one of the
     # three candidates is always an x-coordinate, and BIP324's reference
     # implementation writes this line as `assert False`
-    err_msg = "no x-coordinate for the given field elements"  # pragma: no cover
-    raise BTClibRuntimeError(err_msg)  # pragma: no cover
+    err_msg = "no x-coordinate for the given field elements"  # pragma: no cover -- one of the three candidates is always an x-coordinate
+    raise BTClibRuntimeError(
+        err_msg
+    )  # pragma: no cover -- one of the three candidates is always an x-coordinate
 
 
 def _xswiftec_inv_var(x: int, u: int, case: int, ec: Curve) -> int | None:  # noqa: PLR0911

--- a/src/btclib/ecc/musig2.py
+++ b/src/btclib/ecc/musig2.py
@@ -386,7 +386,9 @@ def key_agg(pub_keys: Sequence[Octets]) -> KeyAggContext:
         if len(points) == 1
         else multi_mult_var(coefficients, points, secp256k1)
     )
-    if Q[1] == 0:  # pragma: no cover
+    if (
+        Q[1] == 0
+    ):  # pragma: no cover -- cancelling every coefficient is the discrete-log problem
         # the coefficients are hashes, so cancelling them all out is the
         # discrete-log problem rather than a case to handle: raise where
         # BIP327's reference asserts, an assert being absent under -O

--- a/src/btclib/psbt/musig2.py
+++ b/src/btclib/psbt/musig2.py
@@ -446,7 +446,9 @@ def partial_sign(
         # the context is the one the signature was just made against.
         # It stays because what it costs is one verification against a
         # partial signature that no other signer can be told to ignore
-        raise BTClibValueError("invalid musig2 partial signature")  # pragma: no cover
+        raise BTClibValueError(
+            "invalid musig2 partial signature"
+        )  # pragma: no cover -- sign() and verify() here share one session.context
     psbt_in.musig2_partial_sigs[key_data] = psig
     return psig
 

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -340,7 +340,7 @@ def no_bindings_bip32(monkeypatch: pytest.MonkeyPatch) -> None:
         def __getattr__(self, name: str) -> Any:
             # a green suite is one where this never runs, which is the
             # pragma curve_test.no_bindings carries for the same reason
-            raise AssertionError(  # pragma: no cover
+            raise AssertionError(  # pragma: no cover -- cleared _libsecp256k1_available keeps this uncalled
                 f"the dispatch is switched off, and bip32 asked for {name}"
             )
 
@@ -441,7 +441,7 @@ def test_public_key_validation_does_not_lift(
     def refuse(*_: object) -> int:
         # a green suite is one where this never runs, which is the pragma
         # curve_test.no_bindings carries for the same reason
-        raise AssertionError(  # pragma: no cover
+        raise AssertionError(  # pragma: no cover -- the fast path here never needs mod_sqrt_var
             "the y of an extended public key was computed"
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,7 +279,9 @@ def check_golden(path: Path, name: str, value: Any, module: str) -> None:
         )
 
 
-def _skip_what_needs_the_bindings(items: list[pytest.Item]) -> None:  # pragma: no cover
+def _skip_what_needs_the_bindings(
+    items: list[pytest.Item],
+) -> None:  # pragma: no cover -- only the no-bindings job reaches this
     """Skip every test marked `bindings`, naming why once.
 
     Runs only where `btclib_secp256k1` is absent, `INSTALLED` being set
@@ -318,4 +320,6 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     into doing only one.
     """
     if not INSTALLED:
-        _skip_what_needs_the_bindings(items)  # pragma: no cover
+        _skip_what_needs_the_bindings(
+            items
+        )  # pragma: no cover -- only the no-bindings job reaches this

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -1011,9 +1011,9 @@ def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def refuse(*_: object, **__: object) -> bytes:
         # a green suite is one where this never runs: the pragma is the
-        # same one borromean and bms carry, for a line the arithmetic --
+        # same one borromean and dleq carry, for a line the arithmetic --
         # here the dispatch above it -- rules out
-        raise AssertionError(  # pragma: no cover
+        raise AssertionError(  # pragma: no cover -- cleared _libsecp256k1_available keeps this uncalled
             "the libsecp256k1 dispatch is switched off"
         )
 
@@ -1056,7 +1056,7 @@ def no_bindings_anywhere(monkeypatch: pytest.MonkeyPatch) -> None:
         def asked(*_args: object, **_kwargs: object) -> Any:
             # a green suite is one where this never runs, the same pragma
             # no_bindings above carries for a call the dispatch rules out
-            raise AssertionError(  # pragma: no cover
+            raise AssertionError(  # pragma: no cover -- cleared _libsecp256k1_available keeps this uncalled
                 f"the Python arm reached libsecp256k1: {what}"
             )
 

--- a/tests/ecc/musig2_test.py
+++ b/tests/ecc/musig2_test.py
@@ -59,7 +59,7 @@ from tests import load, needs_bindings, vector_id
 
 if INSTALLED:
     from btclib_secp256k1 import musig as libsecp256k1_musig
-else:  # pragma: no cover
+else:  # pragma: no cover -- only the no-bindings job reaches this
     # never called from a skipped test, mirroring the fallback
     # `btclib._libsecp256k1` gives every name it wraps
     libsecp256k1_musig = None  # type: ignore[assignment]

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -237,7 +237,7 @@ def test_refusing_an_r_takes_no_square_root(
     """
 
     def refuse(*_: object) -> int:
-        raise AssertionError(  # pragma: no cover
+        raise AssertionError(  # pragma: no cover -- the fast path here never needs mod_sqrt_var
             "an r was lifted to a point in order to refuse it"
         )
 
@@ -869,9 +869,15 @@ def test_musig1() -> None:
     # parity would cover the lines instead, trading away the fresh
     # randomness that makes this protocol demo worth running
     if Q[1] % 2:
-        a1 = ec.n - a1  # pragma: no cover
-        a2 = ec.n - a2  # pragma: no cover
-        a3 = ec.n - a3  # pragma: no cover
+        a1 = (
+            ec.n - a1
+        )  # pragma: no cover -- runs on half of this random parity's coin flips
+        a2 = (
+            ec.n - a2
+        )  # pragma: no cover -- runs on half of this random parity's coin flips
+        a3 = (
+            ec.n - a3
+        )  # pragma: no cover -- runs on half of this random parity's coin flips
 
     # round 1: each signer picks a nonce and publishes only a commitment
     # to it. Committing before any nonce is visible is the round the
@@ -922,9 +928,15 @@ def test_musig1() -> None:
     K = ec.add_var(ec.add_var(K1, K2), K3)
     # the same coin flip as above, on the aggregated nonce
     if K[1] % 2:
-        k1 = ec.n - k1  # pragma: no cover
-        k2 = ec.n - k2  # pragma: no cover
-        k3 = ec.n - k3  # pragma: no cover
+        k1 = (
+            ec.n - k1
+        )  # pragma: no cover -- runs on half of this random parity's coin flips
+        k2 = (
+            ec.n - k2
+        )  # pragma: no cover -- runs on half of this random parity's coin flips
+        k3 = (
+            ec.n - k3
+        )  # pragma: no cover -- runs on half of this random parity's coin flips
     r = K[0]
     e = ssa.challenge_(msg_hash, Q[0], r, ec, hf)
     s_1 = (k1 + e * a1 * q1) % ec.n
@@ -1071,11 +1083,21 @@ def test_threshold() -> None:
     Q = A[0]
     # the same coin flip as in test_musig1: fresh keys, random parity
     if Q[1] % 2:
-        A[1] = ec.negate(A[1])  # pragma: no cover
-        alpha1 = ec.n - alpha1  # pragma: no cover
-        alpha2 = ec.n - alpha2  # pragma: no cover
-        alpha3 = ec.n - alpha3  # pragma: no cover
-        Q = ec.negate(Q)  # pragma: no cover
+        A[1] = ec.negate(
+            A[1]
+        )  # pragma: no cover -- runs on half of this random parity's coin flips
+        alpha1 = (
+            ec.n - alpha1
+        )  # pragma: no cover -- runs on half of this random parity's coin flips
+        alpha2 = (
+            ec.n - alpha2
+        )  # pragma: no cover -- runs on half of this random parity's coin flips
+        alpha3 = (
+            ec.n - alpha3
+        )  # pragma: no cover -- runs on half of this random parity's coin flips
+        Q = ec.negate(
+            Q
+        )  # pragma: no cover -- runs on half of this random parity's coin flips
 
     # SECOND PHASE: generation of the nonces' pair  ######################
     # Assume signer one and three want to sign
@@ -1118,10 +1140,18 @@ def test_threshold() -> None:
     # even help: k1 and k3 come from bip340_nonce_ with aux=None, i.e.
     # fresh OS randomness, so the aux would need pinning too
     if K[1] % 2:
-        B[1] = ec.negate(B[1])  # pragma: no cover
-        beta1 = ec.n - beta1  # pragma: no cover
-        beta3 = ec.n - beta3  # pragma: no cover
-        K = ec.negate(K)  # pragma: no cover
+        B[1] = ec.negate(
+            B[1]
+        )  # pragma: no cover -- runs on half of this random parity's coin flips
+        beta1 = (
+            ec.n - beta1
+        )  # pragma: no cover -- runs on half of this random parity's coin flips
+        beta3 = (
+            ec.n - beta3
+        )  # pragma: no cover -- runs on half of this random parity's coin flips
+        K = ec.negate(
+            K
+        )  # pragma: no cover -- runs on half of this random parity's coin flips
 
     # PHASE THREE: signature generation ###
 

--- a/tests/minikey_test.py
+++ b/tests/minikey_test.py
@@ -98,7 +98,9 @@ def test_out_of_range_scalar(monkeypatch: pytest.MonkeyPatch) -> None:
     CONTRIBUTING.md's coverage rule takes 100% literally, so a statement
     no test reaches is either covered by patching what stands in the way
     -- as the ripemd160 fallback and electrum's round-trip check are --
-    or marked `pragma: no cover` with the reason beside it.
+    or marked `pragma: no cover --` with the reason on that same line,
+    and a reason too long for the line above it as well, the inline
+    half naming the case.
     """
     good_minikey = "SzavMBLoXU6kDrqtUVmffv"
     bad_q = ec.n.to_bytes(32, byteorder="big")

--- a/tests/psbt/psbt_size_test.py
+++ b/tests/psbt/psbt_size_test.py
@@ -90,7 +90,7 @@ def pushes(script: bytes) -> list[bytes] | None:
             # and nothing else. The guard is what keeps the answer None
             # rather than a misreading the day a corpus grows a spend
             # whose script_sig executes something
-            return None  # pragma: no cover
+            return None  # pragma: no cover -- the corpus's script_sigs are all pushes
     return out
 
 
@@ -124,7 +124,7 @@ def psbt_input_from_spend(tx_in: TxIn) -> tuple[PsbtIn, bytes] | None:  # noqa: 
     stack = list(tx_in.script_witness.stack)
     script_sig_pushes = pushes(script_sig) if script_sig else []
     if script_sig_pushes is None or (script_sig and not script_sig_pushes):
-        return None  # pragma: no cover
+        return None  # pragma: no cover -- pushes() is never None or empty here
     redeem_script = script_sig_pushes[-1] if script_sig_pushes else b""
 
     if stack:
@@ -138,13 +138,13 @@ def psbt_input_from_spend(tx_in: TxIn) -> tuple[PsbtIn, bytes] | None:  # noqa: 
             # the witness shapes below are the ones the corpus holds; a
             # key path taproot spend is what would reach this, and the
             # blocks predate it
-            return None  # pragma: no cover
+            return None  # pragma: no cover -- a key-path taproot spend, absent from this corpus
         # the script_sig of a segwit input is empty, or the push of the
         # program and nothing else, which is what p2sh-wrapping is. One
         # comparison rather than three, the push being what says both
         # that there is a single one and that it is the program
         if script_sig and script_sig != serialize([program]):
-            return None  # pragma: no cover
+            return None  # pragma: no cover -- a p2sh-wrapped script_sig is definitionally just that push
         script_pub_key = ScriptPubKey.p2sh(program).script if script_sig else program
         psbt_in = PsbtIn(
             witness_utxo=TxOut(1000, script_pub_key, check_validity=False),

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -286,7 +286,7 @@ def test_the_python_prvkey_tweak_lifts_nothing(
     delegated = [output_prvkey(prv_key, tree) for tree in SCRIPT_TREES]
 
     def refuse(*_: object) -> int:
-        raise AssertionError(  # pragma: no cover
+        raise AssertionError(  # pragma: no cover -- the Python arm reads parity off the y mult returned
             "the internal point's x was lifted to read a parity"
         )
 

--- a/tests/script_engine/python_path_test.py
+++ b/tests/script_engine/python_path_test.py
@@ -142,7 +142,9 @@ def test_verify_answers_false_for_what_cannot_be_parsed(
     So the contract is asserted here, and against both arms rather than
     the one this installation happens to have.
     """
-    if delegated and not curve._libsecp256k1_available:  # pragma: no cover
+    if (
+        delegated and not curve._libsecp256k1_available
+    ):  # pragma: no cover -- pytestmark skips one job, the flag guards the other
         # the id would say `bindings` and the run would be the Python arm:
         # both answer False here, so nothing would go red and half the
         # parametrization would check the same thing twice. Skipped rather

--- a/tests/script_engine/transactions_test.py
+++ b/tests/script_engine/transactions_test.py
@@ -218,7 +218,7 @@ def witness_v0_vectors() -> list[Any]:
         # that brings one, and a synthetic vector written to cover it
         # would test the vendored data, not btclib
         if len(x[0]) != len(tx.vin):
-            continue  # pragma: no cover
+            continue  # pragma: no cover -- today's tx_valid.json has no mismatched-prevouts vector
         params.append(param)
     return params
 
@@ -246,7 +246,9 @@ def test_verify_transaction_does_not_touch_witness_v0(vector: list[Any]) -> None
         # NONE is not a member of the enum, hence the first test: it is
         # how Core spells an empty flag field, not a rule to switch off
         if f in ScriptFlag.__members__ and ScriptFlag[f] in flags:
-            flags &= ~ScriptFlag[f]  # pragma: no cover
+            flags &= ~ScriptFlag[
+                f
+            ]  # pragma: no cover -- today's vectors never carry a flag ALL_FLAGS enforces
 
     prevouts, check_amounts = prevouts_of(vector)
 


### PR DESCRIPTION
Section 8 of the organization standard has every `# pragma: no cover`
carry its case inline, after ` -- `, on the pragma's own line. This is
`btclib`'s share of issue btclib-org/.github#838. It does not close it:
`btclib-node` still owes its own.

- 43 sites, each carrying a half that names the case at *that* line.
  Both acceptance commands answer empty —
  `git grep -nE 'pragma: no cover$' -- '*.py'` and
  `'pragma: no cover - [^-]'` — with the base answering 43 for the
  first as the control, and 46 unanchored occurrences at both shas, of
  which three are prose inside docstrings.
- **Nothing executable changed.** `ast.dump` compared per file at both
  shas: identical everywhere but `tests/minikey_test.py`, whose only
  difference is the docstring text this branch rewrites. The 26 rewraps
  are `ruff format`'s response to the longer lines and nothing else.
- Coverage is unchanged at exactly `100.00%`, with zero missed
  statements and zero missed branches — the measurement that matters
  here, since 26 of the 43 pragmas move onto continuation lines, a
  shape this tree did not previously use.
- Three `SECURITY.md` citations re-derived, since their lines moved,
  and read back with `awk 'NR==N'`.
- `pyproject.toml`, `src/btclib/curves/curve.py` and
  `tests/curves/curve_test.py` stop naming `bms` as carrying such a
  pragma: `src/btclib/ecc/bms.py` carries none, at either sha, where
  `borromean.py`, `dleq.py` and `musig2.py` each carry one for a branch
  the arithmetic rules out. The released `CHANGELOG.md` entry repeating
  the claim is landed text and stays as written; the correction is read
  in a new open-section entry that names it.

Reviewed three times at fresh context. Round 1 found a false sentence
about `# pragma: no branch`, a directive this issue does not reach —
reverted. Round 2 blocked on the absence of a gate report for the sha
under review, correctly. Round 3 cleared it.

**`main` is currently red on the `py arm authority` workflow**, and this
branch does not cause it and does not fix it: that job has failed on
every push since `755d5081b` (PR 1720), and is issue #1753. This diff
changes only comments in `src/btclib/curves/` and `src/btclib/ecc/`, so
it cannot change which test reaches which arm. The fix for #1753 lands
next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Make every no-cover pragma self-documenting by placing its exclusion reason on the same line without changing executable behavior or coverage results.

Bug Fixes:
- Correct references that previously identified `bms` as carrying a `pragma: no cover` directive, pointing to `dleq` instead.

Enhancements:
- Annotate every Python `# pragma: no cover` directive with an inline explanation of the excluded case.
- Update contributor guidance and project coverage documentation to require inline reasons for no-cover pragmas.

Documentation:
- Add changelog entries documenting the inline no-cover convention and the corrected `bms` reference.

Chores:
- Refresh security-documentation line references after the source formatting changes.