### PR TITLE
`release.yml`'s `public-api` job says the red is every griffe finding (closes #1754)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,10 +244,26 @@ jobs:
   # so that entry is what any such gate would read. What it does not
   # settle is the comparison: the walk is against the last release, so a
   # per-pull-request run reports every break already entered earlier in
-  # the same cycle, once more on each pull request that follows. Here
-  # the answer arrives while RELEASE_NOTES.md is already being written,
-  # so a break with no entry is refused at the moment somebody is
-  # already writing entries.
+  # the same cycle, once more on each pull request that follows. Here it
+  # runs once per release: a rehearsal reads the code as checked out,
+  # while RELEASE_NOTES.md is still open, and a tag reads what is about
+  # to be published.
+  # Nothing in this job reads RELEASE_NOTES.md, and every finding griffe
+  # reports fails the step. A break whose entry is already written
+  # reddens this job exactly as an undocumented one does, so any release
+  # with a finding at all leaves a red job behind it. That is the
+  # intended reading rather than an oversight: the red carries the
+  # surface diff to whoever is writing the notes, and says nothing about
+  # whether the entry exists. What it costs is that a red expected on
+  # every cycle with breaking changes in it is a red nobody reads as
+  # news, which is why RELEASING.md asks for the job list rather than
+  # the run's own badge.
+  # A finding is not by itself a change a caller can observe: griffe
+  # compares expressions and does not import, so a constant moved behind
+  # a lookup into a table is reported as changed while its value is
+  # identical. The step's own command below, given both tags, re-derives
+  # the list outside a run, and importing the two releases is what
+  # settles such a finding.
   # No `needs:` of its own, so it starts when the run does, beside the
   # platform sweeps rather than ahead of them. What the graph orders
   # after it is the upload: publish-testpypi and publish-pypi list it,
@@ -328,8 +344,9 @@ jobs:
           if ! uvx griffe==2.2.0 check btclib -s . -s src \
               -a "$PREVIOUS_TAG" "${base_args[@]}" -f github; then
             msg="the public API changed since $PREVIOUS_TAG:"
-            echo "::error::$msg add a breaking-changes bullet to" \
-              "RELEASE_NOTES.md, or say here why the change is not one"
+            echo "::error::$msg reconcile the findings above with" \
+              "RELEASE_NOTES.md's breaking-changes list;" \
+              "not every finding is a break"
             exit 1
           fi
       - name: Skip the check (no previous release to compare against)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1141,6 +1141,26 @@ file of the test tree, and no caller acts on it.
   `scorecard.yml`'s `analysis`, and `claude-review.yml`'s `review` and
   `mention`, each with what the second permission is for.
 
+### What the `public-api` job refuses is every griffe finding
+
+- **`.github/workflows/release.yml`'s `public-api` job stops saying it
+  refuses a break with no `RELEASE_NOTES.md` entry** (closes #1754):
+  nothing in the job reads that file, so a break documented at the tag
+  reddens it exactly as an undocumented one does. What the comment says
+  instead is that every finding `griffe check` reports fails the step,
+  so any release with a finding at all leaves a red job behind; that the
+  red carries the surface diff to whoever is writing the notes; and that
+  a red expected on every cycle with breaking changes in it is a red
+  nobody reads as news.
+- **The comment names the finding that is not a change a caller can
+  observe**: griffe compares expressions and does not import, so a
+  constant moved behind a lookup into a table is reported as changed
+  while its value is identical.
+- **The step's `::error::` message asks for the findings to be
+  reconciled with `RELEASE_NOTES.md`'s breaking-changes list**: the
+  words it replaces offered to "say here why the change is not one",
+  and a run's log is not a place to write that in.
+
 ## v2026.9.3
 
 ### Repository


### PR DESCRIPTION
Closes #1754

`release.yml`'s `public-api` job carried a comment saying a break with
no `RELEASE_NOTES.md` entry is refused. Nothing in the job opens that
file — within it `RELEASE_NOTES.md` occurs in the comment and in the
failure message and in no step — so a break documented at the tag
reddens the job exactly as an undocumented one does, and the sentence
described a discrimination no run makes.

Behaviour is unchanged: no `needs:`, no `if:`, no step and no exit
status moves. `publish-testpypi` and `publish-pypi` list the job for
ordering and neither `if:` names `needs.public-api.result`. What
changes is the prose, plus the `::error::` message, whose "or say here
why the change is not one" left "here" without a referent — the message
is written into a run's log — and whose first half asked for an entry
per finding, which the griffe class the comment now names makes wrong.

Measured between the two tags the job last compared:

    uvx griffe==2.2.0 check btclib -s . -s src \
        -a v2026.8.29 -b v2026.9.3 -f github

`BIP34_HEIGHT`, `MAINNET_POW_LIMIT_BITS` and `REGTEST_POW_LIMIT_BITS`
each moved from a literal to an entry of `CONSENSUS_PARAMS`, and the
published release answers `227931`, `b'\x1d\x00\xff\xff'` and
`b' \x7f\xff\xff'` — the values the replaced expressions spelled out.
Not every finding is of that class: `Version.__init__(version)`'s
default moved from `0` to `PROTOCOL_VERSION`, `70016`.

Gates on this sha: `pre-commit run --all-files` exit 0;
`uv run pytest` exit 0, 32161 passed / 31 skipped / 1 xfailed, TOTAL
100.00%; `sphinx-build -n -W -b html` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Clarify the `public-api` release check’s behavior and correct its guidance for interpreting griffe findings.

Enhancements:
- Clarify that the release `public-api` check fails on any griffe finding rather than only undocumented breaking changes.
- Explain that some griffe findings may reflect equivalent public behavior when values are represented differently.
- Update the failure guidance to reconcile findings with the release notes breaking-changes list.

Documentation:
- Document the corrected behavior and interpretation of the `public-api` job in the changelog.