### PR TITLE
`asks_for_everything` says what resolving the command line's path buys (closes btclib-org/.github#816)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1909,6 +1909,22 @@ file of the test tree, and no caller acts on it.
   a path, a commit and a `behind` of 0 -- with no `blob`, there being no
   file upstream to compare against a table written in markdown.
 
+### `asks_for_everything` says what resolving the command line's path buys
+
+- **`tests/conftest.py`'s `asks_for_everything` docstring said the paths
+  are resolved so that `./tests` and `tests/` compare equal to `tests`**
+  (closes btclib-org/.github#816): `pathlib` collapses `.` and a trailing
+  separator at construction, so those spellings are already one object
+  where the docstring said resolving is what makes them one. What the
+  call on the command-line side buys is measured by removing it: every
+  relative spelling then reads as a subset, where the `testpaths` side is
+  absolute already from the join onto `rootpath` and is resolved because
+  a `rootpath` spelled through a symlink survives the join, where
+  `Path.resolve` follows the link. The docstring gives that reason in
+  place of the spellings, and the enumeration goes with them -- the
+  spellings being one path, what equality misses is the path above
+  `testpaths` and nothing else.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,10 +52,8 @@ def asks_for_everything(
     No path at all narrows nothing and is the whole run. A path above one
     of them -- `pytest .`, or the rootdir spelled out -- collects it too,
     so what decides is containment and not equality. `tests` alone would
-    match either way; `./tests` and `tests/` are the same directory under
-    another name and need the paths resolved before they compare equal;
-    and a path above `testpaths` is never equal to it, so only
-    containment reads all four as the whole run they collect.
+    match either way, and a path above `testpaths` is never equal to it,
+    so only containment reads both as the whole run they collect.
 
     `file_or_dir` is `None` rather than `[]` on the `--help` path, the
     parse having been abandoned rather than left unfinished: `--help` is
@@ -67,12 +65,15 @@ def asks_for_everything(
 
     The two sides are relative to different directories: a path on the
     command line to where pytest was run from, a `testpaths` entry to the
-    rootdir, which is what `testpaths` means. Both are then resolved, and
-    the second needs it as much as the first -- pytest builds `rootpath`
-    with `os.path.abspath`, which leaves a symlink in the path alone,
-    while `Path.resolve` follows one, so a tree reached through `/tmp` on
-    macOS would compare `/tmp/...` against `/private/tmp/...` and find no
-    containment anywhere.
+    rootdir, which is what `testpaths` means. What the join onto
+    `rootpath` does for the second, `Path.resolve` does for the first: a
+    relative path neither equals an absolute one nor is above it, so
+    without that call every relative spelling of the suite reads as a
+    subset. The second is resolved as well because pytest builds
+    `rootpath` with `os.path.abspath`, which leaves a symlink in the path
+    alone, while `Path.resolve` follows one, so a tree reached through
+    `/tmp` on macOS would compare `/tmp/...` against `/private/tmp/...`
+    and find no containment anywhere.
     """
     given = [Path(path).resolve() for path in file_or_dir or []]
     if not given:


### PR DESCRIPTION
`asks_for_everything` says what resolving the command line's path buys (closes btclib-org/.github#816)

The docstring gave the spellings of one directory as a reason for
resolving both sides. `pathlib` collapses `.` and a trailing separator
at construction, so `tests`, `./tests` and `tests/` are one object with
nothing resolved: measured with the tree's own two expressions, the bare
`Path()` for the command-line side and the join onto `rootpath` for the
`testpaths` side, against `Path("tests") == Path("tests/unit")` as the
control that `Path` equality distinguishes anything at all.

What the call on the command-line side buys was measured by removing it
from the function loaded out of the blob at 0a37308a: every relative
spelling `test_a_path_that_collects_the_suite_is_a_whole_run` passes
then answers False, where the absolute spelling and the `--help` `None`
are unchanged. The `testpaths` side is absolute already from the join
onto `rootpath`, and is resolved because a `rootpath` spelled through a
symlink survives the join: measured on a rootdir spelled through `/tmp`
against the same tree named `/private/tmp`, where dropping that call
answers False for the run that is the whole suite. The fourth paragraph
gave that reason before this branch and gives it now without leaning on
the first, which is where the deleted clause was.

The enumeration went with the clause: the sentence read "all four" over
`tests`, `./tests`, `tests/` and a path above `testpaths`, and the
spellings being one path what is left is the path equal to a
`testpaths` entry and the path above it.

The issue's other half is `btclib-benchmarks`, whose docstring drops
the same clause at `a431b6a`, so this half is the last one and the
citation is a close.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr


Local review: CLEARED 46f41c70, which is this head, over two rounds. Round 1 refused the first sha over a false universal — the changelog said the `testpaths` side is resolved *for the symlink alone*, which three `..` counterexamples refute; round 2 confirmed the fix by blob identity on the unchanged file and by a symlink built for the purpose rather than the `/tmp` coincidence. Gates on that tree, all eight at exit 0, run by the coder and re-run independently by the reviewer at this head: `uv sync`; `uv run ruff check --fix`; `uv run ruff format` (415 files unchanged); `uv run mypy src/btclib tests .github/scripts` (364 source files); `uv run pytest` (**32221 passed, 31 skipped, 1 xfailed**, coverage 100.00%); `uv run pre-commit run --all-files` (41 Passed, 1 Skipped, 0 Failed); `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html`; and the documentation job's second step, `/usr/bin/grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'` (exit 1, with both controls firing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Clarify why pytest test paths are resolved and align the documented path cases with pathlib’s normalization behavior.

Enhancements:
- Clarify the `asks_for_everything` documentation to explain that resolving the command-line path makes relative paths comparable with absolute `testpaths` entries, while the joined test paths are resolved to account for symlinked root directories.
- Update the documented path enumeration to reflect that equivalent spellings such as `./tests` and `tests/` are normalized by `pathlib` itself.

Documentation:
- Document the distinct reasons for resolving command-line and configured test paths, including relative-path handling and symlinked root directories.