### PR TITLE
`script_vectors` and `taproot_vectors` drop figures nothing re-derives (closes #1809, closes #1810)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1794,6 +1794,31 @@ file of the test tree, and no caller acts on it.
   implements is btclib-org/.github#843's other half, one decision for
   every tree carrying the hook rather than this tree's to take alone.
 
+### `script_vectors`'s comment drops a proportion nothing re-derives
+
+- **`tests/script_engine/script_test.py`'s `script_vectors` comment stated a
+  proportion of the vendored `script_tests.json` that nothing in the tree
+  checks** (closes #1809): a comment's own figure is checked by no test and
+  pinned in no README, the shape `tests/vendored_data_test.py` spares, so it is
+  a count like any other here. Measured against the vendored file, the comment
+  had the direction backwards -- most vectors carry no trailing comment, not
+  most of them. It now says that `vector_id` falls back to the script itself
+  for the vectors that carry none, without a figure.
+
+### `taproot_vectors`'s docstring drops figures nothing re-derives
+
+- **`tests/script_engine/transactions_test.py`'s `taproot_vectors` docstring
+  stated several figures describing the vendored `script_assets_test.json`,
+  none of which anything in the tree checks** (closes #1810): a docstring
+  figure is checked by no test and pinned in no README, the shape
+  `tests/vendored_data_test.py` spares, so each is a count like any other here.
+  The docstring keeps the argument the figures stood in for -- that filtering
+  by the TAPROOT flag would drop a large part of the file that is not
+  off-topic, and that the large majority of the dropped vectors are reached by
+  no other test while a small remainder is reached only by
+  `test_valid_script_path`, which runs no script -- and states it without the
+  figures.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/script_engine/script_test.py
+++ b/tests/script_engine/script_test.py
@@ -148,8 +148,8 @@ def script_vectors() -> list[Any]:
         vector = ScriptVector(
             stack, amount, x[i], script_pub_key, x[i + 2], x[i + 3] == "OK"
         )
-        # the trailing comment of the vector says what it is testing, and
-        # two thirds of them have one; the script itself for the rest
+        # the trailing comment of the vector says what it is testing; most
+        # vectors carry none, and vector_id falls back to the script itself
         comment = x[i + 4] if len(x) > i + 4 else ""
         params.append(
             pytest.param(vector, id=vector_id(index, comment or vector.script_pub_key))

--- a/tests/script_engine/transactions_test.py
+++ b/tests/script_engine/transactions_test.py
@@ -39,16 +39,15 @@ TAPSCRIPT = load("script", "_data", "script_assets_test.json")
 def taproot_vectors(outcome: str) -> list[Any]:
     """Every vector carrying an `outcome` witness, whatever its flags.
 
-    No `"TAPROOT" in x["flags"]` filter: it would drop 1016 of the
-    file's 3737 cases, 685 `success` and 331 `failure` whose flags field
-    stops at NULLDUMMY, and those are not off-topic vectors. Core's
-    `feature_taproot.py` dumps a spend twice, once with the soft fork
-    enforced and once without, and the second copy is what asserts that
-    a taproot output stays anyone-can-spend to a node that does not
-    know the rule -- the upgrade path. Nothing else covers them: 612 of
-    them are reached by no other test, and the remaining 73 only by
-    `test_valid_script_path`, which checks the taproot commitment and
-    runs no script.
+    No `"TAPROOT" in x["flags"]` filter: it would drop a large part of the file
+    -- both `success` and `failure` cases whose flags field stops at NULLDUMMY
+    -- and those are not off-topic vectors. Core's `feature_taproot.py` dumps a
+    spend twice, once with the soft fork enforced and once without, and the
+    second copy is what asserts that a taproot output stays anyone-can-spend to
+    a node that does not know the rule -- the upgrade path. The large majority
+    of them are reached by no other test, and a small remainder only by
+    `test_valid_script_path`, which checks the taproot commitment and runs no
+    script.
     """
     return [
         pytest.param(x, id=vector_id(index, x["comment"]))


### PR DESCRIPTION
`script_vectors`'s comment and `taproot_vectors`'s docstring each stated
figures of this tree's own vendored data that nothing re-derives. Both
are the shape `tests/vendored_data_test.py` spares: checked by no test,
pinned in no `tests/_data/README.md` entry, and silently wrong after any
vendored-vector update.

The rule applied is the one three landed commits already applied — the
upstream-count exception follows the **place**, tied to a pin in
`tests/_data/README.md`, not the kind. A figure counting what upstream
published is spared where that pin holds it and nowhere else, so a
figure in a test docstring goes with the rest.

`script_vectors`'s sentence was not merely unchecked, it was **backwards**:
it claimed most vectors carry a trailing comment, where measurement over
`script_tests.json` says roughly a third do and the fallback to the script
itself is the common path.

`taproot_vectors`'s docstring exists to justify *not* filtering on
`"TAPROOT" in x["flags"]`, so every relation in it had to survive the
figures being removed: that the filter would drop a large part of the
file, that the dropped cases are not off-topic, that the large majority
are reached by no other test, and that a small remainder is reached only
by `test_valid_script_path`, which runs no script. Each was re-derived
independently at review, the `script_path_vectors` filter replicated
rather than read.

Closes #1809
Closes #1810

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Correct vector documentation by removing unsupported statistics and retaining concise explanations of vector identification and Taproot test coverage.

Bug Fixes:
- Correct inaccurate documentation of script-vector comment coverage and Taproot vector coverage.

Enhancements:
- Remove unverified vendored-data figures while preserving the rationale for retaining all relevant Taproot vectors.

Documentation:
- Update the changelog to document the removal of unsupported figures from the script and Taproot vector documentation.