### PR TITLE
A reference naming a repository outside the organization names its owner (issue #1827)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2358,6 +2358,24 @@ file of the test tree, and no caller acts on it.
   (closes #1828): nothing in this tree's tooling or docs writes a
   directory of that name.
 
+### A reference naming a repository outside the organization names its owner
+
+- **`musig2.py`'s `secp256k1-zkp#330` references are
+  `BlockstreamResearch/secp256k1-zkp#330`** (issue #1827):
+  btclib-org/.github#642's census of cross-repository references is keyed on
+  the organization's own sibling names, so a reference to a repository outside
+  it is invisible to that census and was left behind by db7a4ab7. The
+  docstring's own URL naming the same repository, below one of the two
+  references, does not satisfy section 9's *A reference to another repository
+  is qualified* on its own -- that rule says nothing about a nearby URL doing
+  the work -- so both are qualified explicitly.
+- **`bip32.py`'s `checksig#643` is `checksig-custody/checksig#643`**:
+  `checksig` alone resolves to no organization, and `checksig-custody` is its
+  real name. The repository is private, so the citation stays the opaque
+  provenance note it already is rather than becoming a link a public reader can
+  follow -- the number beside it, a cache hit rate, is what that sentence's
+  reader needs.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/bip32/bip32.py
+++ b/src/btclib/bip32/bip32.py
@@ -119,13 +119,13 @@ def _cached_base58_decode(address: String) -> bytes:
     `address` is caller-supplied, and an unbounded cache on it would be
     a memory leak (issue #287).
 
-    2048 rather than the module's usual bare default (128) is measured
-    on two workloads: btclib's own suite, and a caller that also calls
+    2048 rather than the module's usual bare default (128) is measured on
+    two workloads: btclib's own suite, and a caller that also calls
     `b58decode` directly once per derived key, on top of what `derive`
-    already does (checksig#643, the heavier of the two). Hit rate at
-    128, 512, 1024 and 2048 respectively: 22.2%, 24.3%, 27.5% and 28.8%
-    for the first; 52.8%, 55.6%, 56.1% and 72.9% for the second -- most
-    of the second workload's climb from 1024 to 2048, the first
+    already does (checksig-custody/checksig#643, the heavier of the two).
+    Hit rate at 128, 512, 1024 and 2048 respectively: 22.2%, 24.3%, 27.5%
+    and 28.8% for the first; 52.8%, 55.6%, 56.1% and 72.9% for the second
+    -- most of the second workload's climb from 1024 to 2048, the first
     already flat by then.
 
     Past 2048 the second workload keeps climbing -- at 8192 it is still

--- a/src/btclib/ecc/musig2.py
+++ b/src/btclib/ecc/musig2.py
@@ -79,7 +79,7 @@ secret t behind T, or that `extract_adaptor` recovers t from, given
 both the pre-signature and the signature `adapt` produced. Splitting
 the entry point rather than widening `partial_sig_agg`'s return type
 keeps every existing caller narrowing nothing, and matches where the
-C library is going: secp256k1-zkp#330 is splitting
+C library is going: BlockstreamResearch/secp256k1-zkp#330 is splitting
 `musig_nonce_process` the same way, back to five arguments plus a
 separate `musig_nonce_process_adaptor`, so the base API stays
 uncontaminated by a capability most callers never touch. A DLC's
@@ -105,7 +105,7 @@ the vendored library, mainline `bitcoin-core/secp256k1`, has no
 adaptor support at all, so the round-trip tests below are this
 module's only check for now. What would supply that delegation,
 btclib-org/btclib-secp256k1#283, is decided and waits on
-secp256k1-zkp#330 upstream.
+BlockstreamResearch/secp256k1-zkp#330 upstream.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Issue #1827

Three cross-repository references at `musig2.py`/`bip32.py` named a
repository outside the organization and left the owner off:
`secp256k1-zkp#330` (two sites) qualified to
`BlockstreamResearch/secp256k1-zkp#330`, and `checksig#643` qualified to
`checksig-custody/checksig#643` — that org's real name (`checksig`
alone answers 404), kept as opaque provenance since the number, not the
link, is what the reader needs.

The issue stays open after this branch: `btclib-org/.github#642`'s own
body still needs this third blind spot recorded in its census, which is
that repository's issue and out of scope here. Hence `(issue #1827)`,
not a closing keyword.

Local review: CLEARED 084314d1 (rebased onto origin/main after two other
PRs landed; rebase touched only CHANGELOG.md's union-merge seam,
reconstructed and verified byte-for-byte, lint gate restored the eaten
blank line, re-verified clean).

Gates (pytest full suite, pre-commit --all-files, sphinx -W docs build):
all green.

## Summary by Sourcery

Identify the owners of external repositories in cross-repository references to make their provenance unambiguous.

Enhancements:
- Qualify cross-repository references with their owning organizations in MuSig2 and BIP32 documentation.

Documentation:
- Document the corrected external repository references in the changelog.