### PR TITLE
`Bolt11Invoice.__init__` coerces its network name (closes #1671)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1355,6 +1355,23 @@ file of the test tree, and no caller acts on it.
   `tests/conftest_test.py` gains one case per new flag and passes the
   four extra arguments through every existing call.
 
+### `Bolt11Invoice` takes a network name as the rest of the library does
+
+- **`Bolt11Invoice.__init__` coerces `network` through
+  `network._normalized_network_name`, and `assert_valid` keeps refusing
+  by membership in `_CURRENCY_FROM_NETWORK`, now against the normalized
+  name** (closes #1671). `" MainNet "` resolves to `mainnet`, where the
+  field kept it exactly as given and the refusal read `not a lightning
+  network: MAINNET` for that spelling; two spellings of one network now
+  build invoices that compare equal and hash alike, the dataclass
+  comparing `network` as a plain field. `_validated_network_name` is not
+  the substitution #1662 took for `ScriptPubKey`: `_CURRENCY_FROM_NETWORK`
+  is a strict subset of `NETWORKS`, with no code for `testnet4`, so it
+  would accept a name this class must still refuse.
+- **The refusal now quotes the name it rejects**, `not a lightning
+  network: 'MAINNET'`, matching `_parse_hrp`'s own `!r` for a rejected
+  string elsewhere in this module.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -203,6 +203,18 @@ full year, short month, short day (YYYY-M-D)
   and the names accepted are wider than before — `" MainNet "` resolves
   here as it does everywhere else in the library.
 
+- **`btclib.bolt11.Bolt11Invoice` accepts the network-name spellings the
+  rest of the library does** (closes #1671). `" MainNet "` and
+  `"MAINNET"` now resolve to `"mainnet"` in the `network` field, where
+  the default `check_validity=True` refused them outright; built with
+  `check_validity=False`, two spellings of one network now compare equal
+  and hash alike, where they used to compare unequal and hash apart.
+
+  Act on it if you relied on `Bolt11Invoice(" MainNet ", ...)` raising,
+  or on two differently-spelled invoices built with
+  `check_validity=False` being distinct in a set or as dict keys: they
+  now collapse to one.
+
 ### Worth knowing, though nothing raises
 
 - **`psbt_signer_contract.optional_protocols` returns `OptionalProtocols`,

--- a/src/btclib/bolt11.py
+++ b/src/btclib/bolt11.py
@@ -92,6 +92,7 @@ from btclib.curves import bytes_from_point, secp256k1
 from btclib.ecc.dsa import Sig, gen_keys, recover_pub_key_, sign_recoverable_, verify_
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import sha256
+from btclib.network import _normalized_network_name
 from btclib.utils import assert_type, bytes_from_octets, int_from_integer, is_integer
 
 __all__ = [
@@ -384,7 +385,14 @@ class Bolt11Invoice:
         check_validity: bool = True,
     ) -> None:
         assert_type(network, str, "network")
-        object.__setattr__(self, "network", network)
+        # normalized here and refused in assert_valid below, the split
+        # `ScriptPubKey.__init__` takes for the same field: the set this
+        # class accepts is `_CURRENCY_FROM_NETWORK`, a strict subset of
+        # `network.NETWORKS`, so `_validated_network_name` is not the
+        # substitution -- it would let "testnet4" through. Without the
+        # coercion, " MainNet " and "mainnet" build invoices that are
+        # neither equal nor hashed alike
+        object.__setattr__(self, "network", _normalized_network_name(network))
         object.__setattr__(self, "timestamp", int_from_integer(timestamp))
         object.__setattr__(
             self,
@@ -416,7 +424,7 @@ class Bolt11Invoice:
         that answers it.
         """
         if self.network not in _CURRENCY_FROM_NETWORK:
-            raise BTClibValueError(f"not a lightning network: {self.network}")
+            raise BTClibValueError(f"not a lightning network: {self.network!r}")
         if not 0 <= self.timestamp < (1 << 35):
             raise BTClibValueError(f"timestamp does not fit 35 bits: {self.timestamp}")
         if self.amount_msat is not None and (

--- a/src/btclib/network.py
+++ b/src/btclib/network.py
@@ -574,7 +574,13 @@ def _normalized_network_name(network: Any) -> Any:
     equal nor hashed alike. `script.ScriptPubKey` compares and hashes the
     network *type*, which resolves either spelling on its own; what the
     coercion settles there is the field read back as it stands, which
-    `tx.TxOut.to_dict` reports verbatim.
+    `tx.TxOut.to_dict` reports verbatim. `bolt11.Bolt11Invoice` shares the
+    equality-and-hash reason with the two key classes, and has one of its
+    own besides: `_hrp` reads the field through a raw
+    `_CURRENCY_FROM_NETWORK[network]` lookup, so with
+    `check_validity=False` -- where nothing refuses an unnormalized name --
+    an uncoerced field left `to_invoice` a bare `KeyError` rather than an
+    encoded string.
     """
     return network.strip().lower() if isinstance(network, str) else network
 

--- a/tests/bolt11_test.py
+++ b/tests/bolt11_test.py
@@ -251,8 +251,8 @@ def test_from_invoice_takes_text_not_octets() -> None:
 
 
 def test_assert_valid_refuses_an_unknown_network() -> None:
-    """A network `bech32` never issues a prefix for is refused."""
-    with pytest.raises(BTClibValueError, match="not a lightning network"):
+    """A network `bech32` never issues a prefix for is refused, name quoted."""
+    with pytest.raises(BTClibValueError, match="not a lightning network: 'testnet4'"):
         Bolt11Invoice(
             "testnet4",
             0,
@@ -261,6 +261,70 @@ def test_assert_valid_refuses_an_unknown_network() -> None:
             0,
             check_validity=False,
         ).assert_valid()
+
+
+def test_bolt11_coerces_the_network_name() -> None:
+    """A network name in another spelling builds where it used to be refused."""
+    signed = Bolt11Invoice.sign(
+        _PRV_KEY,
+        "mainnet",
+        1700000000,
+        payment_hash=bytes(range(32)),
+        payment_secret=b"\x11" * 32,
+        description="coercion",
+    )
+    invoice = Bolt11Invoice(
+        " MainNet ",
+        signed.timestamp,
+        signed.tagged_fields,
+        signed.signature,
+        signed.recovery_id,
+        signed.amount_msat,
+    )
+    assert invoice.network == "mainnet"
+
+
+def test_bolt11_coerces_the_network_name_regardless_of_check_validity() -> None:
+    """The coercion runs where the refusal does not: that is why it is here."""
+    invoice = Bolt11Invoice(
+        " MainNet ",
+        0,
+        [(1, (0,) * 52), (16, (0,) * 52), (13, _pow_2_words(b"d"))],
+        Sig(1, 1, check_validity=False),
+        0,
+        check_validity=False,
+    )
+    assert invoice.network == "mainnet"
+
+
+def test_bolt11_two_spellings_of_one_network_are_equal_and_hash_alike() -> None:
+    """Two spellings of one network build equal, equally-hashed invoices."""
+    signed = Bolt11Invoice.sign(
+        _PRV_KEY,
+        "mainnet",
+        1700000000,
+        payment_hash=bytes(range(32)),
+        payment_secret=b"\x11" * 32,
+        description="coercion",
+    )
+    lower = Bolt11Invoice(
+        "mainnet",
+        signed.timestamp,
+        signed.tagged_fields,
+        signed.signature,
+        signed.recovery_id,
+        signed.amount_msat,
+    )
+    upper = Bolt11Invoice(
+        "MAINNET",
+        signed.timestamp,
+        signed.tagged_fields,
+        signed.signature,
+        signed.recovery_id,
+        signed.amount_msat,
+    )
+    assert lower == upper
+    assert hash(lower) == hash(upper)
 
 
 def test_assert_valid_refuses_an_out_of_range_timestamp() -> None:


### PR DESCRIPTION
`Bolt11Invoice.__init__` did not coerce the network name it was given, so
`" MainNet "` and `"MAINNET"` were kept exactly as passed and then refused
by `assert_valid` — the one site the hand-written
`object.__setattr__(self, "network", ...)` family did not reach after
[ISS 1662](https://github.com/btclib-org/btclib/issues/1662) landed the
same split for `ScriptPubKey`.

`_validated_network_name` is not the substitution here: it accepts
`testnet4`, for which `_CURRENCY_FROM_NETWORK` has no currency code. The
class keeps its own membership test and its refusal now quotes the name
it rejects, matching the module's own `!r` convention — and the sibling
test pins that quoting rather than leaving it free to revert silently,
`pytest.raises(match=...)` being `re.search`.

Under `check_validity=False` the difference was observable rather than
merely cosmetic: on the base, `to_invoice()` raised a bare
`KeyError: ' MainNet '` out of `_hrp`'s raw lookup where it now encodes.
That is the half `RELEASE_NOTES.md` names as the thing to act on.

Reviewed locally at fresh context over two rounds. The second round
verified the rebase independently of the coder's own evidence — blob
identity across the two bases, the patch-of-patches against round one,
and an MD022-shaped seam check on both `merge=union` files whose control
was run against the still-reachable glued tree from round one, where it
fires.

Closes #1671

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Normalize Bolt11 invoice network names and clarify validation errors while retaining strict support for recognized Lightning networks.

Bug Fixes:
- Normalize Bolt11 invoice network names so accepted spellings such as whitespace-padded or uppercase mainnet are handled consistently and can be encoded even when validity checks are disabled.

Enhancements:
- Quote rejected network names in Bolt11 validation errors and preserve strict rejection of unsupported networks such as testnet4.

Documentation:
- Document the network-name normalization behavior and its impact on invoice equality, hashing, and invalid-input handling.

Tests:
- Add coverage for normalized network names, behavior with validity checks disabled, equality and hashing across spellings, and quoted validation errors.