### PR TITLE
`tests/interpreters_test.py` reads a `.yaml` workflow as readily as `.yml` (closes #1874)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2548,6 +2548,23 @@ file of the test tree, and no caller acts on it.
   is the spelling `tests/_data/README.md` already uses for that
   repository.
 
+### `interpreters_test.py` reads a `.yaml` workflow as readily as a `.yml` one
+
+- **`tests/interpreters_test.py`'s workflow discovery globs `*.yml` and
+  `*.yaml` alike** (closes #1874): GitHub itself reads both extensions
+  for a workflow file, so a glob matching only one silently drops any
+  workflow written with the other, and the interpreter list such a file
+  declares is then compared against nothing. `os-macos.yml`'s own bytes,
+  copied to a `.yaml` name with `*.yml` alone in place, reproduced this:
+  the copy went unread and the module's own claim that the platform
+  sweeps agree held regardless of what the unread file said. The two
+  other places the issue named as the same question -- `pyproject.toml`'s
+  `[tool.uv.build-backend] source-exclude`, which excludes by test-file
+  name rather than by workflow extension, and the `actionlint` and
+  `zizmor` pre-commit hooks, whose upstream `files:` patterns already
+  match `.yml` and `.yaml` alike -- were checked and found not to share
+  the defect.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/interpreters_test.py
+++ b/tests/interpreters_test.py
@@ -31,7 +31,19 @@ from pathlib import Path
 
 _ROOT = Path(__file__).parents[1]
 _PYPROJECT = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-_WORKFLOWS = sorted((_ROOT / ".github/workflows").glob("*.yml"))
+
+
+def _workflow_files(directory: Path) -> tuple[Path, ...]:
+    """Return every workflow in `directory`, `.yml` and `.yaml` alike.
+
+    GitHub itself reads both extensions for a workflow file, so a glob
+    matching only one silently drops any workflow written with the
+    other (issue #1874).
+    """
+    return tuple(sorted((*directory.glob("*.yml"), *directory.glob("*.yaml"))))
+
+
+_WORKFLOWS = _workflow_files(_ROOT / ".github/workflows")
 
 # "3.10" out of `requires-python = ">=3.10"`, the floor and nothing else:
 # an upper bound is not declared here and would be a different claim
@@ -190,6 +202,21 @@ def test_free_threading_is_classified_exactly_when_the_gate_runs_it() -> None:
         f"the free-threading classifier is {'present' if classified else 'absent'}"
         f" and test.yml names {', '.join(run) or 'no free-threaded interpreter'}"
     )
+
+
+def test_workflow_files_reads_dot_yaml_too(tmp_path: Path) -> None:
+    """`.yml` and `.yaml` are read alike (issue #1874).
+
+    `os-macos.yml`'s own bytes, copied to a `.yaml` name: before the fix
+    the glob matched only the first, and the second's interpreter list
+    went uncompared -- the reproduction the issue carries, with the
+    extension the whole of the difference.
+    """
+    text = (_ROOT / ".github/workflows/os-macos.yml").read_text(encoding="utf-8")
+    (tmp_path / "os-extra.yml").write_text(text, encoding="utf-8")
+    (tmp_path / "os-extra.yaml").write_text(text, encoding="utf-8")
+    found = sorted(p.name for p in _workflow_files(tmp_path))
+    assert found == ["os-extra.yaml", "os-extra.yml"]
 
 
 def test_every_sweep_runs_the_same_interpreters() -> None:


### PR DESCRIPTION
Closes #1874

`tests/interpreters_test.py`'s workflow discovery globbed only `*.yml`,
so a workflow file named `*.yaml` — a spelling GitHub reads identically —
was invisible to it: an interpreter such a file declared was compared
against nothing.

Fixes the glob to match both extensions and adds a regression test
reproducing the issue's own shape (a copy of `os-macos.yml`'s bytes under
both extensions; the test fails against the pre-fix single-glob body and
passes against the fix).

The issue also named two other candidate sites for the same "select by
name/extension" question — `pyproject.toml`'s
`[tool.uv.build-backend] source-exclude` and the `actionlint`/`zizmor`
pre-commit hook filters. Both were measured against the pinned upstream
hook revisions and found not to share the defect; recorded in the
CHANGELOG entry rather than filed as separate issues, since nothing was
found to file.

Local review: CLEARED at the pre-rebase tip `dd63cef7`, content unchanged
by the subsequent rebase onto `origin/main` (verified byte-for-byte via
added/removed lines excluding CHANGELOG.md). The rebase did trigger the
`merge=union` seam defect on CHANGELOG.md — the blank line above this
entry's own `###` heading was eaten joining it with the freshly-landed
ISS 1867 entry — repaired with the pinned `markdownlint-cli2` binary
directly (`pre-commit run`'s own `Passed` was a false pass here; the
direct invocation's `Attempted: 2 fixes in 1 file` is what confirms it).

## Summary by Sourcery

Match GitHub’s workflow file discovery by checking both `.yml` and `.yaml` files in interpreter validation.

Bug Fixes:
- Ensure workflow interpreter checks include workflow files using either the `.yml` or `.yaml` extension.

Tests:
- Add a regression test confirming that both workflow extensions are discovered.