### PR TITLE
`conventions_test.py`'s module docstring names the ways and counts nothing (issue btclib-org/.github#906)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2136,6 +2136,25 @@ file of the test tree, and no caller acts on it.
   issue asks one wording of every tree carrying the sentence, so the
   clause replacing it names no job and no file.
 
+### `conventions_test.py`'s module docstring names the ways and counts nothing
+
+- **The last paragraph of `tests/conventions_test.py`'s module docstring
+  states no number of the assertions below it** (issue
+  btclib-org/.github#906): it said the four assertions below are the ones
+  that fail on the ways a declaration actually rots, and the ways it
+  listed left out `test_the_table_is_not_empty`, which is what fails
+  where a third column added to `tests/README.md`'s table, or the
+  backticks dropped from its second, stops the row pattern matching. An
+  unmatched table is the first of the ways now, the ways standing in the
+  order the assertions are defined in rather than one to an assertion --
+  either mutation fails `test_the_two_halves_account_for_every_convention`
+  too. The number is gone rather than corrected, section 9 of the
+  organization standard refusing a stated total, a line every open branch
+  has to edit. The wording is `btclib-node`'s, landed there as
+  btclib-org/btclib-node#903, and this tree carries that paragraph byte
+  for byte; btclib-org/.github#906 is filed against the copies of this
+  module across the organization and stays open.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/conventions_test.py
+++ b/tests/conventions_test.py
@@ -31,12 +31,12 @@ a transcribed copy is the only form this tree can hold it in, and
 `_CONVENTIONS` is that copy.
 
 What it does not check is whether a named module tests the convention it
-is named against. Nothing short of reading it can, and the four
-assertions below are the ones that fail on the ways a declaration
-actually rots: a convention invented here rather than taken from section
-7, a module renamed or deleted with the row left behind, a module emptied
-of its tests, and a bullet that quietly stops being accounted for by
-either half.
+is named against. Nothing short of reading it can, and the assertions
+below are the ones that fail on the ways a declaration actually rots: a
+table the row pattern no longer matches, a convention invented here
+rather than taken from section 7, a module renamed or deleted with the
+row left behind, a module emptied of its tests, and a bullet that
+quietly stops being accounted for by either half.
 """
 
 import ast


### PR DESCRIPTION
`conventions_test.py`'s module docstring names the ways and counts nothing (issue btclib-org/.github#906)

The last paragraph said the four assertions below are the ones that fail
on the ways a declaration actually rots, and the ways it listed left out
test_the_table_is_not_empty. Measured against tests/README.md with a
third column added to every row of the convention table, and again with
the backticks dropped from the module column: the rows parse to nothing,
the assertions parametrized on _ROWS are skipped on the empty parameter
set, and test_the_table_is_not_empty and
test_the_two_halves_account_for_every_convention both fail. The
unmutated run of the module passes, which is the control, and
tests/README.md was compared byte for byte against its blob at HEAD
after the restore.

The number is gone rather than corrected, section 9 of the organization
standard refusing a stated total. A table the row pattern no longer
matches is the first way in the list, the ways standing in the order the
assertions are defined in; the claim is about that order rather than one
way to an assertion, an unmatched table failing two of them.

The assertions of this copy stand in that order:
test_the_table_is_not_empty,
test_every_convention_named_is_one_of_section_sevens,
test_every_module_named_exists, test_every_module_named_holds_a_test and
test_the_two_halves_account_for_every_convention, read from the module's
ast rather than from a grep.

The wording is btclib-node's, landed there as btclib-org/btclib-node#903
and ported to bitcoin-core-rpc, and this tree now carries that paragraph
byte for byte. What it replaced was byte for byte the paragraph
bitcoin-core-rpc replaced, and word for word btclib-node's, which
wrapped differently from its fourth line.

btclib-org/.github#906 is filed against the copies of this module across
the organization, so it stays open.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr


Local review: CLEARED 113094c1. The reviewer re-derived the failure claim itself from the module regexes rather than reading it, with the unmutated run as a control that could have failed, and confirmed the docstring paragraph now converges byte-for-byte with both sibling landings. Gates on that tree, all eight, each with a sha-named log on disk: `uv sync`; `uv run ruff check --fix`; `uv run ruff format`; `uv run mypy src/btclib tests .github/scripts`; `uv run pytest` (32223 passed, 31 skipped, 1 xfailed, 100.00% coverage); `uv run pre-commit run --all-files`; `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html` — each exit 0; and `/usr/bin/grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'`, which passes at exit 1 over 161 html files, with a planted defect confirming the walk reaches them and the restore checked by `cmp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rnPQdRYnarb7ZdZ1m9wr

## Summary by Sourcery

Update the conventions test documentation to accurately describe all declaration failure modes without asserting a fixed count.

Bug Fixes:
- Clarify the conventions test module docstring so it accurately includes table-format mutations among the declaration failures it describes.

Documentation:
- Document the corrected conventions-test behavior in the changelog.