### PR TITLE
tests/build_system_test.py's reader reaches subdirectories of tests/ (closes #1818)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2324,6 +2324,22 @@ file of the test tree, and no caller acts on it.
   the sentinel above makes wrong, and the reason each gives for its own
   cadence is untouched.
 
+### `tests/build_system_test.py`'s reader reaches subdirectories of `tests/`
+
+- **`_TESTS.glob("*.py")` becomes `_TESTS.rglob("*.py")`, and the
+  reader's own entry for a match is its path relative to `tests/`, not
+  its bare filename** (closes #1818). The top-level-only glob left
+  `tests/bip32/`, `tests/ecc/` and the rest of the package's own
+  subdirectories unopened, so a subdirectory module reaching `.github`
+  or `fuzz` would have passed `source-exclude`'s check unseen -- no such
+  module exists in this tree today, checked by running the widened
+  reader against it, but a future one would have reproduced ISS
+  1509/1736/1801's mechanism one level down. The reader is factored into
+  `_missing_source_excludes`, taking a directory rather than closing over
+  `tests/`, so a second test can exercise the descent and the
+  relative-path naming against a synthetic `sub/offender_test.py` rather
+  than relying on the real tree to happen to hold one.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/build_system_test.py
+++ b/tests/build_system_test.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import ast
 import re
+from collections.abc import Iterable
 from pathlib import Path
 
 _PYPROJECT = Path(__file__).parents[1] / "pyproject.toml"
@@ -225,20 +226,52 @@ def _reaches_outside_the_sdist(tree: ast.Module) -> bool:
     return False
 
 
+def _missing_source_excludes(tests_dir: Path, excluded: Iterable[str]) -> list[str]:
+    """Every `*.py` under `tests_dir`, recursively, unlisted in `excluded`.
+
+    Recursive, `tests/bip32/`, `tests/ecc/` and the rest of the package's
+    own subdirectories being as reachable from an installed test as the
+    top level is -- a module there naming `.github` or `fuzz` would be
+    just as unrunnable from an unpacked sdist. `source-exclude`'s own
+    entries are full paths from the project root, not bare filenames, so
+    a subdirectory member is named by its path relative to `tests_dir`
+    and not by its `name` alone.
+    """
+    excluded = set(excluded)
+    return [
+        f"/tests/{path.relative_to(tests_dir).as_posix()}"
+        for path in sorted(tests_dir.rglob("*.py"))
+        if _reaches_outside_the_sdist(
+            ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        )
+        and f"/tests/{path.relative_to(tests_dir).as_posix()}" not in excluded
+    ]
+
+
 def test_every_test_reaching_outside_the_sdist_is_source_excluded() -> None:
-    """A `tests/*.py` the reader above recognizes is named in the list.
+    """A `tests/**/*.py` the reader above recognizes is named in the list.
 
     Not the other direction: `source-exclude` also names entries no test
     file could match -- `docs/build`, the linter caches -- so only this
     direction closes what ISS 1509 found open.
     """
-    excluded = set(_source_exclude())
-    missing = [
-        f"/tests/{path.name}"
-        for path in sorted(_TESTS.glob("*.py"))
-        if _reaches_outside_the_sdist(
-            ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        )
-        and f"/tests/{path.name}" not in excluded
-    ]
+    missing = _missing_source_excludes(_TESTS, _source_exclude())
     assert not missing, f"reaches outside the sdist, not in source-exclude: {missing}"
+
+
+def test_a_subdirectory_module_is_reached_and_named_by_its_relative_path(
+    tmp_path: Path,
+) -> None:
+    """`_missing_source_excludes` opens a subdirectory, not only the top.
+
+    A synthetic `sub/offender_test.py`, planted under a directory this
+    test builds rather than the real `tests/`, is what proves the reader
+    descends into it -- `_TESTS.glob("*.py")`, the shape this replaced,
+    never opened a subdirectory at all, so a module there naming
+    `.github` would have passed unseen whatever `source-exclude` said.
+    """
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "offender_test.py").write_text('URL = ".github/x.yml"\n', encoding="utf-8")
+
+    assert _missing_source_excludes(tmp_path, []) == ["/tests/sub/offender_test.py"]


### PR DESCRIPTION
Closes #1818

`tests/build_system_test.py`'s `_TESTS.glob("*.py")` only reached
top-level `tests/*.py`; a subdirectory test module reaching `.github` or
`fuzz` off the tree would never have been parsed by `source-exclude`'s
own check. Widened to `_TESTS.rglob("*.py")`, with the reader's entry
for a match now its path relative to `tests/` rather than its bare
filename (subdirectory filenames can collide, and `pyproject.toml`'s
`source-exclude` entries are root-relative paths already). The reader
logic is factored into `_missing_source_excludes(tests_dir, excluded)`
so a new regression test can drive it against a synthetic
`sub/offender_test.py`, since no subdirectory module in the real tree
reaches `.github`/`fuzz` today to exercise that branch.

Local review: CLEARED a36a8e6e (rebased onto origin/main 8f4450e4 after
initial review at 6a88338c; the rebase only touched CHANGELOG.md via the
union driver — reconstructed and verified byte-for-byte, then the
markdownlint gate restored the blank line the driver ate between the
two `###` blocks, re-verified clean).

Gates (pytest full suite, pre-commit --all-files, sphinx -W docs build):
all green, run by the coder and re-run for pre-commit after the rebase.

## Summary by Sourcery

Make source-exclusion validation cover the complete recursive tests tree, including nested modules.

Bug Fixes:
- Ensure the build-system test reader detects Python test modules in subdirectories and verifies their root-relative source-exclude entries.

Enhancements:
- Factor source-exclusion validation into a reusable helper and add regression coverage for nested test modules.

Tests:
- Add a regression test proving nested test modules are discovered and reported using relative paths.