### PR TITLE
tests/build_system_test.py's join reader sees a directory carried in the same literal (closes #1736)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1649,6 +1649,21 @@ file of the test tree, and no caller acts on it.
   whole-line Python comment is reported. The census went with it there
   too.
 
+### `tests/build_system_test.py`'s join reader sees a directory in one literal
+
+- **`_reaches_outside_the_sdist`'s `/`-join check widens from an exact
+  `".github"`/`"fuzz"` match on the right operand to one that also
+  opens with the name and a slash** (closes #1736): `_ROOT /
+  ".github/workflows"` carries the sub-path in the same literal the
+  join reads, which the exact match missed, and `tests/interpreters_test.py`
+  reads `.github/workflows` this way while shipping in the sdist and
+  meeting a missing `.github` when run from an unpacked one.
+  `tests/docs_commands_test.py` ships the same way, but its own
+  `.github/workflows/docs.yml` sits in a dict key the join reaches
+  through a variable rather than through the literal itself, which the
+  widened detector still does not see; both now join
+  `[tool.uv.build-backend] source-exclude`.
+
 ## v2026.9.3
 
 ### Repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,7 +290,12 @@ source-exclude = [
     # recognizes as reaching .github or fuzz/ is named here
     "/tests/check_py_arm_authority_test.py",
     "/tests/check_vendored_vectors_test.py",
+    # a shape the reader above does not see at all: the path sits in a
+    # dict key here, and the join it feeds happens through a variable
+    # rather than through the literal itself (issue #1736)
+    "/tests/docs_commands_test.py",
     "/tests/generate_sbom_test.py",
+    "/tests/interpreters_test.py",
     "/tests/mutation_counts_test.py",
     "/tests/mutation_sessions_test.py",
     "/tests/normalize_sdist_test.py",

--- a/tests/build_system_test.py
+++ b/tests/build_system_test.py
@@ -158,11 +158,19 @@ def _source_exclude() -> list[str]:
 def _reaches_outside_the_sdist(tree: ast.Module) -> bool:
     """Whether a module reads `.github`, `fuzz`, or `.git` off the tree.
 
-    Two shapes. The first is the convention `Path(__file__).parents[1] /
-    ".github" / "scripts" / "<name>.py"` and `Path(__file__).parent.parent
-    / "fuzz"` follow -- a `/` join with one side the literal directory
-    name -- walked rather than matched on the formatted text, so a reflow
-    of the expression across lines is still seen.
+    Two shapes. The first is a `/` join whose right side is the literal
+    directory name or opens with it and a slash -- the convention
+    `Path(__file__).parents[1] / ".github" / "scripts" / "<name>.py"` and
+    `Path(__file__).parent.parent / "fuzz"` follow, and `_ROOT /
+    ".github/workflows"` too -- walked rather than matched on the
+    formatted text, so a reflow of the expression across lines is still
+    seen. Split on the slash rather than matched as a substring, so a
+    name merely starting with the same letters -- ".githubbookmark" --
+    is not mistaken for the directory. What this still does not reach is
+    a literal that never sits at the join itself:
+    `tests/docs_commands_test.py` names ".github/workflows/docs.yml" as
+    a dict key and reads through a variable holding it, so that module
+    is named in `source-exclude` by hand rather than found here.
 
     The second is `tests/changelog_immutability_test.py`'s own: it reads
     a release's own tag with `subprocess.run([_GIT, ...])` rather than a
@@ -182,7 +190,8 @@ def _reaches_outside_the_sdist(tree: ast.Module) -> bool:
             isinstance(node, ast.BinOp)
             and isinstance(node.op, ast.Div)
             and isinstance(node.right, ast.Constant)
-            and node.right.value in (".github", "fuzz")
+            and isinstance(node.right.value, str)
+            and node.right.value.split("/", 1)[0] in (".github", "fuzz")
         ):
             return True
         if (
@@ -206,12 +215,13 @@ def test_every_test_reaching_outside_the_sdist_is_source_excluded() -> None:
     direction closes what ISS 1509 found open.
 
     And not every test that reaches outside the sdist: what the reader
-    sees of a directory is a `/` join on its own name, so a path with
-    the whole of it in one literal -- `_ROOT / ".github/workflows"` --
-    is outside its reach and outside this assertion's, which is issue
-    #1736. Widening the sentence here without widening the reader is
-    what would put the guarantee ISS 1509 asked for on a green run that
-    does not give it.
+    sees is a `/` join whose own right side names the directory, so a
+    literal that reaches a join only through a variable -- a dict key
+    read out by name and joined later, the way
+    `tests/docs_commands_test.py` reads ".github/workflows/docs.yml" --
+    is outside its reach and outside this assertion's. Widening the
+    sentence here without widening the reader is what would put the
+    guarantee ISS 1509 asked for on a green run that does not give it.
     """
     excluded = set(_source_exclude())
     missing = [


### PR DESCRIPTION
`tests/build_system_test.py`'s reader recognized a `/` join whose right
operand is exactly `".github"` or `"fuzz"`. A join carrying the sub-path
in that same literal — `_ROOT / ".github/workflows"` — was invisible to
it, and `tests/interpreters_test.py` reads its workflows that way while
shipping in the sdist, where it meets a missing `.github`. That is
[ISS 1509](https://github.com/btclib-org/btclib/issues/1509)'s failure,
reported green by the test that exists to make it impossible.

The reader now matches the operand's first slash-separated segment, so a
name merely opening with the same letters is not mistaken for the
directory. `tests/interpreters_test.py` joins `source-exclude` and the
assertion is what keeps it there: removing the entry fails the test,
naming that module.

`tests/docs_commands_test.py` ships the same way and is named in
`source-exclude` by hand, the reader not reaching it — its
`.github/workflows/docs.yml` sits in a dict key, and the join reads a
variable holding it. That residual is stated in the code rather than
papered over, and the alternative was measured rather than assumed:
matching the literal anywhere in the module rather than at the join
flags `docs_commands_test.py`, which is wanted, and
`build_system_test.py` itself, which is not — that module holds
`".github"` and `"fuzz"` as the reader's own data and reads nothing.

The reviewer sharpened why that false positive is disqualifying rather
than merely untidy: `build_system_test.py` is the module whose test
verifies the sdist's contents, so excluding it from the sdist would
remove that check from an unpacked-sdist run — the same "green because
nothing looked" mechanism ISS 1509 and ISS 1736 exist to close, one
level up.

A coder wrote this and a watchdog killed it before it committed. I read
its uncommitted work, took the measurements it had not reported, and
wrote the commit message, so the diff reached review with no author's
round behind it and the message held to the tree's standard with no
author to defer to. Reviewed at fresh context afterwards: the reviewer
re-ran the old and new readers over every `tests/*.py` (the widening
adds exactly `interpreters_test.py` and drops nothing), confirmed
`".githubbookmark"` is refused, established that the added `isinstance`
guard is load-bearing rather than decorative, re-ran the removal
experiment and proved its restore against the object rather than the
working tree, and re-derived the broad-alternative comparison
independently.

It noted one non-blocking thing: this entry's own `CHANGELOG.md` bullet
wraps to more lines than an optimal fill needs. True, and left as it is
— the entry has to be right rather than tight.

Closes #1736

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Strengthen source-distribution validation so all tests that access external repository directories are excluded or detected reliably.

Bug Fixes:
- Ensure the source-distribution coverage check detects tests that join a directory name with a subpath in the same string literal.
- Prevent similarly prefixed directory names from being falsely recognized as `.github` or `fuzz` paths.

Enhancements:
- Explicitly exclude the documentation command tests whose external workflow path is accessed indirectly and cannot be detected by the join reader.

Tests:
- Update the build-system test’s source-exclusion expectations to cover the newly detected interpreter tests and the indirectly detected documentation command tests.

Chores:
- Document the source-distribution path detection fix in the changelog.