### PR TITLE
check_vendored_vectors.py's field separator no longer crosses a newline (closes #1807)

### DIFF
--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -88,11 +88,17 @@ _GH = shutil.which("gh") or "gh"
 # path
 _HEADING = re.compile(r"^### (.+)$", re.MULTILINE)
 
-# a fenced block's key/value lines; a value's own continuation onto a
-# further, unindented-marker line (BIP327's "behind" wraps) is not
-# captured, and is not needed -- every check below reads only the first
-# line of a field
-_FIELD = re.compile(r"^(repo|path|commit|blob|pulled|behind)\s+(.*)$", re.MULTILINE)
+# a fenced block's key/value lines; a value's own continuation onto a further,
+# unindented-marker line (BIP327's "behind" wraps) is not captured, and is not
+# needed -- every check below reads only the first line of a field. The
+# separator is `[ \t]+` rather than `\s+`: `\s` also matches the newline ending
+# a bare key's own line, so a key written with no value and no trailing
+# whitespace, and not last in its block, would let the separator cross into the
+# following line and capture that whole line as its own value -- leaving the
+# field the next line actually names unmatched. Confining the separator to the
+# line answers a bare key with no match at all, which is what the checks below
+# already treat as that field being absent.
+_FIELD = re.compile(r"^(repo|path|commit|blob|pulled|behind)[ \t]+(.*)$", re.MULTILINE)
 
 
 @dataclass(frozen=True)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1753,6 +1753,18 @@ file of the test tree, and no caller acts on it.
   so the other three names rest on this test alone -- and states it without
   the figure.
 
+### `check_vendored_vectors.py`'s field separator no longer crosses a newline
+
+- **`_FIELD`'s separator between a key and its value is `[ \t]+`, not `\s+`**
+  (closes #1807): `\s` also matches the newline ending a bare key's own line,
+  so a key written with no value and no trailing whitespace, and not last in
+  its fenced block, let the separator cross into the following line and
+  capture that whole line as the bare key's own value, leaving the field that
+  line actually names unmatched. A bare key now matches nothing at all, which
+  `_entries_at_tip` already reads as that field being absent -- `(no behind
+  line at all)` for `behind`, `(no commit to check against)` for a bare
+  `repo`, `path` or `commit`.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/check_vendored_vectors_test.py
+++ b/tests/check_vendored_vectors_test.py
@@ -206,6 +206,29 @@ def test_a_pin_with_an_empty_behind_line_is_skipped(checker: ModuleType) -> None
     assert skipped == ["stale (behind line present but empty)"]
 
 
+def test_a_bare_field_that_is_not_last_does_not_swallow_the_next_line(
+    checker: ModuleType,
+) -> None:
+    r"""A bare key with nothing after it on its own line matches nothing.
+
+    `\s+` between a key and its value also matches the newline ending a
+    bare key's own line, so the separator used to cross into the
+    following line and capture it whole as the bare key's own value --
+    and the field that line actually names was then never matched at
+    all. Here `behind` is bare and is not the last field in its block,
+    so under the old separator it would swallow `commit`'s whole line
+    and the entry would wrongly read as having no commit rather than no
+    `behind`. `entry()` cannot pose this: it always writes a value,
+    hence the block is written out by hand, README-shaped.
+    """
+    text = (
+        "### `f.json`\n\n```text\nrepo  r\npath  p.json\nbehind\ncommit  cafe1234\n```"
+    )
+    entries, skipped = checker._entries_at_tip(text)
+    assert entries == []
+    assert skipped == ["`f.json` (no behind line at all)"]
+
+
 @pytest.mark.parametrize(
     "fields",
     [


### PR DESCRIPTION
`_FIELD`'s separator was `\s+`, and `\s` matches a newline. A bare key
with no trailing whitespace that is **not last in its block** therefore
made the greedy separator cross the line break, take the following line
as its value, and leave that line's own field unmatched entirely:

```python
>>> _FIELD.findall("repo x\nbehind\ncommit y")
[('repo', 'x'), ('behind', 'commit y')]   # 'commit' never matched
```

The separator is now `[ \t]+`, so a bare key matches nothing and reads
as an absent field, which `_entries_at_tip` already handles. No new skip
category was needed and none was invented — which matters, because this
is the third defect of one family closed in this file today, after
[PR 1800](https://github.com/btclib-org/btclib/pull/1800) and
[PR 1808](https://github.com/btclib-org/btclib/pull/1808), and each was
a case folded silently into a label that misdescribes it. A fourth fold
here would have been the same mistake again.

So the review checked the whole table rather than the sentence, and all
six field names land somewhere that describes them: a bare `behind`
reaches `(no behind line at all)`; a bare `repo`, `path` or `commit`
reaches `(no commit to check against)`; `blob` and `pulled` are read
nowhere, verified by producing an identical `Entry` from a block with a
bare `blob`, a block with `blob` removed, and the base block.

A narrowing can break a value the old pattern accepted, so that was
measured rather than assumed: the two regexes' output was compared
block-by-block over every fenced block in both ledgers,
`tests/_data/README.md` and `TF2.md`, and is identical — every entry
separates key from value with plain spaces. The reviewer also asked what
CRLF would do, since `[ \t]` does not match `\r`, and answered it from
the tree rather than in principle: `mixed-line-ending` runs with
`--fix=lf` and excludes only `fuzz/corpus/`, so neither ledger can carry
CRLF and pass this repository's own gate.

The new test builds its block by hand because the `entry()` fixture
always writes `key<two spaces>value` and so cannot pose a truly bare
key; the reviewer confirmed the hand-built block keeps that same
convention otherwise, a bypassed fixture being a place a test can
quietly test something else. It fails against the script as `main` had
it and passes against this one, and both ledgers' entry and skip lists
are unchanged, this shape being latent.

`btclib-org/btclib-secp256k1` carries a copy of this script still at the
shape all three fixes started from — it is owed ISS 1741's, ISS 1799's
and this one, in that order.

Closes #1807

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Constrain vendored-vector field parsing to spaces and tabs so bare fields cannot cross line boundaries and hide subsequent fields.

Bug Fixes:
- Prevent bare field names in vendored vector blocks from consuming the following line as their value.
- Treat bare fields as absent so existing validation reports the appropriate skip reason.

Documentation:
- Document the field-separator fix in the changelog.

Tests:
- Add coverage for a bare, non-final field and verify it does not swallow the next field.