### PR TITLE
`script_test.py` and `transactions_test.py` drop counts nothing re-derives (closes #1814, closes #1815, closes #1816)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1819,6 +1819,45 @@ file of the test tree, and no caller acts on it.
   `test_valid_script_path`, which runs no script -- and states it without the
   figures.
 
+### `test_disabled_op_codes` and `test_script` drop counts nothing re-derives
+
+- **`tests/script_engine/script_test.py`'s `test_disabled_op_codes` docstring
+  and `test_script`'s own comment each counted the vendored
+  `script_tests.json`'s DISABLED_OPCODE vectors, in whole and split by whether
+  a conditional branch ever reaches the op code** (closes #1814): neither count
+  is checked by any test or pinned in any README, the shape
+  `tests/vendored_data_test.py` spares, so both are counts like any other here.
+  The branch split does not reproduce either: traced through each vector's own
+  conditional nesting against the vendored file, the split is not the one
+  either sentence stated. Both drop, and the docstring and the comment keep the
+  argument the counts stood in for -- that Core's vectors refuse the op code
+  whether or not a conditional branch ever reaches it, and that none of them
+  could reach the engine while the disabled op codes' names were missing.
+
+### `legacy_vectors`'s comment drops a count and id nothing matches
+
+- **`tests/script_engine/transactions_test.py`'s `legacy_vectors` comment
+  illustrated the id a governing comment gives `vector_id`, and its third
+  example named neither a count nor an id `vector_id` actually produces**
+  (closes #1815): checked against `vector_id`'s own output on the vendored
+  `tx_valid.json` and `tx_invalid.json`, no index produces that literal id, and
+  the count of vectors whose governing comment shares the example's subject
+  falls short of what the comment claimed. The comment keeps its two real
+  examples and the argument they illustrate -- that a governing comment gives
+  `vector_id` something the flags field cannot -- and drops the invented third
+  one.
+
+### `annex_vectors`'s docstring drops a count nothing re-derives
+
+- **`tests/script_engine/transactions_test.py`'s `annex_vectors` docstring
+  stated a count of the vendored `script_assets_test.json`'s annex-bearing
+  vectors** (closes #1816): the count is checked by no test and pinned in no
+  README, the shape `tests/vendored_data_test.py` spares, so it is a count like
+  any other here even though it is confirmed against the vendored file. The
+  docstring keeps the argument the count stood in for -- that the same vectors
+  are selected whether or not the TAPROOT flag filter is applied, and that no
+  vector short of TAPROOT carries an annex -- and states it without the figure.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/script_engine/script_test.py
+++ b/tests/script_engine/script_test.py
@@ -192,14 +192,14 @@ def test_script(vector: ScriptVector) -> None:
     if vector.valid:
         verify()
     else:
-        # BTClibValueError, not Exception: a vector expecting a failure
-        # gets one from anything that raises, the harness included, and
-        # `parse_script` raises KeyError on an op code name btclib does
-        # not know. That is how the seventeen DISABLED_OPCODE vectors
-        # below passed while the rule they test was missing -- the names
-        # were unknown, the scripts were never built, and no engine ever
-        # saw them. Everything the engine refuses is a BTClibValueError,
-        # ScriptError included, so a KeyError is now a red test
+        # BTClibValueError, not Exception: a vector expecting a failure gets
+        # one from anything that raises, the harness included, and
+        # `parse_script` raises KeyError on an op code name btclib does not
+        # know. That is how the DISABLED_OPCODE vectors below passed while the
+        # rule they test was missing -- the names were unknown, the scripts
+        # were never built, and no engine ever saw them. Everything the engine
+        # refuses is a BTClibValueError, ScriptError included, so a KeyError is
+        # now a red test
         with pytest.raises(BTClibValueError):
             verify()
 
@@ -566,11 +566,11 @@ def test_verif_in_an_unexecuted_branch(op_code: bytes) -> None:
 def test_disabled_op_codes() -> None:
     """The fifteen op codes CVE-2010-5137 switched off, named and refused.
 
-    Core's own vectors cover the refusal — twenty-four DISABLED_OPCODE
-    cases, seventeen of them in a branch never taken — and not one of
+    Core's own vectors cover the refusal, some of them placing the op
+    code where a conditional branch never reaches it — and not one of
     them could reach the engine while the names were missing:
     `parse_script` raised KeyError, `pytest.raises(Exception)` took it
-    for a verdict, and all twenty-four passed against a rule that was
+    for a verdict, and every one of them passed against a rule that was
     not there. What is left to pin here is the property they assume,
     which is also why the names are in the tables: every byte has one,
     the name serializes back to the byte, and the engine refuses it

--- a/tests/script_engine/transactions_test.py
+++ b/tests/script_engine/transactions_test.py
@@ -100,11 +100,11 @@ def test_invalid_taproot(vector: dict[str, Any]) -> None:
 def annex_vectors() -> list[Any]:
     """Select the TAPROOT vectors whose witness carries an annex to strip.
 
-    The flags test `taproot_vectors` above omits is made here, and
-    selects the same 248 vectors with or without it: no vector whose
-    flags stop short of TAPROOT carries an annex, measured. It stands as
-    the statement that an annex is a taproot notion, which is what makes
-    a future vector contradicting it worth looking at.
+    The flags test `taproot_vectors` above omits is made here, and selects
+    the same vectors with or without it: no vector whose flags stop short
+    of TAPROOT carries an annex, measured. It stands as the statement that
+    an annex is a taproot notion, which is what makes a future vector
+    contradicting it worth looking at.
     """
     params = []
     for index, x in enumerate(TAPSCRIPT):
@@ -179,8 +179,8 @@ def legacy_vectors(fname: str) -> list[Any]:
     for index, x in enumerate(load("script_engine", "_data", fname)):
         if isinstance(x[0], str):
             # a comment line, and it describes the vectors that follow:
-            # "MAX_MONEY output", "Coinbase of size 2" -- an id the
-            # flags field cannot give, naming a dozen vectors "41-P2SH"
+            # "MAX_MONEY output", "Coinbase of size 2" -- an id the flags field
+            # cannot give
             comment = x[0]
             continue
         params.append(pytest.param(x, id=vector_id(index, comment, x[2])))


### PR DESCRIPTION
Four sites in `tests/script_engine/` stated figures of this tree's own
vendored data that nothing re-derives — the shape
`tests/vendored_data_test.py` spares: checked by no test, pinned in no
`tests/_data/README.md` entry, and silently wrong after any
vendored-vector update.

The rule is the one the preceding commits applied: the upstream-count
exception follows the **place**, tied to a pin in
`tests/_data/README.md`, not the kind. Two of these four figures were
measured and found **correct**, and go anyway.

The other two were not merely unchecked. Both are false, and neither is
a stale figure that drifted:

- `legacy_vectors`' "a dozen vectors `41-P2SH`" was invented. Vectors
  whose governing comment mentions P2SH number six across both files,
  and `vector_id` for that index yields a full slug of the vendored
  comment, nothing resembling `41-P2SH`.
- `test_disabled_op_codes`' "seventeen ... in a branch never taken"
  reproduces under no method. Traced with real `CastToBool` semantics
  the figure is smaller; the naive "any `IF` token means skipped"
  approach gives a different number again and is independently wrong,
  reading `'abc' / IF INVERT ELSE 1 ENDIF` as skipped when `'abc'` is
  truthy and the branch is taken.

Each site keeps the argument the figure sat inside — why the harness
catches `BTClibValueError` and not `Exception`, why a comment line is
carried forward as an id the flags field cannot give, and why the annex
selection is unaffected by the TAPROOT filter. Where a figure carried a
relation, the relation is now stated exactly rather than numerically:
the annex docstring's two claims were re-derived independently at
review.

Closes #1814
Closes #1815
Closes #1816

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Remove inaccurate and non-derived vendored-data counts from script-engine test documentation while retaining the underlying test rationale.

Enhancements:
- Remove unsupported vendored-vector counts and an invented vector identifier from script-engine test documentation while preserving the behavioral rationale those statements explain.

Documentation:
- Update the changelog to document removal of unverified or inaccurate counts from script and transaction test comments and docstrings.