### PR TITLE
`borromean.py` states its zkp agreement as an assertion (closes #1853)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2653,6 +2653,35 @@ file of the test tree, and no caller acts on it.
   `os-macos.yml`'s bytes under three names and reads back the two spellings
   GitHub runs.
 
+### `borromean.py` states its agreement with secp256k1-zkp as an assertion
+
+- **The module docstring says what this module and zkp's rangeproof
+  agree on over secp256k1 with sha256, rather than that each verifies
+  the other's signatures** (closes #1853). The challenge preimage
+  (issue #1070) and the wire layout (issue #1054) are aligned
+  deliberately, and what pins them is `tests/ecc/borromean_test.py`,
+  against zkp's source transcribed by hand rather than against the
+  library: `secp256k1_borromean_verify` and `secp256k1_borromean_sign`
+  are declared `static` in `src/modules/rangeproof/borromean.h`, an
+  internal header with no counterpart under zkp's `include/`, so no
+  cffi `cdef` binds them and the bindings wrap no borromean, the
+  flagged `zkp` extension included.
+- **What would discharge the assertion is named in its place**:
+  btclib-org/btclib-secp256k1#828, which asks the bindings for
+  borromean over serialized arguments, and failing that the rangeproof
+  of issue #1072, whose `secp256k1_rangeproof_sign_impl` and
+  `secp256k1_rangeproof_verify_impl` call the borromean pair and whose
+  `zkp.rangeproof` wrapper is there to reach them through.
+- **The same paragraph stops naming btclib-org/btclib-secp256k1#283 as
+  what issue #1072 waits on**: that work wraps zkp's public headers,
+  and the ring signature under the rangeproof has none, so it gave
+  borromean nothing to check an answer against.
+- **`BorromeanSig`'s class docstring and `parse`'s no longer call the
+  serialization interoperable**: the first points at the module
+  docstring for what the alignment covers and what rests on it
+  unchecked, and the second says that the 32-byte `e0` and 32-byte
+  scalars are the widths zkp's layout fixes.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/ecc/borromean.py
+++ b/src/btclib/ecc/borromean.py
@@ -41,19 +41,40 @@ the two agreeing wherever `ec` is secp256k1, zkp's only curve.
 `BorromeanSig.parse` reads that layout back at secp256k1 and sha256
 always, as `ssa.Sig.parse` reads BIP340's one curve: the serialization
 does not name either, so a `BorromeanSig` on another curve or hash
-function is built directly rather than parsed. With the challenge hash
-aligned too (issue #1070), the *primitive* now interoperates over
-secp256k1 with sha256: a signature this module produces there verifies
-under zkp's `secp256k1_borromean_verify`, and one zkp produces verifies
-here. That is not the same as producing a
-Confidential Transactions rangeproof: `rangeproof_impl.h` wraps this
-signature in a digit decomposition, a value commitment and an
+function is built directly rather than parsed.
+
+With the challenge hash aligned too (issue #1070), this module and
+zkp's rangeproof agree over secp256k1 with sha256 on the challenge
+preimage and on the wire layout of the ring signature itself -- the
+primitive, as against the rangeproof built on top of it. That the two
+therefore accept each other's signatures is an assertion, not a
+measurement: the agreement is with zkp's source, read and transcribed
+by hand, which is what `tests/ecc/borromean_test.py` pins, and no test
+here hands a signature to `secp256k1_borromean_verify` or checks one
+that function produced. Nothing in reach can:
+`secp256k1_borromean_verify` and `secp256k1_borromean_sign` are
+declared `static` in `src/modules/rangeproof/borromean.h`, an internal
+header with no counterpart under zkp's `include/`, and `static` is
+internal linkage, so no cffi `cdef` binds them -- the
+`btclib_secp256k1` bindings wrap no borromean, the flagged `zkp`
+extension included.
+
+Agreeing on the primitive is not the same as producing a Confidential
+Transactions rangeproof: `rangeproof_impl.h` wraps this signature in a
+digit decomposition, a value commitment and an
 exponent/mantissa/min-value/sign-bits header this module has no
 counterpart for, rebuilding its pubkey rings from that commitment
 where this module takes them as an explicit argument. Issue #1072 is
-that remaining distance, filed and decided wanted -- after
-btclib-org/btclib-secp256k1#283 gives it something to check the
-answer against.
+that remaining distance, filed and decided wanted.
+
+btclib-org/btclib-secp256k1#828 asks the bindings for borromean over
+serialized arguments, which is what would discharge the assertion in
+both directions. Where it is declined, issue #1072 would discharge it
+instead: `zkp.rangeproof.sign` and `zkp.rangeproof.verify` are
+wrapped, and the proof they write and read carries this signature
+inside it -- `secp256k1_rangeproof_sign_impl` and
+`secp256k1_rangeproof_verify_impl` call `secp256k1_borromean_sign` and
+`secp256k1_borromean_verify`.
 """
 
 from __future__ import annotations
@@ -173,8 +194,8 @@ class BorromeanSig:
     `ssa.sign`/`verify` take theirs.
 
     `serialize`/`parse` follow secp256k1-zkp's `rangeproof` module's own
-    layout for this signature -- the module docstring has why that is
-    not only a format but, since issue #1070, an interoperable one.
+    layout for this signature -- the module docstring has what that
+    alignment covers, and what about it is asserted rather than checked.
     """
 
     e0: bytes
@@ -267,7 +288,7 @@ class BorromeanSig:
         The serialization does not name its curve or its hash function,
         the same reason `ssa.Sig.parse` reads BIP340's alone: `e0` is a
         32-byte sha256 digest and each `s` is secp256k1's 32-byte
-        scalar, which is what makes this the interoperable spelling. A
+        scalar, which are the widths zkp's own layout fixes. A
         BorromeanSig on another curve or another hash function is built
         directly, as `ssa.Sig.parse`'s docstring says for BIP340's one
         curve.


### PR DESCRIPTION
Closes #1853.

`borromean.py`'s module docstring said the primitive *interoperates*
with secp256k1-zkp's. Nothing in this tree measures that, and nothing
in it can: `secp256k1_borromean_verify` and `secp256k1_borromean_sign`
are declared `static` in `src/modules/rangeproof/borromean.h`, there is
no counterpart under `include/`, and internal linkage leaves no symbol
for a cffi `cdef` to bind. The bindings' cdef is built by concatenating
the public `include/` headers, so the flagged `zkp` extension has no
borromean declaration to make either.

What is true is narrower, and the docstring now says exactly it: the
two agree on the challenge preimage and on the wire layout of the ring
signature itself — the primitive, as against the rangeproof built on
top of it. That agreement is with zkp's source **read and transcribed
by hand**, pinned that way in `tests/ecc/borromean_test.py`, which
already says so of itself: one test pins the hash order "computed by
hand from zkp's documented source rather than from any live
cross-check", the other checks the layout "against a hand-built
expectation". No test hands a signature to zkp.

So the claim is an assertion, and it is now labelled as one rather than
written in the present tense of a measurement.

### What would discharge it

`btclib-org/btclib-secp256k1#828` asks for borromean over serialized
arguments, which would discharge it directly. Where that is declined,
issue #1072's rangeproof would discharge it transitively:
`secp256k1_rangeproof_sign_impl` and `_verify_impl` call the borromean
pair, and `zkp.rangeproof` already wraps `sign` and `verify`. Both moods
are conditional; neither of the two is done.

The closing sentence that pointed at `btclib-org/btclib-secp256k1#283`
as "what gives it something to check the answer against" was already
false when it was written — that issue closed without exposing
anything — and is gone rather than reworded.

### Also in scope

`parse`'s docstring called the `e0`-then-`s` widths "what makes this the
interoperable spelling": the same claim, unlabelled, one paragraph away.
It now names the widths zkp's layout fixes and claims nothing about
acceptance. `BorromeanSig`'s docstring pointed at the same idea and now
points at where the module separates the two.

`borromean.py:278`'s statement that zkp takes `rsizes` as a
caller-supplied argument stands: it is a fact about the C signature,
checkable from the header text, and it claims no interoperation.

### Not fixed here

`borromean.py:16-17` calls zkp's rangeproof "the only other
implementation of this construction anything reads" — an exhaustive
quantifier with no survey and no date behind it. This change does not
lean on it, so it is filed as #1881 rather than rewritten in passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Narrow the Borromean interoperability claim to the source-level agreements that are currently established and label cross-signature acceptance as unverified.

Enhancements:
- Clarify that btclib’s Borromean implementation and secp256k1-zkp align on the challenge preimage and signature wire layout based on manually transcribed source, rather than verified cross-implementation interoperability.
- Update related class and parser documentation to distinguish confirmed layout widths from the unverified interoperability assertion and identify future work that could validate it.

Documentation:
- Document the limits of the Borromean agreement claim and remove the outdated reference to an issue that could not provide interoperability validation.