### PR TITLE
zkp's rangeproof rides on a commitment `pedersen.commit` computed (closes #1679)

### DIFF
--- a/.github/workflows/zkp-oracle.yml
+++ b/.github/workflows/zkp-oracle.yml
@@ -25,18 +25,22 @@ name: zkp-oracle
 # `bindings` marker's own.
 #
 # What it must not do, issue #1679's own words: move any run-time path.
-# `tests/ecc/commit_nonce_test.py`'s `test_dsa_commitment_opens_under_zkp`
-# and `test_zkp_commitment_opens_under_dsa` are the first of the three
-# oracles issue #1679 names, sign-to-contract over random keys, messages
-# and commitments, in both directions. The other two -- the MuSig2
-# adaptor and the rangeproof -- are each their own issue and their own
-# pull request.
+# Every oracle that issue names compares btclib against
+# libsecp256k1-zkp and moves nothing: `tests/ecc/commit_nonce_test.py`'s
+# `test_dsa_commitment_opens_under_zkp` and
+# `test_zkp_commitment_opens_under_dsa`, sign-to-contract over random
+# keys, messages and commitments in both directions;
+# `tests/ecc/musig2_test.py`'s adaptor tests; and
+# `tests/ecc/pedersen_test.py`'s, where `second_generator` and `commit`
+# are asked of `zkp.generator` and the commitment `commit` returns goes
+# to `zkp.rangeproof` to be proved, verified and rewound.
 #
-# Landing that first oracle with the workflow is not, on its own, what
-# keeps a compile-only green run silent: `pytest -m zkp`'s selection is
-# not empty whether or not the flagged extension actually built, because
-# `tests/conftest.py`'s `_skip_what_needs_zkp` marks the two tests skip
-# rather than dropping them, and a skipped test is still a selected one.
+# Landing an oracle with the workflow is not, on its own, what keeps a
+# compile-only green run silent: `pytest -m zkp`'s selection is not
+# empty whether or not the flagged extension actually built, because
+# `tests/conftest.py`'s `_skip_what_needs_zkp` marks the marked tests
+# skip rather than dropping them, and a skipped test is still a selected
+# one.
 # Pytest's own exit 5 ("no tests ran") is real protection against a
 # renamed marker or a moved file, never against `tests.ZKP_AVAILABLE`
 # reading False -- which is what a build that silently kept the
@@ -101,14 +105,24 @@ on:
     # same reason `curves/` does above: a two-field big-endian
     # concatenation, already exhaustively checked by BIP340's own
     # vectors, not the sort of surface a MuSig2-specific oracle exists to
-    # cover a second time
+    # cover a second time.
+    # `pedersen.py` and its own test file join for the rangeproof oracle,
+    # itemized the way `dsa.py` is rather than named whole: of that
+    # module, `second_generator` and `commit` are what
+    # `tests/ecc/pedersen_test.py`'s zkp-marked tests compare against
+    # `zkp.generator`, and the commitment `commit` returns is what
+    # `zkp.rangeproof` then proves, verifies and rewinds. `curves/`,
+    # which `commit` calls and those tests call directly, stays out for
+    # the reason `curves/` stays out above
     paths:
       - .github/workflows/zkp-oracle.yml
       - tests/ecc/commit_nonce_test.py
       - tests/ecc/musig2_test.py
+      - tests/ecc/pedersen_test.py
       - src/btclib/ecc/dsa.py
       - src/btclib/ecc/commit_nonce.py
       - src/btclib/ecc/musig2.py
+      - src/btclib/ecc/pedersen.py
 
 permissions:
   contents: read
@@ -171,7 +185,8 @@ jobs:
       # below what matters here, where `zkp.lib` is the exact attribute
       # `tests.ZKP_AVAILABLE` reads -- so this step fails on precisely
       # the condition that would otherwise leave `pytest -m zkp` below
-      # selecting two tests and skipping both, in silence
+      # selecting the marked tests and skipping every one of them, in
+      # silence
       - name: Assert the flagged extension is loadable
         run: >
           uv run --locked --no-default-groups --group test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2682,6 +2682,39 @@ file of the test tree, and no caller acts on it.
   unchecked, and the second says that the 32-byte `e0` and 32-byte
   scalars are the widths zkp's layout fixes.
 
+### zkp's rangeproof rides on a commitment `pedersen.commit` computed
+
+- **`tests/ecc/pedersen_test.py` asks `btclib_secp256k1.zkp.generator`
+  for `second_generator`'s H and for `commit`'s rG + vH, and hands the
+  commitment to `zkp.rangeproof`** (closes #1679). H for (secp256k1,
+  sha256) is the generator libsecp256k1-zkp calls
+  `secp256k1_generator_h`, so `zkp.generator.h()` answers with the value
+  `test_second_generator` pins as a literal transcribed from that
+  library's source. zkp then proves a commitment btclib built,
+  verifies the proof, and rewinds it to the value and the blinding
+  factor btclib chose. btclib gains no rangeproof from any of it:
+  nothing here builds or reads a proof.
+- **The bridge between the two serializations reads quadratic
+  residuosity, not parity.** libsecp256k1-zkp writes a generator as
+  `11 ^ secp256k1_fe_is_square_var(y)` followed by x and a Pedersen
+  commitment as `9 ^` the same bit, where a SEC compressed point's
+  leading octet says whether y is even -- so `bytes_from_point` is not
+  the bridge, and one reading `y & 1` instead agrees wherever the two
+  bits happen to. Where a test loops over commitments it asserts both
+  octets turned up, so a parity bridge cannot pass on a sample that
+  happened to carry only the agreeing cases.
+- **That is the issue's third item re-scoped.** As written it was met
+  once `zkp.rangeproof.verify` and `rewind` were callable from this
+  suite, which is zkp compared against itself: btclib builds no digit
+  decomposition, no exponent/mantissa header and no value-anchored ring
+  set, so it has no rangeproof for that library to check. The Pedersen
+  layer underneath is what both sides do have, and it is what the tests
+  compare.
+- **`.github/workflows/zkp-oracle.yml`'s `pull_request` filter names
+  `src/btclib/ecc/pedersen.py` and its test file**, so a change to what
+  this oracle compares selects the sentinel rather than waiting for the
+  weekly run.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/ecc/pedersen.py
+++ b/src/btclib/ecc/pedersen.py
@@ -69,9 +69,13 @@ def second_generator(ec: Curve = secp256k1, hf: HashF = sha256) -> Point:
     module by default, the derived H equals the H hardcoded as
     `secp256k1_generator_h` in libsecp256k1-zkp -- the H of Elements and
     of Confidential Transactions.
-    `tests/ecc/pedersen_test.py::test_second_generator` pins that
-    value; no published constant exists to pin it against on another
-    curve or hash function.
+    `tests/ecc/pedersen_test.py::test_second_generator` pins that value
+    against a literal, and
+    `tests/ecc/pedersen_test.py::test_second_generator_matches_zkp`
+    against `btclib_secp256k1.zkp.generator.h()`, which is that library
+    answering with its own copy rather than a transcription of it. No
+    published constant exists to pin either against on another curve or
+    hash function.
 
     idea:
     https://crypto.stackexchange.com/questions/25581/second-generator-for-secp256k1-curve

--- a/tests/ecc/pedersen_test.py
+++ b/tests/ecc/pedersen_test.py
@@ -2,16 +2,43 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Tests for the `btclib.pedersen` module."""
+"""Tests for the `btclib.ecc.pedersen` module.
 
+The `zkp`-marked tests at the end are issue #1679's third oracle. H for
+(secp256k1, sha256) is the generator libsecp256k1-zkp calls
+`secp256k1_generator_h`, and `commit` is the rG + vH that library's
+`secp256k1_pedersen_commit` computes, so both are asked of
+`btclib_secp256k1.zkp` and compared; a commitment btclib computed then
+goes to `zkp.rangeproof`, which proves it, verifies the proof and
+rewinds it back to the value and the blinding factor btclib chose.
+
+That gives this tree no rangeproof. The proof, its verification and its
+rewind are libsecp256k1-zkp's throughout, and what btclib contributes is
+the commitment they are about: nothing here builds or reads a proof.
+"""
+
+import secrets
 from hashlib import sha256, sha384
 
 import pytest
 
-from btclib.curves import secp256k1
+from btclib.alias import Point
+from btclib.curves import mult, secp256k1
 from btclib.curves.curve import CURVES
 from btclib.ecc import pedersen
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
+from tests import needs_zkp
+
+# guarded module scope, the same shape `btclib._libsecp256k1` uses: this
+# file is collected in every job, including the no-bindings one where
+# `btclib_secp256k1` does not exist at all, and pytest imports every
+# module it collects before `tests.needs_zkp` can skip anything in it
+try:
+    from btclib_secp256k1.zkp import generator as zkp_generator
+    from btclib_secp256k1.zkp import rangeproof as zkp_rangeproof
+except ImportError:  # pragma: no cover -- only the no-bindings job reaches this
+    zkp_generator = None  # type: ignore[assignment]
+    zkp_rangeproof = None  # type: ignore[assignment]
 
 secp256r1 = CURVES["secp256r1"]
 secp384r1 = CURVES["secp384r1"]
@@ -23,6 +50,10 @@ def test_second_generator() -> None:
     `second_generator`'s docstring says what the constant is and why
     only this one `(ec, hf)` pair is pinned; the two other pairs below
     are only exercised, not pinned, for that same reason.
+
+    This holds the literal; `test_second_generator_matches_zkp` at the
+    end of this file asks libsecp256k1-zkp itself for the same value,
+    wherever the flagged extension is built.
     """
     H = (
         0x50929B74C1A04954B78B4B6035E97A5E078A5A0F28EC96D547BFEE9ACE803AC0,
@@ -135,3 +166,194 @@ def test_commit_blinding_factor_sum() -> None:
     err_msg = r"invalid \(unblinded\) commitment"
     with pytest.raises(BTClibValueError, match=err_msg):
         pedersen.commit(r_1 + 3, 9, ec)  # r_1 + 3 == ec.n
+
+
+# libsecp256k1-zkp's own serializations, both in
+# `src/modules/generator/main_impl.h`: `secp256k1_generator_serialize`
+# writes `11 ^ secp256k1_fe_is_square_var(y)` and then the 32 bytes of x,
+# and `secp256k1_pedersen_commitment_serialize` hands back what
+# `secp256k1_pedersen_commitment_save` stored the same way, `9 ^` the same
+# bit. So the leading octet says whether y is a quadratic residue, where a
+# SEC compressed point's says whether y is even: `bytes_from_point` is not
+# the bridge, and `_zkp_octets` below is.
+_ZKP_GENERATOR_TAG = 11
+_ZKP_COMMITMENT_TAG = 9
+
+
+def _zkp_octets(
+    point: Point, tag: int
+) -> bytes:  # pragma: no cover -- only the marked tests below call this
+    """Write a point the way libsecp256k1-zkp serializes one.
+
+    Euler's criterion is what reads the bit the two serializations
+    share: y is a quadratic residue exactly where y**((p-1)/2) is 1.
+
+    Called from the `zkp`-marked tests below alone, hence the pragma.
+    """
+    x, y = point
+    p = secp256k1.p
+    return bytes([tag ^ int(pow(y, (p - 1) // 2, p) == 1)]) + x.to_bytes(32, "big")
+
+
+# `pragma: no cover` on every `@needs_zkp` below, that marker being the
+# reason: `ZKP_AVAILABLE` is False in every job that measures coverage,
+# `.github/workflows/zkp-oracle.yml` being the one job where it is True,
+# and that job's own `pytest -m zkp --no-cov` collects no coverage data
+# for any report to combine. The marker's line and not the `def` under
+# it: `ruff format` reflows a `def` line a comment carries past 88
+# columns, splitting `-> None:` across three lines to hang it, and
+# leaves a decorator line alone.
+#
+# `secrets` and not a seeded `random`, as `tests/ecc/musig2_test.py`'s own
+# zkp tests: what the loops below have to reach is a sample of each
+# leading octet, and each asserts that at its end rather than arranging
+# it with a seed.
+@needs_zkp  # pragma: no cover -- no zkp.generator.h() to compare H against
+def test_second_generator_matches_zkp() -> None:
+    """H is the `secp256k1_generator_h` the library itself holds.
+
+    `test_second_generator` above pins H against a constant transcribed
+    from libsecp256k1-zkp's source; this asks that library for it, so the
+    two agree about a value neither of them copied from the other.
+
+    It settles nothing about the leading octet: H's y is neither a
+    quadratic residue nor odd, so `11 ^ is_square(y)` and the SEC-shaped
+    `11 ^ (y & 1)` write the same octet for it.
+    `test_commit_matches_zkp` below is where the two conventions part.
+    """
+    H = pedersen.second_generator(secp256k1, sha256)
+    assert _zkp_octets(H, _ZKP_GENERATOR_TAG) == zkp_generator.h()
+    # and not a bridge that answers h() for whatever it is handed
+    assert _zkp_octets(secp256k1.G, _ZKP_GENERATOR_TAG) != zkp_generator.h()
+
+
+@needs_zkp  # pragma: no cover -- no zkp.generator.pedersen_commit to compare against
+def test_commit_matches_zkp() -> None:
+    """`commit` is `zkp.generator.pedersen_commit`: rG + vH over one H.
+
+    Sampled inside what both sides accept, a blinding factor in [1, n)
+    and a value below 2**64; `test_commit_outside_the_zkp_intersection`
+    below is what each does at the edges and why they are left out.
+
+    A bridge reading `y & 1` instead writes the same octet as the real
+    one wherever y's parity and its quadratic residuosity agree, so a
+    sample carrying only those cases would report agreement about the
+    wrong convention. Both octets have to turn up, which is what the
+    assertion after the loop asks for.
+    """
+    octets_seen = set()
+    for _ in range(64):
+        r = 1 + secrets.randbelow(secp256k1.n - 1)
+        v = secrets.randbelow(2**64)
+        commitment = zkp_generator.pedersen_commit(r, v)
+        assert _zkp_octets(pedersen.commit(r, v), _ZKP_COMMITMENT_TAG) == commitment
+        octets_seen.add(commitment[0])
+        # another value under the same blinding factor is another point:
+        # the agreement above is not a comparison against a constant
+        assert zkp_generator.pedersen_commit(r, v ^ 1) != commitment
+    assert octets_seen == {_ZKP_COMMITMENT_TAG, _ZKP_COMMITMENT_TAG ^ 1}
+
+
+@needs_zkp  # pragma: no cover -- no zkp side to hold each edge against
+def test_commit_outside_the_zkp_intersection() -> None:
+    """Each edge belongs to one side alone, which is why neither is sampled.
+
+    r = 0 mod n: `commit` refuses the unblinded commitment its own
+    docstring names, and libsecp256k1-zkp answers v*H, the very point
+    anyone who guesses v recomputes. r past n: `commit` takes it, a sum
+    of blinding factors being a blinding factor, and the C call refuses
+    the scalar overflow. v past 2**64: `commit` takes it, and zkp's value
+    is a uint64.
+    """
+    n = secp256k1.n
+    H = pedersen.second_generator(secp256k1, sha256)
+
+    err_msg = r"invalid \(unblinded\) commitment"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        pedersen.commit(0, 7)
+    assert zkp_generator.pedersen_commit(0, 7) == _zkp_octets(
+        mult(7, H, secp256k1), _ZKP_COMMITMENT_TAG
+    )
+
+    assert pedersen.verify(n + 5, 7, pedersen.commit(n + 5, 7))
+    with pytest.raises(RuntimeError, match="Pedersen commitment failed"):
+        zkp_generator.pedersen_commit(n + 5, 7)
+
+    assert pedersen.verify(7, 2**64, pedersen.commit(7, 2**64))
+    with pytest.raises(ValueError, match=r"value must be an int in \[0, 2\*\*64\)"):
+        zkp_generator.pedersen_commit(7, 2**64)
+
+
+@needs_zkp  # pragma: no cover -- no zkp.rangeproof to prove and rewind with
+def test_zkp_rangeproof_over_a_btclib_commitment() -> None:
+    """Prove, verify and rewind a commitment `commit` computed.
+
+    All three are libsecp256k1-zkp's, and the rewind is what makes them
+    a comparison rather than a round trip inside that library: the value
+    and the blinding factor it hands back are the ones btclib chose,
+    recovered from a proof about a point btclib computed.
+
+    Both leading octets again, for the reason `test_commit_matches_zkp`
+    gives: a proof rides on the commitment's serialization, so a bridge
+    right on one octet and wrong on the other verifies here and fails
+    there.
+    """
+    octets_seen = set()
+    for _ in range(64):
+        r = 1 + secrets.randbelow(secp256k1.n - 1)
+        v = secrets.randbelow(2**64)
+        commitment = _zkp_octets(pedersen.commit(r, v), _ZKP_COMMITMENT_TAG)
+        octets_seen.add(commitment[0])
+        nonce = secrets.token_bytes(32)
+        proof = zkp_rangeproof.sign(commitment, r, nonce, v)
+
+        proven_range = zkp_rangeproof.verify(commitment, proof)
+        assert proven_range is not None
+        min_value, max_value = proven_range
+        assert min_value <= v <= max_value
+
+        blind, value, _message, rewound_min, rewound_max = zkp_rangeproof.rewind(
+            commitment, proof, nonce
+        )
+        assert int.from_bytes(blind, "big") == r
+        assert value == v
+        assert (rewound_min, rewound_max) == (min_value, max_value)
+    assert octets_seen == {_ZKP_COMMITMENT_TAG, _ZKP_COMMITMENT_TAG ^ 1}
+
+
+@needs_zkp  # pragma: no cover -- no zkp.rangeproof to put a wrong opening to
+def test_zkp_rangeproof_refuses_a_wrong_opening() -> None:
+    """Each half of the agreement above can fail, and is made to.
+
+    A proof is bound to the value and to the blinding factor the
+    commitment was built from, and the rewind to the nonce as well.
+    Flipping the leading octet is the control on the bridge itself: the
+    flipped octets name the other of the two points sharing that x, and
+    no proof of this commitment is a proof of that one -- so a bridge
+    writing the wrong octet would be verifying a proof about a point
+    `commit` never returned.
+
+    `sign` answers a proof in each of these: what refuses them is
+    `verify`, which returns None where a proof does not open its
+    commitment, that being a verdict and not an exception.
+    """
+    r = 1 + secrets.randbelow(secp256k1.n - 1)
+    v = secrets.randbelow(2**64)
+    commitment = _zkp_octets(pedersen.commit(r, v), _ZKP_COMMITMENT_TAG)
+    nonce = secrets.token_bytes(32)
+    proof = zkp_rangeproof.sign(commitment, r, nonce, v)
+    assert zkp_rangeproof.verify(commitment, proof) is not None
+
+    flipped = bytes([commitment[0] ^ 1]) + commitment[1:]
+    assert zkp_rangeproof.verify(flipped, proof) is None
+
+    other_value = zkp_rangeproof.sign(commitment, r, nonce, v ^ 1)
+    assert zkp_rangeproof.verify(commitment, other_value) is None
+
+    other_r = 1 + secrets.randbelow(secp256k1.n - 1)
+    other_blind = zkp_rangeproof.sign(commitment, other_r, nonce, v)
+    assert zkp_rangeproof.verify(commitment, other_blind) is None
+
+    err_msg = "proof does not verify, or rewind failed"
+    with pytest.raises(ValueError, match=err_msg):
+        zkp_rangeproof.rewind(commitment, proof, secrets.token_bytes(32))


### PR DESCRIPTION
Closes #1679, the last of the three oracles it asked for — the
sign-to-contract pair landed first and the MuSig2 adaptor in
`b631fccf`.

**This closes a question the issue reserved, and it closes it against
the issue's own wording, so the objection should arrive before the
merge rather than after.** Item 3 asked for a rangeproof oracle. There
is no btclib rangeproof to hold an oracle against, so what lands is a
comparison one layer down — the Pedersen commitment both libraries do
build — with zkp's rangeproof riding on a commitment btclib computed.
If that is not the trade wanted, the cut-back is to keep the first two
comparisons (H, and `commit` against `pedersen_commit`), drop the third
test, and leave #1679 open on the rangeproof alone: the first two stand
by themselves and nothing else in the branch depends on the third.

### Why the third item is re-scoped

As written, that item was satisfied the moment `zkp.rangeproof.verify`
and `rewind` became callable from this suite: zkp signs a proof, zkp
verifies it, and nothing of btclib's is under test. btclib has no
rangeproof — no digit decomposition, no exponent/mantissa header, no
value-anchored ring set — so there is no btclib proof for that library
to check, and a test shaped like the issue's own wording would be a
smoke test wearing an oracle's name.

What both sides *do* have is the Pedersen layer underneath, and that is
what these tests compare:

- `pedersen.second_generator` against `zkp.generator.h()`. H for
  (secp256k1, sha256) is the generator libsecp256k1-zkp calls
  `secp256k1_generator_h`, so the library now answers with the value
  `test_second_generator` otherwise holds as a literal transcribed by
  hand from that library's source.
- `pedersen.commit(r, v)` against `zkp.generator.pedersen_commit` —
  the same `rG + vH`, in two different serializations.
- `zkp.rangeproof` over a commitment **btclib built**: zkp proves it,
  verifies the proof, and rewinds it to the value and blinding factor
  btclib chose. btclib gains no rangeproof from this; nothing here
  builds or reads a proof.

### The bridge is quadratic residuosity, not parity

libsecp256k1-zkp serializes a generator as
`11 ^ secp256k1_fe_is_square_var(y)` followed by x, and a Pedersen
commitment as `9 ^` the same bit — where a SEC compressed point's
leading octet says whether y is **even**. So `bytes_from_point` is not
the bridge, and a bridge reading `y & 1` agrees only where the two bits
happen to coincide.

H cannot show the difference: its y is even *and* a non-residue, so both
rules write `0x0b` for it. Over 200 random commitments the two rules
disagreed on 101 — so where a test loops over commitments it closes on
`octets_seen == {8, 9}`, and a parity bridge cannot slip through on a
sample that happened to carry only the agreeing cases. The tests that
do not loop stand on fixed points instead, and the one comparing H
settles nothing about the leading octet at all, as its own docstring
says.

### The intersection of what the two accept

Measured on both sides, not assumed, and pinned by
`test_commit_outside_the_zkp_intersection`:

| input | btclib | zkp |
| --- | --- | --- |
| `r = 0 mod n` | raises `BTClibValueError` | commits, and the answer is exactly `7H` |
| `r >= n` | commits (the homomorphism) | raises `RuntimeError` |
| `v >= 2**64` | commits | raises `ValueError` |

Sampling stays inside `1 <= r < n`, `0 <= v < 2**64`.

### Why a green marked run proves nothing on its own

`pytest -m zkp` exits 5 only on an *empty* selection. A selection whose
tests `conftest.py` skips exits **0** — measured here: with the
published wheel in place the same command reports `9 skipped`, exit 0.
So `zkp-oracle.yml`'s assertion on `zkp.lib`, in its own step before
pytest, is what makes the run mean anything, and the flagged build was
reproduced locally with the workflow's own commands: `9 passed`, five of
them new.

The workflow's `pull_request` filter now names `src/btclib/ecc/pedersen.py`
and its test file, so a change to what this oracle compares selects the
sentinel instead of waiting for the weekly cron. Two sentences of its
own comments went stale when the second oracle landed and are corrected
here.

### A pragma placement this tree has not used before

The five new tests carry `# pragma: no cover` on their `@needs_zkp`
line rather than on the `def` under it, which no other site here does.
It is not a preference. Section 8 of the organization standard requires
the reason on the pragma's own line, and appending one to these
signatures makes `ruff format` reflow them — a test taking no argument
has nothing to split but its return annotation, so the result is

```python
def test_second_generator_matches_zkp() -> (
    None
):  # pragma: no cover -- no zkp.generator.h() to compare H against
```

and the lint gate is red until that artefact is accepted. The remaining
width on three of the six lines is 5 to 9 characters, which is a token
rather than a reason.

The standard is silent on which line a pragma sits on, and coverage
treats the two placements as one case rather than two: `coverage/parser.py`
excludes `range(first_decorator_lineno, node.lineno + 1)`, so a
decorator-carried pragma and a signature-carried one would break in the
same commit. `git grep -nE 'pragma: no cover$' -- '*.py'` — the gate that
position buys — names nothing this branch adds.

The measurement is posted on `btclib-org/.github#841`, which is the live
thread on this collision and whose analysis has not met the no-argument
case, so the convention can be ratified or overruled there without this
branch waiting on it.

### Not fixed here

`uv run pytest` fails its own 100% floor in a working copy that has the
flagged extension built — the arms in `tests/__init__.py` and
`tests/conftest.py` that only an unflagged environment takes. Flagged
`99.98%` with a coverage failure, unflagged `100.00%`, both measured.
That predates this branch and is filed as #1885.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Extend the zkp interoperability oracle to validate btclib Pedersen commitments as inputs to libsecp256k1-zkp rangeproofs.

New Features:
- Add zkp oracle tests comparing btclib Pedersen generators and commitments with libsecp256k1-zkp, including rangeproof verification and rewinding over btclib-created commitments.

Enhancements:
- Validate the serialization bridge using quadratic residuosity and cover the intersection and boundary behavior accepted by both libraries.
- Document the re-scoped rangeproof oracle and clarify that btclib supplies the commitment while zkp supplies the proof operations.

CI:
- Extend the zkp oracle workflow trigger paths to Pedersen implementation and tests while preserving explicit detection of unavailable flagged bindings.

Documentation:
- Add changelog coverage for the Pedersen and rangeproof interoperability oracle.

Tests:
- Add coverage for generator matching, commitment interoperability, boundary behavior, rangeproof round trips, and rejection of incorrect openings.