### PR TITLE
check_vendored_vectors.py names a `behind` line present but empty (closes #1799)

### DIFF
--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -46,9 +46,11 @@ this project composed itself), a path carrying a `<name>` placeholder
 the "commits touching a path" call above cannot be asked about in one
 request; a heading with no fenced block under it at all, which is
 either a group heading the pins below it supersede or a pin whose
-block an edit broke; and a block carrying no `behind` line at all,
-which is neither a documented gap nor a tip a human confirmed and is
-named on its own rather than folded into either.
+block an edit broke; a block carrying no `behind` line at all, which
+is neither a documented gap nor a tip a human confirmed and is named
+on its own rather than folded into either; and a `behind` line
+present but empty, closer to that same broken block than to a
+decision anybody made, and named apart from both.
 
 No current entry uses the placeholder shape: BIP327's eight files and
 BIP324's two were themselves written that way once, each pin citing
@@ -128,9 +130,10 @@ def _entries_at_tip(ledger: str) -> tuple[list[Entry], list[str]]:
     A heading is skippable for several reasons: no fenced block of its
     own, no repo/path/commit triple, a path carrying a `<name>`
     placeholder, a `behind` already other than 0 -- a gap a human
-    already decided not to close -- or no `behind` line at all, which
-    is distinct from that gap and is named as its own reason rather
-    than folded into it.
+    already decided not to close -- no `behind` line at all, which is
+    distinct from that gap and is named as its own reason rather than
+    folded into it, or a `behind` line present but empty, closer to a
+    broken block than to either decision and named apart from both.
 
     The first is the one the loop below cannot see, walking blocks as it
     does: a heading owning none never enters it. A group heading a finer
@@ -171,6 +174,9 @@ def _entries_at_tip(ledger: str) -> tuple[list[Entry], list[str]]:
         behind = fields.get("behind")
         if behind is None:
             skipped.append(f"{heading} (no behind line at all)")
+            continue
+        if not behind.strip():
+            skipped.append(f"{heading} (behind line present but empty)")
             continue
         if not behind.startswith("0"):
             skipped.append(f"{heading} (already documented as behind)")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1730,6 +1730,17 @@ file of the test tree, and no caller acts on it.
   other here. Both docstrings keep the argument the figure was
   standing in for and state it without the figure.
 
+### `check_vendored_vectors.py` names a `behind` line present but empty
+
+- **`_entries_at_tip` skips a `behind` line that is present but carries
+  no value of its own as `(behind line present but empty)`, not
+  `(already documented as behind)`** (closes #1799): `.get("behind")`
+  answers `""` for such a line, and `"".startswith("0")` is False, so
+  it fell into the same skip as a `behind` a human has already read
+  and left at something other than 0. Nobody has "already documented"
+  anything by leaving the value blank -- the shape is closer to a
+  broken block than to a decision, and is now named apart from both.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/check_vendored_vectors_test.py
+++ b/tests/check_vendored_vectors_test.py
@@ -183,6 +183,29 @@ def test_a_pin_with_no_behind_line_is_skipped(checker: ModuleType) -> None:
     assert skipped == ["stale (no behind line at all)"]
 
 
+def test_a_pin_with_an_empty_behind_line_is_skipped(checker: ModuleType) -> None:
+    """A `behind` line present but blank is a skip of its own, not a gap.
+
+    `fields.get("behind")` answers `""` here, not `None`, so
+    `"".startswith("0")` is False and the entry would otherwise fall
+    into the same skip as a `behind` a human has already read and left
+    at something other than 0 -- which nobody has done by leaving the
+    value blank.
+    """
+    text = readme(
+        entry(
+            "stale",
+            repo="btclib-org/btclib",
+            path="tests/f.json",
+            commit="deadbeef  2026-01-01",
+            behind="",
+        )
+    )
+    entries, skipped = checker._entries_at_tip(text)
+    assert entries == []
+    assert skipped == ["stale (behind line present but empty)"]
+
+
 @pytest.mark.parametrize(
     "fields",
     [


### PR DESCRIPTION
[PR 1800](https://github.com/btclib-org/btclib/pull/1800) split
`_entries_at_tip`'s `behind` handling an hour earlier: `behind is None`
became `(no behind line at all)`, and everything else that does not
start with `0` stayed `(already documented as behind)`. A `behind` line
**present but empty** is not `None`, so it kept falling into the second
branch — the same mislabelling one shape along, telling a reader a gap
had been decided where nobody has decided anything by leaving a value
blank.

The two are told apart, and both docstrings name the shape. The
reasoning is deliberately not the one the absent case got: an absent
`behind` is ambiguous between two decisions and has a legitimate
by-design instance in the ledger, while an empty one is edit residue,
which is why it is likened to the pin whose block an edit broke rather
than to a decision.

No entry in either ledger has this shape, so the evidence is that the
skip lists are **identical** before and after over both
`tests/_data/README.md` and `TF2.md` — a change there would mean an
entry that was fine got moved — while the new test fails against the
old script with `assert ['stale (already documented as behind)'] ==
['stale (behind line present but empty)']` and passes against this one.

Reviewed at fresh context, and the review went past the diff to ask what
the field can hold at all. It enumerated the output space of
`fields.get("behind")` structurally and confirmed the branch covers it:
whitespace-only content reduces to `""` because `behind` is the last
field in every current entry, so `{None, "", starts-with-0,
other-non-empty}` is the whole of it. It confirmed `TF2.md` is genuinely
a second ledger this script is run over rather than a file that merely
parses, by reading the workflow's matrix.

It also found something the branch does not touch and filed it as
[ISS 1807](https://github.com/btclib-org/btclib/issues/1807):
`_FIELD`'s `\s+` separator matches a newline, so a bare key that is
**not** last in its block swallows the following line whole and that
line's own field is never matched. Dormant today only because `behind`
is always last.

One caveat the reviewer raised is closed here rather than left standing:
the coder had run `pytest` and `sphinx` through `.venv/bin/python`,
which establishes that an environment passed rather than that the locked
one did. Both were re-run through `uv run --locked` before this landed,
along with both steps of the docs gate.

Closes #1799

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Distinguish empty `behind` fields from documented gaps when checking vendored vectors.

Bug Fixes:
- Correctly classify vendored vector entries with a present but empty `behind` line as `behind line present but empty` instead of `already documented as behind`.
- Add regression coverage for the distinct empty-`behind` skip reason.

Enhancements:
- Clarify the documentation for the different vendored vector skip conditions.

Documentation:
- Document the empty `behind` line classification in the changelog.

Tests:
- Add a test covering entries whose `behind` field is present but blank.