### PR TITLE
A cross-repository reference in this tree's prose names its owner (issue btclib-org/.github#642)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1967,6 +1967,24 @@ file of the test tree, and no caller acts on it.
   `version-check`, declaring no block in the same run, logs
   `Contents: read` under the same workflow-level grant.
 
+### A cross-repository reference in this tree's prose names its owner
+
+- **The references to `btclib-secp256k1`'s and `bitcoin-core-rpc`'s
+  trackers in source comments, docstrings, `pyproject.toml`,
+  `RELEASING.md` and `REPOSITORY.md` are written `btclib-org/<repo>#N`**
+  (issue btclib-org/.github#642): section 9's *A reference to another
+  repository is qualified* asks for `owner/repo#N`, and it is a general
+  bullet of that section rather than one of its `CHANGELOG.md`
+  subsection's, so it reaches a comment and a docstring the way it
+  reaches an entry. Its one exemption is a pull request's closing
+  keyword, which the forge reads.
+- **`CHANGELOG.md`'s own unqualified references stay as they are**:
+  *Nothing already written is rewritten* binds what is written next.
+- **A paragraph that `btclib-org/` pushed past 80 columns is rewrapped,
+  and its words are unchanged**: `max-doc-length` holds a docstring and
+  a whole-line comment to that width, and `toml-comment-width` a toml
+  comment.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -368,7 +368,7 @@ to `deps-latest`'s own result.
 
    `gh pr merge <n> --squash` alone can still refuse this pull request —
    `the base branch policy prohibits the merge` — the way it did on
-   btclib-secp256k1's own v0.8.0.4 (btclib-secp256k1#288): a
+   btclib-secp256k1's own v0.8.0.4 (btclib-org/btclib-secp256k1#288): a
    solo-maintainer repository never clears `REVIEW_REQUIRED`, so gh's
    client-side mergeable check declines before it asks the server at
    all, and `--auto` only waits longer for the same review that will not

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -758,7 +758,7 @@ answering an empty list, so the `0` above is a repository with no hook
 and not a permission ceiling that reads like one. Every repository of the
 organization answers `0`; the last per-repository webhook left anywhere
 was bitcoin-core-rpc's, dead since the App arrived and deleted on
-2026-08-28 (bitcoin-core-rpc#291).
+2026-08-28 (btclib-org/bitcoin-core-rpc#291).
 
 ## Security settings
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,23 +141,24 @@ classifiers = [
 # upgrade onto the Python arithmetic, which is tens of times slower and
 # is not constant-time -- SECURITY.md publishes both
 secp256k1 = [
-    # 0.8.0.3 for `xonly.tweak_add_` (btclib-secp256k1#158), which
-    # `script.taproot` calls: it tweaks the parsed internal key, where
-    # `xonly.tweak_add` parses the x again and that parse is a field square
-    # root. The same version for `keys.pubkey_sum`, `xonly.pubkey_verify`
-    # and `xonly.to_pubkey` (btclib-secp256k1#171), which `curves.curve`
-    # calls -- one sum instead of a combine per term, and the two
-    # questions about an x asked as x-only questions. The same version
-    # again for `keys.pubkey_tweak_mul_sum` (btclib-secp256k1#182), which
+    # 0.8.0.3 for `xonly.tweak_add_` (btclib-org/btclib-secp256k1#158),
+    # which `script.taproot` calls: it tweaks the parsed internal key,
+    # where `xonly.tweak_add` parses the x again and that parse is a field
+    # square root. The same version for `keys.pubkey_sum`,
+    # `xonly.pubkey_verify` and `xonly.to_pubkey`
+    # (btclib-org/btclib-secp256k1#171), which `curves.curve` calls -- one
+    # sum instead of a combine per term, and the two questions about an x
+    # asked as x-only questions. The same version again for
+    # `keys.pubkey_tweak_mul_sum` (btclib-org/btclib-secp256k1#182), which
     # is that sum with its terms as well, so that no product of a
     # multi-scalar multiplication crosses the boundary; and for
-    # `ssa.Signer` (btclib-secp256k1#154), which `ecc.ssa.Signer` holds so
-    # that a keypair is built once per key rather than once per signature;
-    # and for `dsa.sign` accepting a caller-owned 32-octet cffi array as
-    # `prvkey` and passing it through unconverted (btclib-secp256k1#253),
-    # which `ecc.dsa.Signer` now holds so that `wipe` reaches the
-    # delegated arm too (issue #1009).
-    # 0.8.0.4 for the `musig` module (btclib-secp256k1#282), which
+    # `ssa.Signer` (btclib-org/btclib-secp256k1#154), which
+    # `ecc.ssa.Signer` holds so that a keypair is built once per key rather
+    # than once per signature; and for `dsa.sign` accepting a caller-owned
+    # 32-octet cffi array as `prvkey` and passing it through unconverted
+    # (btclib-org/btclib-secp256k1#253), which `ecc.dsa.Signer` now holds
+    # so that `wipe` reaches the delegated arm too (issue #1009).
+    # 0.8.0.4 for the `musig` module (btclib-org/btclib-secp256k1#282), which
     # `btclib._libsecp256k1` imports and `btclib.ecc.musig2` calls --
     # `KeyAggCache` and `Session`, which is issue #1049's delegation of
     # `partial_sig_verify_`.

--- a/src/btclib/_libsecp256k1.py
+++ b/src/btclib/_libsecp256k1.py
@@ -89,7 +89,7 @@ try:
     # package can overwrite, the way `ssa.Signer` already can through the
     # keypair `ssa` itself builds. Nothing else here needs it, `dsa.sign`
     # and every other wrapped call taking that buffer as the `prvkey` a
-    # caller may already hold (btclib-secp256k1#253)
+    # caller may already hold (btclib-org/btclib-secp256k1#253)
     from btclib_secp256k1 import (
         dsa,
         ellswift,

--- a/src/btclib/curves/curve.py
+++ b/src/btclib/curves/curve.py
@@ -664,12 +664,12 @@ def _libsecp256k1_multi_mult_(
     including `double_mult_var`'s two, the count most callers have.
     Handing over the whole equation is what stops it, and that is the one
     composition the bindings hold rather than this side
-    (btclib-secp256k1#182): a term of a multi-scalar multiplication is a
-    `secp256k1_pubkey` nobody outside the sum has a use for, and this
-    library holds no parsed key by design. The measurement per term count
-    is in the CHANGELOG entry that took each half, which is where a
-    figure belongs: an entry is read as the history of a release and this
-    is read as a statement about the code as it stands.
+    (btclib-org/btclib-secp256k1#182): a term of a multi-scalar
+    multiplication is a `secp256k1_pubkey` nobody outside the sum has a use
+    for, and this library holds no parsed key by design. The measurement
+    per term count is in the CHANGELOG entry that took each half, which is
+    where a figure belongs: an entry is read as the history of a release
+    and this is read as a statement about the code as it stands.
 
     At least one term, the sum refusing an empty sequence as
     `pubkey_combine` does, and as many scalars as points, which is what

--- a/src/btclib/ecc/dsa.py
+++ b/src/btclib/ecc/dsa.py
@@ -891,8 +891,8 @@ def sign_(
     # parsed: a caller who declined the check and supplied a key to check
     # with should hear about the two arguments rather than about the
     # octets of one of them. The bindings refuse the same pair
-    # (btclib-secp256k1#245), and this raises it on both arms so that a
-    # dispatch nobody asked for is not what decides
+    # (btclib-org/btclib-secp256k1#245), and this raises it on both arms
+    # so that a dispatch nobody asked for is not what decides
     if pub_key is not None and not verify:
         raise BTClibValueError("pub_key is for the check that verify=False declines")
 
@@ -1167,10 +1167,10 @@ def sign_recoverable_(
         # reads the recovery id, and the id is a value this call is made
         # for and that nothing downstream re-derives -- a faulted r or s
         # fails the first verification anybody makes, a wrong id does not.
-        # A verification's worth (btclib-secp256k1#224), once per
+        # A verification's worth (btclib-org/btclib-secp256k1#224), once per
         # signature, this path not grinding. Written out, it survives
         # the day the wrapper's default is asked again in
-        # btclib-secp256k1#224
+        # btclib-org/btclib-secp256k1#224
         sig_bytes, key_id = libsecp256k1_recovery.sign(msg_hash, q, verify=True)
         # `_sig_from_compact` for `sign_`'s reason, stated there: these
         # are the values secp256k1_ecdsa_sign_recoverable has just
@@ -1230,7 +1230,7 @@ def _delegated_sign_(
     holds, not an `int`: `dsa.sign`'s `prvkey` argument passes a cffi
     array of exactly that length straight through to libsecp256k1
     unconverted rather than coercing it to a fresh `bytes`
-    (btclib-secp256k1#253), which is what lets the class docstring's
+    (btclib-org/btclib-secp256k1#253), which is what lets the class docstring's
     `wipe` reach every signature this makes and not only the reference
     this object drops.
 
@@ -1284,11 +1284,11 @@ class Signer:
     `Signer` holding one copy of the key needs somewhere of its own to
     keep it. `dsa.sign`'s `prvkey` argument takes a cffi array of
     exactly 32 octets and passes it through unconverted
-    (btclib-secp256k1#253), so a caller who owns the buffer keeps owning
-    it. This class builds one such buffer at construction --
+    (btclib-org/btclib-secp256k1#253), so a caller who owns the buffer
+    keeps owning it. This class builds one such buffer at construction --
     `ffi.new("unsigned char[32]", ...)` -- and hands the bindings that
-    same pointer on every signature it makes, so there is one copy of
-    the secret this holds throughout its life, on both arms, and `wipe`
+    same pointer on every signature it makes, so there is one copy of the
+    secret this holds throughout its life, on both arms, and `wipe`
     overwrites it on both: the buffer's own 32 octets here,
     `secp256k1_keypair`'s there.
 
@@ -1348,8 +1348,8 @@ class Signer:
         # signature and `wipe` overwrites on the way out, built here
         # rather than left as the `int` above: `dsa.sign`'s `prvkey`
         # passes a 32-octet cffi array through unconverted
-        # (btclib-secp256k1#253), so this is the one copy of the secret
-        # this arm holds for the whole of the instance's life
+        # (btclib-org/btclib-secp256k1#253), so this is the one copy of
+        # the secret this arm holds for the whole of the instance's life
         self._prvkey_buffer: Any | None = (
             libsecp256k1_ffi.new("unsigned char[32]", self._q.to_bytes(32, "big"))
             if self._pub_key_sec is not None
@@ -1386,7 +1386,7 @@ class Signer:
 
         On the delegated arm the buffer built at construction is what is
         overwritten, `ffi.buffer(self._prvkey_buffer)[:] = bytes(32)`
-        (btclib-secp256k1#253 is what makes it the same memory every
+        (btclib-org/btclib-secp256k1#253 is what makes it the same memory every
         signature reads, rather than a copy the bindings threw away):
         this arm's every signature has read the same 32 octets this
         instance holds, so wiping them reaches every one of them at

--- a/src/btclib/ecc/ssa.py
+++ b/src/btclib/ecc/ssa.py
@@ -480,9 +480,9 @@ def sign_(
     multiplication the check would otherwise do per signature; here there
     is none to save, the keypair holding the point already, so the check
     costs what it costs whether the caller holds the key or not --
-    btclib-secp256k1#224 is where that is measured, and #982 is where the
-    two schemes are put side by side. It would buy nothing and sell one
-    thing: a second reason a check can fail, and with it the
+    btclib-org/btclib-secp256k1#224 is where that is measured, and #982 is
+    where the two schemes are put side by side. It would buy nothing and
+    sell one thing: a second reason a check can fail, and with it the
     discrimination step `dsa._abort_unless_checked` has to pay for.
 
     commit_hash is a value to commit to inside the nonce, sign-to-contract
@@ -533,9 +533,9 @@ def sign_(
         # BIP340's step being a bare verification under a point the
         # keypair already holds. What it costs is measured where it is
         # performed -- cheaper than ECDSA's own analogous step,
-        # btclib-secp256k1#224 -- and is not re-measured here, a figure
-        # of theirs kept in this file being one that ages when they
-        # change and says nothing when it does
+        # btclib-org/btclib-secp256k1#224 -- and is not re-measured here,
+        # a figure of theirs kept in this file being one that ages when
+        # they change and says nothing when it does
         try:
             signature = libsecp256k1_ssa.sign_custom(msg, q, aux, verify=verify)
         except RuntimeError as e:
@@ -839,7 +839,7 @@ class Signer:
         # largest share of what it is added to: the keypair was built
         # when this signer was, so signing here is markedly cheaper than
         # a fresh signature, and the same check on it is 61% of the call
-        # against 44% there (btclib-secp256k1#224). It is the
+        # against 44% there (btclib-org/btclib-secp256k1#224). It is the
         # one of btclib's signing calls a caller would most plausibly
         # want to decline, which is why the keyword reaching here is the
         # point of exposing it at all

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -2316,14 +2316,14 @@ def test_a_wiped_python_signer_refuses_rather_than_signing_with_the_zeros(
 def test_a_delegated_signer_s_wipe_zeroes_the_buffer_it_signs_from() -> None:
     """`wipe` reaches this arm's key now, not only the reference to it.
 
-    btclib-secp256k1#253 is what makes this true: `dsa.sign`'s `prvkey`
-    argument passes a 32-octet cffi array through unconverted rather
-    than coercing it to a fresh, unreachable `bytes` on every call
-    (btclib-secp256k1#247, closed by that change), so the buffer this
-    signer built at construction is the same 32 octets every signature
-    it has made was read from, and overwriting it now reaches every one
-    of them at once -- not only the copy this object happens to be
-    holding when `wipe` is called.
+    btclib-org/btclib-secp256k1#253 is what makes this true: `dsa.sign`'s
+    `prvkey` argument passes a 32-octet cffi array through unconverted
+    rather than coercing it to a fresh, unreachable `bytes` on every call
+    (btclib-org/btclib-secp256k1#247, closed by that change), so the
+    buffer this signer built at construction is the same 32 octets every
+    signature it has made was read from, and overwriting it now reaches
+    every one of them at once -- not only the copy this object happens to
+    be holding when `wipe` is called.
     """
     signer = dsa.Signer(prv_key_int)
     assert signer.sign(b"a message")


### PR DESCRIPTION
Section 9 of `README.md`: *A reference to another repository is
qualified*. This tree's live prose carried **22** unqualified
cross-repository references -- `btclib-secp256k1#253` where
`btclib-org/btclib-secp256k1#253` belongs -- across eight files. All 22
now carry the owner.

**The census's guard is the whole of the measurement.** Without
`[^/[:alnum:]_.-]` in front, the pattern matches the tail of an
*already* qualified reference and scores correct citations as defects;
the issue records that this has already produced a false claim. Guarded,
the census answers 22 at the base and **0** at the tip, with **22** still
answering when the `CHANGELOG.md` filter is dropped -- that last is the
control saying the zero is an absence rather than a broken pattern.
Per-file counts agree with the issue's table in every cell. The reviewer
built a five-line probe to confirm the `(^|...)` alternation actually
fires at column 1 in both `git grep -nE` and `/usr/bin/grep -nE`, the
shell `grep` here being `ugrep`, which has dropped an anchored
alternation in this campaign before.

**Nothing moved except the inserted `btclib-org/` and the line breaks.**
Eleven of the 22 lines would have passed 80 columns with the owner
added, so those paragraphs are rewrapped. That is asserted twice and
from the base blob rather than the tip: a token-stream comparison over
all eight files against the base with the substitution applied
independently (control against the unsubstituted blob: differs), and a
blank-line-block partition comparing block **count** and content, which
a word-stream assertion cannot do -- a rewrap has already dropped a
subject's blank line in this campaign while a word assertion passed.
Both controls fire: deleting one blank line gives 283 vs 282, changing
one word gives a content mismatch. Longest added line is 79 columns.

**`CHANGELOG.md`'s own 22 unqualified references are deliberately left
alone**, and the entry says so. Section 9's *Nothing already written is
rewritten* is explicit that both changelog files are append-only in
practice and `merge=union` in fact, and that the rule binds what is
written next. The reviewer re-derived the reading from the standard at
`7cfc442` and went further than the three line numbers it was given:
listing every heading between `## 9.` and `## 10.` shows the
`CHANGELOG.md` subsection is the *only* `###` in section 9, so there is
no intervening subsection the qualifier bullet could belong to instead.

**The references point at real objects.** All eleven distinct numbers
resolve in the repository now named, with titles matching the sentence
around them. The bare `#N` left in place beside the edits were checked
individually and each is this tree's own issue -- `ssa.py:483`'s `#982`
resolves in `btclib` while `btclib-secp256k1#982` 404s, so it cannot be
a sibling's.

The citation names the issue rather than closing it: ISS 642 has four
*Done when* boxes and this branch answers one. `bitcoin-core-rpc` (2
references) and `btclib-secp256k1` (1) still owe theirs, and so does the
box asking for a command or a suite that holds the rule.

A cross-repository reference in this tree's prose names its owner (issue btclib-org/.github#642)

Section 9's *A reference to another repository is qualified* is a general
bullet of the section, above the `CHANGELOG.md` subsection that ties
itself back to it, so it reaches a source comment, a docstring, a toml
comment, REPOSITORY.md and RELEASING.md alike. This tree's references to
btclib-org/btclib-secp256k1's and btclib-org/bitcoin-core-rpc's trackers
named the repository and left the owner off; they now carry it.

The census is the issue's own, run per sibling name with the
`[^/[:alnum:]_.-]` guard that stops an already-qualified reference
matching by its tail, and with CHANGELOG.md filtered out. It answers
nothing outside CHANGELOG.md on this branch, while dropping the
CHANGELOG.md filter still answers, so the pattern is one that could
still have found something.

Where `btclib-org/` took a line past 80 columns the paragraph is
rewrapped. Each rewrapped region was compared as a word stream against
the same region before the rewrap, so only the line breaks moved.

The issue's other boxes -- btclib-org/bitcoin-core-rpc's instances,
btclib-org/btclib-secp256k1's, and whether a command holds the rule --
are not this branch's, so the subject cites the issue and does not
close it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr


Local review: CLEARED 97e0667, which is this head. The reviewer relied on the coder's recorded gate run rather than repeating it, as `REVIEWING.md`'s *The gates are the evidence* permits for an author who gated the branch and said so, and it says so plainly; it re-derived the census, the guard, the widths, the changelog position, the section-9 reading and the citation choice from scratch. Gates on that tree, all eight run in the worktree by the coder: `uv sync` exit 0; `uv run ruff check --fix` exit 0; `uv run ruff format` exit 0 (415 files unchanged); `uv run mypy src/btclib tests .github/scripts` exit 0 (364 source files); `uv run pytest` exit 0 (32223 passed, 31 skipped, 1 xfailed, 100.00% coverage); `uv run pre-commit run --all-files` exit 0 (41 Passed, 1 Skipped, 0 Failed); `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html` exit 0; and `grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'`, which passes at exit 1 and was run with both its controls -- a populated root (161 html files) and a planted `<a href="#../CHANGELOG.md">` that makes it exit 0, restored from a backup held outside the worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Qualify unowned cross-repository issue references in the repository’s live prose without rewriting historical changelog entries.

Enhancements:
- Qualify cross-repository issue references throughout source comments, docstrings, configuration comments, and repository documentation with their owning organization.
- Rewrap affected prose while preserving its wording and leave historical CHANGELOG references unchanged under the append-only convention.

Documentation:
- Document the repository-reference qualification update and the intentional CHANGELOG exception in the changelog.