### PR TITLE
`curves/curve.py`'s prose names the standards a sentence is about (closes #1657, #1658)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1201,6 +1201,43 @@ file of the test tree, and no caller acts on it.
   converged on**, so a later reader compares against a tree rather than
   against an issue's quotation of one.
 
+### `curves.curve`'s prose names the standards a sentence is about
+
+- **`curve.py`'s module docstring, its `datadir` paragraph, the comment
+  over the order check, `_catalogued_curve`'s docstring and the comment
+  over `CURVES` name the standards, the files and the curves they are
+  about, in place of a total of them** (closes #1657). The docstring
+  names SEC2v1, SEC2v2, NIST and Brainpool, which is the form
+  `btclib/curves/__init__.py` already uses for the same list.
+  `tests/curves/curve_test.py` asserts `len(CURVES) == len(SEC2v1) +
+  len(NIST) + len(Brainpool)`, which is the de-counted form and pins none
+  of the numbers those sentences gave, so a curve added to a shipped json
+  file left each of them reading exactly as it read before.
+- **`test_wif_without_a_network`'s docstring names the rows driving it
+  rather than counting them** (closes #1658). `WIF_VECTORS` filters
+  `tests/_data/key_io_valid.json` on `isPrivkey`, so what moves the
+  number is a refresh of that vendored file, and nothing in such a
+  refresh reads this docstring. The exception `CLAUDE.md` keeps for a
+  count of what upstream published does not reach it: that one is in
+  `tests/_data/README.md`, the only file `tests/vendored_data_test.py`
+  reads.
+- **`curve.py`'s remaining counts go with them**, in prose the same diff
+  rewrites and outside what issue #1657 lists: the comment over
+  `_libsecp256k1_available` counted the modules importing the predicate
+  by name, and the comment over the order check counted the mult
+  implementations `tests/curves/curve_group_test.py` and
+  `curve_group_2_test.py` drive `n*G == INF` through. An `ast` walk over
+  `src/btclib` for the first and over those two modules for the second
+  answers neither total. The order-check comment also stops naming
+  `curve_group_2_test.py`: `all_curves`, the union that reaches
+  `CURVES`, does not appear in it, so what it drives `n*G == INF`
+  through is low-cardinality curves and secp256k1 alone.
+- **A count of a fixed structure the sentence names stays**: the
+  multiplications, which the line above them names; `multi_mult_var`'s
+  own entry points, which the sentence holding them lists; and the
+  version numbers of SEC 2 itself. A curve added to a shipped json file
+  moves none of them.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/curves/curve.py
+++ b/src/btclib/curves/curve.py
@@ -11,13 +11,13 @@ the bindings cannot express -- with curve_group's arithmetic.
 What this module exports is the class, the three multiplications,
 `PreparedPoint` -- the one way a caller has of saying that a point of
 its own will come back, so that the tables built for it are kept -- the
-catalogue, the four standards it is the union of -- which is where
-btclib.curves keeps them, a standard being a question about a curve and
-not a way of finding one -- and the `*_params2` each of those four is
-built from, which is what test_catalogued_curves rebuilds every curve
-out of with both expensive checks on.
+catalogue, the standards it is the union of, and the `*_params2` each of
+those is built from, which is what test_catalogued_curves rebuilds every
+curve out of with both expensive checks on. The standards are SEC2v1,
+SEC2v2, NIST and Brainpool, and this module is where btclib.curves keeps
+them: a standard is a question about a curve, not a way of finding one.
 
-`datadir` stays out: it is where this package keeps the four json files
+`datadir` stays out: it is where this package keeps the json files
 loaded below, so it answers a question about the installation rather than
 about a curve, and `btclib.network` has a `datadir` of its own for the
 network files. The loader's own names are underscored, a `with` target and
@@ -242,19 +242,19 @@ class Curve(CurveGroup):
             raise BTClibValueError(err_msg)
         # n*G is by far the most expensive check here -- a Python
         # double-and-add over nlen bits -- and it dominates the cost of
-        # building a curve: at import time the 27 catalogued curves would
+        # building a curve: at import time the catalogued curves would
         # spend most of it on n*G alone, and next to none of it on the
         # primality of n. The catalogue therefore passes
         # order_check=False, as it does weakness_check=False below: its
         # parameters are constants, and test_catalogued_curves rebuilds
         # every one of them from the json data with both checks on, while
-        # tests/curves/curve_group_test.py and curve_group_2_test.py assert
-        # n*G == INF for every curve of CURVES through ten distinct mult
-        # implementations. It stays on by default all the same, and is not
-        # merely a test-time luxury: a caller-defined curve whose n is
-        # not the order of G is accepted by every other check here and
-        # then fails silently downstream, mult and sign returning
-        # answers in a group nobody asked for
+        # tests/curves/curve_group_test.py asserts n*G == INF for every
+        # curve of CURVES through the affine and Jacobian double-and-adds
+        # and their recursive forms. It stays on by default all the same,
+        # and is not merely a test-time luxury: a caller-defined curve
+        # whose n is not the order of G is accepted by every other check
+        # here and then fails silently downstream, mult and sign
+        # returning answers in a group nobody asked for
         if order_check and _mult(n, self.GJ, self)[2] != 0:
             err_msg = "n is not the group order: "
             err_msg += f"{hex_string(n)}" if n > HEX_THRESHOLD else f"{n}"
@@ -371,7 +371,7 @@ datadir = Path(__file__).parent / "_data"
 def _catalogued_curve(params: list[Any], name: str) -> Curve:
     """Build one curve of the shipped catalogue, from its json parameters.
 
-    One function for the four catalogues, so that the flags cannot drift
+    One function for every catalogue, so that the flags cannot drift
     apart. Both expensive checks are off: these parameters are the
     standardized constants of SEC 2, FIPS 186-4 and RFC 5639, and
     re-deriving from them at every interpreter start that n is the order
@@ -433,9 +433,9 @@ for _ec_name in SEC2v2_params2:
 
 # a new dict, deliberately: aliasing (CURVES = SEC2v1) followed by
 # update() calls would pour NIST and Brainpool into the SEC 2 v.1
-# catalogue -- SEC2v1 with 27 entries instead of its own 15, and
-# SEC2v1["nistp256"] answering a curve that is not in SEC 2 v.1 at all.
-# Each catalogue holds what it is named after
+# catalogue -- SEC2v1 holding every catalogued curve instead of its own,
+# and SEC2v1["nistp256"] answering a curve that is not in SEC 2 v.1 at
+# all. Each catalogue holds what it is named after
 CURVES = SEC2v1 | NIST | Brainpool
 
 secp256k1 = CURVES["secp256k1"]
@@ -446,9 +446,10 @@ secp256k1 = CURVES["secp256k1"]
 # bindings serve this call" but "may they serve any of them". Assigning
 # False turns the delegation off across the whole package, because every
 # dispatch asks the predicate and the predicate reads this global --
-# whereas rebinding the predicate itself reaches one module of the nine
-# that import it by name, so a caller that names them delegates in
-# silence wherever it forgets one, and times C while calling it Python.
+# whereas the predicate is imported by name, so rebinding it reaches the
+# one module it is rebound in: a caller that goes module by module
+# delegates in silence wherever it forgets one, and times C while calling
+# it Python.
 #
 # What the import answered, and not a constant: `btclib._libsecp256k1` is
 # the one place the bindings are imported, so an installation without

--- a/tests/key_io_test.py
+++ b/tests/key_io_test.py
@@ -173,7 +173,7 @@ def test_wif_without_a_network(
     prefix, issue #207 again. Naming the chain is what the argument above
     is for, and passing it is not a workaround: `_wif_network` checks the
     prefix against that network rather than comparing lookup names, so
-    every one of the sixteen rows is accepted on the chain Core names.
+    every one of `WIF_VECTORS`'s rows is accepted on the chain Core names.
     Nothing else moves -- the key and the compression flag are the
     payload, and the payload is unambiguous.
     """


### PR DESCRIPTION
`src/btclib/curves/curve.py` stated how many standards the catalogue is
the union of, how many json files `datadir` keeps, how many curves the
catalogue holds and how many entries an aliased SEC2v1 would end up
with, and `tests/key_io_test.py`'s `test_wif_without_a_network` stated
how many rows drive it. Nothing reads any of those words, and
`tests/curves/curve_test.py` asserts `len(CURVES) == len(SEC2v1) +
len(NIST) + len(Brainpool)` — the de-counted form, which pins none of
them — so a curve added to a shipped json file leaves every one of those
sentences reading exactly as it read before.

Each sentence now names what it is about: the standards the catalogue is
the union of, spelled SEC2v1, SEC2v2, NIST and Brainpool as
`btclib/curves/__init__.py` already spells them; the json files
`datadir` keeps; the catalogued curves whose `n*G` would dominate an
import; the catalogue an aliased SEC2v1 would end up holding; the one
function every catalogue is built through; and the rows of
`WIF_VECTORS`.

The order-check comment also stops naming `curve_group_2_test.py`:
`all_curves`, the union that reaches `CURVES`, does not appear in that
file, so what it drives `n*G == INF` through is the low-cardinality
curves and secp256k1 alone. The comment now names
`curve_group_test.py`'s affine and Jacobian double-and-adds and their
recursive forms, which is what does run over `CURVES`.

No `RELEASE_NOTES.md` bullet: that file says what a caller has to act
on, and comment and docstring prose changes nothing a caller sees.

Gates, run on `044b9c68` in the branch worktree and read by exit code:
`uv run pre-commit run --all-files` 0, `uv run pytest` 0,
`uv run sphinx-build -n -W -b html docs/source <scratch>` 0.

Reviewed at fresh context before opening. The reviewer re-derived the
dropped-`curve_group_2_test.py` claim from the imports of both test
modules rather than from the diff, and filed
[ISS 1767](https://github.com/btclib-org/btclib/issues/1767) for the two
sentences of `tests/curves/curve_test.py` that hold the same species of
count and are outside both issues' scope.

Closes #1657
Closes #1658

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEtm21iP58u32f7MeB7fvZ

## Summary by Sourcery

Enhancements:
- Clarify curve catalogue, data directory, validation, aliasing, backend dispatch, and WIF test prose by naming the standards, files, curves, implementations, and vectors they describe instead of using mutable totals.