### PR TITLE
REPOSITORY.md's declaration census is keyed on position, not on the end of the line (closes #1833)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2389,6 +2389,18 @@ file of the test tree, and no caller acts on it.
   entry now names, so the refresh corrects what commit each pin names
   without changing a vector.
 
+### `REPOSITORY.md`'s declaration census is keyed on where `permissions:` sits
+
+- **The command that names every `permissions:` declaration is
+  `git grep -nE '^[[:blank:]]*permissions:$'`, not
+  `git grep -n "permissions:$"`** (closes #1833): the retired form keys
+  on the end of a line, so a comment whose own text happens to end in
+  the word `permissions:` would land in its answer -- the same shape
+  issue btclib-org/.github#897 fixed for the elevation census beside it.
+  The anchored form still matches every declaration, at the workflow
+  level and at the job level, and excludes a comment line by its own
+  leading `#`.
+
 ## v2026.9.3
 
 ### Repository

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -574,7 +574,7 @@ authentication at all.
 These are the declarations this file argues, not a roster of them.
 
 ```shell
-git grep -n "permissions:$" -- .github/workflows
+git grep -nE '^[[:blank:]]*permissions:$' -- .github/workflows
 ```
 
 names every declaration, and the write grants among them read out of a


### PR DESCRIPTION
Closes #1833

`REPOSITORY.md`'s command that finds every `permissions:` block was
keyed on the end of the line (`git grep -n "permissions:$"`), the same
shape ISS 897 fixed for the elevation-census command in this file: a
comment line ending in the literal word `permissions:` would land in
its answer. Anchored to the position instead
(`git grep -nE '^[[:blank:]]*permissions:$'`), matching the form
already used a few lines below for the elevation census.

Nothing in the tree matches wrongly today (both forms answer 32 and
agree), so this is a latent defect fixed before it produces a false
positive, not a live one.

Local review: CLEARED 6a0f3b4d (rebased onto origin/main after several
other PRs landed; rebase touched only CHANGELOG.md's union-merge seam,
reconstructed and verified byte-for-byte, lint gate restored the eaten
blank line).

Gates (pytest full suite, pre-commit --all-files, sphinx -W docs build):
all green on the originally pushed sha; the CHANGELOG.md-only rebase
re-ran the lint gate only, per this repository's documented rule for a
rebase touching nothing else.

## Summary by Sourcery

Correct the `REPOSITORY.md` permissions census so it identifies declarations by their line position rather than merely by line ending.

Bug Fixes:
- Anchor the `REPOSITORY.md` permissions declaration census to lines whose content is exactly a declaration, preventing comment text ending in `permissions:` from being counted.

Chores:
- Document the corrected permissions census command in the changelog.