### PR TITLE
The permissions prose argues what it can check (closes #1758) (closes #1759)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -63,9 +63,11 @@ on:
 # links only, where an unauthenticated runner is rate limited hard enough
 # to look like rot; contents: read is all that needs.
 # Deliberately not issues: write: an automatic "link rot" issue is the
-# usual next step here, and it would be the only workflow in this
-# repository that can write anything, to save a maintainer from reading a
-# failure notification they already get
+# usual next step here, and it carries nothing past the failed run's own
+# notification -- a link is noticed the next time somebody follows it.
+# vendored-vectors.yml's header states the other side of that test, a
+# vendored vector being trusted without anybody looking at it again, and
+# py-arm-authority.yml's is answered against it
 permissions:
   contents: read
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1120,6 +1120,27 @@ file of the test tree, and no caller acts on it.
   this repository**, that workflow no longer being the only one here
   whose script files an issue.
 
+### Which workflows elevate is left to the command that lists them
+
+- **`.github/workflows/links.yml`'s permissions comment states no claim
+  about what else in this repository can write**
+  (closes #1758): what keeps the workflow at `contents: read` is the
+  signal argument -- a link is noticed the next time somebody follows
+  it, so nothing has to carry the finding past the failed run's own
+  notification. `vendored-vectors.yml`'s header states the other side of
+  that test, and `py-arm-authority.yml`'s is answered against it.
+- **`REPOSITORY.md`'s *Token permissions* says the jobs it names are the
+  declarations it argues rather than a roster of them**
+  (closes #1759), and names the grep that narrows the section's own
+  command to the jobs that elevate. The enumeration it replaces named
+  neither `scorecard.yml`'s `analysis` nor `claude-review.yml`'s
+  `review` and `mention`, and a roster costs a sentence for every job
+  that starts elevating.
+- **The section argues each job departing from its own
+  one-elevation-per-job shape**: `release.yml`'s `attest`,
+  `scorecard.yml`'s `analysis`, and `claude-review.yml`'s `review` and
+  `mention`, each with what the second permission is for.
+
 ## v2026.9.3
 
 ### Repository

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -524,15 +524,14 @@ asking.
 **The default `GITHUB_TOKEN` is read-only repository-wide**, so a job
 needing more must declare it. Most of those declarations are in
 `release.yml`: `contents: write` on `github-release`, `id-token: write` on
-`publish-pypi` and `publish-testpypi`, `id-token: write` with
-`attestations: write` on
-`attest`, and `contents: read` with `pull-requests: read` on `test` — that
-last one there because `test` calls `test.yml`, and a caller's
-`permissions:` block replaces the callee's default outright rather than
-adding to it, so it has to grant what `test.yml`'s own jobs declare, not
-only what `release.yml` itself needs. `test.yml` has one such declaration
-of its own, on `changes`: `pull-requests: read`, to list a pull request's
-files. And `codeql.yml`'s `analyze` has one: `security-events: write` is
+`publish-pypi` and `publish-testpypi`, and `contents: read` with
+`pull-requests: read` on `test` — that last one there because `test`
+calls `test.yml`, and a caller's `permissions:` block replaces the
+callee's default outright rather than adding to it, so it has to grant
+what `test.yml`'s own jobs declare, not only what `release.yml` itself
+needs. `test.yml` has one such declaration of its own, on `changes`:
+`pull-requests: read`, to list a pull request's files. And
+`codeql.yml`'s `analyze` has one: `security-events: write` is
 what uploading a SARIF to code scanning takes, with `actions: read` beside
 it — redundant while this repository is public, and written down so that
 the file does not quietly stop working the day it is not. Every
@@ -550,12 +549,31 @@ open as well as into the red run that notifies once (issue #1753).
 The workflow-level `permissions: contents: read` is belt and braces; keep
 it, it is what makes the intent readable in the file.
 
+Two elevations on one job is the exception to that shape, and the reason
+for the pair sits beside it. `release.yml`'s `attest` holds `id-token:
+write` with `attestations: write`: OIDC for the short-lived Sigstore
+signing certificate, and the write that persists the attestation against
+the repository. `scorecard.yml`'s `analysis` holds `id-token: write` with
+`security-events: write`: the transparency-log entry `publish_results`
+asks for, and the SARIF filed as code-scanning alerts, with `contents` at
+the workflow's `read` because the analysis pushes nothing back to the
+tree.
+`claude-review.yml`'s `review` and `mention` hold `pull-requests: write`
+with `id-token: write`, where only the first is a write of theirs: the
+action mints a GitHub OIDC token during its own startup whatever the
+Anthropic credential is, and without it the run dies before reaching
+authentication at all.
+
+These are the declarations this file argues, not a roster of them.
+
 ```shell
 git grep -n "permissions:$" -- .github/workflows/*.yml
 ```
 
-re-derives the current list, whenever it's wanted, rather than a count
-here going stale the next time a job's own needs change.
+names every declaration, and `: write` in place of `permissions:$`
+narrows it to the jobs that elevate, comments discussing one included.
+Either is re-derived whenever it's wanted, where a list here goes stale
+the next time a job's own needs change.
 
 ### Whether that default is pinned here is untested
 


### PR DESCRIPTION
Closes [ISS 1758](https://github.com/btclib-org/btclib/issues/1758) and
[ISS 1759](https://github.com/btclib-org/btclib/issues/1759) — one
decision in two files: what this tree says about which workflows can
write.

`links.yml`'s permissions comment said an automatic link-rot issue
"would be the only workflow in this repository that can write anything".
False, and false before either issue was filed. The **setting is
untouched** — `links.yml` still opens no issue — and only the reason
changes, to the one that actually decided it: a link is noticed the next
time somebody follows it, so nothing has to carry the finding past the
failed run's own notification. That repairs a dangling pointer as well
as a false clause: both `vendored-vectors.yml`'s header and
`py-arm-authority.yml`'s attribute to `links.yml` an argument
`links.yml` did not make.

`REPOSITORY.md`'s *Token permissions* omitted `scorecard.yml`'s
`analysis` and `claude-review.yml`'s `review` and `mention`. It takes
the **sample-plus-command** shape rather than a restored roster: a
roster owes a sentence to every job that starts elevating and was
already short before `py-arm-authority.yml`'s `authority` was appended,
and answering one issue by lengthening a list while answering the other
by deleting a claim would treat one defect two opposite ways. What does
not rot is the rule and its exceptions, so the prose keeps those and
hands the list to the command.

Every job that departs from the section's own one-elevation-per-job
shape is now argued. That is four — `review`, `mention`, `attest` and
`analysis` — and `attest` is one of them: ISS 1759 offered it as the
model that already carried its reason, and it carried none, the
"because" in that sentence belonging to `test`. The issue body has since
been corrected.

Gates:

```
pre-commit run --all-files     exit 0, actionlint and zizmor Passed
pytest                         exit 0
                               TOTAL 55156 0 9570 0 100.00%
                               32161 passed, 31 skipped, 1 xfailed
sphinx-build -n -W -b html …   exit 0
```

Reviewed at fresh context before opening. The reviewer re-took the
permissions census by parsing the workflows rather than grepping them,
and ran both of the commands the section names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Align workflow permission commentary and repository documentation with the permissions actually declared by each workflow.

Bug Fixes:
- Correct inaccurate workflow permission commentary and remove its unsupported claim about being the repository's only workflow able to write.
- Clarify the documented workflow permission exceptions, including the previously omitted Scorecard and Claude review jobs.

Enhancements:
- Restructure the token-permissions documentation to explain multi-permission jobs and direct readers to commands for deriving the current declarations.

Documentation:
- Update the changelog and repository permission documentation to align explanations with the workflows' actual permission requirements.