### PR TITLE
`REPOSITORY.md` and `scorecard.yml` count an elevation the same way (closes #1762)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,7 +33,7 @@ on:
     # scheduled runs; this covers what push cannot -- a week with none.
     - cron: "4 5 * * 0"
 
-# least privilege for the GITHUB_TOKEN at the workflow level, with one
+# least privilege for the GITHUB_TOKEN at the workflow level, with
 # elevation on the job below: the analysis reads the tree, requests a
 # transparency-log entry for its own result and files that result as
 # code-scanning alerts, and pushes nothing back to the tree.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1293,6 +1293,18 @@ file of the test tree, and no caller acts on it.
   `ast` walk over `src/btclib` for modules importing `_libsecp256k1_serves`
   by name answers more than the stated count.
 
+### `REPOSITORY.md` and `scorecard.yml` count an elevation the same way
+
+- **`REPOSITORY.md`'s *Token permissions* stops calling `release.yml`'s
+  share of the job-level declarations "most" of them** (closes #1762):
+  it is the largest single group, not a majority, and the sentence now
+  says that instead. `scorecard.yml`'s header comment drops the "one" in
+  front of "elevation on the job below", matching `analysis`'s own
+  `permissions:` block, which holds two — `id-token: write` and
+  `security-events: write`, both argued in the comments beside them —
+  and matching `btclib-node`'s `scorecard.yml`, which already reads this
+  way. Neither file's actual permissions change.
+
 ## v2026.9.3
 
 ### Repository

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -522,8 +522,8 @@ asking.
 ## Token permissions
 
 **The default `GITHUB_TOKEN` is read-only repository-wide**, so a job
-needing more must declare it. Most of those declarations are in
-`release.yml`: `contents: write` on `github-release`, `id-token: write` on
+needing more must declare it. The largest group of those declarations is
+in `release.yml`: `contents: write` on `github-release`, `id-token: write` on
 `publish-pypi` and `publish-testpypi`, and `contents: read` with
 `pull-requests: read` on `test` — that last one there because `test`
 calls `test.yml`, and a caller's `permissions:` block replaces the


### PR DESCRIPTION
`851be338` gave `REPOSITORY.md`'s *Token permissions* a vocabulary — an
elevation is one permission raised above the read-only default — and two
sentences elsewhere did not survive it.

`REPOSITORY.md` said "Most of those declarations are in `release.yml`" where
five of twelve is the largest group and not a majority; it now says the
largest group, naming no proportion. `scorecard.yml`'s header said "with one
elevation on the job below" where `analysis` declares `id-token: write` and
`security-events: write`; it now says "with elevation", which is what
`btclib-node`'s copy of the same file already reads.

Neither workflow's actual permissions change. `analysis` needs both of its
writes for the reasons its own comment gives.

The census was parsed rather than grepped, twice and independently — once
before briefing and once in review, with an indentation-aware scan agreeing
on all twelve declarations, including the two that carry a `permissions:`
block and elevate nothing, which is what says the parse read values and not
only keys. `git grep -n "permissions:$" -- .github/workflows/*.yml`, the
command the section itself names, answers 31 hits with 12 indented and 5 in
`release.yml`, so the sentence is re-derivable from what is already written
there.

The `elevation-per-job:` marker inside `analysis`'s own block was checked and
left: it states no count, it argues why `contents` stays at `read`, and
`btclib-node` carries it byte-identically.

One thing the issue says is now stale: its second comment holds that
`btclib-node` reads the other way. That tree landed `27b728e1` on
2026-09-06, which makes it read as this branch does — the branch is right and
the comment was measured before that commit.

Local review at fresh context: `CLEARED cdb1f58b`.

Rebased onto `3b63e4b5` after that clearance. The union driver ate the blank
line before the entry's `###` heading — `merge-tree` with the driver disabled
exits 1 where the plain form exits 0. The line is restored, and the file was
verified by reconstruction rather than by reading the diff: the new base's
blob with the branch's own block appended at the end of the open section
matches byte for byte, with a one-word mutation of the heading as the control.
The rebase moved only the base: the branch's added and removed lines outside
`CHANGELOG.md` hash identically before and after, on six lines that are not
empty.

Gates re-run on the sha that lands, by exit code: `pre-commit run --all-files`
0 (41 passed, zero failed), `pytest` 0 (32162 passed, 31 skipped, 1 xfailed),
`sphinx-build -n -W` 0.

Closes #1762

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Align repository documentation and Scorecard workflow comments with the actual GitHub token permission declarations.

Bug Fixes:
- Correct the documentation and workflow comment so permission elevations are described consistently and accurately.

Enhancements:
- Clarify that `release.yml` contains the largest group of token-permission declarations rather than most of them.
- Align `scorecard.yml` terminology with its two job-level permission elevations without changing workflow permissions.

Documentation:
- Update the token-permission documentation and changelog to reflect the corrected declaration counts and terminology.