### PR TITLE
The yamllint and max-doc-length comments name the prose W505 reaches (closes #1792)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -478,10 +478,10 @@ repos:
         name: taplo (toml, in place fixes)
         exclude: ^uv\.lock$
   # the width of a yaml line, which nothing else here measured: the hook
-  # above holds markdown to 80 columns and ruff holds Python comments and
-  # docstrings to the same, and the workflows were a place prose could
-  # grow without a limit -- 117 columns at the worst. Toml was the other,
-  # and the hook below is what closed it.
+  # above holds markdown to 80 columns and ruff holds a docstring and a
+  # comment on a line of its own to the same, and the workflows were a
+  # place prose could grow without a limit -- 117 columns at the worst.
+  # Toml was the other, and the hook below is what closed it.
   # Width is the half of this a sibling gate could in principle have
   # covered; a key written twice, a block indented under nothing, a value
   # that is octal by accident are read by nothing else at all.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1677,6 +1677,18 @@ file of the test tree, and no caller acts on it.
   now names this as one more shape the script does not attempt,
   beside the ones it already listed.
 
+### The yamllint and `max-doc-length` comments name the prose W505 reaches
+
+- **`.pre-commit-config.yaml`'s yamllint-hook comment said ruff holds
+  Python comments and docstrings to 80 columns, and `pyproject.toml`'s
+  `max-doc-length` comment called itself the rest of what the formatter
+  leaves alone** (closes #1792): both are unqualified over a comment,
+  and so read as covering one following code on its line, which `W505`
+  does not reach — `line-too-long` reaches that shape and this tree
+  ignores it. Each now names the docstring and the comment on a line of
+  its own, and `max-doc-length` holds part of what the formatter leaves
+  rather than the whole of it.
+
 ## v2026.9.3
 
 ### Repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1260,9 +1260,10 @@ max-complexity = 10
 [tool.ruff.lint.pycodestyle]
 # 80 columns on the prose, where the code keeps the formatter's 88. Not a
 # compromise between two numbers: ruff-format reflows code and never a
-# comment or a docstring, so 88 is what it can enforce and this is the
-# rest -- the half of a file that carries the reasoning, held to the width
-# every markdown file here is already held to by MD013.
+# comment or a docstring, so 88 is what it can enforce and this holds
+# part of what it leaves -- a docstring and a comment on a line of its
+# own, where a file carries its reasoning -- to the width every markdown
+# file here is already held to by MD013.
 # W505 is in the "W" set selected above and is inert without this line,
 # ruff having no default doc length; setting it is the whole of the
 # switch. Which over-width lines the rule passes over is section 9 of


### PR DESCRIPTION
Two comments credited `max-doc-length` with a width it does not reach,
the overclaim [ISS 1749](https://github.com/btclib-org/btclib/issues/1749)
corrected at the `line-too-long` entry beside one of them.

`.pre-commit-config.yaml`'s yamllint-hook comment said ruff holds Python
comments and docstrings to 80 columns, unqualified over a comment and so
reading as covering one that follows code on its line.
`pyproject.toml`'s comment beside `max-doc-length = 80` called itself
"the rest" of what the formatter leaves alone, which reads the same way.
`W505` reaches a docstring and a comment on a line of its own;
`line-too-long` is what reaches the third shape, and this tree ignores
it, so nothing measures that width.

Each comment now names the two shapes, and `max-doc-length` holds part
of what the formatter leaves rather than the whole of it.

The other half of what ISS 1792 reports at the `pyproject.toml` site —
the residual claim that every comment still over 80 columns is a link —
is already gone, removed by `29d1bb58` under `btclib-org/.github#866`,
which replaced it with a pointer to section 9 of the organization
standard rather than a census. This branch credits that commit for it
and does not reintroduce it.

That landing is also why this branch is a rewrite rather than a rebase.
A coder wrote a version against the earlier tip and a watchdog killed it
before it committed; `29d1bb58` landed meanwhile and rewrote the very
comment the coder had edited, so `git merge-tree --write-tree` exits 1
with the plain driver, not only with the union driver disabled — a real
content conflict. The coder's version was discarded and both edits
written against the landed text. Nothing here had an author's round: the
diff and the message are the orchestrator's, and the review was told so.

Reviewed at fresh context. The reviewer re-established the three
premises itself — that the yamllint sentence survived `29d1bb58`
untouched, that `pyproject.toml`'s first claim survived and its second
did not — ran its own `W505` and `E501` probe with controls firing on
both, and read the whole `pyproject.toml` comment as one piece to check
that the landed paragraph's "either one of those" still refers to
something, which it does: the new sentence names the two shapes it
points back at.

Closes #1792

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Clarify the documented scope of Ruff's prose-length checks so comments accurately distinguish W505 from line-too-long.

Enhancements:
- Clarify repository comments to accurately describe which standalone docstrings and comments Ruff's W505 rule checks.

Documentation:
- Document the corrected scope of W505 and max-doc-length in the changelog.