### PR TITLE
Drop stated counts from prose over the curve catalogue and the word-lists (closes #1668, closes #1670)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1397,6 +1397,36 @@ file of the test tree, and no caller acts on it.
   sections, with a synthetic pair proving the comparison can actually
   disagree with itself.
 
+### Prose outside `curve.py` stops counting the catalogued curves
+
+- **`src/btclib/ecc/ellswift.py`, `tests/ecc/ellswift_test.py`,
+  `tests/curves/curve_test.py` and `tests/ecc/dsa_test.py` no longer
+  state how many catalogued curves hold a property** (closes #1668):
+  each such count was a fact about the shipped json data rather than
+  about the module stating it, and nothing re-derived any of it, so a
+  curve added to or removed from the catalogue would leave it false
+  with nothing red. `src/btclib/curves/__init__.py`'s form, naming its
+  catalogues beside the count, is the one case this does not touch.
+
+### `alias.py` and the mnemonic package stop counting their word-lists
+
+- **`src/btclib/alias.py`, every module of `src/btclib/mnemonic/` and
+  every test file of `tests/mnemonic/` that stated one no longer state
+  how many word-lists btclib ships, how many of electrum's it holds, or
+  how many `lang: str` parameters the package has** (closes #1670):
+  `alias.py`'s stated count of `lang: str` parameters had already gone
+  stale without any test failing, which is what a stated count nothing
+  checks does. Where the count named no members, it is gone; where
+  removing it would have left a bare total with nothing to attach it
+  to, the sentence names the members instead of counting them, as
+  `electrum.py`'s "the four 2048-word lists" becoming "the 2048-word
+  lists" does. `alias.py`'s `MnemonicLang` `Literal` and `electrum.py`'s
+  "Electrum reads five word-lists -- en, es, ja, pt, zh --", both
+  already naming every member beside the count, are untouched.
+- **`tests/mnemonic/electrum_test.py` states what `ELECTRUM_WORDLISTS`
+  holds now rather than what btclib used to ship**, dropping the two
+  counts the sentence carried along with the past tense.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/alias.py
+++ b/src/btclib/alias.py
@@ -238,18 +238,17 @@ NetworkField = Literal[
 # keeps this list equal to the data
 NetworkName = Literal["mainnet", "testnet", "regtest", "signet", "testnet4"]
 
-# The word-lists btclib ships: BIP39's twelve languages, and SLIP-0039's
-# single list under a key that is a scheme and not a language code -- the
-# SLIP defines no localization, so "slip39" is the whole of it. Every key
-# of the WORDLISTS registry is named here, which is what keeps this list
-# equal to the data; that the thirteen are not interchangeable is the
-# schemes' business, and bip39 enforces its own half by refusing any list
-# that is not 2048 words long.
+# The word-lists btclib ships: BIP39's languages, and SLIP-0039's own list
+# under a key that is a scheme and not a language code -- the SLIP defines no
+# localization, so "slip39" is the whole of it. Every key of the WORDLISTS
+# registry is named here, which is what keeps this list equal to the data;
+# that they are not interchangeable is the schemes' business, and bip39
+# enforces its own half by refusing any list that is not 2048 words long.
 #
 # Open, as NetworkName is, and more plainly so:
 # WordLists.load_lang(lang, filename) adds a language, which is how a
 # word-list btclib does not ship is read -- electrum's 1626-word
-# Portuguese is one, on a registry of its own -- so the ten `lang: str`
+# Portuguese is one, on a registry of its own -- so the `lang: str`
 # parameters of mnemonic, bip39 and electrum stay str: a Literal there
 # would type check the library's own languages and reject the file a
 # caller has just loaded

--- a/src/btclib/ecc/ellswift.py
+++ b/src/btclib/ecc/ellswift.py
@@ -45,7 +45,7 @@ btclib would be a promise the specification does not make.
 
 **The map wants a curve with a == 0**, y^2 = x^3 + b, and every function
 here refuses one with a != 0. secp256k1 is such a curve and so are the
-other three Koblitz curves of the catalogue, which is why these take an
+other Koblitz curves of the catalogue, which is why these take an
 `ec` at all: the Python arithmetic below is what serves them, where
 secp256k1 is handed to the libsecp256k1 bindings.
 """

--- a/src/btclib/mnemonic/bip39.py
+++ b/src/btclib/mnemonic/bip39.py
@@ -27,8 +27,8 @@ Checksummed entropy (**ENT+CS**) is converted from/to mnemonic.
 | 256 |  8 |    264 | 24 |
 +-----+----+--------+----+
 
-Every word-list of the reference implementation is here, twelve of them,
-and three things follow from a mnemonic being more than English.
+Every word-list of the reference implementation is here, and three
+things follow from a mnemonic being more than English.
 
 - the sentence is NFKD-normalized before it is looked up, hashed or
   stretched, and so is the passphrase. That is what BIP39 asks for and

--- a/src/btclib/mnemonic/electrum.py
+++ b/src/btclib/mnemonic/electrum.py
@@ -21,13 +21,13 @@ BIP39's behaviour, so none of them can be guessed from `bip39.py`:
   or accented sentence is read, not rejected
 
 Electrum reads five word-lists -- en, es, ja, pt, zh -- and its own
-registry here holds all twelve of BIP39's beside them, so a language
+registry here holds all of BIP39's beside them, so a language
 Electrum does not read is still a language this module writes: an
 "electrum" mnemonic in Italian is btclib's extension, and Electrum
 cannot read it.
 
-Four of the five are BIP39's file after NFKD normalization, byte for
-byte, so nothing above depends on which of the two schemes loaded them.
+Most are BIP39's file after NFKD normalization, byte for byte, so
+nothing above depends on which of the two schemes loaded them.
 Portuguese is the exception and the reason this module has a registry of
 its own rather than sharing WORDLISTS: Electrum's Portuguese is Monero's
 word-list, 1626 words rather than 2048, and "pt" therefore names one
@@ -291,7 +291,7 @@ def _is_bip39_mnemonic(mnemonic: Mnemonic, lang: str) -> bool:
     towards generating what electrum generates.
 
     Electrum's bip39_is_checksum_valid, arithmetic included, rather than a
-    call into bip39.py -- which is the same answer for the four 2048-word
+    call into bip39.py -- which is the same answer for the 2048-word
     lists, and a test pins that, but not for Portuguese. Electrum hands
     that function its own word-list whatever the language, so for
     Portuguese it is 1626 words being read with eleven bits per word:

--- a/src/btclib/mnemonic/mnemonic.py
+++ b/src/btclib/mnemonic/mnemonic.py
@@ -34,8 +34,8 @@ def data_file(filename: str) -> str:
     return str(Path(__file__).parent / "_data" / filename)
 
 
-# The twelve word-lists of BIP39's reference implementation, keyed by
-# ISO 639-1 code. Ten are bip-0039/'s own; russian and turkish are in
+# The word-lists of BIP39's reference implementation, keyed by ISO
+# 639-1 code. Most are bip-0039/'s own; russian and turkish are in
 # trezor/python-mnemonic and on no page of the BIP, which is what makes
 # them a way to read what that implementation writes rather than a
 # language to reach for when generating -- and BIP39 itself says
@@ -60,7 +60,7 @@ BIP39_LANGUAGE_FILES = {
     "zh_tw": data_file("chinese_traditional.txt"),
 }
 
-# every word-list btclib ships: BIP39's twelve and slip39's, which is a
+# every word-list btclib ships: BIP39's and slip39's, which is a
 # scheme and not a language code, as its key says. SLIP-0039 supports no
 # localization at all, so there is no "en" of it to collide with BIP39's
 # -- which is a different list of a different length, 1024 words of ten
@@ -80,13 +80,13 @@ class WordLists:
     """Class for word-lists to be used in entropy/mnemonic conversions.
 
     The word-lists loaded by default are DEFAULT_LANGUAGE_FILES: the
-    twelve of BIP39's reference implementation, plus slip39's. More can
+    languages of BIP39's reference implementation, plus slip39's. More can
     be added, or an existing language pointed at another file, with the
     load_lang method; a caller wanting an altogether different set -- as
     electrum.py does, electrum's Portuguese not being BIP39's -- passes
     language_files to the constructor.
 
-    The thirteen keys above are what alias.MnemonicLang names, and
+    The keys above are what alias.MnemonicLang names, and
     load_lang is why no lang parameter here or in bip39 and electrum is
     typed with it: the set is open, so a Literal would reject the
     language a caller has just loaded (issue #216).
@@ -177,10 +177,10 @@ class WordLists:
 
     def _read_wordlist(self, filename: str) -> list[str]:
         """Return the words of a word-list file, NFKD and comments dropped."""
-        # utf-8 and not ascii: nine of the twelve word-lists are not
-        # ascii, japanese and korean not even close, and the BIP
-        # publishes them NFKD-encoded. A '#' starts a comment, which is
-        # what carries the licence header of electrum's Portuguese list
+        # utf-8 and not ascii: most word-lists are not ascii, japanese and
+        # korean not even close, and the BIP publishes them NFKD-encoded.
+        # A '#' starts a comment, which is what carries the licence
+        # header of electrum's Portuguese list
         with Path(filename).open(encoding="utf-8") as file_:
             lines = file_.readlines()
         stripped = (line.split("#")[0].strip() for line in lines)

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -208,7 +208,7 @@ def test_anomalous_curve(p: Integer) -> None:
 
 
 def test_curves_with_n_above_p() -> None:
-    """Hasse admits n > p, and six catalogued curves take it up (issue 183).
+    """Hasse admits n > p, and catalogued curves take it up (issue 183).
 
     The neighbour of the n == p check that issue #166 found never fired: p
     and n are within 2*sqrt(p) of each other, so which is the larger is a
@@ -730,7 +730,7 @@ def test_curve_equality() -> None:
 
 def test_sec2_catalogues_share_one_curve() -> None:
     """Verify SEC 2 v.2 holds the very objects of v.1, secp256k1 too."""
-    # the eight curves of SEC 2 v.2 are in v.1 too; guards against them
+    # the curves of SEC 2 v.2 are in v.1 too; guards against them
     # being built twice, where only one of the two objects is the
     # secp256k1 the dispatch compares against and SEC2v2 holds the other
     for ec_name, ec in SEC2v2.items():
@@ -743,7 +743,7 @@ def test_each_catalogue_holds_what_it_is_named_after() -> None:
 
     "CURVES = SEC2v1" would bind the same dict, so CURVES.update(NIST) and
     CURVES.update(Brainpool) would pour those catalogues into the SEC 2 v.1
-    one: SEC2v1 with 27 entries instead of its own 15, and
+    one, holding every catalogued curve instead of its own, and
     SEC2v1["nistp256"] answering a curve that is not in SEC 2 v.1 at all.
     The union operator builds a new dict, which is what keeps them apart.
     """

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -386,16 +386,15 @@ def test_key_id_is_j_above_the_parity_bit() -> None:
 def test_key_id_is_the_j_zero_pair_when_n_is_above_p() -> None:
     """The mirror of the case above, and issue 183's n > p box.
 
-    `r = x_K % ec.n` can only reduce while n < p, so on a curve whose order
-    is above the field prime -- four of the eight low-cardinality curves,
-    and six of the 27 catalogued ones, `secp224k1` among them -- r *is* x_K
-    and the signer is always named by the j = 0 pair, key_id 0 or 1. Which
-    makes the j >= 1 candidates spurious rather than merely unlikely: they
-    are the `(r + j*ec.n) % ec.p` wrap, and every one of them either misses
-    the curve or fails to verify. Over the 5832 signatures ec13_19 admits,
-    every one of them: 18 private keys, 18 nonces and 18 challenges, no r
-    of them zero -- which is itself the n > p property, x_K never reaching
-    a multiple of the order.
+    `r = x_K % ec.n` can only reduce while n < p, so on a curve whose order is
+    above the field prime -- a low-cardinality curve or a catalogued one,
+    `secp224k1` among them -- r *is* x_K and the signer is always named by the
+    j = 0 pair, key_id 0 or 1. Which makes the j >= 1 candidates spurious
+    rather than merely unlikely: they are the `(r + j*ec.n) % ec.p` wrap, and
+    every one of them either misses the curve or fails to verify. Over the 5832
+    signatures ec13_19 admits, every one of them: 18 private keys, 18 nonces
+    and 18 challenges, no r of them zero -- which is itself the n > p property,
+    x_K never reaching a multiple of the order.
     """
     ec = low_card_curves["ec13_19"]
     assert ec.n > ec.p

--- a/tests/ecc/ellswift_test.py
+++ b/tests/ecc/ellswift_test.py
@@ -26,7 +26,7 @@ from btclib.ecc.ellswift import _xswiftec_inv_var, _xswiftec_var
 from btclib.exceptions import BTClibValueError
 from tests import load_csv, needs_bindings, vector_id
 
-# the other three Koblitz curves of the catalogue: a == 0 and a square
+# the other Koblitz curves of the catalogue: a == 0 and a square
 # -3, which is all the map wants, so the Python path serves them and this
 # is what says so. secp224k1 is the one with p % 4 == 1, i.e. the one
 # whose square roots go through Tonelli-Shanks rather than a single pow

--- a/tests/mnemonic/bip39_test.py
+++ b/tests/mnemonic/bip39_test.py
@@ -106,7 +106,7 @@ BIP39_VECTORS.append(
 
 @pytest.mark.parametrize("lang, entr, mnemonic, seed, xprv", BIP39_VECTORS)
 def test_vectors(lang: str, entr: str, mnemonic: str, seed: str, xprv: str) -> None:
-    """BIP39 test vectors, all twelve languages of them.
+    """BIP39 test vectors, every language of them.
 
     https://github.com/trezor/python-mnemonic/blob/master/vectors.json
 

--- a/tests/mnemonic/electrum_test.py
+++ b/tests/mnemonic/electrum_test.py
@@ -193,8 +193,8 @@ SEED_VECTORS = [
 ]
 
 # the entropy field of those same SEED_TEST_CASES, i.e. what electrum's
-# mnemonic_decode answers. Only now testable: decoding takes the
-# word-list of the language, and btclib shipped two of electrum's five
+# mnemonic_decode answers. Decoding takes the word-list of the language, and
+# btclib holds every language electrum's own scheme needs.
 DECODE_VECTORS = [
     pytest.param(
         JAPANESE, "ja", 1938439226660562861250521787963972783469, id="japanese"
@@ -220,11 +220,12 @@ DECODE_VECTORS = [
 # kind for any language, so these are btclib's in the sense
 # electrum_test_vectors.json is: cross-checked against the application.
 #
-# Not the full five-by-four matrix. The version is what the four columns
-# vary and it is a hash of the sentence, language and all, so one
-# language shows it; Portuguese has all four because it is the one
-# word-list that is not 2048 words -- thirteen words to the sentence,
-# which is what makes "2fa" impossible there and nowhere else.
+# Not the full language-by-version matrix. The version is what the
+# columns vary and it is a hash of the sentence, language and all, so
+# one language shows it for most versions; Portuguese needs every
+# version because it is the one word-list that is not 2048 words --
+# thirteen words to the sentence, which is what makes "2fa" impossible
+# there and nowhere else.
 #
 # In a file and not inline, unlike every other vector here, and for a
 # reason the values cannot defend themselves against: the two spell
@@ -853,7 +854,7 @@ def test_generated_vectors(
 
 def test_electrum_wordlists() -> None:
     """Electrum's word-lists are BIP39's, but for Portuguese."""
-    # the shipped twelve, and not WORDLISTS.languages: that one is a
+    # BIP39_LANGUAGE_FILES, and not WORDLISTS.languages: that one is a
     # singleton another test adds a language to
     assert ELECTRUM_WORDLISTS.languages == list(BIP39_LANGUAGE_FILES)
     for lang in BIP39_LANGUAGE_FILES:

--- a/tests/mnemonic/mnemonic_test.py
+++ b/tests/mnemonic/mnemonic_test.py
@@ -210,13 +210,13 @@ def test_wordlist_2() -> None:
 
 
 def test_every_wordlist() -> None:
-    """Twelve BIP39 languages, and 2048 unique NFKD words in each.
+    """Every BIP39 language, and 2048 unique NFKD words in each.
 
     A private WordLists rather than the singleton: test_wordlist_2 adds
     two languages to that one, so a count taken from it would depend on
     which test ran first.
 
-    Thirteen entries and twelve languages, because the registry holds
+    One entry more than the BIP39 languages, because the registry holds
     every word-list btclib ships: "slip39" is a scheme keyed beside them,
     1024 words rather than 2048, and it is what bip39._base refuses.
     """


### PR DESCRIPTION
Prose in two packages stated how many things the data holds, and nothing
re-derived any of it: how many catalogued curves hold a property, and how
many word-lists btclib ships, how many of electrum's it holds, how many
`lang: str` parameters the mnemonic package has.

One of them was **already false**. `src/btclib/alias.py` said "the ten
`lang: str` parameters of mnemonic, bip39 and electrum stay str"; an AST
walk over the three modules counts fifteen. The paragraph stayed
grammatical, nothing turned red, and the mechanism that same paragraph
advertises — the `MnemonicLang` `Literal` keeping the list equal to the
data — does not reach the count beside it.

Each site drops the count rather than correcting it, a truer number being
just as unchecked. The exception is a sentence naming every member **in
the same clause as the number**: `src/btclib/curves/__init__.py`'s four
catalogues, `alias.py`'s `MnemonicLang` `Literal`, and `electrum.py`'s own
"Electrum reads five word-lists -- en, es, ja, pt, zh --" all do, and are
untouched. A count whose members are named only in a separate code object
below it, or only partly named nearby, does not meet that bar — which is
the distinction the review settled, after a first round that had read
adjacency to an enumeration as sufficient.

`tests/mnemonic/electrum_test.py` also loses a past-tense claim about what
btclib used to ship: `ELECTRUM_WORDLISTS` now holds every one of electrum's
languages, which the prose states as a present fact instead of narrating
the tree's history.

Reviewed locally at fresh context over two rounds plus a rebase check. The
first round found the branch had met [ISS 1668](https://github.com/btclib-org/btclib/issues/1668)
and not [ISS 1670](https://github.com/btclib-org/btclib/issues/1670), whose
*Done when* names `src/btclib/mnemonic/` and `tests/mnemonic/` whole; seven
sites were still standing, and the branch's own sweep had missed them
because both issues' `git grep` patterns match only the phrasings their
author had already spotted. The second round rebuilt the sweep with a
positive control that correctly classifies the compliant sites, and the
reviewer re-derived it independently — a broader pattern set, 195 lines,
every one read — finding no survivor exempted for a wrong reason.

Two further defects were found and filed rather than folded in:
[ISS 1779](https://github.com/btclib-org/btclib/issues/1779) and
[ISS 1782](https://github.com/btclib-org/btclib/issues/1782), the latter a
docstring describing which object a test mutates that has been wrong since
the commit that introduced it.

Closes #1668
Closes #1670

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Remove stale, unverifiable counts from curve and mnemonic documentation while preserving counts whose members are explicitly named.

Enhancements:
- Remove unchecked numeric claims from curve catalogue and mnemonic word-list prose, replacing them with data-independent descriptions or explicitly named members.
- Update Electrum mnemonic test documentation to describe the currently supported word-lists rather than historical contents.

Documentation:
- Clarify documentation and comments throughout curve, mnemonic, and Electrum modules and tests so descriptions remain accurate as catalogues and word-lists change.