### PR TITLE
check_vendored_vectors.py names an entry carrying no `behind` line of its own (closes #1741)

### DIFF
--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -39,22 +39,28 @@ A path upstream has renamed or deleted is reported rather than raising:
 it has no commit to name as a tip, and a pin standing on a file that is
 not there any more is the one drift nobody would otherwise notice.
 
-Three shapes a ledger can carry that this script does not attempt: an
-entry with no `commit` at all (chain data self-identified by hash,
-files this project composed itself), a path carrying a `<name>`
-placeholder -- one pin standing in for several real paths under a
-directory, which the "commits touching a path" call above cannot be
-asked about in one request -- and a heading with no fenced block under
-it at all, which is either a group heading the pins below it supersede
-or a pin whose block an edit broke. No current entry uses the
-placeholder shape: BIP327's eight files and BIP324's two were
-themselves written that way once, each pin citing one commit as the tip
-of every path it stood in for.
-Splitting them into one pin per real path is what brought them into
-this script's scope, and also corrected BIP327's, whose shared commit
-was the tip of only one of the eight. Every heading the ledger carries
-but this script did not check is listed in its own report, so nothing
-silently reads as "checked and clean" that was not checked at all.
+Shapes a ledger can carry that this script does not attempt: an entry
+with no `commit` at all (chain data self-identified by hash, files
+this project composed itself), a path carrying a `<name>` placeholder
+-- one pin standing in for several real paths under a directory, which
+the "commits touching a path" call above cannot be asked about in one
+request; a heading with no fenced block under it at all, which is
+either a group heading the pins below it supersede or a pin whose
+block an edit broke; and a block carrying no `behind` line at all,
+which is neither a documented gap nor a tip a human confirmed and is
+named on its own rather than folded into either.
+
+No current entry uses the placeholder shape: BIP327's eight files and
+BIP324's two were themselves written that way once, each pin citing
+one commit as the tip of every path it stood in for. Splitting them
+into one pin per real path is what brought them into this script's
+scope, and also corrected BIP327's, whose shared commit was the tip of
+only one of the eight. `tests/_data/descriptor_checksums.json` carries
+no `behind` line: it pins the document revision its checksums were
+checked against, not a copy this repository re-derives. Every heading
+the ledger carries but this script did not check is listed in its own
+report, so nothing silently reads as "checked and clean" that was not
+checked at all.
 
     python .github/scripts/check_vendored_vectors.py \
         tests/_data/README.md "Vendored vectors behind upstream"
@@ -119,10 +125,12 @@ class Drift:
 def _entries_at_tip(ledger: str) -> tuple[list[Entry], list[str]]:
     """Return the checkable entries, and the headings this skips.
 
-    A heading is skippable for any of four reasons: no fenced block of
-    its own, no repo/path/commit triple, a path carrying a `<name>`
-    placeholder, or a `behind` already other than 0 -- a gap a human
-    already decided not to close.
+    A heading is skippable for several reasons: no fenced block of its
+    own, no repo/path/commit triple, a path carrying a `<name>`
+    placeholder, a `behind` already other than 0 -- a gap a human
+    already decided not to close -- or no `behind` line at all, which
+    is distinct from that gap and is named as its own reason rather
+    than folded into it.
 
     The first is the one the loop below cannot see, walking blocks as it
     does: a heading owning none never enters it. A group heading a finer
@@ -160,7 +168,11 @@ def _entries_at_tip(ledger: str) -> tuple[list[Entry], list[str]]:
         if "<" in path:
             skipped.append(f"{heading} (one pin serves several files)")
             continue
-        if not fields.get("behind", "").startswith("0"):
+        behind = fields.get("behind")
+        if behind is None:
+            skipped.append(f"{heading} (no behind line at all)")
+            continue
+        if not behind.startswith("0"):
             skipped.append(f"{heading} (already documented as behind)")
             continue
         entries.append(Entry(heading, repo, path.strip(), commit.split()[0]))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1664,6 +1664,19 @@ file of the test tree, and no caller acts on it.
   widened detector still does not see; both now join
   `[tool.uv.build-backend] source-exclude`.
 
+### `check_vendored_vectors.py` names an entry with no `behind` line of its own
+
+- **`_entries_at_tip` skips an entry carrying no `behind` line at all as
+  `(no behind line at all)`, not `(already documented as behind)`**
+  (closes #1741). `.get("behind", "").startswith("0")` answered the
+  same skip for both, so a pin nobody has confirmed at upstream's tip
+  read as a gap somebody had already decided to leave —
+  `tests/_data/descriptor_checksums.json` is that shape, its `commit`
+  pinning a document revision rather than a copy this repository
+  re-derives, so it carries no `behind` line by design. The docstring
+  now names this as one more shape the script does not attempt,
+  beside the ones it already listed.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/check_vendored_vectors_test.py
+++ b/tests/check_vendored_vectors_test.py
@@ -146,27 +146,41 @@ def test_a_placeholder_path_is_skipped(checker: ModuleType) -> None:
     assert skipped == ["group (one pin serves several files)"]
 
 
-@pytest.mark.parametrize(
-    "fields",
-    [
-        {"behind": "3 revisions, none touching the vectors"},
-        {},  # no `behind` field at all
-    ],
-)
-def test_a_behind_pin_is_skipped(checker: ModuleType, fields: dict[str, str]) -> None:
-    """A `behind` reading anything but 0, explicit or absent, is a skip."""
+def test_a_behind_pin_is_skipped(checker: ModuleType) -> None:
+    """A `behind` reading anything but 0 is a skip, named as documented."""
     text = readme(
         entry(
             "stale",
             repo="btclib-org/btclib",
             path="tests/f.json",
             commit="deadbeef  2026-01-01",
-            **fields,
+            behind="3 revisions, none touching the vectors",
         )
     )
     entries, skipped = checker._entries_at_tip(text)
     assert entries == []
     assert skipped == ["stale (already documented as behind)"]
+
+
+def test_a_pin_with_no_behind_line_is_skipped(checker: ModuleType) -> None:
+    """No `behind` line at all is a skip distinct from a documented one.
+
+    `.get("behind", "").startswith("0")` would answer False here too,
+    which is the defect this tells apart: an entry that was never
+    marked either way is not the same as one a human has already
+    decided to leave behind.
+    """
+    text = readme(
+        entry(
+            "stale",
+            repo="btclib-org/btclib",
+            path="tests/f.json",
+            commit="deadbeef  2026-01-01",
+        )
+    )
+    entries, skipped = checker._entries_at_tip(text)
+    assert entries == []
+    assert skipped == ["stale (no behind line at all)"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`_entries_at_tip` skipped an entry whose `behind` field does not start
with `0` as `(already documented as behind)`, and an entry carrying no
`behind` line at all took the same branch, `.get` answering `""`. The
weekly report then told a reader a gap had been decided where the ledger
documents none — and a pin whose `behind` line an edit removed would
arrive wearing a label that reads as deliberate, which the script's own
docstring says it should name rather than swallow.

The two are told apart, and the docstring names the shape beside the
others it already lists. `tests/_data/descriptor_checksums.json` is that
shape and is not a defect to correct in the ledger: its `commit` pins
the document revision its checksums were checked against, not a copy
this repository re-derives, so it carries no `behind` line by design and
the script has to accommodate one rather than demand it.

Over the ledger as it stands the change moves exactly that entry's line
and nothing else — `tests/ecc/_data/rfc6979.json` still leaves through
`(no fenced block)`, a different and correct branch of the same
function — and the new test fails against the unfixed script and passes
against the fixed one.

A coder wrote this and a watchdog killed it before it committed. I read
its uncommitted work and found three defects in it: the `CHANGELOG.md`
entry had been written into `## v2026.9.3`, a **released** section; the
docstring stated a count, which is the shape this tree forbids and which
goes stale the moment a second such entry exists; and an edit had left a
paragraph ragged, a line closing at 55 columns against full ones. All
three fixed, the refill proved whitespace-only against a control, before
the branch went to review.

Reviewed at fresh context afterwards. The reviewer re-derived both
measurements from its own copies of the two script versions rather than
accepting mine, read the `descriptor_checksums.json` characterisation
against that entry in the ledger, and confirmed nothing the removed
parametrized case covered is now uncovered.

It found one adjacent shape this diff does not reach: a `behind` line
**present but empty** is not `None`, so it still falls through to
`(already documented as behind)` — the same mislabelling one step
along, pre-existing, folding the same way before this change, and with
no entry of that shape in the ledger today. Filed as
[ISS 1799](https://github.com/btclib-org/btclib/issues/1799) rather than
folded in here.

`btclib-org/btclib-secp256k1` carries a copy of this script and still
has the unfixed line; the reviewer confirmed its own ledger has no entry
lacking a `behind` line, so the bug is dormant there. The port is the
same three-file shape as this branch and is owed in the same campaign.

Closes #1741

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Correct vendored vector reporting so entries without their own `behind` line are identified separately instead of being mislabeled as already documented gaps.

Bug Fixes:
- Distinguish ledger entries with no `behind` line from entries explicitly documented as being behind, and report the former with a dedicated skip reason.

Enhancements:
- Update the checker documentation to describe entries lacking a `behind` line as an unsupported ledger shape.

Tests:
- Add coverage confirming entries without a `behind` line are skipped and named distinctly from documented gaps.