### PR TITLE
tests/_data/README.md's recorded and composed entries carry a verdict, and CONTRIBUTING.md credits `init` with the mutant count (closes #1780, closes #1785)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1545,6 +1545,36 @@ file of the test tree, and no caller acts on it.
   tests, so reading it directly would make a test's result depend on
   what earlier tests had already loaded.
 
+### `tests/_data/README.md` gives a verdict where its vocabulary already fits
+
+- **`tests/block/_data/block_*.bin`, `tests/tx/_data/*.bin`,
+  `tests/mnemonic/_data/fakeenglish.txt` and
+  `tests/psbt/_data/btclib_test_vectors.json` each carry a `Verdict:`
+  line now** (closes #1780): the block and transaction files are
+  **recorded**, one reply a program gave and kept verbatim, per *Reading
+  an entry*'s own definition, except `block_481824.bin`, which the entry
+  already says is derived rather than returned by any call;
+  `fakeenglish.txt` and `btclib_test_vectors.json` are **composed
+  locally**, a case this tree wrote, joining `descriptor_checksums.json`
+  in the Summary's own `composed rather than recorded` sentence.
+  `tests/ecc/_data/rfc6979.json`,
+  `tests/script/_data/unspendable_script_pub_keys.json`,
+  `tests/mnemonic/_data/electrum_test_vectors.json` and
+  `tests/mnemonic/_data/electrum_language_vectors.json` keep no
+  `Verdict:` line: each already explains, in its own prose, why neither
+  word reaches it.
+
+### `CONTRIBUTING.md` attributes the mutant count to `cosmic-ray init`, not `baseline`
+
+- **The mutation section's arithmetic sentence now reads that
+  `cosmic-ray init` enumerates the mutant count and `cosmic-ray
+  baseline` reports the cpu cost** (closes #1785): `baseline --help`
+  runs the test suite over unmutated code and says nothing about mutant
+  enumeration; `init --help` is what scans the modules under test and
+  generates the work order, which is where the count comes from,
+  matching what every `.github/mutation/*.toml` profile's own comment
+  already says of `init`.
+
 ## v2026.9.3
 
 ### Repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -929,12 +929,12 @@ same five commands run any of them: `parsers.toml` is the one that
 excludes a family, and it states which and why. `sig_hash.toml` or
 `engine.toml` in place of it is the consensus profile, minutes of cpu
 against hours; the parser profile is the one that finishes fastest. Each
-configuration carries its own arithmetic — `cosmic-ray baseline` reports
-the mutant count and the cpu cost for whichever one is run, rather than a
-figure fixed here that the source can grow past. The report is
-`--surviving-only`, which is the whole of what anybody acts on: a killed
-mutant is the suite doing its job, and printing every one of them buries
-the handful that are not.
+configuration carries its own arithmetic — `cosmic-ray init` enumerates
+the mutant count and `cosmic-ray baseline` reports the cpu cost for
+whichever one is run, rather than a figure fixed here that the source can
+grow past. The report is `--surviving-only`, which is the whole of what
+anybody acts on: a killed mutant is the suite doing its job, and printing
+every one of them buries the handful that are not.
 
 Three things to know before starting one. The session mutates the source
 file in place and restores it afterwards, so nothing else may read the

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -2106,6 +2106,9 @@ block_481824.bin and block_481824_complete.bin
 
 Pulled 2020-06-08, except `block_200000.bin`, 2020-06-09.
 
+Verdict: **recorded**, except `block_481824.bin`, which is derived rather
+than returned by any call (below).
+
 `bitcoin-cli getblock <hash> 0` returns the first three and
 `block_481824_complete.bin`. It does not return `block_481824.bin`: that
 is the same block serialized *without* witness data, as a pre-segwit node
@@ -2122,9 +2125,10 @@ size   4,740 bytes, vsize 1,471, 8 inputs, 1 output
 pulled 2020-12-02
 ```
 
-The file is named after the txid, and `Tx.parse` recomputes it, so a
-corrupted copy announces itself. `bitcoin-cli getrawtransaction <txid>`
-returns these bytes, given a node with the transaction index.
+Verdict: **recorded**. The file is named after the txid, and `Tx.parse`
+recomputes it, so a corrupted copy announces itself. `bitcoin-cli
+getrawtransaction <txid>` returns these bytes, given a node with the
+transaction index.
 
 ### `tests/script/_data/unspendable_script_pub_keys.json`
 
@@ -2343,7 +2347,8 @@ Pulled 2018-06-11; the pre-2.0 values 2026-08-02.
 
 ### `tests/mnemonic/_data/fakeenglish.txt`
 
-btclib's own, and deliberately broken: `english.txt` with the first word,
+Verdict: **composed locally**. btclib's own, and deliberately broken:
+`english.txt` with the first word,
 `abandon`, deleted — 2047 words, so that `WORDLISTS.load_lang` raises
 "invalid wordlist length". Not vendored, nothing to pin; regenerate it
 from `english.txt` if that ever changes, which it has not since 2014.
@@ -2352,7 +2357,7 @@ Pulled 2018-06-01.
 
 ### `tests/psbt/_data/btclib_test_vectors.json`
 
-**btclib's own, composed rather than copied.** Cases that no BIP
+Verdict: **composed locally**, not vendored. Cases that no BIP
 publishes: each is a psbt btclib must refuse, and what it must say. There
 is no upstream URL to give, because there is no upstream — inventing one
 is the failure mode this entry exists to prevent.
@@ -2542,11 +2547,12 @@ Not checked byte for byte against one:
 - not vendored: `rfc6979.json` (an RFC), `electrum_test_vectors.json`,
   `electrum_language_vectors.json`, `fakeenglish.txt`,
   `gettxoutsetinfo_regtest.json`, `descriptor_checksums.json` and
-  `btclib_test_vectors.json` (btclib's own). `descriptor_checksums.json`
-  and `btclib_test_vectors.json` are composed rather than recorded:
-  the former's checksums come from a third implementation run over
-  Core's own descriptors, and the latter's cases were built here, out of
-  psbts BIP174 prints as prose.
+  `btclib_test_vectors.json` (btclib's own). `descriptor_checksums.json`,
+  `fakeenglish.txt` and `btclib_test_vectors.json` are composed rather
+  than recorded: `descriptor_checksums.json`'s checksums come from a
+  third implementation run over Core's own descriptors, `fakeenglish.txt`
+  is `english.txt` with one word deleted, and `btclib_test_vectors.json`'s
+  cases were built here, out of psbts BIP174 prints as prose.
 
 ### Left for a maintainer to decide
 


### PR DESCRIPTION
`tests/_data/README.md` gives every entry a verdict drawn from its own
*Reading an entry* vocabulary, and some entries had none.

`tests/block/_data/block_*.bin` and `tests/tx/_data/*.bin` name the
program and the exact call that returned their bytes, which is what the
file calls **recorded** — `block_481824.bin` excepted, being derived from
`block_481824_complete.bin` rather than returned by any call, and stated
as an exception in the shape the file already uses two lines above it.
`fakeenglish.txt` and `btclib_test_vectors.json` are cases this tree
wrote, which is **composed locally**.

Four entries deliberately keep no verdict, each for a reason the entry
itself already carries: `rfc6979.json` is transcribed from an RFC but
sits under *Not vendored from anywhere*, so giving it the verdict without
also moving it and its Summary bullet would leave the file inconsistent
in a new way — that is
[ISS 1788](https://github.com/btclib-org/btclib/issues/1788), filed
rather than folded in here. The two Electrum files pin no version, so
neither *recorded* nor *composed locally* fits.
`unspendable_script_pub_keys.json` interleaves a recorded scriptPubKey
with decode expectations this tree composed, inside every row.

Separately, `CONTRIBUTING.md`'s mutation section credited
`cosmic-ray baseline` with the mutant count. `baseline` runs the suite
over unmutated code; `init` scans the modules and generates the work
order, which is where the count comes from — as every
`.github/mutation/*.toml` profile's own comment already says. The
sentence now credits `init` with the count and `baseline` with the cpu
cost.

Reviewed locally at fresh context, entirely from the object store. The
reviewer re-ran `tests/vendored_data_test.py`'s two guard functions
against this sha rather than reading them, confirming that inserting the
refused `rfc6979.json` verdict would break
`test_summary_names_every_transcribed_vendored_file` — which is the
mechanical form of why that one is a separate issue. It also verified the
MD013 amnesty claim by running `markdownlint-cli2` against a fixture
rather than by reading the rule.

Its one finding was the commit subject, a list of topics with no verb
where every sibling commit on this branch's history is a sentence; since
a single-commit branch lands under its own subject, that string is
permanent. Rewritten. Correcting it also removed two numerals from the
commit body that stated how many entries the file holds, which the
entries being named one by one makes redundant.

Rebased onto `main` after clearance: the `merge=union` seam ate the blank
line before the new `###` heading and was repaired, with the repair
proved by the added-line block being identical to the one reviewed and by
the heading count moving by exactly this branch's own two. The rebase
also brought
[PR 1787](https://github.com/btclib-org/btclib/pull/1787)'s new
`REVIEWING.md` sentence, which cites the very `CONTRIBUTING.md` section
this branch edits; the two were read together and agree — that sentence
licenses a per-profile count, and this edit changes only which command
produces it.

Closes #1780
Closes #1785

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Clarify test-data provenance and correct the mutation-testing command guidance.

Enhancements:
- Document verdicts for applicable test data entries and clarify why specific exceptions remain unlabeled.
- Correct the mutation-testing guidance to attribute mutant enumeration to `cosmic-ray init` and CPU-cost reporting to `baseline`.

Documentation:
- Update the changelog and test-data documentation to describe recorded versus locally composed fixtures and their exceptions.