### PR TITLE
tests/_data/README.md's entries, its Summary and its gate agree on what is transcribed (closes #1636, closes #1669)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1372,6 +1372,31 @@ file of the test tree, and no caller acts on it.
   network: 'MAINNET'`, matching `_parse_hrp`'s own `!r` for a rejected
   string elsewhere in this module.
 
+### `tests/_data/README.md` agrees with itself about what is transcribed
+
+- **`tests/_data/README.md`'s *Reading an entry* no longer claims every entry
+  gives a blob, or ties a blob's presence to a single upstream file to hash**
+  (closes #1636): a `blob` line, where an entry carries one, names the git blob
+  SHA-1 of what that entry pins, and the entry itself says what that is and
+  whether it was compared byte for byte; `transcribed` over a source file's own
+  test cases is checked the way the entry itself states, since that differs
+  from matching values against pinned prose. Most entries close on a verdict,
+  and one with nothing upstream to compare against says so in prose instead.
+  The *What is not pinned, and why* bullet on the transcribed files made the
+  same prose-only claim and is corrected the same way, and the Summary's
+  heading above the transcribed bullet now says what is actually absent there:
+  a byte comparison, not a blob.
+- **The Summary's transcribed bullet names every vendored file whose own
+  entry carries that verdict, and drops one that does not carry it**
+  (closes #1669): some transcribed vendored files were missing from the
+  bullet, and `descriptor_checksums.json`, whose own verdict is composed
+  locally, was named there by mistake; it moves to the Summary's
+  not-vendored bullet, beside the other file composed rather than
+  recorded. `tests/vendored_data_test.py` gains a
+  check comparing the two lists by reading the file's own `###`
+  sections, with a synthetic pair proving the comparison can actually
+  disagree with itself.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -94,15 +94,19 @@ outstanding half of this convention rather than an exception to it.
 
 ## Reading an entry
 
-Each entry gives the upstream repository, the path in it, the commit the
-citation is pinned to, the git blob SHA-1 that was compared, and a
-verdict. The verdicts used:
+Where an entry pins to a commit, it gives the upstream repository, the
+path in it, and the commit. A `blob` line, where the entry carries one,
+gives the git blob SHA-1 of what that entry pins; what it pins, and
+whether it was compared byte for byte, is the entry's own to say. Most
+entries close on a verdict; one with nothing upstream to compare
+against says so in prose instead. The verdicts used:
 
 - **identical** — our file and the upstream blob are the same bytes.
 - **reformatted** — same parsed JSON value, different whitespace.
-- **transcribed** — the upstream is prose (a BIP, an RFC), so there is no
-  file to compare; the check is that every value in our copy appears
-  verbatim in the pinned text.
+- **transcribed** — there is no file compared byte for byte. Over prose
+  (a BIP, an RFC, a BOLT) the check is that every value in our copy
+  appears verbatim in the pinned text; over a source file the check is
+  the entry's own to state.
 - **composed locally**, **recorded** — there is nothing upstream to
   compare, so the entry says what stands in for one. *composed locally*
   is a case this tree wrote, naming the third implementation that
@@ -2461,10 +2465,11 @@ rather than a refreshed one.
 - **`tests/script/_data/script_assets_test.json`** has a commit, but
   in a repository that rewrites its history. The blob SHA-1 is the pin
   that will still resolve next year.
-- **The transcribed files** are pinned to a prose revision, not to a
-  blob, so "identical" is not a claim that can be made about them. What
-  was checked instead is stated in each entry: every value present,
-  verbatim, in the pinned text.
+- **The transcribed files** are pinned to a prose revision, or, where the
+  upstream is a source file rather than a document, to that file's blob;
+  neither makes "identical" a claim that can be made about them. What was
+  checked is stated in each entry: matching every value verbatim against
+  the pinned text, or a check the entry states on its own.
 - **`tests/psbt/_data/btclib_test_vectors.json`** pins the prose revision
   its raw material came from, which is not the same as having an
   upstream: the cases are btclib's, so the pin says where the psbts were
@@ -2516,14 +2521,16 @@ Against a pinned upstream blob:
   `ecdsa_custom_nonce_sig.json`, `signmessage.json`,
   `test_JP_BIP39.json`.
 
-No upstream blob exists for the rest:
+Not checked byte for byte against one:
 
-- transcribed from a pinned prose revision, every value matched:
+- transcribed, every value matched either in the pinned text or, for a
+  source file, by the check the entry itself states:
   `bip32_test_vectors.json`, `bip32_invalid_keys.json`,
   `bip174_test_vectors.json`, `bip370_test_vectors.json`,
   `bip371_test_vectors.json`, `bip373_test_vectors.json`,
   `bip67_test_vectors.json`, `bip85_test_vectors.json`,
-  `descriptor_checksums.json`.
+  `chacha20_vectors.json`, `muhash_vectors.json`,
+  `miniscript_fixed_tests.json`, `bolt11_test_vectors.json`.
 - chain data, identified by block hash or txid: the blocks and
   transactions under `tests/block/_data/` and `tests/tx/_data/`, and
   `unspendable_script_pub_keys.json`, which is scripts rather than whole
@@ -2534,10 +2541,12 @@ No upstream blob exists for the rest:
   chain data two of the entries above already hold.
 - not vendored: `rfc6979.json` (an RFC), `electrum_test_vectors.json`,
   `electrum_language_vectors.json`, `fakeenglish.txt`,
-  `gettxoutsetinfo_regtest.json` and `btclib_test_vectors.json`
-  (btclib's own). The last is the only one composed rather than
-  recorded: its cases were built here, out of psbts BIP174 prints as
-  prose.
+  `gettxoutsetinfo_regtest.json`, `descriptor_checksums.json` and
+  `btclib_test_vectors.json` (btclib's own). `descriptor_checksums.json`
+  and `btclib_test_vectors.json` are composed rather than recorded:
+  the former's checksums come from a third implementation run over
+  Core's own descriptors, and the latter's cases were built here, out of
+  psbts BIP174 prints as prose.
 
 ### Left for a maintainer to decide
 

--- a/tests/vendored_data_test.py
+++ b/tests/vendored_data_test.py
@@ -81,6 +81,8 @@ in any `needs` list.
 import re
 from pathlib import Path
 
+import pytest
+
 _README = Path(__file__).parents[1] / "tests" / "_data" / "README.md"
 
 # a digit run, or a spelled-out cardinal as a whole word ("one" and "zero"
@@ -134,7 +136,7 @@ _EXEMPT: dict[str, str] = {
     "citation is pinned to a commit and the two blobs are compared.": _UPSTREAM_FACT,
     "The two halves are kept in agreement in one direction only: a test module": _UPSTREAM_FACT,
     "one of the five that *is* a copy, upstream publishing a file of that very": _UPSTREAM_FACT,
-    "citation is pinned to, the git blob SHA-1 that was compared, and a": _UPSTREAM_FACT,
+    "gives the git blob SHA-1 of what that entry pins; what it pins, and": _UPSTREAM_FACT,
     "whatever had drifted was refreshed, so `behind` is 0 wherever a refresh": _UPSTREAM_FACT,
     "The comparison is on git blob SHA-1, not sha256: it is what a tree entry": _UPSTREAM_FACT,
     "alternative and caps out — `script_assets_test.json` is 9 MB.": _UPSTREAM_FACT,
@@ -520,3 +522,139 @@ def test_a_numeral_that_names_something_is_subtracted_and_a_count_is_not() -> No
         "`.github/workflows/integration-hwi.yml` installs release 3.2.0, so two",
     ):
         assert _NUMERAL.search(_countable(counted)), counted
+
+
+# a "## " or "### " heading, matched to split the README into sections without
+# a sliding window: a window over-counts a "### " heading's own verdict past
+# the next entry, which is what first over-counted here (issue #1669)
+_SECTION_HEADING = re.compile(r"^#{2,3} .+$", re.MULTILINE)
+
+# a "### " heading that is nothing but one file path in backticks -- a "Not
+# vendored as a file: ..." heading has prose of its own and never matches,
+# which is the point: such an entry has no name to compare the Summary
+# against. The same shape also excludes a heading with trailing prose after
+# the path -- "### `tests/tx/_data/*.bin` — segwit transactions" and "###
+# `tests/fetch/_data/*` — response bodies" among them -- and neither is
+# transcribed today, so nothing is missed; a transcribed entry written with a
+# trailing dash would drop out of both sets with nothing red to say so
+_VENDORED_FILE_HEADING = re.compile(r"^### `([^`]+)`$")
+
+_TRANSCRIBED_VERDICT = "Verdict: **transcribed**"
+
+_SUMMARY_FILENAME = re.compile(r"`([\w.-]+\.\w+)`")
+
+
+def _sections(text: str) -> list[tuple[str, str]]:
+    """Every heading of `text`, paired with the section text that follows it."""
+    heads = [(m.start(), m.group(0)) for m in _SECTION_HEADING.finditer(text)]
+    return [
+        (
+            heading,
+            text[pos : heads[i + 1][0] if i + 1 < len(heads) else len(text)],
+        )
+        for i, (pos, heading) in enumerate(heads)
+    ]
+
+
+def _transcribed_vendored_files(text: str) -> set[str]:
+    """Basenames of the vendored files whose own entry is transcribed."""
+    return {
+        match.group(1).rsplit("/", 1)[-1]
+        for heading, body in _sections(text)
+        if (match := _VENDORED_FILE_HEADING.match(heading))
+        and _TRANSCRIBED_VERDICT in body
+    }
+
+
+def _summary_transcribed_files(text: str) -> set[str]:
+    """Basenames the Summary lists in its transcribed bullet."""
+    for heading, body in _sections(text):
+        if heading.strip() != "## Summary":
+            continue
+        lines = body.split("\n")
+        start = next(
+            (i for i, line in enumerate(lines) if line.startswith("- transcribed")),
+            None,
+        )
+        if start is None:
+            raise AssertionError(
+                'tests/_data/README.md\'s Summary has no "- transcribed" bullet'
+            )
+        end = start + 1
+        while end < len(lines) and not lines[end].startswith("- "):
+            end += 1
+        return set(_SUMMARY_FILENAME.findall("\n".join(lines[start:end])))
+    raise AssertionError("tests/_data/README.md has no ## Summary section")
+
+
+def test_summary_names_every_transcribed_vendored_file() -> None:
+    """The Summary names exactly the vendored files whose entry is transcribed.
+
+    [ISS 1669](https://github.com/btclib-org/btclib/issues/1669) found
+    the bullet naming fewer files than the entries carry, and naming one,
+    `descriptor_checksums.json`, whose own verdict is **composed
+    locally**, not transcribed. Reading the file by its own `###`
+    sections is what finds either kind of drift; a sliding window over a
+    fixed span of text is not, since it can run past the next entry's own
+    verdict and count it as the current one's.
+    """
+    text = _README.read_text(encoding="utf-8")
+    entries = _transcribed_vendored_files(text)
+    summary = _summary_transcribed_files(text)
+    assert entries == summary, (
+        f"in the entries but not the Summary: {sorted(entries - summary)!r}; "
+        f"in the Summary but not transcribed in the entries: "
+        f"{sorted(summary - entries)!r}"
+    )
+
+
+def test_the_transcribed_comparison_can_actually_fail() -> None:
+    """The check above passes for free if it can never disagree with itself.
+
+    Mirrors `test_the_pattern_still_matches`'s idiom: a synthetic pair,
+    identical but for one file name, proves the comparison distinguishes
+    a matching Summary from a mismatched one rather than only ever
+    confirming the real file, which cannot itself demonstrate that.
+    """
+    heading_and_verdict = (
+        "### `tests/_data/kept.json`\n\n"
+        "Verdict: **transcribed**, for the purpose of this test.\n\n"
+    )
+    matching = heading_and_verdict + (
+        "## Summary\n\n- transcribed, matched:\n  `kept.json`.\n"
+    )
+    mismatched = heading_and_verdict + (
+        "## Summary\n\n- transcribed, matched:\n  `other.json`.\n"
+    )
+
+    assert _transcribed_vendored_files(matching) == _summary_transcribed_files(matching)
+    assert _transcribed_vendored_files(mismatched) != _summary_transcribed_files(
+        mismatched
+    )
+
+
+def test_a_summary_transcribed_read_needs_a_summary_section() -> None:
+    """`_summary_transcribed_files` raises rather than answering an empty set.
+
+    The real README always has a `## Summary`, so nothing in the check
+    above trips this path; a text with none is what does, and is what
+    keeps a rewrite that drops the heading loud instead of silently
+    reading as "the Summary names nothing transcribed".
+    """
+    with pytest.raises(AssertionError, match="no ## Summary section"):
+        _summary_transcribed_files("### `tests/_data/kept.json`\n\nno Summary here.\n")
+
+
+def test_a_summary_transcribed_read_needs_a_transcribed_bullet() -> None:
+    """`_summary_transcribed_files` raises with a message, not `StopIteration`.
+
+    A `## Summary` with no bullet starting "- transcribed" is what trips
+    this: the generator `next()` reads has nothing to give it, and the
+    message is what keeps such a rewrite loud instead of surfacing as an
+    unrelated `RuntimeError` with no README path in it -- the same
+    failure class the sibling test above guards, on the other bullet.
+    """
+    with pytest.raises(AssertionError, match='no "- transcribed" bullet'):
+        _summary_transcribed_files(
+            "### `tests/_data/kept.json`\n\n## Summary\n\n- identical: `kept.json`.\n"
+        )


### PR DESCRIPTION
`tests/_data/README.md`'s *Reading an entry* described a shape most of its
entries no longer have, and its Summary's transcribed list disagreed with
the entries themselves. The front matter now describes the file instead of
legislating for it, and a test holds the two in agreement.

**The front matter.** The old sentence said a blob SHA-1 follows "where a
single upstream file exists to hash", which was false in both directions:
five entries pin a commit whose path is a single upstream file and give no
blob, and three carry a blob where, by the same paragraph's own definition
of *transcribed*, nothing was compared. It now says what the field means
when it appears and leaves what it pins to the entry:

> A `blob` line, where the entry carries one, gives the git blob SHA-1 of
> what that entry pins; what it pins, and whether it was compared byte for
> byte, is the entry's own to say.

Measured over every pin block in the file: 74 carry a commit and all 74
also carry repo and path; 56 carry a blob and all 56 sit in a block that
pins a repo, a path and a commit. No counterexample to either claim.

"Every entry closes on a verdict" was likewise false for eight per-file
entries, and is now "Most entries close on a verdict; one with nothing
upstream to compare against says so in prose instead" — which the eight
satisfy, each stating in its own words that there is nothing upstream.
Softening rather than labelling those eight was deliberate: a wrong
verdict is worse than none. Whether four of them could carry the file's
existing `recorded` verdict is
[ISS 1780](https://github.com/btclib-org/btclib/issues/1780), filed in
review rather than argued here.

**The Summary.** "No upstream blob exists for the rest" headed a bullet
naming three entries that do pin one; it is now "Not checked byte for byte
against one", which holds for all twelve and no longer contradicts the
`What is not pinned, and why` bullet a few lines above.

**The gate.** `tests/vendored_data_test.py` compares the transcribed
entries against the Summary's list and fails when they diverge. Against
this branch the two sets are equal at twelve; run against the previous
`main`'s README it goes red with exactly the defect
[ISS 1669](https://github.com/btclib-org/btclib/issues/1669) describes —
four names in the entries and not the Summary, and
`descriptor_checksums.json` in the Summary while its own entry reads
`composed locally, not vendored`.

Reviewed locally at fresh context over three rounds. The first found four
false claims in the branch's own new prose; the second re-measured every
correction; the third verified the rebase moved only the base, by blob
identity on the two non-CHANGELOG files and by `git range-diff`, whose
only reported difference across the two ranges is the context above the
CHANGELOG hunk.

Closes #1636
Closes #1669

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Align the vendored-data documentation with its entries and enforce agreement between entry verdicts and the Summary.

Bug Fixes:
- Correct the data README so its entry guidance and Summary accurately describe transcribed, vendored, and locally composed files.
- Prevent drift between the Summary’s transcribed-file list and the verdicts in individual entries.

Enhancements:
- Clarify the meaning of optional blob pins and the range of checks represented by a transcribed verdict.
- Strengthen README consistency checks with section-aware parsing and focused failure-case coverage.

Documentation:
- Update the data README’s entry conventions and Summary classifications to match the files’ actual provenance and verification status.

Tests:
- Add a gate that compares transcribed vendored entries with the Summary list and tests both mismatches and malformed Summary sections.