### PR TITLE
The `uv_build` floor moves to the boundary it keeps (issue btclib-org/.github#858)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -733,7 +733,7 @@ repos:
     hooks:
       - id: check-sdist
         args: [--inject-junk, --installer=pip]
-        additional_dependencies: ["uv_build>=0.12.9,<0.13"]
+        additional_dependencies: ["uv_build>=0.12.0,<0.13"]
   - repo: https://github.com/regebro/pyroma
     # the newest *stable* tag: 5.1b1 and 5.1b2 sit above it, and
     # `pre-commit autoupdate` offers a prerelease as readily as a release,
@@ -761,4 +761,4 @@ repos:
         # dependencies elsewhere in this file: what this has to match is
         # a range rather than a release, and the isolated build it
         # replaces would have resolved the same range itself
-        additional_dependencies: ["uv_build>=0.12.9,<0.13"]
+        additional_dependencies: ["uv_build>=0.12.0,<0.13"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1305,6 +1305,43 @@ file of the test tree, and no caller acts on it.
   and matching `btclib-node`'s `scorecard.yml`, which already reads this
   way. Neither file's actual permissions change.
 
+### `[build-system] requires`'s `uv_build` floor moves to the boundary
+
+- **The floor is `0.12.0`, the boundary itself, rather than a range
+  under the `uv-pre-commit` rev** (issue btclib-org/.github#858):
+  btclib-org/.github#835 and btclib-org/.github#834 name that
+  alignment, and a sibling's own number, as the organization standard's
+  two rejected alternatives for this floor, so the comment above
+  `requires` drops the reason and gains the measurement recipe the
+  boundary was found by, matching the family's wording rather than
+  inventing a fourth. `[tool.uv] required-version` does not move: it
+  answers a different question, the uv that reads `uv.lock` rather
+  than the backend that builds the archive. This supersedes the entry
+  above for #1743, whose reason for sitting above the boundary is what
+  is removed here.
+- **The `check-sdist` and `pyroma` hook environments move with it**,
+  both to `uv_build>=0.12.0,<0.13`. Each carries a comment saying its
+  specifier is `[build-system]`'s own range and not a number of its
+  own, and #1743's entry above says the two move together; a floor
+  lowered on one side alone leaves both those sentences false. No gate
+  catches it, and `.pre-commit-config.yaml` says why in the lines
+  above `check-sdist`: a `requires` widened past the hook's line leaves
+  that line still satisfying it, so `build --no-isolation` stays green
+  either way.
+- **The comment says why `uv build` cannot run the version sweep that
+  recipe is, and for which direction.** A `requires` asking for a
+  backend older than the one running is where `uv build` falls back to
+  the copy it bundles and only warns, answering for that copy and not
+  for the pin; above the running uv it resolves the pin from the index
+  and answers for it, so the sweep needs the hook call, its versions
+  being the ones below. Both directions were measured on three
+  projects differing only in that key, by the count of uv's own
+  `Selecting: uv-build` lines and again in the archive -- the
+  below-direction sdist carries
+  `pyproject.toml.orig`, which no version its pin admits can write.
+  btclib-org/.github#834 is where the second direction stood recorded
+  as unmeasured.
+
 ## v2026.9.3
 
 ### Repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,21 +4,28 @@
 # language of a MANIFEST.in. The sdist's own pyproject.toml becomes a
 # normalized copy of this file at 0.12.0, with the verbatim source kept
 # beside it as pyproject.toml.orig; below it, pyproject.toml is that
-# verbatim file itself, with no .orig. The floor sits above that boundary
-# and no higher than the rev .pre-commit-config.yaml pins for
-# uv-pre-commit -- a range and not an equality on purpose: pre-commit.ci
-# moves that rev upward on this repository's own weekly schedule with
-# nothing moving this number, so a floor written equal to it stops being
-# equal at the next bump where a floor under it stays right. The upper
-# bound, and the number to lower first if a resolver ever wants this one
-# lower:
+# verbatim file itself, with no .orig. The floor is that boundary,
+# measured by calling the backend's own hook at each version -- uv build
+# being no use for that sweep, whose whole point is the versions below
+# the running uv: asking for a backend older than the one running is the
+# ceiling-below case, where uv build falls back to the copy it bundles
+# and only warns, so it answers for that copy rather than for the pin.
+# Above the running uv it does resolve the pin and answer for it, which
+# is the other half of the same fact and not a way to run the sweep. The
+# version stands on a line of its own so that an unfilled paste of the
+# line below it fails on ${version:?} rather than measuring whatever is
+# installed:
 #
-#     grep -A1 'astral-sh/uv-pre-commit' .pre-commit-config.yaml
+#     version=<the version to measure>
 #
-# The ceiling is the next minor, which is where uv's versioning policy
-# puts a breaking change, this backend releasing with uv and versioned by
-# it
-requires = ["uv_build>=0.12.9,<0.13"]
+#     uv run --no-project --with uv_build=="${version:?}" python -c \
+#       "import uv_build; print(uv_build.build_sdist('<outdir>'))"
+#
+# which answers with nothing below the boundary and with
+# pyproject.toml.orig at it. The ceiling is the next minor, which is
+# where uv's versioning policy puts a breaking change, this backend
+# releasing with uv and versioned by it
+requires = ["uv_build>=0.12.0,<0.13"]
 build-backend = "uv_build"
 
 [project]


### PR DESCRIPTION
One of the four rows of
[ISS 858](https://github.com/btclib-org/.github/issues/858). Section 3
of the organization standard, at `c61cbb3`, now says the `uv_build`
floor **is** the boundary of the property it keeps, and names a floor
above it — aligned with the `uv` the gate pins through `uv-pre-commit`,
or with the sibling the number was copied from — as the rejected
alternative. This tree's floor was `0.12.9` and its comment gave the
first of those two as the reason. The subject cites the issue rather
than closing it: four trees owe it, and it is closed by hand once the
last row lands.

The floor goes to `0.12.0`, the ceiling is unchanged, and
`[tool.uv] required-version` is untouched at `>=0.12.7` — it answers
what uv reads `uv.lock` with, not what the backend builds the archive
with. The `uv-pre-commit` hook rev at `.pre-commit-config.yaml:694` is
still `0.12.9` and is not the floor.

**The comment gains the measurement this tree did not carry**, in the
family's own two-block shape: the version on a line of its own ahead of
`${version:?}`, so an unfilled paste fails rather than measuring
whatever `uv_build` happens to be installed. That shape is section 9's
placeholder rule applied to a command whose flag puts the placeholder
first, and it was a review finding rather than something the branch
arrived at.

**Two `.pre-commit-config.yaml` specifiers move with the floor**, the
`check-sdist` and `pyroma` hook environments, both to
`uv_build>=0.12.0,<0.13`. Each carries a comment saying its specifier
is `[build-system]`'s own range and not a number of its own, and this
tree's earlier `#1743` entry says the two move together — so lowering
one side alone leaves those sentences false. Nothing goes red on it:
the file says so itself, a `requires` widened past a hook's line
leaving that line still satisfying it. The gate confirmed the change is
live rather than cosmetic — `pre-commit` re-initialised the environment
and its log names it `regebro/pyroma:uv_build>=0.12.0,<0.13`, with both
`check sdist` and `Check package with Pyroma` passing on it.

**The comment now says which direction the `uv build` caveat holds
in, and that is a measurement rather than an edit.** A `requires`
asking for a backend older than the one running is where `uv build`
falls back to the copy it bundles and only warns, answering for that
copy and not for the pin. Above the running uv it resolves the pin from
the index and answers for it — which is the half
[ISS 834](https://github.com/btclib-org/.github/issues/834) recorded as
unmeasured, its own session's command having been refused.

Measured three times independently this session on three projects
differing only in that key, under `uv 0.12.7`: by this branch's
reviewer, who found the over-general clause and built the probe; by the
`btclib-node` branch's reviewer, who added the check that does not
depend on a debug line; and by the orchestrator. The discriminator is
the count of uv's own `Selecting: uv-build` lines — 0 below, 1 above, 0
when the range contains the running version. The below-direction half
also shows in the artefact: its sdist carries `pyproject.toml.orig`,
which no version its pin admits can write. The above-direction half has
no such check, every version at or above the boundary writing that
member, so it rests on the resolution line and the absent warning; the
wording claims no more.

The wide reading the family had to correct came from
[ISS 143](https://github.com/btclib-org/.github/issues/143)'s own
sentence, measured with the pin below the running uv.
`bitcoin-core-rpc` already opened with the restriction and is what this
tree's wording follows.

Three review rounds. The first raised the over-general clause, the two
hook specifiers and the missing placeholder guard; the second, on a sha
the orchestrator amended, raised that a changelog bullet described a
revision internal to the branch — nothing on `main` had been narrowed,
`main` carrying no `uv build` account in that comment at all — which in
an append-only file sends a reader looking for a wider version that
never landed.

The `uv_build` floor moves to the boundary it keeps (issue btclib-org/.github#858)

`pyproject.toml`'s `[build-system] requires` floor moves from
`uv_build>=0.12.9` to `uv_build>=0.12.0`, the version at which the
sdist's own `pyproject.toml` becomes a normalized copy of this file
with the verbatim one kept beside it as `pyproject.toml.orig`. The
ceiling is unchanged.

The comment above `requires` drops the reason this tree gave for
sitting above that boundary -- alignment with the rev
`.pre-commit-config.yaml` pins for `uv-pre-commit` -- which
btclib-org/.github's README.md, section 3, now names as one of the
two rejected alternatives for this floor. In its place the comment
gains the measurement recipe that finds the boundary, calling the
backend's own hook at each version, which this tree did not carry
before, in the family's own two-block shape: the version on a line of
its own ahead of `${version:?}`, so an unfilled paste fails rather
than measuring whatever `uv_build` happens to be installed.

That recipe comes with the direction it is needed for. Where a
`requires` asks for a backend older than the one running, `uv build`
falls back to the copy it bundles and only warns, answering for that
copy and not for the pin; above the running uv it resolves the pin
from the index and answers for it. Both were measured on three
projects differing only in that key, by the count of uv's own
`Selecting: uv-build` lines and again in the archive: the
below-direction sdist carries pyproject.toml.orig, which no version
its pin admits can write. btclib-org/.github#834 is where the second
direction stood recorded as unmeasured, its own session's command
having been refused.

The wide reading the family had to correct came from
btclib-org/.github#143's own sentence, which states the fallback for
any `requires` the running version does not satisfy and was measured
with the pin below it. bitcoin-core-rpc's comment already opened with
the restriction and is what this tree's wording follows.

`.pre-commit-config.yaml`'s `check-sdist` and `pyroma` environments
move with the floor, both to `uv_build>=0.12.0,<0.13`. Each carries a
comment saying its specifier is `[build-system]`'s own range rather
than a number of its own, and that file's own prose says no gate
catches them parting: a `requires` widened past a hook's line leaves
that line still satisfying it, so `build --no-isolation` stays green
either way.

`CHANGELOG.md` gets an entry at the end of the open section, citing
this issue and superseding the earlier entry that gave the
`uv-pre-commit` alignment as this floor's reason.

`[tool.uv] required-version` does not move: it answers a different
question, the uv that reads `uv.lock`, not the backend that builds
the archive.

The other trees carrying a `uv_build` floor owe the same change; this
issue is closed by hand once the last of them lands, so the subject
cites it rather than closing it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr


Reviewed locally at fresh context, three rounds with the same reviewer. Round 1 was CHANGES REQUESTED on an over-general `uv build` clause, on the two stale hook specifiers and on a missing placeholder guard; round 2 raised a changelog bullet that described a revision internal to the branch; round 3 is `CLEARED 4392958867e0fd3363e6976ab656153373daeb28`, no findings. Rounds 2 and 3 were edits by the orchestrator, the coder having finished. Gates on that tree. On the cleared sha `43929588`, with exit codes captured: `uv run pre-commit run --all-files` exit 0 (42 hook ids declared, 41 Passed, 1 Skipped, 0 Failed) and `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html` exit 0. On `686e7eeb`, whose tree differs only in three lines of `CHANGELOG.md` prose: `uv sync` exit 0, `uv run ruff check --fix` exit 0, `uv run ruff format` exit 0, `uv run mypy src/btclib tests .github/scripts` exit 0, and `uv run pytest --basetemp=<scratchpad>/pytest-btclib-858-round2` exit 0 with `32162 passed, 31 skipped, 1 xfailed in 28.71s` at 100% coverage. The reviewer was offered the suite on the final sha and declined it with its reasoning, having instead re-derived the changelog immutability property by byte comparison and run `release_notes_test.py`'s three patterns against the file with their own control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Move the uv_build floor and related hook dependencies to the 0.12.0 compatibility boundary, and document the updated rationale.

Enhancements:
- Move the uv_build build-system floor to the 0.12.0 boundary while retaining the existing upper bound and uv required-version.
- Align the pre-commit check-sdist and pyroma environments with the updated uv_build range.
- Document the boundary measurement and uv build resolution behavior in the build-system comment.

Documentation:
- Add changelog coverage for the uv_build floor change and its rationale.