### PR TITLE
PSBT finalization drops fields only at serialization, matching Core (closes #1859)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2474,6 +2474,23 @@ file of the test tree, and no caller acts on it.
   what the line under the table is. btclib-org/.github#910 is filed
   against the copies in the other trees and stays open.
 
+### PSBT fields drop only at serialization, matching Bitcoin Core
+
+- **`finalize` no longer mutates an input's non-kept fields to their
+  empty value** (closes #1859): `_FINALIZED_KEEPS` and
+  `_clear_finalized` are removed, and `PsbtIn.serialize`'s own
+  `_DROPPED_ONCE_FINALIZED` guard -- already the mechanism Bitcoin
+  Core's `PSBTInput::Serialize` uses -- is what drops those fields, at
+  the point a finalized input is written rather than at the point it is
+  finalized. A finalized `PsbtIn` still carries its partial signatures,
+  key origins and scripts in memory; only its wire form omits them.
+  This also fixes a drift between the two removed lists and the
+  serializer's own: `_FINALIZED_KEEPS` did not exempt
+  `sp_ecdh_shares`/`sp_dleq_proofs`, so finalizing destroyed them in
+  memory even though `_DROPPED_ONCE_FINALIZED` deliberately keeps them
+  for BIP375's Transaction Extractor. Collapsing to the one list removes
+  that drift by construction.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/psbt/psbt.py
+++ b/src/btclib/psbt/psbt.py
@@ -2898,10 +2898,10 @@ def assert_signed(psbt: Psbt, *, allow_partial: bool = False) -> None:
     partial signature is not one until the session's are added up, which
     is `musig2.partial_sigs_agg` and which writes the taproot signature
     this then checks -- so an input holding a session mid-round is
-    unsigned, and saying so is the point. And a finalized input carries
-    no signature at all, BIP174 having the Finalizer clear them: it is
-    refused with that said rather than reported unsigned, what it now
-    carries being a spend for the script engine to verify.
+    unsigned, and saying so is the point. And a finalized input is
+    refused before its signature is asked about at all, on the presence
+    of its final scripts alone: what it carries by then is a spend for
+    the script engine to verify, not a signature for this function.
     """
     assert_type(allow_partial, bool, "allow_partial")
     if not psbt.inputs:
@@ -3144,73 +3144,6 @@ def _assert_partial_sigs_verify(psbt_in: PsbtIn, tx: Tx, vin_i: int) -> None:
             raise BTClibValueError(err_msg)
 
 
-# what a finalized input keeps, BIP174's rule being that everything else
-# goes: "All other data except the UTXO and unknown fields in the input
-# key-value map should be cleared from the PSBT". Three groups, and the
-# BIP names only the first two --
-#
-# - the utxo and `unknown`, exempted by that sentence: the utxo so that
-#   "Transaction Extractors [can] verify the final network serialized
-#   transaction", and the unknown fields because no reader here knows
-#   what dropping one would cost;
-# - the two finalized scripts, which are what finalizing produced;
-# - BIP370's transaction fields, which are not "data" about how the input
-#   is spent but the input *itself*: clearing `previous_tx_id` and
-#   `output_index` would leave a version 2 psbt naming no outpoint, and
-#   the sequence and the two required lock times are what its unsigned
-#   transaction is computed from.
-#
-# A keep list and not a clear list, so that a field added to PsbtIn is
-# cleared by default: BIP174's sentence is about everything, and a new
-# field that has to survive finalization is the exception worth writing
-# down here.
-_FINALIZED_KEEPS = frozenset(
-    {
-        "non_witness_utxo",
-        "witness_utxo",
-        "unknown",
-        "final_script_sig",
-        "final_script_witness",
-        "previous_tx_id",
-        "output_index",
-        "sequence",
-        "required_time_lock_time",
-        "required_height_lock_time",
-    }
-)
-
-
-def _clear_finalized(psbt_in: PsbtIn) -> None:
-    """Drop everything finalizing the input made redundant.
-
-    One rule for both kinds of input, which is the point of it being one
-    function: a taproot input cleared nothing at all, so a finalized psbt
-    went on publishing that input's key origins -- master fingerprint and
-    derivation path, per key -- where an ECDSA input published none. The
-    asymmetry was not a wrong spend, the witness being built already, but
-    no reader could state what the rule was.
-
-    Each field is set to what a fresh `PsbtIn` has, rather than to a
-    literal per field: the empty value of a field is the constructor's
-    business, and spelling it twice is how the two drift.
-
-    This keep list agrees with what Bitcoin Core actually puts on the
-    wire for a finalized input: `PSBTInput::Serialize` guards
-    `partial_sigs`, `hd_keypaths`, `redeem_script`, `witness_script`, the
-    taproot fields, the sighash type and the preimages behind
-    `if (final_script_sig.empty() && final_script_witness.IsNull())`, so
-    none of them are serialized once an input is finalized.
-    `PSBTInput::FromSignatureData` clears only the first four of those in
-    memory, but that function is not the wire format. BIP174's sentence
-    covers all of them, and what they buy after finalization is nothing:
-    the preimage a hash-locked script needs is in the witness by then.
-    """
-    empty = PsbtIn(check_validity=False)
-    for field in fields(psbt_in):
-        if field.name not in _FINALIZED_KEEPS:
-            setattr(psbt_in, field.name, getattr(empty, field.name))
-
-
 # the spend of one input, by the caller who knows: the final script_sig
 # and the final witness, and None for an input this caller leaves to the
 # generic finalizer
@@ -3247,10 +3180,12 @@ def finalize(psbt: Psbt, *, solver: InputSolver | None = None) -> Psbt:
     them into the input key-value map.
 
     All other data except the UTXO and unknown fields in the input key-
-    value map should be cleared from the PSBT. The UTXO should be kept
-    to allow Transaction Extractors to verify the final network
-    serialized transaction. `_FINALIZED_KEEPS` is that list, and one list
-    for both kinds of input is what keeps the two from drifting apart.
+    value map should be dropped from the wire representation. The UTXO
+    is kept to allow Transaction Extractors to verify the final network
+    serialized transaction. This function does not clear those fields on
+    the input it returns: `PsbtIn.serialize` drops them, guarded on the
+    same finalized state this function produces, which is where Bitcoin
+    Core's own `PSBTInput::Serialize` does it too.
 
     Deciding that an input has enough data is two checks beyond the
     presence of a signature, and both are per input: the sighash type
@@ -3283,9 +3218,9 @@ def finalize(psbt: Psbt, *, solver: InputSolver | None = None) -> Psbt:
     of this function for a reason of layering: `descriptors` imports this
     module and nothing here imports back.
 
-    What the solver does not take over is the bookkeeping: the clearing
-    BIP174 asks for, what is kept, and the verification of whatever
-    signatures the input does carry are this function's either way.
+    What the solver does not take over is the bookkeeping: what is kept
+    and dropped at serialization, and the verification of whatever
+    signatures the input does carry, are this function's either way.
     """
     psbt = deepcopy(psbt)
     psbt.assert_valid()
@@ -3314,7 +3249,6 @@ def finalize(psbt: Psbt, *, solver: InputSolver | None = None) -> Psbt:
             _assert_partial_sigs_verify(psbt_in, tx, vin_i)
             script_sig, witness = _finalized_input(psbt_in)
 
-        _clear_finalized(psbt_in)
         psbt_in.final_script_sig = script_sig
         psbt_in.final_script_witness = witness
     return psbt

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -49,7 +49,7 @@ from btclib.psbt.psbt import (
 from btclib.psbt.psbt_in import _V2_FIELDS as _V2_INPUT_FIELDS
 from btclib.psbt.psbt_in import LOCK_TIME_THRESHOLD
 from btclib.psbt.psbt_out import _V2_FIELDS as _V2_OUTPUT_FIELDS
-from btclib.psbt.psbt_utils import PSBT_SEPARATOR
+from btclib.psbt.psbt_utils import PSBT_SEPARATOR, PSBT_V2
 from btclib.script import (
     ScriptPubKey,
     TaprootScriptTree,
@@ -1163,7 +1163,11 @@ def test_finalize() -> None:
 
     to_be_finalized_psbt = Psbt.b64decode(TO_BE_FINALIZED)
     finalized_psbt = finalize(to_be_finalized_psbt)
-    assert finalized_psbt == psbt
+    # finalizing does not clear the fields BIP174 drops: `serialize`
+    # drops them, at the point Bitcoin Core's own `PSBTInput::Serialize`
+    # does, so the wire form and not the object's own fields is what
+    # reproduces the example
+    assert finalized_psbt.b64encode() == psbt_str
 
 
 def test_extract_tx() -> None:
@@ -3883,13 +3887,26 @@ def test_a_finalized_input_keeps_the_utxo_and_the_unknown_fields_only(
 
     signed, signed_vins = sign(_fully_populated(psbt), key_manager)
     assert signed_vins == [0]
-    psbt_in = finalize(signed).inputs[0]
+    finalized_psbt = finalize(signed)
+    psbt_in = finalized_psbt.inputs[0]
 
-    # spelled out rather than imported from psbt.py: `_FINALIZED_KEEPS`
-    # is what the code believes, and a test that imported it would agree
-    # with a wrong list as readily as with a right one. Every other field
-    # of PsbtIn is walked, so a field added there and left out of both
-    # lists fails here
+    # finalizing no longer clears these in memory -- `PsbtIn.serialize`
+    # drops them, at the point Bitcoin Core's own `PSBTInput::Serialize`
+    # does -- so the object finalize() returns still legitimately carries
+    # what an eager clear used to destroy, and this is what proves the
+    # mechanism moved rather than merely that the test below was loosened
+    assert psbt_in.hd_key_paths == {_PUB_KEY: BIP32KeyOrigin(b"\x00" * 4, "m/0")}
+    assert psbt_in.ripemd160_preimages == {ripemd160(b"one"): b"one"}
+
+    # what actually reaches the wire is what BIP174's rule, and Core's
+    # own guarantee, are about
+    round_tripped = Psbt.b64decode(finalized_psbt.b64encode()).inputs[0]
+
+    # spelled out rather than imported from psbt_in.py:
+    # `_DROPPED_ONCE_FINALIZED` is what the code believes, and a test
+    # that imported it would agree with a wrong list as readily as with
+    # a right one. Every other field of PsbtIn is walked, so a field
+    # added there and left out of both lists fails here
     kept = {
         "non_witness_utxo",
         "witness_utxo",
@@ -3901,19 +3918,52 @@ def test_a_finalized_input_keeps_the_utxo_and_the_unknown_fields_only(
         "required_height_lock_time",
         "final_script_sig",
         "final_script_witness",
+        "sp_ecdh_shares",
+        "sp_dleq_proofs",
     }
     empty = PsbtIn(check_validity=False)
-    for field in dataclasses.fields(psbt_in):
+    for field in dataclasses.fields(round_tripped):
         if field.name not in kept:
-            assert getattr(psbt_in, field.name) == getattr(empty, field.name), (
+            assert getattr(round_tripped, field.name) == getattr(empty, field.name), (
                 f"{field.name} survived finalization"
             )
 
     # the two BIP174 exempts by name, and the spend it built
-    assert psbt_in.unknown == {b"\xfc\x01": b"vendor"}
-    assert psbt_in.witness_utxo or psbt_in.non_witness_utxo
-    assert psbt_in.final_script_sig or psbt_in.final_script_witness
+    assert round_tripped.unknown == {b"\xfc\x01": b"vendor"}
+    assert round_tripped.witness_utxo or round_tripped.non_witness_utxo
+    assert round_tripped.final_script_sig or round_tripped.final_script_witness
     verify_transaction(prevouts, extract_tx(finalize(signed), check_validity=False))
+
+
+def test_finalizing_keeps_the_silent_payment_input_fields() -> None:
+    """The incidental bug this same change fixes.
+
+    The removed eager clearer did not exempt `sp_ecdh_shares` and
+    `sp_dleq_proofs` the way the serializer's own `_DROPPED_ONCE_FINALIZED`
+    deliberately does -- BIP375 gives the Transaction Extractor the job
+    of recomputing every silent payment output script, which it cannot do
+    once finalizing has thrown the shares and their proofs away. So a
+    finalized input had already lost data the serializer's own design
+    says should survive it. With nothing clearing fields at finalization
+    any more, both fields survive in memory, and the wire behavior --
+    `_DROPPED_ONCE_FINALIZED` not naming either -- is unchanged by this
+    fix.
+    """
+    signed, _ = _single_key_psbt("p2wsh")
+    signed.version = PSBT_V2  # BIP375's fields are refused in a v0 psbt
+    share = b"\x02" + b"\x11" * 32
+    proof = b"\x22" * 64
+    signed.inputs[0].sp_ecdh_shares = {_PUB_KEY: share}
+    signed.inputs[0].sp_dleq_proofs = {_PUB_KEY: proof}
+
+    finalized_psbt = finalize(signed)
+    psbt_in = finalized_psbt.inputs[0]
+    assert psbt_in.sp_ecdh_shares == {_PUB_KEY: share}
+    assert psbt_in.sp_dleq_proofs == {_PUB_KEY: proof}
+
+    round_tripped = Psbt.b64decode(finalized_psbt.b64encode()).inputs[0]
+    assert round_tripped.sp_ecdh_shares == {_PUB_KEY: share}
+    assert round_tripped.sp_dleq_proofs == {_PUB_KEY: proof}
 
 
 @pytest.mark.parametrize("kind", ["p2wsh", "p2tr"])
@@ -4662,11 +4712,16 @@ def test_a_solver_spends_a_script_this_finalizer_would_guess_at() -> None:
     solved = finalize(signed, solver=solver)
     assert solved.inputs[0].final_script_witness == stack
     assert solved.inputs[0].final_script_sig == b""
-    # the bookkeeping is the finalizer's either way: what BIP174 says to
-    # clear is cleared, and the utxo it says to keep is kept
-    assert not solved.inputs[0].partial_sigs
-    assert not solved.inputs[0].witness_script
-    assert solved.inputs[0].witness_utxo or solved.inputs[0].non_witness_utxo
+    # the bookkeeping is the finalizer's either way, and it happens at
+    # serialization rather than here: finalizing no longer clears the
+    # input in memory, so what BIP174 says to drop is still there on
+    # `solved` and only gone once the wire form is read back
+    assert solved.inputs[0].partial_sigs
+    assert solved.inputs[0].witness_script
+    round_tripped = Psbt.b64decode(solved.b64encode()).inputs[0]
+    assert not round_tripped.partial_sigs
+    assert not round_tripped.witness_script
+    assert round_tripped.witness_utxo or round_tripped.non_witness_utxo
     assert prevouts_
 
 
@@ -4715,7 +4770,12 @@ def test_a_solver_spends_the_taproot_leaf_the_psbt_cannot_choose() -> None:
     # an empty script_sig, which is what BIP341 spends a witness v1
     # program with, and the caller's to get right
     assert solved.inputs[0].final_script_sig == b""
-    assert not solved.inputs[0].taproot_script_spend_signatures
+    # finalizing does not clear the input in memory any more, so the
+    # unchosen signature is still on `solved` and only gone once the
+    # wire form -- what `PsbtIn.serialize` actually drops -- is read back
+    assert solved.inputs[0].taproot_script_spend_signatures
+    round_tripped = Psbt.b64decode(solved.b64encode()).inputs[0]
+    assert not round_tripped.taproot_script_spend_signatures
 
 
 def test_a_solver_does_not_take_over_checking_the_signatures() -> None:


### PR DESCRIPTION
Closes #1859.

`finalize` no longer mutates an input's non-kept fields to their empty
value: `_FINALIZED_KEEPS` and `_clear_finalized` are removed, and
`PsbtIn.serialize`'s own `_DROPPED_ONCE_FINALIZED` guard -- already the
mechanism Bitcoin Core's `PSBTInput::Serialize` uses -- is what drops
those fields, at the point a finalized input is written rather than at
the point it is finalized. The two mechanisms had drifted apart:
`sp_ecdh_shares`/`sp_dleq_proofs` were destroyed eagerly at finalization
even though the serializer deliberately keeps them for BIP375's
Transaction Extractor. Removing the eager mechanism fixes that drift by
construction rather than by chasing the list back into sync.

Two tests that asserted on the finalized object's own field state are
rewritten to assert on the serialized/round-tripped wire form instead,
each also proving the in-memory object still carries what the eager
clear used to destroy. A new test
(`test_finalizing_keeps_the_silent_payment_input_fields`) covers the
sp_ecdh_shares/sp_dleq_proofs fix directly.

Reviewed locally (CLEARED at `a062e7eb`); rebased onto current `main`
afterward, non-CHANGELOG diff verified byte-identical across the
rebase, CHANGELOG.md's union-driver seam damage repaired and verified
via the pinned markdownlint-cli2 tool. Gates green at the final sha:
`pre-commit run --all-files` (all hooks passed), `pytest` (32226
passed, 35 skipped, 1 xfailed, 100.00% coverage).

## Summary by Sourcery

Align PSBT finalization with Bitcoin Core by retaining input fields in memory and dropping them only when finalized inputs are serialized.

Bug Fixes:
- Preserve silent-payment input shares and proofs during PSBT finalization so they remain available to transaction extraction.

Enhancements:
- Defer removal of finalized input fields until serialization, aligning in-memory behavior and wire output with Bitcoin Core.

Tests:
- Update finalization tests to validate serialized and round-tripped PSBT contents while confirming finalized objects retain fields in memory.
- Add coverage for preserving silent-payment fields through finalization and serialization.