### PR TITLE
`coverage_fail_under` reads the wide selection set section 8 names (issue btclib-org/.github#424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1342,6 +1342,19 @@ file of the test tree, and no caller acts on it.
   btclib-org/.github#834 is where the second direction stood recorded
   as unmeasured.
 
+### `coverage_fail_under` reads the wide selection set section 8 names
+
+- **`--deselect`, `--ignore`, `--ignore-glob` and `--lf` now drop the
+  coverage floor alongside a path, `-k` and `-m`** (issue
+  btclib-org/.github#424): section 8 of the organization standard counts
+  all six as a selection, and this tree's `coverage_fail_under` read only
+  the first three, its own docstring naming the gap and pointing at this
+  issue. The docstring now states the wide set with its reason and
+  carries the narrower reading as the rejected alternative rather than
+  as what the function does, and the pointer paragraph goes with it.
+  `tests/conftest_test.py` gains one case per new flag and passes the
+  four extra arguments through every existing call.
+
 ## v2026.9.3
 
 ### Repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -401,9 +401,11 @@ with the reason on that same line, and a reason too long for the line
 above it as well, the inline half naming the case. `--cov` is in
 pyproject.toml's addopts, so `uv run
 pytest` prints the total and enforces the ratchet on every whole run, on
-the 3.14 the gate is checked on — a run that selects a subset with paths,
-`-k` or `-m` reports without gating, since `fail_under` would otherwise
-fail it on the tree's coverage rather than on its own.
+the 3.14 the gate is checked on — a run that selects a subset reports
+without gating, since `fail_under` would otherwise fail it on the tree's
+coverage rather than on its own. Which flags select is section 8 of the
+organization standard's, and `tests/README.md` is where this tree states
+it.
 See [Tests, code coverage, and profiling](./tests/README.md).
 
 These requirements are easily checked (and partially fixed) with:

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,15 +32,14 @@ have it there: the suite takes the same time either way on the 3.14
 **A run that selects a subset is not gated.** `fail_under` applies to
 every report coverage writes, so `uv run pytest tests/bip32` would fail
 on the tree's coverage rather than on anything about that run. A path
-that leaves part of the suite behind, `-k` or `-m` therefore drops the
-threshold to zero: `coverage_fail_under` in `tests/conftest.py` is where
-that happens, and its docstring is why. The report still prints, which is
-what makes it worth reading while iterating on one module. Ways of
-shortening a run that are not a selection — `--lf`, `--deselect`, an `-x`
-that stops early — keep the full threshold and will report a shortfall
-the tree does not have. Section 8 of the organization standard counts
-the first two of those as selections, which this tree does not yet do;
-btclib-org/.github#424 is that gap.
+that leaves part of the suite behind, `-k`, `-m`, `--deselect`,
+`--ignore`, `--ignore-glob` or `--lf` therefore drops the threshold to
+zero: `coverage_fail_under` in `tests/conftest.py` is where that
+happens, and its docstring is why. The report still prints, which is
+what makes it worth reading while iterating on one module. An `-x` that
+stops early is outside the set: what cuts that run short is a failure
+and not what the invocation asked for. Section 8 of the organization
+standard is what names the set.
 
 `uv run pytest tests` is not a selection either. What decides is whether
 the paths named contain every `testpaths` entry, so the directory that

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,10 @@ def coverage_fail_under(
     file_or_dir: list[str] | None,
     keyword: str,
     markexpr: str,
+    deselect: list[str] | None,
+    ignore: list[str] | None,
+    ignore_glob: list[str] | None,
+    lf: bool,
     testpaths: list[str],
     rootpath: Path,
 ) -> float | None:
@@ -128,27 +132,37 @@ def coverage_fail_under(
     untouched whichever kind of run it is -- the caller naming the
     threshold is the one thing this must not overrule.
 
-    A subset is what pytest was *asked* for: a path that leaves part of
-    the suite behind, `-k` or `-m`. Not every way a run can be short --
-    `--lf`, `--deselect` and an `-x` that stops early are not read -- so
-    those still meet the full threshold and report a shortfall the tree
-    does not have. They are the flags of an iteration whose next run is
-    the whole suite, and reading intent off all of them would make this a
-    second definition of what a real run is.
+    A subset is what pytest was *asked* for, and section 8 of the
+    organization standard is what names the set: a path that leaves part
+    of the suite behind, `-k`, `-m`, `--deselect`, `--ignore`,
+    `--ignore-glob`, or `--lf`. A run that leaves tests out measures the
+    same source with fewer tests, so what its report is short of is the
+    tests it did not run: a shortfall it reports cannot be told apart
+    from one the tree has, and a gate whose red cannot be read is what
+    teaches whoever runs it to reach for `--no-cov`.
 
-    Section 8 of the organization standard has since taken the other
-    side -- it counts `--deselect`, `--ignore`, `--ignore-glob` and
-    `--lf` as selections too, and records the paragraph above as the
-    reading it rejects. This tree agreeing with the wider set is
-    btclib-org/.github#424, and is not what the containment rule here
-    was about.
+    The narrower reading -- paths, `-k` and `-m` alone -- is rejected: it
+    holds the rest to be the flags of an iteration whose next run is the
+    whole suite, and reading intent off all of them to make this
+    function a second definition of what a real run is. What the wider
+    set costs is the occasion where such a run would have cleared 100
+    anyway -- a `--lf` that finds nothing to rerun and so is the whole
+    suite, a `--deselect` of one arm of a parametrization the others
+    cover -- and the next bare run measures the tree again. An early
+    `-x` is outside the set either way: what cuts that run short is a
+    failure and not what the invocation asked for.
+
+    `lf` arrives as a plain `bool` rather than read off `config.option`
+    here, because `-p no:cacheprovider` leaves the attribute unregistered
+    rather than false, and a run that cannot pass the flag has not passed
+    it -- the caller is where that distinction is made.
 
     Which paths leave nothing behind is `asks_for_everything` above, and
     it is the reason `testpaths` and the rootdir are arguments here.
     """
     if asked is not None:
         return asked
-    if keyword or markexpr:
+    if keyword or markexpr or deselect or ignore or ignore_glob or lf:
         return 0
     if not asks_for_everything(file_or_dir, testpaths, rootpath):
         return 0
@@ -172,6 +186,10 @@ def pytest_configure(config: pytest.Config) -> None:
         config.option.file_or_dir,
         config.option.keyword,
         config.option.markexpr,
+        config.option.deselect,
+        config.option.ignore,
+        config.option.ignore_glob,
+        getattr(config.option, "lf", False),
         config.getini("testpaths"),
         config.rootpath,
     )

--- a/tests/conftest_test.py
+++ b/tests/conftest_test.py
@@ -32,6 +32,10 @@ _ROOT = Path(__file__).parents[1]
 # `testpaths`, and reading the real one would make them a test of the
 # configuration as well
 _TESTPATHS = ["tests"]
+# `deselect, ignore, ignore_glob, lf`, all unset: spliced into a call that
+# is testing something else, so the four further triggers stay off
+# without restating "None, None, None, False" at every one of them
+_NO_FURTHER_SELECTION = (None, None, None, False)
 
 
 @pytest.fixture(autouse=True)
@@ -128,8 +132,18 @@ def test_a_whole_run_is_gated_at_what_pyproject_configured() -> None:
     worth pinning: pyproject.toml is where 100 is decided, and a copy of
     it in this file would be a second place to change it.
     """
-    assert coverage_fail_under(None, 100.0, [], "", "", _TESTPATHS, _ROOT) == 100.0
-    assert coverage_fail_under(None, 42.0, [], "", "", _TESTPATHS, _ROOT) == 42.0
+    assert (
+        coverage_fail_under(
+            None, 100.0, [], "", "", *_NO_FURTHER_SELECTION, _TESTPATHS, _ROOT
+        )
+        == 100.0
+    )
+    assert (
+        coverage_fail_under(
+            None, 42.0, [], "", "", *_NO_FURTHER_SELECTION, _TESTPATHS, _ROOT
+        )
+        == 42.0
+    )
 
 
 @pytest.mark.parametrize(
@@ -165,7 +179,9 @@ def test_a_path_that_collects_the_suite_is_a_whole_run(
     rootdir for them to mean the suite.
     """
     monkeypatch.chdir(_ROOT)
-    gate = coverage_fail_under(None, 100.0, file_or_dir, "", "", _TESTPATHS, _ROOT)
+    gate = coverage_fail_under(
+        None, 100.0, file_or_dir, "", "", *_NO_FURTHER_SELECTION, _TESTPATHS, _ROOT
+    )
     assert gate == 100.0
 
 
@@ -195,7 +211,55 @@ def test_a_selected_subset_is_gated_at_nothing(
     """
     monkeypatch.chdir(_ROOT)
     gate = coverage_fail_under(
-        None, 100.0, file_or_dir, keyword, markexpr, _TESTPATHS, _ROOT
+        None,
+        100.0,
+        file_or_dir,
+        keyword,
+        markexpr,
+        *_NO_FURTHER_SELECTION,
+        _TESTPATHS,
+        _ROOT,
+    )
+    assert gate == 0
+
+
+@pytest.mark.parametrize(
+    "deselect, ignore, ignore_glob, lf",
+    [
+        (["tests/bip32/bip32_test.py::test_one"], None, None, False),
+        (None, ["tests/bip32"], None, False),
+        (None, None, ["tests/**/*_test.py"], False),
+        (None, None, None, True),
+    ],
+    ids=["--deselect", "--ignore", "--ignore-glob", "--lf"],
+)
+def test_a_further_selection_is_gated_at_nothing(
+    deselect: list[str] | None,
+    ignore: list[str] | None,
+    ignore_glob: list[str] | None,
+    lf: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Section 8's four further triggers drop the threshold too.
+
+    The path still collects the whole suite and neither `-k` nor `-m` is
+    set, so each case here isolates the one flag it names -- the same
+    property `test_a_selected_subset_is_gated_at_nothing` checks for a
+    path, `-k` and `-m`.
+    """
+    monkeypatch.chdir(_ROOT)
+    gate = coverage_fail_under(
+        None,
+        100.0,
+        ["tests"],
+        "",
+        "",
+        deselect,
+        ignore,
+        ignore_glob,
+        lf,
+        _TESTPATHS,
+        _ROOT,
     )
     assert gate == 0
 
@@ -208,7 +272,10 @@ def test_without_testpaths_a_named_path_is_a_subset() -> None:
     answer the opposite -- every run a whole one, and the floor never
     relaxed for the one-file run it exists for.
     """
-    assert coverage_fail_under(None, 100.0, ["tests"], "", "", [], _ROOT) == 0
+    gate = coverage_fail_under(
+        None, 100.0, ["tests"], "", "", *_NO_FURTHER_SELECTION, [], _ROOT
+    )
+    assert gate == 0
 
 
 def test_cov_is_not_the_last_token_of_addopts() -> None:
@@ -243,8 +310,23 @@ def test_cov_is_not_the_last_token_of_addopts() -> None:
 def test_an_explicit_threshold_survives_either_kind_of_run() -> None:
     """`--cov-fail-under` is the caller's, and outranks both branches."""
     subset = ["tests/bip32"]
-    assert coverage_fail_under(90.0, 100.0, subset, "", "", _TESTPATHS, _ROOT) == 90.0
-    assert coverage_fail_under(90.0, 100.0, [], "", "", _TESTPATHS, _ROOT) == 90.0
+    assert (
+        coverage_fail_under(
+            90.0, 100.0, subset, "", "", *_NO_FURTHER_SELECTION, _TESTPATHS, _ROOT
+        )
+        == 90.0
+    )
+    assert (
+        coverage_fail_under(
+            90.0, 100.0, [], "", "", *_NO_FURTHER_SELECTION, _TESTPATHS, _ROOT
+        )
+        == 90.0
+    )
     # zero is a threshold somebody asked for, not a missing answer: it
     # has to survive the `is not None` test rather than be falsy
-    assert coverage_fail_under(0, 100.0, [], "", "", _TESTPATHS, _ROOT) == 0
+    assert (
+        coverage_fail_under(
+            0, 100.0, [], "", "", *_NO_FURTHER_SELECTION, _TESTPATHS, _ROOT
+        )
+        == 0
+    )


### PR DESCRIPTION
Third and last row of [ISS 424](https://github.com/btclib-org/.github/issues/424).
`bitcoin-core-rpc` landed at `b647723` and `btclib-node` at `7c68b4da`; this is
`btclib`'s.

The citation is `(issue btclib-org/.github#424)` and not a closing keyword: the
issue's ruling comment says it is closed by hand once every row is in, which is
what follows this landing.


`coverage_fail_under` reads the wide selection set section 8 names (issue btclib-org/.github#424)

Section 8 of the organization standard names six triggers that drop the
coverage floor for a selective run; this tree's `coverage_fail_under`
read three of them (a path, `-k`, `-m`) and its own docstring already
named the gap, pointing at this issue.

- `tests/conftest.py`: `coverage_fail_under` gains `deselect`, `ignore`,
  `ignore_glob` and `lf` parameters and reads them alongside the three
  it already had; `pytest_configure` passes them from `config.option`,
  `lf` through `getattr` because `-p no:cacheprovider` leaves it
  unregistered rather than false. `asks_for_everything` is untouched.
- The docstring states the wide set with its reason, names section 8 as
  where the set comes from, and keeps the narrower reading as the
  rejected alternative; the paragraph pointing at this issue is removed.
  The citation is not decoration: what replaces that paragraph is
  section 8's own wording, and a tree that transcribes the standard and
  drops the pointer is how two files come to disagree with nothing
  comparing them. Of the four sibling trees that carry the wide set,
  the three whose function is called `coverage_fail_under` all cite it
  at this same site; `btclib-node`, which spells the hook differently,
  cites it nowhere, and that is a defect of that tree rather than a
  precedent.
- `tests/README.md`: the same correction, in the document section 7
  makes this tree's answer for its test conventions. It said `--lf` and
  `--deselect` keep the full threshold and that the tree did not yet
  count them, and carried the twin of the `conftest.py` pointer at this
  issue. All three were true when written and are what this commit
  falsifies, so they are in this diff rather than filed.
- `CONTRIBUTING.md`: the gates section stated the narrow set as the
  definition. It now says a selective run reports without gating, and
  names section 8 as where the list of selecting flags comes from and
  `tests/README.md` as where this tree states it -- one fact in one
  place, and no third copy of the list to keep true. The edit is below
  `## This repository in particular`, so section 14 compares none of it
  and no `EXPECTED_DRIFT` entry is owed.
- `tests/conftest_test.py`: every existing call to `coverage_fail_under`
  passes the four new arguments unset, and a new parametrized test adds
  one case per new flag.
- `CHANGELOG.md` gains one entry in the open section.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr


Local review: CLEARED dd478a1, which is this head — cleared twice, at `ed760caa` for the change and again after a message-only amend whose tree sha is identical, so no gate was re-run and none was owed. Gates on that tree, all exit 0: `uv sync`; `uv run ruff check --fix`; `uv run ruff format`; `uv run mypy src/btclib tests .github/scripts`; `uv run pytest`; `uv run pre-commit run --all-files`; `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Align coverage gating with the organization standard by treating all section 8 selection flags as non-gated test runs.

New Features:
- Extend coverage threshold relaxation to all selection triggers defined by section 8: `--deselect`, `--ignore`, `--ignore-glob`, and `--lf`, in addition to paths, `-k`, and `-m`.

Bug Fixes:
- Prevent selectively run tests using the newly recognized flags from being incorrectly held to the full coverage threshold.

Enhancements:
- Align coverage behavior and contributor-facing guidance with the organization-wide definition of a selective test run.
- Document the expanded selection rules and update coverage tests to validate each additional trigger.

Documentation:
- Update the testing and contribution documentation to describe the complete selection flag set and its coverage-gating behavior.

Tests:
- Add parametrized coverage tests for `--deselect`, `--ignore`, `--ignore-glob`, and `--lf`, while updating existing calls for the expanded function interface.

Chores:
- Add a changelog entry for the expanded coverage selection handling.