### PR TITLE
`release.yml`'s caller-permissions comment names the scope it is about (issue btclib-org/.github#896)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,7 +374,7 @@ jobs:
     # declares, not against what it goes on to do. contents: read is
     # repeated rather than left to test.yml's own default for the same
     # reason: a caller's grant replaces the callee's default outright, so
-    # anything this list leaves off becomes none for every job over
+    # contents omitted from this list would be none for every job over
     # there, not only for the one this comment names
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2125,6 +2125,17 @@ file of the test tree, and no caller acts on it.
   byte, and the issue stays open for the copies that still say
   otherwise.
 
+### `release.yml`'s caller-permissions comment names the scope it is about
+
+- **The comment above the `test` job's `permissions:` says what omitting
+  `contents` from the caller's list would do rather than what omitting
+  any scope would do** (issue btclib-org/.github#896): `metadata` is
+  where the wider reading fails, `actionlint` refusing it as a scope a
+  `permissions:` block may name while `test.yml`'s `changes` job,
+  reached through that call, logs `Metadata: read` all the same. The
+  issue asks one wording of every tree carrying the sentence, so the
+  clause replacing it names no job and no file.
+
 ## v2026.9.3
 
 ### Repository


### PR DESCRIPTION
`release.yml`'s caller-permissions comment names the scope it is about (issue btclib-org/.github#896)

The comment above the `test` job's `permissions:` block drew its
consequence for every scope -- "anything this list leaves off becomes
none for every job over there". It now says what omitting `contents`
would do, that being the scope the repeated `contents: read` under it is
there for, and `metadata` is where the wider reading fails.

Measured here rather than taken from the issue.

- Release run 33248410519 (tag v2026.8.29, a6502da0), job "Run the test
  workflow / Decide whether the jobs below have anything to check" --
  `test.yml`'s `changes` job, reached through the `uses:` this comment
  sits above -- logs `Metadata: read` and `PullRequests: read` in its
  GITHUB_TOKEN Permissions group, and `metadata` is in neither the
  caller's list nor that job's own block. Control, same run: the lint
  job logs `Contents: read` beside `Metadata: read`, a different pair,
  so the group varies with the declaration rather than being a constant.
- actionlint refuses `metadata` as a scope a `permissions:` block may
  name. The caller's block with `contents: read` replaced by
  `metadata: read` exits 1 -- unknown permission scope "metadata" -- and
  the unmodified file exits 0, run with the binary from this
  repository's own pre-commit cache entry, actionlint-py v1.7.12.24
  with shellcheck-py==0.11.0.1 and pyflakes==3.4.0. That hook's
  selector is `files: "^.github/workflows/"` and `types: [yaml]`,
  overridden nowhere here, so the file is in the gate's input set.
- `metadata:` is declared in no workflow of this tree:
  `git grep -cn '^ *metadata:' HEAD -- .github/workflows/` exits 1 with
  no output, where the same pattern shape on `contents:` answers across
  the directory.

The narrowed clause holds whether the sentence above it is read as
substitution or as a cap, so the branch does not rest on which is meant.
That the two readings differ, and that the run log refutes the first, is
btclib-org/.github#912, filed rather than folded into this diff: every
job of that run declaring no `permissions:` block of its own is granted
`Contents: read` and not the caller's `PullRequests: read`, which
substitution would give it.

The clause is written to port unchanged: it names no job and no file. At
58bf3d72 `btclib-secp256k1` carries the same sentence, so the citation
advances the issue rather than closing it.

The census is re-run at each tree's own tip rather than at the issue's.
Folding each `release.yml` to one line and stripping comment markers,
the wide clause is in `btclib` 7004b856 and `btclib-secp256k1`
58bf3d72, and in neither `btclib-node` 8e0a0a48 nor `bitcoin-core-rpc`
c9ac78f3, whose comments send a reader to REPOSITORY.md's "Token
permissions" instead of stating the mechanism. A sham pattern answers
zero in all four, and a wrapped phrase drawn from each file answers
once folded against never unfolded, so those two zeros are absences.
No entry in this tree's open CHANGELOG.md section states the wide
version, so the new entry supersedes none by name.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr


Local review: CLEARED ce613c1f. The reviewer re-derived the counterexample from the run logs and read all five block-less jobs rather than sampling one, so the measurement under this wording is 5/5 rather than a single case. Gates on that tree, all eight: `uv sync`; `uv run ruff check --fix`; `uv run ruff format`; `uv run mypy src/btclib tests .github/scripts`; `uv run pytest` (32223 passed, 31 skipped, 1 xfailed, 100.00% coverage); `uv run pre-commit run --all-files`; `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html` — each exit 0; and `/usr/bin/grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'`, which passes at exit 1 over 161 html files, with a planted defect confirming the walk reaches them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Clarify the scope described by the release workflow's caller-permissions comment and record the wording correction in the changelog.

Enhancements:
- Clarify the release workflow permissions comment so it specifically describes the effect of omitting the `contents` scope from the caller's permissions list.

Documentation:
- Document the permissions-comment clarification in the changelog.