### PR TITLE
The `line-too-long` reason names the lines the formatter left over 88 (closes btclib-org/.github#873)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1508,6 +1508,22 @@ file of the test tree, and no caller acts on it.
   points at `REVIEWING.md`'s exception rather than restating it, adding
   only the test and the re-derivation commands.
 
+### The `line-too-long` reason names the lines the formatter left over 88
+
+- **`pyproject.toml`'s `line-too-long` entry no longer gives as the rule's
+  residual a shape the rule passes over** (closes btclib-org/.github#873):
+  the reason named a test vector, an extended key or a base64 signature on
+  one line, and an extended key written on a line of its own is silent
+  under `--select E501` where the same line carrying one space inside the
+  key is reported, at the same width. What the rule does report here is a
+  line carried past 88 by a string literal or a comment -- take those out
+  and every one of them is back under the limit -- so that is what the
+  entry says now, with the command that lists them. It names two classes
+  and not one: some of those lines sit inside a `# fmt: off` region, where
+  the formatter was never asked, and calling the whole residual what it
+  could not shorten would have been a third wrong reason in the same
+  place.
+
 ## v2026.9.3
 
 ### Repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -983,9 +983,15 @@ ignore = [
     "undocumented-public-init",
     # code length is enforced by the formatter, which reflows to its 88
     # columns everything it is allowed to rewrite. What is left for this
-    # rule to find is what no width can break, almost all of it a test
-    # vector, an extended key or a base64 signature on one line. The
-    # prose the formatter never touches is measured instead by
+    # rule to find is the line the formatter could not shorten and, in a
+    # `# fmt: off` region, the line it was never given: what carries
+    # each of them past 88 is a string literal or a comment, and taking
+    # those out puts every one back under the limit. Neither gets
+    # shorter for being reported, the region's lines only at the cost of
+    # the layout it is there to hold, so the rule kept buys a
+    # suppression at each site or a limit raised past the longest of
+    # them. `uv run ruff check --select E501 --no-cache .` lists them.
+    # The prose the formatter never touches is measured instead by
     # max-doc-length below
     "line-too-long",
     # complexity metrics this codebase does not bound globally: measured


### PR DESCRIPTION
`pyproject.toml`'s `line-too-long` entry gave as the rule's residual "a test
vector, an extended key or a base64 signature on one line" — a shape the rule
**passes over**. An extended key on a line of its own, 118 columns, is silent
under `--select E501`; the same line with one character swapped for a space,
still 118 columns, is reported. The entry named the exemption and called it the
finding.

What the rule does report was measured instead: every one of the sites
`uv run ruff check --select E501 --no-cache .` lists is carried past 88 by a
string literal or by a comment, and deleting those token spans puts **all** of
them back under the limit, largest residual 64 columns. A planted line of pure
code over 88 survives the same deletion, so the zero is an absence rather than
a broken instrument.

The first draft of this branch then got the *reason* wrong in its turn, and
local review caught it. It called the whole residual "the line the formatter
could not shorten", but 100 of the sites sit inside `tests/kdf_test.py`'s two
`# fmt: off` regions — the formatter was never asked about them. Deleting those
four directives and formatting takes that file from every one of them reported
to none, against a width-40 control that still answers. So the entry now names
two classes, and says what shortening the second would cost: the layout the
region exists to hold. `# fmt: skip` was checked and contributes nothing, so
the second class is closed.

That is the third wrong reason to stand in this one comment. `a2a2bae5`
introduced "what no width can break"; `92251639` rewrote that sentence to drop
its count and kept the false characterisation; this branch's own first draft
made the third. The entry now states **no mechanism of ruff's at all** — that
belongs to section 9 of the organization standard, which `btclib-org/.github`
`19eac906` rewrote today — and says only a property of the lines it is about,
with the command that re-derives it beside it.

Reviewed locally at fresh context across two rounds, the first returning a
blocking finding that was correct and is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

The `line-too-long` reason names the lines the formatter left over 88 (closes btclib-org/.github#873)

The reason gave as the rule's residual "a test vector, an extended key or
a base64 signature on one line". Written on a line of its own each of
those is silent under `--select E501`: one extended key, 118 columns
either way, is passed over on a line of its own and reported with a
single space inside the key, so the sentence named a shape the rule does
not report.

What the rule does report was measured instead. Every line
`uv run ruff check --select E501 --no-cache .` lists is carried past 88
by a string literal or by a comment -- removing the string and comment
tokens puts all of them back under the limit, while a planted line of
pure code over 88 survives that same removal, so the absence is an
absence and not a broken instrument.

That residual is two classes and not one, which the first draft of this
entry got wrong in its turn. Most of the reported lines the formatter saw
and handed back unchanged, having no split that fits. The rest sit inside
a `# fmt: off` region, where it was never asked: deleting that region's
directives and formatting the file takes it from every one of those
reported to none, against a width-40 control that still answers, so they
are not lines the formatter could not shorten. Naming only the first
class would have been a third wrong reason in the same place, which is
why the entry now names both and says what shortening the second would
cost -- the layout the region exists to hold.

Two sibling repairs were available. bitcoin-core-rpc's 4a755cd kept a
reason and named the residual, which works there because the residual is
one recorded script; here it is spread across the test tree and no list
of shapes stays true. .github's branch for btclib-org/.github#869 deleted
its statement of the mechanism and pointed at section 9, which carries
one. This entry keeps a reason, section 9 saying that section 5's
`ignore` is where a rule declined on its own merits is argued, and states
no mechanism of ruff's at all: what it says is a property of the lines it
is about, checkable with the command written beside it. Section 9's own
sentence was under btclib-org/.github#874 and is not transcribed here.

The site count btclib-org/.github#873 carries from another tree's coder
was re-derived at this base: the total reproduces and the `tests/` share
does not, in the checkout and in a `git archive` export alike. No
sentence that lands depends on either number.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr


Local review at fresh context over two rounds. Round 1 returned a blocking finding — the residual named one class where there are two — which was reproduced independently and fixed. Round 2 cleared 42320dba after re-deriving all 566 sites, the 100/466 split and the token-deletion residual at the new base, and reading the gate log itself. This sha is that cleared commit rebased onto a base that moved during the round: pyproject.toml is a byte-identical blob, the changelog block is byte-identical and contiguous against a damaged control, and the union seam the reviewer predicted at line 1510 was repaired in the branch. Seven gates green on the landed sha `ebe8ec3`: `uv sync`, `uv run ruff check --fix`, `uv run ruff format`, `uv run mypy src/btclib tests .github/scripts`, `uv run pytest`, `uv run pre-commit run --all-files`, `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html` — all EXIT 0; suite 32179 passed, 31 skipped, 1 xfailed, coverage 100.00%; pre-commit 41 Passed / 1 Skipped / 0 Failed; clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Correct the `line-too-long` rule rationale to accurately describe the remaining overlong lines and their formatter context.

Bug Fixes:
- Correct the `line-too-long` ignore reason so it describes the actual reported lines rather than exempted line shapes.

Enhancements:
- Document that remaining overlong lines are caused by string literals or comments, including lines in formatter-disabled regions, and provide the command used to re-derive them.

Documentation:
- Add a changelog entry explaining the corrected `line-too-long` rationale and its two residual classes.