### PR TITLE
`conventions_test.py` splits the Not tested here list at its separator, not at the semicolon alone (closes #1836) (issue btclib-org/.github#911)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2171,6 +2171,32 @@ file of the test tree, and no caller acts on it.
   whoever reads the diff is the whole of what declines it. The comment
   beside the pin now says that as well.
 
+### `conventions_test.py` splits the *Not tested here* list at its separator
+
+- **`tests/conventions_test.py` splits the collapsed list at a semicolon
+  and a space, and collapses the whitespace of each name no further**
+  (issue btclib-org/.github#911): the line above the split replaces every
+  run of whitespace, newlines included, with one space, so a semicolon
+  the declaration wrote with a space or a line break after it is that
+  separator by the time the split runs, and collapsing a name again is
+  `strip()` over a piece with nothing left to strip. Where the two
+  spellings answer differently is a separator written some other way: the
+  semicolon alone takes it as one and this does not, so the name keeps
+  whatever the split left and the assertion that every name listed is one
+  of section 7's reports it.
+- **The comment above the split stops giving an eighty-column wrap
+  falling inside a name as the reason for a collapse the line above it
+  has already made** (closes #1836): `tests/README.md`'s *Not tested
+  here* line does not wrap, and the collapse that takes a wrap out of a
+  name whatever the list grows into is the one that stays. What replaces
+  the comment says why the separator carries its space, which is what
+  stops the next reader from splitting on the semicolon alone.
+- **That assertion's message quotes the names it read out of the
+  declaration**: a separator written with a space on each side of the
+  semicolon leaves a name differing from a convention in whitespace
+  alone, which unquoted reads as one the same message goes on to list as
+  known.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/conventions_test.py
+++ b/tests/conventions_test.py
@@ -173,14 +173,12 @@ def test_the_two_halves_account_for_every_convention() -> None:
         " the declaration is half of one"
     )
     listed = " ".join(match[1].split())
-    # whitespace collapsed inside each name and not only around it: the
-    # list wraps at eighty columns wherever the column falls, which for a
-    # long one is in the middle of a name rather than at a semicolon
-    absent = (
-        ()
-        if listed == "none"
-        else tuple(" ".join(s.split()) for s in listed.split(";"))
-    )
+    # the separator is a semicolon and a space, which is what the
+    # collapse above leaves of one written with a space or a line break
+    # after it. The semicolon alone would take any other spelling for a
+    # separator too; here the name keeps whatever the split did not
+    # take, and the assertions below report it
+    absent = () if listed == "none" else tuple(listed.split("; "))
     tested = {convention for convention, _ in _ROWS}
 
     overlap = tested.intersection(absent)
@@ -189,9 +187,12 @@ def test_the_two_halves_account_for_every_convention() -> None:
     )
 
     unknown = [name for name in absent if name not in _CONVENTIONS]
+    # the names come from the file, so repr: one differing from a
+    # convention in whitespace alone is invisible unquoted, and reads as
+    # a name this same message goes on to list as known
     assert not unknown, (
-        f"{', '.join(unknown)} is listed as not tested and is not one of"
-        f" section 7's: {', '.join(_CONVENTIONS)}"
+        f"{', '.join(map(repr, unknown))} is listed as not tested and is not"
+        f" one of section 7's: {', '.join(_CONVENTIONS)}"
     )
 
     unaccounted = [


### PR DESCRIPTION
`conventions_test.py` splits the Not tested here list at its separator, not at the semicolon alone (closes #1836) (issue btclib-org/.github#911)

The line above the split replaces every run of whitespace, newlines
included, with one space, so collapsing a name after it is strip() over
a piece with nothing left to strip: the two forms answer alike over
fuzzed whitespace strings, and differ once that first collapse is taken
away. The second collapse goes, and the comment explaining it goes with
it -- the eighty-column wrap falling inside a name that it gave as its
reason is not something this tree's tests/README.md list does.

The separator keeps its space rather than being the semicolon alone.
Where the two spellings answer differently is a separator written some
other way: the semicolon alone takes it as one and this does not, so the
name keeps whatever the split left and the assertion that every listed
name is one of section 7's reports it. A declaration audit reports prose
it cannot read rather than repairing it in the reader, and the comment
replacing the old one carries that as its negative result.

That report is usable only quoted, so the assertion's join takes repr. A
semicolon written with a space on each side is consumed by the split and
leaves the name a trailing one, so unquoted the message names something
differing from a convention in whitespace alone, and reads as naming one
it goes on to list as known.

btclib-org/.github#911 holds the same decision for the copies of this
module in the other trees.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WKQAgJcSkNPKgqAHWPWySX


Local review at fresh context, two rounds: round 1 returned CHANGES REQUESTED on a comment clause false for one separator spelling, and round 2 CLEARED `fad5c742` after the clause was narrowed to the losslessness of the split, the diagnostic given `repr`, and the same sentence corrected in the changelog entry and the commit body alike. Gates on that tree, all eight run at this head: `uv sync`; `uv run ruff check --fix`; `uv run ruff format` (415 files unchanged); `uv run mypy src/btclib tests .github/scripts` (364 files); `uv run pytest` (32223 passed, 31 skipped, 1 xfailed, 100.00%); `uv run pre-commit run --all-files` (41 Passed, 1 Skipped, 0 Failed); the docs `sphinx-build` under `-n -W`; and the fragment-link grep over `docs/build/html`, whose exit 1 is the pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKQAgJcSkNPKgqAHWPWySX

## Summary by Sourcery

Fix conventions-list parsing and diagnostics to accurately validate declarations and expose whitespace-related errors.

Bug Fixes:
- Correct parsing of the conventions test’s “Not tested here” list so separators are recognized only in the intended semicolon-and-space form.

Enhancements:
- Remove redundant per-name whitespace normalization after the list has already been collapsed.
- Improve unknown-convention diagnostics by quoting names to make whitespace differences visible.
- Update the changelog with the parsing and diagnostic behavior changes.