### PR TITLE
`conventions_test.py`'s comment says what this tree answers, its docstring what the assertions do (closes btclib-org/.github#903) (issue btclib-org/.github#904)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2095,6 +2095,36 @@ file of the test tree, and no caller acts on it.
   where it is, which is section 9's *Nothing already written is
   rewritten*, and the bullet above is what the tree holds.
 
+### `conventions_test.py` says what this tree answers and what it asserts
+
+- **The comment above `_NOT_TESTED` stops calling `none` the answer this
+  repository gives** (closes btclib-org/.github#903): `tests/README.md`
+  answers with the conventions this suite leaves untested, so the clause
+  was false here. The sentence replacing it is `btclib-node`'s, which
+  `bitcoin-core-rpc` ported: `none` is the literal the code below
+  special-cases, and the deletion `btclib-secp256k1` took instead leaves
+  nothing saying why that branch exists. This is the last copy of the
+  module carrying the clause, so the issue closes with it.
+- **The clause beside it, which gave a sibling repository's declaration
+  as the reason `re.DOTALL` is on the pattern, goes with it** (closes
+  btclib-org/.github#903): this tree's own answer fits a line, so
+  nothing here demonstrated the wrap that clause was offered for. The
+  reason names the wrap a list of names outgrowing eighty columns takes,
+  which is what the flag is for whether or not this declaration has
+  grown into one.
+- **`test_the_table_is_not_empty`'s docstring stops saying an unmatched
+  table satisfies every assertion below it silently** (issue
+  btclib-org/.github#904):
+  `test_the_two_halves_account_for_every_convention` is not
+  parametrized, so on a table this module's regex stopped matching it
+  fails, naming every convention the table declared as accounted for by
+  neither half; the parametrized assertions are skipped on the empty
+  parameter set, with the reason `-ra` prints. A retitled heading
+  reaches neither: `_section` asserts while the module is imported, so
+  collection errors. The docstring is `bitcoin-core-rpc`'s byte for
+  byte, and the issue stays open for the copies that still say
+  otherwise.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/conventions_test.py
+++ b/tests/conventions_test.py
@@ -68,13 +68,12 @@ _CONVENTIONS = (
 
 _HEADING = "## Convention tests"
 # the sentinel for the other half of the declaration. DOTALL as well as
-# MULTILINE because eighty columns wrap the list of names across lines
-# and the non-greedy match then stops at the first full stop that ends
-# one -- which is why no name in that list may carry a full stop of its
-# own. "none" is a legal answer and the one this repository gives, and it
-# fits a line; the six btclib-secp256k1 names do not, which is where the
-# single-line form was found wanting. The two halves are checked against
-# each other below rather than each against nothing
+# MULTILINE because a list of names that outgrows eighty columns wraps
+# across lines and the non-greedy match then stops at the first full stop
+# that ends one -- which is why no name in that list may carry a full
+# stop of its own. "none" is a legal answer this repository does not give
+# today; the two halves are checked against each other below rather than
+# each against nothing.
 _NOT_TESTED = re.compile(r"^Not tested here: (.+?)\.$", re.MULTILINE | re.DOTALL)
 # a table row, and the separator row is what the second group's leading
 # backtick excludes: `| --- | --- |` has no backtick to match
@@ -102,11 +101,15 @@ _ROWS = tuple((m["convention"], m["module"]) for m in _ROW.finditer(_SECTION))
 
 
 def test_the_table_is_not_empty() -> None:
-    """A declaration that parsed to nothing is the failure that hides.
+    """No other assertion here reports an unmatched table as one.
 
-    Every assertion below is parametrized by the rows, so a table this
-    module's regex stopped matching -- a column added, the backticks
-    dropped, the heading retitled -- would satisfy all of them silently.
+    The assertions parametrized on the rows are skipped on an empty
+    parameter set, so a table this module's regex stopped matching -- a
+    column added, the backticks dropped -- leaves the two-halves
+    assertion below, which is not parametrized, to fail naming every
+    convention the table declared as accounted for by neither half. A
+    retitled heading reaches neither: _section asserts while the module
+    is imported, so collection errors.
     """
     assert _ROWS, f"{_README.name}'s {_HEADING} section parsed to no rows"
 


### PR DESCRIPTION
`conventions_test.py`'s comment says what this tree answers, its docstring what the assertions do (closes btclib-org/.github#903) (issue btclib-org/.github#904)

The comment above `_NOT_TESTED` said `none` was the answer this
repository gives. `tests/README.md` answers `Not tested here: the suite
opens no socket.`, so the clause was false here.

Two resolutions have landed elsewhere: `btclib-secp256k1` dropped the
clause, `btclib-node` rewrote it to "a legal answer this repository does
not give today" and `bitcoin-core-rpc` ported that. The rewrite is what
lands here for the same reason it landed there, re-derived against this
tree's code: the branch below reads `() if listed == "none" else ...`,
so a deletion leaves that literal unexplained.

What followed the clause is this tree's own and neither landing covers
it -- the answer fits a line where a sibling's list of names does not,
given as the reason `re.DOTALL` is on the pattern. It goes: it sends a
reader to another repository, and the count it carries is a fact of a
file no gate here reads. Removing it leaves the sentence above it
claiming a wrap this tree's declaration does not have, so that sentence
now reads on a list that outgrows eighty columns rather than on this
one. That is the only divergence from the block `btclib-node` and
`bitcoin-core-rpc` share; their own answers wrap, and this one does not.
Nothing else leans on the removed words: `git grep -i -e 'single-line'
-e 'fits a line' -e btclib-secp256k1 -- tests/` returns them and no
reader of them.

`test_the_table_is_not_empty`'s docstring said every assertion below is
parametrized by the rows, so an unmatched table would satisfy all of
them silently. Run against a copy of this tree's own `tests/README.md`
with a column added to every row, `pytest` skips the parametrized
assertions with `got empty parameter set` printed by `-ra`, and
`test_the_two_halves_account_for_every_convention`, which carries no
decorator, fails naming the conventions the table declared. Those are
the same list: with `_ROWS` empty `unaccounted` is `_CONVENTIONS` minus
the "Not tested here" names, and the suite passing makes that difference
the set the table declares. With the heading retitled instead, the run
exits 2 on `README.md has no one ## Convention tests`, `_section`
asserting while the module is imported. The docstring `bitcoin-core-rpc`
landed says that and is what this tree now carries, byte for byte.

btclib-org/.github#903 has no other carrier: every other copy of the
module answers 0 to the clause, folded, with `Not tested here` as the
control answering 1 in each. btclib-org/.github#904 is a different
matter -- the docstring it is about still stands in copies of the
module -- so that citation advances it and nothing here answers it in
full.


Local review: CLEARED bbd4a261, which is this head; the round-1 base was unchanged and no rebase was owed. Gates on that tree, all eight re-run on this sha: `uv sync`; `uv run ruff check --fix`; `uv run ruff format`; `uv run mypy src/btclib tests .github/scripts`; `uv run pytest`; `uv run pre-commit run --all-files`; `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html` — each exit 0; and `/usr/bin/grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'`, which passes at exit 1, over 161 html files with a planted defect confirming the walk reaches them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Clarify the conventions test’s documented assumptions and failure behavior to accurately reflect this repository.

Enhancements:
- Clarify the conventions test comments to describe the repository’s actual declaration and the purpose of multiline parsing.
- Update the table validation test documentation to explain how unmatched tables and renamed headings are detected.

Documentation:
- Document the conventions-test clarification and validation behavior in the changelog.