### PR TITLE
`silent_payments.py` qualifies its bips-PR citation (closes #1867)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2539,6 +2539,15 @@ file of the test tree, and no caller acts on it.
   `[tool.uv.build-backend] source-exclude` names the module as
   `tests/build_system_test.py` asks.
 
+### `silent_payments.py`'s citation of another repository's pull request is qualified
+
+- **`_ordered_sp_outputs`'s docstring cites `bitcoin/bips#2207`, not
+  `bips PR 2207`** (closes #1867): the bare form carries neither a
+  qualifier nor a `#`, so the forge renders it as plain text reaching
+  nothing, and a scan keyed on `#N` cannot see it either. `bitcoin/bips`
+  is the spelling `tests/_data/README.md` already uses for that
+  repository.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/psbt/silent_payments.py
+++ b/src/btclib/psbt/silent_payments.py
@@ -281,7 +281,7 @@ def _ordered_sp_outputs(psbt: Psbt) -> list[tuple[int, PsbtOut]]:
     produces, the two values swapped in one and three permuted in the
     other. `tests/psbt/silent_payments_test.py` pins each of those facts,
     so a revision of the BIP that settles it the other way fails here
-    rather than passing quietly -- which is what bips PR 2207 proposes,
+    rather than passing quietly -- which is what bitcoin/bips#2207 proposes,
     correcting the vectors and the validator to match the prose.
     """
     return [(i, o) for i, o in enumerate(psbt.outputs) if o.sp_v0_info]


### PR DESCRIPTION
`src/btclib/psbt/silent_payments.py:284` cited another repository's pull
request as `bips PR 2207`, with neither a qualifier nor a `#`. Section 9
of the organization standard requires a cross-repository reference to be
`owner/repo#123`, and the forge renders bare prose like this as plain
text, reaching nothing. This qualifies it as `bitcoin/bips#2207`, the
spelling `tests/_data/README.md:185` already uses for that repository.

Scope is held to exactly this one site, per the issue's own instruction:
a wider census in the issue body finds ~206 other unqualified
issue/PR-number citations in the tree, all of them this repository's own
self-references (which the standard does not require a `#` on).
Normalizing those is a decision reserved for the standard, not a cleanup
riding on this issue.

Closes #1867

## Summary by Sourcery

Correct the silent-payments documentation reference to the BIPs pull request and record the fix in the changelog.

Bug Fixes:
- Qualify the silent-payments docstring's cross-repository pull-request citation as `bitcoin/bips#2207` so it links correctly.

Documentation:
- Document the corrected cross-repository citation in the changelog.