### PR TITLE
bolt9.py's _walk_dependencies terminates on a cyclic table (closes #1822)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2340,6 +2340,18 @@ file of the test tree, and no caller acts on it.
   relative-path naming against a synthetic `sub/offender_test.py` rather
   than relying on the real tree to happen to hold one.
 
+### `_walk_dependencies` terminates on a cyclic table
+
+- **`btclib.bolt9._walk_dependencies` skips a bit it has already
+  expanded rather than re-queueing it** (closes #1822): a `visited` set
+  is what a table whose cycle is reached only transitively -- three or
+  more nodes, none of them set in the vector -- needs to stop the walk
+  instead of requeuing the cycle's members forever.
+  `FEATURE_DEPENDENCIES` carries no such cycle, which
+  `test_no_feature_depends_on_itself` holds it to independently of the
+  walk itself; the new guard is what protects a table that does, and
+  `test_a_transitively_reached_cycle_terminates` drives it against one.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/bolt9.py
+++ b/src/btclib/bolt9.py
@@ -129,13 +129,18 @@ def _walk_dependencies(
 
     The walk is transitive: a feature the vector must set for one it does
     set is itself asked for, so a chain through the table is followed to
-    its end. What ends the walk is the table having no cycle, and
-    `tests/bolt9_test.py` is what holds BOLT9's own to that.
+    its end. A bit already expanded is skipped rather than re-queued, so
+    a cycle in `dependencies` stops the walk instead of running it
+    forever.
     """
     unmet: set[tuple[int, int]] = set()
+    visited: set[int] = set()
     pending = [bit for bit in dependencies if value >> bit & 0b11]
     while pending:
         bit = pending.pop()
+        if bit in visited:
+            continue
+        visited.add(bit)
         for required in dependencies.get(bit, ()):
             if not value >> required & 0b11:
                 unmet.add((bit, required))

--- a/tests/bolt9_test.py
+++ b/tests/bolt9_test.py
@@ -12,13 +12,14 @@ feature example sets. `tests/bolt11_test.py` drives those two invoices
 themselves.
 
 The Dependencies column is the same kind of transcription and is held to
-the same kind of shape, with one addition: the walk over it ends because
-the table has no cycle, so a cycle is what one of the tests below refuses.
-Every row of that column is asked for in turn, which is what a
-mistranscribed bit fails. A chain -- a dependency that has one of its own
--- is what `_walk_dependencies` is separable for: BOLT9 assigns none at
-the pinned revision, so the transitive step is driven over a table
-written here instead.
+the same kind of shape, with one addition: a mistranscribed row could
+introduce a cycle, which one of the tests below refuses regardless of
+whether `_walk_dependencies` itself would terminate on one. Every row of
+that column is asked for in turn, which is what a mistranscribed bit
+fails. A chain -- a dependency that has one of its own -- and a cycle
+reached through one are what `_walk_dependencies` is separable for:
+BOLT9 assigns neither at the pinned revision, so both are driven over
+tables written here instead.
 """
 
 from __future__ import annotations
@@ -89,11 +90,11 @@ def test_every_dependency_is_between_assigned_features() -> None:
 
 
 def test_no_feature_depends_on_itself() -> None:
-    """Directly or through a chain, which is what ends the walk.
+    """Directly or through a chain.
 
-    Its own closure rather than `_walk_dependencies`: that one is what
-    this guarantees terminates, so asking it would be asking the question
-    of itself, and the answer to a cycle would be a hung suite.
+    Its own closure rather than `_walk_dependencies`, which terminates on
+    any table, cyclic or not: this test is a claim about
+    `FEATURE_DEPENDENCIES` itself, independent of the walk's own safety.
     """
     for bit in FEATURE_DEPENDENCIES:
         reached: set[int] = set()
@@ -154,4 +155,19 @@ def test_a_chain_is_followed_to_its_end() -> None:
     assert _walk_dependencies(dependencies, (1 << 4) | (1 << 16) | (1 << 18)) == (
         (4, 8),
         (8, 12),
+    )
+
+
+def test_a_transitively_reached_cycle_terminates() -> None:
+    """2 depends on 4, which depends on 6, which depends back on 4.
+
+    None of the cycle's three nodes is set in the vector, so 4 is reached
+    twice -- once from 2 and once from 6 -- and the second time is where
+    the walk has to stop rather than requeue it forever.
+    """
+    dependencies = {2: (4,), 4: (6,), 6: (4,)}
+    assert _walk_dependencies(dependencies, 1 << 2) == (
+        (2, 4),
+        (4, 6),
+        (6, 4),
     )


### PR DESCRIPTION
Closes #1822

`_walk_dependencies` appended to `pending` unconditionally and never
consulted its own deduplication set for termination, so a transitively
reached cycle of three or more nodes (none of them set in the bit
vector) hung it forever. Added a `visited` set inside the walk, mirroring
what the acyclicity test already builds externally, and a new test
drives it against the exact non-terminating shape from the issue
(`{2: (4,), 4: (6,), 6: (4,)}` against bit 2), confirmed hanging on the
pre-fix code under a SIGALRM guard and returning correctly after.

Local review: CLEARED 72cd096c (already based on current origin/main,
no rebase needed).

Gates (pytest full suite, pre-commit --all-files, sphinx -W docs build):
all green.

## Summary by Sourcery

Ensure dependency walks terminate safely on cyclic dependency tables.

Bug Fixes:
- Prevent `_walk_dependencies` from hanging when dependency tables contain transitively reached cycles.

Enhancements:
- Track expanded dependency bits during walks so cyclic dependency graphs terminate safely.

Tests:
- Add coverage for termination and expected unmet dependencies in a transitively reached cyclic dependency graph.