### PR TITLE
A held `rev:` carries its version in a marker on that line (closes #1843) (closes #1873) (closes #1875)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,16 +27,27 @@ ci:
   skip: [mypy]
 
 repos:
-  # this file checking itself, and the only two hooks here with no
-  # environment to install. A `files` or `exclude` pattern that stops
-  # matching anything is a hook that has quietly stopped running, which is
-  # the shape of issue #145 one level up: the rule is still written down
-  # and no longer enforced
+  # this file checking itself, on hooks pre-commit ships rather than a
+  # repository's: no `rev`, pre-commit requiring its absence wherever the
+  # repo is `meta` or `local`, and no `additional_dependencies`, because
+  # `language: unsupported` -- what a meta hook is validated as -- installs
+  # no environment to put one in. Neither property is this block's alone.
+  # pygrep installs nothing either, which is what `pinned-rev` and
+  # `held-rev` below are written in; `language: system` is `unsupported`
+  # after translation, and the mypy hook that declares it runs in the
+  # project environment uv provisions for it; and a local hook that does
+  # need an environment says so, `typos` below being `language: python`
+  # with its version in `additional_dependencies`.
+  #
+  # A `files` or `exclude` pattern that stops matching anything is a hook
+  # that has quietly stopped running, which is the shape of issue
+  # btclib-org/.github#145: the rule is still written down and no longer
+  # enforced
   - repo: meta
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
-  # this file checking itself further, on the two moves `autoupdate` makes
+  # this file checking itself further, on the moves `autoupdate` makes
   # that it must not take. A rev naming only a major version follows every
   # future release of that major, which is the one thing a rev is here to
   # prevent -- and a prerelease is not a release.
@@ -54,14 +65,99 @@ repos:
   # a gate.
   #
   # A commit SHA stays acceptable, should a hook ever want one: the pattern
-  # requires the prerelease marker and its digits to end the value, which
-  # forty hex characters do not
+  # refuses a value that is all digits, or one ending in a prerelease marker
+  # and its digits, and forty hex characters are neither -- unless every one
+  # of them is a digit, which is a SHA nobody has.
+  #
+  # What may follow the value is a comment, which `held-rev` below makes
+  # the prescribed form for a rev held at a version. Stopping at the quote
+  # instead would let a bare major or a prerelease through on any line
+  # carrying a trailer -- the rule still written down and no longer
+  # enforced, which is the shape above
   - repo: local
     hooks:
       - id: pinned-rev
         name: every pre-commit rev names a released version
         language: pygrep
-        entry: '^ *rev: "?v?([0-9]+|[0-9][0-9.]*(a|b|rc|dev)[0-9]+)"?$'
+        entry: '^ *rev: "?v?([0-9]+|[0-9][0-9.]*(a|b|rc|dev)[0-9]+)"? *(?:#.*)?$'
+        files: ^\.pre-commit-config\.yaml$
+      # the move a shape cannot describe: a rev held below the latest
+      # release for a stated reason. `autoupdate` proposes that release on
+      # every run, so a hold needs a value to compare the rev against, and
+      # the `rev:` line is the only place pygrep can read one -- it matches
+      # a line at a time, which puts a comment above the value out of
+      # reach.
+      #
+      # Nothing lets the updater be told instead. `autoupdate` has no flag for
+      # a repository to leave alone -- --repo is an allow list for the one
+      # run, and --bleeding-edge and --freeze change what it writes, --freeze
+      # the trailing comment included -- a repository entry takes `repo`,
+      # `rev` and `hooks`, with pre-commit warning on any other key, and
+      # pre-commit.ci's `ci:` block has no autoupdate exclusion either, its
+      # `skip:` being hook ids at run time. So the guard comes after the bump,
+      # and it can: an ordinary run rewrites the value and re-emits the marker
+      # verbatim. The bump the marker is there to catch therefore leaves the
+      # value and the marker disagreeing inside one line, which is the whole
+      # of what pygrep sees. `# frozen:` is the one trailer an ordinary run
+      # does not keep, pre-commit writing that one itself and dropping it
+      # wherever the run is not `--freeze`.
+      #
+      # `--freeze` is the exception, and it erases a marker rather than
+      # preserving it: that run writes `# frozen: <tag>` in place of
+      # whatever trailed the value, the frozen branch of
+      # `_write_new_config` being taken ahead of the one that keeps a
+      # comment, so the hold goes and this hook has nothing left to find
+      # disagreeing. Measured, not read: a `--freeze` run over a held
+      # entry leaves the line a sha with a `# frozen:` trailer and this
+      # hook silent. No run here passes it.
+      #
+      # `"? +#` right after the capture is what makes the marker name the
+      # whole value. With no fixed anchor there the group gives characters
+      # back until it matches a shorter string, that shorter string then
+      # differs from the marker legitimately, and the hook fails a correct
+      # line as readily as a bumped one. The space is ` +` rather than a
+      # fixed width because prettier below settles what precedes a trailing
+      # comment.
+      #
+      # The marker names the issue that says when the hold lifts, and that
+      # is the half a paragraph does not deliver: what the reader of the
+      # bot's two-line diff has in front of them is the `rev:` line.
+      #
+      # Its form is the rev's own value and then, anywhere after it on that
+      # line, the word issue with a reference -- `#<digits>`, or
+      # `owner/repo#<digits>` where the issue is another repository's,
+      # which is the form section 9 of the organization standard requires
+      # of a cross-repository reference, a bare number resolving in the
+      # repository it is written in. What precedes the `#` is admitted as
+      # any run of characters that are neither whitespace nor a `#`, this
+      # hook being no judge of whether a qualification names a real
+      # repository; what it insists on is the keyword and a number, so
+      # `see #1563` is refused and `issues #1563 and #1600` with it. A
+      # marker on a line of its own is refused by the first branch, since
+      # there it would enforce nothing -- the shape `check-hooks-apply` above
+      # answers for a hook that matches no file. One further along the line,
+      # behind another comment, is silent rather than refused: what stops the
+      # capture backtracking to a shorter string is that ` +#` follows it, so
+      # the position is the anchor and relaxing it gives up the comparison.
+      #
+      # A hold written with no marker is what this does not reach: a `rev:`
+      # line carrying none matches nothing here, so the guard is opt-in and
+      # the hold after this one is invisible to it until somebody writes
+      # the marker. Nothing local closes that, the value to compare against
+      # being the marker itself, so what catches it is the review of the
+      # diff that adds the hold -- which is where the reason for the hold
+      # is being written anyway.
+      #
+      # What the census left outside the pattern: pyroma's hold below
+      # refuses a prerelease, and that is a shape `pinned-rev` already
+      # reads; actionlint's is a floor rather than a ceiling, and
+      # `autoupdate` only ever proposes the newest release; a version in
+      # `additional_dependencies` is not a `rev`, and `autoupdate` rewrites
+      # `rev` and nothing else
+      - id: held-rev
+        name: a held rev names the version it is held at, and its issue
+        language: pygrep
+        entry: '^(?: *# hold:| *rev: "?([^\s"]+)"? +# hold:(?! \1 .*\bissue [^\s#]*#[0-9]))'
         files: ^\.pre-commit-config\.yaml$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -588,11 +684,12 @@ repos:
     # understands `$/`, or GitHub's runner requirement (>=2.336.0) making
     # workspace-relative references the thing to flag instead.
     #
-    # Nothing enforces that: `pinned-rev` above is a pygrep pattern over
-    # one line, so it refuses a shape -- a bare major, a prerelease -- and
-    # a hold naming a version is not one. `autoupdate` offers 1.30.0 on
-    # every run, and whoever reads the diff is the whole of what declines it
-    rev: v1.29.0
+    # `autoupdate` offers 1.30.0 on every run, and the marker on the rev
+    # line is what declines it: `held-rev` above reads the value and the
+    # marker as one line and fails wherever the two differ. `pinned-rev`
+    # cannot, being a refusal of a shape -- a bare major, a prerelease --
+    # and a hold naming a version is not one
+    rev: v1.29.0 # hold: v1.29.0 -- issue #1563
     hooks:
       - id: zizmor
         # offline is what it does by default, said out loud: it warns about

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2565,6 +2565,54 @@ file of the test tree, and no caller acts on it.
   match `.yml` and `.yaml` alike -- were checked and found not to share
   the defect.
 
+### A held `rev:` carries its version in a marker on that line
+
+- **`held-rev` fails wherever a `rev:` line's `# hold:` marker names a
+  version other than the value beside it** (closes #1843). A hold that
+  names a version to stay at is what `pinned-rev` cannot read: that hook
+  refuses a shape -- a bare major, a prerelease -- and a version is not
+  one, so `pre-commit autoupdate` proposes the newer release with nothing
+  local to tell the two apart. Declaring the hold to the updater is not
+  available: `autoupdate` has no flag for a repository to leave alone, a
+  repository entry takes `repo`, `rev` and `hooks`, and pre-commit.ci's
+  `ci:` block skips hook ids at run time and nothing at autoupdate time.
+  The guard can come after the bump because an ordinary `autoupdate` run
+  re-emits the marker verbatim, so it outlives the bump it is there to
+  catch and the disagreement lands inside the one line pygrep reads. `--freeze`
+  erases the marker instead, writing its own `# frozen:` trailer over it, and
+  no run here passes it. The marker names the issue that says when the hold
+  lifts, which puts what declines the bot's two-line diff on the line that diff
+  shows; a marker on a line of its own is refused, since there it would enforce
+  nothing. The reference is `#<digits>` or `owner/repo#<digits>`, so a hold
+  tracked in another repository does not have to be written in the one form
+  section 9 of the organization standard refuses. A `rev:` line with no marker
+  matches nothing, which leaves the guard opt-in: what catches a hold written
+  without one is the review of the diff that adds it. zizmor's rev carries the
+  marker, held at v1.29.0 (issue #1563).
+- **The `- repo: meta` block's comment gives the reason those hooks carry
+  no `rev` and no `additional_dependencies`, in place of calling them the
+  only ones here with no environment to install** (closes #1873). Neither
+  property is that block's: pre-commit requires `rev` absent wherever the
+  repo is `meta` or `local`, and `language: unsupported`, which a meta
+  hook is validated as, installs no environment to put a dependency in --
+  as pygrep installs none, which is what `pinned-rev` and `held-rev` are
+  written in, and as `language: system` installs none, being
+  `unsupported` after translation. A local hook that does need an
+  environment says so: `typos` is `language: python` with its version in
+  `additional_dependencies`.
+- **That same comment's second paragraph cites `btclib-org/.github#145`
+  rather than a bare `#145`** (closes #1875): a bare number resolves
+  inside the repository it is written in, and that one is a different
+  real issue of this tree, so the reference named the wrong thing while
+  reading as precise. The prose qualifier it leaned on goes with the
+  change, the reference now saying which tracker it means.
+- **`pinned-rev` tolerates a comment after the value, so a held rev is
+  still held to naming a released version.** Its pattern ended at the
+  value, so any trailing comment defeated it -- and a trailing comment is
+  what a hold now is, which would have let a bare major or a prerelease
+  through on the very lines this convention creates, the rule still
+  written down and no longer enforced.
+
 ## v2026.9.3
 
 ### Repository


### PR DESCRIPTION
Closes #1843. Closes #1873. Closes #1875.

## The issue ruled out the design that works

ISS 1843 called a durable guard "an open design question, not a small
fix", listed three candidates, and ruled out the first — a pygrep entry
keyed to a marker — because pygrep sees "a single line, no
cross-reference to a comment above it". The single line is right; the
conclusion is not.

**A hold cannot be declared to the updater.** `autoupdate --help` offers
`--bleeding-edge`, `--freeze`, `--repo` (an allow list for one run) and
`-j`; `CONFIG_REPO_DICT` accepts `repo`, `rev` and `hooks` and warns on
anything else; pre-commit.ci's `ci:` block has no autoupdate exclusion,
its `skip:` being hook ids at run time.

**But the marker can ride the `rev:` line, and there it survives.**
`_write_new_config` re-emits the trailing comment verbatim on an ordinary
run, so the bump the marker exists to catch leaves the value and the
marker disagreeing *within one line* — which is what pygrep reads.

## The guard, seen to fail

ISS 1843's own scenario, end to end, with the real tool doing the bump:

```console
$ pre-commit run held-rev --all-files
a held rev names the version it is held at, and its issue.......Passed

$ pre-commit autoupdate --repo .../zizmor-pre-commit
[zizmor-pre-commit] updating v1.29.0 -> v1.30.0

$ pre-commit run held-rev --all-files
a held rev names the version it is held at, and its issue.......Failed
.pre-commit-config.yaml:  rev: v1.30.0 # hold: v1.29.0 -- issue #1563
```

That is what PR #1842 did — landing a bump over a comment that said not
to — caught by a machine instead of by a reader.

`pinned-rev` is widened with it, and that is not scope creep but the
thing this convention falsifies: its pattern ended at the value, so any
trailing comment defeated it, and a trailing comment is now what a hold
*is*. Without the widening a hold on a bare major or a prerelease would
pass both hooks — the rule still written down and no longer enforced,
which is the shape the same comment cites `btclib-org/.github#145` for.

## What the reviews took out

Four rounds of local review at fresh context, and **every round found
the defect in the correction rather than in the code** — twice in text I
had written myself. Worth recording, because it is the pattern rather
than the instances:

- the comment called the meta hooks "the only two hooks here with no
  environment to install" (ISS 1873). False: every `language: pygrep`
  hook qualifies, and `language: system` after translation.
- the repair replaced that with "what is this block's alone is its
  **subject**, this configuration file". False, refuted twice in the same
  file — and the branch adds the second counterexample.
- the next repair said "what is this block's alone is what it **reads**
  … where every hook below reads some file's content". False for four
  hooks: `check-case-conflict` reads `git ls-files` output,
  `name-tests-test` basenames, `check-added-large-files` a size, and
  `forbid-submodules` is `language: fail` and opens nothing.

Three claims of the form *X is unique to this block*, each repaired by
substituting a new subject into the same shape. The fourth answer is
**deletion**: the comment's opening clause already carries a true and
checkable distinction (`repo: meta`), and the paragraph below already
says what those hooks check, so the sentence was decoration that had to
be true and three times was not.

Two more over-broad claims went the same way. "re-emits whatever trails
it verbatim, unless that trailer opens with `# frozen:`" was false —
`--freeze` replaces the trailer whatever it opens with, the frozen branch
being taken ahead of the `elif`, which erases a marker and leaves the
hook silent. And an ordinary run *drops* a `# frozen:` trailer rather
than keeping it, so even the scoped version had to become "re-emits the
marker verbatim". Each was corrected in the comment, in `CHANGELOG.md`
and in the commit message, which is where such a claim lives three
times.

## Gates

Run on `52fbefdd`, working tree and `HEAD` identical, `git status
--porcelain` empty before the first and after the last:

| gate | exit |
| --- | --- |
| `uv run --locked --only-group lint pre-commit run --all-files --show-diff-on-failure` | 0 — 42 hooks Passed, both rev hooks among them |
| `uv run --locked pytest` | 0 — 32230 passed, 35 skipped, 1 xfailed, 100.00% coverage |
| `uv run --locked --no-default-groups --group docs sphinx-build -n -W` | 0 |

One earlier lint run exited 1 on `MD013 CHANGELOG.md:2583`, a line this
work created; it was rewrapped and the gate re-run. Reported rather than
hidden — and it also establishes that `markdownlint-cli2` did read
`CHANGELOG.md` on that run, so this branch's green is not the
intermittent-skip case of #1863.

The `merge=union` seam was paid on three successive rebases. Each time
the driver ate the blank line above the new `###`, invisible to `git
diff`, `range-diff` and `--numstat` alike. Repaired and verified two
ways: the whole-file invariant (253 `###` headings, 0 missing a blank
line — which catches a heading somebody else wrote being glued, where
checking only one's own would not) and a byte reconstruction with `cmp`,
each with the defect planted in a copy first, because a blind check and
a clean file print the same thing.

## The sha that was cleared, and the one that is landing

Local review answered `CLEARED 5fd7ada9`. This lands `52fbefdd`, which
differs by exactly that round's non-blocking findings — the reviewer's
own prescription — plus an answer to the question it raised:

- the "whatever trails it" universal narrowed to the marker, in all
  three sites;
- `pinned-rev`'s comment no longer explains a SHA's acceptability by
  "forty hex characters do not" end in a prerelease marker, which is not
  the pattern's reason: its first alternative `[0-9]+` matches an
  all-digit value, so an all-digit SHA is refused;
- a clause saying the marker sits immediately after the value, and that
  one further along the line is silent rather than refused — because
  ` +#` following the capture is what stops it backtracking to a shorter
  string, so the position *is* the anchor and relaxing it gives up the
  comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNydCktysAkoGbGcdfKRit

## Summary by Sourcery

Add marker-based validation for held pre-commit revisions while preserving released-version checks for revisions with trailing comments.

New Features:
- Add a `held-rev` hook that detects when an autoupdated revision differs from the version recorded in its issue-linked hold marker.
- Allow held revision markers to reference issues in the current or another repository.

Bug Fixes:
- Prevent trailing hold comments from bypassing `pinned-rev` validation of released revision versions.
- Correct the cross-repository issue reference in the meta-hook documentation.

Enhancements:
- Clarify why the meta hooks do not use revisions or additional dependencies and document the behavior and limitations of held revisions.

Documentation:
- Document the held-revision convention and its interaction with autoupdate, freeze, and revision validation in the changelog.