### PR TITLE
`CONTRIBUTING.md`'s *What runs when* table is held to naming every workflow (closes #1849)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2514,6 +2514,31 @@ file of the test tree, and no caller acts on it.
   source it runs against**, since `testpaths` is relative and `--project`
   does not bind the process's working directory.
 
+### `CONTRIBUTING.md`'s *What runs when* table names every workflow
+
+- **`zkp-oracle` takes a row, and `tests/what_runs_when_test.py`
+  compares the table's first column with `.github/workflows/` in both
+  directions** (closes #1849): the paragraph under the table leaves
+  which day each workflow runs to section 10 of the organization
+  standard, which reads the table as covering the rest, so a table
+  exhaustive but for one workflow is read as exhaustive and the row that
+  is missing says "there is no such workflow" rather than "nobody wrote
+  the row". The `when` cell says weekly: a paths-filtered `pull_request`
+  is not what a `when` cell reports, the `links` and `vendored-vectors`
+  rows carrying one each and saying weekly, and `py-arm-authority`'s row
+  naming its unconditional push rather than its own filtered trigger.
+  What `zkp-oracle` varies is a bindings build carrying `secp256k1-zkp`.
+  A table the module cannot locate is refused by the `assert` inside its
+  own extraction, which fires through every test that calls it, and each
+  comparison being a set difference leaves an empty side loud in the
+  other's message, so what `test_both_sides_were_read` holds is the one
+  case they cannot see between them: both sides empty at once. The cells
+  are not read, which the paragraph now under the table says in as many
+  words, beside what the test does hold. An unpacked sdist carries no
+  `.github/`, so a test reading it off the tree cannot run from one, and
+  `[tool.uv.build-backend] source-exclude` names the module as
+  `tests/build_system_test.py` asks.
+
 ## v2026.9.3
 
 ### Repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -502,6 +502,7 @@ read by every checkout of this repository.
 | `os-windows` | weekly, a release | Windows images and interpreters |
 | `deps-latest` | weekly | platforms sampled, deps upgraded |
 | `integration-hwi` | weekly, push to main | two device emulators |
+| `zkp-oracle` | weekly | a bindings build carrying `secp256k1-zkp` |
 | `links`, `mutation` | weekly | — |
 | `vendored-vectors` | weekly | the pin ledgers |
 | `pypi-install` | weekly, a release | what PyPI serves |
@@ -525,6 +526,13 @@ Which day each of the rest runs is section 10 of the organization
 standard, in `btclib-org/.github`, and not this file's to restate — one
 calendar in one place is one thing to keep true, where a copy of it in
 every repository would be one more.
+
+Every workflow the tree holds has a row above, and
+`tests/what_runs_when_test.py` is what holds it to that: it compares the
+first column with `.github/workflows/` both ways, so a workflow added
+without a row fails the suite, and so does a row left behind by one
+renamed or removed. What the cells say is nobody's to check but the
+reader's.
 
 Why so little gates is one number: the ceiling GitHub Free puts on an
 organization's concurrent jobs, shared across every repository in it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,6 +310,7 @@ source-exclude = [
     "/tests/wait_for_hwi_device_test.py",
     "/tests/wait_for_pypi_release_test.py",
     "/tests/wait_for_readthedocs_build_test.py",
+    "/tests/what_runs_when_test.py",
     # the same reasoning, for fuzz/ rather than .github/scripts: git-only
     # below is why it is not in the sdist, and this test reads
     # fuzz/fuzz_*.py and fuzz/corpus/ off the tree, both absent from an

--- a/tests/what_runs_when_test.py
+++ b/tests/what_runs_when_test.py
@@ -1,0 +1,128 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""`CONTRIBUTING.md`'s *What runs when* table names every workflow.
+
+The paragraph under that table leaves *which day* each workflow runs to
+section 10 of the organization standard, "not this file's to restate",
+which reads the table as covering the rest: every workflow this tree
+holds, with the calendar deliberately out of the `when` cell. A table
+exhaustive but for one workflow is read as exhaustive, so a missing row
+says "there is no such workflow" rather than "nobody wrote the row", and
+the reader it misleads is the one who went to the table to find out
+(issue #1849).
+
+Nothing else compares the two. For the interpreters their matrices name,
+`interpreters_test.py` reads the workflows; for a command spelled in
+several places, `docs_commands_test.py` reads one of them. Neither asks
+which workflows exist.
+
+Both directions are checked, because a renamed workflow is both failures
+at once -- a row naming a file that is gone, and a file no row names --
+and either half alone reports it as the other thing. The converse also
+catches what no reading of `.github/workflows/` would: a row for a
+workflow that was proposed and never written.
+
+Neither comparison goes quietly vacuous on its own, both being set
+differences: a side that comes back empty leaves the other one naming
+every element of the side that did not. An extraction that finds nothing
+fails the forward comparison with every workflow in its message, and a
+glob that finds nothing fails the converse with every row in its own.
+What that leaves is both sides empty at once, which is the whole of what
+`test_both_sides_were_read` refuses. A table this module cannot locate
+is refused a layer earlier, by the `assert` inside `_named_workflows`,
+which fires through every test that calls it.
+
+The cells are not read. A `when` naming triggers the workflow's own `on:`
+block does not carry, or a `what it varies` describing a matrix it no
+longer has, is as invisible here as a missing row is without this
+module. Neither is this a count: `lint`/`docs` and `links`/`mutation`
+each share a row, so rows and workflows do not correspond one to one,
+and what is compared is the set of names.
+
+Only the first cell of a row is read. The last cell of the `release` row
+names `release.yml`, so a pattern taking every backticked word in a row
+would read that file as named by whichever row mentioned it.
+
+`REPOSITORY.md` is not read the same way, and could not be: it names the
+workflows a setting or a measurement is about and is silent on the rest,
+which is what makes the reading above this table's own.
+"""
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).parents[1]
+_CONTRIBUTING = (_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+
+# both extensions GitHub reads, rather than the `.yml` every file here
+# happens to use: a workflow added as `.yaml` runs, and a comparison
+# that could not see it would leave open the same thing a missing row
+# leaves open
+_WORKFLOWS = frozenset(
+    path.stem for path in (_ROOT / ".github/workflows").glob("*.y*ml")
+)
+
+# scoped to the one table, its heading and its header row included: a
+# renamed heading, a reordered column or a reindented table leaves this
+# unmatched, which the `assert` in `_named_workflows` below refuses
+# rather than reading as a table that names nothing
+_TABLE = re.compile(
+    r"^### What runs when\n\n"
+    r"^\| workflow \| when \| what it varies \|\n"
+    r"^\| --- \| --- \| --- \|\n"
+    r"(?P<rows>(?:^\|.*\|\n)+)",
+    re.MULTILINE,
+)
+
+
+def _named_workflows() -> frozenset[str]:
+    """Return the workflow stems the table's first column names."""
+    table = _TABLE.search(_CONTRIBUTING)
+    assert table, (
+        "CONTRIBUTING.md's *What runs when* heading, or the table under it,"
+        " was not found where this test expects it"
+    )
+    return frozenset(
+        stem
+        for row in table["rows"].splitlines()
+        for stem in re.findall(r"`([^`]+)`", row.split("|")[1])
+    )
+
+
+def test_both_sides_were_read() -> None:
+    """Neither side of the comparison is empty, so neither is vacuous.
+
+    The two below are set differences, so a single empty side is loud
+    already: the other comparison names every element of the side that
+    came back full. Both empty at once is the case neither of them can
+    see -- a table matching the pattern while naming nothing, and a glob
+    finding no workflow -- and this is what refuses it, naming the side
+    that was empty rather than leaving a difference of nothing to read
+    as agreement.
+    """
+    assert _named_workflows(), "CONTRIBUTING.md's *What runs when* table names none"
+    assert _WORKFLOWS, "no workflow was read from .github/workflows/"
+
+
+def test_every_workflow_has_a_row() -> None:
+    """A workflow the table does not name reads as one that does not exist."""
+    missing = sorted(_WORKFLOWS - _named_workflows())
+    assert not missing, (
+        "CONTRIBUTING.md's *What runs when* table names no row for"
+        f" .github/workflows/: {missing}"
+    )
+
+
+def test_no_row_names_an_absent_workflow() -> None:
+    """A row for a file the tree does not hold answers for a run nobody makes.
+
+    It is what a rename or a removal leaves behind, and the row goes on
+    telling a reader when that workflow runs.
+    """
+    stale = sorted(_named_workflows() - _WORKFLOWS)
+    assert not stale, (
+        "CONTRIBUTING.md's *What runs when* table names workflows"
+        f" .github/workflows/ does not hold: {stale}"
+    )


### PR DESCRIPTION
Closes #1849.

## The decision the issue reserved

ISS 1849 says in as many words that "whether the row is owed is a
decision this issue does not take". This branch takes it, and the honest
account of the ground is narrower than "the issue measured it":

- the paragraph under the table leaves which day each workflow runs to
  section 10 of the organization standard, and so reads the table as
  covering "the rest" — but that is a *reading* of a sentence about the
  `when` cells, and "the rest" is literally the rest of the rows. It
  does not by itself oblige the table to be exhaustive;
- `integration-hwi`, the comparable sentinel, has a row — which is a
  consistency argument from what the tree does, and
  `commands/issues.md`'s *A distribution is not a rule* says that cannot
  create the obligation on its own.

So the branch does not claim the rule pre-existed. It **writes the rule
down** — `CONTRIBUTING.md`, "Every workflow the tree holds has a row
above" — and puts a test behind it. That is the shape a reserved
decision should take: propose the rule, in the file that carries it,
rather than assume it was always there.

**The cut-back, if the rule is unwanted.** The commit is purely
additive across four files, so reverting it restores `main` exactly. A
narrower answer — keep `zkp-oracle`'s row, drop the rule — is the
`CONTRIBUTING.md` paragraph, the test module and the `pyproject.toml`
line; the row itself survives untouched.

## What refuses a vacuous pass

The first version of this branch claimed the wrong thing about its own
guard, and local review refuted it by running it. Recording the
corrected account here because it is the part worth reading:

| tampered tree | `both_sides_were_read` | forward | converse |
| --- | --- | --- | --- |
| `.github/workflows/` renamed away | **fails**, naming the empty side | passes | **fails**, all 20 rows |
| first-column names stripped | **fails** | **fails**, all 20 workflows | passes |
| both at once | **fails** | passes | passes |
| heading renamed or table reindented | fails | fails | fails |

Each comparison is a set difference, so a single empty side is loud in
the *other* comparison's message rather than silent in its own. What is
left is both sides empty at once, which neither comparison can see, and
that is the whole of what `test_both_sides_were_read` exists for. A
table the pattern cannot locate is refused a layer earlier, by the
`assert` inside `_named_workflows`, which fires through every test that
calls it.

The cells are not read. A `when` naming a trigger the workflow's `on:`
block does not carry is as invisible here as a missing row was without
the module.

## Gates, on the rebased tip

Run on `0f473350` after the rebase onto `190dcb7f`, the working tree and
`HEAD` identical, `git status --porcelain` empty before the first and
after the last:

| gate | exit |
| --- | --- |
| `uv run --locked --only-group lint pre-commit run --all-files --show-diff-on-failure` | 0 — 41 hooks Passed, tree unchanged afterwards |
| `uv run --locked pytest` | 0 — 32229 passed, 35 skipped, 1 xfailed, 100.00% coverage |
| `uv run --locked --no-default-groups --group docs sphinx-build -n -W` | 0 |

The `merge=union` seam was paid on that rebase: the driver glues a new
`###` to the entry above it without showing a deletion in `git diff`,
`range-diff` or `--numstat`. Repaired and verified by reconstruction,
then checked as an invariant — every `###` in the file has its blank
line — with a planted control proving the check can see the defect.

Two rounds of local review at fresh context. The first was CHANGES
REQUESTED on the false account above; the second cleared this content
across eight tampered trees, by the failure messages and not only by
pass/fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNydCktysAkoGbGcdfKRit

## Summary by Sourcery

Keep the `CONTRIBUTING.md` workflow schedule table exhaustive and synchronized with the workflows stored in the repository.

New Features:
- Add the `zkp-oracle` workflow to the `CONTRIBUTING.md` workflow schedule table.
- Enforce that the workflow schedule table stays synchronized with the repository's GitHub Actions workflows in both directions.

Enhancements:
- Document that every workflow must have a corresponding table row while leaving trigger and schedule interpretation to readers.
- Add safeguards against vacuous or malformed table/workflow comparisons.

Build:
- Exclude the tree-dependent workflow consistency test from source distributions.

Documentation:
- Update the changelog with the workflow-table coverage and validation behavior.

Tests:
- Add tests validating table discovery, non-empty workflow and table data, missing workflow rows, and stale workflow rows.