### PR TITLE
RELEASING.md's griffe step stops promising every finding an entry (closes #1763)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1161,6 +1161,17 @@ file of the test tree, and no caller acts on it.
   words it replaces offered to "say here why the change is not one",
   and a run's log is not a place to write that in.
 
+### RELEASING.md's griffe step stops promising every finding an entry
+
+- **RELEASING.md's griffe step no longer says every line it prints wants a
+  breaking-changes entry** (closes #1763): griffe compares the expression an
+  attribute is assigned rather than the value it resolves to, so a constant
+  moved from a literal into a lookup table reports as changed while the value
+  a caller sees is unchanged.
+- **The noise paragraph beside it names that shape next to PEP 604 spelling
+  and `check_validity` going keyword-only**, and its own opening sentence no
+  longer counts the shapes it lists.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -239,21 +239,27 @@ to `deps-latest`'s own result.
    reads both revisions and answers that: it reports breakage alone — a
    public object removed, a parameter that changed kind or default or
    moved, an attribute whose value changed — and says nothing at all about
-   an addition, so every line it prints wants an entry. What the step asks
-   is that nothing it names is missing from RELEASE_NOTES.md. The converse is
-   not its to answer: an entry describing a break it did not find is a
+   an addition. It compares the expression an attribute is assigned rather
+   than the value the module resolves it to, so a line can print for a
+   change no caller can observe; the paragraph below names the shapes that
+   fall out that way. What the step asks is that nothing it names, once
+   that noise is set aside, is missing from RELEASE_NOTES.md. The converse
+   is not its to answer: an entry describing a break it did not find is a
    claim about the prose, which review still has to read. It exits 1 on a
    finding.
 
-   Breakage by griffe's classification is not breakage a user would
-   notice, though, and two shapes are most of the noise. `Attribute value
-   was changed: Union[X, Y] -> X | Y` is PEP 604 spelling and breaks
-   nobody, and `__version__` and `__copyright__` report the same way. And
-   one systemic change repeats once per site: `check_validity` going
-   keyword-only is dozens of lines on its own and belongs in
-   RELEASE_NOTES.md once, as a rule, not once per class. Discount those and
-   what is left is short enough to check bullet by bullet — four entries
-   were missing from v2026.8.7's list, and all four were in that remainder.
+   Breakage by griffe's classification is not breakage a user would notice,
+   though, and the noise recurs in recognizable shapes. `Attribute value was
+   changed: Union[X, Y] -> X | Y` is PEP 604 spelling and breaks nobody, and
+   `__version__` and `__copyright__` report the same way. A constant moved from
+   a literal into a lookup table reports the same way too: `BIP34_HEIGHT`
+   moving into `CONSENSUS_PARAMS` prints as a changed attribute while the
+   constant itself is unchanged. And one systemic change repeats once per site:
+   `check_validity` going keyword-only is dozens of lines on its own and
+   belongs in RELEASE_NOTES.md once, as a rule, not once per class. Discount
+   those and what is left is short enough to check bullet by bullet — four
+   entries were missing from v2026.8.7's list, and all four were in that
+   remainder.
 
    Not a gate on every commit, and deliberately so: the comparison is
    against the previous *release* tag, so it reports the whole of a


### PR DESCRIPTION
Closes #1763

`RELEASING.md`'s griffe step said every line the check prints wants a
breaking-changes entry. griffe compares the expression an attribute is
assigned rather than the value it resolves to, so a constant moved from
a literal into a lookup table reports as changed while nothing a caller
can observe did — and the paragraph directly under that sentence
already took it back by naming what to discount.

The mechanism is now stated where the promise was. The noise paragraph
gains that shape next to PEP 604 spelling and `check_validity` going
keyword-only, and its opening sentence stops counting the shapes it
lists, a count a fourth shape would falsify.

`.github/workflows/release.yml`'s `public-api` job names the same class
in its own comment since [PR 1764](https://github.com/btclib-org/btclib/pull/1764)
rewrote it (closing ISS 1754); the two documents now
describe griffe's output the same way, with neither restating the other.

Gates on this sha: `uv run pre-commit run --all-files` exit 0;
`uv run pytest` exit 0, 32161 passed / 31 skipped / 1 xfailed, TOTAL
100.00%; `uv run sphinx-build -n -W -b html docs/source docs/build/html`
exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Refine Griffe release-check guidance so maintainers distinguish actionable API breaks from non-observable reporting noise.

Enhancements:
- Clarify that Griffe findings require release-note entries only after known non-user-visible noise is discounted.
- Document additional sources of Griffe noise, including implementation-expression changes, PEP 604 spelling, metadata attributes, and repeated keyword-only parameter reports.
- Align the release workflow comment with the updated Griffe guidance.

Documentation:
- Update RELEASING.md to accurately describe how to interpret Griffe public API comparison results.

Chores:
- Record the release-process documentation correction in the changelog.