### PR TITLE
tests/fuzz_test.py's decoder walks widen past parse and decode (closes #1646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1689,6 +1689,21 @@ file of the test tree, and no caller acts on it.
   its own, and `max-doc-length` holds part of what the formatter leaves
   rather than the whole of it.
 
+### `tests/fuzz_test.py`'s walks widen past `parse` and `decode`
+
+- **`test_every_class_that_decodes_is_driven_here` walks `parse`,
+  `b64decode` and `b58decode` together, and
+  `test_every_module_function_that_decodes_is_driven_here` walks
+  `parse`, `decode` and `checksum`** (closes #1646): a class gaining a
+  `b64decode` or a `b58decode`, or a module gaining a `checksum`, used
+  to join `TEXT_PARSERS` only where somebody remembered the line, which
+  is the mechanism issue #1629's own walk left standing for every family
+  beside `parse` and `decode`. The module-function walk stays a
+  containment check rather than an equality one: `point_from_octets`
+  and `b58.h160_from_address` are driven by the dicts under names no
+  literal tuple reaches without turning into the exclusion list this
+  file otherwise avoids, and its docstring says so.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/fuzz_test.py
+++ b/tests/fuzz_test.py
@@ -232,21 +232,40 @@ TEXT_PARSERS: dict[str, Callable[[str], Any]] = {
 }
 
 
+# A class-level decoder is one of these three: `parse` for octets, `b64decode`
+# and `b58decode` for the two text encodings a class reads on its own.
+# `serialization_boundary_test.py`'s `test_every_decoder_is_covered` draws the
+# same three names for the same reason -- no class in the library has ever
+# needed a fourth -- so widening this tuple is what a class gaining one would
+# ask for, in both files at once.
+_CLASS_DECODER_METHODS = ("parse", "b64decode", "b58decode")
+
+# And the module-function side of the same family: a bare function takes the
+# same three roles under different names, `descriptors.checksum` being the one
+# member with no class to read a `b64decode` or a `b58decode` off. What this
+# tuple does not reach is a decoder named otherwise -- `point_from_octets` and
+# `b58.h160_from_address` are two such, both driven by the dicts above and
+# found by neither this walk nor any tuple of literal names, since nothing
+# about their name says they decode. Their coverage rests on the dicts, by
+# hand, not on this walk
+_MODULE_DECODER_NAMES = ("parse", "decode", "checksum")
+
+
 def _classes_driven_here() -> set[str]:
-    """Every class the two dicts above drive through its own `parse`.
+    """Every class the two dicts above drive, through which decoder.
 
     A bound classmethod carries in `__self__` the class it was read off
     rather than the one that defines the method, which is what the entry
     names: `GetCFilters` inherits `_FilterRangeRequest.parse`, and
     `__qualname__` answers with a private base the walk below never
-    returns. A `b58decode` or a `b64decode` entry is not counted, its
-    class being driven here through a decoder and not through `parse`.
+    returns. The method name is part of the key, since a class offering
+    two of the three would otherwise collide.
     """
     driven = set()
     for entry_point in (*BINARY_PARSERS.values(), *TEXT_PARSERS.values()):
         cls = getattr(entry_point, "__self__", None)
-        if isinstance(cls, type) and entry_point.__name__ == "parse":
-            driven.add(f"{cls.__module__}.{cls.__qualname__}")
+        if isinstance(cls, type) and entry_point.__name__ in _CLASS_DECODER_METHODS:
+            driven.add(f"{cls.__module__}.{cls.__qualname__}.{entry_point.__name__}")
     return driven
 
 
@@ -259,17 +278,21 @@ def _functions_driven_here() -> set[str]:
     }
 
 
-def test_every_class_that_parses_is_driven_here() -> None:
+def test_every_class_that_decodes_is_driven_here() -> None:
     """The inventory is a promise only if omission is what fails.
 
     A class added to the library and given no line above is held to
     nothing here: the tests keep passing on the entry points they were
-    given, and the new parser answers hostile octets however it likes.
+    given, and the new decoder answers hostile input however it likes.
     The walk is `tests/__init__.py`'s, `parse_contract_test.py` and
     `serialization_boundary_test.py` holding these same classes to their
     own contracts through it.
     """
-    found = public_classes_with("parse")
+    found = {
+        f"{name}.{method}"
+        for method in _CLASS_DECODER_METHODS
+        for name in public_classes_with(method)
+    }
     # a walk returning nothing is a defect in the walk and not in the
     # inventory, and the equality alone answers it with a mismatch of
     # every name: this is what says which of the two a red run is
@@ -277,19 +300,22 @@ def test_every_class_that_parses_is_driven_here() -> None:
     assert found == _classes_driven_here()
 
 
-def test_every_module_function_that_parses_is_driven_here() -> None:
+def test_every_module_function_that_decodes_is_driven_here() -> None:
     """And the same promise where the entry point is a module function.
 
-    The walk above finds classes, so `var_int.parse` and `bech32.decode`
-    would be invisible to it. What is asserted is containment and not
-    equality: the dicts drive entry points these two names do not reach
-    -- `psbt_utils.deserialize_map`, `point_from_octets` -- and a family
-    wide enough to find those is a census this file does not keep.
+    The walk above finds classes, so a module-level decoder needs its
+    own names: `parse`, `decode` and `checksum` are what a bare function
+    carries in place of a class's `parse`, `b64decode` and `b58decode`.
+    What is asserted is containment and not equality: the dicts already
+    drive entry points named otherwise, and a tuple of literal names wide
+    enough to find every one of those is the exclusion list this file
+    otherwise avoids -- their coverage rests on the dicts above, by
+    hand, not on this walk.
     """
     found = set()
     for module_name in module_names():
         module = importlib.import_module(module_name)
-        for name in ("parse", "decode"):
+        for name in _MODULE_DECODER_NAMES:
             function = getattr(module, name, None)
             if not callable(function) or isinstance(function, type):
                 continue


### PR DESCRIPTION
`tests/fuzz_test.py`'s two completeness walks covered the entry points
named `parse` and, for a module function, `decode`. The decoder families
beside them were covered by nothing: a class gaining a `b64decode` or a
`b58decode`, or a module gaining a `checksum`, joined the driving dicts
only where somebody remembered the line — which is the mechanism
[ISS 1629](https://github.com/btclib-org/btclib/issues/1629) named, left
standing for the families the walk it added does not reach.

Nothing was missing, which is what made this a mechanism issue rather
than a gap one. So what was owed is the assertion.

The class walk now enumerates `parse`, `b64decode` and `b58decode`, and
asserts equality against what the dicts drive. That family is not a new
decision: `tests/serialization_boundary_test.py`'s
`test_every_decoder_is_covered` already draws exactly those three names
for the same reason, and the comment names that test.

The module-function walk gains `checksum` and stays a containment check,
which is the asymmetry worth explaining rather than smoothing over. A
module decoder has no small fixed vocabulary — `point_from_octets`,
`psbt_utils.deserialize_map`, `b32.witness_from_address` and
`b58.h160_from_address` are all driven under names no literal tuple
reaches without becoming the exclusion list this file otherwise avoids.
The docstring says so, and says their coverage rests on the dicts by
hand rather than on the walk, so a reader meeting two walks of two
strengths is told why in the file rather than left to "fix" the weaker.

Both walks were shown to fail before being trusted: removing
`BIP32KeyData.b58decode` from `TEXT_PARSERS` fails the class walk naming
it, and removing `descriptors.checksum` fails the module walk naming
that.

Reviewed at fresh context. The reviewer re-ran both demonstrations and
proved each restore against the object rather than the working tree,
walked `public_classes_with` live to confirm the equality holds exactly
today, and probed for a class decoder under any other name — only
`from_bytes` hits, and that is `int.from_bytes` inherited by a few
`IntFlag` classes, not a domain decoder.

It also corrected the branch's account of its own precedent: the model
is not `serialization_boundary_test.py`'s `_FAMILY`, which is a wider
eight-name family, but that file's own inline three-name tuple — which
is what the comment in the diff actually cites, so the citation stands
where the coder's report did not.

One gap in the coder's evidence, closed before this landed: it built the
docs outside `docs/build/html`, so the docs gate's second step — the
grep for a broken relative link over the built HTML, whose pass is exit
1 — had never run on any sha. Run here, it passes, with a control that
fires.

Closes #1646

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Broaden decoder completeness checks in the fuzz tests to detect missing dictionary coverage across class and module entry points.

Bug Fixes:
- Expand decoder coverage assertions in `tests/fuzz_test.py` so newly added class and module decoders cannot be omitted from the driving dictionaries.

Enhancements:
- Cover class-level `parse`, `b64decode`, and `b58decode` entry points with an exact inventory check.
- Cover module-level `parse`, `decode`, and `checksum` entry points while retaining containment semantics for decoders with nonstandard names.

Tests:
- Strengthen fuzz-test completeness walks and document why class and module decoder checks use different assertion strategies.