### PR TITLE
`CHANGELOG.md` supersedes the entries saying an issue stays open (issue btclib-org/.github#946)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2730,6 +2730,58 @@ file of the test tree, and no caller acts on it.
   `src/modules/rangeproof/borromean_impl.h`, Elements and Confidential
   Transactions among its callers.
 
+### An entry cites an issue for what it records, not for its state
+
+- **This supersedes *`conventions_test.py`'s docstring says what it reads
+  and departs* above, whose entry says btclib-org/.github#690 stays open
+  for the other copies of this module owing the same header sentence**
+  (issue btclib-org/.github#946): that issue is closed, on 2026-09-07.
+  This repository took the replacement in `62d58055`, `btclib-benchmarks`
+  in btclib-org/btclib-benchmarks@81f1313c, `btclib-secp256k1` in
+  btclib-org/btclib-secp256k1@1e587dac, `btclib-node` in
+  btclib-org/btclib-node@3a8a719e and `bitcoin-core-rpc` in
+  btclib-org/bitcoin-core-rpc@85f7dbd3.
+- **This supersedes *`conventions_test.py` says what this tree answers and
+  what it asserts* above, whose entry says btclib-org/.github#904 stays
+  open for the copies that still say otherwise** (issue
+  btclib-org/.github#946): that issue is closed, on 2026-09-07. This
+  repository took the replacement in `7004b856`, `btclib-secp256k1` in
+  btclib-org/btclib-secp256k1@58bf3d72, `bitcoin-core-rpc` in
+  btclib-org/bitcoin-core-rpc@c9ac78f3 and `btclib-node` in
+  btclib-org/btclib-node@8e0a0a48. The bullets citing
+  btclib-org/.github#903 in that entry make no claim about an issue's
+  state, so they stand.
+- **This supersedes *`conventions_test.py`'s module docstring names the
+  ways and counts nothing* above, whose entry says btclib-org/.github#906
+  is filed against the copies of this module across the organization and
+  stays open** (issue btclib-org/.github#946): that issue is closed, on
+  2026-09-08. This repository took the replacement in `385406f1`,
+  `btclib-secp256k1` in btclib-org/btclib-secp256k1@8d84015d,
+  `btclib-node` in btclib-org/btclib-node@8e0a0a48, `bitcoin-core-rpc` in
+  btclib-org/bitcoin-core-rpc@be5bacd7 and `btclib-benchmarks` in
+  btclib-org/btclib-benchmarks@dc47a41f.
+- **This supersedes *`templates_path` goes, this tree keeping no
+  templates* above, whose entry says btclib-org/.github#901 is owed by the
+  trees still carrying the key and stays open** (issue
+  btclib-org/.github#946): that issue is closed, on 2026-09-08. This
+  repository dropped the key in `c352c145`, `btclib-node` in
+  btclib-org/btclib-node@a035aab8, `btclib-secp256k1` in
+  btclib-org/btclib-secp256k1@76766d18 and `bitcoin-core-rpc` in
+  btclib-org/bitcoin-core-rpc@fd9a7c87, and `btclib-benchmarks` carries no
+  such key. That sentence wraps between `stays` and `open`, so a search
+  by line does not find it.
+- **This supersedes *The declaration says what it is and leaves its
+  assertions to the module* above, whose entry says btclib-org/.github#910
+  is filed against the copies in the other trees and stays open** (issue
+  btclib-org/.github#946): that issue is closed, on 2026-09-08. This
+  repository took the replacement in `bd4a4654`, `btclib-secp256k1` in
+  btclib-org/btclib-secp256k1@d80e2c07, `bitcoin-core-rpc` in
+  btclib-org/bitcoin-core-rpc@a0bb7ef6 and `btclib-node` in
+  btclib-org/btclib-node@c8586937.
+- **The trees and the shas are what each of those sentences owed a
+  reader**: an issue's state is what a landing in another tree moves,
+  where a tree and a sha are not.
+
 ## v2026.9.3
 
 ### Repository


### PR DESCRIPTION
Five entries in this tree's open section say an issue stays open, and all
five issues are closed. A `CHANGELOG.md` entry is append-only and
`merge=union`, so such a sentence cannot be corrected in place — it can
only be superseded by a later entry, which is what this one does.

Each bullet names the superseded entry by heading, paraphrases the
sentence that says an issue stays open, gives the date the issue closed,
and gives what the sentence owed a reader instead: the trees that took
the same replacement and the shas they took it at. Twenty-one
tree-and-sha citations; the reviewer checked every one exists, is an
ancestor of its tree's `origin/main`, and names its issue in its own
subject, and established the per-issue tree lists from each issue's own
timeline rather than from a `git log` window.

## The fifth site, which the issue's census did not name

`btclib`:2211's sentence wraps between `stays` and `open`, so a
line-oriented search does not find it — `awk '/stays open/'` over the
open section answers five lines and not that one, against a
newline-tolerant sweep answering six. The issue's census has since been
corrected twice on that mechanism and a second, lexical one; it now reads
thirteen sites across four trees rather than nine.

**The two claims the same sweep finds and that are true stay as they
are**: `bitcoin-core/secp256k1#1140` is open upstream and
`btclib-org/btclib#1127` is open on the half its entry names. Both were
re-read the day this landed.

## What the entry does not claim

It cites no sha for the census and says nothing about what the issue
body lists. An earlier draft did, and it went false twenty-five minutes
later when the issue body was corrected — the same defect class this
entry exists to supersede, committed inside the supersession. The
reviewer caught it. What is left is a claim about this tree's own frozen
file.

## The base moved under the review, and the seam was damaged

`a0e07d41` landed at the same anchor mid-round. `merge-tree` predicted
the damage before the rebase ran — a file one byte short with this
entry's heading glued to the bullet above it — the rebase produced
exactly that, showing only as `--numstat` reading 51 where 52 were owed,
and the repair was to rebuild the file as `newbase[:i] + block +
newbase[i:]` rather than to edit the seam. Both sides then re-derived it
independently from the base blob with the splice point printed first and
two controls, one of them the driver's own damage.

The block is provably the one that was cleared: the 52 added lines before
and after the rebase are byte-identical, 3174 bytes, `sha256
007e9dc93c2bee60…` both sides.

All eight gates were run at the rebased sha. The suite has now answered
`32230 passed, 40 skipped, 1 xfailed` four times across three loads and
three trees.

`CHANGELOG.md` supersedes the entries saying an issue stays open (issue btclib-org/.github#946)

One entry at the end of the open `## v2026.9` section, and no other
file. `git diff --numstat` reports a deletion column of zero, so the
diff is a pure append.

Each bullet supersedes one entry by naming its heading and
paraphrasing the sentence that says an issue stays open, gives the
date that issue closed, and gives what the sentence owed a reader
instead: the trees that took the same replacement and the shas they
took it at. That is the form btclib-org/.github#946 draws from
`btclib-node`'s entry for btclib-org/.github#910, which
`btclib-secp256k1` took in btclib-org/btclib-secp256k1@b7d1583f.

This landing answers one tree of the several btclib-org/.github#946
names, so the citation is `(issue ...)` rather than a closing keyword.

Five sites here, and the fifth wants saying: the `templates_path`
entry's sentence about btclib-org/.github#901 wraps between `stays`
and `open`, so a search by line does not find it. A pattern crossing
the newline returns it, and btclib-org/.github#901 closed on
2026-09-08.

The two hits that same search returns here and that are true stay as
they are: bitcoin-core/secp256k1#1140 is open upstream, and
btclib-org/btclib#1127 is open on the half its entry names.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011PgNKwAoV6S7Gvjcizbh6L


Reviewed locally at fresh context before this pull request was opened, over three rounds. The reviewer found a clause that had gone false after the branch was written and required it removed from the file and from the commit body together; then, when the base moved beneath its own clear, reproduced the predicted seam damage, verified the repair against a reconstruction built from the new base blob with the splice point printed first and two controls, and settled that the entry itself was unchanged by blob identity of the added block rather than by re-reading it. All eight gates of this tree were run on the cleared sha and their logs read whole: `uv sync`; `uv run ruff check --fix`; `uv run ruff format` (416 files left unchanged); `uv run mypy src/btclib tests .github/scripts` (no issues in 365 source files); `uv run pytest` (32230 passed, 40 skipped, 1 xfailed, total coverage 100.00%); `uv run pre-commit run --all-files` (42 Passed, 0 Failed, 0 Attempted, counted over the whole log); `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html`; and the second step of that job, `grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'`, which fails if it exits 0 and here exits 1, with an unchained control answering `docs/build/html/index.html:22`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PgNKwAoV6S7Gvjcizbh6L

## Summary by Sourcery

Enhancements:
- Add an append-only CHANGELOG entry that supersedes five outdated statements claiming closed issues remain open, documenting their closure dates and corresponding replacement landings across related trees.