### PR TITLE
test_const_scriptcode_refuses_signature_checks drops a proportion nothing re-derives (closes #1804)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1741,6 +1741,18 @@ file of the test tree, and no caller acts on it.
   anything by leaving the value blank -- the shape is closer to a
   broken block than to a decision, and is now named apart from both.
 
+### `test_const_scriptcode_refuses_signature_checks` drops a proportion
+
+- **`tests/script_engine/script_test.py`'s
+  `test_const_scriptcode_refuses_signature_checks` docstring stated "three
+  quarters of the list" without a command that derives it** (closes #1804): a
+  docstring figure is checked by no test and pinned in no README, the shape
+  `tests/vendored_data_test.py` spares, so it is a count like any other here.
+  The docstring keeps the argument the figure was standing in for -- that the
+  vendored vectors cover only `OP_CHECKSIG` in a `script_sig` under the flag,
+  so the other three names rest on this test alone -- and states it without
+  the figure.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/script_engine/script_test.py
+++ b/tests/script_engine/script_test.py
@@ -1006,13 +1006,14 @@ def test_wrapped_p2wsh_codeseparator_cuts_the_same_script() -> None:
 def test_const_scriptcode_refuses_signature_checks(op_code: str) -> None:
     """CONST_SCRIPTCODE refuses every signature-check op in a script_sig.
 
-    Core watches all four through one rule -- FindAndDelete of the
-    signature from the script code, an error on a match under the flag,
-    before the signature is read at all -- so the class is one list of
-    four names here, and a name missing from it is a rule that does not
-    run rather than a rule that fails. Which is what the vectors cannot
-    say: they put only OP_CHECKSIG in a script_sig under the flag, so
-    three quarters of the list rest on this test alone.
+    Core watches all four through one rule -- FindAndDelete of the signature
+    from the script code, an error on a match under the flag, before the
+    signature is read at all -- so the class is one list of four names here,
+    and a name missing from it is a rule that does not run rather than a rule
+    that fails. Which is what the vendored vectors cannot say: OP_CHECKSIG is
+    the only one of the four they carry in a script_sig under the flag, so
+    OP_CHECKSIGVERIFY, OP_CHECKMULTISIG and OP_CHECKMULTISIGVERIFY rest on this
+    test alone.
     """
     prevout = TxOut(1000, ScriptPubKey(""))
     tx_in = TxIn(OutPoint(b"\x01" * 32, 0), serialize([op_code]), 1, Witness([]))


### PR DESCRIPTION
`test_const_scriptcode_refuses_signature_checks`'s docstring said "they
put only OP_CHECKSIG in a script_sig under the flag, so **three quarters
of the list** rest on this test alone" — a proportion of this tree's own
vendored data that nothing re-derives, and that a future vendored-vector
update could make false with no test failing.

It now names the members instead: OP_CHECKSIG is the one the vectors
carry, so OP_CHECKSIGVERIFY, OP_CHECKMULTISIG and OP_CHECKMULTISIGVERIFY
rest on this test alone. That reads better than the fraction did, which
told a reader nothing about *which* three.

This is the third site of a shape closed twice today, after
[PR 1793](https://github.com/btclib-org/btclib/pull/1793)'s wall clocks
and [PR 1806](https://github.com/btclib-org/btclib/pull/1806)'s two
counts — the second of which was found, in review, to have already
drifted, which is the argument for naming members rather than
refreshing a figure.

Naming members only helps if the names are right, so both the coder and
the reviewer derived them from the vendored files rather than from the
sentence being replaced. That derivation turns on an asymmetry:
`tx_valid.json`'s named flags are turned **off** from the full set while
`tx_invalid.json`'s named flags are the **only** ones turned on,
matching Core's `~verify_flags` and `verify_flags`. The reviewer wrote
its own byte-level script parser rather than searching for opcode names
as substrings, and found `OP_CHECKSIG` in four of `tx_invalid.json`'s
flag-carrying vectors and none of the other three names anywhere;
`script_tests.json` never carries the flag at all. Its parser accounted
for every vector's bytes, and its count of `tx_valid.json` matches the
figure `tests/_data/README.md` pins for that file, which is independent
corroboration that it read the file correctly.

A gate would be better than a careful sentence, and it was weighed
rather than waved off. The reviewer's finding here was that the commit
message overstated the cost, and it was right: `flags_of` is an
importable function, so `tx_invalid.json`'s half is within reach and
only `tx_valid.json`'s inline computation would have to be extracted
first. The message was corrected to say that, and to say that a check
over `tx_invalid.json` alone would reach every occurrence the
measurement found. That amendment is message-only — both blobs
identical to the reviewed sha, `git diff` empty.

Closes #1804

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Replace the test documentation’s fragile coverage proportion with explicit signature-check opcode names.

Enhancements:
- Clarify the signature-check coverage documented by the constant-scriptcode test by naming the three opcodes that are not independently exercised by the vendored vectors instead of citing an unverified proportion.

Documentation:
- Update the changelog and test docstring to replace the non-derived “three quarters” claim with explicit opcode names.