### PR TITLE
pyproject.toml says which prose max-doc-length measures, and which nothing does (closes #1749)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1594,6 +1594,26 @@ file of the test tree, and no caller acts on it.
   "1 s-value" are untouched: their figures are assertions' expected
   strings, not prose making an argument.
 
+### `pyproject.toml`'s `line-too-long` comment narrows what `max-doc-length` measures
+
+- **The comment above `"line-too-long"` in `[tool.ruff.lint]`'s
+  `ignore` said the prose the formatter never touches is measured
+  instead by `max-doc-length`, true of a docstring and a standalone
+  comment and false of a comment following code on its line**
+  (closes #1749): `W505` reports the first two and stays silent on
+  the third, a positive control in the same run confirming the
+  silence rather than a rule that found nothing. The comment now
+  narrows the claim to the shapes `max-doc-length` reaches, and names
+  what leaves a trailing comment unmeasured: `line-too-long` is the
+  rule that reaches one, `E501` counting the physical line and
+  reporting a line a trailing comment carries past 88 like any other,
+  so it is this entry and not the rule's scope that leaves the width
+  unmeasured -- for the reason the entry already gives, reaching a
+  trailing comment costing a report on every other line the rule
+  finds. `# pragma: no cover`'s inline reason (btclib-org/.github#838)
+  makes the shape common rather than incidental, so the comment says
+  plainly that whoever reads the diff is what catches it.
+
 ## v2026.9.3
 
 ### Repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -991,8 +991,17 @@ ignore = [
     # the layout it is there to hold, so the rule kept buys a
     # suppression at each site or a limit raised past the longest of
     # them. `uv run ruff check --select E501 --no-cache .` lists them.
-    # The prose the formatter never touches is measured instead by
-    # max-doc-length below
+    # A docstring and a standalone comment are what max-doc-length
+    # below measures, and a comment following code on its line is
+    # neither. This rule is the one that reaches it -- E501 counts the
+    # physical line, so a trailing comment carrying one past 88 is
+    # reported like any other -- which leaves that width measured by
+    # nothing here, the rule being ignored. `# pragma: no cover`'s
+    # inline reason (btclib-org/.github#838) makes the shape common
+    # rather than incidental, and the reason above still decides it:
+    # reaching a trailing comment means reporting every other line the
+    # rule finds too, none of which gets shorter for being reported. A
+    # trailing comment's width is left to whoever reads the diff
     "line-too-long",
     # complexity metrics this codebase does not bound globally: measured
     # one at a time, too-many-arguments and too-many-positional-arguments


### PR DESCRIPTION
`pyproject.toml`'s comment on the ruff `"line-too-long"` ignore ended by
saying the prose the formatter never touches is measured instead by
`max-doc-length`. That is true of a docstring and a standalone comment
and false of a comment sitting after code on the same line, which is one
of the shapes the formatter never touches.

Measured, with a control in the same run so the silence is an absence
rather than a rule that missed. A probe carrying a long docstring, a long
standalone comment and a long trailing comment:

```
ruff check --isolated --select W505 --config 'lint.pycodestyle.max-doc-length = 80'
  → the docstring and the standalone comment, and nothing on the trailing one
ruff check --isolated --select E501
  → all three, the trailing comment's line reported at 109 > 88
```

So the comment now says which prose `max-doc-length` measures and names
what leaves a trailing comment's width unmeasured. It is not that the
shape falls outside every rule: `line-too-long` reaches it, `E501`
counting the physical line, and what leaves it unmeasured here is this
entry ignoring that rule — for the reason the entry already gives, since
reaching a trailing comment costs a report on every other line the rule
finds, none of which gets shorter for being reported.

That is the second half of ISS 1749's *Done when*, which asked for a
decision rather than a preference: either something measures a trailing
comment's width or the comment says plainly that nothing does and why.
Nothing does, and it now says so — the more so because
`btclib-org/.github#838` puts every `# pragma: no cover`'s reason in
exactly that slot, making the shape common rather than incidental.

Reviewed locally at fresh context. The reviewer ran the probe itself
rather than reading the report, with its own controls, and reached the
same two results. It also checked that nothing else in the tree gates a
trailing comment's width, so the comment's "left to whoever reads the
diff" does not overclaim a gap that is not there.

One correction happened between the coder and this pull request, worth
recording because the review round it needed is not the one it got: the
first version said a trailing comment is "outside both rules" and that
"the formatter's 88 columns already decide the width such a line leaves
it". The first is false — `E501` reaches it, as above — and the second
contradicts the paragraph directly above it in the same comment, which
says what the rule finds is the line the formatter could not shorten and
that a comment is what carries such a line past 88. Both claims had
reached all three prose sites — the comment, the commit message and the
`CHANGELOG.md` entry — and all three were corrected together.

The two further sites making the same false claim are
[ISS 1792](https://github.com/btclib-org/btclib/issues/1792), filed
rather than folded in here; the reviewer confirmed this branch neither
touches them nor pre-empts it.

Closes #1749

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Clarify the repository’s Ruff line-length policy for prose and trailing comments.

Enhancements:
- Clarify which comment forms Ruff’s `max-doc-length` measures and document that trailing comment widths remain unchecked because `line-too-long` is ignored.

Documentation:
- Update the changelog and Ruff configuration comments to accurately describe line-length checking for docstrings, standalone comments, and trailing comments.