### PR TITLE
psbt: finalization keeps agree with Bitcoin Core's serializer, not FromSignatureData (closes #1841)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2401,6 +2401,18 @@ file of the test tree, and no caller acts on it.
   level and at the job level, and excludes a comment line by its own
   leading `#`.
 
+### `_clear_finalized`'s docstring names Core's wire serializer
+
+- **The docstring and its test's mirror said btclib is stricter than
+  Bitcoin Core here, reasoning from `PSBTInput::FromSignatureData`,
+  Core's in-memory clearing function rather than its wire serializer**
+  (closes #1841). `PSBTInput::Serialize` guards partial sigs, keypaths,
+  the redeem and witness scripts, the taproot fields, the sighash type
+  and the preimages behind the same emptiness check on the final
+  scripts that `_FINALIZED_KEEPS` already encodes, so a finalized
+  input's wire serialization carries the same fields whether it is
+  Core's or btclib's. `_FINALIZED_KEEPS` needed no change.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/psbt/psbt.py
+++ b/src/btclib/psbt/psbt.py
@@ -3194,12 +3194,16 @@ def _clear_finalized(psbt_in: PsbtIn) -> None:
     literal per field: the empty value of a field is the constructor's
     business, and spelling it twice is how the two drift.
 
-    btclib is stricter than Bitcoin Core here, whose
-    `PSBTInput::FromSignatureData` clears `partial_sigs`, `hd_keypaths`,
-    `redeem_script` and `witness_script` and leaves the taproot fields,
-    the sighash type and the preimages in place. BIP174's sentence covers
-    those too, and what they buy after finalization is nothing: the
-    preimage a hash-locked script needs is in the witness by then.
+    This keep list agrees with what Bitcoin Core actually puts on the
+    wire for a finalized input: `PSBTInput::Serialize` guards
+    `partial_sigs`, `hd_keypaths`, `redeem_script`, `witness_script`, the
+    taproot fields, the sighash type and the preimages behind
+    `if (final_script_sig.empty() && final_script_witness.IsNull())`, so
+    none of them are serialized once an input is finalized.
+    `PSBTInput::FromSignatureData` clears only the first four of those in
+    memory, but that function is not the wire format. BIP174's sentence
+    covers all of them, and what they buy after finalization is nothing:
+    the preimage a hash-locked script needs is in the witness by then.
     """
     empty = PsbtIn(check_validity=False)
     for field in fields(psbt_in):

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -3862,9 +3862,13 @@ def test_a_finalized_input_keeps_the_utxo_and_the_unknown_fields_only(
     the four preimage maps, which after finalization are in the witness
     anyway.
 
-    btclib is stricter than Bitcoin Core here, whose
-    `PSBTInput::FromSignatureData` clears four fields and leaves the
-    taproot ones, the sighash type and the preimages.
+    This is what Bitcoin Core's `PSBTInput::Serialize` writes for a
+    finalized input too: it guards partial sigs, keypaths, the redeem
+    and witness scripts, the taproot fields, the sighash type and the
+    preimages behind the same emptiness check on the final scripts, so
+    none of them reach the wire. `PSBTInput::FromSignatureData` clears
+    only four of those fields in memory, but that function is not the
+    wire format.
     """
     if kind == "p2tr":
         psbt, prevouts = _taproot_key_path_psbt()


### PR DESCRIPTION
Closes #1841

Three docstrings claimed btclib is "stricter than Bitcoin Core" at PSBT
finalization, reasoning from Core's `PSBTInput::FromSignatureData` (an
in-memory clearing function, not the wire format). Core's actual wire
gate is `PSBTInput::Serialize`, which drops the taproot fields, sighash
type and preimages whenever `final_script_sig`/`final_script_witness`
are set — exactly what btclib's `_FINALIZED_KEEPS` already does. The two
agree; btclib was never stricter. Docstrings in `psbt.py` and
`psbt_test.py` corrected to name the actual mechanism
(`PSBTInput::Serialize`); `_FINALIZED_KEEPS` itself is unchanged
(documentation-only fix). The pre-existing CHANGELOG.md entry from when
the wrong claim was first written is left untouched, per this file's
append-only convention.

Local review: CLEARED 27ef24a8 (rebased onto origin/main across three
intervening landings; each rebase touched only CHANGELOG.md's
union-merge seam, reconstructed and verified byte-for-byte). The
reviewer independently confirmed the core factual claim against Bitcoin
Core's own source (`src/psbt.h`/`src/psbt.cpp` at Core's current
master) rather than trusting the issue's citation.

Gates (pytest full suite, pre-commit --all-files, sphinx -W docs build):
green on the final rebased sha, re-run by the reviewer since the rebase
voided the coder's original run.

Collateral from this review, filed separately: #1859 (maintainer's
broader proposal to move field-clearing to serialization time generally
— design question, out of scope here) and #1862 (a pre-existing,
unrelated test failure on current origin/main from PR #1857 — this
branch's tip carries tests/_data/README.md and
tests/vendored_data_test.py byte-identical to origin/main, so #1862's
failure is not this branch's).

## Summary by Sourcery

Align PSBT finalization documentation with Bitcoin Core’s actual wire serialization behavior.

Enhancements:
- Correct PSBT finalization documentation to compare btclib with Bitcoin Core’s wire serializer rather than its in-memory signature-data clearing function.

Documentation:
- Clarify that Bitcoin Core and btclib serialize the same finalized PSBT fields, including taproot data, sighash types, and preimages.