### PR TITLE
CLAUDE.md's SECURITY.md-citations bullet is corrected, and REVIEWING.md gains the no-count rule's second exception (closes #1750, closes #1777)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1483,6 +1483,31 @@ file of the test tree, and no caller acts on it.
   than naming an exhaustive list of which ones do**, and gives
   `descriptors.Descriptor` as one more class reaching for it.
 
+### `CLAUDE.md`'s `SECURITY.md`-citations bullet names the gate that checks them
+
+- **`CLAUDE.md`'s bullet on `SECURITY.md`'s `path:line` citations stops
+  claiming no gate checks them** (closes #1750): `tests/security_citations_test.py`
+  parses every citation's anchor and checks a dotted-name one against
+  its enclosing function, via `ast`, and a citation that quotes its own
+  line against that line's exact text. The former passes a citation
+  that has drifted within its own function, which the bullet's
+  `awk 'NR==N' <file>` advice still answers for; the latter is already
+  checked by the gate.
+
+### The no-stated-count rule gains a second exception, in `REVIEWING.md`
+
+- **`REVIEWING.md`'s closed set of exceptions to "never state a count"
+  gains a second member, `.github/mutation/`'s profiles, beside
+  `tests/_data/README.md`'s** (closes #1777): each profile states what
+  a mutation session measured over its own scope at its own sha, which
+  `CONTRIBUTING.md`'s mutation section already licenses. Unlike the
+  vendored-data exception, no test spares this one:
+  `tests/mutation_counts_test.py` tests the counting script's
+  arithmetic, not whether a profile states a figure, so a stale count
+  is caught by hand rather than by a gate. `CLAUDE.md`'s own bullet
+  points at `REVIEWING.md`'s exception rather than restating it, adding
+  only the test and the re-derivation commands.
+
 ## v2026.9.3
 
 ### Repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,12 +233,21 @@ Do not use Fable unless explicitly instructed.
   enforces as `formatter.exclude`, so `file_resolver.exclude`, which
   holds ruff's built-in defaults, answers no for a file the formatter
   does skip.
-- **`SECURITY.md`'s file:line citations are unchecked by any gate and
-  drift silently.** An unrelated edit to a cited file shifts the line
-  with nothing red; verify with `awk 'NR==N' <file>` against the
-  claimed content, not against which function the line lands in — a
-  citation landing inside the right function has still been off by
-  several lines.
+- **`tests/security_citations_test.py` checks every `path:line` citation
+  `SECURITY.md` carries, but a symbol anchor pins only the function.**
+  The anchor is the backticked span in front of a citation: a dotted
+  name (`dsa.Signer.__init__`) is matched with `ast` against the
+  definition enclosing the cited line, while a citation that quotes its
+  line instead of naming a symbol — the way musig2.py's sum and dsa.py's
+  `to_bytes` call do — is matched verbatim against that line. A
+  dotted-name anchor is satisfied by any line inside the right function,
+  which is most of what `SECURITY.md` cites, so a citation that drifts a
+  few lines within its own function still passes there. `awk 'NR==N'
+  <file>` verified against the claimed content, not against which
+  function the line lands in, is still the check for a dotted-name
+  citation — a citation landing inside the right function has still been
+  off by several lines; a quoted-line citation already gets that from
+  the gate.
 - **`btclib-org/.github`'s weekly calendar is two tables, and either can
   move mid-campaign.** Section 10 splits day/hour (per workflow) from
   minute (per repository, `btclib` is `04`); the issue proposing one
@@ -358,10 +367,19 @@ Do not use Fable unless explicitly instructed.
 
   A survey that says "with the count, so that nobody has to run it
   again" is the shape to distrust: every one of the twelve it recorded
-  was wrong when re-run. The exception is a count of what upstream
+  was wrong when re-run. One exception is a count of what upstream
   published — `tests/_data/README.md`'s "121 vectors, Core's entire
   file" — which pins a vendored file rather than measuring this tree,
   and which `tests/vendored_data_test.py` spares on purpose.
+  `REVIEWING.md`'s *This repository in particular* names the other:
+  `.github/mutation/`, where a profile's stated mutant count,
+  kill/survive/skip breakdown or wall clock is what a session measured
+  over its own scope at its own sha, re-derived by the commands
+  `CONTRIBUTING.md`'s mutation section already gives.
+  `tests/mutation_counts_test.py` is not what spares it: that script
+  tests the counting script's own arithmetic against a synthetic
+  session, never whether a profile's prose states a figure, so a stale
+  count there fails nothing.
 
 ## Verifying
 

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -468,8 +468,12 @@ because that document, and not this one, is where the rule lives.
   this tree's is the exception under it. A count of what **upstream**
   published pins a vendored file rather than measuring this tree, and
   `tests/vendored_data_test.py` says which shapes it spares for that
-  reason. A count outside those is a finding whether or not a test
-  caught it.
+  reason. A count under `.github/mutation/` is what a mutation session
+  measured over one profile's own scope at its own sha, which
+  `CONTRIBUTING.md`'s mutation section licenses — no test spares it the
+  way the first exception is spared, so a stale one there is caught by
+  hand, not by a gate. A count outside those is a finding whether or not
+  a test caught it.
 - A new file in the repository root: `[tool.check-sdist]`'s `git-only`
   is what says it is deliberately not in the distribution, and its
   default is that a matching `source-include` pattern puts it there.


### PR DESCRIPTION
Two claims the tree refutes, in the files a session reads before it reads
anything else.

**`CLAUDE.md` said `SECURITY.md`'s citations are unchecked by any gate.**
`tests/security_citations_test.py` has checked them since PR #1707. The
bullet now says what the gate actually does, which is less uniform than
either "unchecked" or "checked": the anchor is the backticked span in
front of a citation, and a **dotted name** is matched with `ast` against
the definition *enclosing* the cited line, while a citation that **quotes
its line** is matched verbatim against that line. So a dotted-name anchor
is satisfied by any line inside the right function — which is most of what
`SECURITY.md` cites — and a citation drifting a few lines within its own
function still passes.

That is why the old bullet's `awk 'NR==N' <file>` advice was kept rather
than deleted with the false claim beside it: it is still the check for a
dotted-name citation, and redundant only for a quoted-line one. Verified
in review by running the gate and reading its parser: every citation in
`SECURITY.md` parses, 7 for 7, with the dotted-name and quoted-fragment
split exactly as the bullet describes.

**And the no-stated-count rule had one exception where the tree has two.**
Every profile under `.github/mutation/` states what a session measured,
which `CONTRIBUTING.md`'s mutation section licenses — and `CLAUDE.md`'s
rule carved out no room for it, so a session that had read both met two
landed rules pointing opposite ways. Two reviewers on this campaign broke
the tie differently, one suspecting the figures were the defect and the
other their absence.

The exception lands in **`REVIEWING.md`**, not `CLAUDE.md`, because the
two files already divide this rule that way: `CLAUDE.md` names the
enforcing tests and the re-derivation commands, `REVIEWING.md` states what
counts as a finding. `CLAUDE.md` keeps only the half that is its own —
that `tests/mutation_counts_test.py` does *not* enforce this, testing the
counting script's arithmetic against a synthetic session rather than any
profile's prose — so the carve-out rests on convention with no gate behind
it, and says so.

Reviewed locally at fresh context over three rounds. The first found that
adding the exception to `CLAUDE.md` alone left `REVIEWING.md`'s closed-set
sentence contradicting it — a defect in a file the diff did not contain.
The third found that the repair had reintroduced the very defect the
branch removes, stating "it has two members now" inside the sentence that
forbids stating counts; the discriminator settled there is that a numeral
survives where it sits beside its own compact enumeration, and goes where
a later addition would let the sentence go quietly false instead of
forcing a rewrite.

Closes #1750
Closes #1777

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Correct repository guidance for security citation validation and permit scoped counts in mutation profiles under the review rules.

Bug Fixes:
- Correct the `CLAUDE.md` guidance for `SECURITY.md` citations to accurately describe the validation gate and identify cases that still require manual line verification.
- Add the `.github/mutation/` profile counts as an exception to the no-stated-count review rule, resolving the contradiction with the mutation guidance.

Enhancements:
- Align `CLAUDE.md` and `REVIEWING.md` so count-review rules and their enforcement status are described consistently.

Documentation:
- Update the changelog with the corrected security-citation guidance and the additional mutation-profile count exception.