### PR TITLE
A reference whose sentence names the other tree still carries the qualifier (closes btclib-org/.github#907)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2613,6 +2613,25 @@ file of the test tree, and no caller acts on it.
   through on the very lines this convention creates, the rule still
   written down and no longer enforced.
 
+### A reference whose sentence names the other tree still carries the qualifier
+
+- **`ssa.py`'s back-reference to `bitcoin-core/secp256k1#1140` is written in
+  full, as the citation opening the same comment is**
+  (closes btclib-org/.github#907): section 9's *A reference to another
+  repository is qualified* exempts a pull request's closing keyword and
+  nothing else, and bare the number is a pull request of this tree about
+  `latest.yml`. The comment is rewrapped around the longer reference and its
+  other words are unchanged.
+- **`compact_blocks.py`'s differential-index paragraph cites
+  `btclib-org/btclib-node#20`, not `btclib_node issue #20`**: bare, the number
+  is this tree's *Schnorr speed up*. `btclib_node` is the package and
+  `btclib-node` the repository holding its tracker, so the sentence keeps the
+  first where it names the code and the citation takes the second.
+- **`test_a_payload_carries_the_command_bitcoin_core_spells`'s docstring cites
+  `btclib-org/btclib-node#12`, not `its issue #12`**: the qualified form does
+  not fit the summary line under `max-doc-length`, so it goes into a body
+  paragraph.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/ecc/ssa.py
+++ b/src/btclib/ecc/ssa.py
@@ -120,12 +120,12 @@ __all__ = [
 # spells these `s2c/schnorr/point` and `s2c/schnorr/data`, in
 # src/modules/schnorrsig/main_impl.h at its head 49c31379, and this tree
 # matches it byte for byte: if it lands, a commitment made here opens
-# there. #1140 is open and unmerged, so it is a reference and not an
-# authority -- its spelling can still change, and the pull request may
-# never land at all. Named for the standard rather than for btclib's
-# `ssa`, and not under BIP0340/, which would claim the BIP defines this.
-# Frozen all the same: a different string is a different scheme, and
-# every signature already made would stop opening
+# there. bitcoin-core/secp256k1#1140 is open and unmerged, so it is a
+# reference and not an authority -- its spelling can still change, and
+# the pull request may never land at all. Named for the standard rather
+# than for btclib's `ssa`, and not under BIP0340/, which would claim the
+# BIP defines this. Frozen all the same: a different string is a
+# different scheme, and every signature already made would stop opening
 _S2C_POINT_TAG = b"s2c/schnorr/point"
 _S2C_DATA_TAG = b"s2c/schnorr/data"
 

--- a/src/btclib/p2p/compact_blocks.py
+++ b/src/btclib/p2p/compact_blocks.py
@@ -54,7 +54,7 @@ Nothing is lost by storing the absolute index: over indexes that
 strictly increase the two are the same sequence written twice, so the
 octets round-trip either way. btclib_node holds the wire's value and
 never undoes the difference, which is a decoder that agrees with its own
-encoder and with nothing else (btclib_node issue #20).
+encoder and with nothing else (btclib-org/btclib-node#20).
 
 **Version 2 alone is implemented, and version 1 is not.** The two differ
 in one field and one hash: version 2 writes the transactions inside

--- a/tests/p2p/compact_blocks_test.py
+++ b/tests/p2p/compact_blocks_test.py
@@ -725,7 +725,10 @@ def test_reconstruct_says_what_it_was_handed_rather_than_reading_a_field() -> No
 
 
 def test_a_payload_carries_the_command_bitcoin_core_spells() -> None:
-    """The four names, which btclib_node misspells two of (its issue #12)."""
+    """The four names, which btclib_node misspells two of.
+
+    btclib-org/btclib-node#12 names the two.
+    """
     assert SendCmpct.command == "sendcmpct"
     assert CmpctBlock.command == "cmpctblock"
     assert GetBlockTxn.command == "getblocktxn"


### PR DESCRIPTION
Three bare `#N` in this tree are references to other repositories, so
each resolves here instead, silently:

| site | as written | means | what `btclib#N` is |
|---|---|---|---|
| `src/btclib/ecc/ssa.py:123` | `#1140 is open and unmerged` | `bitcoin-core/secp256k1#1140` | a closed pull request about `latest.yml` |
| `src/btclib/p2p/compact_blocks.py:57` | `(btclib_node issue #20)` | `btclib-org/btclib-node#20` | *Schnorr speed up* |
| `tests/p2p/compact_blocks_test.py:728` | `(its issue #12)` | `btclib-org/btclib-node#12` | *02 10 2018 test minus one* |

Section 9 of the standard states one exemption and this is not it: a
pull request's closing keyword takes the forge's own form, and
everything else that leaves the repository is `owner/repo#123`. The
forms are copied from this tree rather than invented —
`ssa.py:119` and `tests/ecc/commit_nonce_test.py:14` already write
`bitcoin-core/secp256k1#1140` in full, and `tests/integration/p2p_test.py:30`
writes `btclib-org/btclib-node#374`.

The `ssa.py` paragraph is rewrapped and **its other words are
unchanged**: 101 whitespace-separated tokens at both shas, one hunk, and
the only difference is the qualifier. The test docstring grows from one
line to four because the faithful one-liner measures 89 columns against
`max-doc-length = 80`, and the multi-line shape is that file's own.

What this branch deliberately does **not** do is reword the claims those
two `btclib-node` citations hang on. Both are false in the present tense
at that tree's `c8586937` — it no longer implements BIP152, it imports
this package's codec — but retiring or past-tensing a cautionary
counter-example is a design decision with more than one defensible
answer, and section 9's *No history in the prose* resists the obvious
rewrite. It is filed rather than smuggled in under a qualifier branch.

`19 0 CHANGELOG.md`, `6 6`, `1 1`, `4 1`; the changelog entry is
appended last in the open section, with nothing above it edited.

A reference whose sentence names the other tree still carries the qualifier (closes btclib-org/.github#907)

ISS 907's method is that the sentence around a bare number settles it,
and the findings it left in this tree are here: each names the other
tree in words and leaves the number bare, so the reference resolves in
this tree instead, to something real and unrelated.

Section 9's *A reference to another repository is qualified* exempts a
pull request's closing keyword and nothing else, so each citation takes
the `owner/repo#N` form this tree already writes elsewhere.

`ssa.py`'s comment is rewrapped around the longer reference.
`compact_blocks_test.py`'s docstring gains a body paragraph, the
qualified form not fitting its summary line under `max-doc-length`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011PgNKwAoV6S7Gvjcizbh6L


Local review: CLEARED cace3568, which is this head, at fresh context, with the rewrap proved token-for-token, every citation resolved against the forge, section 9 re-read at the standard rather than taken from the report, and the seam controls re-run rather than accepted. Gates on that tree, all in the branch worktree with each exit code written into its own log: `uv sync`; `uv run ruff check --fix`, `uv run ruff format` (416 files left unchanged) and `uv run mypy src/btclib tests .github/scripts` (no issues in 365 source files), all exit 0; `uv run pytest` exit 0, 32230 passed, 35 skipped, 1 xfailed, coverage 100.00%; `uv run pre-commit run --all-files` exit 0 with 42 Passed and none Failed; `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html` exit 0; and the docs job second step, `/usr/bin/grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'`, exit 1 with no output — which is the pass, the job failing when it exits 0 — with an unchained positive control in the same log naming three built pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PgNKwAoV6S7Gvjcizbh6L

## Summary by Sourcery

Qualify cross-repository issue references to prevent them from resolving to unrelated issues in this repository.

Bug Fixes:
- Qualify references to issues and pull requests in other repositories so they resolve to the intended external trackers.

Enhancements:
- Update related source comments and test documentation while preserving their original claims and meaning.