### PR TITLE
Test docstrings stop claiming what the tree does not support (closes #1779, closes #1782)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1524,6 +1524,27 @@ file of the test tree, and no caller acts on it.
   could not shorten would have been a third wrong reason in the same
   place.
 
+### `test_curves_with_n_above_p`'s docstring names its curves, not their count
+
+- **The sentence naming the low-cardinality curves on the `n > p` side
+  now names `ec13_19`, `ec17_23`, `ec19_23` and `ec23_31` instead of
+  stating a count** (closes #1779), matching the sentence above it,
+  which already names its `secp*` curves rather than counting them.
+  Neither count was re-derived by anything, and the names are exactly
+  what the test's own assertion checks.
+
+### `tests/mnemonic`'s prose stops crediting a test with mutating `WORDLISTS`
+
+- **Docstrings in `tests/mnemonic/mnemonic_test.py` and
+  `tests/mnemonic/bip39_test.py` said a sibling test adds a language to
+  the shared `WORDLISTS` singleton, which no test does** (closes #1782):
+  every `.load_lang()` call taking a language the registry does not
+  already carry runs on a private `WordLists()` instance, never on
+  `WORDLISTS` itself. They now say why a private instance is used
+  regardless -- `WORDLISTS` is process-wide and is never reset between
+  tests, so reading it directly would make a test's result depend on
+  what earlier tests had already loaded.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -214,8 +214,8 @@ def test_curves_with_n_above_p() -> None:
     and n are within 2*sqrt(p) of each other, so which is the larger is a
     property of the curve and not of the library, and `secp112r1`,
     `secp128r1`, `secp160k1`, `secp160r1`, `secp160r2` and `secp224k1` all
-    have the order above the field prime. Four of the eight
-    low-cardinality curves are on that side too, which is what makes the
+    have the order above the field prime. `ec13_19`, `ec17_23`,
+    `ec19_23` and `ec23_31` are on that side too, which is what makes the
     case testable at all: every (private key, nonce, challenge) triple of a
     curve of order 19 fits in a test.
 

--- a/tests/mnemonic/bip39_test.py
+++ b/tests/mnemonic/bip39_test.py
@@ -22,9 +22,10 @@ from tests.mnemonic.mnemonic_test import fullwidth
 def candidates(mnemonic: str) -> list[str]:
     """List the languages of the shipped word-lists that hold every word.
 
-    A private WordLists and not the singleton bip39 reads: another test
-    adds a language to that one, so a candidate list taken from it would
-    depend on which test ran first.
+    A private WordLists and not the singleton bip39 reads: that
+    singleton is process-wide and is never reset between tests, so a
+    candidate list taken from it would depend on which tests had already
+    run.
     """
     return WordLists().langs_of_words(mnemonic.split())
 

--- a/tests/mnemonic/mnemonic_test.py
+++ b/tests/mnemonic/mnemonic_test.py
@@ -212,9 +212,9 @@ def test_wordlist_2() -> None:
 def test_every_wordlist() -> None:
     """Every BIP39 language, and 2048 unique NFKD words in each.
 
-    A private WordLists rather than the singleton: test_wordlist_2 adds
-    two languages to that one, so a count taken from it would depend on
-    which test ran first.
+    A private WordLists rather than the singleton: the singleton is
+    process-wide and is never reset between tests, so a count taken from
+    it would depend on which tests had already run.
 
     One entry more than the BIP39 languages, because the registry holds
     every word-list btclib ships: "slip39" is a scheme keyed beside them,
@@ -382,9 +382,12 @@ def test_load_lang_is_idempotent_and_reads_once() -> None:
 def test_mnemonic_lang_names_the_shipped_word_lists() -> None:
     """MnemonicLang is what a fresh WordLists knows, and no more.
 
-    A fresh one, not the WORDLISTS singleton the tests above add two
-    languages to: that openness is the reason no lang parameter is typed
-    with the alias (issue #216), and the reason the alias needs a check
-    of its own here rather than one from mypy.
+    A fresh one, not the WORDLISTS singleton: `load_lang` lets any
+    WordLists take a language at runtime, and the singleton is never
+    reset between tests, so a fresh instance is what keeps this check
+    independent of what ran before it. That dynamic loading is the
+    reason no lang parameter is typed with the alias (issue #216), and
+    the reason the alias needs a check of its own here rather than one
+    from mypy.
     """
     assert set(get_args(MnemonicLang)) == set(WordLists().languages)


### PR DESCRIPTION
Two test docstrings told a reader something the tree does not support.

**`tests/curves/curve_test.py`** said "Four of the eight low-cardinality
curves are on that side too". Both numbers were true and neither was
re-derived by anything. The sentence now names the curves —
`ec13_19`, `ec17_23`, `ec19_23`, `ec23_31` — which is the shape the
sentence immediately above it already uses for its own six `secp*` curves,
and which the test's own `assert above == {...}` two lines below checks.

**`tests/mnemonic/`'s prose** credited a sibling test with adding a
language to the shared `WORDLISTS` singleton, given as the reason another
test needs a private `WordLists()`. No test does that, and none has since
`9a8c8b23` — the same commit that wrote those docstrings also changed
`test_wordlist_2` to a private instance, so the prose was describing the
version it was replacing.

The true reason was already in the tree, in `test_wordlist_2`'s own
comment: the singleton is process-wide and is never reset between tests,
so a count or a candidate list taken from it would depend on what had
already run. Each docstring now says that in its own voice.

One of them needed more than a swapped reason. Its false clause was also
the antecedent for why no `lang` parameter is typed with `MnemonicLang`;
the replacement makes `load_lang`'s runtime extensibility the antecedent
instead, which is what
[ISS 216](https://github.com/btclib-org/btclib/issues/216)'s own
resolution gives as the reason and what `mnemonic.py`'s class docstring
already says.

Reviewed locally at fresh context. The reviewer re-ran the `load_lang`
sweep independently, read `tests/conftest.py` in full to confirm nothing
resets the singleton, and checked the antecedent rewrite against ISS 216's
resolution comment rather than against the docstring it replaces. Its one
blocking finding was the commit subject, which claimed two docstrings
where the diff changes four — corrected by dropping the numeral, the same
repair the diff applies throughout.

Closes #1779
Closes #1782

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Correct test docstrings and changelog entries so they accurately describe supported behavior and test isolation assumptions.

Enhancements:
- Clarify test documentation to accurately describe curve coverage, shared word-list state, and runtime language loading without implying unsupported behavior.

Documentation:
- Update the changelog with the corrected explanations for the curve and mnemonic test documentation.