### PR TITLE
tests/ state the relation a wall clock argued for (closes #1770)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1575,6 +1575,25 @@ file of the test tree, and no caller acts on it.
   matching what every `.github/mutation/*.toml` profile's own comment
   already says of `init`.
 
+### `tests/` states the relation a wall clock argued for, not the wall clock
+
+- **Docstrings in `tests/` stated a millisecond or second figure that
+  nothing re-derives, one of them restating a measurement its own
+  `src/btclib` twin no longer makes** (closes #1770):
+  `tests/curves/curve_test.py`'s `test_catalogued_curves` docstring said
+  "123 ms of a 168 ms module import", the same import cost
+  `src/btclib/curves/curve.py`'s `_catalogued_curve` docstring already
+  describes without a figure since `8d8fd0f3`. Each site now carries the
+  relation its argument needs instead: a growth ratio in
+  `tests/base58_test.py`, a noise-floor comparison in
+  `tests/curves/curve_group_test.py`, a one-time-cost argument in
+  `tests/script/sig_hash_taproot_test.py`, and, in
+  `tests/ripemd160_test.py`, an argument for excluding the slowest
+  upstream vector that no longer ranks it against the rest of the suite.
+  `tests/wait_for_*_test.py` and `tests/ecc/borromean_test.py`'s
+  "1 s-value" are untouched: their figures are assertions' expected
+  strings, not prose making an argument.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/base58_test.py
+++ b/tests/base58_test.py
@@ -165,9 +165,10 @@ def test_integers() -> None:
 def test_max_length() -> None:
     """Decoding is quadratic, so the input is bounded first.
 
-    Measured 13 ms at 10k characters, 198 ms at 40k and 3312 ms at 160k,
-    four times the cost per doubling -- and the checksum that rejects
-    the string is verified only once the decoding has been paid for.
+    Measured across three input sizes, each four times the last,
+    quadrupling the input multiplies the decoding time by about
+    sixteen -- and the checksum that rejects the string is verified
+    only once the decoding has been paid for.
     """
     # the longest thing btclib encodes: a 78-byte BIP32 extended key,
     # here the one whose 112 characters no payload can exceed

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -430,8 +430,9 @@ class _CountingGroup(CurveGroup):
 
     The number of additions is what the scalar used to decide (issue 254),
     and counting them is how the test below says it no longer does: a
-    timing at 0.8 ms a multiplication is noise against a spread of one
-    addition in seventy.
+    wall-clock timing per multiplication is too noisy to resolve a spread
+    of one addition in seventy, which is why the test counts additions
+    directly instead.
     """
 
     def __init__(self) -> None:
@@ -876,8 +877,9 @@ def test_multi_mult_distant_magnitudes() -> None:
     indifferent to their magnitudes, so the pathological pairs reach
     Bos-Coster only inside a batch above the threshold -- where they are
     the whole of the batch's cost. Euclid's quotient is what bounds it:
-    the subtractive step takes 10.6 s on the first pair and does not
-    finish on the third, and this test would say so by not returning.
+    the subtractive step is slow enough on the first pair to notice, and
+    does not finish at all on the third, so this test would say so by
+    not returning.
     """
     ec = secp256k1
     HJ = _jac_from_aff(second_generator(ec))

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -289,11 +289,11 @@ def test_catalogued_curves() -> None:
     """Rebuild the catalogue from its json data, with every check on.
 
     btclib.curves.curve builds it with order_check=False and
-    weakness_check=False, the two being 123 ms of a 168 ms module
-    import; this is where they happen instead, and both
-    default to on, so constructing the curves here is what runs them. A
-    wrong n in the json data, or a curve whose embedding degree is small,
-    fails a test rather than nothing at all.
+    weakness_check=False, since re-deriving them at every interpreter
+    start would cost most of a module import; this is where they happen
+    instead, and both default to on, so constructing the curves here is
+    what runs them. A wrong n in the json data, or a curve whose
+    embedding degree is small, fails a test rather than nothing at all.
 
     Not the only place either check happens -- test_ec_repr rebuilds each
     curve from its repr, and tests/curves/curve_group_test.py asserts n*G

--- a/tests/imports_test.py
+++ b/tests/imports_test.py
@@ -45,10 +45,9 @@ def unimported_btclib() -> Iterator[None]:
 
     A subprocess per module would be the obvious way to get a virgin
     interpreter, and it is what issue #147 used to demonstrate the
-    failure, but as a test it costs an interpreter start-up per module
-    (~0.2 s, times some sixty of them) and buys nothing: the import
-    machinery decides what to execute by consulting sys.modules and
-    nothing else.
+    failure, but as a test it costs an interpreter start-up per module,
+    some sixty of them, and buys nothing: the import machinery decides
+    what to execute by consulting sys.modules and nothing else.
 
     What the modules imported inside the fixture must not do is outlive
     it. They are fresh objects, so a class reimported here is not the

--- a/tests/ripemd160_test.py
+++ b/tests/ripemd160_test.py
@@ -10,11 +10,11 @@ upstream carries them in its own unittest -- Bitcoin Core's
 test/functional/test_framework/crypto/ripemd160.py, whose revision
 `TF2.md` pins.
 
-Eight of that upstream's nine. The ninth is 10^6 times "a", and in pure
-Python it takes 1.5 s, which would make it the slowest test in this suite
-(the slowest today is 1.47 s) for the one property it has over the others,
-that the input spans many blocks. `test_matches_hashlib` covers that
-property over 138 lengths, 4096 bytes among them, in some 5 ms.
+Eight of that upstream's nine. The ninth is 10^6 times "a"; in pure
+Python, excluding it saves meaningfully on this suite's running time,
+for the one property it has over the others, that the input spans many
+blocks. `test_matches_hashlib` covers that property over 138 lengths,
+4096 bytes among them, without paying for a full megabyte of input.
 """
 
 from __future__ import annotations

--- a/tests/script/sig_hash_taproot_test.py
+++ b/tests/script/sig_hash_taproot_test.py
@@ -70,7 +70,7 @@ def key_path_vectors(outcome: str, taproot_flag: bool) -> list[Any]:
     key path spends.
 
     The parse of every prevout is the price, paid once per worker at
-    collection: 3 ms for the file.
+    collection rather than repeated per test.
     """
     params = []
     for index, x in enumerate(TAPSCRIPT):

--- a/tests/script_engine/python_path_test.py
+++ b/tests/script_engine/python_path_test.py
@@ -76,11 +76,11 @@ def python_verification(monkeypatch: pytest.MonkeyPatch) -> None:
     installation will do.
 
     The price is real and was measured rather than assumed: the vectors
-    of this module take 2.95 s with the arithmetic delegated and 17.21 s
-    without, one process, `-p no:randomly`, one machine. The suite runs
-    distributed, so what a contributor waits is the slowest worker and
-    not this; and the alternative buys back fourteen seconds by testing a
-    configuration nobody installs.
+    of this module take several times longer with the arithmetic in
+    Python than with it delegated, one process, `-p no:randomly`, one
+    machine. The suite runs distributed, so what a contributor waits is
+    the slowest worker and not this; and the alternative buys back that
+    difference by testing a configuration nobody installs.
     """
     monkeypatch.setattr(curve, "_libsecp256k1_available", False)
 


### PR DESCRIPTION
Eight docstrings across seven test files stated wall clocks in
milliseconds and seconds. Nothing re-derives any of them, and
`CLAUDE.md` puts a wall clock in the same class as a count: what a
comment carries instead is the reason that decided the thing.

Each figure is gone and the relation its argument needed has stayed.
`base58_test.py` argued a growth curve from three measured points and
now states the growth itself — quadrupling the input multiplies the
decoding time by about sixteen, which is what its three points said
(198/13 and 3312/198 are both about sixteen for a fourfold step).
`python_path_test.py` contrasted delegated against pure-Python
arithmetic and now says several times longer.

The sharpest one was `ripemd160_test.py`, which ranked itself: "the
slowest today is 1.47 s" is a superlative over a whole suite that only a
run re-derives. The ranking is gone and the argument it served — this
test would dominate the suite for one property the others already
cover — is not.

`curves/curve_test.py` was the twin of a figure `src/btclib/curves/curve.py`
stopped making. `8d8fd0f3` rewrote the source docstring under
[ISS 1505](https://github.com/btclib-org/btclib/issues/1505) from "118 ms
and 5 ms of a ~168 ms module import" to a relation, and left the test
saying "123 ms of a 168 ms module import" — the same measurement, in the
file that commit did not touch. The two now agree in kind, the test
keeping its own point rather than copying the source's words.

The rows the sweep finds and this branch leaves alone are assertions'
expected strings rather than prose: `borromean_test.py`'s "1 s-value",
which is a term and not a duration, and the CLI output the three
`wait_for_*_test.py` files assert on.

Reviewed locally at fresh context. The reviewer re-derived the sweep at
the branch sha rather than accepting the exclusions, checked the
`base58_test.py` arithmetic against the figures the old text carried,
and read the source twin's docstring beside the test's to confirm they
agree. It named two pre-existing counts elsewhere in `tests/` that this
branch neither introduces nor worsens; those are filed separately.

Rebased onto `main` after clearance: the `merge=union` seam ate the blank
line before the new `###` heading and was repaired, proved by the added
block being identical to the one reviewed and by every touched test file's
blob being unchanged.

Closes #1770

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Replace stale wall-clock figures in test documentation with durable explanations of the behavior and trade-offs they describe.

Enhancements:
- Replace hard-coded wall-clock measurements in test docstrings with the qualitative relationships and rationale those measurements supported.

Documentation:
- Document the rationale for removing timing figures from test prose while retaining expected-output timing values and other assertion data.