### PR TITLE
`conftest_test.py` defends each `.resolve()` of `asks_for_everything` (issue btclib-org/.github#806)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1925,6 +1925,26 @@ file of the test tree, and no caller acts on it.
   spellings being one path, what equality misses is the path above
   `testpaths` and nothing else.
 
+### `conftest_test.py` defends each `.resolve()` of `asks_for_everything`
+
+- **Two cases fail where either `.resolve()` of `asks_for_everything`
+  is removed** (issue btclib-org/.github#806): the `testpaths` side's
+  call was the one with nothing to fail, a suite without it green where
+  a suite without the command line's is red on the relative spellings
+  the whole-run case names. What a missing call costs is not a red test
+  but the coverage ratchet relaxed to zero for a run that collects
+  everything, in a tree reached through a symlink -- `/tmp` on macOS.
+- **The symlink case asserts each call separately**, the command line
+  spelled through a link against a real rootdir and then the mirror, so
+  neither assertion stands in for the other. The parent-segment case is
+  the `testpaths` side's alone and asks for no symlink and no
+  privilege: `pathlib` keeps `..` at construction, so the unresolved
+  join `tests/../src` has `tests` among its parents, and a command line
+  naming `tests` reads as above an entry that collects nothing of `src`.
+- **`asks_for_everything`'s own docstring is unchanged**, what it says
+  about the parent-directory case being btclib-org/.github#836's one
+  decision across the trees that carry the function.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/conftest_test.py
+++ b/tests/conftest_test.py
@@ -185,6 +185,97 @@ def test_a_path_that_collects_the_suite_is_a_whole_run(
     assert gate == 100.0
 
 
+def test_a_symlinked_spelling_of_one_tree_is_still_the_whole_suite(
+    tmp_path: Path,
+) -> None:
+    """Both sides are resolved, so one directory named twice is one path.
+
+    A path on the command line and a `testpaths` entry joined onto the
+    rootdir can each be spelled through a symlink -- `/tmp` is one on
+    macOS, and a checkout under a linked home is another. pytest builds
+    `rootpath` with `os.path.abspath`, which leaves the link in the path
+    alone, so the two sides meet only once `Path.resolve` has followed
+    it: unresolved on one side, `/tmp/...` neither equals
+    `/private/tmp/...` nor is above it, and the run that collects
+    everything is gated at nothing.
+
+    One assertion per call, and neither stands in for the other: the
+    first answers the ratchet with the `testpaths` side left unresolved,
+    the second with the command line's side left unresolved.
+
+    The link is made here rather than taken from the machine, so what
+    the case is about is the comparison and not which directories an
+    operating system happens to link. Creating one on Windows takes a
+    privilege a runner need not hold, so a platform that refuses says so
+    as a skip, which `-ra` reports.
+    """
+    base = tmp_path.resolve()
+    real = base / "real"
+    (real / "tests").mkdir(parents=True)
+    link = base / "link"
+    try:
+        link.symlink_to(real, target_is_directory=True)
+    except OSError as refused:  # pragma: no cover -- Windows without the privilege
+        pytest.skip(f"this platform will not create a symlink: {refused}")
+
+    named_through_the_link = coverage_fail_under(
+        None,
+        100.0,
+        [str(link / "tests")],
+        "",
+        "",
+        *_NO_FURTHER_SELECTION,
+        _TESTPATHS,
+        real,
+    )
+    assert named_through_the_link == 100.0
+
+    rootdir_through_the_link = coverage_fail_under(
+        None,
+        100.0,
+        [str(real / "tests")],
+        "",
+        "",
+        *_NO_FURTHER_SELECTION,
+        _TESTPATHS,
+        link,
+    )
+    assert rootdir_through_the_link == 100.0
+
+
+def test_a_testpaths_entry_is_the_directory_its_parent_segment_reaches(
+    tmp_path: Path,
+) -> None:
+    """`tests/../src` is `src`, which a command line naming `tests` misses.
+
+    `pathlib` keeps a parent-directory segment where it collapses `.`
+    and a trailing separator, so the unresolved join carries `..` into a
+    path whose parents include the directory that segment left: `tests`
+    then reads as above `tests/../src`, and a run collecting nothing of
+    `src` is handed the whole suite's ratchet. Resolving the join makes
+    the entry the directory it reaches, which `tests` is not above.
+
+    That is the `testpaths` side's second reason, and it asks for no
+    symlink and no privilege, so it holds where the case above can only
+    skip. A `..` that re-enters the directory it left -- `tests/../tests`
+    -- cannot see it: the unresolved target then has more parents and the
+    command line's path is one of them, so containment answers the same
+    with the call and without it.
+    """
+    base = tmp_path.resolve()
+    gate = coverage_fail_under(
+        None,
+        100.0,
+        [str(base / "tests")],
+        "",
+        "",
+        *_NO_FURTHER_SELECTION,
+        ["tests/../src"],
+        base,
+    )
+    assert gate == 0
+
+
 @pytest.mark.parametrize(
     "file_or_dir, keyword, markexpr",
     [


### PR DESCRIPTION
**This branch takes a decision the issue reserved, and here it is first.**
ISS 806 asks for one case per tree, "whose paths differ only by a
symlink". This branch ships **two**: the symlink case the issue names,
and a second, `test_a_testpaths_entry_is_the_directory_its_parent_segment_reaches`,
which uses a parent-directory segment instead.

**The ground.** The symlink case's whole body sits behind a
`pytest.skip`, because `os.symlink` may be refused. On a platform that
refuses it, the branch would defend nothing at all. The parent-segment
case asks for no symlink and no privilege, so it holds where the first
can only skip -- and it is the only thing in any of the four trees that
defends `resolve(wanted)` without one.

**The cut-back if that is unwanted**: delete the second case and its
changelog bullet's second half. The symlink case alone answers box 1 as
written, and the diff is a strict superset of the minimal answer.

Two things this body deliberately does **not** claim, both refuted in
review: that `btclib` is in `btclib-benchmarks`'s position rather than
`bitcoin-core-rpc`'s (their `asks_for_everything` predicates are
byte-identical once docstrings are stripped), and that the `..` route
cannot defend `wanted` (it can -- that is what the new case does). The
issue carries a correction comment for the second, since the claim was
written there.

---

`tests/conftest.py`'s `asks_for_everything` resolves both sides of its
containment test, and at `04100c7d` **the `testpaths` side's call was
entirely undefended**: drop `resolve(wanted)` there and the suite is
green at 100.00%. That is the measurement the branch exists for, taken
in a worktree at the base by the coder and independently by the
reviewer.

At the tip both mutants die on a **named assertion**, not on the
coverage floor:

| variant | exit | outcome | coverage |
| --- | --- | --- | --- |
| as written | 0 | 32223 passed | 100.00% |
| drop `resolve(wanted)` | 1 | 2 failed | **100.00%**, ratchet still *reached* |
| drop `resolve(given)` | 1 | 5 failed | 99.99% |

The `wanted` row is the control that matters: coverage at 100% and the
suite red, so nothing here is caught by the floor. Each mutation was
asserted before use -- anchor unique with a firing sham, `.resolve()`
count 2 to 1, `--numstat` `1 1` -- and each restore proved by `cmp` with
a tampered-reference control, ending at the commit's own blob.

The two symlink assertions are independent: dropping `wanted` kills the
case's second assertion, dropping `given` its first, one call each.

`(issue ...)` and not `(closes ...)`: box 1 is now answered in all four
trees, and box 2 -- `btclib-node`'s case reachable without a
`pytest.Config`, or the absence stated where the function is -- is not.
At `btclib-node` the signature is still
`asks_for_everything(config: pytest.Config)` and its docstring says
nothing about it, at `71f6aee1` and at that tree's tip today. No branch
in **this** repository can satisfy that box, so closing here would shut
an issue on an unmet one.

`conftest_test.py` defends each `.resolve()` of `asks_for_everything` (issue btclib-org/.github#806)

Two cases, one per call. The symlink case names one directory twice --
the command line through a link against a real rootdir, then the mirror
-- so each of its assertions answers the ratchet with the other side's
call removed. The parent-segment case is the `testpaths` side's second
reason: `pathlib` keeps `..` at construction, so an unresolved
`tests/../src` has `tests` among its parents and a run collecting
nothing of `src` reads as the whole suite.

Take either call away and the suite is red. `Path(path).resolve()`
reduced to `Path(path)` breaks the symlink case's first assertion;
`(rootpath / path).resolve()` reduced to the join breaks its second and
the parent-segment case with it.

The `testpaths` side is what this branch adds a defence for: at
04100c7d the same edit there leaves the suite green, where the edit to
the command line's side fails the relative spellings the whole-run case
names.

`asks_for_everything`'s own docstring is untouched: what it says about
`..` is btclib-org/.github#836, which asks for one decision across the
trees that carry the function.

The citation names the issue rather than closing it. Its first box is
now answered in all four trees; its second is not. That box asks that
`btclib-node`'s case be reachable without a `pytest.Config`, or that the
absence be stated where the function is. At `btclib-node` `71f6aee1` the
signature is still `asks_for_everything(config: pytest.Config)` and its
docstring says nothing about it, so neither alternative holds and the
issue stays open for that tree.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr


Reviewed locally at fresh context before this pull request was opened: `CLEARED da84c1f30af354c8356ee33807b6aa2b1a273b82`, after a first round on `183ca9d3` whose box-2 finding is what changed the citation from `closes` to `issue`. Gates on that tree, the eight of `CONTRIBUTING.md`'s last section: `uv sync`; `uv run ruff check --fix`; `uv run ruff format` (415 files unchanged); `uv run mypy src/btclib tests .github/scripts` (364 source files); `uv run pytest` (32223 passed, 31 skipped, 1 xfailed, 100.00%); `uv run pre-commit run --all-files` (41 Passed, 1 Skipped, 0 Failed); `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html`; and the docs job's recursive grep for a `href="#../` form over `docs/build/html`, which passes at exit 1 -- run with both controls, a populated root and a planted match that makes the same command exit 0. All run by the coder and independently by the reviewer, twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Strengthen `asks_for_everything` coverage so both path-resolution checks are protected against regression.

Enhancements:
- Add coverage tests that independently defend both path-resolution checks in `asks_for_everything`, including symlinked paths and parent-directory path segments.

Tests:
- Add symlink and parent-segment test cases that fail when either containment operand is no longer resolved.