### PR TITLE
`scorecard.yml`'s comments point at the block and name the scope (issue btclib-org/.github#891, closes btclib-org/.github#893)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,10 +33,9 @@ on:
     # scheduled runs; this covers what push cannot -- a week with none.
     - cron: "4 5 * * 0"
 
-# least privilege for the GITHUB_TOKEN at the workflow level, with
-# elevation on the job below: the analysis reads the tree, requests a
-# transparency-log entry for its own result and files that result as
-# code-scanning alerts, and pushes nothing back to the tree.
+# least privilege for the GITHUB_TOKEN at the workflow level, elevated
+# on the job below -- each grant explained at its own line there -- and
+# pushes nothing back to the tree.
 permissions:
   contents: read
 
@@ -62,8 +61,8 @@ jobs:
       # this job writes neither a release nor anything else to the
       # tree, so read is all it takes -- granted here rather than
       # inherited, a job's own block replacing the workflow-level one
-      # rather than adding to it, so a scope this block omits is none
-      # for this job
+      # rather than adding to it, so contents omitted from this block
+      # would be none for this job
       contents: read
       # what the Packaging check reads workflow-run history with, to see
       # whether release.yml has runs that succeeded -- ossf/scorecard's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1985,6 +1985,37 @@ file of the test tree, and no caller acts on it.
   a whole-line comment to that width, and `toml-comment-width` a toml
   comment.
 
+### `scorecard.yml`'s workflow-level comment points at the job block
+
+- **The comment over the workflow-level `permissions:` enumerates
+  nothing and leaves each grant to the line explaining it in the
+  analysis job's own block** (issue btclib-org/.github#891): it named
+  the tree read, the transparency-log entry and the code-scanning
+  alerts, and nothing for the `actions: read` that the Packaging check's
+  workflow-run history call asks for. The wording is
+  `btclib-secp256k1`'s, which `bitcoin-core-rpc` and `btclib-node` took
+  for this issue. *`REPOSITORY.md` and `scorecard.yml` count an
+  elevation the same way* above records this comment dropping the "one"
+  in front of "elevation on the job below": the phrase it names is gone
+  and the comment counts nothing at all, and the agreement with
+  `btclib-node`'s copy that the same entry records holds under the new
+  wording, that tree having taken it too. That entry stays where it is.
+
+### `scorecard.yml`'s `contents: read` comment names the scope it is about
+
+- **The comment says what omitting `contents` from the analysis job's
+  block would do rather than what omitting any scope would do**
+  (closes btclib-org/.github#893): `metadata` is where the wider
+  reading fails, `actionlint` refusing it as a scope a `permissions:`
+  block may name while the analysis job's `GITHUB_TOKEN Permissions`
+  group logs `Metadata: read` all the same. `contents` is the only
+  scope this file grants at both levels, so it is the only one for
+  which replacing rather than adding decides anything.
+  *`scorecard.yml`'s `actions: read` carries its own reason* above
+  draws that consequence for every scope, and this entry supersedes
+  that sentence, which holds of `contents`, the scope the `release.yml`
+  run it cites measured. That entry stays where it is.
+
 ## v2026.9.3
 
 ### Repository


### PR DESCRIPTION
Two comment blocks in `.github/workflows/scorecard.yml`, thirty lines
apart, answering two issues; both are **ports of wordings settled and
landed in the three sibling trees**, not decisions taken here.

**ISS 891's part B -- the workflow-level comment.** It enumerated three
activities and omitted the `actions: read` the Packaging check's
workflow-run history call asks for, so it was a census that was short.
It now carries the wording the other three trees hold, which enumerates
nothing and points at the job block, where each grant carries its reason
at its own line.

**ISS 893 -- the analysis-job comment.** Its consequence was drawn for
every scope; `metadata` is where that reading fails, and it now names
`contents`, the scope it sits over.

```text
-      # rather than adding to it, so a scope this block omits is none
-      # for this job
+      # rather than adding to it, so contents omitted from this block
+      # would be none for this job
```

**Byte-identity across the family, measured from the object store by the
reviewer's own anchors rather than the author's.** The analysis-job
`permissions:` block here is identical to `btclib-secp256k1`'s at
`5716b6cc`, `btclib-node`'s at `d82ccc37` and `bitcoin-core-rpc`'s at
`5f5c280b`, with the pre-edit blob as a control that differs at char
427, line 9. And four trees is the whole family rather than a convenient
subset: `btclib-benchmarks`, `bbt`, `portanode`, `.github` and
`btclib-org.github.io` have no `scorecard.yml` at all, against a control
of 3 to 11 workflow files present in each.

**Both evidentiary halves re-measured in this tree.** `actionlint` --
whose hook carries `files: "^.github/workflows/"`, read from the hook
repository rather than assumed, so this file is genuinely in the gate's
input set -- exits 1 with *unknown permission scope "metadata"* on the
head blob with its single `      contents: read` replaced by
`      metadata: read`, and 0 unmodified, on the Homebrew binary and on
the pinned `actionlint-py v1.7.12.24` hook's. And this repository's own
scorecard run `34087914588`, at `db7a4ab7`, logs `Metadata: read` beside
`Actions: read`, `Contents: read` and `SecurityEvents: write`, while
`metadata` is declared in no workflow here against a control of 19 files
declaring `contents`.

**No YAML key or value moved**, and the reviewer took a tighter route
than a parser: the file holds no block scalar anywhere, so no
`#`-opening line can be YAML data, and identical non-comment lines is
therefore identical YAML. Every one of the eleven changed lines is a
comment line, against a control of eleven.

**Two entries, each superseding a different earlier one.** Section 9's
*An entry in the open section is a live claim* fires twice here. The
first names the entry saying the header comment "drops the 'one' in
front of 'elevation on the job below'" -- a phrase this port removes
outright, measured 1 in the base and 0 at head, with `elevated on the
job below` going 0 to 1 and `least privilege` unchanged as the control.
The second names this tree's carrier of the wide clause. A sweep of the
whole open section on seven markers over sliding windows found no third
bearing entry.

**The one sentence written here rather than ported is true**: `contents`
is the only scope this file grants at both levels, so it is the only one
for which replacing rather than adding decides anything -- for any scope
outside the intersection the two semantics give `none` either way.

**ISS 893 closes with this landing, and that was checked rather than
assumed.** Its two remaining boxes are the identical block across all
four trees, measured above, and the five landed changelog carriers each
superseded by a sentence naming the earlier one. The carrier census,
folded and counted with `re.findall` rather than `grep -c`, which
saturates at 1 on a folded file: 1 in `btclib-secp256k1`, 1 in
`btclib-node`, **2** in `bitcoin-core-rpc`, 1 here -- five, and each
sibling's entry was read rather than counted, `bitcoin-core-rpc`'s
naming both of its carriers.

ISS 891 does not close: `btclib-secp256k1` and `bitcoin-core-rpc` carry
a one-elevation-per-job sentence without this tree's exception clause,
which is that issue's own recorded remaining item.

Closes btclib-org/.github#893

`scorecard.yml`'s comments point at the block and name the scope (issue btclib-org/.github#891, closes btclib-org/.github#893)

The workflow-level permissions comment named the tree read, the
transparency-log entry and the code-scanning alerts, and nothing for the
actions: read that the Packaging check's workflow-run history call asks
for. It takes btclib-secp256k1's wording, which enumerates nothing and
leaves each grant to the line explaining it in the analysis job's own
block.

The analysis job's contents: read comment drew its consequence for every
scope, and takes btclib-secp256k1's corrected wording, which draws it for
contents. metadata is where the wider reading fails, and both halves are
re-measured in this tree. actionlint 1.7.12 exits 1 with unknown
permission scope "metadata" on this file with its single six-space
contents: read replaced by metadata: read, against exit 0 on the
unmodified file, on the Homebrew binary and on the one the pinned
actionlint-py v1.7.12.24 hook installs alike. And this repository's
scorecard run 34087914588, at this branch's base db7a4ab7, logs
Metadata: read in the analysis job's GITHUB_TOKEN Permissions group
beside Actions: read, Contents: read and SecurityEvents: write, where
git grep '^ *metadata:' over .github/workflows answers nothing.

Parsing the file's two permissions blocks, contents is the only scope
granted at both levels, so it is the only one for which replacing rather
than adding decides anything.

Both comment blocks are copied rather than re-derived: extracted by
identical anchors, each asserted to occur exactly once with a mutated
copy answering nothing, cmp reports each block equal to
btclib-secp256k1's at 5716b6cc, btclib-node's at d82ccc37 and
bitcoin-core-rpc's at 5f5c280b, and reports a difference against the
wording each replaces. No YAML key or value moves: the non-comment lines
are equal before and after, and the same comparison reports a difference
under a contents: read to contents: write control.

CHANGELOG.md gains two entries at the end of the open section, one per
issue. Each says what it does to an earlier entry of that same section,
which section 9 of the standard reads as a live claim: the workflow-level
entry to "REPOSITORY.md and scorecard.yml count an elevation the same
way", whose quoted phrase this wording removes, and the contents entry to
"scorecard.yml's actions: read carries its own reason", whose second
bullet draws the wide consequence. Both of those entries stay where they
are, and the append stays an append.

The two citations differ, and the family's state is what decides them.
btclib-org/.github#891 stays open: btclib-secp256k1 and bitcoin-core-rpc
carry a "one elevation per job" sentence without this tree's exception
clause, which that issue records as its remaining item.
btclib-org/.github#893 closes here, its two open boxes being answered
together: the settled wording now stands in every tree that carried the
clause, and each of those trees' landed changelog carriers is superseded
by a sentence in its own tree's new entry, this one being the last.
That is a departure from the brief, which asked for (issue ...) on both
and was written while two of the three sibling ports were still in
review; they landed at d82ccc37 and 5f5c280b while this branch was being
gated.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr


Local review: CLEARED a77d6b3, which is this head. The reviewer relied on the coder's recorded run rather than repeating it, as `REVIEWING.md` permits for an author who gated the branch and said so, and it says so plainly; it re-derived the byte-identity with its own anchors, both evidentiary halves, both supersessions, the five-carrier census across four trees and the closing count itself, and it closed the one gap the coder had declared open by reading the `actionlint` hook's own `files:` selector from the hook repository. Gates on that tree, all eight run in the worktree by the coder in two full rounds, the second at this head: `uv sync` exit 0; `uv run ruff check --fix` exit 0; `uv run ruff format` exit 0 (415 files unchanged); `uv run mypy src/btclib tests .github/scripts` exit 0 (364 source files); `uv run pytest` exit 0 (32223 passed, 31 skipped, 1 xfailed, 100.00% coverage); `uv run pre-commit run --all-files` exit 0 (41 Passed, 1 Skipped, 0 Failed); `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html` exit 0; and `grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'`, which passes at exit 1 and was run with both its controls in both rounds. The second round is the heavier one and it is the one quoted -- its suite ended at load 10.98 and its hooks ran at 10.10, both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Clarify Scorecard permission comments and update the changelog to reflect their corrected scope and wording.

Enhancements:
- Clarify the Scorecard workflow permission comments by delegating grant explanations to the analysis job and limiting the replacement semantics note to the `contents` scope.

Documentation:
- Document the corrected Scorecard comment behavior and record the supersession of the earlier changelog entries.