### PR TITLE
The `zkp` guard is excluded on both arms, and every zkp pragma names its case (closes #1885) (closes #1887)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2849,6 +2849,39 @@ file of the test tree, and no caller acts on it.
   spellings a broken local link can render is what that sentence is
   about, and it does not turn on when the refusal lands.
 
+### The `zkp` guard carries an exclusion on each arm, one per build
+
+- **`uv run pytest` reaches its 100% floor in a working copy that has
+  the flagged `btclib_secp256k1.zkp` extension built** (closes #1885).
+  `tests/__init__.py`'s `except ImportError` arm, `tests/conftest.py`'s
+  `_skip_what_needs_zkp` and the call to it run only where the extension
+  is absent, and only the arm a flagged build takes carried a pragma, so
+  whoever built the extension to run `pytest -m zkp` met a coverage
+  failure naming files their own branch never touched.
+- **Each arm's reason names the build that takes it, not the job.** The
+  `bindings` guard beside it is measured by `test.yml`'s `coverage` and
+  `no-bindings` jobs between them, and `coverage-union` combines their
+  data; `zkp-oracle.yml` runs `pytest -m zkp --no-cov` and writes no
+  data file, so there is nothing for a union to combine and the
+  exclusion is what the floor has here.
+
+### Every `# pragma: no cover` in the suite carries its reason inline
+
+- **The `zkp` sites that carried a bare `# pragma: no cover` gain the
+  half that goes on the pragma's own line** (closes #1887), which is
+  what makes `git grep -nE 'pragma: no cover$' -- '*.py'` answer empty:
+  section 8 of the organization standard reads every line that command
+  names as a defect, whether or not a reason for it is written
+  elsewhere, and a fuller reason in the block comment above a group does
+  not replace the inline one.
+- **The pragma sits on the `@needs_zkp` line rather than on the `def`
+  under it**, as `tests/ecc/pedersen_test.py` already does: a trailing
+  comment carries a signature past the formatter's 88 columns, and
+  `ruff format` then splits a no-argument test's return annotation
+  across three lines to hang the comment on. coverage carries an
+  exclusion from a decorator to the body under it, so the two placements
+  exclude the same lines.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -235,21 +235,28 @@ needs_bindings = pytest.mark.bindings
 # only for the comparison this suite makes to be runnable, not for a
 # dispatch, so the question "is zkp available" is this suite's own and
 # has no answer `_libsecp256k1.py` would ever read.
+#
+# Both arms below carry a pragma, the build deciding which one a run
+# takes: a flagged build never raises here and an unflagged one never
+# reaches the `else`, so an arm left measured is one that run cannot
+# execute. Unlike `INSTALLED` above, whose arms `test.yml`'s `coverage`
+# and `no-bindings` jobs measure between them and its `coverage-union`
+# combines: `zkp-oracle.yml` runs `pytest -m zkp --no-cov`, which
+# collects nothing for a union to combine. What the reasons name is the
+# build and not the job, because a contributor who builds the extension
+# to run `pytest -m zkp` measures coverage in that build too, and a
+# reason true only of CI leaves that run short of the floor in files
+# the contributor never touched (issue #1885).
 try:
     from btclib_secp256k1 import zkp
 
     # the probe itself: not assigned because nothing here reads it back,
     # `ffi` answering the same question `lib` does once either has run
     _ = zkp.lib
-except ImportError:
+except ImportError:  # pragma: no cover -- the arm an unflagged build takes
     ZKP_AVAILABLE = False
 else:
-    # unlike `INSTALLED` above, whose `try` is what an ordinary job
-    # reaches and whose `except` is the no-bindings job's alone: every
-    # job that measures coverage builds without the flag, so this is
-    # the arm only `zkp-oracle.yml` ever takes, and that job's own
-    # `pytest -m zkp --no-cov` collects no coverage data to combine
-    ZKP_AVAILABLE = True  # pragma: no cover
+    ZKP_AVAILABLE = True  # pragma: no cover -- the arm a flagged build takes
 
 needs_zkp = pytest.mark.zkp
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -331,15 +331,23 @@ def _skip_what_needs_the_bindings(
             item.add_marker(skip)
 
 
-def _skip_what_needs_zkp(items: list[pytest.Item]) -> None:
+def _skip_what_needs_zkp(
+    items: list[pytest.Item],
+) -> None:  # pragma: no cover -- an unflagged build is what calls this
     """Skip every test marked `zkp`, naming why once.
 
     Runs wherever `btclib_secp256k1.zkp.lib` is not the flagged
-    extension -- every job but `zkp-oracle.yml`'s, `ZKP_AVAILABLE` being
-    set once at import from that same attribute access, in
-    `tests/__init__.py`. The reason is worded like `bindings`' own rather
-    than naming the extension by name: a contributor reading a skip
-    report wants to know what to build, not which cffi module answered.
+    extension, `ZKP_AVAILABLE` being set once at import from that same
+    attribute access, in `tests/__init__.py`. The reason is worded like
+    `bindings`' own rather than naming the extension by name: a
+    contributor reading a skip report wants to know what to build, not
+    which cffi module answered.
+
+    The pragma is the other half of the pair `tests/__init__.py` carries
+    on the guard itself: a build with the extension never calls this,
+    and excluding what a build cannot execute is what leaves the floor a
+    measurement of the suite rather than of the build the machine has
+    (issue #1885).
     """
     skip = pytest.mark.skip(
         reason="btclib_secp256k1.zkp is not built with BTCLIB_LIBSECP256K1_ZKP"
@@ -362,13 +370,12 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
         _skip_what_needs_the_bindings(
             items
         )  # pragma: no cover -- only the no-bindings job reaches this
-    # `no branch` rather than a pragma on the function above, the two
-    # being each other's mirror image: `ZKP_AVAILABLE` is False in every
-    # job that measures coverage, `zkp-oracle.yml`'s own `pytest -m zkp
-    # --no-cov` run being the one place it is True, and that run carries
-    # no coverage instrumentation to combine -- there is no `coverage`
-    # counterpart here for a `coverage-union` to lean on, unlike
-    # `INSTALLED` above. So this line runs, and is covered, in every
-    # measured job; only the branch that skips it never is
+    # `no branch`: the build decides which way this goes, so an
+    # unflagged run never takes the branch around the body and a flagged
+    # one never takes the branch into it. The line itself runs either
+    # way; what a flagged run leaves uncovered is the call, and the
+    # function it calls (issue #1885)
     if not ZKP_AVAILABLE:  # pragma: no branch
-        _skip_what_needs_zkp(items)
+        _skip_what_needs_zkp(
+            items
+        )  # pragma: no cover -- a flagged build has nothing to skip

--- a/tests/ecc/commit_nonce_test.py
+++ b/tests/ecc/commit_nonce_test.py
@@ -240,12 +240,14 @@ def test_libsecp256k1_zkp_fixed_vectors(commit_hash: str, opening: str) -> None:
 # opposite direction. `bytes_from_point`/`point_from_pub_key` do the same
 # for a receipt against zkp's 33-byte compressed opening.
 #
-# `# pragma: no cover` on both signatures below: `ZKP_AVAILABLE` is False
-# in every job that measures coverage, `.github/workflows/zkp-oracle.yml`
-# being the one job where it is True, and that job's own `pytest -m zkp
-# --no-cov` collects no coverage data for any report to combine.
-@needs_zkp
-def test_dsa_commitment_opens_under_zkp() -> None:  # pragma: no cover
+# `pragma: no cover` on both `@needs_zkp` lines below: an unflagged
+# build skips these tests, and CI's flagged build runs them under
+# `.github/workflows/zkp-oracle.yml`'s `pytest -m zkp --no-cov`, which
+# collects no coverage data for any report to combine. The marker's line
+# and not the `def` under it, as `tests/ecc/pedersen_test.py` does and
+# for the reason it gives there.
+@needs_zkp  # pragma: no cover -- no zkp ecdsa_s2c.verify_commit to open the receipt
+def test_dsa_commitment_opens_under_zkp() -> None:
     """A btclib sign-to-contract commitment opens under zkp's own check."""
     for _ in range(16):
         prv_key = 1 + random.randrange(secp256k1.n - 1)
@@ -260,8 +262,8 @@ def test_dsa_commitment_opens_under_zkp() -> None:  # pragma: no cover
         assert not ecdsa_s2c.verify_commit(_compact(sig), b"\x00" * 32, opening)
 
 
-@needs_zkp
-def test_zkp_commitment_opens_under_dsa() -> None:  # pragma: no cover
+@needs_zkp  # pragma: no cover -- no zkp ecdsa_s2c.sign to write the commitment
+def test_zkp_commitment_opens_under_dsa() -> None:
     """A zkp sign-to-contract commitment opens under `dsa.verify_` too."""
     for _ in range(16):
         prv_key = 1 + random.randrange(secp256k1.n - 1)

--- a/tests/ecc/musig2_test.py
+++ b/tests/ecc/musig2_test.py
@@ -1025,8 +1025,8 @@ def test_adaptor_must_be_a_valid_point() -> None:
     assert exc_info.value.contrib == "adaptor"
 
 
-@needs_zkp
-def test_musig2_matches_zkp_with_no_adaptor() -> None:  # pragma: no cover
+@needs_zkp  # pragma: no cover -- no zkp.musig.Session to aggregate the same partial sigs
+def test_musig2_matches_zkp_with_no_adaptor() -> None:
     """Pin session agreement with no adaptor, before the adaptor test adds one.
 
     `zkp.musig.Session` is its own implementation, over its own opaque
@@ -1062,8 +1062,8 @@ def test_musig2_matches_zkp_with_no_adaptor() -> None:  # pragma: no cover
     assert session.partial_sig_agg(psigs[:1]) != sig.serialize()
 
 
-@needs_zkp
-def test_musig2_adaptor_matches_zkp() -> None:  # pragma: no cover
+@needs_zkp  # pragma: no cover -- no zkp.musig adapt and extract_adaptor to compare with
+def test_musig2_adaptor_matches_zkp() -> None:
     """A btclib pre-signature completes and extracts the same as zkp's.
 
     Both parities of the final nonce R, exercised the way


### PR DESCRIPTION
Closes #1885. Closes #1887.

Two issues, one branch, because they are the same lines: 1887's
`tests/__init__.py:252` is the **flagged** arm of the zkp guard, and
1885 is about the **unflagged** arm of that same guard.

### 1885 — the floor failed where the extension is built

`uv run pytest` failed its own 100% floor in a working copy that had the
flagged zkp extension built, and nothing said so. `tests/__init__.py`'s
`except ImportError` arm and `tests/conftest.py`'s `_skip_what_needs_zkp`
run only where the extension is **absent**; the opposite arm carried a
pragma whose comment said every job measuring coverage builds without the
flag — true of CI, false of a contributor's machine ten seconds after
building the extension to run `pytest -m zkp`.

Both arms now carry an exclusion, and each inline reason names the
**build** that takes it rather than the job. Measured in both
environments, told apart by whether `zkp.lib` resolves rather than by
which sync ran last:

| | before | after |
| --- | --- | --- |
| unflagged | exit 0, 100.00% | exit 0, 100.00% |
| flagged | **exit 1, 99.98%** | exit 0, 100.00% |

Eight statements leave the denominator. Seven are the lines the issue
reports missing in a flagged build; the eighth is a `def` header, which
coverage cannot exclude a body without, and which can never be uncovered
— the neighbouring `_skip_what_needs_the_bindings` pays the same price
for the same reason.

Rejected: `exclude_also`, which section 8 reserves for one shape
repeated; and a union of two measured runs, which section 8 does
prescribe where a native dependency splits the code but gates *beside*
the single run rather than instead of it — so the local run would still
have to reach 100 on its own, which is what the exclusion is for.

### 1887 — five bare pragmas

Section 8 puts the reason on the pragma's own line so that

```shell
git grep -nE 'pragma: no cover$' -- '*.py'
```

answers empty, and every line it names is a defect whether or not a
reason is written elsewhere. It answered five. It now answers nothing,
with the same command one revision earlier printing those five as the
control.

Four of the five are `def` lines, where appending a reason carries the
signature past 88 columns and `ruff format` splits a no-argument test's
return annotation across three lines. Those four take the pragma on the
`@needs_zkp` line instead, which the formatter leaves alone and which
excludes the same statements — `coverage/parser.py` carries exclusions
from a decorator through the `def` to the body, one code path rather
than two.

`# pragma: no branch` stays bare: the standard's rule and its grep are
written for `pragma: no cover`, and all nine sites in this tree carry
that reason in the comment above.

### Left for their own issues

`#1897` — two pragmas still justified by the job-framed premise this
branch replaced with a build-framed one; one of them is in a file
another branch holds, and the pair should move together.

`btclib-org/.github#965` — nothing anywhere runs section 8's grep: no
hook, no test. That is 1887's second half and it cannot land in this
tree, both candidate fixes being org-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Make ZKP coverage exclusions build-aware and ensure every no-cover pragma states its reason inline.

Bug Fixes:
- Ensure coverage reaches the 100% floor in both flagged and unflagged ZKP builds by excluding build-specific, unreachable guard paths.
- Add inline reasons to all ZKP-related `# pragma: no cover` directives and move exclusions to decorators where needed for formatting and coverage behavior.

Enhancements:
- Clarify that ZKP coverage exclusions are determined by the build configuration rather than the CI job.

Documentation:
- Document the build-specific ZKP coverage behavior and the requirement that every no-cover pragma include an inline reason.