### PR TITLE
docs/source/conf.py drops the templates_path key (issue btclib-org/.github#901)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2197,6 +2197,20 @@ file of the test tree, and no caller acts on it.
   alone, which unquoted reads as one the same message goes on to list as
   known.
 
+### `templates_path` goes, this tree keeping no templates
+
+- **`docs/source/conf.py` no longer assigns `templates_path`** (issue
+  btclib-org/.github#901): nothing is tracked under
+  `docs/source/_templates` and `docs/` holds no template of its own, so
+  the key named a directory this repository does not have. Section 2 of
+  the organization standard is where the rule this converges on lives --
+  "`templates_path` names the directory under `docs/source/` where the
+  tree keeps its own templates, and a tree keeping none does not carry
+  the key" -- and it names writing the key empty, the way
+  `exclude_patterns` beside it is written, as the rejected alternative.
+  The issue is owed by the trees still carrying the key, so it stays
+  open.
+
 ## v2026.9.3
 
 ### Repository

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -128,8 +128,6 @@ nitpick_ignore = [
 # resolve is not a visibly broken link, it is an anchor to an id the page
 # does not have
 
-templates_path = ["_templates"]
-
 exclude_patterns: list[str] = []
 
 


### PR DESCRIPTION
docs/source/conf.py drops the templates_path key (issue btclib-org/.github#901)

Section 2 of the organization standard, at btclib-org/.github 413987f,
says templates_path names the directory under docs/source/ where a tree
keeps its own templates and that a tree keeping none does not carry the
key; it names writing the key empty, the way exclude_patterns beside it
is written, as the rejected alternative.

This tree keeps none: git ls-tree of docs/source/_templates at
origin/main answers nothing, git ls-files over docs/ names no template
of its own, and no html, jinja, j2 or tmpl file is tracked anywhere.

The assignment carried no comment of its own. The block above it opens
"# no suppress_warnings" and explains that key, and it keeps the blank
line it already had, so what goes is the assignment and the blank line
under it.

No "# no templates_path:" comment replaces it. The absence comments this
file carries -- for sphinx.ext.todo, suppress_warnings and
html_static_path -- each explain reasoning the standard does not hold:
at btclib-org/.github 413987f, README.md answers nothing for the first
two keys, and its one html_static_path hit is a clause inside the
templates_path paragraph rather than a rule about carrying that key.
This key is the opposite case, section 2 now carrying the whole reason,
and section 9's One fact in one place is what then decides it.

The issue is owed by the trees still carrying the key, so the subject
and the changelog entry carry (issue ...) rather than a close.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WKQAgJcSkNPKgqAHWPWySX


Local review at fresh context: CLEARED `c57f5b5a`, no blocking findings. The reviewer re-derived the removal as a byte splice with two failing controls, enumerated every comment block in the file to test the blank-line convention whole rather than at three sites, re-measured the standard at `413987f` with loose controls proving its two zeros, and probed gate 8`s regex directly to show both branches of the pattern fire. Gates on that tree, all eight run at this head: `uv sync`; `uv run ruff check --fix`; `uv run ruff format` (415 files unchanged); `uv run mypy src/btclib tests .github/scripts` (364 files); `uv run pytest` (32223 passed, 31 skipped, 1 xfailed, 100.00%); `uv run pre-commit run --all-files` (41 Passed, 1 Skipped, 0 Failed, and re-run green after the docs build); the docs `sphinx-build` under `-n -W`, whose log shows `[new config] 24 added` so the changed `conf.py` was read; and the fragment-link grep over `docs/build/html`, whose exit 1 is the pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKQAgJcSkNPKgqAHWPWySX

## Summary by Sourcery

Remove the unused Sphinx templates path configuration from the documentation build.

Enhancements:
- Remove the unused Sphinx templates path configuration because the documentation tree has no repository-owned templates.

Documentation:
- Document the removal of the unused `templates_path` setting and its rationale in the changelog.