### PR TITLE
`ScriptPubKey` takes a network name as the rest of the library does (closes #1662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1238,6 +1238,50 @@ file of the test tree, and no caller acts on it.
   version numbers of SEC 2 itself. A curve added to a shipped json file
   moves none of them.
 
+### `ScriptPubKey` takes a network name as the rest of the library does
+
+- **`ScriptPubKey.__init__` coerces its `network` through
+  `network._normalized_network_name`, and `ScriptPubKey.assert_valid`
+  refuses through `network._validated_network_name`** (closes #1662). A
+  script accepts the spellings issue #216 decided to keep — `" MainNet "`
+  resolves to `mainnet` — where `assert_valid` checked membership of
+  `NETWORKS` itself and refused them. It is the last site of the family
+  #1631 answered in `btclib.hwi` and #1641 in `Fetcher` and `Wallet`:
+  `git grep -n 'not in NETWORKS' -- src` answers `network.py`, the
+  converter, alone.
+- **`ScriptPubKey` is a frozen dataclass**, so `__init__` sets `network`
+  through `object.__setattr__` and `assert_valid` writes nothing at all.
+  That is what splits the pair between them: the refusal is what
+  `check_validity=False` switches off, and the coercion is not a check,
+  so a name settles its spelling whether or not anything validates it —
+  `TxOut.to_dict` reports the field verbatim. Deferring the refusal gets
+  the answer the constructor would have given, which is what
+  `TxOut.assert_valid` asks of the pair.
+- **Refusing in `__init__` and normalizing in `assert_valid` are the two
+  rejected alternatives.** The first takes away what
+  `tests/check_validity_test.py` states — that the flag still switches
+  validation off — and with it the spelling
+  `ScriptPubKey(script, "notanetwork", check_validity=False)` that
+  `tests/tx/tx_out_test.py` and `tests/descriptors/descriptors_test.py`
+  build their deferred refusal from. The second writes a frozen field
+  during a validity check, and not only on the object being validated:
+  `TxOut.__init__` and `sig_hash._assert_valid_prevouts` call
+  `assert_valid()` on a `ScriptPubKey` their caller still holds.
+- **A `network` of a type no conversion accepts is a `BTClibTypeError`**,
+  which is a `TypeError` and not a `ValueError`;
+  [RELEASE_NOTES.md](./RELEASE_NOTES.md) has what a caller catching
+  `BTClibValueError` around a `ScriptPubKey` does about it. An unhashable
+  one was hashed as a dict key by the membership test and left as a
+  builtin `TypeError`, which `btclib.exceptions` does not declare.
+- **`key._normalized` becomes `network._normalized_network_name`**, in
+  the module that states the tolerance rule and beside the
+  `_validated_network_name` that applies it. `key.PubKeyData`,
+  `key.PrvKeyData` and `ScriptPubKey` are the frozen classes that reach
+  for it, and not for one reason: the two in `key.py` compare and hash
+  the field itself, where `ScriptPubKey` compares and hashes the network
+  type, which resolves either spelling — there the coercion settles the
+  field rather than the comparison.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -187,6 +187,22 @@ full year, short month, short day (YYYY-M-D)
   `Uncompressed SEC / compressed BIP32 mismatch` at v2026.9.3 and at
   v2023.7.12, where reading an extended key was `to_pub_key`'s.
 
+- **`btclib.script.ScriptPubKey` refuses a `network` that is not a string
+  with `BTClibTypeError`** (closes #1662). `assert_valid` — which
+  `__init__` runs unless `check_validity=False`, and which `TxOut`,
+  `sig_hash` and the descriptor and wallet lookups run again on a script
+  handed to them — puts the name through
+  `btclib.network._validated_network_name`, which raises
+  `BTClibTypeError`, a `TypeError`, where it raised
+  `BTClibValueError: unknown network: None`.
+
+  Act on it if you catch `BTClibValueError` around building or validating
+  a `ScriptPubKey` to handle a name you have not checked is a `str`:
+  catch `BTClibException`, which is the base of both, or check the type
+  yourself. A `str` no network answers to is still a `BTClibValueError`,
+  and the names accepted are wider than before — `" MainNet "` resolves
+  here as it does everywhere else in the library.
+
 ### Worth knowing, though nothing raises
 
 - **`psbt_signer_contract.optional_protocols` returns `OptionalProtocols`,

--- a/src/btclib/key.py
+++ b/src/btclib/key.py
@@ -64,14 +64,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any
 
 from typing_extensions import override
 
 from btclib.alias import Octets, Point
 from btclib.curves import Curve, bytes_from_prv_key_int, point_from_octets
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.network import network_from_name
+from btclib.network import _normalized_network_name, network_from_name
 from btclib.utils import assert_type, bytes_from_octets, is_integer
 
 __all__ = [
@@ -95,32 +94,6 @@ __all__ = [
 _COMPRESSED_PREFIXES = (0x02, 0x03)
 _UNCOMPRESSED_PREFIX = 0x04
 _HYBRID_PREFIXES = (0x06, 0x07)
-
-
-def _normalized(network: Any) -> Any:
-    """Return a network name in the one spelling two of them share.
-
-    `network_from_name` accepts " MainNet " for "mainnet" -- the
-    tolerance issue #216 decided to keep, and `network`'s
-    `_validated_network_name` is where that rule is stated. Without the
-    same coercion here the two spellings build objects that are not equal
-    and do not hash alike, and the claim above that equality reads the
-    declared fields would be true of the fields and false of the key.
-
-    A normalization and not a check, which is why it refuses nothing:
-    `check_validity=False` means the validity checks do not run, so that
-    a test can build the invalid object it means to exercise, and a
-    coercion that raised would take that away. Whether the name is a
-    network at all -- and whether it is a string -- stays
-    `assert_valid`'s question.
-
-    `sec` is asymmetric here, and only the refusal is inherited:
-    `bytes_from_octets` refuses a wrong type whatever `check_validity`
-    says, and it belongs to `utils` rather than to this module. The
-    coercion beside it is this module's own, and the constructor says
-    what it is for.
-    """
-    return network.strip().lower() if isinstance(network, str) else network
 
 
 @dataclass(frozen=True, init=False)
@@ -151,7 +124,15 @@ class PubKeyData:
         # a merkle root to the x it reads off `sec` before hashing the
         # pair under a tag
         object.__setattr__(self, "sec", bytes_from_octets(sec))
-        object.__setattr__(self, "network", _normalized(network))
+        # the two fields are asymmetric in what they inherit from their
+        # converter: `bytes_from_octets` refuses a wrong type whatever
+        # `check_validity` says, where `_normalized_network_name` refuses
+        # nothing and leaves the refusal to `assert_valid`. Without the
+        # coercion, " MainNet " and "mainnet" build keys that are not
+        # equal and do not hash alike, and the docstring above -- equality
+        # reads the declared fields -- would be true of the fields and
+        # false of the key
+        object.__setattr__(self, "network", _normalized_network_name(network))
 
         if check_validity:
             self.assert_valid()
@@ -194,7 +175,8 @@ class PubKeyData:
         where the curve is asked. That `sec` is bytes at all is not asked
         here, `bytes_from_octets` having refused anything else in the
         constructor whatever `check_validity` said; `network` is asked,
-        `_normalized` being a coercion that refuses nothing.
+        `_normalized_network_name` being a coercion that refuses
+        nothing.
         """
         assert_type(self.network, str, "network")
         # refuses a name no network has, which is what this is called for
@@ -242,7 +224,7 @@ class PrvKeyData:
         check_validity: bool = True,
     ) -> None:
         object.__setattr__(self, "q", q)
-        object.__setattr__(self, "network", _normalized(network))
+        object.__setattr__(self, "network", _normalized_network_name(network))
         object.__setattr__(self, "compressed", compressed)
 
         if check_validity:

--- a/src/btclib/network.py
+++ b/src/btclib/network.py
@@ -555,6 +555,30 @@ def network_type_from_key_value(
     return NETWORKS[networks[0]].network_type if networks else None
 
 
+def _normalized_network_name(network: Any) -> Any:
+    """Return a network name in the one spelling its variants share.
+
+    A normalization and not a check, which is why it refuses nothing and
+    why its parameter is `Any`: a class whose `check_validity=False`
+    means the validity checks do not run still has to build the invalid
+    object a caller means to exercise, and a coercion that raised would
+    take that away. Whether the name is a network at all -- and whether
+    it is a string -- is `_validated_network_name`'s question.
+
+    `_validated_network_name` below applies it between its type check and
+    its membership test, so every name that function returns or refuses has
+    been through here. The frozen classes that keep a `network` field reach
+    for it directly, and it buys each of them something different.
+    `key.PubKeyData` and `key.PrvKeyData` compare and hash the field itself,
+    so two spellings of one network would build objects that are neither
+    equal nor hashed alike. `script.ScriptPubKey` compares and hashes the
+    network *type*, which resolves either spelling on its own; what the
+    coercion settles there is the field read back as it stands, which
+    `tx.TxOut.to_dict` reports verbatim.
+    """
+    return network.strip().lower() if isinstance(network, str) else network
+
+
 def _validated_network_name(network: str) -> str:
     """Return the name of a network, normalized, or refuse it.
 
@@ -564,7 +588,7 @@ def _validated_network_name(network: str) -> str:
     """
     if not isinstance(network, str):
         raise BTClibTypeError(f"not a network name: {network!r}")
-    name = network.strip().lower()
+    name: str = _normalized_network_name(network)
     if name not in NETWORKS:
         err_msg = f"unknown network: '{network}'"
         err_msg += f"; it must be one of {sorted(NETWORKS)}"

--- a/src/btclib/script/script_pub_key.py
+++ b/src/btclib/script/script_pub_key.py
@@ -26,7 +26,11 @@ from btclib.alias import Octets, ScriptList, ScriptType, String, TaprootScriptTr
 from btclib.curves import point_from_octets
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, sha256
-from btclib.network import NETWORKS, network_type_from_network
+from btclib.network import (
+    _normalized_network_name,
+    _validated_network_name,
+    network_type_from_network,
+)
 from btclib.script.script import Script, op_int, serialize
 from btclib.script.taproot import output_pubkey
 from btclib.to_pub_key import Key, pub_keyinfo_from_key
@@ -610,7 +614,16 @@ class ScriptPubKey(Script):
         *,
         check_validity: bool = True,
     ) -> None:
-        object.__setattr__(self, "network", network)
+        # normalized here and refused in assert_valid below, which is the
+        # split `key.PubKeyData` takes for the same field:
+        # `_normalized_network_name` refuses nothing, so
+        # `check_validity=False` still builds the invalid object a caller
+        # means to exercise, and asking `assert_valid()` afterwards gets
+        # the answer the constructor would have given. The coercion is not
+        # deferred with the refusal, because it is not a check: the field
+        # is read as it stands -- `TxOut.to_dict` reports it verbatim --
+        # so its spelling is settled even where no check runs
+        object.__setattr__(self, "network", _normalized_network_name(network))
         # network first, then super(): Script.__init__ calls
         # self.assert_valid(), which dispatches to the override below and
         # so needs the field set. That call is also the whole validation,
@@ -621,10 +634,16 @@ class ScriptPubKey(Script):
 
     @override
     def assert_valid(self) -> None:
-        """Run Script's checks, then refuse a network name not in NETWORKS."""
+        """Run Script's checks, then refuse a name no network answers to."""
         super().assert_valid()
-        if self.network not in NETWORKS:
-            raise BTClibValueError(f"unknown network: {self.network}")
+        # `_validated_network_name` and not a `NETWORKS` membership test:
+        # membership hashes its operand, which leaves a name of an
+        # unhashable type a builtin `TypeError` that `btclib.exceptions`
+        # does not declare, where this raises `BTClibTypeError`. It also
+        # quotes the name it refuses, beside the names there are. Its
+        # return value is not read: `__init__` above applies the same
+        # normalization to the field
+        _validated_network_name(self.network)
 
     @classmethod
     def from_address(cls, addr: String, *, check_validity: bool = True) -> ScriptPubKey:

--- a/tests/descriptors/descriptors_test.py
+++ b/tests/descriptors/descriptors_test.py
@@ -3460,7 +3460,7 @@ def test_an_invalid_output_is_refused_and_not_answered_about() -> None:
     assert descriptor.index_of(descriptor.script_pub_key()) == 0
 
     bad = ScriptPubKey(b"\x51", "notanetwork", check_validity=False)
-    err_msg = "unknown network: notanetwork"
+    err_msg = "unknown network: 'notanetwork'"
     with pytest.raises(BTClibValueError, match=err_msg):
         bad.assert_valid()
     with pytest.raises(BTClibValueError, match=err_msg):

--- a/tests/script/script_pub_key_test.py
+++ b/tests/script/script_pub_key_test.py
@@ -14,7 +14,7 @@ import pytest
 from btclib import b32, b58, var_bytes
 from btclib.alias import ScriptList
 from btclib.curves import bytes_from_point, mult
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160, sha256
 from btclib.script import (
     Script,
@@ -65,10 +65,41 @@ def test_eq() -> None:
     assert script_pub_key != Script(script_pub_key.script)
 
 
-def test_unknown_network() -> None:
-    """Refuse an unknown network name at construction."""
-    with pytest.raises(BTClibValueError, match="unknown network: "):
+def test_a_network_name_is_taken_as_the_rest_of_the_library_takes_one() -> None:
+    """`ScriptPubKey` normalizes the name it is given, and refuses the rest.
+
+    `__init__` coerces through `network._normalized_network_name` and
+    `assert_valid` refuses through `network._validated_network_name`, so
+    the spellings issue #216 decided to keep reach a script, and
+    `ScriptPubKey.network` is the name `network_from_name` answers to.
+    """
+    assert ScriptPubKey(b"", " TestNet4 ").network == "testnet4"
+    with pytest.raises(BTClibValueError, match="unknown network: 'no_network'"):
         ScriptPubKey(b"", "no_network")
+    # a name that is not a string is the type rule, which RELEASE_NOTES.md
+    # tells a caller to act on
+    with pytest.raises(BTClibTypeError, match="not a network name"):
+        ScriptPubKey(b"", [])  # type: ignore[arg-type]
+
+
+def test_the_coercion_runs_where_the_refusal_does_not() -> None:
+    """`check_validity=False` still settles the spelling of the name.
+
+    The two halves are split because they answer to different flags: the
+    refusal is what `check_validity` switches off, and the field is read
+    as it stands -- `TxOut.to_dict` reports it verbatim -- whether or not
+    a check has run. Deferring the refusal gets the answer the
+    constructor would have given, which is what `TxOut.assert_valid` asks
+    of it.
+    """
+    script_pub_key = ScriptPubKey(b"", " TestNet4 ", check_validity=False)
+    assert script_pub_key.network == "testnet4"
+    script_pub_key.assert_valid()
+
+    unchecked = ScriptPubKey(b"", "no_network", check_validity=False)
+    assert unchecked.network == "no_network"
+    with pytest.raises(BTClibValueError, match="unknown network: 'no_network'"):
+        unchecked.assert_valid()
 
 
 def test_nulldata() -> None:
@@ -791,7 +822,7 @@ def test_script_pub_key_construction_parses_nothing() -> None:
         script_module.parse = real_parse
 
     # what is left of the check, and the network half of it
-    with pytest.raises(BTClibValueError, match="unknown network: mainet"):
+    with pytest.raises(BTClibValueError, match="unknown network: 'mainet'"):
         ScriptPubKey(script, "mainet")
 
 

--- a/tests/tx/tx_out_test.py
+++ b/tests/tx/tx_out_test.py
@@ -191,7 +191,7 @@ def test_a_pre_built_script_pub_key_is_validated_as_octets_are() -> None:
     the widths the parse enforces, so the check is unreachable by design.
     """
     bad = ScriptPubKey(b"\x51", "notanetwork", check_validity=False)
-    err_msg = "unknown network: notanetwork"
+    err_msg = "unknown network: 'notanetwork'"
 
     with pytest.raises(BTClibValueError, match=err_msg):
         TxOut(1000, bad)


### PR DESCRIPTION
`ScriptPubKey.__init__` coerces its `network` through
`network._normalized_network_name` and `ScriptPubKey.assert_valid` refuses
through `network._validated_network_name`, which is the split
`key.PubKeyData` and `key.PrvKeyData` already take for the same field.
`assert_valid` checked membership of `NETWORKS` itself, and that cost the
tolerance issue #216 decided to keep, the exception class an unhashable name
raises, and the names quoted beside the one refused. It is the last site of
the family #1631 answered in `btclib.hwi` and #1641 in `Fetcher` and
`Wallet`.

The coercion is in `__init__` and the refusal in `assert_valid` because
`check_validity` switches only one of the two off; the commit message has the
two rejected alternatives and what each takes away.

## What the three review rounds changed, since none of it is in the diff's shape

Round one found the docstring and the `CHANGELOG.md` bullet claiming the
coercion is what keeps two spellings of a network from building
`ScriptPubKey` objects that are unequal and hash apart. That is false for
`ScriptPubKey`, whose `__eq__` and `__hash__` compare
`network_type_from_network(self.network)`, which resolves either spelling on
its own; it is true for `key.PubKeyData` and `key.PrvKeyData`, plain frozen
dataclasses comparing the field itself. Both sentences now separate the two
reasons, and what the coercion buys `ScriptPubKey` is the field read back as
it stands, which `tx.TxOut.to_dict` reports verbatim.

Round two found this entry in `RELEASE_NOTES.md` under *Worth knowing, though
nothing raises* when it says of itself "Act on it if you catch
`BTClibValueError`". It is now under the open release's `Breaking changes`.
The move was checked as a move: the multiset of the file's lines hashes
identically before and after, with a one-word mutation of a line producing a
different hash, since an equality that cannot fail proves nothing.

Round three's finding was non-blocking and was taken anyway, the text being a
docstring, which is read every time somebody opens the function and cannot be
rewritten after a squash. The docstring claimed a name resolved anywhere in
the library passes through the coercion; `bolt11.Bolt11Invoice` resolves one
against a table of its own and imports nothing from `btclib.network`. The
scoping the review proposed was measured and rejected as false in the other
direction — `_validated_network_name` is called directly from `descriptors`,
`fetcher`, `hwi`, `p2p.magic`, `script_pub_key` and `wallet`, not only through
`network_from_name` — so the sentence names the mechanism instead: every name
that function returns or refuses has been through the coercion. A caller added
tomorrow does not falsify it.

Local review at fresh context, same reviewer for all three rounds:
`CLEARED 7609843a`.

Gates on the sha that lands, by exit code: `pre-commit run --all-files` 0
(41 passed, zero failed), `pytest` 0 (32162 passed, 31 skipped, 1 xfailed),
`sphinx-build -n -W` 0. The docs build went to a scratch directory so nothing
untracked could reach `check-sdist`.

Closes #1662

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Align `ScriptPubKey` network handling with the library-wide normalization and validation behavior.

Bug Fixes:
- Make `ScriptPubKey` accept normalized network-name variants consistently with the rest of the library.
- Report invalid non-string networks as `BTClibTypeError` and quote unknown network names in validation errors.

Enhancements:
- Centralize network-name normalization in the network module and reuse it across key and script data classes.
- Preserve deferred validation while normalizing network fields even when `check_validity=False`.

Documentation:
- Document the updated `ScriptPubKey` network handling and the exception change for callers.

Tests:
- Update and expand tests for normalized names, deferred validation, and network type errors.