### PR TITLE
The weekly pin re-check reads `TF2.md` too (issue #1732)

### DIFF
--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -2,27 +2,36 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Re-check every vendored-vector pin against upstream, weekly.
+r"""Re-check a pin ledger against upstream, weekly.
 
-tests/_data/README.md pins each vendored file to a commit and a git blob
-SHA-1, with a documented manual procedure to re-check one -- last done
-by hand on specific dates the file itself records. This automates that
-procedure and reports drift, rather than fixing it: refreshing a vector
-file is a decision this script does not get to make, so what it opens
-is an issue, never a commit.
+A ledger pins each entry to a repository, a path and a commit, and
+carries a documented manual procedure to re-check one pin. This
+automates that procedure and reports drift, rather than fixing it: what
+to do about a pin that has moved is a decision this script does not get
+to make, so what it opens is an issue, never a commit.
+
+The ledger and the issue title are both the caller's, because the
+ledgers this repository passes go stale in different ways and are acted
+on differently: tests/_data/README.md pins the revision a file here was
+copied from, so a moved commit says the copy is behind, and TF2.md pins
+the revision a verdict was read at, so a moved commit says the verdict
+is a claim about a file that has moved. One title over both would name
+one issue for the pair, each run rewriting what the other wrote.
 
 btclib-secp256k1 carries a copy under this same name, over its own
 tests/README.md, whose entries are each pinned to a commit under a
-heading owning one fenced block. A fix to the parsing, to the `gh` call
-or to a field's spelling is owed to the other copy in the same
-campaign; the collapsing of identical skip lines below is not, a
-heading owning several blocks being a shape that README does not carry.
+heading owning one fenced block. What the two copies share is owed to
+the other in the same campaign: the parsing, the `gh` calls, a field's
+spelling, the arguments this takes. What answers to one ledger's own
+shape is not, and the collapsing of identical skip lines below is
+that -- a heading owning several blocks being a shape that README does
+not carry.
 
-Scope is narrower than the README: only entries whose `behind` already
+Scope is narrower than the ledger: only entries whose `behind` already
 reads 0 -- the ones a human last confirmed were exactly at upstream's
 tip. An entry documented as behind is a decision already made, and
 re-reporting the same gap every week would just be noise; if a *new*
-commit moves it further, `behind`'s own count in the README goes stale
+commit moves it further, `behind`'s own count in the ledger goes stale
 in a way this script cannot see either, which is the reason it never
 tries to judge relevance, only tip-vs-pinned identity.
 
@@ -30,23 +39,25 @@ A path upstream has renamed or deleted is reported rather than raising:
 it has no commit to name as a tip, and a pin standing on a file that is
 not there any more is the one drift nobody would otherwise notice.
 
-Three shapes in the README this script does not attempt: an entry with
-no `commit` at all (chain data self-identified by hash, files this
-project composed itself), a path carrying a `<name>` placeholder -- one
-pin standing in for several real paths under a directory, which the
-"commits touching a path" call above cannot be asked about in one
-request -- and a heading with no fenced block under it at all, which is
-either a group heading the pins below it supersede or a pin whose block
-an edit broke. No current entry uses the placeholder shape: BIP327's
-eight files and BIP324's two were themselves written that way once,
-each pin citing one commit as the tip of every path it stood in for.
+Three shapes a ledger can carry that this script does not attempt: an
+entry with no `commit` at all (chain data self-identified by hash,
+files this project composed itself), a path carrying a `<name>`
+placeholder -- one pin standing in for several real paths under a
+directory, which the "commits touching a path" call above cannot be
+asked about in one request -- and a heading with no fenced block under
+it at all, which is either a group heading the pins below it supersede
+or a pin whose block an edit broke. No current entry uses the
+placeholder shape: BIP327's eight files and BIP324's two were
+themselves written that way once, each pin citing one commit as the tip
+of every path it stood in for.
 Splitting them into one pin per real path is what brought them into
 this script's scope, and also corrected BIP327's, whose shared commit
-was the tip of only one of the eight. Every heading the README carries
+was the tip of only one of the eight. Every heading the ledger carries
 but this script did not check is listed in its own report, so nothing
 silently reads as "checked and clean" that was not checked at all.
 
-    python .github/scripts/check_vendored_vectors.py tests/_data/README.md
+    python .github/scripts/check_vendored_vectors.py \
+        tests/_data/README.md "Vendored vectors behind upstream"
 """
 
 from __future__ import annotations
@@ -59,15 +70,13 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-_ISSUE_TITLE = "Vendored vectors behind upstream"
-
 # resolved once: S607 is what a bare "gh" in a subprocess list would be,
 # a partial executable path relying on PATH's own search order rather
 # than naming what actually runs
 _GH = shutil.which("gh") or "gh"
 
-# a vendored file's own ### heading, so a drift report -- and the
-# skipped-entry list -- can name the file rather than only its upstream
+# a ledger entry's own ### heading, so a drift report -- and the
+# skipped-entry list -- can name the entry rather than only its upstream
 # path
 _HEADING = re.compile(r"^### (.+)$", re.MULTILINE)
 
@@ -107,7 +116,7 @@ class Drift:
         return not self.latest_commit
 
 
-def _entries_at_tip(readme: str) -> tuple[list[Entry], list[str]]:
+def _entries_at_tip(ledger: str) -> tuple[list[Entry], list[str]]:
     """Return the checkable entries, and the headings this skips.
 
     A heading is skippable for any of four reasons: no fenced block of
@@ -132,8 +141,8 @@ def _entries_at_tip(readme: str) -> tuple[list[Entry], list[str]]:
     owned: set[str] = set()
     heading = ""
     pos = 0
-    for match in re.finditer(r"```text\n(.*?)\n```", readme, re.DOTALL):
-        headings_before = _HEADING.findall(readme[pos : match.start()])
+    for match in re.finditer(r"```text\n(.*?)\n```", ledger, re.DOTALL):
+        headings_before = _HEADING.findall(ledger[pos : match.start()])
         if headings_before:
             heading = headings_before[-1]
         pos = match.end()
@@ -157,7 +166,7 @@ def _entries_at_tip(readme: str) -> tuple[list[Entry], list[str]]:
         entries.append(Entry(heading, repo, path.strip(), commit.split()[0]))
     skipped.extend(
         f"{unowned} (no fenced block)"
-        for unowned in _HEADING.findall(readme)
+        for unowned in _HEADING.findall(ledger)
         if unowned not in owned
     )
     # dict.fromkeys keeps the first of each identical line, in the
@@ -202,9 +211,9 @@ def _latest_commit(repo: str, path: str) -> tuple[str, str] | None:
     return sha, date
 
 
-def find_drift(readme_path: Path) -> tuple[list[Drift], list[str]]:
+def find_drift(ledger_path: Path) -> tuple[list[Drift], list[str]]:
     """Return every pin no longer at upstream's tip, and what was skipped."""
-    entries, skipped = _entries_at_tip(readme_path.read_text(encoding="utf-8"))
+    entries, skipped = _entries_at_tip(ledger_path.read_text(encoding="utf-8"))
     drifted = []
     for entry in entries:
         latest = _latest_commit(entry.repo, entry.path)
@@ -216,9 +225,9 @@ def find_drift(readme_path: Path) -> tuple[list[Drift], list[str]]:
     return drifted, skipped
 
 
-def _issue_body(readme_path: Path, drifted: list[Drift], skipped: list[str]) -> str:
+def _issue_body(ledger_path: Path, drifted: list[Drift], skipped: list[str]) -> str:
     lines = [
-        f"`{readme_path}` pins below are no longer at upstream's tip.",
+        f"`{ledger_path}` pins below are no longer at upstream's tip.",
         "Refreshing is a decision, not a chore -- this issue only reports it.",
         "",
     ]
@@ -243,7 +252,7 @@ def _issue_body(readme_path: Path, drifted: list[Drift], skipped: list[str]) -> 
     return "\n".join(lines)
 
 
-def _open_issue_number() -> str | None:
+def _open_issue_number(title: str) -> str | None:
     result = subprocess.run(  # noqa: S603
         [
             _GH,
@@ -252,7 +261,7 @@ def _open_issue_number() -> str | None:
             "--state",
             "open",
             "--search",
-            f'"{_ISSUE_TITLE}" in:title',
+            f'"{title}" in:title',
             "--json",
             "number",
         ],
@@ -264,9 +273,17 @@ def _open_issue_number() -> str | None:
     return str(issues[0]["number"]) if issues else None
 
 
-def report(readme_path: Path, drifted: list[Drift], skipped: list[str]) -> None:
-    """Open, update, or close the tracking issue, whichever applies."""
-    number = _open_issue_number()
+def report(
+    ledger_path: Path, title: str, drifted: list[Drift], skipped: list[str]
+) -> None:
+    """Open, update, or close this ledger's tracking issue, whichever applies.
+
+    The title is what tells one ledger's issue from another's: it is the
+    search term that finds an issue already open as well as the title a
+    new one is created under, so a caller passing a title of its own
+    gets an issue of its own.
+    """
+    number = _open_issue_number(title)
     if not drifted:
         if number is not None:
             subprocess.run(  # noqa: S603
@@ -281,10 +298,10 @@ def report(readme_path: Path, drifted: list[Drift], skipped: list[str]) -> None:
                 check=True,
             )
         return
-    body = _issue_body(readme_path, drifted, skipped)
+    body = _issue_body(ledger_path, drifted, skipped)
     if number is None:
         subprocess.run(  # noqa: S603
-            [_GH, "issue", "create", "--title", _ISSUE_TITLE, "--body", body],
+            [_GH, "issue", "create", "--title", title, "--body", body],
             check=True,
         )
     else:
@@ -294,26 +311,32 @@ def report(readme_path: Path, drifted: list[Drift], skipped: list[str]) -> None:
 
 
 def main() -> int:
-    """Check the README named on argv, report drift, and say so on stdout.
+    """Check the ledger named on argv, report drift, and say so on stdout.
+
+    The title names the issue this run opens, updates or closes. It is
+    required, which is what makes it a positional beside the path: a
+    default would file one ledger's drift onto whichever issue the
+    default happened to name. The one option here is a boolean, so what
+    reads it is the filter below rather than a parser.
 
     --dry-run skips opening, updating or closing the issue: what the
     pull_request trigger of vendored-vectors.yml passes, so a change to
-    this script or to the README is exercised without the run editing
+    this script or to a ledger is exercised without the run editing
     whatever tracking issue happens to be open at the time.
     """
     args = [a for a in sys.argv[1:] if a != "--dry-run"]
     dry_run = len(args) != len(sys.argv) - 1
-    if len(args) != 1:
+    if len(args) != 2:
         # a human running this by hand is the only way here, the workflow
-        # passing the path every time: without this check, `args[0]`
-        # below would answer with an IndexError naming a list instead
+        # passing both every time: without this check, the indexing below
+        # would answer with an IndexError naming a list instead
         print(
-            f"usage: {Path(sys.argv[0]).name} <README path> [--dry-run]",
+            f"usage: {Path(sys.argv[0]).name} <ledger path> <issue title> [--dry-run]",
             file=sys.stderr,
         )
         return 2
-    readme_path = Path(args[0])
-    drifted, skipped = find_drift(readme_path)
+    ledger_path, title = Path(args[0]), args[1]
+    drifted, skipped = find_drift(ledger_path)
     for drift in drifted:
         if drift.path_is_gone:
             print(
@@ -331,7 +354,7 @@ def main() -> int:
     if not drifted:
         print("Every checked pin is still at upstream's tip.")
     if not dry_run:
-        report(readme_path, drifted, skipped)
+        report(ledger_path, title, drifted, skipped)
     return 0
 
 

--- a/.github/workflows/py-arm-authority.yml
+++ b/.github/workflows/py-arm-authority.yml
@@ -30,13 +30,15 @@ name: py arm authority
 # an arm `_WITHOUT_AN_AUTHORITY` says nothing reaches. It exits non-zero
 # on any of the three, which is what makes this job red.
 #
-# No `issues: write`, unlike `vendored-vectors.yml`: that workflow's
-# subject is a vendored file nothing else in this repository ever looks
-# at again, so a failed run's notification is the only signal a drifted
-# pin gets and a persistent issue is what carries it past that one
-# email. `_AUTHORITY` is different -- it is a tracked file a pull request
-# touching `src/btclib/curves/` or `src/btclib/ecc/` can and does edit,
-# reviewed the ordinary way, so a red scheduled run and the Actions tab it lands
+# No `issues: write`, unlike `vendored-vectors.yml`: what that workflow
+# measures is a pin against somebody else's tree, so a pin that has
+# drifted is visible to nothing here -- the suite reads both of its
+# ledgers, and reads their shape rather than upstream -- and a failed
+# run's notification is the only signal that drift gets, and a
+# persistent issue is what carries it past that one email. `_AUTHORITY`
+# is different -- it is a tracked file a pull request touching
+# `src/btclib/curves/` or `src/btclib/ecc/` can and does edit, reviewed
+# the ordinary way, so a red scheduled run and the Actions tab it lands
 # on are enough, the same choice `links.yml` and `pypi-install.yml`
 # already make for a comparable reason.
 

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -1,13 +1,19 @@
 ---
 name: vendored vectors
 
-# tests/_data/README.md pins every vendored test vector to a commit and a
-# git blob SHA-1, with a documented manual procedure to re-check one --
-# last done by hand on specific dates the file itself records. This runs
-# that procedure once a week instead, over every pin the script can
-# check, and opens or updates an issue on drift rather than fixing
-# anything: refreshing a vector file is a decision the script does not
-# get to make.
+# tests/_data/README.md pins every vendored test vector to a commit and
+# a git blob SHA-1, and TF2.md pins every Python file of Core's test
+# framework to the commit its verdict was read at. Both carry a
+# documented manual procedure to re-check one pin. This runs that
+# procedure once a week instead, over every pin the script can check,
+# and opens or updates an issue on drift rather than fixing anything:
+# what to do about a pin that has moved is a decision the script does
+# not get to make.
+#
+# One issue per ledger, under a title of its own, because the two kinds
+# of staleness are acted on differently: a vendored file behind upstream
+# means this tree holds a stale copy, where a TF2.md pin behind upstream
+# means a verdict is now a claim about a file that has moved.
 #
 # issues: write is new to this repository -- links.yml's own comment
 # explains why every other scheduled workflow here stops at contents:
@@ -49,6 +55,7 @@ on:
       - .github/workflows/vendored-vectors.yml
       - .github/scripts/check_vendored_vectors.py
       - tests/_data/README.md
+      - TF2.md
 
 permissions:
   contents: read
@@ -65,7 +72,7 @@ concurrency:
 
 jobs:
   vectors:
-    name: Check vendored vectors against upstream
+    name: Check ${{ matrix.ledger }} against upstream
     # a draft pull request is work in progress and spends no runner
     # here either: a draft is work its author is not asking anyone to
     # read yet. The same condition lint.yml and test.yml carry, and
@@ -76,6 +83,20 @@ jobs:
     if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # the ledger and the title of its issue travel together, which is
+    # what a matrix is for: two run: blocks would repeat the dry-run
+    # preamble below and let the pair drift apart. fail-fast is off
+    # because the two checks answer different questions -- one gh error
+    # against upstream is no reason to leave the other ledger unchecked
+    # for the week, and a matrix's default would cancel it.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ledger: tests/_data/README.md
+            title: Vendored vectors behind upstream
+          - ledger: TF2.md
+            title: tf2 ledger verdicts pinned to superseded revisions
     # the elevation, on the job that needs it and nowhere else: no other
     # job in this workflow declares permissions, so no other job elevates.
     # issues: write is what the script's gh issue create/edit/close calls
@@ -99,7 +120,7 @@ jobs:
       # already has.
       # --dry-run on the pull_request trigger only: a fork's read-only
       # token could not write the issue anyway, and a same-repository
-      # pull request testing a change to this script or the README
+      # pull request testing a change to this script or to a ledger
       # should not close or edit whatever tracking issue is open at the
       # time as a side effect of that test.
       # The flag reaches the shell through the environment rather than
@@ -110,14 +131,19 @@ jobs:
       # pattern). The array built from it, rather than an unquoted
       # expansion, is release.yml's own shape for an optional flag
       # (its "Check the public API against the previous release" step).
+      # The ledger and the title take that same route for that same
+      # reason, a matrix value being this file's own as much as the flag
+      # is.
       - name: Re-check every pin already at upstream's tip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
+          LEDGER: ${{ matrix.ledger }}
+          ISSUE_TITLE: ${{ matrix.title }}
         run: |
           args=()
           if [ -n "$DRY_RUN" ]; then
             args=(--dry-run)
           fi
           python .github/scripts/check_vendored_vectors.py \
-            tests/_data/README.md "${args[@]}"
+            "$LEDGER" "$ISSUE_TITLE" "${args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1055,6 +1055,24 @@ file of the test tree, and no caller acts on it.
   landed text and stands as written, this entry being where the
   correction is read instead.
 
+### The weekly pin re-check reads `TF2.md`, under a title of its own
+
+- **`.github/workflows/vendored-vectors.yml` runs
+  `.github/scripts/check_vendored_vectors.py` over `TF2.md` as well as
+  `tests/_data/README.md`** (issue #1732), as a matrix whose cells pair
+  a ledger with the title of the issue its drift is reported under, and
+  its `paths:` filter names `TF2.md` so a pull request touching that
+  file is checked.
+- **Each title says which kind of staleness it is**: a vendored file
+  behind upstream means this tree holds a stale copy, where a `TF2.md`
+  pin behind upstream means a verdict is now a claim about a file that
+  has moved. They are acted on differently, so they are reported apart.
+- **The script takes that title beside the ledger path** rather than
+  naming it in a module constant: one title across both ledgers would
+  file a single issue for them, each run rewriting what the other
+  wrote. `btclib-org/btclib-secp256k1` carries a copy of the script
+  under the same name, which the same signature change is owed.
+
 ## v2026.9.3
 
 ### Repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -501,7 +501,7 @@ read by every checkout of this repository.
 | `deps-latest` | weekly | platforms sampled, deps upgraded |
 | `integration-hwi` | weekly, push to main | two device emulators |
 | `links`, `mutation` | weekly | — |
-| `vendored-vectors` | weekly | upstream's vectors |
+| `vendored-vectors` | weekly | the pin ledgers |
 | `pypi-install` | weekly, a release | what PyPI serves |
 | `py-arm-authority` | weekly, push to main | the arm-authority table |
 | `release` | a tag | the workflows `release.yml` names in a `uses:` |

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -541,7 +541,8 @@ elevation per job is the shape to keep — the job that writes releases holds
 no OIDC token, and the job that signs writes no release.
 `vendored-vectors.yml`'s `vectors` job has one such declaration of its
 own: `issues: write`, for the `gh issue create`/`edit`/`close` calls its
-script makes on the tracking issue it maintains.
+script makes on the tracking issue of each ledger its matrix checks, one
+title per ledger.
 The workflow-level `permissions: contents: read` is belt and braces; keep
 it, it is what makes the intent readable in the file.
 

--- a/TF2.md
+++ b/TF2.md
@@ -36,11 +36,10 @@ upstream revisions of that path have landed since. That is the grammar
 `tests/_data/README.md` uses, so an entry here can be read without
 learning a second shape -- by a person, and by
 `.github/scripts/check_vendored_vectors.py`, which parses exactly those
-fields. That script is not yet asked to read this file: it takes one
-README path and names one drift issue in a module constant, and
-btclib-secp256k1 carries a copy of it under the same name that a change
-to either would be owed. Wiring is therefore its own change, not this
-file's.
+fields. `.github/workflows/vendored-vectors.yml` runs that script over
+this file weekly, under an issue title of its own: a pin here that has
+moved says a verdict is now a claim about a file that has moved, where
+a pin in that README says this tree holds a stale copy.
 
 An entry's `commit` is the tip of the path the entry names, so `behind`
 reads zero and a re-check can clear it. A repository-wide revision is a

--- a/tests/check_vendored_vectors_test.py
+++ b/tests/check_vendored_vectors_test.py
@@ -319,11 +319,13 @@ def test_every_heading_of_the_pin_file_is_checked_or_named_once(
 
     A fixture answers for the shapes it was written to carry, and this
     parser's failure mode is a shape nobody thought to write down: what
-    it does not match, it drops. `tests/_data/README.md` is what the
-    workflow passes, so it is what settles whether a heading can go
-    missing from the report -- and the first assertion is what says the
-    parse still sees the file at all, a parser that matched nothing
-    passing every other line here.
+    it does not match, it drops. `tests/_data/README.md` is one of the
+    ledgers the workflow passes, so it is what settles whether a heading
+    of it can go missing from the report -- and the first assertion is
+    what says the parse still sees the file at all, a parser that
+    matched nothing passing every other line here. The other ledger,
+    `TF2.md`, is asked the same question by
+    `tests/tf2_ledger_test.py`, beside what else that file owes.
     """
     readme = _PIN_README.read_text(encoding="utf-8")
 
@@ -427,18 +429,26 @@ def test_find_drift_reports_a_path_upstream_no_longer_has(
     assert "renamed, moved or deleted upstream" in body
 
 
-@pytest.mark.parametrize("argv", [["prog"], ["prog", "a.md", "b.md"]])
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["prog"],
+        ["prog", "a.md"],  # a ledger and no title
+        ["prog", "a.md", "a title", "b.md"],
+    ],
+)
 def test_main_says_how_to_be_called_when_it_is_not(
     checker: ModuleType,
     argv: list[str],
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """No README, or two of them, is the usage rather than an IndexError.
+    """Anything but a ledger and a title is the usage, not an IndexError.
 
     Only a human running this by hand reaches it -- the workflow passes
-    the path every time -- and what they used to get was `IndexError:
-    list index out of range` naming a list they never saw.
+    both every time -- and what an unchecked index into `args` gives
+    them is `IndexError: list index out of range` naming a list they
+    never saw.
     """
     monkeypatch.setattr(sys, "argv", argv)
 
@@ -447,7 +457,7 @@ def test_main_says_how_to_be_called_when_it_is_not(
     captured = capsys.readouterr()
     # argv[0] is what names the program, so the fixture's own "prog" is
     # what comes back here rather than the script's file name
-    assert captured.err == "usage: prog <README path> [--dry-run]\n"
+    assert captured.err == "usage: prog <ledger path> <issue title> [--dry-run]\n"
     assert not captured.out
 
 
@@ -470,7 +480,7 @@ def test_main_says_gone_rather_than_behind_for_a_vanished_path(
         ),
     )
     fake_gh.commits["r", "gone.json"] = None
-    monkeypatch.setattr(sys, "argv", ["prog", str(path), "--dry-run"])
+    monkeypatch.setattr(sys, "argv", ["prog", str(path), "A title", "--dry-run"])
 
     assert checker.main() == 0
 
@@ -544,14 +554,16 @@ def test_open_issue_number_reads_the_first_match(
 ) -> None:
     """The number of the first issue `gh issue list` names, as a string."""
     fake_gh.open_issue = 42
-    assert checker._open_issue_number() == "42"
+    assert checker._open_issue_number("A title") == "42"
+    (call,) = fake_gh.calls
+    assert '"A title" in:title' in call
 
 
 def test_open_issue_number_is_none_when_none_is_open(
     checker: ModuleType, fake_gh: FakeGh
 ) -> None:
     """An empty `gh issue list` is None, not an empty string."""
-    assert checker._open_issue_number() is None
+    assert checker._open_issue_number("A title") is None
 
 
 def test_report_closes_an_open_issue_when_nothing_drifted(
@@ -559,7 +571,7 @@ def test_report_closes_an_open_issue_when_nothing_drifted(
 ) -> None:
     """Nothing drifted, an issue was open: it gets closed."""
     fake_gh.open_issue = 7
-    checker.report(tmp_path / "README.md", [], [])
+    checker.report(tmp_path / "README.md", "A title", [], [])
     verbs = [call[2] for call in fake_gh.calls if call[1] == "issue"]
     assert verbs == ["list", "close"]
 
@@ -568,18 +580,27 @@ def test_report_does_nothing_when_clean_and_no_issue_is_open(
     checker: ModuleType, fake_gh: FakeGh, tmp_path: Path
 ) -> None:
     """Nothing drifted, no issue was open: nothing is written."""
-    checker.report(tmp_path / "README.md", [], [])
+    checker.report(tmp_path / "README.md", "A title", [], [])
     assert [call[2] for call in fake_gh.calls] == ["list"]
 
 
 def test_report_creates_an_issue_when_none_is_open(
     checker: ModuleType, fake_gh: FakeGh, tmp_path: Path
 ) -> None:
-    """Something drifted, no issue was open: a new one is created."""
+    """Something drifted, no issue was open: a new one is created.
+
+    Under the title it was handed, and the same title is what the search
+    before it asked for: one ledger's run finds and files its own issue
+    rather than the other ledger's (issue #1732).
+    """
     drift = checker.Drift(_entry(checker, "`p.json`"), "new0000", "2026-01-01")
-    checker.report(tmp_path / "README.md", [drift], [])
+    checker.report(tmp_path / "README.md", "Ledger A behind upstream", [drift], [])
     verbs = [call[2] for call in fake_gh.calls if call[1] == "issue"]
     assert verbs == ["list", "create"]
+    (list_call,) = (call for call in fake_gh.calls if call[2] == "list")
+    assert '"Ledger A behind upstream" in:title' in list_call
+    (create_call,) = (call for call in fake_gh.calls if call[2] == "create")
+    assert create_call[create_call.index("--title") + 1] == "Ledger A behind upstream"
 
 
 def test_report_edits_the_open_issue(
@@ -588,7 +609,7 @@ def test_report_edits_the_open_issue(
     """Something drifted, an issue was already open: it is edited, by number."""
     fake_gh.open_issue = 9
     drift = checker.Drift(_entry(checker, "`p.json`"), "new0000", "2026-01-01")
-    checker.report(tmp_path / "README.md", [drift], [])
+    checker.report(tmp_path / "README.md", "A title", [drift], [])
     verbs = [call[2] for call in fake_gh.calls if call[1] == "issue"]
     assert verbs == ["list", "edit"]
     (edit_call,) = (call for call in fake_gh.calls if call[2] == "edit")
@@ -621,7 +642,7 @@ def test_main_dry_run_prints_but_never_calls_issue(
         entry("stale", repo="r", path="s.json", commit="x", behind="1"),
     )
     fake_gh.commits["r", "p.json"] = ("new0000", "2026-01-01")
-    monkeypatch.setattr(sys, "argv", ["prog", str(path), "--dry-run"])
+    monkeypatch.setattr(sys, "argv", ["prog", str(path), "A title", "--dry-run"])
 
     assert checker.main() == 0
 
@@ -651,7 +672,7 @@ def test_main_reports_and_says_nothing_drifted_when_clean(
     )
     fake_gh.commits["r", "p.json"] = ("old0000", "2020-01-01")
     fake_gh.open_issue = 3
-    monkeypatch.setattr(sys, "argv", ["prog", str(path)])
+    monkeypatch.setattr(sys, "argv", ["prog", str(path), "A title"])
 
     assert checker.main() == 0
 
@@ -688,7 +709,7 @@ def test_the_main_guard_runs_the_script_as___main__(
     fake = FakeGh()
     fake.commits["r", "p.json"] = ("old0000", "2020-01-01")
     monkeypatch.setattr(subprocess, "run", fake)
-    monkeypatch.setattr(sys, "argv", ["prog", str(path), "--dry-run"])
+    monkeypatch.setattr(sys, "argv", ["prog", str(path), "A title", "--dry-run"])
 
     with pytest.raises(SystemExit) as excinfo:
         runpy.run_path(str(_SCRIPT), run_name="__main__")

--- a/tests/tf2_ledger_test.py
+++ b/tests/tf2_ledger_test.py
@@ -393,10 +393,9 @@ def test_the_weekly_re_checker_reads_every_entry(checker: ModuleType) -> None:
 
     The grammar is that script's, so this is what says the ledger is in
     it: an entry whose fenced block lacks `repo`, `path` or `commit`, or
-    whose `behind` does not read zero, is skipped by the script and
-    would be skipped in silence once the ledger is wired into the weekly
-    run. Wiring it is a change owed to btclib-secp256k1's copy of the
-    script as well, and is not this file's; being parseable is.
+    whose `behind` does not read zero, is skipped by the script, and
+    `.github/workflows/vendored-vectors.yml` runs that script over this
+    file weekly -- so a skip is a pin nothing re-checks, silently.
     """
     entries, skipped = checker._entries_at_tip(_TEXT)
     assert not skipped, f"the re-checker would skip: {skipped}"


### PR DESCRIPTION
`.github/workflows/vendored-vectors.yml` now runs
`.github/scripts/check_vendored_vectors.py` over `TF2.md` as well as
`tests/_data/README.md`, as a matrix whose cells pair a ledger with the
title of the issue its drift is reported under, and its `paths:` filter
names `TF2.md` so a pull request touching it is checked.

This does **not** close issue #1732: `btclib-org/btclib-secp256k1`
carries a copy of the script under the same name, over its own
`tests/README.md`, and is owed the same signature. That is the issue's
fourth *Done when*, and the mirror is what finishes it.

- **The script takes the issue title as a positional beside the ledger
  path**, `_ISSUE_TITLE` deleted. One title across both ledgers would
  file one issue for them, each run rewriting what the other wrote. Both
  arguments are required, which is what keeps them positional: the one
  option here is a boolean, read by an `argv` filter rather than a
  parser.
- **Each title says which kind of staleness it is.** A vendored file
  behind upstream means this tree holds a stale copy; a `TF2.md` pin
  behind upstream means a verdict is now a claim about a file that has
  moved. The lookup is a phrase search on `in:title`, and neither
  phrase matches the other's issue.
- **`fail-fast: false`**, so one `gh` failure cannot cancel the sibling
  cell and leave the other ledger unchecked for the week. `matrix`
  values reach the shell through `env:`, never `${{ }}` inside `run:`.
- Live against real GitHub at this sha: `TF2.md` → 36 entries, 0
  skipped, every pin still at upstream's tip; `tests/_data/README.md` →
  73 entries, 18 named skips, and 13 Wycheproof pins already behind,
  which is pre-existing drift this job exists to report.
- **Sentences this change falsified, fixed here rather than filed**:
  `REPOSITORY.md` described the job as maintaining *the* tracking issue,
  singular; `.github/workflows/py-arm-authority.yml` justified having no
  `issues: write` on the ground that the other workflow's subject is *a
  vendored file nothing else here reads*, where half of it is now a
  ledger of Core files this tree does not vendor at all. The ground is
  reworded; that paragraph's `_AUTHORITY` clause is issue #1753's and is
  untouched — byte-identical as prose, only its line breaks moved.

Reviewed twice at fresh context, cleared both times. Two wording
findings from the second round went in after its clearance and are
mine: `TF2.md` pins every *Python* file of Core's test framework, not
every file — Core's directory carries three `.csv` besides — and one
clause of my own rewording had no grammatical reading and is restored to
the coordinate shape it replaced. Gates re-run after both: `pre-commit`
exit 0 with zero `Failed`, `pytest` exit 0 with coverage `100.00%`,
`sphinx-build -n -W` exit 0.

`main` is red on the `py arm authority` workflow, which this branch does
not cause and does not fix; that is issue #1753 and its fix is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Expand weekly pin verification to cover `TF2.md` while isolating drift reporting for each checked ledger.

New Features:
- Extend the weekly pin verification workflow to check both `tests/_data/README.md` and `TF2.md`, with separate tracking issues for each ledger.

Bug Fixes:
- Prevent drift reports from different ledgers from sharing and overwriting a single tracking issue.

Enhancements:
- Make the checker accept the ledger path and issue title as required arguments and report issues using the supplied title.
- Run ledger checks independently so a failure in one check does not cancel the other.

CI:
- Include `TF2.md` in the workflow path filter and matrix-based weekly checks.

Documentation:
- Update repository, contributor, changelog, and ledger documentation to describe the expanded pin checks and per-ledger issue tracking.

Tests:
- Update checker and ledger tests for required issue titles, separate issue searches, and `TF2.md` coverage.