### PR TITLE
Two test docstrings drop counts nothing re-derives (closes #1796)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1720,6 +1720,16 @@ file of the test tree, and no caller acts on it.
   `p2p/inventory.py`'s `Headers` docstring now matches the pinned "not
   hashable" shape instead of a wording of its own.
 
+### `key_path_vectors` and `unimported_btclib` drop counts nothing re-derives
+
+- **`tests/script/sig_hash_taproot_test.py`'s `key_path_vectors` and
+  `tests/imports_test.py`'s `unimported_btclib` each stated a figure
+  that nothing in the tree re-derives** (closes #1796): a docstring
+  figure is checked by no test and pinned in no README, the shape
+  `tests/vendored_data_test.py` spares, so each is a count like any
+  other here. Both docstrings keep the argument the figure was
+  standing in for and state it without the figure.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/imports_test.py
+++ b/tests/imports_test.py
@@ -46,8 +46,8 @@ def unimported_btclib() -> Iterator[None]:
     A subprocess per module would be the obvious way to get a virgin
     interpreter, and it is what issue #147 used to demonstrate the
     failure, but as a test it costs an interpreter start-up per module,
-    some sixty of them, and buys nothing: the import machinery decides
-    what to execute by consulting sys.modules and nothing else.
+    and buys nothing: the import machinery decides what to execute by
+    consulting sys.modules and nothing else.
 
     What the modules imported inside the fixture must not do is outlive
     it. They are fresh objects, so a class reimported here is not the

--- a/tests/script/sig_hash_taproot_test.py
+++ b/tests/script/sig_hash_taproot_test.py
@@ -66,8 +66,7 @@ def key_path_vectors(outcome: str, taproot_flag: bool) -> list[Any]:
 
     Selecting them here rather than skipping the others with `continue`
     inside the test is what makes the count in the report the count of
-    what ran: of the 2243 vectors in the file, three quarters are not
-    key path spends.
+    what ran: most of the vectors in the file are not key path spends.
 
     The parse of every prevout is the price, paid once per worker at
     collection rather than repeated per test.


### PR DESCRIPTION
Two test docstrings stated a figure nothing re-derives.
`tests/script/sig_hash_taproot_test.py`'s `key_path_vectors` said "of
the 2243 vectors in the file, three quarters are not key path spends",
and `tests/imports_test.py`'s `unimported_btclib` said a subprocess per
module costs an interpreter start-up "some sixty of them".

[ISS 1770](https://github.com/btclib-org/btclib/issues/1770) closed the
same file family for wall clocks a few hours ago and its sweep could not
see these: its pattern was `(ms|s)`, and a count carries no unit.

The question the issue existed to settle was whether the
upstream-count exception follows the *kind* of count or the *place* it
is written — `2243` being a count of what upstream published, which is
the exception `REVIEWING.md` names. It follows the place: that rule ties
the exception to a pin in `tests/_data/README.md`, and
`tests/vendored_data_test.py` spares exactly the shapes in that file, so
a figure in a test docstring is spared by nothing and checked by
nothing. Both figures go, "three quarters" with them — a proportion of
this tree's own data is the same shape, and `REVIEWING.md`'s own
enumeration lists a percentage beside the rest.

Each sentence keeps the argument the figure was standing in for.
`key_path_vectors` exists to say that selecting at collection makes the
reported count mean what it looks like it means, which needs a majority
excluded and not a fraction; `unimported_btclib`'s "costs an interpreter
start-up per module and buys nothing" does not depend on how many
modules there are.

Reviewed at fresh context, and the review earned the change rather than
approving it: the reviewer re-derived the real proportion from the
vendored file — about seven in eight of the p2tr candidates are not key
path spends, not three quarters — so the figure had already drifted and
nothing had noticed, which is the argument for removing it rather than
refreshing it. It also read the two paragraphs of that docstring
together, the neighbour having lost its own wall clock in
[PR 1793](https://github.com/btclib-org/btclib/pull/1793), and confirmed
they now read as one voice.

The reviewer filed
[ISS 1804](https://github.com/btclib-org/btclib/issues/1804) for a third
site of the same shape, in a file this branch does not touch.

Both steps of the docs gate were run before landing, the relative-link
grep over the built HTML included, with a control that fires.

Closes #1796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Replace untracked test-documentation counts with durable qualitative descriptions.

Enhancements:
- Remove stale, unverified numeric claims from two test docstrings while preserving their explanations of test behavior.

Documentation:
- Document the removal of unvalidated figures from the affected test documentation in the changelog.