### PR TITLE
tests/build_system_test.py's reader recognizes a literal by its shape, not its join (closes #1801)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1858,6 +1858,21 @@ file of the test tree, and no caller acts on it.
   are selected whether or not the TAPROOT flag filter is applied, and that no
   vector short of TAPROOT carries an annex -- and states it without the figure.
 
+### `_reaches_outside_the_sdist` matches a literal by its shape, not its join
+
+- **The reader recognizes a `.github`- or `fuzz`-opening string literal
+  wherever it sits in a module, not only at a `/` join's own right
+  side** (closes #1801): `tests/docs_commands_test.py` reaches
+  ".github/workflows/docs.yml" through a dict key and a variable a
+  comprehension binds later, a shape the join-only reader could not see,
+  so its `source-exclude` entry was correct by memory and removing it
+  failed nothing. Removing it now fails the assertion, naming the
+  module. Exempted is a literal that never leaves a closed membership
+  test -- an element of the tuple, list or set an `in` or `not in`
+  comparison reads its answer from -- which is why the reader stays
+  silent about its own `(".github", "fuzz")` and about
+  `tests/tf2_ledger_test.py`'s unrelated `{"tests", "src", ".github"}`.
+
 ## v2026.9.3
 
 ### Repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,9 +290,6 @@ source-exclude = [
     # recognizes as reaching .github or fuzz/ is named here
     "/tests/check_py_arm_authority_test.py",
     "/tests/check_vendored_vectors_test.py",
-    # a shape the reader above does not see at all: the path sits in a
-    # dict key here, and the join it feeds happens through a variable
-    # rather than through the literal itself (issue #1736)
     "/tests/docs_commands_test.py",
     "/tests/generate_sbom_test.py",
     "/tests/interpreters_test.py",

--- a/tests/build_system_test.py
+++ b/tests/build_system_test.py
@@ -158,26 +158,36 @@ def _source_exclude() -> list[str]:
 def _reaches_outside_the_sdist(tree: ast.Module) -> bool:
     """Whether a module reads `.github`, `fuzz`, or `.git` off the tree.
 
-    Two shapes. The first is a `/` join whose right side is the literal
-    directory name or opens with it and a slash -- the convention
-    `Path(__file__).parents[1] / ".github" / "scripts" / "<name>.py"` and
-    `Path(__file__).parent.parent / "fuzz"` follow, and `_ROOT /
-    ".github/workflows"` too -- walked rather than matched on the
-    formatted text, so a reflow of the expression across lines is still
-    seen. Split on the slash rather than matched as a substring, so a
-    name merely starting with the same letters -- ".githubbookmark" --
-    is not mistaken for the directory. What this still does not reach is
-    a literal that never sits at the join itself:
-    `tests/docs_commands_test.py` names ".github/workflows/docs.yml" as
-    a dict key and reads through a variable holding it, so that module
-    is named in `source-exclude` by hand rather than found here.
+    Two shapes. The first is any string literal that is the directory
+    name or opens with it and a slash -- split on the slash rather than
+    matched as a substring, so a name merely starting with the same
+    letters (".githubbookmark") is not mistaken for the directory.
+    Walked rather than matched on the formatted text, so a reflow across
+    lines is still seen, and wherever in the module the literal sits: a
+    `/` join's own right side, the way `Path(__file__).parents[1] /
+    ".github" / "scripts" / "<name>.py"` and `_ROOT /
+    ".github/workflows"` hold it, or a dict key read out by name and
+    joined once a comprehension binds it, the way
+    `tests/docs_commands_test.py` reaches ".github/workflows/docs.yml".
 
-    The second is `tests/changelog_immutability_test.py`'s own: it reads
-    a release's own tag with `subprocess.run([_GIT, ...])` rather than a
-    `Path` join, `.git` not being a directory any test builds a path
-    through. `_GIT` -- `shutil.which("git") or "git"`, resolved once, the
-    convention `generate_sbom.py` and its own test already use -- is a
-    bare name and not the string "git" itself, ruff's own
+    Exempted is a literal that never leaves a closed membership test --
+    an element of the tuple, list or set an `in` or `not in` comparison
+    reads its answer from, this function's own `(".github", "fuzz")`
+    included. Comparing a value against a fixed set of names reads
+    nothing off the tree; joining a path or keying a dict on the name
+    does, whichever of the two shapes above carries it there. The
+    exemption is why this module reports nothing about its own two
+    literals, and why `tests/tf2_ledger_test.py`'s `{"tests", "src",
+    ".github"}` -- the same kind of comparison, holding the same word --
+    is silent too; that module is excluded for a read its own `/` join
+    makes elsewhere, not for this one.
+
+    The second shape is `tests/changelog_immutability_test.py`'s own: it
+    reads a release's own tag with `subprocess.run([_GIT, ...])` rather
+    than a `Path` join, `.git` not being a directory any test builds a
+    path through. `_GIT` -- `shutil.which("git") or "git"`, resolved
+    once, the convention `generate_sbom.py` and its own test already
+    use -- is a bare name and not the string "git" itself, ruff's own
     start-process-with-partial-path check being what a literal there
     would trip; matching that name is what the shape actually looks like
     now, a call whose first argument is a list or tuple literal opening
@@ -185,13 +195,21 @@ def _reaches_outside_the_sdist(tree: ast.Module) -> bool:
     called (`run`, `check_output`, ...) or what object the call is made
     through (issue #1512).
     """
+    exempt = {
+        id(elt)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Compare)
+        for op, comparator in zip(node.ops, node.comparators, strict=True)
+        if isinstance(op, (ast.In, ast.NotIn))  # codespell:ignore notin
+        and isinstance(comparator, (ast.Tuple, ast.List, ast.Set))
+        for elt in comparator.elts
+    }
     for node in ast.walk(tree):
         if (
-            isinstance(node, ast.BinOp)
-            and isinstance(node.op, ast.Div)
-            and isinstance(node.right, ast.Constant)
-            and isinstance(node.right.value, str)
-            and node.right.value.split("/", 1)[0] in (".github", "fuzz")
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and node.value.split("/", 1)[0] in (".github", "fuzz")
+            and id(node) not in exempt
         ):
             return True
         if (
@@ -213,15 +231,6 @@ def test_every_test_reaching_outside_the_sdist_is_source_excluded() -> None:
     Not the other direction: `source-exclude` also names entries no test
     file could match -- `docs/build`, the linter caches -- so only this
     direction closes what ISS 1509 found open.
-
-    And not every test that reaches outside the sdist: what the reader
-    sees is a `/` join whose own right side names the directory, so a
-    literal that reaches a join only through a variable -- a dict key
-    read out by name and joined later, the way
-    `tests/docs_commands_test.py` reads ".github/workflows/docs.yml" --
-    is outside its reach and outside this assertion's. Widening the
-    sentence here without widening the reader is what would put the
-    guarantee ISS 1509 asked for on a green run that does not give it.
     """
     excluded = set(_source_exclude())
     missing = [


### PR DESCRIPTION
`tests/build_system_test.py` asserts that every test module reaching
outside the sdist is named in `[tool.uv.build-backend] source-exclude`.
Its reader only saw a `/` join whose right operand was itself the
literal, so `tests/docs_commands_test.py` — which reaches
`.github/workflows/docs.yml` through a dict key and a variable a
comprehension binds later — was invisible to it. That entry was correct
by memory alone: removing it failed nothing, which is the failure the
test exists to make impossible, one shape along.

The reader now matches a `.github`- or `fuzz`-opening literal wherever
it sits in a module, exempting only a literal that never leaves a closed
membership test — an element of the tuple, list or set an `in` or
`not in` comparison reads its answer from. The exemption is keyed by the
AST node, not the string, so it cannot leak between two occurrences of
the same literal in one module: `tests/tf2_ledger_test.py` holds
`".github"` both in a membership set and at a real join, and is still
flagged, by the join. Verified at review as the case that would have
broken a value-keyed rule.

The `source-exclude` entry that was kept by hand loses the comment
saying the reader cannot see it, that being what this change falsifies.

A first review found the branch silencing `codespell` for `ast.NotIn`
through the repository-global `ignore-words-list`, where a per-site
`# codespell:ignore` suppresses exactly the one word at the one line;
the local form is what landed, measured with a control that names the
wrong word and still fails.

Closes #1801

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Make outside-the-sdist validation recognize relevant path literals by their syntax rather than requiring them to appear directly in a path join.

Bug Fixes:
- Update the build-system test reader to detect `.github`- and `fuzz`-opening literals wherever they occur in a test module, including indirect path and dictionary-key usage.
- Prevent membership-test literals from being treated as filesystem reads while preserving detection of other occurrences of the same literal.

Enhancements:
- Remove the obsolete manual-exclusion explanation for `tests/docs_commands_test.py` and document the expanded reader behavior.

Documentation:
- Add a changelog entry describing the expanded outside-the-sdist detection and its membership-test exemption.