### PR TITLE
`.gitignore` drops `envtest/` (closes #1828)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ sbom/
 .env
 .venv
 env/
-envtest/
 venv/
 ENV/
 env.bak/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2352,6 +2352,12 @@ file of the test tree, and no caller acts on it.
   walk itself; the new guard is what protects a table that does, and
   `test_a_transitively_reached_cycle_terminates` drives it against one.
 
+### `.gitignore` drops `envtest/`
+
+- **`.gitignore`'s `# Environments` block no longer carries `envtest/`**
+  (closes #1828): nothing in this tree's tooling or docs writes a
+  directory of that name.
+
 ## v2026.9.3
 
 ### Repository


### PR DESCRIPTION
Closes #1828

`.gitignore`'s `envtest/` entry matched nothing tracked or produced by
this tree's own tooling or docs. Removed, matching the sibling
repositories' resolution of the same inherited entry
(btclib-org/btclib-secp256k1#722, btclib-org/bitcoin-core-rpc#392).

Local review: CLEARED 34dfb8d6 (rebased onto origin/main after two other
PRs landed; the rebase touched only CHANGELOG.md's union-merge seam,
reconstructed and verified byte-for-byte, then the markdownlint gate
restored the blank line the driver ate).

Gates (pytest full suite, pre-commit --all-files, sphinx -W docs build):
all green.

## Summary by Sourcery

Remove the unused `envtest/` ignore rule and record the repository cleanup in the changelog.

Enhancements:
- Remove the obsolete `envtest/` entry from `.gitignore`.
- Document the `.gitignore` cleanup in the changelog.