### PR TITLE
`tests/curves/curve_test.py` names what its counts describe (closes #1767)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1282,6 +1282,17 @@ file of the test tree, and no caller acts on it.
   type, which resolves either spelling — there the coercion settles the
   field rather than the comparison.
 
+### `tests/curves/curve_test.py`'s stated counts go the way `curve.py`'s went
+
+- **`test_catalogued_curves`'s docstring and `test_libsecp256k1_available`'s
+  comment name what they are about in place of a total** (closes #1767):
+  the docstring now names `tests/curves/curve_group_test.py` and what it
+  asserts `n*G == INF` through, and the comment now says the assignment
+  reaches every module that imported the predicate by name rather than a
+  fixed number of them. The comment's own number was already wrong: an
+  `ast` walk over `src/btclib` for modules importing `_libsecp256k1_serves`
+  by name answers more than the stated count.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -296,9 +296,10 @@ def test_catalogued_curves() -> None:
     fails a test rather than nothing at all.
 
     Not the only place either check happens -- test_ec_repr rebuilds each
-    curve from its repr, and test_curve_group and test_curve_group_2
-    assert n*G == INF through ten distinct mult implementations -- but the
-    one that is about them.
+    curve from its repr, and tests/curves/curve_group_test.py asserts n*G
+    == INF for every curve of CURVES through the affine and Jacobian
+    double-and-adds and their recursive forms -- but the one that is
+    about them.
     """
     catalogues = (Brainpool_params2, NIST_params2, SEC2v1_params2, SEC2v2_params2)
     checked = set()
@@ -781,8 +782,8 @@ def test_libsecp256k1_serves() -> None:
 def test_libsecp256k1_available(monkeypatch: pytest.MonkeyPatch) -> None:
     """The switch refuses the pair the predicate otherwise takes."""
     # read on every call and not captured at import, which is the whole
-    # point of it: one assignment reaches the nine modules that imported
-    # the predicate by name
+    # point of it: one assignment reaches every module that imported the
+    # predicate by name
     monkeypatch.setattr(curve, "_libsecp256k1_available", False)
     assert not _libsecp256k1_serves(secp256k1, None)
     assert not _libsecp256k1_serves(secp256k1, sha256)


### PR DESCRIPTION
`tests/curves/curve_test.py` carried two stated counts of the same species
[ISS 1657](https://github.com/btclib-org/btclib/issues/1657) removed from
`src/btclib/curves/curve.py`'s own comments over the same facts, and that
issue's *Done when* scoped it to `curve.py`, so the twins were left behind.

`test_catalogued_curves`'s docstring named "ten distinct mult
implementations"; it now names `tests/curves/curve_group_test.py` and what
it asserts `n*G == INF` through, which is verbatim the sentence `a3c371b8`
landed in `curve.py`. `test_libsecp256k1_available`'s comment named "the nine
modules that imported the predicate by name"; it now says every module that
did.

The second was not merely unwatched but wrong: an `ast` walk over
`src/btclib` for `ImportFrom` of `_libsecp256k1_serves` answers thirteen
modules, with `Curve` at fifteen and a symbol that exists nowhere at zero as
the controls that prove the walk discriminates. So the fix removes the number
rather than correcting it — a corrected count is the same defect one release
later.

The docstring names one test file where the issue's *Done when* named two.
That follows the landed precedent, which dropped `curve_group_2_test.py` for
a stated reason, and the review re-derived it rather than accepting it:
`curve_group_2_test.py` imports `low_card_curves` and `secp256k1` and never
`all_curves` or `CURVES`, so it does not drive `n*G == INF` for every
catalogued curve; `curve_group_test.py` does, through exactly the four loops
the new sentence names.

Local review at fresh context: `CLEARED 1f7a3335`.

Rebased onto `89f3a278` after that clearance. The union driver ate the blank
line before the entry's `###` heading, as it does — `merge-tree` with the
driver disabled exits 1 where the plain form exits 0, and the numstat fell
from eleven added lines to ten. The line is restored, and the file was
verified by reconstruction rather than by reading the diff: the new base's
blob with the branch's own block appended at the end of the open section
matches the rebased file byte for byte, with a one-word mutation of the
heading as the control that makes the match mean something. The rebase moved
only the base — the branch's added and removed lines outside `CHANGELOG.md`
hash identically before and after, on eleven lines that are not empty.

Gates on the sha that lands, by exit code: `pre-commit run --all-files` 0
(41 passed, zero failed), `pytest` 0 (32162 passed, 31 skipped, 1 xfailed),
`sphinx-build -n -W` 0.

Closes #1767

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Update curve test documentation to describe coverage accurately without relying on brittle or incorrect module counts.

Bug Fixes:
- Correct inaccurate test documentation by replacing stale fixed counts with descriptions of the behavior and modules actually covered.

Enhancements:
- Clarify which curve-group tests verify n*G == INF for all catalogued curves and that the libsecp256k1 availability assignment affects every importing module.

Documentation:
- Document the corrected scope of the curve catalog and libsecp256k1 availability tests in the changelog.