### PR TITLE
`tests/README.md`'s declaration sentence leaves the assertions to the module (issue btclib-org/.github#910)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2453,6 +2453,27 @@ file of the test tree, and no caller acts on it.
   which is why the cross-validation is against zkp specifically. The
   rangeproof oracle, which issue #1679 also asks for, stays its own issue.
 
+### The declaration says what it is and leaves its assertions to the module
+
+- **`tests/README.md`'s *Convention tests* sentence names no assertion of
+  `conventions_test.py`** (issue btclib-org/.github#910): the list it
+  carried left out `test_the_table_is_not_empty`, which is what fails
+  where a column added to the table or the backticks dropped from its
+  second stops a row parsing, either mutation failing
+  `test_the_two_halves_account_for_every_convention` too. That module
+  reads the heading, the row pattern and the *Not tested here* line and
+  not the sentence, so a list of its assertions there is a second
+  statement of what it checks with no gate holding the two together, and
+  completing the list would leave the next assertion free to go out of
+  step the same way. What replaces it says what the declaration is -- the
+  table and the *Not tested here* line under it, accounting between them
+  for every one of section 7's conventions -- and sends a reader wanting
+  what those assertions catch to that module's docstring, section 9 of
+  the organization standard asking that the second statement point at the
+  first. The halves are named because nothing else in the section says
+  what the line under the table is. btclib-org/.github#910 is filed
+  against the copies in the other trees and stays open.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/README.md
+++ b/tests/README.md
@@ -381,12 +381,13 @@ idea three different ways, and one of them folds several checks into the
 file that is about its single module.
 
 So which of section 7's conventions this repository tests is **declared
-here**, and `conventions_test.py` asserts the declaration is true: every
-convention named below is one of section 7's, every module named exists
-and holds at least one test, and the two halves together account for
-every one of them. One row per module, so a convention answered by more
-than one file is named once per file rather than in a row too wide for
-eighty columns.
+here**, in two halves that together account for every one of them: the
+table below and the "Not tested here" line under it.
+`conventions_test.py` asserts the declaration is true, and what its
+assertions catch is written in that module's docstring, a second list
+here being the statement section 9 refuses. One row per module, so a
+convention answered by more than one file is named once per file rather
+than in a row too wide for eighty columns.
 
 | convention | tested in |
 | --- | --- |


### PR DESCRIPTION
`tests/README.md`'s convention-tests section restated what
`conventions_test.py` asserts, and the restatement had gone stale — the
module has five assertions and the sentence listed three. This replaces
the list with the two things the declaration is made of, and points at
the module's own docstring for what its assertions catch.

The decision taken here binds the other three trees, and the reason is
in the changelog entry rather than left to be re-derived: section 9's
*One fact in one place* says the second of two statements points at the
first, `btclib-benchmarks` already carries this shape with both halves
of a declaration present, and the same drift has been fixed twice this
week in the docstring's own copy of the list — a completed list here
would be the third ungated roster of one set of facts.

The issue stays open: `btclib-secp256k1`, `bitcoin-core-rpc` and
`btclib-node` still owe the port, so the citation is
`(issue btclib-org/.github#910)` and not a closing keyword.

`tests/README.md`'s declaration sentence leaves the assertions to the module (issue btclib-org/.github#910)

The sentence read "asserts the declaration is true: every convention
named below is one of section 7's, every module named exists and holds
at least one test, and the two halves together account for every one of
them", and the module defines test_the_table_is_not_empty besides those,
read from tests/conventions_test.py's ast rather than from a grep. The
same omission in the module docstring was btclib-org/.github#906, landed
here as 385406f1.

Two shapes were available: complete the list, or stop listing. Stopping
is what this takes, and the reason is that the list is ungated. Nothing
reads the sentence -- conventions_test.py reads "## Convention tests",
the row pattern and the "Not tested here" line -- so a list of the
module's assertions in that file is a second statement of what the
module checks with nothing holding the two together, which is how it
came to be short of one. Completing it restores the agreement for as
long as the module's assertions stand and re-arms the same failure for
the next one added. Section 9 of the organization standard is the rule:
"Two files stating the same thing become two files disagreeing about
it; the second points at the first."

So the file keeps what is its own subject and points at the module for
what is the module's. The declaration is this document's: its two
halves, and that between them they account for section 7's conventions.
What those assertions catch is conventions_test.py's docstring's, where
the ways a declaration rots are named.

The halves are named rather than dropped with the list because nothing
else in that section says what the "Not tested here" line under the
table is: at 7522369d "Not tested" occurs once in the file, on the line
itself, and the paragraphs around the table are section 7's escape
clause and the calling convention's three modules. btclib-benchmarks
carries the sentence with no list at all, at 6fb1cdfe, so the shape is
not invented here.

The wording is this tree's rather than the docstring's moved: the
docstring's list of the ways a declaration rots is not copied, and the
tail clause "every one of them" is the one this copy already carried.

Measured on the edited file: the whole suite passes, so the heading, the
rows and the "Not tested here" line still parse; and with "Not tested
here: the copyright header." planted as a line inside the new sentence's
paragraph, test_the_two_halves_account_for_every_convention fails, which
is the control saying the suite reads that region at all. What the old
list left out was measured the same way: with a third column added to
every row of the table, and again with the backticks dropped from its
second, the rows parse to nothing, the parametrized assertions are
skipped on the empty parameter set, and test_the_table_is_not_empty and
test_the_two_halves_account_for_every_convention both fail.
tests/README.md was compared byte for byte against its blob at HEAD
after each restore.

`tests/README.md` is not one of the paths section 14 compares, so no
EXPECTED_DRIFT entry is owed: the section names .markdownlint.jsonc,
.yamllint.yaml, .taplo.toml, COPYRIGHT, LICENSE,
.claude/commands/review.md, CONTRIBUTING.md, REVIEWING.md and
.gitattributes, and tests/verbatim_test.py reads that list out of the
section itself.

btclib-org/.github#910 is filed against the copies in the other trees
and stays open.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WKQAgJcSkNPKgqAHWPWySX


Local review: CLEARED ebd20deb, then CLEARED d5836964, then CLEARED 2503a832 after seven rebases, which is this head. Gates on that tree, all eight at this head: `uv sync`; `uv run ruff check --fix`; `uv run ruff format` (415 files unchanged); `uv run mypy src/btclib tests .github/scripts` (364 files); `uv run pytest` (32225 passed, 35 skipped, 1 xfailed, coverage 100.00%, zero FAILED lines — the two extra skips against the previous round are the base's own new zkp-gated tests, attributed four ways by the reviewer); `uv run pre-commit run --all-files` (41 Passed, 1 Skipped, 0 Failed); `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html` (161 html files); and the docs anchor fence, which passes at exit 1 and was given a planted positive control that fires and restores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKQAgJcSkNPKgqAHWPWySX

## Summary by Sourcery

Remove the stale assertion list from the convention-tests documentation and make the module docstring the authoritative source for those checks.

Enhancements:
- Clarify that the convention-test declaration consists of the table and “Not tested here” line, while directing readers to `conventions_test.py` for the assertions it covers.

Documentation:
- Document the rationale for removing the duplicated assertion list and retain the open issue tracking the corresponding changes in other trees.