### PR TITLE
`borromean.py` stops calling zkp's rangeproof the only other implementation (closes #1881)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2715,6 +2715,21 @@ file of the test tree, and no caller acts on it.
   this oracle compares selects the sentinel rather than waiting for the
   weekly run.
 
+### `borromean.py` stops calling zkp's rangeproof the only other implementation
+
+- **The module docstring no longer says that secp256k1-zkp's
+  `rangeproof` module is the only other implementation of this
+  construction anything reads** (closes #1881). A code search for
+  `borromean_sign` reaches implementations in Python and in Rust that
+  are not copies of that C, so the clause was false rather than merely
+  unmeasured. Nothing replaces it: a survey named in a docstring ages
+  the same way, and issue #1881 carries the search, its date and what
+  it found. The sentence still says what the paragraph and
+  `tests/ecc/borromean_test.py` rest on -- that `_hash`'s challenge
+  preimage matches `secp256k1_borromean_hash` in
+  `src/modules/rangeproof/borromean_impl.h`, Elements and Confidential
+  Transactions among its callers.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/ecc/borromean.py
+++ b/src/btclib/ecc/borromean.py
@@ -13,8 +13,7 @@ first; they are here because the module is what one arrives at.
 
 `_hash`'s challenge preimage matches secp256k1-zkp's `rangeproof`
 module -- `secp256k1_borromean_hash`,
-`src/modules/rangeproof/borromean_impl.h` -- which is the only other
-implementation of this construction anything reads, Elements and
+`src/modules/rangeproof/borromean_impl.h` -- Elements and
 Confidential Transactions among its callers: `e || m || ring || pos`,
 the point or `e0` bytes first, then the message hash, then the ring
 index and the position each as 4 bytes big-endian. It did not always:


### PR DESCRIPTION
Closes #1881.

`borromean.py`'s module docstring called secp256k1-zkp's `rangeproof`
module "the only other implementation of this construction anything
reads". Nothing behind that sentence said how the field had been
surveyed, and section 9 of the organization standard admits an
exhaustive enumeration only where a command counted it.

Surveyed, and the quantifier is **false** rather than merely unmeasured.
`gh search code "borromean_sign"` — a command and a date, 2026-09-09 —
finds mostly vendored copies of that same C, which the sentence would
have survived: `ElementsProject/elements`, `KomodoPlatform/dPoW`,
`21-DOT-DEV/swift-secp256k1`, `TiValue`, `bitconch-core`,
`Veil-Project/veil`. It does not survive these, each an independent
implementation rather than a copy:

- `cslashm/ECPy`, `src/ecsnipet/draft/borromean-draft.py`, Python,
  Apache-2.0, defining `borromean_hash`, `borromean_sign` and
  `borromean_verify`
- `jbird186/RingCT`, `src/rangeproof/borromean.rs`, Rust, MPL-2.0,
  headed *"Borromean ring signature-based rangeproofs"*, over Ristretto
  points
- `blondfrogs/veil-secp256k1-wasm`, `veil-crypto/src/borromean.rs`

Whether any of them is *wire-compatible* with zkp's format is a
different question, was not measured, and is claimed nowhere here.

### The clause goes, and nothing replaces it

A replacement quantifier would age the same way, and a survey named in
the sentence would age faster. What is left is what the paragraph and
`tests/ecc/borromean_test.py` actually rest on: zkp's `rangeproof`
module is the implementation this one is aligned against, which
`test_challenge_hash_matches_zkps_preimage_order` is what pins.

The kept facts are untouched: `secp256k1_borromean_hash` in
`src/modules/rangeproof/borromean_impl.h`, Elements and Confidential
Transactions among its callers, the `e || m || ring || pos` preimage,
the issue #1070 history and the RELEASE_NOTES pointer.

### Why now

Today the quantifier is decorative — the paragraph rests on the preimage
matching, and the quantifier only explains why there is one reference
rather than several. Issue #1072 makes it load-bearing: once this tree
builds a rangeproof verified against that same module, "the only other
implementation" becomes the stated justification for aligning against
exactly one thing. A false decorative claim costs a line; a false
load-bearing one costs a round and a correction in an append-only file.

### Left standing, deliberately

The same sentence is in `CHANGELOG.md`'s **released** `## v2026.8.21`
section, which `tests/changelog_immutability_test.py` seals against its
tag. Editing it either reddens that gate or needs a deliberate
`_KNOWN_DRIFT` registration, which is a policy act rather than a
prose fix — filed as #1889 with both sides stated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Correct the Borromean implementation documentation to describe secp256k1-zkp as the reference implementation without making an unsupported exclusivity claim.

Bug Fixes:
- Remove the false claim that secp256k1-zkp provides the only other implementation of the Borromean construction.

Enhancements:
- Clarify that btclib's Borromean implementation is aligned with secp256k1-zkp through its challenge-hash preimage compatibility.

Documentation:
- Document the correction and its rationale in the changelog while preserving the released changelog entry.