### PR TITLE
`zizmor`'s refusal of `write-all` is keyed on where the grant sits (issue btclib-org/.github#902)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2077,6 +2077,24 @@ file of the test tree, and no caller acts on it.
   workflow is a `.yml`, and the directory goes on answering the day one
   is not.
 
+### `zizmor`'s refusal of `write-all` is keyed on where the grant sits
+
+- **`REPOSITORY.md`'s *Token permissions* names the placements of
+  `permissions: write-all` that `zizmor` reports, beside the command
+  that returns none of them** (issue btclib-org/.github#902): the
+  `excessive-permissions` audit reports the grant written on a job, and
+  written on a workflow only where that workflow holds more than one
+  job. `lint.yml` holds one job, and with its `permissions:` block
+  replaced whole by `permissions: write-all` and nothing else changed
+  the audit takes it, the finding suppressed under the persona the hook
+  runs; the same grant written on that file's job instead is reported.
+  The `--persona=auditor` run `.pre-commit-config.yaml` names beside the
+  hook reports the suppressed one.
+- **The entry *The census of token elevations is keyed on where the key
+  sits* above states that refusal without the condition**: it stays
+  where it is, which is section 9's *Nothing already written is
+  rewritten*, and the bullet above is what the tree holds.
+
 ## v2026.9.3
 
 ### Repository

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -586,6 +586,15 @@ mapping, or a quoted key or value — is outside that answer. Either
 command is re-derived whenever it's wanted, where a list here goes stale
 the next time a job's own needs change.
 
+`zizmor`'s `excessive-permissions` audit reaches
+`permissions: write-all`, and reaches it conditionally: it reports the
+grant written on a job, and written on a workflow only where that
+workflow holds more than one job. On a workflow holding a single job the
+audit takes the grant, the finding suppressed under the persona the hook
+runs, so it is then outside that audit's answer as well as the
+position-keyed command's. The `--persona=auditor` run named beside the
+hook in `.pre-commit-config.yaml` reports it.
+
 ### Whether that default is pinned here is untested
 
 ```shell


### PR DESCRIPTION
Advances [ISS 902](https://github.com/btclib-org/.github/issues/902),
which stays open: its remaining box is about `btclib-node` and
`bitcoin-core-rpc` and this branch cannot reach them.

**It corrects a sentence this repository landed two hours earlier**, at
`0142e0c0`:

> What refuses `write-all` here is `zizmor`'s `excessive-permissions`
> audit, and not this command.

Unqualified, in a tree where 13 of 19 workflows hold a single job. The
audit reports a `write-all` written on a **job**; it passes one written on
a **workflow** where that workflow holds a single job, at the persona the
hook runs, which is the default. So the shape can sit in a workflow here
with neither the census command nor the audit reporting it — which is
exactly what `REPOSITORY.md`'s disclosure exists to warn a reader about,
and what it did not say.

Section 9's *Nothing already written is rewritten* reaches an entry still
sitting in the open section — the rule's own second sentence says so and
forwards to *An entry in the open section is a live claim*. So this is an
append whose second bullet says what it does to the earlier one, on the
precedent of `babf6fd8`, and the deletion column is 0.

`REPOSITORY.md` gets the same fact, because that is where the reader being
warned actually is: a changelog entry is met once, that section whenever
the census is re-derived.

**How the sentence was arrived at, since the tree now records two
attempts.** The mechanism was pinned down by probes that vary placement
against job count rather than scope: a top-level grant in a two-job
workflow whose second job declares its own `permissions:` is still
reported, and a single-job workflow whose job overrides the grant is
still passed — so the condition is the workflow's job count and not
whether anything inherits it. All three personas were run, not two: the
default passes, `pedantic` and `auditor` both report.

Its first draft carried a reproduction recipe that, read literally, left a
duplicated `permissions:` key and exited 3 where the entry claimed 0. The
review built that file and ran it. The word `whole` is the repair, and the
reworded recipe was checked by building the file its new words describe
and proving it byte-identical to the probe whose result the entry reports.

`zizmor`'s refusal of `write-all` is keyed on where the grant sits (issue btclib-org/.github#902)

`CHANGELOG.md`'s entry *The census of token elevations is keyed on where
the key sits*, landed at 0142e0c0, ends "What refuses `write-all` here
is `zizmor`'s `excessive-permissions` audit, and not this command."
Unqualified, and the refusal is conditional on where the grant is
written.

Measured with the rev `.pre-commit-config.yaml` pins for the hook, run
with the hook's own `--offline --no-progress`, against
`.github/workflows/lint.yml` at 0142e0c0 with nothing changed but the
permissions block; this tree carries no `.github/zizmor.yml`. The
workflow unmodified reports nothing, which says the probe is sane.
`permissions: write-all` at the top of it is taken, the finding
suppressed. The same grant on the job instead is reported, and so is a
top-level grant once a second job is appended: the audit is live in this
exact file and could have fired. `contents: wrong` at the top fails as a
schema error rather than as a finding, so the runner discriminates
rather than answering one thing for everything. Most of this tree's
workflows hold a single job, `lint.yml` among them, so the top-level
shape sits in a real file with neither the census command nor the audit
returning it.

This issue exists because of the trap: a probe with the grant on the job
answers the same way under both readings, and a control that varies the
scope granted rather than its placement agrees with both too. The
persona is a second such trap. The hook passes no `--persona`, and under
the default the finding is suppressed; `--persona=pedantic` and
`--persona=auditor` each report it. All three were run rather than
inferred from one, `--persona=auditor` being the by-hand run
`.pre-commit-config.yaml` already names beside the hook.

The landed entry is not corrected in place. Section 9's *Nothing already
written is rewritten* binds "what is written next, not the entries that
predate it", and it names what a new entry owes one still sitting in the
open section: *An entry in the open section is a live claim*, which asks
for "a sentence in the new entry saying what it does to the earlier one,
and the append stays an append". An entry that has landed and not
shipped is therefore inside that rule and not outside it, and the second
bullet here is that sentence.

`REPOSITORY.md` carries the statement too, because that is where the
reader being warned is: its *Token permissions* says a `write-all` grant
is outside the census command's answer and stops there. A changelog
entry is met once; that section is met whenever the census is
re-derived. The file is not on section 14's verbatim list, so it owes no
`EXPECTED_DRIFT` entry in the tracker repository.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr


Reviewed locally at fresh context over two rounds by one reviewer. Round one blocked on the entry's own reproduction recipe, which read literally produced a duplicated key and exit 3 rather than the exit 0 the entry claimed; round two verified the repair against a probe the reviewer had built in round one, before the fix existed. Gates on this tree, all eight re-run by the coder on this exact sha after the repair: `uv sync`; `uv run ruff check --fix`; `uv run ruff format` (415 files unchanged); `uv run mypy src/btclib tests .github/scripts` (364 source files); `uv run pytest` (32223 passed, 31 skipped, 1 xfailed); `uv run pre-commit run --all-files` (41 Passed, 1 Skipped, 0 Failed); `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html`; and `/usr/bin/grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'`, which passes at exit 1 and whose two controls were re-run on this sha rather than carried. Exit codes 0,0,0,0,0,0,0,1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Clarify the placement- and workflow-shape-dependent behavior of zizmor's `write-all` audit in the changelog and repository guidance.

Bug Fixes:
- Clarify when zizmor's excessive-permissions audit reports `permissions: write-all` based on whether the grant is placed at the job or workflow level and on workflow job count.

Enhancements:
- Document the conditional `write-all` audit behavior in the changelog and repository token-permissions guidance, including the default and auditor personas.
- Correct the earlier changelog statement without rewriting the existing entry, preserving the append-only changelog policy.