### PR TITLE
`toml-comment-width`'s comment describes the pattern and no other tool (issue btclib-org/.github#843)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -504,12 +504,7 @@ repos:
   # formats values and leaves comments alone, by design, a formatter that
   # reflowed prose being a formatter that rewrites it.
   # `.{80}\S*[ \t]` reports a line only when whitespace is left past
-  # column 80, which is MD013's test and not W505's: a line whose
-  # overflow is one unbroken token passes here and in markdownlint, and
-  # the same text in a whole-line .py comment is reported. What W505
-  # passes over instead is section 9 of the organization standard's.
-  # With no amnesty at all this would be stricter on toml prose than the
-  # rules it mirrors are on the same sentences in a .py or a .md.
+  # column 80: a comment whose overflow is one unbroken token is exempt.
   # The `#` after optional indent selects a comment and not a long value:
   # `addopts` and `skip` in pyproject.toml are single tokens no width can
   # break, and a value is not prose.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1765,6 +1765,35 @@ file of the test tree, and no caller acts on it.
   line at all)` for `behind`, `(no commit to check against)` for a bare
   `repo`, `path` or `commit`.
 
+### `toml-comment-width`'s comment describes the pattern and no other tool
+
+- **The comment above the hook no longer says that a comment whose
+  overflow is one unbroken token is reported where the same text is a
+  whole-line Python comment** (issue btclib-org/.github#843): of two
+  94-column comments alike but for the `:` of `https://`, `W505` at this
+  tree's `max-doc-length = 80` passes over the one whose last word is a
+  link and reports the other, and one space inserted just after column
+  80 in the passed-over line makes both it and the pygrep report the
+  line, which is the control saying that silence is an absence. The
+  clause read the two rules as disjoint besides, and they overlap: the
+  pygrep reports a comment opening with `# type:` or `# noqa:` that
+  `W505` passes over, a `# abcd:` of the same width and shape flipping
+  the answer. What replaces it states the pattern's own predicate and
+  names no other tool, which is the wording btclib-org/.github#843
+  settled for the trees carrying this hook.
+- **The entry that stated the clause stays as written**: this file
+  rewrites nothing already in it, so *`pyproject.toml` and
+  `.pre-commit-config.yaml` stop wording the URL amnesty* keeps both its
+  `toml-comment-width` bullet and its `max-doc-length` bullet, of which
+  this corrects the `toml-comment-width` one. That change's commit
+  message says the same thing and reaches `git log` under
+  `squash_merge_commit_message = COMMIT_MESSAGES`, which nothing
+  rewrites, so this entry is where a reader of either is told otherwise.
+- **The hook's `name:` and `entry:` are left alone**: the lexical
+  amnesty the `name:` states against the positional rule the `entry:`
+  implements is btclib-org/.github#843's other half, one decision for
+  every tree carrying the hook rather than this tree's to take alone.
+
 ## v2026.9.3
 
 ### Repository


### PR DESCRIPTION
The comment above `toml-comment-width` said the pattern's test "is MD013's
test and not W505's", that a line whose overflow is one unbroken token
"passes here and in markdownlint, and the same text in a whole-line .py
comment is reported", and that what W505 passes over "instead" is section 9
of the organization standard's. The second clause is false where the token
is a link, and "instead" states a disjointness the two rules do not have.

The replacement is `btclib-node`'s landed sentence, read from that
repository's `origin/main` at `71f6aee1` rather than retyped, with a full
stop added because sentences follow it here where it ends the block there.
It states the pattern's own predicate and names no other tool, which is the
wording [ISS 843](https://github.com/btclib-org/.github/issues/843) settled
for the trees carrying this hook: every wording anyone wrote about a second
tool's behaviour has been refuted, each in its own way, and the record is on
that issue. `btclib-secp256k1` and `btclib-benchmarks` have already landed
it; this is the fourth tree.

The citation is `(issue …)` and not `(closes …)` on purpose. ISS 843's other
half — the lexical amnesty the hook's `name:` states against the positional
rule its `entry:` implements — is untaken, and it is one decision for every
tree carrying the hook rather than this tree's to take alone. The `name:`,
the `entry:` and `pyproject.toml`'s `[tool.ruff.lint.pycodestyle]` comment
are all untouched here.

`29d1bb58`'s changelog entry is still in the open section and states the
same clause, so section 9's *An entry in the open section is a live claim*
applies: the new entry says what it does to the earlier one and leaves it
where it is, and `--numstat` reports `29 0` on `CHANGELOG.md` — no deletion,
against the `6` on `.pre-commit-config.yaml` in the same instrument as the
control that the column is not blind.

`toml-comment-width`'s comment describes the pattern and no other tool (issue btclib-org/.github#843)

The comment above the hook said the pattern's test "is MD013's test and
not W505's", that a line whose overflow is one unbroken token "passes
here and in markdownlint, and the same text in a whole-line .py comment
is reported", and that what W505 passes over "instead" is section 9 of
the organization standard's. The second clause is false where the token
is a link, and "instead" states a disjointness the two rules do not
have.

Measured at ruff 0.16.6, the version `uv.lock` locks and
`.pre-commit-config.yaml` pins, through a config file setting the
`preview = true` and `max-doc-length = 80` this tree sets, matching on
`Doc line too long`: under preview ruff prints the rule's name rather
than `W505`, so a probe scored on the code answers zero whatever the
rule did. The pygrep is scored the way pre-commit runs it, one
`re.search` per line. Two 94-column whole-line comments, each carrying
its overflow past column 80 inside one unbroken token and alike but for
the `:` of `https://` at column 36: the pygrep is silent on both, W505
passes over the link and reports the other `94 > 80`. Replacing that
token with an unbroken run of letters, same width and same column, gives
the same pair of answers, so what W505 keys on is the link and not the
token's length. One space inserted just after column 80 in the
passed-over line makes W505 and the pygrep both report it, which is the
control saying that silence is an absence. A line whose last word
contains `://` is section 9's first named pass-over, which the
sentence's own next clause sent the reader to.

"Instead" fails in the other direction as well: a 97-column comment
opening `# type: ` or `# noqa: ` is reported by the pygrep and passed
over by W505, while `# abcd: ` at the same width, column and shape is
reported by both. That sham varies the pragma's spelling and nothing
else, and an ordinary over-width comment reported by both is the control
saying the rule reports at all.

The replacement is `btclib-node`'s landed sentence, read from that
repository's `origin/main` at `71f6aee1` rather than retyped, with a
full stop added because sentences follow it here where it ends the block
there. It states the pattern's own predicate and names no other tool,
which is btclib-org/.github#843's decision for the trees carrying this
hook: every wording that described a second tool's behaviour has been
refuted, each in its own way, and the record is on that issue.

No joining sentence replaces the paragraph's last one -- that with no
amnesty at all this would be stricter on toml prose than the rules it
mirrors. It has no antecedent once no other rule is named, and a fresh
reason for the exemption would be a fresh claim of exactly the kind the
issue is about: the obvious one, that a line the amnesty covers could
not be brought under the width, is false wherever the token fits a line
of its own -- 94 columns of prose ending in a 64-character link become
66 with the link moved down. What surrounds the sentence already carries
the reasoning -- why a local pygrep, what the `#` after optional indent
selects, and how pygrep counts a non-ascii character.

The `name:` and the `entry:` are untouched. The lexical amnesty the
`name:` states against the positional rule the `entry:` implements is
btclib-org/.github#843's other half, one decision for every tree
carrying the hook rather than this tree's to take alone.
`pyproject.toml`'s `[tool.ruff.lint.pycodestyle]` comment is untouched
too: it defers to section 9 for which over-width lines the rule passes
over and restates none of them.

`29d1bb58`'s changelog entry is still in the open section and states the
same clause, so the new entry says what it does to it and leaves it
where it is; the deletion count on `CHANGELOG.md` is zero. That commit's
message states the clause too and reaches `main` under
`squash_merge_commit_message = COMMIT_MESSAGES`, which nothing here
rewrites, so the new entry is where the record is corrected.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr


Reviewed locally at fresh context before opening, and again after the rebase onto a base that had moved five commits: the reviewer settled the rebase at patch level by diffing `git diff c7ea7fef 79cb0748` against `git diff dc01f366 17875e0d`, finding only the index line, the shifted hunk header and the one reworded sentence. Gates on that tree, all exit 0: `uv sync`; `uv run ruff check --fix`; `uv run ruff format`; `uv run mypy src/btclib tests .github/scripts`; `uv run pytest` (32208 passed, 31 skipped, 1 xfailed, coverage 100.00%); `uv run pre-commit run --all-files` (41 Passed, 1 Skipped, 0 Failed); `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Correct the `toml-comment-width` documentation to accurately describe the pattern it enforces without making claims about other linting rules.

Enhancements:
- Clarify the `toml-comment-width` hook documentation by describing only its own unbroken-token exemption and removing inaccurate comparisons with other tools.

Chores:
- Add a changelog entry documenting the correction and preserving the hook configuration and existing lexical amnesty decision.