### PR TITLE
`pyproject.toml` and `.pre-commit-config.yaml` stop wording the URL amnesty (issue btclib-org/.github#866)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -504,11 +504,12 @@ repos:
   # formats values and leaves comments alone, by design, a formatter that
   # reflowed prose being a formatter that rewrites it.
   # `.{80}\S*[ \t]` reports a line only when whitespace is left past
-  # column 80, which is MD013's amnesty and ruff's: a comment ending in a
-  # link that cannot be broken is not a defect, and every Python comment
-  # here over 80 columns is exactly that. Without the amnesty this would
-  # be stricter on toml prose than the rules it mirrors are on the same
-  # sentences in a .py or a .md.
+  # column 80, which is MD013's test and not W505's: a line whose
+  # overflow is one unbroken token passes here and in markdownlint, and
+  # the same text in a whole-line .py comment is reported. What W505
+  # passes over instead is section 9 of the organization standard's.
+  # With no amnesty at all this would be stricter on toml prose than the
+  # rules it mirrors are on the same sentences in a .py or a .md.
   # The `#` after optional indent selects a comment and not a long value:
   # `addopts` and `skip` in pyproject.toml are single tokens no width can
   # break, and a value is not prose.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1627,6 +1627,28 @@ file of the test tree, and no caller acts on it.
   `tests/vendored_data_test.py`'s cross-check between the two still
   agrees.
 
+### `pyproject.toml` and `.pre-commit-config.yaml` stop wording the URL amnesty
+
+- **The `max-doc-length` comment no longer states that a comment ending
+  in a URL is exempt, nor that the comments over 80 columns are every
+  one of them a link** (issue btclib-org/.github#866): of two whole-line
+  comments ending in the same link, the one whose prose fills 80 columns
+  before the link begins is reported and the one whose prose does not is
+  passed over, so the exemption is conditional where the sentence gave
+  it flat. The clause beside it described a population that moves --
+  comments following code on their line are over 80 columns throughout
+  this tree, and none of those ends in a link. What the comment says now
+  is what a passing `uv run ruff check --select W505 --no-cache .` makes
+  true of any comment left over 80 columns, and section 9 of the
+  organization standard is where the condition is stated.
+- **The `toml-comment-width` reason no longer identifies its own test
+  with W505's** (issue btclib-org/.github#866): the hook reports a
+  comment only where whitespace is left past column 80, which is
+  markdownlint's test -- a line whose overflow is one unbroken token
+  passes the hook and markdownlint alike, and the same text as a
+  whole-line Python comment is reported. The census went with it there
+  too.
+
 ## v2026.9.3
 
 ### Repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1260,9 +1260,11 @@ max-complexity = 10
 # every markdown file here is already held to by MD013.
 # W505 is in the "W" set selected above and is inert without this line,
 # ruff having no default doc length; setting it is the whole of the
-# switch. A comment that ends in a URL is exempt, which is the amnesty
-# MD013 gives an unbreakable link: the comments still over 80 columns are
-# every one of them a link, and none is a defect
+# switch. Which over-width lines the rule passes over is section 9 of
+# the organization standard's and is not restated here. While
+# `uv run ruff check --select W505 --no-cache .` passes, a comment over
+# 80 columns is either one of those or one this key does not reach, and
+# not a defect
 max-doc-length = 80
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
ISS 866's second box, this tree's row and the last of the pair. The issue
stays open — its section 5 box and the `.github` copy are still outstanding —
so the citation is `(issue ...)` and not a closing keyword.

Two sites in this tree worded the URL amnesty as unconditional. The
`[tool.ruff.lint.pycodestyle]` comment is replaced by a pointer to section 9,
which now states both amnesties and closes the transfer itself, plus a
disjunction the gate makes exhaustive: while `uv run ruff check --select W505
--no-cache .` passes, a comment over 80 columns is either one of those or one
this key does not reach, and not a defect. The reviewer measured that
disjunction rather than reading it — there is no `noqa` for `W505` or `E501`
anywhere in the tree's 393 tracked `.py`, with a bare `noqa` count non-zero as
the control, and `per-file-ignores` names `F822`, `T201` and the `tests/**` set
and never `W505` — so the two disjuncts do partition.

The `.pre-commit-config.yaml` half deletes a claim about two other tools rather
than restating one: the `toml-comment-width` hook's comment said its width
test "is MD013's amnesty **and ruff's**". It is not ruff's. A whole-line comment
carrying one unbroken 100-character non-URL token is passed over by the pygrep
and by MD013 and **reported** by W505, measured independently by the coder and
by the reviewer on nine probes with a firing positive control. That clause sits
in text ISS 843 owns as a seven-tree decision — it is live in four of the
seven carriers, `btclib-node` in a different wording that a grep for this
one misses; ISS 843's own comment delegates
the prose — "folding it in costs nothing" — and the branch leaves the hook's
`name:` and `entry:`, which is what ISS 843 is actually about, untouched.

`.pre-commit-config.yaml` is not one of section 14's nine compared paths, so no
`EXPECTED_DRIFT` entry is owed — and equally, no test will notice that this
tree's copy has moved. The convergence port must take this text as an input
rather than assuming the four carriers still agree; that is going on ISS 843 as
a comment.

Collateral the reviewer found and did not fix here: section 9 names two ruff
pass-overs and there is a third — a whole-line comment containing no whitespace
at all is silent at `max-doc-length = 80`, where the same token behind `# ` is
reported. Empty in this tree today (all 18 whole-line comments over 80 end in a
`://` word), but this branch makes section 9 the sole statement of the rule
here, so it is filed rather than left in a report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

`pyproject.toml` and `.pre-commit-config.yaml` stop wording the URL amnesty (issue btclib-org/.github#866)

Two comments here stated ruff's `max-doc-length` URL exemption as
unconditional, and then said which comments it covers. The exemption is
conditional, and the second half is a census of a population that moves.

Measured with this tree's own configuration -- ruff 0.16.6, the version
`.pre-commit-config.yaml` pins and `uv.lock` locks, `preview = true`,
`max-doc-length = 80` -- over five whole-line comments in one probe
file. A comment of 131 columns ending in a link that begins at column 88
is reported. The same link at column 43, on a comment of 86 columns, is
silent. A comment of 115 columns with no link is reported, which is the
control saying that silence is an absence. The same link at column 43
with four words after it, 105 columns, is reported. And `https_//` in
place of `https://`, same position and same length, is reported, which
is the control varying only the two characters the rule keys on. So the
exemption asks that the link be what carries the line over and that it
end the line, and the sentence asked neither.

A `tokenize` pass over every tracked Python file, printing its token and
comment-token totals beside its answer, is what refutes the census. The
whole-line comments over 80 columns do all end in a link. The comments
following code on their line that are over 80 columns do not, and they
are the larger group -- a `type: ignore`, a `noqa` or a `pragma` reason
where it is not an ordinary remark, one of them
`src/btclib/ecc/ellswift.py:171` at 137 columns. The same classifier
over the probe file separates linked from unlinked whole-line comments,
so the zero on one side is an absence and not a broken instrument.
ruff's own input set is exactly the files that pass read,
`pyproject.toml` aside.

`.pre-commit-config.yaml` said the `toml-comment-width` pygrep's test
"is MD013's amnesty and ruff's". It is MD013's and not ruff's: a line of
prose ending in a 40-character unbroken token, 91 columns, passes
markdownlint-cli2 v0.23.2 under this tree's `.markdownlint.jsonc` and
passes the pygrep, and the same text as a whole-line comment is reported
`93 > 80`. A 90-column line with whitespace past column 80 is the
control and both report it.

`bitcoin-core-rpc`'s coder replaced its copy with a pointer to section 9
rather than a corrected condition. This tree points at section 9 too --
two statements of one mechanism are what produced this issue -- but a
pointer alone leaves the census standing, so what replaces it is a
property the gate makes true: while
`uv run ruff check --select W505 --no-cache .` passes, a comment over 80
columns is either one the rule passes over or one the key never reaches.
Nothing in that ages while the gate is green.

One neighbour was left alone. `.vscode/settings.json` says W505 holds a
comment and a docstring to 80, without the distinction the
`line-too-long` comment above now draws, and that paragraph is shared
by four of the trees; btclib-org/.github#841 is where the family sits.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr


Local review: CLEARED 42253aa, which is this head — at fresh context, re-deriving the census with its own tokenize pass and re-measuring the W505 disjunction and the pygrep/MD013/W505 divergence on its own probes rather than reading them. Gates on that tree, all exit 0: `uv sync`; `uv run ruff check --fix`; `uv run ruff format`; `uv run mypy src/btclib tests .github/scripts`; `uv run pytest` (32179 passed, 31 skipped, 1 xfailed, 100.00% coverage); `uv run pre-commit run --all-files` (41 Passed, 1 Skipped, 0 Failed); `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Correct the documented behavior of comment-width exemptions across Ruff, markdownlint, and the TOML pre-commit check.

Enhancements:
- Clarify the Ruff W505 URL exemption and comment coverage in pyproject.toml by referring to the organization standard instead of stating an unconditional rule or inaccurate census.
- Correct the pre-commit configuration comment to distinguish the TOML comment-width check from Ruff's W505 behavior.

Documentation:
- Document the corrected comment-width and URL-amnesty guidance in the changelog.
