### PR TITLE
tests/_data/README.md files rfc6979.json where its own verdict puts it (closes #1788)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1614,6 +1614,19 @@ file of the test tree, and no caller acts on it.
   makes the shape common rather than incidental, so the comment says
   plainly that whoever reads the diff is what catches it.
 
+### `tests/_data/README.md` files `rfc6979.json` where its own verdict puts it
+
+- **`tests/ecc/_data/rfc6979.json`'s entry now carries `Verdict:
+  **transcribed**` and sits under `## Other projects` rather than `##
+  Not vendored from anywhere`** (closes #1788): its own prose already
+  says the file is Appendix A.2 of RFC 6979, transcribed, which is
+  *Reading an entry*'s own definition of that verdict — an RFC is not a
+  git repository, so there is no commit to pin, not an absence of
+  anything upstream to compare against. The Summary's transcribed
+  bullet gains the file and its not-vendored bullet drops it, so
+  `tests/vendored_data_test.py`'s cross-check between the two still
+  agrees.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -2077,6 +2077,15 @@ Both sections are transcribed whole, the invalid case adding "unknown
 feature 100" included: what refuses that one is `btclib.bolt9`'s
 assignment table, which `Bolt11Invoice.assert_valid` reads.
 
+### `tests/ecc/_data/rfc6979.json`
+
+Verdict: **transcribed**. Appendix A.2 of RFC 6979 gives 50 vectors, ten each
+for NIST P-192, P-224, P-256, P-384 and P-521, as `tests/ecc/rfc6979_test.py`
+says. An RFC number is already an immutable reference — there is no commit to
+pin, and `rfc-editor.org/rfc/rfc6979` is the document.
+
+Pulled 2020-05-08.
+
 ## Chain data, not a repository
 
 These are consensus bytes. There is no upstream repository to pin and no
@@ -2271,15 +2280,6 @@ out, the `rest_*` files take those bytes unwrapped, and
 refresh any of them, and nothing should.
 
 ## Not vendored from anywhere
-
-### `tests/ecc/_data/rfc6979.json`
-
-Appendix A.2 of RFC 6979, transcribed: 50 vectors, ten each for NIST
-P-192, P-224, P-256, P-384 and P-521, as `tests/ecc/rfc6979_test.py`
-says. An RFC number is already an immutable reference — there is no
-commit to pin, and `rfc-editor.org/rfc/rfc6979` is the document.
-
-Pulled 2020-05-08.
 
 ### `tests/mnemonic/_data/electrum_test_vectors.json`
 
@@ -2535,7 +2535,8 @@ Not checked byte for byte against one:
   `bip371_test_vectors.json`, `bip373_test_vectors.json`,
   `bip67_test_vectors.json`, `bip85_test_vectors.json`,
   `chacha20_vectors.json`, `muhash_vectors.json`,
-  `miniscript_fixed_tests.json`, `bolt11_test_vectors.json`.
+  `miniscript_fixed_tests.json`, `bolt11_test_vectors.json`,
+  `rfc6979.json`.
 - chain data, identified by block hash or txid: the blocks and
   transactions under `tests/block/_data/` and `tests/tx/_data/`, and
   `unspendable_script_pub_keys.json`, which is scripts rather than whole
@@ -2544,7 +2545,7 @@ Not checked byte for byte against one:
 - response bodies under `tests/fetch/_data/`, whose envelopes are
   composed from Core's and Esplora's own source and whose payload is
   chain data two of the entries above already hold.
-- not vendored: `rfc6979.json` (an RFC), `electrum_test_vectors.json`,
+- not vendored: `electrum_test_vectors.json`,
   `electrum_language_vectors.json`, `fakeenglish.txt`,
   `gettxoutsetinfo_regtest.json`, `descriptor_checksums.json` and
   `btclib_test_vectors.json` (btclib's own). `descriptor_checksums.json`,

--- a/tests/vendored_data_test.py
+++ b/tests/vendored_data_test.py
@@ -388,7 +388,7 @@ _EXEMPT: dict[str, str] = {
     "is the same 275 bytes as the hex in `getrawtransaction.json` and": _UPSTREAM_FACT,
     "`rest_headers.bin` the same eighty bytes as `getblockheader.json` and": _UPSTREAM_FACT,
     "Regenerating one of these is reading the two block files: the Core and": _UPSTREAM_FACT,
-    "Appendix A.2 of RFC 6979, transcribed: 50 vectors, ten each for NIST": _UPSTREAM_FACT,
+    "Verdict: **transcribed**. Appendix A.2 of RFC 6979 gives 50 vectors, ten each": _UPSTREAM_FACT,
     "**Unresolved, and probably unresolvable.** These 12-word mnemonics with": _UPSTREAM_FACT,
     "citation two lines above the values is one that gets checked.": _UPSTREAM_FACT,
     "`SEED_VECTORS`' five passphrase-bearing rows each carry the": _UPSTREAM_FACT,


### PR DESCRIPTION
`tests/_data/README.md` filed `tests/ecc/_data/rfc6979.json` under
*Not vendored from anywhere*, and the entry's own prose said otherwise:
Appendix A.2 of RFC 6979, transcribed. What it lacks is a commit to pin,
an RFC not being kept in a repository — not an upstream.

The file's own *Reading an entry* names this shape and names an RFC as
an example of it: "there is no file compared byte for byte. Over prose
(a BIP, an RFC, a BOLT) the check is that every value in our copy
appears verbatim in the pinned text." The entry already performs that
check. `## Naming` had already been calling it transcribed in as many
words.

So the entry now carries `Verdict: **transcribed**`, sits at the end of
*Other projects* beside `bolt11_test_vectors.json` — the other
transcribed spec document — and moves between the Summary's two lists
accordingly. That is one change rather than three:
`tests/vendored_data_test.py` cross-checks the verdicts against the
Summary's own bullet, so a verdict added without the move would leave
the file vendored by its verdict and not vendored by its heading. That
coupling is why
[PR 1791](https://github.com/btclib-org/btclib/pull/1791) left this
entry alone and filed it instead.

The hazard worth naming: `.github/scripts/check_vendored_vectors.py`
reads this file weekly, and moving an entry out of *Not vendored from
anywhere* could bring it into that script's view for the first time —
where [ISS 1741](https://github.com/btclib-org/btclib/issues/1741) says
an entry with no `behind` field is wrongly reported as "already
documented as behind". It does not: this entry owns no fenced pin block
at all, so it leaves through the separate and correctly labelled
"no fenced block" branch. Measured by running `_entries_at_tip` against
the file before and after the move — identical skip lines, identical
entry headings — so this can land without waiting on ISS 1741.

Reviewed locally at fresh context, and the reviewer re-derived rather
than read: it executed the two cross-checking functions and the count
guard directly against the branch's file, and ran `_entries_at_tip`
itself on both sides of the move. It also checked the one edit that
deserves the most suspicion — a `_EXEMPT` entry in the test adjusted to
match a reworded line — and confirmed the exemption still covers the
same single upstream-published count, "50 vectors, ten each", which is
the exception `REVIEWING.md` names and the test spares on purpose.

Rebased onto `main` after clearance: the `merge=union` seam ate the
blank line before the new `###` heading and was repaired, with both
touched files' blobs identical to the reviewed ones.

Closes #1788

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Classify the RFC 6979 vectors consistently as transcribed test data across the repository documentation and validation checks.

Enhancements:
- Classify the RFC 6979 test vectors as transcribed data and move their documentation to the appropriate summary category.
- Keep the vendored-data consistency checks aligned with the revised entry wording.

Documentation:
- Update the test-data documentation and changelog to reflect RFC 6979's transcribed status.

Tests:
- Update the vendored-data test fixture to match the revised RFC 6979 documentation.