### PR TITLE
vendored_data_test.py's _EXEMPT key matches #1857's rewrapped line (closes #1862)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2413,6 +2413,16 @@ file of the test tree, and no caller acts on it.
   input's wire serialization carries the same fields whether it is
   Core's or btclib's. `_FINALIZED_KEEPS` needed no change.
 
+### `tests/vendored_data_test.py`'s `_EXEMPT` key tracks the rewrapped README line
+
+- **`tests/vendored_data_test.py`'s `_EXEMPT` dict names the wrapped
+  line as `tests/_data/README.md` carries it today** (closes #1862): the
+  rewrap that landed with #1857 moved "the split between" onto the line
+  `_EXEMPT` names, and the dict still carried the pre-#1857 wrapping
+  verbatim, so both tests reading it against the file's current wrapping
+  failed. The key now reads "the split between the two ECDSA profiles is
+  explained, and where the", matching the line as it stands in the file.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/vendored_data_test.py
+++ b/tests/vendored_data_test.py
@@ -363,7 +363,7 @@ _EXEMPT: dict[str, str] = {
     "the 1-of-1 shares, whose value is the encrypted master secret itself and": _UPSTREAM_FACT,
     "regenerates each of the four mnemonics word for word from the master": _UPSTREAM_FACT,
     "secret. The other 11 are recovery only, a 2-of-3 share being random by": _UPSTREAM_FACT,
-    "the two ECDSA profiles is explained, and where the difference the files": _UPSTREAM_FACT,
+    "the split between the two ECDSA profiles is explained, and where the": _UPSTREAM_FACT,
     "measured, all files verify identically at 32 and at 64.": _UPSTREAM_FACT,
     "and its verifier no longer applies that rule, so two of these verdicts": _UPSTREAM_FACT,
     "are exempted rather than asserted — `wycheproof_test.py` reads which two": _UPSTREAM_FACT,


### PR DESCRIPTION
Closes #1862

PR #1857 rewrapped a sentence in `tests/_data/README.md`; the
`_EXEMPT` dict in `tests/vendored_data_test.py` still carried the
pre-rewrap line verbatim. Updated the key to match the file as it
stands today. Both previously-failing tests
(`test_every_exemption_is_still_a_line_that_needs_one`,
`test_every_numeral_outside_the_allowlist_is_a_count_of_this_tree`)
pass.

Local review: CLEARED ec45f722 (no rebase needed, already based on
current origin/main). Reviewer independently re-read the current
tests/_data/README.md line, confirmed the new _EXEMPT key matches it
byte-for-byte, and ran both named tests directly rather than trusting
the report.

Gates (pytest full suite, pre-commit --all-files, sphinx -W docs
build): all green.

## Summary by Sourcery

Synchronize the vendored-data exemption with the rewrapped README content.

Bug Fixes:
- Update the vendored-data exemption to match the current wrapped README line, restoring the affected validation tests.

Chores:
- Document the exemption correction in the changelog.