### PR TITLE
The mutation profile headers stop deferring what a session already found (closes #1745, closes #1752)

### DIFF
--- a/.github/mutation/curve_group.toml
+++ b/.github/mutation/curve_group.toml
@@ -1,10 +1,10 @@
 # The pure-Python point arithmetic, mutated: `curve_group.py`'s generic
 # window/ladder/NAF methods and `curve_group_2.py`'s secp256k1-only GLV
-# endomorphism and interleaved wNAF beside them. Issue #822 is why the
-# scope exists at all: `signatures.toml`'s own header names this pair as
-# invisible to it, because `curve.py`'s dispatch sends a default-curve
-# call to the libsecp256k1 bindings before either module's code ever
-# runs, and no profile other than this one names them.
+# endomorphism and interleaved wNAF beside them. `signatures.toml`'s own
+# header names this pair as invisible to it, because `curve.py`'s
+# dispatch sends a default-curve call to the libsecp256k1 bindings before
+# either module's code ever runs, and no profile other than this one
+# names them.
 #
 # Neither module goes through that dispatch here. Both test files below
 # import and call the underscore-prefixed algorithm functions directly
@@ -21,13 +21,46 @@ module-path = [
     "src/btclib/curves/curve_group_2.py",
 ]
 
-# each file's own dedicated test, and only those: curve_test.py's own
-# subject is curve.py's dispatch, already exercised by a profile of its
-# own question (mutation coverage of the dispatch itself is issue #822's
-# follow-up, not this file's); curve_group_f_test.py's subject is
-# curve_group_f.py, a third, separate module this scope does not name
+# curve_group_test.py and curve_group_2_test.py are each file's own
+# dedicated test. curve_test.py joins them for a different reason than
+# either: `CurveGroup.__init__`'s own parameter checks, `_is_prime`,
+# `p_is_3_mod_4`, and the y-symmetry and coordinate-extraction methods
+# (`y_even_var`, `y_low_var`, `y_quadratic_residue_var`,
+# `x_aff_from_jac_var`, `y_aff_from_jac_var`) are defined in
+# curve_group.py and mutated here. Three of those eight names are
+# already reached by the pair: both files import `btclib.curves`, whose
+# module-level `Curve(...)` calls run the constructor checks and
+# `_is_prime` at import time, `curve_group_test.py` constructs further
+# `Curve`s of its own, and `curve_group_test.py`'s own
+# `second_generator(ec)` calls `y_even_var` -- but nothing in the pair
+# asserts which root `y_even_var` returns or that an invalid parameter
+# is refused, so a mutant that changes only the root `y_even_var`
+# returns, or only which parameters the checks refuse, survives here
+# regardless. A mutant of `_is_prime` or of the constructor checks that
+# instead makes a catalogued curve's own `p` or `n` fail to build is
+# killed at that same import, before either test file collects --
+# checked rather than assumed: `pow(2, x - 1, x)` weakened to
+# `pow(2, x + 1, x)` raises `BTClibValueError("p is not prime")` while
+# `btclib.curves` is being imported, Fermat answering 4 and not 1 for
+# every prime `p` above 4. The other five -- `p_is_3_mod_4`'s own read,
+# `y_low_var`, `y_quadratic_residue_var`, `x_aff_from_jac_var`,
+# `y_aff_from_jac_var` -- the pair never reaches at all. curve_test.py
+# is what exercises all eight for correctness (`test_exceptions`,
+# `test_symmetry`, `test_aff_jac_conversions`), for curve.py's own
+# dispatch and not for this scope. Leaving it out means every mutant of
+# those five survives regardless of correctness, which is most of
+# what the header below reads back. curve.py's dispatch itself stays a
+# different profile's question, mutation coverage of it not being this
+# file's -- adding curve_test.py judges more of *this* module-path's
+# mutants, not more of curve.py's. curve_group_f_test.py is left out
+# still: its subject is curve_group_f.py, a third, separate module this
+# scope does not name.
+# The addition measured 2 s of overhead locally (`pytest -q -n0
+# -p no:randomly`, the pair alone against the three together) against
+# the 90-minute session budget below
 test-command = """python -m pytest -x -q -n0 -p no:randomly \
-  tests/curves/curve_group_test.py tests/curves/curve_group_2_test.py"""
+  tests/curves/curve_group_test.py tests/curves/curve_group_2_test.py \
+  tests/curves/curve_test.py"""
 
 timeout = 300
 
@@ -39,9 +72,91 @@ excluded-modules = []
 # issue #987, which is what wires this profile into a job at last),
 # nearly double signatures.toml's dsa.py/ssa.py pair at 2980, and the
 # weekly job cuts the session at the budget mutation.yml's matrix gives
-# it. What it judged is in the run's own artifact; reading the survivors
-# back into a header here, the way signatures.toml's header reports its
-# own session, is issue #1745
+# it. What it judged is in the run's own artifact:
+#
+#   gh run list --repo btclib-org/btclib --workflow mutation.yml \
+#     --json databaseId,createdAt,event,conclusion \
+#     --jq '.[] | select(.event == "schedule")'
+#   gh api repos/btclib-org/btclib/actions/runs/<id>/artifacts \
+#     --jq '.artifacts[] | select(.name | test("curves"))'
+#   gh api repos/btclib-org/btclib/actions/artifacts/<artifact-id>/zip \
+#     > run.zip
+#
+# unzips to `curve_group-survivors.txt`, one `cr-report
+# --surviving-only --show-diff` entry per surviving mutant. Several
+# recurring families, each checked against the source rather than
+# assumed, account for much of what both of the last two sessions found:
+#
+# - modular-reduction elision: `X = ... % p` weakened to `... + p` or
+#   `... - p` inside `add_jac`, `add_jac_aff` and `_double_jac_helper`.
+#   `p` is congruent to zero mod itself, so `x + p` and `x - p` are
+#   congruent to `x` mod p for every integer x, and `MV2`, `V2`, `V3`
+#   and `X` each feed only a further expression closed by its own
+#   `% p` -- `X = (W * W - V3 - 2 * MV2) % p` reduces to the same value
+#   whichever representative `MV2` carried. `V` and `W` are not of this
+#   kind in `add_jac` and `add_jac_aff`: their own `if V == 0 and Q[2]
+#   and R[2]:` branch (`R[1]` in the affine one) reads the reduced value
+#   directly, so a representative shifted by `p` can flip which branch
+#   runs and not just an intermediate value -- the low-cardinality
+#   curves take that branch constantly, which is what kills those
+#   mutants rather than this argument. Checked rather than assumed:
+#   applying `MV2 = M * V2 - p` by hand and running the test-command
+#   above, widened, still passes in full.
+# - the family the widened test-command above exists for: `Curve`
+#   inherits `p_is_3_mod_4`, `y_even_var`, `y_low_var`,
+#   `y_quadratic_residue_var`, `x_aff_from_jac_var` and
+#   `y_aff_from_jac_var` from `CurveGroup`. curve_test.py's own fixtures
+#   assert on every one of the six; the pair reaches `y_even_var` too,
+#   through `second_generator` in curve_group_test.py, but asserts
+#   nothing about which root it returns -- the other five the pair
+#   never reaches at all. Checked rather than assumed, four mutants by
+#   hand: `self.p + root`, `-root` and a hardcoded `0` each still pass
+#   the pair; `self.p / root` does not -- the float survives into a
+#   Jacobian coordinate and is caught when `aff_from_jac_batch_var`
+#   calls `number_theory.mod_inv_batch_var`, whose own per-operand
+#   integer check rejects it, not any assertion on what `y_even_var`
+#   returns.
+#   Checked rather than assumed: `self.p_is_3_mod_4 = p ** 4 == 3` in
+#   place of `p % 4 == 3`, and `// self.p` in place of `% self.p` in
+#   `x_aff_from_jac_var`, each now fails `test_symmetry` and
+#   `test_aff_jac_conversions` respectively under the widened command,
+#   where both survived under the pair alone.
+# - memoization only: `_double_mult_w_NAF_var` and
+#   `_multi_mult_w_NAF_var`'s `fixed`/`_fixed_points` membership tests
+#   decide which point gets a precomputed table and at what width, never
+#   the arithmetic result, so a wrong `|`/`&` or a negated `in` there
+#   changes cost and not the returned point -- the same class
+#   `_sliding_window_table`'s own table-length mutants belong to, since
+#   `_mult_sliding_window_var` computes its own indexing offset
+#   independently of that table's length and never reads past it.
+#   Checked rather than assumed: both `fixed = fixed & {U1, U2}` beside
+#   `if not QJ in fixed:`, and `pow(2, w ** 1)` in place of
+#   `pow(2, w - 1)` in the table's own loop bound, still pass the widened
+#   command in full.
+# - `_multiplier_decomposer`'s rounding constant (`_N // 2` weakened to
+#   `_N // 3` and similar): the docstring's "at most 128 bits" is what
+#   the correct constant buys, not what `_double_mult_regular_window`
+#   requires of its callers -- that function's own `bits = max(scalar_len
+#   or ec.scalar_len, u.bit_length(), v.bit_length())` sizes the digit
+#   array to the actual coefficients it is handed, so a coarser split
+#   costs doublings rather than correctness. Checked rather than
+#   assumed: applying `_N // 3` and running the widened command still
+#   passes in full.
+#
+# `_is_prime`'s own parity check (`x % 2 != 0` weakened to `x - 2 != 0`
+# or to `x << 2 != 0`) is equivalent for an unrelated reason: every x
+# either `Curve` or `CurveGroup` ever calls it with is odd already or is
+# an even composite above 2, and `pow(2, x - 1, x) == 1` right after it
+# already answers False for every even x above 2 on its own, x and 2
+# sharing a factor there -- checked rather than assumed, applying the
+# weakened check and running the widened command still passes in full.
+#
+# Neither run's survivor list was read past these families: a family
+# this header does not yet name, and the exact list either run actually
+# found, is what the commands above -- run against the two artifacts
+# while they have not expired, or against a fresh session under the
+# widened command -- answer, rather than a count fixed here that the
+# next weekly run outdates
 
 [cosmic-ray.distributor]
 name = "local"

--- a/.github/mutation/musig2.toml
+++ b/.github/mutation/musig2.toml
@@ -84,7 +84,7 @@ exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 #   `Q[1] % 2 == 0` as `<= 0` -- the interned-int and the `% 2` classes.
 # - `apply_tweak`'s `(g * gacc) % n` as `+ n`: the value is reduced again
 #   before use, so it is equivalent here and fragile rather than wrong.
-# - `key_agg`'s `Q[0] == 0` sits under `# pragma: no cover` -- BIP327's
+# - `key_agg`'s `Q[1] == 0` sits under `# pragma: no cover` -- BIP327's
 #   placeholder for an aggregate key at infinity, which no vector
 #   reaches -- so its mutants are unkillable by construction, the way an
 #   annotation's are.

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -233,14 +233,13 @@ jobs:
             sessions: |
               signatures.toml 90m
           # the pure-Python point arithmetic under the two signing modules
-          # above: 5529 mutants, nearly double their pair's 2980, and the
-          # scope issue #822 asks for -- why it is invisible to the
-          # signatures profile is curve_group.toml's own header. 90
-          # minutes, matching signatures.toml's budget for a scope nearly
-          # double the size, samples the scope rather than finishing it:
-          # the weekly job cuts the session there and reports what it
-          # judged, and triaging that is issue #1745, the same note
-          # curve_group.toml itself makes
+          # above: 5529 mutants, nearly double their pair's 2980; why it
+          # is invisible to the signatures profile is curve_group.toml's
+          # own header. 90 minutes, matching signatures.toml's budget for
+          # a scope nearly double the size, samples the scope rather than
+          # finishing it: the weekly job cuts the session there and
+          # reports what it judged, and triaging that session's own
+          # survivors is curve_group.toml's own header too
           - profile: the pure-Python curve arithmetic
             slug: curves
             ceiling: 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1427,6 +1427,32 @@ file of the test tree, and no caller acts on it.
   holds now rather than what btclib used to ship**, dropping the two
   counts the sentence carried along with the past tense.
 
+### `.github/mutation`'s two profile headers stop citing what does not hold
+
+- **`curve_group.toml`'s header now states what two mutation sessions' own
+  survivors are, rather than pointing a reader at issue #822, which closed
+  without anything else taking up the triage it deferred to** (closes #1745).
+  Read against the source rather than counted, the survivors in both sessions'
+  artifacts sort into recurring families: intermediate values reduced mod `p` a
+  second time downstream, where `% p` weakened to `+ p` or `- p` stays
+  congruent to the original and is unkillable by construction; `CurveGroup`'s
+  own constructor checks, `_is_prime`, and its y-symmetry and
+  coordinate-extraction methods -- three of those eight names are already
+  reached by the pair's own `Curve` construction and by `second_generator`, but
+  asserted on by neither, and the other five the pair never reaches at all,
+  where `Curve`'s own tests assert on all eight — closed by adding
+  `tests/curves/curve_test.py` to the profile's own `test-command`; the
+  `fixed`-point memoization sets and the sliding-window table's own length,
+  whose mutants change cost and not the returned point; and
+  `_multiplier_decomposer`'s rounding constant, which
+  `_double_mult_regular_window`'s own digit count absorbs rather than relies on
+  for correctness. `mutation.yml`'s matrix comment, which named the same closed
+  issue for the same scope, now points at `curve_group.toml`'s header instead.
+- **`musig2.toml` names `key_agg`'s BIP327 infinity guard `Q[1] == 0`,
+  not `Q[0] == 0`**: the guard reads `Q`'s y-coordinate, index 1 of a
+  `Point`, and no `Q[0] == 0` comparison exists anywhere in the module
+  (closes #1752).
+
 ## v2026.9.3
 
 ### Repository


### PR DESCRIPTION
`.github/mutation/curve_group.toml`'s header pointed a reader at issue #822
for the survivors two mutation sessions had already recorded. #822 is
closed and no open issue names that work, so the deferral pointed nowhere.

The header now reads both sessions' downloaded artifacts and sorts the
survivors into families a source reading confirms: modular-reduction
elision, `CurveGroup`'s constructor checks and `_is_prime` and its
y-symmetry and coordinate methods, the `fixed`-point memoization sets and
table-length loops, and `_multiplier_decomposer`'s rounding constant. The
scope gap the second family exposes is closed by widening this profile's
own `test-command` to include `curve_test.py`, which is what asserts on
those eight names.

`.github/mutation/musig2.toml` named `key_agg`'s BIP327 infinity guard
`Q[0] == 0`; the guard reads `Q[1]`, the y-coordinate, and no `Q[0] == 0`
comparison exists anywhere in the module. It now names the guard and no
line number.

**On the review.** Five rounds, and every one of them found something. The
recurring defect was a single shape: a universal quantifier over mutants,
struck when found false and then rewritten *narrower* rather than removed
— "neither dedicated test file ever calls them", then "a mutant of any of
the three survives it regardless", then "a mutant that still returns some
other integer". Each new scope rested on the evidence that had supported
the last one plus a little, and each was false again. The third was
refuted by a standalone simulation of the group law showing that
`self.p // root` and `self.p % root` — integer-valued mutants of the same
operator family — are killed by the pair, the three surviving samples
having been one residue class rather than three points.

The resolution was to stop re-scoping and report the four measurements
that were actually run, with no quantifier over the ones that were not.
The final round found the last stranded clause: a sentence saying every
mutant of the eight surface names survives without `curve_test.py`, which
by then contradicted two measurements the same file had gained. A sweep of
all thirteen universal-shaped claims in the file bounded the ground —
twelve held.

Closes #1745
Closes #1752

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Refresh mutation-profile scope and survivor documentation to reflect current evidence and correct the MuSig2 infinity-guard reference.

Bug Fixes:
- Correct the MuSig2 mutation profile documentation to identify the `key_agg` infinity guard by its actual y-coordinate check.

Enhancements:
- Update the curve-group mutation profile to document survivor families from recent mutation sessions and include curve tests that exercise the affected APIs.
- Remove obsolete references to closed issue-based mutation triage and align workflow commentary with the profile-owned survivor analysis.

Documentation:
- Document the mutation-profile findings and test-scope rationale in the changelog.