### PR TITLE
The MuSig2 adaptor oracle, against `zkp.musig` in both directions and both parities (issue #1679)

### DIFF
--- a/.github/workflows/zkp-oracle.yml
+++ b/.github/workflows/zkp-oracle.yml
@@ -88,12 +88,27 @@ on:
     # surface shared by nearly every other test in the suite, so a break
     # there is already caught elsewhere, and naming them here would be
     # "most of ecc/ and most of curves/", wrong the next time either
-    # grows a function
+    # grows a function.
+    # `musig2.py` and its own test file join the list for the MuSig2
+    # adaptor oracle: unlike `dsa.py`, where three shared functions are
+    # the whole dependency, `tests/ecc/musig2_test.py`'s zkp-marked tests
+    # exercise nearly all of `musig2.py`'s own public surface --
+    # `key_sort`, `key_agg`, `nonce_gen`, `nonce_agg`, `sign`,
+    # `SessionContext`, `partial_sig_agg_adaptor`, `adapt` and
+    # `extract_adaptor` -- so the file is named whole rather than
+    # itemized. `ssa.py`'s `Sig.serialize()`, which those same tests call
+    # on what `musig2.adapt`/`partial_sig_agg` return, stays out for the
+    # same reason `curves/` does above: a two-field big-endian
+    # concatenation, already exhaustively checked by BIP340's own
+    # vectors, not the sort of surface a MuSig2-specific oracle exists to
+    # cover a second time
     paths:
       - .github/workflows/zkp-oracle.yml
       - tests/ecc/commit_nonce_test.py
+      - tests/ecc/musig2_test.py
       - src/btclib/ecc/dsa.py
       - src/btclib/ecc/commit_nonce.py
+      - src/btclib/ecc/musig2.py
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2423,6 +2423,36 @@ file of the test tree, and no caller acts on it.
   failed. The key now reads "the split between the two ECDSA profiles is
   explained, and where the", matching the line as it stands in the file.
 
+### The MuSig2 adaptor is cross-validated against `zkp.musig`
+
+- **`partial_sig_agg_adaptor`, `adapt` and `extract_adaptor` are checked
+  against `btclib_secp256k1.zkp.musig`'s `Session.partial_sig_agg`,
+  `adapt` and `extract_adaptor`, both directions and both parities of
+  the final nonce** (issue #1679). `tests/ecc/musig2_test.py` gains
+  `test_musig2_matches_zkp_with_no_adaptor`, pinning
+  that the two independent sessions -- `zkp.musig.Session` builds its
+  own, over its own opaque struct, not `btclib_secp256k1.musig`'s --
+  agree with no adaptor before one is added, and
+  `test_musig2_adaptor_matches_zkp`, which does add one: the same
+  pre-signature, the same completed signature and the same extracted
+  secret from both implementations, over fresh keys and an adaptor
+  secret each run, until both parities of the final nonce have been
+  seen. `zkp.musig.Session.nonce_parity()` is what zkp asks its caller
+  to track and pass to its own `adapt`/`extract_adaptor`;
+  `musig2.session_values(session_ctx).R[1] % 2` is the identical bit,
+  which btclib derives on its own -- the two are asserted equal before
+  anything downstream of it is compared, since a disagreement there is
+  exactly the sign error `adapt` and `extract_adaptor` each hide behind
+  a negation. `.github/workflows/zkp-oracle.yml`'s `pull_request.paths`
+  gains `src/btclib/ecc/musig2.py` for the same reason it already names
+  `src/btclib/ecc/dsa.py`. `src/btclib/ecc/musig2.py`'s own module
+  docstring is corrected to describe this rather than name it an open question:
+  btclib-org/btclib-secp256k1#156 and btclib-org/btclib-secp256k1#283 are both
+  closed, and mainline libsecp256k1 -- what `_bindings_session` delegates the
+  rest of this module's arithmetic to -- still has no adaptor support at all,
+  which is why the cross-validation is against zkp specifically. The
+  rangeproof oracle, which issue #1679 also asks for, stays its own issue.
+
 ## v2026.9.3
 
 ### Repository

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -116,7 +116,7 @@ used to teach and to prototype as much as to build:
     measured rather than assumed: the point-multiplication side has
     been regular since #254, and `sign`'s own line, `s = (k_1_ +
     values.b * k_2_ + values.e * a * d) % secp256k1.n`
-    (`src/btclib/ecc/musig2.py:840`), spreads 1.016x over uniform scalars
+    (`src/btclib/ecc/musig2.py:850`), spreads 1.016x over uniform scalars
     in `[1, n-1]` -- the magnitude leak that remains shows only for
     scalars with zero high bits, keys already lost for other reasons.
     The gain left is narrower than that figure suggests: delegating

--- a/src/btclib/ecc/musig2.py
+++ b/src/btclib/ecc/musig2.py
@@ -99,13 +99,23 @@ negates t exactly when the final nonce has odd y, because the
 pre-signature's nonce is then really -(r+t)*G rather than (r+t)*G --
 `adaptor_impl.h`'s own comment gives this reasoning in full.
 
-Cross-validating this construction against zkp is
-btclib-org/btclib-secp256k1#156's open question, not answered here:
-the vendored library, mainline `bitcoin-core/secp256k1`, has no
-adaptor support at all, so the round-trip tests below are this
-module's only check for now. What would supply that delegation,
-btclib-org/btclib-secp256k1#283, is decided and waits on
-BlockstreamResearch/secp256k1-zkp#330 upstream.
+This construction is cross-validated against secp256k1-zkp's own musig
+module, `btclib_secp256k1.zkp.musig`, in `tests/ecc/musig2_test.py`:
+`partial_sig_agg_adaptor`, `adapt` and `extract_adaptor` against its
+`Session.partial_sig_agg`, `adapt` and `extract_adaptor`, both
+directions and both parities of the final nonce, over fresh keys and an
+adaptor secret each run. `zkp.musig.Session.nonce_parity()` is what zkp
+asks its caller to track and pass to its own `adapt`/`extract_adaptor`;
+`session_values(session_ctx).R[1] % 2` is the identical bit, derived
+here instead of carried by the caller, and the two are asserted equal
+before anything downstream of it is compared. Mainline
+`bitcoin-core/secp256k1`, `_bindings_session`'s own
+`btclib_secp256k1.musig`, still has no adaptor support at all -- which
+is why a session that carries one takes the Python arm in
+`partial_sig_verify_` below regardless of whether the bindings would
+otherwise serve -- so this cross-validation is against zkp specifically,
+the one implementation this module has to check against for the
+capability BIP327 itself does not cover.
 """
 
 from __future__ import annotations
@@ -960,12 +970,12 @@ def partial_sig_verify_(
     resolved it there, and BIP327's own empty-message and
     38-byte-message vectors are what keeps this Python arm live and
     validated for a message of any size. The bindings have no adaptor
-    extension at all (this module's own docstring's "Cross-validating
-    this construction against zkp" paragraph), so a session that
-    carries one takes the Python arm regardless of the other two
-    conditions. Nothing else in this module is delegated -- `key_agg`,
-    `key_sort` and `nonce_agg` measured too close to their Python cost,
-    or run once per session already, to be worth a second code path.
+    extension at all (this module's own docstring's paragraph on
+    cross-validating against zkp), so a session that carries one takes
+    the Python arm regardless of the other two conditions. Nothing else
+    in this module is delegated -- `key_agg`, `key_sort` and `nonce_agg`
+    measured too close to their Python cost, or run once per session
+    already, to be worth a second code path.
 
     The signer's pubkey has to be one of the session's -- a membership
     test with no C equivalent, `musig_partial_sig_verify` answering a

--- a/tests/ecc/musig2_test.py
+++ b/tests/ecc/musig2_test.py
@@ -55,7 +55,7 @@ from btclib.exceptions import (
     BTClibValueError,
     InvalidContributionError,
 )
-from tests import load, needs_bindings, vector_id
+from tests import load, needs_bindings, needs_zkp, vector_id
 
 if INSTALLED:
     from btclib_secp256k1 import musig as libsecp256k1_musig
@@ -63,6 +63,21 @@ else:  # pragma: no cover -- only the no-bindings job reaches this
     # never called from a skipped test, mirroring the fallback
     # `btclib._libsecp256k1` gives every name it wraps
     libsecp256k1_musig = None  # type: ignore[assignment]
+
+# `INSTALLED`, not `tests.ZKP_AVAILABLE`: `btclib_secp256k1.zkp.musig`'s
+# own docstring defers every `ffi`/`lib`/`ctx` lookup to call time, through
+# `context._bindings()`, precisely so that importing this module never
+# needs the flag -- Sphinx's autodoc does exactly this import, in a build
+# that never sets `BTCLIB_LIBSECP256K1_ZKP`. So this import succeeds
+# whenever the bindings exist at all, flagged or not, the same condition
+# `libsecp256k1_musig` above already guards on; a job with the bindings
+# installed but not flagged imports a real, merely uncallable module here,
+# and never calls it, since every test below reaching for it is also
+# `@needs_zkp`
+if INSTALLED:
+    from btclib_secp256k1.zkp import musig as zkp_musig
+else:  # pragma: no cover -- only the no-bindings job reaches this
+    zkp_musig = None  # type: ignore[assignment]
 
 # the two exception types BIP327 tells apart: a caller's own bad
 # argument, and a peer's bad contribution
@@ -1008,6 +1023,117 @@ def test_adaptor_must_be_a_valid_point() -> None:
         musig2.session_values(session_ctx)
     assert exc_info.value.signer is None
     assert exc_info.value.contrib == "adaptor"
+
+
+@needs_zkp
+def test_musig2_matches_zkp_with_no_adaptor() -> None:  # pragma: no cover
+    """Pin session agreement with no adaptor, before the adaptor test adds one.
+
+    `zkp.musig.Session` is its own implementation, over its own opaque
+    session struct built by its own `nonce_process` call (that module's
+    own docstring: "nothing here is `btclib_secp256k1.musig`'s code
+    reused") -- a different module from the one
+    `test_partial_sig_agg_matches_bindings` above already checks, so
+    agreement with it is not proven by that test. Checked here on its
+    own, with no adaptor, so that a disagreement in the adaptor test
+    below is attributable to the adaptor arithmetic rather than to the
+    two sessions describing different sessions to begin with: btclib
+    folds the adaptor point into R_1 before b is hashed, and if zkp's
+    own `nonce_process` disagreed anywhere upstream of that, every
+    comparison downstream would fail at once, which would read as "the
+    adaptor math is wrong" rather than "the harness mirrored the session
+    badly".
+    """
+    pk_1 = musig2.individual_pub_key(_SK_1)
+    pk_2 = musig2.individual_pub_key(_SK_2)
+    pub_keys = musig2.key_sort([pk_1, pk_2])
+    sk_of = {pk_1: _SK_1, pk_2: _SK_2}
+    nonces = {pk: musig2.nonce_gen(sk_of[pk], pk, None, _MSG32) for pk in pub_keys}
+    agg_nonce = musig2.nonce_agg([nonces[pk][1] for pk in pub_keys])
+    session_ctx = musig2.SessionContext(agg_nonce, pub_keys, [], [], _MSG32)
+    psigs = [musig2.sign(nonces[pk][0], sk_of[pk], session_ctx) for pk in pub_keys]
+    sig = musig2.partial_sig_agg(psigs, session_ctx)
+
+    cache = zkp_musig.KeyAggCache(pub_keys)
+    session = zkp_musig.Session(agg_nonce, _MSG32, cache)
+    assert session.partial_sig_agg(psigs) == sig.serialize()
+    # dropping a signer's contribution is a different sum: the
+    # agreement above is not a vacuous comparison against a constant
+    assert session.partial_sig_agg(psigs[:1]) != sig.serialize()
+
+
+@needs_zkp
+def test_musig2_adaptor_matches_zkp() -> None:  # pragma: no cover
+    """A btclib pre-signature completes and extracts the same as zkp's.
+
+    Both parities of the final nonce R, exercised the way
+    `test_adapt_and_extract_adaptor_round_trip` above does: fresh keys,
+    nonces and adaptor secret each iteration, real randomness rather
+    than a seed -- this file's own idiom for exactly this "cover both
+    parities" problem, kept rather than a seeded `random` module this
+    file otherwise never imports -- until both have been seen.
+    `zkp.musig.Session`'s `adapt` and `extract_adaptor` are its own
+    `secp256k1_musig_adapt`/`secp256k1_musig_extract_adaptor` calls,
+    entirely independent of the `session_values`/`adapt`/
+    `extract_adaptor` above, so agreement here is a real cross-check and
+    not the same arithmetic read twice through two names.
+
+    `Session.nonce_parity()` is what zkp asks the caller to track and
+    pass to `adapt`/`extract_adaptor`; btclib derives the identical bit
+    on its own, from `session_values(session_ctx).R[1] % 2`. Asserting
+    the two agree is plausibly the single most valuable assertion this
+    test makes: a disagreement there is exactly the sign error `adapt`
+    and `extract_adaptor` each hide behind a negation, on the parity
+    where it matters, and it is checked before any other comparison
+    below is allowed to run.
+    """
+    pk_1 = musig2.individual_pub_key(_SK_1)
+    pk_2 = musig2.individual_pub_key(_SK_2)
+    pub_keys = musig2.key_sort([pk_1, pk_2])
+    sk_of = {pk_1: _SK_1, pk_2: _SK_2}
+
+    parities_seen: set[int] = set()
+    for _ in range(64):
+        t = 1 + secrets.randbelow(secp256k1.n - 1)
+        adaptor = bytes_from_point(mult(t, ec=secp256k1), secp256k1)
+
+        nonces = {pk: musig2.nonce_gen(sk_of[pk], pk, None, _MSG32) for pk in pub_keys}
+        agg_nonce = musig2.nonce_agg([nonces[pk][1] for pk in pub_keys])
+        session_ctx = musig2.SessionContext(
+            agg_nonce, pub_keys, [], [], _MSG32, adaptor
+        )
+        psigs = [musig2.sign(nonces[pk][0], sk_of[pk], session_ctx) for pk in pub_keys]
+        pre_sig = musig2.partial_sig_agg_adaptor(psigs, session_ctx)
+        pre_sig_bytes = pre_sig.r.to_bytes(32, "big") + pre_sig.s.to_bytes(32, "big")
+
+        cache = zkp_musig.KeyAggCache(pub_keys)
+        session = zkp_musig.Session(agg_nonce, _MSG32, cache, adaptor)
+        parity = session.nonce_parity()
+        assert parity == musig2.session_values(session_ctx).R[1] % 2
+        parities_seen.add(parity)
+
+        # the pre-signature: the same sum over the same psigs, from two
+        # independent implementations
+        assert session.partial_sig_agg(psigs) == pre_sig_bytes
+
+        # completion: btclib's own adapt agrees with zkp's, byte for byte
+        sig = musig2.adapt(pre_sig, t, session_ctx)
+        zkp_sig = zkp_musig.adapt(pre_sig_bytes, t, parity)
+        assert zkp_sig == sig.serialize()
+        # the wrong parity is a different negation, not a rejected call:
+        # 1 - parity is still 0 or 1, so this still runs and disagrees
+        assert zkp_musig.adapt(pre_sig_bytes, t, 1 - parity) != sig.serialize()
+
+        # extraction: whoever holds the completed signature and the
+        # pre-signature recovers t, in either implementation
+        extracted = musig2.extract_adaptor(sig, pre_sig, session_ctx)
+        zkp_extracted = zkp_musig.extract_adaptor(zkp_sig, pre_sig_bytes, parity)
+        assert extracted == zkp_extracted == t.to_bytes(32, "big")
+        assert zkp_musig.extract_adaptor(
+            zkp_sig, pre_sig_bytes, 1 - parity
+        ) != t.to_bytes(32, "big")
+
+    assert parities_seen == {0, 1}
 
 
 def test_sec_nonce_signs_once() -> None:


### PR DESCRIPTION
The MuSig2 adaptor oracle — the second of
[ISS 1679](https://github.com/btclib-org/btclib/issues/1679)'s three, on
the sentinel machinery the first one landed with.

**No closing keyword, deliberately.** That issue stays open: the
rangeproof is the third, and the maintainer has decided to stop before
it. The measurement behind that decision is on the issue.

## What it asserts

`tests/ecc/musig2_test.py` gains two `zkp`-marked tests against
`btclib_secp256k1.zkp.musig` — a different implementation over its own
opaque struct from the mainline `btclib_secp256k1.musig` the file's
existing `bindings` tests already compare against, and the only one with
adaptor support at all.

The pinning step comes first, on a session carrying **no** adaptor, so
that a later divergence is attributable to the adaptor rather than to a
harness that mirrored the session badly. Then, over fresh keys and an
adaptor secret each run, until both parities of the final nonce have been
seen: the pre-signature, the completed signature and the extracted secret
all agree, in both directions.

**The assertion the two implementations most needed.** btclib derives the
final nonce's parity from `session_values(session_ctx).R[1] % 2`; zkp
makes its caller track it and pass it to `adapt` and `extract_adaptor`.
Those two are asserted equal *before* anything downstream of them is
compared, so a sign error that `adapt` would otherwise absorb is caught
where it happens rather than as an unexplained mismatch.

Every positive assertion has a negative one beside it, and local review
checked that each tampers rather than taking it on faith: the flipped
parity differs because `t` and `-t mod n` coincide only at `t = 0`, which
the sampling excludes by construction.

## The prose it owes

`src/btclib/ecc/musig2.py`'s module docstring said cross-validating this
construction against zkp was an open question, that mainline has no
adaptor support, and that the round-trip tests were the module's only
check. `btclib-org/btclib-secp256k1#156` and
`btclib-org/btclib-secp256k1#283` are both closed and the round-trips
stop being the only check, so the paragraph now says what is true.
Mainline still has no adaptor support, which is why the cross-validation
is against zkp specifically — that clause survives, on its own terms.

`SECURITY.md` carries a quoted-line citation into this file; the
docstring rewrite moved it, and it moved with it.

## Verified on a runner, not only locally

`zkp-oracle.yml` was dispatched by hand on `main` after the first oracle
landed: `Prepared 18 packages in 29.79s`, the loadability assertion
passed, and `Run the tests marked zkp` reported **`2 passed`** — passed,
not skipped, so the comparison actually happened. With this branch's
tests in the same tree the flagged local run reports **4 passed**.

## Gates, on this tip

| gate | exit |
| --- | --- |
| `uv run --locked --only-group lint pre-commit run --all-files --show-diff-on-failure` | 0 |
| `uv run --locked pytest` | 0 — 32225 passed, 100.00% coverage, no deselect |
| `uv run --locked --group docs sphinx-build -n -W -b html docs/source docs/build/html` | 0 |
| `BTCLIB_LIBSECP256K1_ZKP=true … pytest -m zkp --no-cov` | 0 — 4 passed |

`git status --porcelain` empty, the commit signed. Four rounds of local
review: the first cleared the diff, the second caught a directional
reference pointing the wrong way, the third caught a bare `#283` that
resolved to an unrelated merged pull request in this repository, and the
fourth cleared the fix after reconstructing the rebase byte for byte
rather than trusting the `cmp`.

One earlier suite run was red on two `tests/vendored_data_test.py` tests.
That was `main`'s own defect, reproduced at `main`'s exact sha in a
disposable worktree before it was attributed anywhere;
[ISS 1862](https://github.com/btclib-org/btclib/issues/1862) is closed
and its fix is this branch's base, so the green above carries no
deselect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNydCktysAkoGbGcdfKRit

## Summary by Sourcery

Cross-validate MuSig2 adaptor operations against secp256k1-zkp and keep the oracle workflow and documentation aligned with the new coverage.

New Features:
- Cross-validate MuSig2 adaptor pre-signature aggregation, signature adaptation, and secret extraction against secp256k1-zkp in both directions and for both final-nonce parities.

Enhancements:
- Update MuSig2 documentation to reflect the completed zkp cross-validation and current adaptor-support limitations.
- Ensure the zkp oracle workflow runs when MuSig2 implementation or tests change.

CI:
- Extend the zkp oracle workflow path filters to cover MuSig2 source and tests.

Documentation:
- Correct the MuSig2 module documentation and security reference after the documented validation status and line locations changed.

Tests:
- Add zkp-marked tests that first verify adaptor-free session agreement, then compare adaptor operations and reject incorrect nonce parity handling.

Chores:
- Record the MuSig2 adaptor cross-validation in the changelog.