### PR TITLE
docs/source/conf.py's exclude_patterns names what this tree writes (issue btclib-org/.github#418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2016,6 +2016,20 @@ file of the test tree, and no caller acts on it.
   that sentence, which holds of `contents`, the scope the `release.yml`
   run it cites measured. That entry stays where it is.
 
+### `exclude_patterns` converges on `btclib-benchmarks`'s empty list
+
+- **`exclude_patterns` drops `sphinx-quickstart`'s stock
+  `["_build", "Thumbs.db", ".DS_Store"]` for `list[str] = []`** (issue
+  btclib-org/.github#418): `Thumbs.db` and `.DS_Store` never survive
+  `path2doc` under the `.md`/`.rst` this tree declares, and nothing
+  writes a `_build` directory inside `docs/source` for the entry naming
+  it to ever match. Section 2 of the organization standard is where the
+  rule this converges on now lives -- "`exclude_patterns` names what the
+  tree writes under `docs/source/`, and is empty where nothing does" --
+  and the three lines dropped above the line were `sphinx-quickstart`'s
+  own boilerplate about sphinx's API, not this tree's reasoning, so
+  nothing this tree said is lost with them.
+
 ## v2026.9.3
 
 ### Repository

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -130,10 +130,7 @@ nitpick_ignore = [
 
 templates_path = ["_templates"]
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-# This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns: list[str] = []
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
docs/source/conf.py's exclude_patterns names what this tree writes (issue btclib-org/.github#418)

sphinx-quickstart's stock ["_build", "Thumbs.db", ".DS_Store"] names
nothing this tree's build reaches. .DS_Store and Thumbs.db never
survive path2doc under the .md/.rst source_suffix this tree declares,
and _build is dead here for a layout reason rather than a sphinx one:
docs.yml and .readthedocs.yaml both write the built html outside
docs/source, and docs/Makefile's BUILDDIR is docs/build, so no page
ever lands where the entry would catch it. Neither html_static_path
nor html_extra_path is assigned here either, so exclude_patterns has
no second, suffix-free path to act through.

This converges the line on btclib-benchmarks' form,
exclude_patterns: list[str] = [], keeping the annotation since that
tree carries it and neither this tree's mypy invocation nor its
pre-commit hooks type-check docs/source/conf.py. The three lines
dropped above the line were sphinx-quickstart's own boilerplate about
sphinx's API, not this tree's reasoning, so nothing this tree said is
lost with them. Section 2 of the organization standard,
btclib-org/.github's README.md (issue btclib-org/.github#589), is
where the rule this converges on now lives: "exclude_patterns names
what the tree writes under docs/source/, and is empty where nothing
does."

This is a port of a rule already settled on the issue, not a new
decision, and it converges one of the four trees the issue's Done
when asks for, so btclib-org/.github#418 stays open.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr


Local review: CLEARED c0b4f950, whose tree this head carries byte for byte — the amend since is the commit message only, rewording a sentence whose "does not close" GitHub parsed as a closing keyword despite the negation. Round 1 blocked on a changelog sentence naming `README.md` where the organization standard was meant, and on a false claim about what the removed comment said. Gates on that tree, run on the cleared sha and carrying by tree identity: `uv sync`; `uv run ruff check --fix`; `uv run ruff format`, 415 files; `uv run mypy src/btclib tests .github/scripts`, 364 source files; `uv run pytest`, 32223 passed, 31 skipped, 1 xfailed at 100.00%; `uv run pre-commit run --all-files`, 41 Passed, 1 Skipped, 0 Failed; the docs `sphinx-build`, `build succeeded.`; and the unresolved-link grep at exit 1 with both its controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Align documentation source exclusions with the organization standard by removing unused Sphinx quickstart patterns.

Enhancements:
- Align Sphinx documentation exclusions with the repository layout by making `exclude_patterns` an explicitly typed empty list and removing obsolete quickstart boilerplate.

Documentation:
- Document the `exclude_patterns` standard and rationale in the changelog.