### PR TITLE
`sign` and `Descriptor` take a network name as the rest of the library does (closes #1775, closes #1776)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1453,6 +1453,36 @@ file of the test tree, and no caller acts on it.
   `Point`, and no `Q[0] == 0` comparison exists anywhere in the module
   (closes #1752).
 
+### `Bolt11Invoice.sign` refuses a network name with a `BTClibValueError`
+
+- **`sign` normalizes `network` once at its own top, ahead of `_hrp` and
+  `_fallback_field`, and refuses what does not resolve to a lightning
+  network there rather than deferring to `_hrp`'s own dict lookup**
+  (closes #1775). `_hrp` reads the parameter through a bare
+  `_CURRENCY_FROM_NETWORK[network]` lookup, so a spelling `network_from_name`
+  resolves elsewhere in the library, `" MainNet "`, reached a bare `KeyError`
+  before `Bolt11Invoice.__init__`'s own coercion ever ran; `KeyError` is a
+  `LookupError`, not a `BTClibException`, so no `except BTClibValueError`
+  written against this library caught it. The refusal is not conditional on
+  `check_validity` the way `assert_valid`'s own copy of it is: the wire's
+  currency prefix is part of the message `sign` builds and signs, so it needs
+  one regardless of whether the resulting invoice is checked.
+
+### `Descriptor` takes a network name as the rest of the library does
+
+- **`Descriptor.__post_init__` coerces `network` through
+  `network._normalized_network_name`, and every fragment class inherits
+  the coercion rather than defining its own `__init__`** (closes #1776).
+  The parse path already normalized through `_validated_network_name`;
+  the direct constructor -- `RawDescriptor(script=..., network=" MainNet ")`
+  and the like -- kept the name exactly as given, so two spellings of one
+  network built descriptors that were neither equal nor hashed alike, the
+  dataclass comparing `network` as a plain field.
+- **`network.py`'s `_normalized_network_name` docstring states the split as
+  a mechanism a frozen class with a `network` field reaches for, rather
+  than naming an exhaustive list of which ones do**, and gives
+  `descriptors.Descriptor` as one more class reaching for it.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -215,6 +215,33 @@ full year, short month, short day (YYYY-M-D)
   `check_validity=False` being distinct in a set or as dict keys: they
   now collapse to one.
 
+- **`btclib.bolt11.Bolt11Invoice.sign` accepts the same network-name
+  spellings, and refuses the rest with `BTClibValueError`** (closes
+  #1775). `" MainNet "` now resolves to `"mainnet"` where it raised a
+  bare `KeyError` before `sign` ever reached `Bolt11Invoice.__init__`'s
+  own coercion; a name no lightning network answers to, `"testnet4"`
+  included, now raises `BTClibValueError` where it raised that same bare
+  `KeyError`.
+
+  Act on it if you relied on `Bolt11Invoice.sign(..., " MainNet ", ...)`
+  raising, or if you catch `KeyError` around `sign` to detect a network
+  it does not recognize: catch `BTClibValueError`, or the `BTClibException`
+  it is a subclass of, instead.
+
+- **`btclib.descriptors.Descriptor` and every fragment class built on it
+  accept the network-name spellings the rest of the library does**
+  (closes #1776). `" MainNet "` now resolves to `"mainnet"` in the
+  `network` field of a directly constructed descriptor —
+  `RawDescriptor(script=..., network=" MainNet ")` and the like — where
+  the field kept it exactly as given; two spellings of one network now
+  compare equal and hash alike, where they used to compare unequal and
+  hash apart.
+
+  Act on it if you rely on two differently-spelled descriptors built
+  this way being distinct in a set or as dict keys: they now collapse to
+  one. The parse path, `descriptors.parse`, already normalized the name
+  and is unaffected.
+
 ### Worth knowing, though nothing raises
 
 - **`psbt_signer_contract.optional_protocols` returns `OptionalProtocols`,

--- a/src/btclib/bolt11.py
+++ b/src/btclib/bolt11.py
@@ -728,6 +728,21 @@ class Bolt11Invoice:
             err_msg = "exactly one of description and description_hash is required"
             raise BTClibValueError(err_msg)
 
+        # normalized once here, ahead of every read below: `_hrp` and
+        # `_fallback_field` take the raw parameter, and `_hrp` reads it
+        # through a bare `_CURRENCY_FROM_NETWORK[network]` lookup, so an
+        # unnormalized " MainNet " reached a bare `KeyError` before `cls`
+        # -- and `__init__`'s own coercion -- were ever called. The
+        # membership refusal below is not deferred to `assert_valid`
+        # either: the wire's currency prefix is part of the message this
+        # signs, so `sign` needs one whether or not `check_validity` later
+        # runs, where `Bolt11Invoice.__init__` can build an object
+        # `check_validity=False` leaves unchecked
+        assert_type(network, str, "network")
+        network = _normalized_network_name(network)
+        if network not in _CURRENCY_FROM_NETWORK:
+            raise BTClibValueError(f"not a lightning network: {network!r}")
+
         _, payee_point = gen_keys(prv_key, secp256k1)
         payee = bytes_from_point(payee_point, secp256k1, compressed=True)
 

--- a/src/btclib/descriptors/descriptors.py
+++ b/src/btclib/descriptors/descriptors.py
@@ -189,6 +189,7 @@ from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
 from btclib.network import (
     NETWORKS,
+    _normalized_network_name,
     _validated_network_name,
     network_from_xkeyversion,
 )
@@ -724,6 +725,17 @@ class Descriptor(ABC):
     """
 
     network: str = "mainnet"
+
+    def __post_init__(self) -> None:
+        # every fragment's generated `__init__` calls this, none of them
+        # defining its own: the parse path already refuses a name no
+        # network answers to (`_validated_network_name`, above), so what
+        # is left to the direct constructor is the same tolerance rule
+        # issue #216 kept for everything else, not a new refusal. Without
+        # it, two spellings of one network build descriptors that are
+        # neither equal nor hashed alike, `network` comparing and hashing
+        # as the plain field it is
+        object.__setattr__(self, "network", _normalized_network_name(self.network))
 
     @property
     @abstractmethod

--- a/src/btclib/network.py
+++ b/src/btclib/network.py
@@ -567,19 +567,23 @@ def _normalized_network_name(network: Any) -> Any:
 
     `_validated_network_name` below applies it between its type check and
     its membership test, so every name that function returns or refuses has
-    been through here. The frozen classes that keep a `network` field reach
-    for it directly, and it buys each of them something different.
-    `key.PubKeyData` and `key.PrvKeyData` compare and hash the field itself,
-    so two spellings of one network would build objects that are neither
-    equal nor hashed alike. `script.ScriptPubKey` compares and hashes the
-    network *type*, which resolves either spelling on its own; what the
-    coercion settles there is the field read back as it stands, which
-    `tx.TxOut.to_dict` reports verbatim. `bolt11.Bolt11Invoice` shares the
-    equality-and-hash reason with the two key classes, and has one of its
-    own besides: `_hrp` reads the field through a raw
+    been through here. A frozen class that keeps a `network` field reaches
+    for it directly, in whichever of `__init__` or `__post_init__` builds
+    it, and what it buys differs by how the class compares and hashes that
+    field. `key.PubKeyData` and `key.PrvKeyData` compare and hash the field
+    itself, so two spellings of one network would build objects that are
+    neither equal nor hashed alike; `descriptors.Descriptor` and its
+    fragment subclasses share that reason, `network` being a plain
+    dataclass field there too, and none of them defining its own `__init__`
+    is why the coercion sits in `__post_init__` instead. `script.ScriptPubKey`
+    compares and hashes the network *type*, which resolves either spelling
+    on its own; what the coercion settles there is the field read back as it
+    stands, which `tx.TxOut.to_dict` reports verbatim. `bolt11.Bolt11Invoice`
+    shares the equality-and-hash reason with the two key classes, and has
+    one of its own besides: `_hrp` reads the field through a raw
     `_CURRENCY_FROM_NETWORK[network]` lookup, so with
     `check_validity=False` -- where nothing refuses an unnormalized name --
-    an uncoerced field left `to_invoice` a bare `KeyError` rather than an
+    an uncoerced field leaves `to_invoice` a bare `KeyError` rather than an
     encoded string.
     """
     return network.strip().lower() if isinstance(network, str) else network

--- a/tests/bolt11_test.py
+++ b/tests/bolt11_test.py
@@ -194,6 +194,77 @@ def test_sign_refuses_neither_or_both_description() -> None:
         )
 
 
+def test_sign_coerces_the_network_name() -> None:
+    """`sign` accepts the spellings `Bolt11Invoice.__init__` accepts.
+
+    `_hrp` and `_fallback_field` read the raw parameter before `cls`, so
+    `sign` normalizes it once at its own top rather than relying on the
+    coercion `__init__` applies afterwards.
+    """
+    invoice = Bolt11Invoice.sign(
+        _PRV_KEY,
+        " MainNet ",
+        0,
+        payment_hash=bytes(32),
+        payment_secret=bytes(32),
+        description="d",
+    )
+    assert invoice.network == "mainnet"
+
+
+def test_sign_refuses_an_unknown_network_with_a_value_error() -> None:
+    """`sign` refuses what `_hrp`'s own dict lookup would otherwise KeyError on.
+
+    `KeyError` is a `LookupError`, not a `BTClibException`, so no
+    `except BTClibValueError` written against this library would have
+    caught it.
+    """
+    with pytest.raises(BTClibValueError, match="not a lightning network: 'testnet4'"):
+        Bolt11Invoice.sign(
+            _PRV_KEY,
+            "testnet4",
+            0,
+            payment_hash=bytes(32),
+            payment_secret=bytes(32),
+            description="d",
+        )
+
+
+def test_sign_refuses_a_network_that_is_not_a_string() -> None:
+    """A `network` of a type no conversion accepts is a `BTClibTypeError`."""
+    with pytest.raises(BTClibTypeError, match="invalid network type"):
+        Bolt11Invoice.sign(
+            _PRV_KEY,
+            None,  # type: ignore[arg-type]
+            0,
+            payment_hash=bytes(32),
+            payment_secret=bytes(32),
+            description="d",
+        )
+
+
+def test_sign_two_spellings_of_one_network_build_equal_invoices() -> None:
+    """Two spellings signed through `sign` compare equal and hash alike."""
+    lower = Bolt11Invoice.sign(
+        _PRV_KEY,
+        "mainnet",
+        0,
+        payment_hash=bytes(32),
+        payment_secret=bytes(32),
+        description="d",
+    )
+    upper = Bolt11Invoice.sign(
+        _PRV_KEY,
+        "MAINNET",
+        0,
+        payment_hash=bytes(32),
+        payment_secret=bytes(32),
+        description="d",
+    )
+    assert lower == upper
+    assert hash(lower) == hash(upper)
+
+
 def test_bolt11_defaults_expiry_and_min_final_cltv_expiry() -> None:
     """BOLT11's own defaults stand where the tags are absent."""
     invoice = Bolt11Invoice.sign(

--- a/tests/descriptors/descriptors_test.py
+++ b/tests/descriptors/descriptors_test.py
@@ -1055,6 +1055,31 @@ def test_network() -> None:
         parse(descriptor).script_pub_key()
 
 
+def test_descriptor_coerces_the_network_name() -> None:
+    """A direct constructor takes the spellings the parse path already did.
+
+    `descriptors.py:2346`'s `parse` already normalizes through
+    `_validated_network_name`; `Descriptor.__post_init__` is what does the
+    same for `RawDescriptor(...)` and every other fragment class built
+    directly rather than parsed.
+    """
+    descriptor = RawDescriptor(script=b"\x51", network=" MainNet ")
+    assert descriptor.network == "mainnet"
+
+
+def test_descriptor_two_spellings_of_one_network_are_equal_and_hash_alike() -> None:
+    r"""Two spellings of one network build equal, equally-hashed descriptors.
+
+    Without the coercion `RawDescriptor(script=b"\x51", network=" MainNet ")`
+    and `RawDescriptor(script=b"\x51", network="mainnet")` compare unequal
+    and hash apart, the dataclass comparing `network` as a plain field.
+    """
+    spaced = RawDescriptor(script=b"\x51", network=" MainNet ")
+    plain = RawDescriptor(script=b"\x51", network="mainnet")
+    assert spaced == plain
+    assert hash(spaced) == hash(plain)
+
+
 def test_addr_takes_the_network_of_its_address() -> None:
     """An address states its own chain, so no parameter can contradict it."""
     address = "tb1qjwxuan3npm4489vlt0gcyqxwvaghkux009tfyd"


### PR DESCRIPTION
Two more sites in the family [ISS 1662](https://github.com/btclib-org/btclib/issues/1662)
and [ISS 1671](https://github.com/btclib-org/btclib/issues/1671) belong to:
`network_from_name` resolves `" MainNet "`, the `strip().lower()` tolerance
issue #216 decided to keep, so anything that stores a network name without
coercing it lets two spellings of one network become two objects.

**`Bolt11Invoice.sign`** passed its raw `network` to `_hrp` and
`_fallback_field` before the value ever reached `cls(...)`, so a tolerated
spelling died on `_CURRENCY_FROM_NETWORK[network]` with a bare `KeyError` —
a `LookupError`, not a `BTClibException`, so no `except BTClibValueError`
written against this library caught it. `sign` now normalizes once at its
own top, `_hrp` and `_fallback_field` staying the unvalidated private twins
`CONTRIBUTING.md` describes.

It also refuses a normalized-but-unrecognized name there rather than
letting the dict lookup leak. That is not a second copy of `assert_valid`'s
membership test: `__init__` calls `assert_valid()` only `if check_validity`,
so on the `check_validity=False` path this is the *only* check that runs —
and `sign` needs the currency to build the very message it signs, before
`cls(...)` is reached either way.

**`descriptors.Descriptor`** is frozen with a `network` field and took the
generated `__init__`, so the direct constructor kept whatever spelling it
was handed while the parse path already normalized. Two spellings built
descriptors that were neither equal nor hashed alike.

**And a docstring that had been wrong three times.** `network.py` said "The
frozen classes that keep a `network` field reach for it directly", an
exhaustive claim `Descriptor` falsified — which is what ISS 1776 was filed
for. It now states the mechanism rather than a closed set, and the
enumeration behind it was re-derived on the rebased tree rather than the
one it was written against: five frozen classes carry a `network` field,
and each reaches the coercion in whichever of `__init__` or `__post_init__`
builds it.

Reviewed locally at fresh context. The reviewer re-derived the enumeration
itself, confirmed no subclass overrides `Descriptor.__post_init__`,
reproduced all four transcripts on base and branch independently, and
**reverted each fix to re-run the six new tests** — all six turn red with
the failures they are meant to pin, which is the check a loose
`pytest.raises(match=...)` failed on the ISS 1671 branch.

Closes #1775
Closes #1776

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Normalize network names consistently across invoice signing and descriptor construction, and surface invalid Lightning networks through library exceptions.

New Features:
- Make `Bolt11Invoice.sign` accept normalized network-name spellings and report unknown networks with `BTClibValueError`.
- Normalize network names for directly constructed descriptors and their fragment classes so equivalent spellings produce equivalent objects.

Bug Fixes:
- Prevent raw `KeyError` failures when signing invoices with tolerated or unsupported network names.
- Ensure descriptors constructed with differently formatted names compare and hash consistently.

Enhancements:
- Clarify the network normalization documentation to describe the mechanism used by frozen classes rather than an exhaustive class list.

Documentation:
- Update the changelog and release notes with the network handling and exception behavior changes.

Tests:
- Add coverage for invoice network coercion, invalid network types and names, invoice equality and hashing, and descriptor coercion, equality, and hashing.