### PR TITLE
`_sec_from_octets`'s authority entry names `bip32/bip32_test.py` (issue #1753)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1073,6 +1073,20 @@ file of the test tree, and no caller acts on it.
   wrote. `btclib-org/btclib-secp256k1` carries a copy of the script
   under the same name, which the same signature change is owed.
 
+### The `_sec_from_octets` authority entry names `bip32/bip32_test.py`
+
+- **`tests/py_arm_authority_test.py`'s `_AUTHORITY` entry for
+  `curves.sec_point._sec_from_octets` names `bip32/bip32_test.py`**
+  (issue #1753): that module, run under coverage in an environment with
+  no bindings installed, executes the arm's body, its `_p2pkh_of` helper
+  handing `bip32.pub_keyinfo_from_xkey`'s octets to `b58.p2pkh`, where
+  `to_pub_key.pub_keyinfo_from_pub_key` proves them a point of the
+  curve -- the composition a caller writes now that no converter
+  resolves an extended key (issue #1188). The issue's two questions
+  about `.github/workflows/py-arm-authority.yml`'s header comment --
+  whether a red run is signal enough, and whether the pull requests it
+  names are the ones that invalidate the table -- are not answered here.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/py_arm_authority_test.py
+++ b/tests/py_arm_authority_test.py
@@ -233,6 +233,7 @@ _AUTHORITY: dict[str, tuple[str, ...]] = {
         "silent_payments_test.py",
     ),
     "curves.sec_point._sec_from_octets": (
+        "bip32/bip32_test.py",
         "bip322_test.py",
         "curves/sec_point_test.py",
         "ecc/bms_test.py",


### PR DESCRIPTION
`main` has been red on the `py arm authority` workflow since
`755d5081b`, on every push. The job reports
`curves.sec_point._sec_from_octets` as reached by
`bip32/bip32_test.py` and not named in its entry. This names it.

**The reach is measured, not taken from the failing run.** A table
entry added because a job said so is an appeasement; the same entry
added because a measurement said so is a fact, and only the second
survives the next refactor. The module alone, under coverage in an
environment asserted free of the bindings, executes the arm's body; the
route is `bip32_test.py`'s `_p2pkh_of` handing
`bip32.pub_keyinfo_from_xkey`'s octets to `b58.p2pkh`, where
`to_pub_key.pub_keyinfo_from_pub_key` proves them a point of the curve.
`curves/curve_test.py` under the same harness is the control that can
answer no: it reaches `bytes_from_prv_key_int`, which its entry names,
and not this arm, which its entry does not.

**The cause is PR 1720** (issue #1188), which withdrew the BIP32 parse
from `to_pub_key`: at `755d5081b^` that path returned `to_prove` false
for an extended key, so the arm was never called. The understatement is
a true new reach created on purpose by a design change, not a table
slip.

This carries **`(issue #1753)` and not `closes`**. Two of that issue's
three *Done when* boxes stay open, both about the workflow's header
comment — whether a red run is signal enough, given sixteen identical
failures nobody answered, and whether *"a pull request touching
`src/btclib/curves/` or `src/btclib/ecc/`"* names the population that
actually invalidates the table. PR 1720 touched neither directory. Each
is a decision of its own and neither is part of making the table true.

Reviewed at fresh context, which returned CHANGES REQUESTED on **two
clauses of the commit-message body and nothing in the diff**: one said
another branch was editing that workflow's header, which the rebase
falsified — that branch is this commit's own parent, `9d409b7d` — and
one enumerated executed line numbers, of which the reviewer measured a
different set with four instruments. The first is corrected; the second
is removed rather than corrected, a line-number figure in a message
being something nothing re-derives. **The tree is byte-identical to the
sha reviewed**; only the message changed, and the gates were re-run on
it: `pre-commit` exit 0 with zero `Failed`, `pytest` exit 0 with
coverage `100.00%`, `sphinx-build -n -W` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Record the newly measured BIP32 authority path for `_sec_from_octets`.

Bug Fixes:
- Update the authority coverage table to recognize `bip32/bip32_test.py` as a caller of `curves.sec_point._sec_from_octets`.

Documentation:
- Document the authority-table correction and its unresolved workflow-header questions in the changelog.