### PR TITLE
`zizmor`'s pin and the paragraph holding it name one version (issue #1563)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -587,7 +587,12 @@ repos:
     # bump waits on whichever lands first: an actionlint release that
     # understands `$/`, or GitHub's runner requirement (>=2.336.0) making
     # workspace-relative references the thing to flag instead.
-    rev: v1.30.0
+    #
+    # Nothing enforces that: `pinned-rev` above is a pygrep pattern over
+    # one line, so it refuses a shape -- a bare major, a prerelease -- and
+    # a hold naming a version is not one. `autoupdate` offers 1.30.0 on
+    # every run, and whoever reads the diff is the whole of what declines it
+    rev: v1.29.0
     hooks:
       - id: zizmor
         # offline is what it does by default, said out loud: it warns about

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2155,6 +2155,22 @@ file of the test tree, and no caller acts on it.
   for byte; btclib-org/.github#906 is filed against the copies of this
   module across the organization and stays open.
 
+### `zizmor`'s pin and the paragraph holding it name one version
+
+- **`.pre-commit-config.yaml` pins `zizmor` at v1.29.0, which is the
+  version the paragraph above the pin says it holds** (issue #1563):
+  1.30.0's `self-repository` audit reports every `uses: ./...` reference
+  in `.github/workflows/` and auto-fixes each to `uses: $/...`, which the
+  pinned actionlint does not parse, so the bump trades one red hook for
+  another. `gh api repos/rhysd/actionlint/releases/latest` answers the
+  version pinned here, so neither condition that paragraph names for
+  lifting the hold has arrived. With the pin ahead of its own comment the
+  lint gate was red on `main`. Nothing enforces the hold: `pinned-rev`
+  refuses a shape -- a bare major, a prerelease -- and a hold naming a
+  version is not one, so `autoupdate` offers 1.30.0 on every run and
+  whoever reads the diff is the whole of what declines it. The comment
+  beside the pin now says that as well.
+
 ## v2026.9.3
 
 ### Repository


### PR DESCRIPTION
`main` is red on `lint`, and this puts the `zizmor` pin back to the
version its own paragraph says it holds.

[ISS 1563](https://github.com/btclib-org/btclib/issues/1563) holds zizmor
below v1.30.0 until actionlint parses the `$/...` self-repository syntax
that zizmor's auto-fix writes, and `.pre-commit-config.yaml` carries that
hold as a paragraph above the pin.
[PR 1842](https://github.com/btclib-org/btclib/pull/1842) moved the `rev:`
and left the paragraph, so the file states one thing and its pin another.

**No closing keyword here, deliberately.** That issue stays open: the
bump is still owed, and what it waits on has not arrived.

## Measured

```shell
gh run view 34191574641 --repo btclib-org/btclib --log-failed
# lint on 0ca5c207: exit 1 on the zizmor hook, every other hook passed

gh api repos/rhysd/actionlint/releases/latest --jq .tag_name
# v1.7.12 -- the version actionlint-py pins here (rev: v1.7.12.24)
```

So neither condition the paragraph names for lifting the hold has
arrived, and taking zizmor's auto-fix would move the failure to
actionlint rather than remove it. The reviewer of this branch reproduced
that trade-off with both tools against an archive of the base: zizmor
1.30.0 flags the `uses: ./...` references and rewrites them under
`--fix=all`, and actionlint 1.7.12.24 then rejects every rewritten one.

## What the comment gains

That nothing enforces the hold. `pinned-rev` is a `pygrep` entry over one
line and refuses a shape — a bare major, a prerelease — where this hold
names a version, so `autoupdate` offers 1.30.0 on every run and review is
the whole of what declines it. Designing a guard is a separate question,
filed as [ISS 1843](https://github.com/btclib-org/btclib/issues/1843).

## Gates, on this tip

| gate | exit |
| --- | --- |
| `uv run --locked --only-group lint pre-commit run --all-files --show-diff-on-failure` | 0 |
| `uv run pytest` | 0 |
| `uv run --group docs sphinx-build -n -W -b html docs/source docs/build/html` | 0 |

`git status --porcelain` empty after each; the commit is signed.
Cleared at local review on this sha, which re-derived `pinned-rev`'s
regex, the actionlint release, the failing hook in the base's own run,
and the citation token, rather than taking them from the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dtjf2shJChDxTDCENd3NKg

## Summary by Sourcery

Align the `zizmor` pin with its documented hold while retaining the compatibility rationale for postponing the upgrade.

Bug Fixes:
- Restore the `zizmor` pre-commit pin to v1.29.0 so it matches the documented compatibility hold and resolves the failing lint gate.

Enhancements:
- Clarify that the version hold is intentionally manual and remains in place until the documented actionlint or runner prerequisite changes.

Documentation:
- Document the corrected `zizmor` pin and the reason the upgrade remains blocked in the changelog.