### PR TITLE
`conventions_test.py`'s docstring says what it reads and departs (issue btclib-org/.github#690)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2030,6 +2030,20 @@ file of the test tree, and no caller acts on it.
   own boilerplate about sphinx's API, not this tree's reasoning, so
   nothing this tree said is lost with them.
 
+### `conventions_test.py`'s docstring says what it reads and departs
+
+- **The docstring's second half stops restating how the organization's
+  suites name convention tests -- `tests/README.md` already says that
+  -- and instead names what this module itself reads and which of its
+  departures from the standard are decided** (issue
+  btclib-org/.github#690): `_CONVENTIONS` transcribes section 7's list
+  of conventions rather than reading `README.md` live, because the
+  standard lives in `btclib-org/.github` and a copy in this tuple is
+  the only form this tree can hold it in; a sibling whose standard and
+  declaration are the same commit reads it live instead. The issue names
+  other copies of this module owing the same header sentence, so it
+  stays open.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/conventions_test.py
+++ b/tests/conventions_test.py
@@ -11,14 +11,24 @@ of them. That clause is right, and its price is that an *absent*
 convention test is indistinguishable from a convention this repository
 does not have. Nothing anywhere recorded which of the two it was.
 
-A filename cannot answer it either. The suites of the organization name
-the same idea three ways -- a module per bullet here, a `test_` prefix in
-btclib-secp256k1, and in bitcoin-core-rpc several of these checks folded
-into the one file that is about its single module, which is the honest
-shape for a package that is one module. So the audit reads a declaration
-rather than a directory, and this module is what keeps the declaration
-from being prose: section 7's own rule, that a convention worth stating
-is worth a test, applied to section 7 itself.
+A filename cannot answer it either -- tests/README.md already says the
+suites of the organization name this idea differently tree to tree, and
+saying it again here would be the second statement section 9 refuses.
+What is left to this module is what follows from that: the audit reads
+a declaration rather than a directory, and this module is what keeps
+the declaration from being prose -- section 7's own rule, that a
+convention worth stating is worth a test, applied to section 7 itself.
+
+The header section 14 asks of every copy of this module is not that
+naming point again -- it is what this module itself reads, and which of
+its departures are decided rather than accidental. `_CONVENTIONS` below
+transcribes section 7's list rather than reading it live: the
+organization standard's own suite can read `README.md` straight, because
+the standard and the declaration are the same commit there, and a
+transcribed copy would be the second statement section 9 refuses and the
+one that goes stale. Here the standard lives in `btclib-org/.github`, so
+a transcribed copy is the only form this tree can hold it in, and
+`_CONVENTIONS` is that copy.
 
 What it does not check is whether a named module tests the convention it
 is named against. Nothing short of reading it can, and the four
@@ -94,7 +104,7 @@ _ROWS = tuple((m["convention"], m["module"]) for m in _ROW.finditer(_SECTION))
 def test_the_table_is_not_empty() -> None:
     """A declaration that parsed to nothing is the failure that hides.
 
-    Every assertion below quantifies over the rows, so a table this
+    Every assertion below is parametrized by the rows, so a table this
     module's regex stopped matching -- a column added, the backticks
     dropped, the heading retitled -- would satisfy all of them silently.
     """


### PR DESCRIPTION
Section 14 of the organization standard asks every copy of
`tests/conventions_test.py` for a header sentence about the module itself:
what it reads, and which of its departures are decided rather than accidental.
This tree's docstring carried a paragraph that reads like that sentence and is
not it -- it explained how the organization's suites name their convention
tests, which is section 7's own point and is already stated a second time in
this tree's own `tests/README.md`.

The paragraph now points at `tests/README.md` instead of restating it, and the
sentence section 14 asks for takes its place: `_CONVENTIONS` transcribes
section 7's list rather than reading `README.md` live, because the standard
lives in another repository, which is the mirror image of
`btclib-org/.github`'s own copy where the standard and the declaration are the
same commit.

Two smaller things ride along, both named by the review: the header now cites
section 14 as the authority it answers, as the landed `btclib-benchmarks` copy
does; and a neighbouring docstring said the assertions below it quantify over
the rows where they are parametrized by them, the family reserving "quantify"
for the other shape.

Other copies of this module still owe the same sentence, so
[ISS 690](https://github.com/btclib-org/.github/issues/690) stays open.

`conventions_test.py`'s docstring says what it reads and departs (issue btclib-org/.github#690)

Section 14 of the organization standard asks every copy of this module
for a header sentence about itself: what it reads, and which of its
departures from the standard are decided rather than accidental. This
tree's docstring carried a paragraph that reads like that sentence and
is not it: it explained how the organization's suites name convention
tests differently tree to tree (a module per bullet here, a `test_`
prefix elsewhere, several checks folded into one file elsewhere still),
which is section 7's own point and, in this tree, already stated a
second time in tests/README.md's own "Convention tests" section. That
duplication is what section 9's "One fact in one place" names, so the
paragraph is trimmed to the reasoning that is this module's own (why it
reads a declaration rather than a directory) and no longer repeats the
naming-conventions example that belongs to tests/README.md.

In its place: `_CONVENTIONS` transcribes section 7's list of
conventions into a tuple rather than reading `README.md` live. That is
the decided departure, and it is the mirror image of `btclib-org/.github`'s
own copy, which reads its conventions off `README.md` directly because
the standard and the declaration are the same commit there. Here the
standard lives in another repository, so a transcribed copy is the only
form this tree can hold it in -- reading it live is what a sibling
cannot do, transcribing it live is what `.github`'s own copy would not
need to.

Of the other two departures the issue names across the family, neither
is true of this tree: the copy lives at tests/conventions_test.py, the
same path every tree but btclib-node uses, and it parametrizes over its
rows rather than quantifying over them the way btclib-benchmarks does.

A CHANGELOG.md entry is appended to the open section, at its end.

The header sentence now names section 14 as the authority it answers,
which the landed btclib-benchmarks copy also does. One neighbouring
docstring said the assertions below it quantify over the rows where
they are parametrized by them; btclib-benchmarks reserves "quantify"
for the other shape in its own comment, so that word is corrected in
the same diff.

The issue names other copies of this module owing the same header
sentence, so btclib-org/.github#690 stays open for the rest of them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr


Reviewed locally at fresh context over two rounds. Round 1 blocked on a count of a moving population -- "Five copies ... owe the same header sentence" -- which was false by one and forbidden outright in an append-only entry; the figure is gone rather than corrected. `CLEARED d60ad7d8` after the fix and a full re-gate. Gates on that tree, all eight of `CONTRIBUTING.md`'s, run by me at this sha in the foreground with exit codes read in the same turn: `uv sync`; `uv run ruff check --fix`; `uv run ruff format`; `uv run mypy src/btclib tests .github/scripts`; `uv run pytest` (32223 passed, 31 skipped, 1 xfailed in 37.97s); `uv run pre-commit run --all-files` (41 Passed, 1 Skipped, 0 Failed); `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html`; and `/usr/bin/grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'`, which passes at exit 1 -- both its controls ran and could have failed (161 html files reached; a planted bad link flipped it to exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Update the convention-test module documentation to explain its data source and intentional divergence while removing duplicated guidance.

Enhancements:
- Align `tests/conventions_test.py`’s docstring with the organization’s section 14 requirements by documenting its input and intentional divergence from the standard.
- Avoid duplicating convention-test naming guidance already documented in `tests/README.md`.
- Clarify that the convention table is transcribed because the standard is maintained in a separate repository, and correct the description of row handling.

Chores:
- Add a changelog entry for the convention-test docstring update.