### PR TITLE
`scorecard.yml`'s `actions: read` carries its own reason (closes btclib-org/.github#871)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,11 +59,19 @@ jobs:
       id-token: write
       # SARIF results filed as code-scanning alerts
       security-events: write
-      # elevation-per-job: this job writes neither a release nor
-      # anything else to the tree, so contents stays at its workflow
-      # default of read
-      actions: read
+      # this job writes neither a release nor anything else to the
+      # tree, so read is all it takes -- granted here rather than
+      # inherited, a job's own block replacing the workflow-level one
+      # rather than adding to it, so a scope this block omits is none
+      # for this job
       contents: read
+      # what the Packaging check reads workflow-run history with, to see
+      # whether release.yml has runs that succeeded -- ossf/scorecard's
+      # checks/raw/github/packaging.go calls
+      # Client.Actions.ListWorkflowRunsByFileName for a workflow file its
+      # matcher recognizes as publishing, which release.yml is by its
+      # pypa/gh-action-pypi-publish step
+      actions: read
     # a run past this is hung rather than analysing
     timeout-minutes: 15
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1945,6 +1945,28 @@ file of the test tree, and no caller acts on it.
   about the parent-directory case being btclib-org/.github#836's one
   decision across the trees that carry the function.
 
+### `scorecard.yml`'s `actions: read` carries its own reason
+
+- **The analysis job's `actions: read` sits under a comment naming the
+  call that asks for it, and `contents: read` moves up under the comment
+  that explains it** (closes btclib-org/.github#871): `ossf/scorecard`'s
+  `checks/raw/github/packaging.go` calls
+  `Client.Actions.ListWorkflowRunsByFileName` for a workflow file its
+  Packaging check recognizes as publishing, which `release.yml` is by
+  its `pypa/gh-action-pypi-publish` step. Measured here rather than
+  ported: this repository's own scorecard result scores Packaging 10 and
+  names `release.yml`'s `publish-testpypi` job, which the check reports
+  only where that call returns a run. The comments are
+  `btclib-secp256k1`'s, landed there first for its own copy.
+- **`REPOSITORY.md`'s *Token permissions* stops putting the analysis
+  job's `contents` at the workflow's `read`**: the job's own block
+  replaces the workflow-level one rather than adding to it, so a scope
+  it omits is `none` for that job. One `release.yml` run shows it --
+  `publish-pypi`, whose block names `id-token: write` alone, logs no
+  `Contents` in its `GITHUB_TOKEN Permissions` group, where
+  `version-check`, declaring no block in the same run, logs
+  `Contents: read` under the same workflow-level grant.
+
 ## v2026.9.3
 
 ### Repository

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -555,9 +555,11 @@ write` with `attestations: write`: OIDC for the short-lived Sigstore
 signing certificate, and the write that persists the attestation against
 the repository. `scorecard.yml`'s `analysis` holds `id-token: write` with
 `security-events: write`: the transparency-log entry `publish_results`
-asks for, and the SARIF filed as code-scanning alerts, with `contents` at
-the workflow's `read` because the analysis pushes nothing back to the
-tree.
+asks for, and the SARIF filed as code-scanning alerts. `contents: read`
+sits in that block too, granted there rather than taken from the
+workflow's: a job's own `permissions:` replaces the workflow-level one
+rather than adding to it. `read` is all the analysis takes of it,
+pushing nothing back to the tree.
 `claude-review.yml`'s `review` and `mention` hold `pull-requests: write`
 with `id-token: write`, where only the first is a write of theirs: the
 action mints a GitHub OIDC token during its own startup whatever the


### PR DESCRIPTION
The **fourth and last** tree of this convergence. `scorecard.yml`'s
analysis job carried a comment saying it elevates above a workflow-level
default of read; a job-level `permissions:` block *replaces* the
workflow-level one rather than merging into it, so the sentence was false
and `actions: read` had no reason at all.

The analysis job's permissions block is now byte-identical in all four
trees -- 972 bytes, md5 `f08ab8b2c70b53f7e3eace3d8fa61ca2` -- measured
from the commit objects by the coder and independently by the reviewer,
each with a tamper control firing at char 847.

**`REPOSITORY.md` is in this diff, and it is the branch's one judgement
call.** That file said the analysis job holds `contents` "at the
workflow's `read`". The comment this branch writes says the opposite
mechanism, so a reader would meet two contradictory claims about one job.
The reviewer checked the reasoning and sharpened it: the sentence was
**already false at the base** -- `contents: read` was already inside the
job's own block -- so this is not *Collateral*'s "your diff falsifies a
sentence elsewhere" but its "evidence you lean on is evidence you own",
together with `REVIEWING.md`'s "what was already wrong and this diff
makes materially worse". No sibling carries the sentence and
`REPOSITORY.md` is in no verbatim-compared set, so nothing converged is
at risk.

**This tree's own evidence, not borrowed** -- 871's first box asks for a
reason "re-measured against that tree rather than copied from here":

- `pypa/gh-action-pypi-publish` at `release.yml:495` and `:542`, with a
  live control and a sham.
- This tree's scorecard run **34081103537** at headSha `47b23298`:
  Packaging **10**, detail naming `release.yml:447` -- the
  `publish-testpypi:` **job** key, a different job from the one
  `btclib-node`'s record names. The reviewer closed the coder's one open
  question here: the job's own log emits the result JSON inline, so the
  published document *is* that run's artefact rather than merely
  contemporaneous with it.
- The analysis job's token logged as `Actions: read, Contents: read,
  Metadata: read, SecurityEvents: write`.
- *Replace, not merge* re-derived from `release.yml` run 33248410519:
  `Contents` absent from exactly the jobs declaring a block that omits
  it, present in the job of the same run declaring none.

**One thing shipped knowingly.** The converged comment ends "so a scope
this block omits is none for this job", which is a false universal --
`metadata` is granted to every job and declared in none. It is
btclib-org/.github#893, it is carried here verbatim rather than fixed in
one tree, and the reviewer disagreed with that call while not blocking on
it. Its reasons and mine are recorded on 893 and on the issue, including
that 893's own box for this branch is being superseded rather than
quietly dropped.

`scorecard.yml`'s `actions: read` carries its own reason (closes btclib-org/.github#871)

The analysis job's `actions: read` sat under the three-line comment that
explains `contents: read`, so one scope carried another's reason and the
other carried none. `contents: read` moves up under the comment that
explains it, and `actions: read` takes a comment of its own naming the
call that asks for it. The block is byte-identical to the one landed in
`btclib-secp256k1` 54e77074, `bitcoin-core-rpc` b38af903 and
`btclib-node` 0d06348a -- `cmp` of the same extraction answers 0 against
each, and answers 1 at line 17 against a one-word tamper of it.

What asks for the scope, read at `ossf/scorecard` c395761d, the commit
tag v5.5.0 dereferences to and the one `ossf/scorecard-action` v2.4.4
requires at its `go.mod:9`: `checks/fileparser/github_workflow.go:540`
matches a job holding a step whose `uses` is
`pypa/gh-action-pypi-publish`, the comparison at :417 being
`strings.HasPrefix(uses.Value, stepToMatch.Uses+"@")`.
`checks/raw/github/packaging.go:76` then calls
`RepoClient.ListSuccessfulWorkflowRuns`, which
`clients/githubrepo/workflows.go:44` implements as
`client.Actions.ListWorkflowRunsByFileName`, and the package the
Packaging check reports is appended at :108, inside `if len(runs) > 0`
and with `Msg` left nil -- which is what
`probes/packagedWithAutomatedWorkflow/impl.go:44` skips a package for
having.

Measured in this repository rather than ported: scorecard run
34081103537, at this branch's base 47b23298, reports `scorecard.commit`
c395761d and scores Packaging 10 with "Info: Project packages its
releases by way of GitHub Actions.: .github/workflows/release.yml:447",
the `publish-testpypi` job key, whose `pypa/gh-action-pypi-publish` step
is at :495. Its siblings in the same result are not all 10 --
Code-Review 3, CII-Best-Practices 2, Signed-Releases 0, CI-Tests 0,
Branch-Protection 5, SAST 7 -- so the score is the check's answer rather
than a constant. The one path to that score without the Actions call is
`ErrUnsupportedFeature`, which `workflows.go:40` returns for a query
that is not `HEAD`; scorecard-action `options/options.go:197` sets
`Commit` to scorecard's `DefaultCommit`, which is `clients.HeadSHA`,
and the assignment is unconditional, so this run took the call.

The old comment also said a scope stays at its workflow default, which a
job-level block does not do. In `release.yml` run 33248410519 the
`publish-pypi` job, whose own block names `id-token: write` alone, logs
`Metadata: read` and no `Contents`, and `attest`, whose block names
`id-token: write` with `attestations: write`, logs `Attestations: write`
and `Metadata: read`; `version-check`, declaring no block in the same
run, logs `Contents: read`. The blocks are read out of `release.yml` at
that run's head a6502da0, whose workflow-level `permissions: contents:
read` is at :18-19.

`REPOSITORY.md`'s *Token permissions* put the same job's `contents` "at
the workflow's `read`", which the comment this branch writes
contradicts, so that clause goes with it. The rule it now states is the
one the section already gives a few lines above for a reusable
workflow's caller.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr


Reviewed locally at fresh context before this pull request was opened: `CLEARED f4aef4b731b65ca6867a28ad3643561dee8db0e2`. The reviewer ran all eight gates itself, re-derived every load-bearing citation including the scorecard source chain at its pinned commits, and recorded a disagreement with one instruction of mine without blocking on it. Gates on that tree, all eight of `CONTRIBUTING.md`'s last section, run by the coder and independently by the reviewer: `uv sync`; `uv run ruff check --fix`; `uv run ruff format` (415 files unchanged); `uv run mypy src/btclib tests .github/scripts` (364 source files); `uv run pytest` (32223 passed, 31 skipped, 1 xfailed, 100.00%); `uv run pre-commit run --all-files` (41 Passed, 1 Skipped, 0 Failed); `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html`; and the docs job's recursive grep over `docs/build/html` for a self-anchored parent-directory href, which passes at exit 1. Both of that gate's controls fired for each of them -- a populated root of 27 files, and a planted match making the identical command exit 0 -- with the plant removed and the removal proved by `cmp` against a backup outside the worktree, itself controlled by a tampered reference. All exit 0 (the eighth, 1 by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Clarify the scorecard workflow's job-level token permissions and align the repository documentation with their actual behavior.

Enhancements:
- Clarify the scorecard analysis job's GitHub token permissions by documenting that job-level permissions replace workflow defaults and by giving `actions: read` its own rationale.
- Correct the repository token-permissions documentation to reflect the analysis job's explicitly granted `contents: read` permission.

Documentation:
- Add a changelog entry describing the scorecard permission clarification and documentation correction.