### PR TITLE
BOLT11 refuses a feature missing its dependencies, and BOLT9's table is watched (closes #1655, closes #1661)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1873,6 +1873,42 @@ file of the test tree, and no caller acts on it.
   silent about its own `(".github", "fuzz")` and about
   `tests/tf2_ledger_test.py`'s unrelated `{"tests", "src", ".github"}`.
 
+### A Lightning invoice states what its features depend on
+
+- **`Bolt11Invoice.assert_valid` refuses a `9` field stating a feature
+  without the features BOLT9 says it depends on** (closes #1655), naming
+  the pair in the message. BOLT9's Dependencies column is what says
+  which: `basic_mpp` on `payment_secret`, `zero_fee_commitments` on
+  `option_channel_type`, `option_zeroconf` on `option_scid_alias`,
+  `option_simple_close` on `option_shutdown_anysegwit`, and
+  `option_onion_messages_only_channels` on `option_onion_messages`.
+- **The verdict is the codec's, because the question is about the vector
+  alone**: answering it takes BOLT9's table and nothing about what a
+  payer implements, which is the division issue #1637 drew, and BOLT9's
+  own rationale is that setting the dependencies is what makes a feature
+  vector well-formed. BOLT11 words the rule as "MUST NOT attempt the
+  payment", which btclib never does -- and words its checksum rule as
+  "MUST fail the payment", which `from_invoice` answers by refusing, so
+  the wording is not what decides whose half a rule is. The rejected
+  alternative is the column and a public lookup with no refusal, which
+  leaves every caller to reach the verdict the BOLT states once.
+- **`btclib.bolt9.FEATURE_DEPENDENCIES` is that column** and
+  `unmet_dependencies` the lookup over a feature vector rather than over
+  an invoice, answering with the pairs the vector leaves unset. The walk
+  is transitive, so a dependency's own dependencies are asked for in
+  turn; either bit of a pair states its feature, so the optional half
+  meets a dependency as the compulsory half does.
+- **`src/btclib/bolt9.py`'s transcription is pinned in
+  `tests/_data/README.md`** (closes #1661), where
+  `.github/workflows/vendored-vectors.yml` reads it every week and opens
+  an issue on a pin upstream has moved past. A pin in the module is read
+  by nobody, and this table decides an outcome: an invoice setting an
+  even bit it does not carry is refused, so a pair assigned upstream
+  after the pin is one a reader at upstream's tip accepts and btclib
+  does not. The entry is the shape that script already reads -- a repo,
+  a path, a commit and a `behind` of 0 -- with no `blob`, there being no
+  file upstream to compare against a table written in markdown.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -242,6 +242,24 @@ full year, short month, short day (YYYY-M-D)
   one. The parse path, `descriptors.parse`, already normalized the name
   and is unaffected.
 
+- **A Lightning invoice stating a feature without the features BOLT9
+  says it depends on is refused** (closes #1655).
+  `bolt11.Bolt11Invoice.from_invoice` and `assert_valid` accepted one,
+  where BOLT9's Dependencies column has `basic_mpp` depend on
+  `payment_secret`, `zero_fee_commitments` on `option_channel_type`,
+  `option_zeroconf` on `option_scid_alias`, `option_simple_close` on
+  `option_shutdown_anysegwit`, and `option_onion_messages_only_channels`
+  on `option_onion_messages`.
+
+  Act on it if you decode invoices whose `9` field is short of one: the
+  refusal is `BTClibValueError: unmet feature dependencies: basic_mpp
+  requires payment_secret`, naming every pair it found.
+  `btclib.bolt9.FEATURE_DEPENDENCIES` is that column and
+  `btclib.bolt9.unmet_dependencies` the same lookup over any feature
+  vector. Either bit of a pair states its feature, so an invoice
+  offering `payment_secret` at bit 15 meets `basic_mpp`'s dependency as
+  one requiring it at bit 14 does.
+
 ### Worth knowing, though nothing raises
 
 - **`psbt_signer_contract.optional_protocols` returns `OptionalProtocols`,

--- a/src/btclib/bolt11.py
+++ b/src/btclib/bolt11.py
@@ -87,7 +87,7 @@ from btclib.b32 import (
 from btclib.b58 import address_from_h160, h160_from_address
 from btclib.bech32 import decode as _bech32_decode
 from btclib.bech32 import encode as _bech32_encode
-from btclib.bolt9 import unknown_even_bits
+from btclib.bolt9 import FEATURE_NAMES, unknown_even_bits, unmet_dependencies
 from btclib.curves import bytes_from_point, secp256k1
 from btclib.ecc.dsa import Sig, gen_keys, recover_pub_key_, sign_recoverable_, verify_
 from btclib.exceptions import BTClibValueError
@@ -420,8 +420,9 @@ class Bolt11Invoice:
 
         An **even** bit of the `9` field that BOLT9 does not assign
         fails the invoice, which is BOLT9's rule for a reader that meets
-        a feature bit it does not know; `btclib.bolt9` carries the table
-        that answers it.
+        a feature bit it does not know; a feature stated without the
+        features BOLT9 says it depends on fails it too. `btclib.bolt9`
+        carries the table that answers both.
         """
         if self.network not in _CURRENCY_FROM_NETWORK:
             raise BTClibValueError(f"not a lightning network: {self.network!r}")
@@ -461,10 +462,22 @@ class Bolt11Invoice:
         # `features` is read here rather than among the accessors above:
         # its own well-formedness is the bits, and an even one BOLT9 does
         # not assign is a requirement no reader has been told how to meet
-        unknown = unknown_even_bits(self.features)
+        features = self.features
+        unknown = unknown_even_bits(features)
         if unknown:
             bits = ", ".join(str(bit) for bit in unknown)
             raise BTClibValueError(f"unknown even feature bits: {bits}")
+
+        # the other half of a well-formed vector, and BOLT9's own word
+        # for it: a feature whose dependencies are set is one a reader can
+        # act on without checking them again at every gate
+        unmet = unmet_dependencies(features)
+        if unmet:
+            missing = ", ".join(
+                f"{FEATURE_NAMES[bit]} requires {FEATURE_NAMES[required]}"
+                for bit, required in unmet
+            )
+            raise BTClibValueError(f"unmet feature dependencies: {missing}")
 
         # the signature itself: this is what makes an invoice acceptable
         _payee = self.payee
@@ -537,8 +550,9 @@ class Bolt11Invoice:
         """Return the `9` field as a bitfield, 0 where none was stated.
 
         The bitfield, and not a verdict on it: `assert_valid` refuses
-        an even bit BOLT9 does not assign, and a caller acting on the
-        invoice checks the assigned ones against what it has itself
+        an even bit BOLT9 does not assign, and a feature whose own
+        dependencies the vector leaves unset. A caller acting on the
+        invoice checks the assigned bits against what it has itself
         implemented, `btclib.bolt9.FEATURE_NAMES` being that table.
         """
         words = _first(self.tagged_fields, _TAG_FEATURES, None)

--- a/src/btclib/bolt9.py
+++ b/src/btclib/bolt9.py
@@ -27,9 +27,19 @@ even bit nothing has been told how to support -- and a wallet acting on
 an invoice takes the other half itself, checking the assigned even bits
 against what it has implemented, with `FEATURE_NAMES` as its table too.
 
-The table is a copy of a document that grows, pinned at the commit it was
-copied from, so a pair assigned upstream after that commit reads as
-unknown here until the pin moves.
+**A feature's dependencies are the features BOLT9 says a vector setting
+it must set too**, listed in the same table's Dependencies column, and
+the BOLT's own rationale is that setting them is what makes a feature
+vector well-formed. `unmet_dependencies` answers that from the table
+alone, so it is the codec's half by the same division: nothing about it
+asks what the reader supports. A feature counts as set where either bit
+of its pair is, the odd half being the optional way of stating it.
+
+The table is a copy of a document that grows, pinned at the revision
+`tests/_data/README.md` records for it beside the vendored files, so a
+pair assigned upstream after that revision reads as unknown here until
+the pin moves. `.github/workflows/vendored-vectors.yml` reads that file
+weekly and opens an issue where a pin is no longer upstream's tip.
 """
 
 from __future__ import annotations
@@ -42,15 +52,15 @@ from btclib.exceptions import BTClibValueError
 from btclib.utils import int_from_integer
 
 __all__ = [
+    "FEATURE_DEPENDENCIES",
     "FEATURE_NAMES",
     "unknown_even_bits",
+    "unmet_dependencies",
 ]
 
-# BOLT9's table, transcribed at lightning/bolts
-# 35e79db504560b9d3494a0ed07bf1e8379c3663a (2026-07-27), the most recent
-# commit touching 09-features.md: the even bit of each assigned pair, and
-# the name the BOLT gives that pair. Every gap in the numbering is a gap
-# in that table
+# BOLT9's table, transcribed: the even bit of each assigned pair, and the
+# name the BOLT gives that pair. Every gap in the numbering is a gap in
+# that table
 _feature_names: dict[int, str] = {
     0: "option_data_loss_protect",
     4: "option_upfront_shutdown_script",
@@ -84,6 +94,54 @@ _feature_names: dict[int, str] = {
 # entry added at run time would be an assignment BOLT9 has not made
 FEATURE_NAMES: Mapping[int, str] = MappingProxyType(_feature_names)
 
+# the Dependencies column of that same table, as the even bit of a pair
+# and the even bits of the pairs its cell names. A cell naming nothing is
+# no entry here, so a feature absent from this mapping depends on nothing
+_feature_dependencies: dict[int, tuple[int, ...]] = {
+    16: (14,),  # basic_mpp -> payment_secret
+    40: (44,),  # zero_fee_commitments -> option_channel_type
+    50: (46,),  # option_zeroconf -> option_scid_alias
+    60: (26,),  # option_simple_close -> option_shutdown_anysegwit
+    66: (38,),  # option_onion_messages_only_channels -> option_onion_messages
+}
+
+FEATURE_DEPENDENCIES: Mapping[int, tuple[int, ...]] = MappingProxyType(
+    _feature_dependencies
+)
+
+
+def _bit_vector(features: Integer) -> int:
+    """Return `features` as an int, refusing a negative one.
+
+    A feature vector is a string of bits and has no sign, where
+    `int_from_integer` reads one.
+    """
+    value = int_from_integer(features)
+    if value < 0:
+        raise BTClibValueError(f"negative feature vector: {value}")
+    return value
+
+
+def _walk_dependencies(
+    dependencies: Mapping[int, tuple[int, ...]], value: int
+) -> tuple[tuple[int, int], ...]:
+    """Return the pairs of `dependencies` that `value` leaves unset.
+
+    The walk is transitive: a feature the vector must set for one it does
+    set is itself asked for, so a chain through the table is followed to
+    its end. What ends the walk is the table having no cycle, and
+    `tests/bolt9_test.py` is what holds BOLT9's own to that.
+    """
+    unmet: set[tuple[int, int]] = set()
+    pending = [bit for bit in dependencies if value >> bit & 0b11]
+    while pending:
+        bit = pending.pop()
+        for required in dependencies.get(bit, ()):
+            if not value >> required & 0b11:
+                unmet.add((bit, required))
+                pending.append(required)
+    return tuple(sorted(unmet))
+
 
 def unknown_even_bits(features: Integer) -> tuple[int, ...]:
     """Return the even bits `features` sets that BOLT9 does not assign.
@@ -91,11 +149,20 @@ def unknown_even_bits(features: Integer) -> tuple[int, ...]:
     Lowest first, and never an odd bit: that is the half a reader may
     ignore, whether or not the table names it.
     """
-    value = int_from_integer(features)
-    if value < 0:
-        raise BTClibValueError(f"negative feature vector: {value}")
+    value = _bit_vector(features)
     return tuple(
         bit
         for bit in range(0, value.bit_length(), 2)
         if value >> bit & 1 and bit not in FEATURE_NAMES
     )
+
+
+def unmet_dependencies(features: Integer) -> tuple[tuple[int, int], ...]:
+    """Return what `features` depends on and does not set, lowest first.
+
+    Each pair is a feature the vector states and one BOLT9's Dependencies
+    column requires beside it, transitively: a dependency's own
+    dependencies come back too. Either bit of a pair states its feature,
+    so the optional half meets a dependency as the compulsory half does.
+    """
+    return _walk_dependencies(FEATURE_DEPENDENCIES, _bit_vector(features))

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -13,6 +13,12 @@ pins `src/btclib/mnemonic/electrum.py` carries beside the constants naming
 them, and `italian.txt` and the eleven other BIP39 lists nowhere, which
 is a gap rather than a statement about them.
 
+`src/btclib/bolt9.py` has an entry too, and it is source rather than
+data: BOLT9's feature table, transcribed into python mappings instead of
+loaded from a file beside the tests. A pin recorded here is re-checked
+against upstream every week and a pin recorded in the module is
+re-checked by nobody, which is the whole of why it is written here.
+
 The other directory holding json beside the tests,
 `tests/**/_generated_files/`, is the opposite kind of thing and has no
 entry here: those files are btclib's own output, `to_dict()`
@@ -2077,6 +2083,29 @@ Both sections are transcribed whole, the invalid case adding "unknown
 feature 100" included: what refuses that one is `btclib.bolt9`'s
 assignment table, which `Bolt11Invoice.assert_valid` reads.
 
+### `src/btclib/bolt9.py`
+
+```text
+repo    lightning/bolts
+path    09-features.md
+commit  35e79db504560b9d3494a0ed07bf1e8379c3663a  2026-07-27
+pulled  2026-09-03
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **transcribed**, off the document's own assignment table: the
+even bit of each assigned pair with the name that table gives it, as
+`FEATURE_NAMES`, and its Dependencies column as `FEATURE_DEPENDENCIES`.
+There is no blob to compare, the table being markdown inside the
+document.
+
+Source rather than a data file, and pinned here for what the table
+decides: `Bolt11Invoice.assert_valid` refuses an invoice setting an even
+bit the table does not carry, so a pair assigned upstream after this
+commit is one a reader at upstream's tip accepts and btclib refuses. The
+module points here for the revision and carries none of its own, which
+is what puts the pin where the weekly workflow reads it.
+
 ### `tests/ecc/_data/rfc6979.json`
 
 Verdict: **transcribed**. Appendix A.2 of RFC 6979 gives 50 vectors, ten each
@@ -2535,7 +2564,7 @@ Not checked byte for byte against one:
   `bip371_test_vectors.json`, `bip373_test_vectors.json`,
   `bip67_test_vectors.json`, `bip85_test_vectors.json`,
   `chacha20_vectors.json`, `muhash_vectors.json`,
-  `miniscript_fixed_tests.json`, `bolt11_test_vectors.json`,
+  `miniscript_fixed_tests.json`, `bolt11_test_vectors.json`, `bolt9.py`,
   `rfc6979.json`.
 - chain data, identified by block hash or txid: the blocks and
   transactions under `tests/block/_data/` and `tests/tx/_data/`, and

--- a/tests/bolt11_test.py
+++ b/tests/bolt11_test.py
@@ -687,3 +687,36 @@ def test_an_unknown_odd_feature_bit_is_carried() -> None:
         features=1 << 99,
     )
     assert Bolt11Invoice.from_invoice(invoice.to_invoice()).features == 1 << 99
+
+
+def test_a_feature_without_its_dependency_is_refused() -> None:
+    """`basic_mpp` names `payment_secret` in BOLT9's Dependencies column.
+
+    The `s` field is the payment secret and is compulsory; the feature bit
+    that says the payee understands one is not set by writing it.
+    """
+    with pytest.raises(BTClibValueError, match="basic_mpp requires payment_secret"):
+        Bolt11Invoice.sign(
+            _PRV_KEY,
+            "mainnet",
+            0,
+            payment_hash=bytes(32),
+            payment_secret=bytes(32),
+            description="d",
+            features=1 << 16,
+        )
+
+
+def test_a_feature_with_its_dependency_is_accepted() -> None:
+    """The same invoice, `payment_secret` offered beside `basic_mpp`."""
+    features = (1 << 16) | (1 << 15)
+    invoice = Bolt11Invoice.sign(
+        _PRV_KEY,
+        "mainnet",
+        0,
+        payment_hash=bytes(32),
+        payment_secret=bytes(32),
+        description="d",
+        features=features,
+    )
+    assert Bolt11Invoice.from_invoice(invoice.to_invoice()).features == features

--- a/tests/bolt9_test.py
+++ b/tests/bolt9_test.py
@@ -10,13 +10,28 @@ own examples make load-bearing: 8 and 14, which its valid "supports
 features 8, 14 and 99" invoice sets, and 100, which its one invalid
 feature example sets. `tests/bolt11_test.py` drives those two invoices
 themselves.
+
+The Dependencies column is the same kind of transcription and is held to
+the same kind of shape, with one addition: the walk over it ends because
+the table has no cycle, so a cycle is what one of the tests below refuses.
+Every row of that column is asked for in turn, which is what a
+mistranscribed bit fails. A chain -- a dependency that has one of its own
+-- is what `_walk_dependencies` is separable for: BOLT9 assigns none at
+the pinned revision, so the transitive step is driven over a table
+written here instead.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from btclib.bolt9 import FEATURE_NAMES, unknown_even_bits
+from btclib.bolt9 import (
+    FEATURE_DEPENDENCIES,
+    FEATURE_NAMES,
+    _walk_dependencies,
+    unknown_even_bits,
+    unmet_dependencies,
+)
 from btclib.exceptions import BTClibValueError
 
 
@@ -64,3 +79,79 @@ def test_a_negative_feature_vector_is_refused() -> None:
     """A bit vector has no sign, and int_from_integer reads one."""
     with pytest.raises(BTClibValueError, match="negative feature vector"):
         unknown_even_bits(-1)
+
+
+def test_every_dependency_is_between_assigned_features() -> None:
+    """Both ends of a row: a feature depending, and one depended on."""
+    for bit, required in FEATURE_DEPENDENCIES.items():
+        assert bit in FEATURE_NAMES
+        assert all(dependency in FEATURE_NAMES for dependency in required)
+
+
+def test_no_feature_depends_on_itself() -> None:
+    """Directly or through a chain, which is what ends the walk.
+
+    Its own closure rather than `_walk_dependencies`: that one is what
+    this guarantees terminates, so asking it would be asking the question
+    of itself, and the answer to a cycle would be a hung suite.
+    """
+    for bit in FEATURE_DEPENDENCIES:
+        reached: set[int] = set()
+        frontier = set(FEATURE_DEPENDENCIES[bit])
+        while frontier:
+            assert bit not in frontier, f"feature {bit} depends on itself"
+            reached |= frontier
+            frontier = {
+                further
+                for required in frontier
+                for further in FEATURE_DEPENDENCIES.get(required, ())
+            } - reached
+
+
+def test_every_row_of_the_column_is_asked_for() -> None:
+    """Each feature alone, so each row answers for itself."""
+    for bit, required in FEATURE_DEPENDENCIES.items():
+        assert unmet_dependencies(1 << bit) == tuple(
+            (bit, dependency) for dependency in required
+        )
+
+
+def test_a_vector_depending_on_nothing_is_met() -> None:
+    """No `9` field at all, and a feature with an empty Dependencies cell."""
+    assert unmet_dependencies(0) == ()
+    assert unmet_dependencies(1 << 48) == ()
+
+
+def test_the_optional_half_meets_a_dependency() -> None:
+    """`payment_secret` offered rather than required still satisfies it."""
+    assert unmet_dependencies((1 << 16) | (1 << 15)) == ()
+    assert unmet_dependencies((1 << 16) | (1 << 14)) == ()
+
+
+def test_the_optional_half_carries_its_own_dependencies() -> None:
+    """A feature is stated by either of its bits, and depends either way."""
+    assert unmet_dependencies(1 << 17) == ((16, 14),)
+
+
+def test_two_features_short_of_their_dependencies_come_back_lowest_first() -> None:
+    """`basic_mpp` and `option_zeroconf`, each missing its own."""
+    assert unmet_dependencies((1 << 50) | (1 << 16)) == ((16, 14), (50, 46))
+
+
+def test_a_negative_vector_is_refused_here_too() -> None:
+    """The same read of a bit vector as `unknown_even_bits` does."""
+    with pytest.raises(BTClibValueError, match="negative feature vector"):
+        unmet_dependencies(-1)
+
+
+def test_a_chain_is_followed_to_its_end() -> None:
+    """The transitive step, over a table shaped like BOLT9's and chained.
+
+    Setting 4 asks for 8, which the vector does not set and which asks for
+    12 in turn; 16 is set, so nothing is asked of it.
+    """
+    dependencies = {4: (8,), 8: (12,), 16: (18,)}
+    assert _walk_dependencies(dependencies, (1 << 4) | (1 << 16) | (1 << 18)) == (
+        (4, 8),
+        (8, 12),
+    )


### PR DESCRIPTION
BOLT9 assigns feature bits in even/odd pairs and gives some of them a
Dependencies column; `bolt11.Bolt11Invoice.assert_valid` did not read
it, so an invoice offering a feature without the feature it depends on
was accepted. `src/btclib/bolt9.py` gains that table and
`unmet_dependencies`, and the invoice refuses, naming both features.

Either bit of a pair satisfies a dependency, and an unknown *odd* bit
stays permitted — BOLT9's own "it's ok to be odd" rule is not narrowed
by this.

The table is also now watched: `tests/_data/README.md` carries a pin on
`lightning/bolts`' `09-features.md`, so the weekly vendored-vectors
check reports it going stale rather than the transcription drifting
unnoticed. Verified at review to be genuinely queried, with a control
zeroing the pin to confirm the entry is checked and not skipped.

Reviewed at fresh context against the upstream file: all five rows
carrying a Dependencies cell are present and none is invented, and the
25 assigned pairs match the existing name table one for one.

This branch was written on 2026-09-03 by a session that finished and
signed it but never opened a pull request. It was rebased across the
intervening commits, which had moved its RELEASE_NOTES.md bullet out of
the breaking-changes list through the union driver; that is repaired,
and a ledger test landed in the meantime is now satisfied.

Closes #1655
Closes #1661

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcpmdXMUR5wjq7ogSmdyH8

## Summary by Sourcery

Enforce BOLT9 feature dependencies when validating Lightning invoices and track the upstream feature table for changes.

New Features:
- Add BOLT9 feature dependency metadata and a lookup for unmet dependencies, including transitive dependencies and support for either bit in a feature pair.

Bug Fixes:
- Reject BOLT11 invoices that advertise features without the dependencies required by BOLT9, while continuing to permit unknown odd feature bits.

Enhancements:
- Expose BOLT9 feature dependency validation alongside the existing feature assignment checks and provide descriptive validation errors.

CI:
- Pin the upstream BOLT9 feature specification in the vendored-vectors tracking data so weekly checks can detect changes.

Documentation:
- Update changelog and release notes with the new invoice validation behavior and public dependency lookup.

Tests:
- Add coverage for dependency table integrity, transitive dependency traversal, optional feature bits, negative vectors, and BOLT11 acceptance and rejection cases.