### PR TITLE
`CONTRIBUTING.md` says what installing the lint gate as a git hook costs (issue btclib-org/.github#949)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2819,6 +2819,36 @@ file of the test tree, and no caller acts on it.
   beside them put the same questions to the library, and check that
   signing again with the recorded arguments answers the recorded octets.
 
+### `CONTRIBUTING.md` says what installing the lint gate as a git hook costs
+
+- **`pre-commit install` writes into the common git directory, which
+  every worktree of this repository shares, and the hook it writes names
+  by absolute path the interpreter that ran the install** (issue
+  btclib-org/.github#949, issue btclib-org/.github#677): one session
+  installing it installs it for every other, and which environment a
+  commit runs through is then decided by where the install was run
+  rather than by which tree the commit is made in. The gate is run by
+  hand instead.
+- **The `--python` paragraph gives a group-restricted rebuild's cost as
+  the environment it leaves, not as a `git commit` dying inside that
+  hook**: which `.venv` the hook reaches for is fixed when the hook is
+  installed and need not be the one a rebuild replaced, so a rebuild does
+  not by itself make the next commit die. What it leaves instead is an
+  environment `uv sync` restores and a group-restricted `uv run` does
+  not, and that a shell entering `.venv` by activation finds without
+  `pre-commit` until `uv sync`.
+- **The lint gate's paragraph says what CI enforces is what that command
+  enforces**: a commit enforces the list only where a hook has been
+  installed, and the command is the `uv run pre-commit run --all-files`
+  the paragraph is about. `.pre-commit-config.yaml`'s header comment says
+  the same thing about a commit and is untouched: it stands in those
+  words in other trees of the organization, so changing it here would
+  open a divergence rather than close one.
+- **The `local-link-prefix` sentence says the hook refuses the other
+  spellings, and no longer says a commit is where it does**: which two
+  spellings a broken local link can render is what that sentence is
+  about, and it does not turn on when the refusal lands.
+
 ## v2026.9.3
 
 ### Repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -354,11 +354,11 @@ report `Removed virtual environment at: .venv` and create it again — so
 whatever groups the command asks for are the only ones installed
 afterwards. With the group-restricted commands under "Reproducing what CI
 runs" below, that leaves an environment holding one group where `uv sync`
-installs them all, and pre-commit is not in it. The git hook pre-commit
-installs `exec`s `.venv/bin/python -mpre_commit` by absolute path, and
-that python does exist, so the hook's own "did you forget to activate your
-virtualenv" fallback never runs: the next `git commit` dies with
-`No module named pre_commit`. `uv sync` puts it back.
+installs them all, and pre-commit is not in it. `uv sync` puts the gate
+back, and so does any `uv run` that is not group-restricted, which syncs
+the environment before it runs anything; the group-restricted ones leave
+it out again. A shell that entered `.venv` with
+`source .venv/bin/activate` finds no `pre-commit` at all until `uv sync`.
 
 To leave `.venv` alone in the first place, put the other interpreter's
 environment somewhere else:
@@ -439,10 +439,20 @@ The failure message names the command, so there is nothing to remember.
 
 That second command is not a convenience: it is the lint gate itself.
 The lint workflow runs this very configuration, so what CI enforces is
-what a commit enforces, mark-down included
+what that command enforces, mark-down included
 ([markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) is
 one of the hooks, as are ruff, mypy, yamllint, actionlint, and the checks
 on packaging metadata and on `uv.lock`).
+
+**The lint gate is not installed as a git hook.** `pre-commit install`
+writes into the common git directory, which every worktree of this
+repository shares: `git -C <worktree> rev-parse --git-path hooks` answers
+with the primary checkout's `.git/hooks` from every one of them, so one
+session installing it installs it for every other. The hook names an
+interpreter by absolute path, the one that ran the install, so which
+environment a commit runs through is decided by where the hook was
+installed rather than by which tree the commit is made in. Run the gate
+by hand before committing, the `uv run pre-commit run --all-files` above.
 
 One of those hooks needs maintenance, and only one. The test vectors under
 `tests/_data/`, `tests/ecc/_data/` and `tests/script/_data/` are private
@@ -598,9 +608,9 @@ it if the machine has none:
 uv run --locked --no-default-groups --group test --python 3.10 pytest --no-cov
 ```
 
-That one rebuilds `.venv` with the test group alone, which is what breaks
-the pre-commit hook until the next `uv sync`: see the note under "The
-environment and the gates" above, and `UV_PROJECT_ENVIRONMENT` for
+That one rebuilds `.venv` with the test group alone, which is what leaves
+the environment without pre-commit until the next `uv sync`: see the note
+under "The environment and the gates" above, and `UV_PROJECT_ENVIRONMENT` for
 running it without touching `.venv`. The command is what CI runs,
 verbatim, and CI has no `.venv` to lose.
 
@@ -1101,8 +1111,8 @@ answer.
 
 The pattern matches `#../` as well as `#./` because a link to another file
 here begins one of those two ways and no other: `.pre-commit-config.yaml`'s
-`local-link-prefix` hook refuses the rest in the commit that writes the
-link, so those are the two spellings a broken one can render.
+`local-link-prefix` hook refuses the rest, so those are the two spellings
+a broken one can render.
 
 A link into a heading of another root file carries a fragment spelled the
 way GitHub derives it from the heading text, as in


### PR DESCRIPTION
`btclib-org/.github#949` asks which trees owe a paragraph saying what
installing the lint gate as a git hook costs. This is `btclib`'s half —
`btclib-benchmarks`'s landed as `c2c0b2a2` — so the citation is
`(issue …)` rather than `(closes …)`.

`btclib` is the tree where the question was live rather than
hypothetical: its hooks directory holds an installed `pre-commit` hook.
The cost is stated as measured, not as assumed. `pre-commit install`
writes into the **common** git directory, which every worktree of a
repository shares, so one session installing it installs it for every
other, the primary checkout included; and the hook names an interpreter
by absolute path — the one that ran the install — so which environment a
commit runs through is decided by where the install was run rather than
by which tree the commit is made in. Measured in a scratch repository:
the install run from a worktree landed the hook in the common directory,
named that worktree's `.venv`, and a commit in the main checkout, which
had run nothing, died in it.

**The branch also corrects a claim this file already made, and that is
the larger half of the diff.** The `--python` paragraph gave a
group-restricted rebuild's cost as the next `git commit` dying inside
the hook with `No module named pre_commit`. That does not follow: the
interpreter the hook names is fixed when the hook is installed and need
not be the tree whose `.venv` a rebuild replaced. Measured in a worktree
here — `uv sync --python 3.10 --no-default-groups --group test` left no
`pre_commit` importable and the next commit ran the whole hook set and
exited 0. What replaces it is the cost that does hold: the environment
the rebuild leaves, which `uv sync` and any unrestricted `uv run`
restore and a group-restricted `uv run` does not, and which a shell that
entered `.venv` by activation finds without `pre-commit` until
`uv sync`.

Two sentences leaned on the rewritten one and move with it: *Reproducing
what CI runs* now says what the matrix command leaves rather than what it
breaks, and the `local-link-prefix` sentence drops *in the commit that
writes the link* — which two spellings a broken local link can render
does not turn on when the refusal lands. No sibling carries that
sentence, so no copy of it diverges.

**What was deliberately left alone.** `.pre-commit-config.yaml`'s header
comments address a commit-time hook and are untouched: `bitcoin-core-rpc`
and `btclib-benchmarks` carry them in the same words, so editing this
copy would open a divergence rather than close one. That is `006153d`'s
own reason, and it is why the change stops at text this tree carries
alone.

One correction the branch made against its own first round is worth
recording, because it decides what a zero is worth here: the census that
said `btclib` names `pre-commit install` nowhere was briefly read as
saying the opposite, on a folded pattern that had matched the **verb**
inside *"The git hook pre-commit installs"*. Split by form over all 708
tracked files at the base, the command form answers **0** and the verb
form **1** — that one sentence, the one this branch rewrites — with a
wrapped-command control proving the command form can cross a line break
and still be seen.

`CONTRIBUTING.md` says what installing the lint gate as a git hook costs (issue btclib-org/.github#949)

`pre-commit install` writes into the common git directory, which every
worktree of this repository shares, so one session installing the hook
installs it for every other, the primary checkout included. The hook it
writes also names an interpreter by absolute path -- the one that ran
the install, which is `INSTALL_PYTHON` in pre-commit's own hook
template -- so which environment a commit runs through is decided by
where the install was run rather than by which tree the commit is made
in. Measured in a scratch repository: the install run from a worktree
landed the hook in the common directory and named that worktree's
`.venv`, and a commit in the main checkout, which had run nothing,
died in it.

No file of this tree asks for the command. Folded over every tracked
file at a3b7d3e3 the command form appears nowhere, the one match being
the verb in the sentence this branch rewrites. What asks for the hook
is the tree's own claim that what CI enforces is what a commit
enforces, and that clause now names the command it is about.

The paragraph on `--python` gave the cost of a group-restricted rebuild
as a `git commit` dying inside that hook. The interpreter the hook
names is fixed when the hook is installed, and need not be the tree
whose `.venv` a rebuild replaced: measured in a worktree of this
repository, `uv sync --python 3.10 --no-default-groups --group test`
left no `pre_commit` importable and the next commit ran the whole hook
set and exited 0. What replaces the sentence was measured the same way.
`uv sync` and an unrestricted `uv run` put pre-commit back; the
documented `uv run --locked --no-default-groups --group test --python
3.10 pytest --no-cov` ran the suite and left the environment on 3.10
without it; a shell that entered `.venv` by activation finds no
`pre-commit` at all until `uv sync`.

Two sentences elsewhere in the file leaned on the one being rewritten.
*Reproducing what CI runs* said the matrix command breaks the
pre-commit hook, sending the reader to that note for the reason, and
now says what the rebuild leaves. The `local-link-prefix` sentence said
the hook refuses the other prefixes in the commit that writes the link;
which two spellings a broken local link can render does not turn on
when the refusal lands, and no sibling tree carries that sentence, so
no copy of it diverges.

The hooks directory of this repository holds an installed `pre-commit`
hook, so the paragraph is about something live rather than
hypothetical. It is left where it is: this branch writes nothing
outside its own worktree.

`.pre-commit-config.yaml`'s header comments address a commit-time hook
and are untouched. `bitcoin-core-rpc` and `btclib-benchmarks` carry
them in the same words, so editing them here would open a divergence
rather than close one.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011PgNKwAoV6S7Gvjcizbh6L


Local review: CLEARED 2954188, which is this head, pinned against base a3b7d3e3. Gates on that tree, all eight from the coder's `set -x` log with `echo "EXIT=$?"` after each: `uv sync`, `uv run ruff check --fix` (418 files), `uv run ruff format`, `uv run mypy src/btclib tests .github/scripts` (367 files), `uv run pytest` (32281 passed, 43 skipped, 1 xfailed, coverage 100.00%), `uv run pre-commit run --all-files` (42 Passed, 0 Failed, 0 Attempted), and `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html` (`build succeeded.`) — each exit 0 — then the unresolved-local-link scan over `docs/build/html`, whose exit 1 is its pass, with its control exiting 0 and naming `docs/build/html/index.html:22`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PgNKwAoV6S7Gvjcizbh6L

## Summary by Sourcery

Clarify contributor guidance around pre-commit installation, environment rebuilds, and the commands that reproduce CI lint enforcement.

Bug Fixes:
- Correct the contribution guide’s description of the effects of group-restricted Python environment rebuilds on pre-commit availability.
- Clarify that local-link-prefix validation is independent of the commit that introduces the link.

Enhancements:
- Document the shared-worktree and absolute-interpreter-path risks of installing pre-commit as a Git hook, and direct contributors to run the lint gate manually.
- Clarify that the documented lint command, rather than every commit, is what mirrors CI enforcement.

Documentation:
- Update CONTRIBUTING.md and the changelog with measured guidance on Git hook installation, environment rebuild behavior, lint-gate usage, and local-link validation.