### PR TITLE
One helper answers which files are the workflows (closes #1879)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2632,6 +2632,27 @@ file of the test tree, and no caller acts on it.
   not fit the summary line under `max-doc-length`, so it goes into a body
   paragraph.
 
+### One helper answers which files are the workflows
+
+- **`tests/what_runs_when_test.py` and `tests/interpreters_test.py` read
+  `.github/workflows/` through `tests.workflow_files`, which globs `*.yml` and
+  `*.yaml`** (closes #1879): a workflow is either spelling, and that rule had a
+  site per module, the two of them written differently. `*.y*ml` is a `y`,
+  anything and an `ml`, so it takes `test.yXml` and `test.ymml`, which GitHub
+  does not run, and a comparison with `CONTRIBUTING.md`'s *What runs when* table
+  built on it asks for a row naming a file nothing runs. Every file the
+  directory holds is `.yml`, so the two globs answered alike and what was wrong
+  was the second site rather than an answer. The reason moves onto the function
+  and each call keeps what is local to it: the stems, the table's first column
+  writing `release` where the file is `release.yml`. `tests/__init__.py` is
+  where it lives, beside the walks and loaders the suite already shares from
+  there, and it returns paths -- the one caller wanting stems takes `.stem`,
+  where a second function returning them would be a second thing to hold in
+  agreement. The directory is a parameter, so
+  `test_workflow_files_reads_the_names_github_runs` points it at one holding
+  `os-macos.yml`'s bytes under three names and reads back the two spellings
+  GitHub runs.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -90,6 +90,27 @@ def public_classes_with(method_name: str) -> set[str]:
     return found
 
 
+def workflow_files(directory: Path) -> tuple[Path, ...]:
+    """Return the workflow files in `directory`, `.yml` and `.yaml` alike.
+
+    GitHub reads both extensions, so a glob matching one spelling drops
+    a workflow written with the other and leaves it out of whatever the
+    caller holds the set to (issue #1874).
+
+    The two are named rather than globbed as `*.y*ml`, which is `y`,
+    anything, `ml`: that matches `test.yXml` and `test.ymml` as well,
+    which GitHub does not run, and a caller comparing this set with
+    `CONTRIBUTING.md`'s *What runs when* table would ask for a row
+    naming a file no run exists for (issue #1879).
+
+    Here rather than in each caller: `what_runs_when_test.py` compares
+    the set with that table, `interpreters_test.py` reads each file for
+    the interpreters it names, and a rule stated at both sites is a rule
+    that gets corrected at one.
+    """
+    return tuple(sorted((*directory.glob("*.yml"), *directory.glob("*.yaml"))))
+
+
 def load(*relative_path: str, encoding: str = "ascii") -> Any:
     """Read a vendored JSON vector file, named relative to `tests/`.
 

--- a/tests/interpreters_test.py
+++ b/tests/interpreters_test.py
@@ -29,21 +29,11 @@ carries a parser for that either.
 import re
 from pathlib import Path
 
+from tests import workflow_files
+
 _ROOT = Path(__file__).parents[1]
 _PYPROJECT = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-
-
-def _workflow_files(directory: Path) -> tuple[Path, ...]:
-    """Return every workflow in `directory`, `.yml` and `.yaml` alike.
-
-    GitHub itself reads both extensions for a workflow file, so a glob
-    matching only one silently drops any workflow written with the
-    other (issue #1874).
-    """
-    return tuple(sorted((*directory.glob("*.yml"), *directory.glob("*.yaml"))))
-
-
-_WORKFLOWS = _workflow_files(_ROOT / ".github/workflows")
+_WORKFLOWS = workflow_files(_ROOT / ".github/workflows")
 
 # "3.10" out of `requires-python = ">=3.10"`, the floor and nothing else:
 # an upper bound is not declared here and would be a different claim
@@ -204,18 +194,17 @@ def test_free_threading_is_classified_exactly_when_the_gate_runs_it() -> None:
     )
 
 
-def test_workflow_files_reads_dot_yaml_too(tmp_path: Path) -> None:
-    """`.yml` and `.yaml` are read alike (issue #1874).
+def test_workflow_files_reads_the_names_github_runs(tmp_path: Path) -> None:
+    """`.yml` and `.yaml` are read alike, `.yXml` is not a workflow.
 
-    `os-macos.yml`'s own bytes, copied to a `.yaml` name: before the fix
-    the glob matched only the first, and the second's interpreter list
-    went uncompared -- the reproduction the issue carries, with the
-    extension the whole of the difference.
+    `os-macos.yml`'s own bytes under three names, the extension the
+    whole of the difference: the two spellings GitHub runs come back and
+    the third, which a `*.y*ml` glob would take, does not.
     """
     text = (_ROOT / ".github/workflows/os-macos.yml").read_text(encoding="utf-8")
-    (tmp_path / "os-extra.yml").write_text(text, encoding="utf-8")
-    (tmp_path / "os-extra.yaml").write_text(text, encoding="utf-8")
-    found = sorted(p.name for p in _workflow_files(tmp_path))
+    for name in ("os-extra.yml", "os-extra.yaml", "os-extra.yXml"):
+        (tmp_path / name).write_text(text, encoding="utf-8")
+    found = sorted(path.name for path in workflow_files(tmp_path))
     assert found == ["os-extra.yaml", "os-extra.yml"]
 
 

--- a/tests/what_runs_when_test.py
+++ b/tests/what_runs_when_test.py
@@ -53,15 +53,15 @@ which is what makes the reading above this table's own.
 import re
 from pathlib import Path
 
+from tests import workflow_files
+
 _ROOT = Path(__file__).parents[1]
 _CONTRIBUTING = (_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
 
-# both extensions GitHub reads, rather than the `.yml` every file here
-# happens to use: a workflow added as `.yaml` runs, and a comparison
-# that could not see it would leave open the same thing a missing row
-# leaves open
+# the stems: the table's first column writes `release`, where the file
+# is `release.yml`
 _WORKFLOWS = frozenset(
-    path.stem for path in (_ROOT / ".github/workflows").glob("*.y*ml")
+    path.stem for path in workflow_files(_ROOT / ".github/workflows")
 )
 
 # scoped to the one table, its heading and its header row included: a


### PR DESCRIPTION
Closes #1879.

`8a3699b2` taught `tests/interpreters_test.py` to read a `.yaml`
workflow as readily as a `.yml` one, and left the rule stated twice:
that module's own `_workflow_files` and `tests/what_runs_when_test.py`'s
`_ROOT.glob("*.y*ml")`, each deciding independently what GitHub runs.

The two spellings are not equivalent, and the measurement chose the
direction of the fix rather than confirming it. `*.y*ml` is
`y`-anything-`ml`, so it admits `test.yXml` and `test.ymml`, which
GitHub does not run — the module that changes is the one that landed
last, not the older one. Reproduced over the whole table, on exports of
both shas:

```text
test.yml    yes    test.yXml   no
test.yaml   yes    test.ymml   no
                   test.yl     no
                   test.yamlx  no
```

`tests/__init__.py` gains `workflow_files(directory)`, beside
`module_names`, `public_classes_with` and `load`, returning the paths
under either extension. It returns paths and not stems: the stem is
local to one caller, because *What runs when*'s first column writes
`release` where the file is `release.yml`, and a second function
returning stems would be a second thing to hold in agreement with the
first — the defect this closes, one level down.

The contract test stays in `tests/interpreters_test.py`, renamed. No
helper in `tests/__init__.py` has a test module of its own; they are all
exercised through their callers, and this is a caller's test that
happens to pin the shared contract. It now also pins the exclusion,
writing `os-macos.yml`'s bytes under `os-extra.yml`, `os-extra.yaml` and
`os-extra.yXml` and asserting only the first two come back.

The reason moved with the function rather than being copied: the
docstring in `tests/__init__.py` carries both halves — GitHub reads both
extensions (issue #1874), and `*.y*ml` admits names it does not run
(issue #1879) — and what stays beside the one caller is the one thing
local to it, why stems.

### The controls

The new test fails on a helper regressed to `directory.glob("*.y*ml")`
(`found == ['os-extra.yXml', 'os-extra.yaml', 'os-extra.yml']`, exit 1)
and passes unregressed, so it is not vacuous. On the real tree the
change is a no-op today — `.github/workflows/` holds no `.yaml` file, and
the two spellings' stems compare equal, with dropping one element as the
control that the comparison can be false.

`.yXml` planted on an export of `531c323f` fails the older module's row
check; the same file planted on this branch's export passes, which is
the loose-glob behaviour present before and absent after.

### Not measured here

That GitHub itself refuses `.yXml` and `.ymml`: that is its documented
`.yml`/`.yaml` requirement, the same claim `8a3699b2` already landed on.
What is measured above is only the glob semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Centralize workflow discovery so all tests consistently identify the files GitHub runs.

Bug Fixes:
- Ensure workflow discovery includes only GitHub-supported `.yml` and `.yaml` files, excluding similarly named extensions such as `.yXml` and `.ymml`.
- Use the same workflow-file selection logic when validating interpreter workflows and the What runs when documentation table.

Enhancements:
- Centralize workflow file discovery in a shared `tests.workflow_files` helper and retain filename-stem handling at the caller that needs it.

Documentation:
- Document the centralized workflow discovery behavior and its supported extensions in the changelog.

Tests:
- Extend workflow discovery coverage to verify both supported extensions are included and unsupported lookalike extensions are excluded.