### PR TITLE
The token-elevation census keys on where the key sits (issue btclib-org/.github#897)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2044,6 +2044,39 @@ file of the test tree, and no caller acts on it.
   other copies of this module owing the same header sentence, so it
   stays open.
 
+### The census of token elevations is keyed on where the key sits
+
+- **`REPOSITORY.md`'s *Token permissions* reads the jobs that elevate
+  out of a second command rather than out of a substitution into its
+  first** (issue btclib-org/.github#897): the substitution, `: write` in
+  place of `permissions:$`, keyed on text anywhere in a line, so it
+  returned the comment lines naming a permission beside the grants --
+  several of them saying a permission is deliberately *not* taken, which
+  is the opposite of what the reader asked for. The command that
+  replaces it, `git grep -nE '^ +[a-z-]+: write([[:blank:]]+#|$)'`, keys
+  on where the key sits, first on its line after the indentation.
+  *Which workflows elevate is left to the command that lists them* above
+  says this section names a grep narrowing its own command; that
+  narrowing is a command of its own now.
+- **The anchored `: write$` form is not what lands here**: it drops a
+  grant carrying a trailing comment, which `codeql.yml`'s
+  `security-events: write` and `py-arm-authority.yml`'s and
+  `vendored-vectors.yml`'s `issues: write` each do. The character class
+  before the `#` rather than a bare space is insurance rather than the
+  fix: what it admits is a tab there, and `yamllint` refuses that line
+  as a syntax error, so the gate is what keeps that shape out.
+- **What the command cannot see is named beside it**:
+  `permissions: write-all`, a flow mapping, and a quoted key or value
+  are each outside its answer. Folding one of them in buys nothing, the
+  shapes a line-oriented pattern reads past having no end -- a value
+  carried onto the line below is the next of them. What refuses
+  `write-all` here is `zizmor`'s `excessive-permissions` audit, and not
+  this command.
+- **Both commands take `.github/workflows` rather than
+  `.github/workflows/*.yml`**: the two answer the same where every
+  workflow is a `.yml`, and the directory goes on answering the day one
+  is not.
+
 ## v2026.9.3
 
 ### Repository

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -569,12 +569,21 @@ authentication at all.
 These are the declarations this file argues, not a roster of them.
 
 ```shell
-git grep -n "permissions:$" -- .github/workflows/*.yml
+git grep -n "permissions:$" -- .github/workflows
 ```
 
-names every declaration, and `: write` in place of `permissions:$`
-narrows it to the jobs that elevate, comments discussing one included.
-Either is re-derived whenever it's wanted, where a list here goes stale
+names every declaration, and the write grants among them read out of a
+second command — keyed on where the key sits, first on its line after
+the indentation, so that a comment naming a permission stays out of the
+answer while a grant carrying a trailing comment stays in:
+
+```shell
+git grep -nE '^ +[a-z-]+: write([[:blank:]]+#|$)' -- .github/workflows
+```
+
+A grant written some other way — `permissions: write-all`, a flow
+mapping, or a quoted key or value — is outside that answer. Either
+command is re-derived whenever it's wanted, where a list here goes stale
 the next time a job's own needs change.
 
 ### Whether that default is pinned here is untested


### PR DESCRIPTION
Ports [ISS 897](https://github.com/btclib-org/.github/issues/897) into
`btclib`. The issue is owed by more than this tree, so this pull request
advances it and leaves it open; the maintainer marks it done once
`btclib-secp256k1` lands its own share.

`REPOSITORY.md`'s *Token permissions* census was keyed on the end of the
line, so it counted nine comment lines — several of them saying a
permission is deliberately **not** taken — as grants. The new form reads
the indentation and admits a trailing comment, and it converges this
tree's pathspec with the family's landed `-- .github/workflows`.

Set algebra at the tip, over `.github/workflows`: the old `: write`
answers 23, the new form 14, and the tighter `: write$` 11. The nine the
new form drops are every one a comment line, in the seven files the
commit body names; nothing the new form admits is outside the old one.
The three it keeps that `: write$` loses are the three grants carrying a
trailing comment.

**What the local review raised and this branch does not change**, both
non-blocking and both recorded rather than amended: `REPOSITORY.md`
names a blind spot without sizing it, where the CHANGELOG entry says
`zizmor`'s `excessive-permissions` audit refuses `write-all` here; and
`#1833`'s body quotes this branch's pathspec while citing
`origin/main`'s line. The second is corrected on that issue.

Collateral open against this pair: `#1833`, now carrying both directions
of the same defect — a declaration whose value sits on its own line is
missed, and one whose value sits inline is missed the other way.

The token-elevation census keys on where the key sits (issue btclib-org/.github#897)

`REPOSITORY.md`'s *Token permissions* offered one command,
`git grep -n "permissions:$"`, and narrowed it to the elevations by a
prose substitution of `: write` for `permissions:$`. That substitution
keys on text anywhere in a line, so it returns the comment lines that
name a permission beside the grants: in `claude-review.yml`,
`codeql.yml`, `deps-latest.yml`, `links.yml`, `mutation.yml`,
`py-arm-authority.yml` and `vendored-vectors.yml`, several of them
saying a permission is deliberately not taken. The file disclosed that
cost -- "comments discussing one included" -- which is honest and still
the wrong form.

The position-keyed form returns exactly the grants the substitution
finds and nothing else, at the same recall. The anchored `: write$` is
not taken: it drops `codeql.yml`'s `security-events: write` and the
`issues: write` of `py-arm-authority.yml` and `vendored-vectors.yml`,
each of which carries a trailing comment.

The structural decision this tree had and the trees that landed the same
form did not: the position-keyed pattern becomes a second fenced command
rather than replacing the first. The two answer different questions --
every declaration block, which includes the `contents: read` and
`pull-requests: read` the section argues, and the elevations among them
-- and a substitution stated in prose is a command the reader has to
assemble, which is how a form nobody would have copied went unnoticed
here. The framing sentence "These are the declarations this file argues,
not a roster of them" is unchanged: it says what the list is for, not
that part of the answer may be noise.

The pathspec moves from `.github/workflows/*.yml` to `.github/workflows`
on both commands, so the two do not disagree about what they read. They
answer the same here, every workflow file being a `.yml`; the directory
goes on answering the day one is written `.yaml`.

The disclosure sentence was measured against probe workflows written
outside this tree. `actionlint` exits 0 on `permissions: write-all`, on
a flow mapping, on a quoted key and on a quoted value, and the pattern
returns none of the four; it exits 1 on `contents: wrong`, which is the
control that could have failed.

`actionlint` exits 0 too on a grant whose trailing comment is separated
by a tab, which the pattern returns and a ` +#` branch does not -- and
that is not why the character class is here. This tree's pinned
`yamllint` 1.38.0, run with the tree's own `.yamllint.yaml`, refuses
that line as a syntax error at exit 1 while taking every other probe at
exit 0, so the shape cannot sit in this tree at all. The class costs
nothing and matches what the trees that landed this form carry, which
is why it is ported; the reason for it is not a claim about what could
be written here.

`zizmor` 1.29.0, this tree's pin, run as the hook runs it with
`--offline --no-progress` and with no `.github/zizmor.yml` in the tree,
exits 14 on `permissions: write-all` with `error[excessive-permissions]`
and exits 0 on every other probe. So that shape is kept out by the gate
rather than only being outside the census, and the entry says which.
It does not repeat the sentence a sibling entry landed, that the gate
leaves every named shape standing: btclib-org/.github#902 has the
measurement refuting it, and asks for no rewrite of what landed.


Reviewed locally at fresh context before this pull request was opened: CLEARED `46365f45`, no blocking findings. The reviewer re-derived every number rather than taking it from the brief, ran the diff's deciding regex against twelve probe shapes, and ran `zizmor` and `actionlint` at the tree's own pins. Gates on this tree, all eight run by the branch's coder on this exact sha over two full rounds, neither falling: `uv sync`; `uv run ruff check --fix`; `uv run ruff format`; `uv run mypy src/btclib tests .github/scripts`; `uv run pytest`; `uv run pre-commit run --all-files`; `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html`; and `/usr/bin/grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'`, which passes at exit 1. Exit codes 0,0,0,0,0,0,0,1 — 415 files unchanged, 364 source files, 32223 passed, 41 Passed / 1 Skipped / 0 Failed, `build succeeded`, and gate 8 with both its controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Update the repository token-permission census to accurately identify workflow write grants and clarify the scope and limitations of its results.

Bug Fixes:
- Correct the token-permission census so it reports actual inline write grants without counting explanatory comment lines.

Enhancements:
- Make the workflow census commands structurally identify permission declarations and grants, preserve grants with trailing comments, and document unsupported permission forms and audit coverage.
- Use the workflow directory as the shared census scope so the commands remain applicable to future workflow file extensions.

Documentation:
- Document the revised token-permission census methodology, its limitations, and the role of zizmor in rejecting write-all permissions.