### PR TITLE
`release.yml`'s comment and `REPOSITORY.md` say the caller's block bounds what it calls (closes btclib-org/.github#917) (issue btclib-org/.github#912)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,19 +363,22 @@ jobs:
     name: Run the test workflow
     needs: version-check
     uses: ./.github/workflows/test.yml
-    # a called workflow's jobs are capped at what the caller grants here,
-    # not at what the called workflow's own top-level default declares:
-    # this workflow's contents: read alone would leave test.yml's
-    # `changes` job, which asks for pull-requests: read to list a pull
-    # request's files, refused before a single job starts, version-check
-    # included -- `changes` never actually reads a file list on a
-    # release, answering code=true unconditionally off anything that is
-    # not a pull_request event, but the check is against what the job
-    # declares, not against what it goes on to do. contents: read is
-    # repeated rather than left to test.yml's own default for the same
-    # reason: a caller's grant replaces the callee's default outright, so
-    # contents omitted from this list would be none for every job over
-    # there, not only for the one this comment names
+    # this block bounds test.yml rather than standing in for what
+    # test.yml declares: a job over there with no block of its own is
+    # granted test.yml's own top-level contents: read and not the
+    # pull-requests: read granted here. The bound refuses rather than
+    # trims, so this workflow's contents: read alone would leave
+    # test.yml's `changes` job, which asks for pull-requests: read to
+    # list a pull request's files, refused before a single job starts,
+    # version-check included -- `changes` never actually reads a file
+    # list on a release, answering code=true unconditionally off anything
+    # that is not a pull_request event, but the check is against what the
+    # job declares, not against what it goes on to do. contents: read is
+    # repeated rather than left to test.yml's own default to keep that
+    # top-level declaration inside this list: what a run does where a
+    # called workflow's top-level declaration falls outside the caller's
+    # list is not measured, and the refusal above is not evidence for it
+    # (btclib-org/.github#912)
     permissions:
       contents: read
       pull-requests: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2262,6 +2262,37 @@ file of the test tree, and no caller acts on it.
   tree, `--write-changes` in the hook's own `args` therefore leaving the
   working tree exactly as it found it.
 
+### The caller-permissions clause says the block bounds what it calls
+
+- **`release.yml`'s comment above the `test` job's `permissions:` says
+  that block bounds `test.yml` rather than standing in for what
+  `test.yml` declares** (issue btclib-org/.github#912): a job over there
+  with no block of its own is granted `test.yml`'s own top-level
+  `contents: read` and not the `pull-requests: read` the caller grants
+  beyond it, which is what refutes the substitution reading. `changes`,
+  reached through the same call in the same run, declares
+  `pull-requests: read` and logs it with no `Contents`, so those
+  absences are absences. The wording follows section 11 of the
+  organization standard.
+- **What omitting `contents` from that list would do is named as
+  unmeasured rather than drawn as a consequence**: `contents: read` is
+  what `test.yml` declares at its own top level, so leaving it off is a
+  called workflow's top-level declaration falling outside the caller's
+  list, which is the case no run covers -- the refusal a called *job*'s
+  declaration draws is not evidence for it. The entry above under
+  *`release.yml`'s caller-permissions comment names the scope it is
+  about*, which cites btclib-org/.github#896, narrowed that consequence
+  to `contents`; the narrowing stands, and what changes is that the
+  comment no longer states the outcome.
+- **`REPOSITORY.md`'s *Token permissions* states the mechanism the same
+  way** (closes btclib-org/.github#917): what the caller's list has to
+  name is what `test.yml`'s own jobs declare, and the reason is the
+  refusal a job's declaration outside that list draws. The unmeasured
+  top-level case is left to `release.yml`'s comment, which is where this
+  tree argues the call. The other `replaces` in that section states a
+  different mechanism -- a job's own `permissions:` against its own
+  workflow's top level -- and is untouched.
+
 ## v2026.9.3
 
 ### Repository

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -526,11 +526,16 @@ needing more must declare it. The largest group of those declarations is
 in `release.yml`: `contents: write` on `github-release`, `id-token: write` on
 `publish-pypi` and `publish-testpypi`, and `contents: read` with
 `pull-requests: read` on `test` — that last one there because `test`
-calls `test.yml`, and a caller's `permissions:` block replaces the
-callee's default outright rather than adding to it, so it has to grant
-what `test.yml`'s own jobs declare, not only what `release.yml` itself
-needs. `test.yml` has one such declaration of its own, on `changes`:
-`pull-requests: read`, to list a pull request's files. And
+calls `test.yml`, and a caller's `permissions:` block bounds the
+workflow it calls rather than standing in for what that workflow
+declares: a job of `test.yml` with no block of its own is granted
+`test.yml`'s own top-level `contents: read` and not the
+`pull-requests: read` the caller grants beyond it, and a scope one of
+its jobs declares that the caller's list leaves off fails the run before
+a job of it starts (btclib-org/btclib-secp256k1#281). So that list has
+to name what `test.yml`'s own jobs declare, not only what `release.yml`
+itself needs. `test.yml` has one such declaration of its own, on
+`changes`: `pull-requests: read`, to list a pull request's files. And
 `codeql.yml`'s `analyze` has one: `security-events: write` is
 what uploading a SARIF to code scanning takes, with `actions: read` beside
 it — redundant while this repository is public, and written down so that


### PR DESCRIPTION
`release.yml`'s comment and `REPOSITORY.md` say the caller's block bounds what it calls (closes btclib-org/.github#917) (issue btclib-org/.github#912)

Both sites read the caller's `permissions:` block as standing in for what
the called workflow declares. `release.yml`'s comment above the `test`
job's block read `a caller's grant replaces the callee's default
outright`, and `REPOSITORY.md`'s Token permissions read `a caller's
permissions: block replaces the callee's default outright rather than
adding to it`. Section 11 of the organization standard settles the
wording: the block bounds the workflow it calls rather than standing in
for what that workflow declares.

Re-derived in this tree's own release run 33248410519, one job at a time.
`dist`, which declares no block of its own, logs `Contents: read` and
`Metadata: read` and no `PullRequests`, where the caller grants
`pull-requests: read`. `changes`, reached through the same call in the
same run and declaring `pull-requests: read`, logs it with no
`Contents` -- the control that could have failed, and what makes those
absences absences.

The comment's closing consequence -- `contents` omitted from the
caller's list would be none for every job over there -- is named as
unmeasured rather than deleted. `contents: read` is what `test.yml`
declares at its own top level, so omitting it from the caller's list is
the callee top-level case the standard marks as covered by no run.
Deleting the sentence would leave the next reader to re-derive the
question the standard fences and take the repeated `contents: read` for
belt and braces.

`REPOSITORY.md` takes the bound and the refusal a called job's
declaration draws, and leaves the unmeasured top-level case to
`release.yml`'s comment, which is where this tree argues the call.
`REPOSITORY.md`'s other `replaces` -- a job's own `permissions:` against
its own workflow's top level -- is a different mechanism and is
untouched.

The subject cites btclib-org/.github#912 with `issue` and not a
keyword. That issue names two trees and this branch is one of the two
halves, so whether it closes is settled after this lands rather than by
a keyword on this subject.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WKQAgJcSkNPKgqAHWPWySX


Local review: CLEARED aa3295c, which is this head. Gates on that tree, exit codes 0,0,0,0,0,0,0,1 with the last being the documented pass: `uv sync`; `uv run ruff check --fix`; `uv run ruff format` (415 files unchanged); `uv run mypy src/btclib tests .github/scripts` (364 files); `uv run pytest` (32223 passed, 33 skipped, 1 xfailed, 100.00% coverage); `uv run pre-commit run --all-files` (41 Passed, 1 Skipped, 0 Failed); `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html`; and `/usr/bin/grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'`, whose exit 1 over 161 files is the pass, with a planted `href` flipping it to 0 as the control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKQAgJcSkNPKgqAHWPWySX

## Summary by Sourcery

Correct reusable-workflow permissions documentation to state that caller permissions bound, rather than replace, the called workflow's declarations.

Enhancements:
- Clarify that permissions granted by a reusable-workflow caller bound the called workflow rather than replacing its declared defaults, and document the resulting job-level permission requirements.
- Preserve the distinction between measured job-level permission refusals and the unmeasured behavior of called workflow top-level permissions.

Documentation:
- Update the repository permissions guidance and release workflow commentary to accurately describe reusable-workflow permission bounds.

Chores:
- Record the permissions documentation correction and its supporting release-run evidence in the changelog.