### PR TITLE
CLAUDE.md's worktree fence takes the standard's form, and names the venv (issue btclib-org/.github#824) (closes #1710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1172,6 +1172,35 @@ file of the test tree, and no caller acts on it.
   and `check_validity` going keyword-only**, and its own opening sentence no
   longer counts the shapes it lists.
 
+### `CLAUDE.md`'s worktree fence takes the standard's form, and names the venv
+
+- **The fence's push is `git -C "$WT" push origin
+  HEAD:refs/heads/<branch>`, in place of a `cd "$WT"` above a bare `git
+  push`** (issue btclib-org/.github#824): a `cd` binds the shell that
+  runs it, so a session running each line as its own command pushes the
+  primary checkout's `HEAD`. The paragraph below the create paragraph
+  gives that binding and its limit, `git -C ""` being documented to
+  leave the working directory unchanged.
+- **The paragraph reasoning about `cd ""` goes with the `cd` it reasons
+  about**, which supersedes this section's *`CLAUDE.md` states the
+  worktree block's absent `uv sync` in one place*: that entry says the
+  paragraph stands as written, and the sentence above the fence is what
+  the worktree section says about the absent `uv sync`.
+- **The create paragraph states what makes the `>` closing `<branch>`
+  reachable**: the `<` ahead of it succeeds only where the reader's own
+  directory already holds that name, and ordinarily nothing holds it.
+- **The removal guard is stated as refusing an unset or empty `WT`**,
+  which is what `${WT:?}` does; this section's *`CLAUDE.md`'s
+  worktree-removal fence takes the `${WT:?}` guard* names the unset case
+  alone.
+- **The paragraph weighing what a worktree costs names the venv it
+  weighs** (closes #1710): a worktree is its own project root, so
+  `uv run` creates and syncs a `.venv` inside it.
+- **A sentence below the removal fence names `btclib-org/.github`'s
+  `CLAUDE.md` at `20ad654` as what the create, the push and the removal
+  converged on**, so a later reader compares against a tree rather than
+  against an issue's quotation of one.
+
 ## v2026.9.3
 
 ### Repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,45 +118,62 @@ once, which the ordinary sequence avoids by each removing its own.
 
 An issue of `btclib-org/.github`'s tracker worked in `btclib` by a coder
 names its worktree `wt-github-255-btclib-coder`. No `uv sync` follows
-the `cd`, the gate doing that itself, and the editing, the gates and the
-commits all happen in the worktree before the push.
+`git worktree add`, the gate doing that itself, and the editing, the
+gates and the commits all happen in the worktree before the push.
 
 ```shell
 WT=<scratchpad>/wt-<tracker>-<issue>-<repo>-<role>
 git worktree add "$WT" origin/main -b <branch>
-cd "$WT"
-git push origin HEAD:refs/heads/<branch>
+git -C "$WT" push origin HEAD:refs/heads/<branch>
 ```
 
 `-b <branch>` sits after the path and the commit-ish so that the
 placeholder ends the command, which is section 9 of the organization
-standard's rule. With the placeholder ahead of `"$WT"` the `>` closing it
-takes that path as its target, and a path with no directory at it is a
-file the paste creates.
+standard's rule. With the placeholder ahead of `"$WT"`, its `<` and its
+`>` are redirections performed left to right, so the `>` is reached only
+where the reader's own directory already holds the name `branch`: there
+the `<` succeeds, the line runs, and the `>` takes `"$WT"` as its
+target — a path with no directory at it is the file it creates.
+Ordinarily nothing holds that name, so the `<` fails first (`no such
+file or directory: branch`) and the line ends before the `>` opens
+anything.
 
-No line in the block writes. The `&&` that used to carry `uv sync` is
-no guard: with `WT` unset, `cd "$WT"` is `cd ""`, which `zsh` and the
-`bash` 3.2 macOS ships answer 0, where `bash` 5 refuses it. So the reach
-is the reader's shell rather than every reader's, and where the chain
-does proceed a sync line here runs in the reader's own directory, which
-for a reader of this file is the primary checkout.
+The push names the worktree with `git -C "$WT"` because a `cd` binds the
+shell that runs it: a session that runs each line as its own command
+starts the next one in the directory it began in, the primary checkout,
+so a push after a `cd` offers that checkout's `HEAD` instead of the
+worktree's. `env -C <dir>` is the same binding for a command that takes
+no `-C` of its own. Neither binding rescues the assignment above it: a
+session that loses the `cd` loses `WT` with it, and `git -C ""` is
+documented to leave the working directory unchanged, so that push lands
+the same way, exit 0 and no diagnostic. What the `-C` buys is a path
+that can be written out in full; write it out.
 
 Removing the worktree is part of finishing, and it stands in a block of
 its own: the block above ends in a placeholder, and a shell that
 discards that line as a parse error reads the next as a fresh command —
 which, in one block, is this line against whatever `$WT` already held.
 Standing alone it is a second fence, so `${WT:?}` is what it writes:
-with no `$WT` set the expansion fails and the removal does not run.
+with `$WT` unset or empty the expansion fails and the removal does not
+run. Those are the only cases it catches — a `$WT` an earlier session or
+command left holding a path expands, and the removal runs against
+whatever worktree that path names.
 
 ```shell
 git worktree remove --force "${WT:?}"
 ```
 
-The venv is the whole of the cost, and it buys the thing that matters: a
-commit cannot contain work that was never in it. Expect `origin/main` to
-move while you work, so `git fetch && git rebase origin/main` before
-pushing, resolving in favour of *both* sides (their change and yours,
-both CHANGELOG.md bullets).
+What the fence says about the create, the push and the removal converged
+in `btclib-org/.github`'s `CLAUDE.md` at `20ad654`, which is what a
+later reader compares it against rather than an issue's quotation of it.
+
+A worktree is its own project root, so `uv run` creates and syncs a
+`.venv` inside it rather than sharing the checkout's. The venv is the
+whole of the cost, and it buys the thing that matters: a commit cannot
+contain work that was never in it. Expect `origin/main` to move while
+you work, so `git fetch && git rebase origin/main` before pushing,
+resolving in favour of *both* sides (their change and yours, both
+CHANGELOG.md bullets).
 
 **Never `git stash` in a worktree either: `refs/stash` is shared.** A
 worktree isolates files, not refs. The stash is a single ref in the


### PR DESCRIPTION
## What this changes

`CLAUDE.md`'s worktree fence takes the create, push and removal
paragraphs of [the organization
standard](https://github.com/btclib-org/.github/blob/20ad654c4e529c186eee55d423671b2ec549aa2e/CLAUDE.md)
at `20ad654`, the sha holding all three. The push and removal paragraphs
are that file's byte for byte; the create paragraph is that file's from
*With the placeholder ahead of* onward, the clause ahead of that phrase
citing section 9 as the organization standard where the standard names
its own `README.md`.

The fence's push is `git -C "$WT" push origin HEAD:refs/heads/<branch>`
in place of a `cd "$WT"` above a bare `git push`. Removing the `cd`
orphans the paragraph that reasoned about `cd ""` and about the `&&`
that used to chain a `uv sync` onto it, so the standard's push paragraph
takes its slot between the create paragraph and the removal paragraph.
What it carries is the limit that matters once the `cd` is gone:
`git -C ""` is documented to leave the working directory unchanged, so a
`-C` written against a lost `WT` lands in the same wrong tree a lost
`cd` does.

The same region is [ISS
1710](https://github.com/btclib-org/btclib/issues/1710), whose defect is
that *The venv is the whole of the cost* opens with a definite article
and nothing above it names a venv. A sentence ahead of it now names one.

Closes #1710

This branch is one row of a port owed by several trees, and it answers
that port for this tree only.

## How it was verified

The push and removal paragraphs are compared against the standard's blob
in the object store rather than by eye, with a paragraph that was not
copied as the control:

```shell
cmp p-push-std.txt p-push-btclib.txt          # exit 0
cmp p-rm-std.txt   p-rm-btclib.txt            # exit 0
cmp p-ctl-std.txt  p-ctl-btclib.txt           # exit 1, char 146
```

The create paragraph is compared folded, `tr '\n' ' ' | tr -s ' '`, from
*With the placeholder ahead of* onward, and matches.

That `uv run` writes the worktree's own `.venv` was measured in this
worktree rather than reasoned about: it printed `Creating virtual
environment at: .venv`, built btclib from the worktree's own path, and
reported `sys.prefix` inside the worktree.

## Checks

- [x] `uv run pre-commit run --all-files` is clean (ruff, mypy strict,
      markdownlint, the copyright notice, `uv.lock`)
- [x] `uv run pytest` passes
- [x] `CHANGELOG.md` has an entry, if a user would notice the change;
      `RELEASE_NOTES.md` too, if it is one a user has to act on

The documentation build was run as well, `docs/source/changelog_link.md`
pulling `../../CHANGELOG.md` through a MyST `include` under `-W`, so a
changelog-only diff still reaches it.

## Anything the reviewer should know

The deleted paragraph carried a measurement the tracker does not have:
that `bash` 5 refuses `cd ""` where `zsh` and the `bash` 3.2 macOS ships
accept it. [ISS
739](https://github.com/btclib-org/.github/issues/739) states the
opposite, that `cd ""` succeeds in all three, and that is the issue the
paragraph pointed at. Re-measured here, one script file per shell:
`/bin/zsh` 5.9, `/bin/bash` 3.2.57, `/bin/sh` 3.2.57 and `/bin/dash`
exit 0; `/opt/homebrew/bin/bash` 5.3.15 exits 1 with `cd: directory
null`. The control, `cd /tmp`, exits 0 in all five.

The rebase onto the new base met the union driver at the `CHANGELOG.md`
seam and swallowed the blank line above the new entry. It was predicted
before the rebase, repaired by reconstruction from the new base, and the
repaired file is byte-identical to that reconstruction.

CLAUDE.md's worktree fence takes the standard's form, and names the venv (issue btclib-org/.github#824) (closes #1710)

The push and removal paragraphs are btclib-org/.github's CLAUDE.md at
20ad654 byte for byte, and the create paragraph is that file's from
"With the placeholder ahead of" onward; what differs ahead of that
phrase is the clause citing section 9, which this tree writes as the
organization standard where the standard names its own README.md.

The paragraph that reasoned about `cd ""` and about the `&&` that used
to chain a `uv sync` onto it goes with the `cd`, and the standard's push
paragraph takes its slot between the create paragraph and the removal
paragraph. What that paragraph carries is the limit that matters once
the `cd` is gone: `git -C ""` is documented to leave the working
directory unchanged, so a `-C` written against a lost `WT` lands in the
same wrong tree a lost `cd` does. The absent `uv sync` is then stated in
the worktree section by the sentence above the fence alone.

The open changelog section carries live claims about this region, and
the new entry says what it does to each. "CLAUDE.md states the worktree
block's absent `uv sync` in one place" says the deleted paragraph stands
as written. "CLAUDE.md's worktree-removal fence takes the `${WT:?}`
guard" names the unset case, where the guard also refuses an empty
value.

btclib-org/btclib#1710 is the same paragraph. "The venv is the whole of
the cost" opened with a definite article and nothing above it naming a
venv; the sentence added ahead of it names one. Measured in this
worktree: `uv run` printed "Creating virtual environment at: .venv",
built btclib from the worktree's own path, and reported `sys.prefix`
inside the worktree.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MJHtQvfB5nJPeeq6QAFWxw


Local review at fresh context: CLEARED b976462, which is this head, with nothing blocking. The reviewer re-derived every sha, both numstats, the byte-identities and their controls, and the union seam with two controls that fail as they must; it built a live stub `git` on a real PATH to run the create fence in three shells across three directory states, rather than reading the claim; and it corroborated the gate logs against the branch reflog, the runs postdating the sha under review. Gates on this tree, at this head: `uv run pre-commit run --all-files` exit 0; the `Lint and type-check` job's own form, `uv run --locked --only-group lint pre-commit run --all-files --show-diff-on-failure`, exit 0 with 42 hooks and none failed; `uv run pytest` exit 0, `32161 passed, 31 skipped, 1 xfailed`, `TOTAL 55156 0 9570 0 100.00%`; `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html` exit 0, and the docs job's second step, the relative-anchor grep, exit 1 as it must; then `pre-commit run --all-files` again with `docs/build/` present, `check sdist` passing. The suite ran at a load peaking at 12,57 and passed there; no run fell and nothing was re-run. `integration-bitcoind` was not run locally — no node here — and the diff reaches no code it exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJHtQvfB5nJPeeq6QAFWxw

## Summary by Sourcery

Align the worktree instructions with the organization standard while making pushes, cleanup, and virtual-environment behavior explicit and safe.

Bug Fixes:
- Make worktree pushes target the intended worktree even when commands are executed independently.
- Clarify the worktree workflow’s handling of missing or empty worktree paths and its virtual-environment behavior.

Enhancements:
- Align the worktree guidance in `CLAUDE.md` with the organization standard and document the standard revision used as the reference.
- Clarify worktree creation redirection behavior and the implications of losing the shell-local worktree context.

Documentation:
- Update the changelog with the revised worktree guidance, removal safeguards, virtual-environment naming, and organization-standard reference.