### PR TITLE
The py-arm authority census opens the issue its red run could not carry (closes #1753)

### DIFF
--- a/.github/scripts/check_py_arm_authority.py
+++ b/.github/scripts/check_py_arm_authority.py
@@ -33,8 +33,24 @@ where each arm's body lives rather than re-walking the AST: one parser,
 one definition of "arm", read by the shape tests, the content tests and
 this script alike.
 
+A disagreement is reported twice: this exits non-zero, which is what
+makes the run red, and it opens or updates a tracking issue under the
+title it is given, closing that issue with a comment once a measurement
+agrees again. The two are not alternatives. A failed scheduled run
+notifies the last person to have touched the cron, once, and
+`tests/py_arm_authority_test.py` reads the table's shape and never its
+values -- so an entry claiming a reach the suite no longer has leaves
+every other check in the tree green, and the open issue is what still
+says otherwise.
+
+The title is the caller's rather than a constant here, which is what
+`check_vendored_vectors.py` beside it does: what an issue this
+repository files is called then sits in the workflow that files it,
+beside the trigger and the permission that let it, rather than in a
+script the workflow only names.
+
     uv sync --no-default-groups --group harness
-    python .github/scripts/check_py_arm_authority.py
+    python .github/scripts/check_py_arm_authority.py "<issue title>"
 
 Not a gate: `.github/workflows/py-arm-authority.yml` runs this on a
 schedule, with no branch rule attached, for the reason `vendored-vectors`
@@ -45,6 +61,7 @@ minutes, and it answers a question no pull request introduces.
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -52,6 +69,11 @@ from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(_ROOT))
+
+# resolved once: S607 is what a bare "gh" in a subprocess list would be,
+# a partial executable path relying on PATH's own search order rather
+# than naming what actually runs
+_GH = shutil.which("gh") or "gh"
 
 from tests.py_arm_authority_test import (  # noqa: E402
     _AUTHORITY,
@@ -144,16 +166,129 @@ def compare(actual: dict[str, frozenset[str]]) -> list[str]:
     return mismatches
 
 
+def _issue_body(mismatches: list[str]) -> str:
+    """Return the issue body: the lines stdout carries, and where to look.
+
+    The same strings `compare` built, rather than a second phrasing of
+    them: one description of a disagreement, printed by the run and read
+    by whoever opens the issue.
+    """
+    return "\n".join(
+        [
+            (
+                "A fresh no-bindings measurement disagrees with"
+                " `tests/py_arm_authority_test.py`'s `_AUTHORITY`."
+            ),
+            (
+                "The run that measured it is red as well, and stays red"
+                " until the table and the measurement agree."
+            ),
+            "",
+            *(f"- {line}" for line in mismatches),
+        ]
+    )
+
+
+def _open_issue_number(title: str) -> str | None:
+    result = subprocess.run(  # noqa: S603
+        [
+            _GH,
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--search",
+            f'"{title}" in:title',
+            "--json",
+            "number",
+        ],
+        capture_output=True,
+        check=True,
+        encoding="utf-8",
+    )
+    issues = json.loads(result.stdout)
+    return str(issues[0]["number"]) if issues else None
+
+
+def report(title: str, mismatches: list[str]) -> None:
+    """Open, update, or close this census's tracking issue, whichever applies.
+
+    The title is the search term that finds an issue already open as
+    well as the title a new one is created under, so it is a caller's
+    argument: the workflow above this script is where what this run
+    files is named.
+    """
+    number = _open_issue_number(title)
+    if not mismatches:
+        if number is not None:
+            subprocess.run(  # noqa: S603
+                [
+                    _GH,
+                    "issue",
+                    "close",
+                    number,
+                    "--comment",
+                    (
+                        "Re-measured: every _AUTHORITY entry matches a fresh"
+                        " no-bindings measurement."
+                    ),
+                ],
+                check=True,
+            )
+        return
+    body = _issue_body(mismatches)
+    if number is None:
+        subprocess.run(  # noqa: S603
+            [_GH, "issue", "create", "--title", title, "--body", body],
+            check=True,
+        )
+    else:
+        subprocess.run(  # noqa: S603
+            [_GH, "issue", "edit", number, "--body", body], check=True
+        )
+
+
 def main() -> int:
-    """Measure, compare, print, and fail on any disagreement found."""
+    """Measure, compare, print, report, and fail on any disagreement found.
+
+    The title names the issue this run opens, updates or closes. It is
+    required, which is what makes it a positional: a default would name
+    the issue in the one place a reader of the workflow does not look.
+    The one option here is a boolean, so what reads it is the filter
+    below rather than a parser.
+
+    --dry-run skips opening, updating or closing that issue: what the
+    pull_request trigger of py-arm-authority.yml passes, so a change to
+    this script, to the workflow or to the table is exercised without
+    the run editing whatever tracking issue happens to be open at the
+    time.
+
+    `report` runs before the non-zero return rather than after it: the
+    exit code is what makes the run red, and the issue is what outlives
+    the notification that run sends.
+    """
+    args = [a for a in sys.argv[1:] if a != "--dry-run"]
+    dry_run = len(args) != len(sys.argv) - 1
+    if len(args) != 1:
+        # a human running this by hand is the only way here, the workflow
+        # passing the title every time: without this check, the unpacking
+        # below would answer with a ValueError naming a list instead
+        print(
+            f"usage: {Path(sys.argv[0]).name} <issue title> [--dry-run]",
+            file=sys.stderr,
+        )
+        return 2
+    (title,) = args
     mismatches = compare(measure())
     for line in mismatches:
         print(line)
     if mismatches:
         print(f"{len(mismatches)} disagreement(s) with a fresh measurement.")
-        return 1
-    print("Every _AUTHORITY entry matches a fresh no-bindings measurement.")
-    return 0
+    else:
+        print("Every _AUTHORITY entry matches a fresh no-bindings measurement.")
+    if not dry_run:
+        report(title, mismatches)
+    return 1 if mismatches else 0
 
 
 if __name__ == "__main__":

--- a/.github/workflows/py-arm-authority.yml
+++ b/.github/workflows/py-arm-authority.yml
@@ -30,17 +30,27 @@ name: py arm authority
 # an arm `_WITHOUT_AN_AUTHORITY` says nothing reaches. It exits non-zero
 # on any of the three, which is what makes this job red.
 #
-# No `issues: write`, unlike `vendored-vectors.yml`: what that workflow
-# measures is a pin against somebody else's tree, so a pin that has
-# drifted is visible to nothing here -- the suite reads both of its
-# ledgers, and reads their shape rather than upstream -- and a failed
-# run's notification is the only signal that drift gets, and a
-# persistent issue is what carries it past that one email. `_AUTHORITY`
-# is different -- it is a tracked file a pull request touching
-# `src/btclib/curves/` or `src/btclib/ecc/` can and does edit, reviewed
-# the ordinary way, so a red scheduled run and the Actions tab it lands
-# on are enough, the same choice `links.yml` and `pypi-install.yml`
-# already make for a comparable reason.
+# `issues: write` on the job below, the same choice `vendored-vectors.yml`
+# makes and by the test its own header states: a link is noticed the next
+# time somebody follows it, where a vendored vector is trusted without
+# anybody looking at it again. `_AUTHORITY` is on that second
+# side. `tests/py_arm_authority_test.py` checks the table's shape and
+# never its values, so an entry claiming a module whose run no longer
+# reaches the arm passes every other check in the tree, and a run of
+# this workflow is the only thing that reads what the entry says.
+#
+# The issue is beside the red run rather than instead of it: the script
+# still exits non-zero on any disagreement, which is what makes this job
+# red, and reports before it returns. What the issue adds is that it
+# stays open, where a failed run notifies the last person to have
+# touched the cron and then sits in the Actions tab.
+#
+# Which pull request can invalidate the table is not a path list. An arm
+# is any function calling `_libsecp256k1_serves`, and what reaches one
+# changes above it: `bip32/bip32_test.py` reaches
+# `curves.sec_point._sec_from_octets` through `to_pub_key`, which holds
+# no arm of its own. That is the push trigger's reasoning below, where a
+# filter naming this surface honestly "would be `every merge`".
 
 on:
   # a merge creates a commit no pull request measured, and this census is
@@ -116,6 +126,14 @@ jobs:
     if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # the elevation, on the job that needs it and nowhere else: the
+    # workflow-level contents: read above stays as it is, so a job added
+    # here later starts read-only rather than inheriting this.
+    # issues: write is what the script's gh issue create/edit/close calls
+    # take, on the tracking issue this run opens, updates or closes
+    permissions:
+      contents: read
+      issues: write # gh issue create/edit/close, in the last step below
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -141,7 +159,33 @@ jobs:
           from btclib.curves import is_libsecp256k1_serving;
           assert not is_libsecp256k1_serving()"
 
+      # --dry-run on the pull_request trigger only: a fork's read-only
+      # token could not write the issue anyway, and a same-repository
+      # pull request testing a change to one of the three paths that
+      # trigger it -- this file, the script, the table -- should not edit
+      # or close whatever tracking issue is open at the time as a side
+      # effect of that test.
+      # The flag reaches the shell through the environment rather than
+      # through a `${{ }}` inside the script, which would be text pasted
+      # into it: the value is this file's own, and the habit is what
+      # zizmor's template-injection rule is asking for. The array built
+      # from it, rather than an unquoted expansion, is release.yml's own
+      # shape for an optional flag (its "Check the public API against the
+      # previous release" step).
+      # The title is written here rather than in the script, so what this
+      # run files is named beside the trigger and the permission that let
+      # it -- the same argument `vendored-vectors.yml` passes its own
+      # script, for a reason of its own
       - name: Re-derive the authority table against a fresh measurement
-        run: >
-          uv run --locked --no-default-groups --group harness
-          python .github/scripts/check_py_arm_authority.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
+        run: |
+          args=()
+          if [ -n "$DRY_RUN" ]; then
+            args=(--dry-run)
+          fi
+          uv run --locked --no-default-groups --group harness \
+            python .github/scripts/check_py_arm_authority.py \
+            "Python arm authority table disagrees with a fresh measurement" \
+            "${args[@]}"

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -15,13 +15,13 @@ name: vendored vectors
 # means this tree holds a stale copy, where a TF2.md pin behind upstream
 # means a verdict is now a claim about a file that has moved.
 #
-# issues: write is new to this repository -- links.yml's own comment
-# explains why every other scheduled workflow here stops at contents:
-# read, an automatic issue being the usual next step it deliberately
-# does not take. This one does take it, on purpose: a link is noticed
-# the next time somebody follows it, where a vendored vector is trusted
-# without anybody looking at it again, and an issue is what carries that
-# past the one email a failed run sends
+# issues: write is what the job below takes; links.yml's own comment is
+# where the opposite choice is argued, an automatic issue being the usual
+# next step a scheduled workflow here does not take. This one does take
+# it, on purpose: a link is noticed the next time somebody follows it,
+# where a vendored vector is trusted without anybody looking at it again,
+# and an issue is what carries that past the one email a failed run
+# sends. py-arm-authority.yml takes it by this same test
 
 on:
   schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1087,6 +1087,39 @@ file of the test tree, and no caller acts on it.
   whether a red run is signal enough, and whether the pull requests it
   names are the ones that invalidate the table -- are not answered here.
 
+### The py-arm census opens an issue, and its header names no population
+
+- **`.github/workflows/py-arm-authority.yml` gives its job `issues:
+  write`, and `.github/scripts/check_py_arm_authority.py` opens, updates
+  or closes a tracking issue under the title the workflow passes it**
+  (closes #1753). The header's earlier answer -- that a red scheduled
+  run and the Actions tab it lands on are signal enough -- was tested by
+  the run that made this issue: the job went red on 2026-09-05 with
+  `755d5081b`, and every push to `main` from there to `9d409b7d` ran it
+  and failed identically with nobody answering. The census still goes
+  red, the script reporting before it returns the same non-zero exit, so
+  the issue is signal added to that run rather than a replacement for
+  it.
+- **The title is the workflow's argument rather than a constant in the
+  script** (issue #1732's choice on `check_vendored_vectors.py`), and
+  says which kind of staleness this one is: a table disagreeing with a
+  fresh measurement, where that script's two titles each name a pin
+  behind upstream. A `pull_request` run passes `--dry-run`, so a pull
+  request touching one of the three paths that trigger it exercises the
+  script without editing whatever issue is open at the time.
+- **The header no longer says the table is edited by a pull request
+  touching `src/btclib/curves/` or `src/btclib/ecc/`**: an arm is any
+  function calling `_libsecp256k1_serves`, and what reaches one changes
+  above it -- `bip32/bip32_test.py` reaches
+  `curves.sec_point._sec_from_octets` through `to_pub_key`, which holds
+  no arm of its own. The push trigger's own comment already said a paths
+  filter naming this surface honestly would be "every merge", and the
+  permissions paragraph now says the same thing rather than the
+  opposite.
+- **`vendored-vectors.yml`'s header stops calling `issues: write` new to
+  this repository**, that workflow no longer being the only one here
+  whose script files an issue.
+
 ## v2026.9.3
 
 ### Repository

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -543,6 +543,10 @@ no OIDC token, and the job that signs writes no release.
 own: `issues: write`, for the `gh issue create`/`edit`/`close` calls its
 script makes on the tracking issue of each ledger its matrix checks, one
 title per ledger.
+`py-arm-authority.yml`'s `authority` job has the same one, for the same
+calls: that workflow's own run is what re-derives the arm-authority
+table, so a disagreement it finds is reported into an issue that stays
+open as well as into the red run that notifies once (issue #1753).
 The workflow-level `permissions: contents: read` is belt and braces; keep
 it, it is what makes the intent readable in the file.
 

--- a/tests/check_py_arm_authority_test.py
+++ b/tests/check_py_arm_authority_test.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Tests for `compare()`, the diff logic of the weekly py-arm sentinel.
+"""Tests for the diff and the reporting halves of the weekly py-arm sentinel.
 
 `measure()` is what actually runs the suite under coverage, module by
 module -- exactly what this repository collects no coverage from, the
@@ -15,6 +15,13 @@ subprocess or coverage run needed to exercise it. `_AUTHORITY` and
 rather than read from `tests/py_arm_authority_test.py`, so a change
 to the real table cannot make this test pass or fail by accident.
 
+`report()` is the other half, and its only external dependency is `gh`.
+`FakeGh` answers each of `gh issue list`, `create`, `edit` and `close`
+the way a real one would rather than reaching GitHub, and records every
+call, so a test can assert what was asked for as well as what came
+back: a real call would need a token and would file an issue against
+this repository.
+
 Loaded by path, the same reason and the same shape as
 `tests/check_vendored_vectors_test.py`.
 """
@@ -22,6 +29,8 @@ Loaded by path, the same reason and the same shape as
 from __future__ import annotations
 
 import importlib.util
+import json
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -43,6 +52,39 @@ def checker(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     monkeypatch.setitem(sys.modules, "check_py_arm_authority", module)
     spec.loader.exec_module(module)
     return module
+
+
+class FakeGh:
+    """A `subprocess.run` stand-in, answering as the `gh` call it names.
+
+    `open_issue` is the number `_open_issue_number` should report open,
+    or None for no issue open at all. Every call is recorded in `calls`,
+    argv and all.
+    """
+
+    def __init__(self) -> None:
+        self.open_issue: int | None = None
+        self.calls: list[list[str]] = []
+
+    def __call__(
+        self, argv: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        """Record the call, and answer as the `gh` sub-command it names."""
+        self.calls.append(list(argv))
+        if argv[2] == "list":
+            issues = (
+                [{"number": self.open_issue}] if self.open_issue is not None else []
+            )
+            return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(issues))
+        return subprocess.CompletedProcess(argv, 0, stdout="")
+
+
+@pytest.fixture
+def fake_gh(checker: ModuleType, monkeypatch: pytest.MonkeyPatch) -> FakeGh:
+    """Install a `FakeGh` in place of the script's own `subprocess.run`."""
+    fake = FakeGh()
+    monkeypatch.setattr(checker.subprocess, "run", fake)
+    return fake
 
 
 def test_compare_finds_nothing_when_every_arm_matches(
@@ -97,3 +139,204 @@ def test_compare_treats_an_arm_missing_from_the_measurement_as_empty(
     assert checker.compare({}) == [
         "STALE: an.arm claims ['a.json'], whose run no longer reaches it"
     ]
+
+
+def test_open_issue_number_reads_the_first_match(
+    checker: ModuleType, fake_gh: FakeGh
+) -> None:
+    """The number of the first issue `gh issue list` names, as a string."""
+    fake_gh.open_issue = 42
+
+    assert checker._open_issue_number("A title") == "42"
+
+    (call,) = fake_gh.calls
+    assert '"A title" in:title' in call
+
+
+def test_open_issue_number_is_none_when_none_is_open(
+    checker: ModuleType, fake_gh: FakeGh
+) -> None:
+    """An empty `gh issue list` is None, not an empty string."""
+    assert checker._open_issue_number("A title") is None
+
+
+def test_the_issue_body_carries_the_lines_stdout_carries(
+    checker: ModuleType,
+) -> None:
+    """The body is `compare()`'s own lines, as bullets, under the header."""
+    body = checker._issue_body(
+        ["STALE: an.arm claims ['a.json'], whose run no longer reaches it"]
+    )
+
+    assert "`tests/py_arm_authority_test.py`'s `_AUTHORITY`" in body
+    assert "- STALE: an.arm claims ['a.json']," in body
+
+
+def test_report_creates_an_issue_when_none_is_open(
+    checker: ModuleType, fake_gh: FakeGh
+) -> None:
+    """A disagreement and no issue open: a new one, under the title given.
+
+    The same title is what the search before it asked for, so a run
+    finds the issue it filed last week rather than opening a second one.
+    """
+    checker.report("A census title", ["STALE: an.arm claims ['a.json']"])
+
+    assert [call[2] for call in fake_gh.calls] == ["list", "create"]
+    (list_call,) = (call for call in fake_gh.calls if call[2] == "list")
+    assert '"A census title" in:title' in list_call
+    (create_call,) = (call for call in fake_gh.calls if call[2] == "create")
+    assert create_call[create_call.index("--title") + 1] == "A census title"
+
+
+def test_report_edits_the_open_issue(checker: ModuleType, fake_gh: FakeGh) -> None:
+    """A disagreement and an issue already open: it is edited, by number."""
+    fake_gh.open_issue = 9
+
+    checker.report("A census title", ["STALE: an.arm claims ['a.json']"])
+
+    assert [call[2] for call in fake_gh.calls] == ["list", "edit"]
+    (edit_call,) = (call for call in fake_gh.calls if call[2] == "edit")
+    assert edit_call[3] == "9"
+
+
+def test_report_closes_an_open_issue_when_nothing_disagrees(
+    checker: ModuleType, fake_gh: FakeGh
+) -> None:
+    """No disagreement and an issue open: it gets closed, with a comment."""
+    fake_gh.open_issue = 7
+
+    checker.report("A census title", [])
+
+    assert [call[2] for call in fake_gh.calls] == ["list", "close"]
+    (close_call,) = (call for call in fake_gh.calls if call[2] == "close")
+    assert "Re-measured" in close_call[close_call.index("--comment") + 1]
+
+
+def test_report_does_nothing_when_clean_and_no_issue_is_open(
+    checker: ModuleType, fake_gh: FakeGh
+) -> None:
+    """No disagreement and no issue open: nothing is written."""
+    checker.report("A census title", [])
+
+    assert [call[2] for call in fake_gh.calls] == ["list"]
+
+
+def _never_measures() -> dict[str, frozenset[str]]:
+    """Raise instead of measuring, where a path must not reach `measure`."""
+    raise AssertionError("measure() ran")
+
+
+def test_the_measure_stand_in_raises_rather_than_measuring() -> None:
+    """The control below is checked before it is relied on.
+
+    A stand-in that quietly returned would leave the usage test passing
+    whether or not the check it guards comes first.
+    """
+    with pytest.raises(AssertionError, match="measure"):
+        _never_measures()
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["prog"],
+        ["prog", "a title", "another title"],
+        ["prog", "--dry-run"],
+    ],
+)
+def test_main_says_how_to_be_called_when_it_is_not(
+    checker: ModuleType,
+    argv: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Anything but one title is the usage, and no measurement at all.
+
+    Only a human running this by hand reaches it -- the workflow passes
+    the title every time -- and what an unchecked unpacking of `args`
+    gives them is a `ValueError` naming a list they never saw. The
+    usage check comes before the measurement, and `_never_measures` is
+    what says so: reached, the real `measure` runs every third-party
+    vector module under coverage, so the regression would be a test
+    taking minutes rather than one failing.
+    """
+    monkeypatch.setattr(checker, "measure", _never_measures)
+    monkeypatch.setattr(sys, "argv", argv)
+
+    assert checker.main() == 2
+
+    captured = capsys.readouterr()
+    # argv[0] is what names the program, so the fixture's own "prog" is
+    # what comes back here rather than the script's file name
+    assert captured.err == "usage: prog <issue title> [--dry-run]\n"
+    assert not captured.out
+
+
+def _measuring(
+    checker: ModuleType, monkeypatch: pytest.MonkeyPatch, measured: set[str]
+) -> None:
+    """Stub the coverage runs over a one-arm table `measured` reaches."""
+    monkeypatch.setattr(checker, "_AUTHORITY", {"an.arm": ("a.json",)})
+    monkeypatch.setattr(checker, "_WITHOUT_AN_AUTHORITY", frozenset())
+    monkeypatch.setattr(checker, "measure", lambda: {"an.arm": frozenset(measured)})
+
+
+def test_main_reports_the_disagreement_before_returning_red(
+    checker: ModuleType,
+    fake_gh: FakeGh,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A disagreement is both the non-zero exit and the issue, not either.
+
+    The exit code is what makes the scheduled run red; the issue is what
+    outlives the notification that run sends (issue #1753).
+    """
+    _measuring(checker, monkeypatch, measured=set())
+    monkeypatch.setattr(sys, "argv", ["prog", "A census title"])
+
+    assert checker.main() == 1
+
+    out = capsys.readouterr().out
+    assert "STALE: an.arm claims ['a.json']" in out
+    assert "1 disagreement(s) with a fresh measurement." in out
+    assert [call[2] for call in fake_gh.calls] == ["list", "create"]
+
+
+def test_main_closes_the_issue_when_the_table_agrees_again(
+    checker: ModuleType,
+    fake_gh: FakeGh,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A measurement that agrees prints the all-clear and closes the issue."""
+    _measuring(checker, monkeypatch, measured={"a.json"})
+    fake_gh.open_issue = 3
+    monkeypatch.setattr(sys, "argv", ["prog", "A census title"])
+
+    assert checker.main() == 0
+
+    out = capsys.readouterr().out
+    assert "Every _AUTHORITY entry matches a fresh no-bindings measurement." in out
+    assert [call[2] for call in fake_gh.calls] == ["list", "close"]
+
+
+def test_main_dry_run_prints_but_never_calls_issue(
+    checker: ModuleType,
+    fake_gh: FakeGh,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--dry-run keeps the red exit and touches no issue at all.
+
+    What the pull_request trigger passes: a pull request exercising this
+    script must not edit or close whatever issue is open at the time.
+    """
+    _measuring(checker, monkeypatch, measured=set())
+    monkeypatch.setattr(sys, "argv", ["prog", "A census title", "--dry-run"])
+
+    assert checker.main() == 1
+
+    assert "1 disagreement(s) with a fresh measurement." in capsys.readouterr().out
+    assert fake_gh.calls == []


### PR DESCRIPTION
Boxes 2 and 3 of [ISS 1753](https://github.com/btclib-org/btclib/issues/1753).
Box 1 landed as `77910fb6` and the workflow is green on `main`.

**Box 2 — a red run was not enough, so the census opens an issue.** The
header argued that no `issues: write` was needed because "a red scheduled
run and the Actions tab it lands on are enough". That claim was tested:
the job failed identically on every push from `755d5081` to `9d409b7d`,
and nobody answered. Documenting the hole in a comment would record it
rather than close it, so `check_py_arm_authority.py` gains the reporting
half its sibling already has — `_open_issue_number(title)`, `report()`
creating, editing or closing one tracking issue, and a `--dry-run` the
`pull_request` trigger passes. The census still reddens the run: `report`
is called *before* the unchanged non-zero exit, so the issue is added
signal, not a replacement for it.

The test the tree applies to which scheduled workflow earns an issue is
`vendored-vectors.yml`'s: a link is noticed the next time somebody
follows it, where a vendored vector is trusted without anybody looking
at it again. `_AUTHORITY` is measurably on the second side.

**Box 3 — the header's `curves/`-or-`ecc/` population goes.** PR 1720,
which invalidated the table, touched neither directory; it touched
`to_pub_key.py`, `to_prv_key.py` and `bip32/`. The arms live in
`curves/`, but the *reach* changes anywhere upstream of them, so no path
list names the population — which is the reasoning this same file's
`push` trigger already gives for carrying no `paths` filter.

`vendored-vectors.yml`'s header is edited too, deliberately outside the
issue's scope: this change falsifies its "`issues: write` is new to this
repository". The clause beside it — that every other scheduled workflow
stops at `contents: read` — was already false, `codeql.yml` and
`scorecard.yml` both being scheduled and both elevating per job.
`REPOSITORY.md`'s account of which jobs elevate gains this one; that it
omits two others is [ISS 1759](https://github.com/btclib-org/btclib/issues/1759),
not this branch.

Gates:

```
pre-commit run --all-files     exit 0, no hook Failed
pytest                         exit 0
                               TOTAL 55156 0 9570 0 100.00%
                               32161 passed, 31 skipped, 1 xfailed
sphinx-build -n -W -b html …   exit 0
```

Reviewed at fresh context over two rounds before opening. Round 1 found
two false statements in prose that lands on `main` — the commit body
claimed this change falsifies two clauses where it falsifies one, and a
new docstring stated a count its own next sentence contradicted. Both
are fixed here. The reviewer also ran five mutants against the new
tests, including `report` moved after the non-zero return, and each
killed exactly the test that owns the property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Make the py-arm authority census persist mismatches in a tracking issue while preserving its failing-run signal and broadening its documented change scope.

New Features:
- Add persistent issue reporting for py-arm authority mismatches, including creation, updates, and automatic closure when measurements recover.

Enhancements:
- Keep the scheduled census run failing while retaining disagreement history beyond transient workflow notifications.
- Allow pull-request runs to exercise the census in dry-run mode without modifying tracking issues.
- Clarify that the authority table can be invalidated by changes beyond the curves and ecc directories.

CI:
- Grant issue-write permission only to the py-arm authority job and pass the tracking issue title from its workflow configuration.

Documentation:
- Document the py-arm authority workflow's issue reporting and permissions in the changelog and repository workflow-permission inventory.
- Correct workflow comments describing issue permissions and the scope of changes that can affect the authority table.

Tests:
- Add coverage for issue discovery, creation, editing, closure, command validation, report-before-failure behavior, and dry-run operation.