### PR TITLE
`CLAUDE.md` takes the standard's worktree order and advance clause (issue btclib-org/.github#854) (issue btclib-org/.github#919)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2882,6 +2882,32 @@ file of the test tree, and no caller acts on it.
   exclusion from a decorator to the body under it, so the two placements
   exclude the same lines.
 
+### `CLAUDE.md`'s worktree name and advance clause take the standard's words
+
+- **The worktree paragraph now argues the order of
+  `wt-<tracker>-<issue>-<repo>-<role>` rather than only listing what
+  each part answers** (issue btclib-org/.github#854): most general part
+  first, an issue filed in `btclib-org/.github` being the key and the
+  repository a detail of it, so the repository is what varies underneath
+  an issue rather than the other way round.
+- **The sentence about sorting every worktree of one issue together
+  moves out of the `repo` collision clause and into that argument**
+  (issue btclib-org/.github#854): sorting needs the order and not just
+  `repo`'s presence, so where it stood it read as a property of one
+  part rather than of the sequence. It is stated once either way.
+- **The clause on a local `refs/heads/main` says where the ref may end
+  up rather than whose work may move it** (issue
+  btclib-org/.github#919): no ruleset reaches that name, a ruleset
+  binding the forge's copy, so the fast-forward onto `origin/main` this
+  file already describes is the move that stays inside the rule.
+- **The mechanism sentence and the pointer to `CONTRIBUTING.md` stay, so
+  this paragraph is deliberately not `btclib-org/.github`'s at `cdb0333`
+  byte for byte** (issue btclib-org/.github#886): that issue's interim
+  instruction is to replace the opening sentence and its reasoning and
+  leave those two standing, so the sentences this paragraph does take
+  are compared against that tree rather than against an issue's
+  quotation of one.
+
 ## v2026.9.3
 
 ### Repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,22 +99,28 @@ it forward.
 
 **Every session works in a worktree**, its own, from the first edit,
 named `wt-<tracker>-<issue>-<repo>-<role>` rather than after the issue
-alone. `tracker` is the repository whose issue tracker holds the issue:
-an issue number is unique only within one tracker, so
-`btclib-org/.github#45` and `btclib-org/btclib#45` are different issues
-that would otherwise name the same worktree. `issue` is what prevents
-the collision that has actually happened — two worktrees of different
-work sharing a generic basename in one repository's own `.git`, keyed on
-its path's basename. `repo` prevents a different collision, a *path*
-one rather than a `.git` one: two repositories each keep their own
-`.git/worktrees/<basename>` and cannot collide there, but the workers of
-one session share one scratchpad directory, so a session carrying one
-issue into several repositories computes the same target path for each
-of them, and `git worktree add` refuses a directory that already
-exists — or worse, a second worker reads the first one's tree; naming it
-this way also sorts every worktree of one issue together. `role` covers
-the narrower case of a coder and its reviewer holding a worktree at
-once, which the ordinary sequence avoids by each removing its own.
+alone, most general part first: an issue filed in `btclib-org/.github`'s
+tracker is the key and the repository is a detail of it —
+`btclib-org/.github#255` is one issue owed by seven repositories,
+`btclib-org/.github#177` by two — so the repository is what varies
+underneath an issue rather than the other way round, which is why `repo`
+comes after `issue`. Naming it that way also sorts every worktree of one
+issue together, which is what a port leaves behind. `tracker` is the
+repository whose issue tracker holds the issue: an issue number is
+unique only within one tracker, so `btclib-org/.github#45` and
+`btclib-org/btclib#45` are different issues that would otherwise name
+the same worktree. `issue` is what prevents the collision that has
+actually happened — two worktrees of different work sharing a generic
+basename in one repository's own `.git`, keyed on its path's basename.
+`repo` prevents a different collision, a *path* one rather than a `.git`
+one: two repositories each keep their own `.git/worktrees/<basename>`
+and cannot collide there, but the workers of one session share one
+scratchpad directory, so a session carrying one issue into several
+repositories computes the same target path for each of them, and
+`git worktree add` refuses a directory that already exists — or worse, a
+second worker reads the first one's tree. `role` covers the narrower
+case of a coder and its reviewer holding a worktree at once, which the
+ordinary sequence avoids by each removing its own.
 
 An issue of `btclib-org/.github`'s tracker worked in `btclib` by a coder
 names its worktree `wt-github-255-btclib-coder`. No `uv sync` follows
@@ -185,13 +191,17 @@ the way the stash only looks to be. What is already lost is still in the
 object store — `git fsck --unreachable` names the commit and `git stash
 store <sha>` puts the ref back.
 
-**Do not rewrite `refs/heads/main`, or advance it with work that is not
-yours.** `git update-ref`, or a push carrying another session's commits,
-leaves every working tree's files alone and moves the base under them, so
-their next commit — built on the older copy — reverts what just landed.
-Your own branch is what you push, and the pull request is what moves
-`main`: `CONTRIBUTING.md`'s *Pull requests* has how a branch under
-review is corrected and how it is merged.
+**Do not rewrite `refs/heads/main`, and move it only onto
+`origin/main`.** That name is the local branch's, and no ruleset reaches
+it: a ruleset binds the forge's copy. The fast-forward above moves it
+onto `origin/main` and is inside that, where a merge, a commit on `main`
+or an `update-ref` to a branch tip leaves the ref somewhere
+`origin/main` is not. `git update-ref`, or a push carrying another
+session's commits, leaves every working tree's files alone and moves the
+base under them, so their next commit — built on the older copy —
+reverts what just landed. Your own branch is what you push, and the pull
+request is what moves `origin/main`: `CONTRIBUTING.md`'s *Pull requests*
+has how a branch under review is corrected and how it is merged.
 
 ## Model
 


### PR DESCRIPTION
Two issues, one paragraph of one file, one branch: `btclib-org/.github`
has already landed both sentences and this is `btclib`'s convergence onto
them. Section 14's default is the ground — a convention that differs
between two repositories and is on neither of section 14's lists is
decided once, in the standard, and ported. `CLAUDE.md` is on neither
list, so nothing gates the copies and no `EXPECTED_DRIFT` entry is owed;
what carries the port is the decision, not a test.

Neither issue is closed here. Each is owed by the sibling trees as a
population, and this is one of them —
[portanode](https://github.com/btclib-org/portanode/pull/529) landed the
pair as `19ffb52b`, `btclib-node` landed ISS 919 as `0bb7fc83`,
[bbt](https://github.com/btclib-org/bbt/pull/45) as `7e09638b` and
[btclib-secp256k1](https://github.com/btclib-org/btclib-secp256k1/pull/839)
as `21a51d1d`; the rest are in flight.

**[ISS 919](https://github.com/btclib-org/.github/issues/919)** replaces
*"Do not rewrite `refs/heads/main`, or advance it with work that is not
yours."* with the standard's paragraph, which says why the prohibition
exists at all — the local ref is one no ruleset reaches, a ruleset
binding the forge's copy — names `update-ref` explicitly, and ends on the
pull request moving `origin/main` rather than `main`.

**Here the result is deliberately *not* byte-identical to the
standard's**, and that is
[ISS 886](https://github.com/btclib-org/.github/issues/886)'s interim
instruction rather than a divergence: this tree carries a mechanism
sentence — what a ref moved under a working tree does to somebody else's
next commit — and a pointer clause that the standard does not, and the
instruction is to leave both standing. So the paragraph is assembled
from the standard's opening and reasoning, this tree's own mechanism
sentence, and the standard's closing with its terminal stop replaced by
this tree's pointer clause. The branch asserts both halves: the assembled
text occurs once, and the standard's own paragraph occurs **zero** times.

**[ISS 854](https://github.com/btclib-org/.github/issues/854)** adds the
argument for the *order* of `wt-<tracker>-<issue>-<repo>-<role>`: most
general part first, the issue being the key and the repository a detail
of it, because one issue is owed by several repositories rather than one
repository holding several issues at a time. Every tree landed the four
parts and the collision each answers; none landed the reason for the
order. The standard's run is byte-identical here under exactly three
substitutions, each asserted to fire once: `this tracker` →
```btclib-org/.github`'s tracker``, and the two bare references
qualified. **That qualification is mandatory rather than stylistic in
this tree**: `btclib#255` and `btclib#177` both resolve to unrelated
closed items, so a literal copy would have pointed two citations at the
wrong issues.

**The third thing this branch does is a deletion, and it is the half
that is easy to get wrong.** This tree carried the sorting sentence
inside the `repo` collision clause; the standard carries it after the
ordering argument, gaining a clause it has nowhere else — *"which is what
a port leaves behind"*. That relocation is a decision the standard
already made, so a port that merely *adds* the standard's sentence
leaves the tree stating one fact twice, which section 9 refuses. The
clause is deleted from the `repo` position and the standard's sentence
added after the ordering argument. Where the sentence sits is the
substance rather than the tidiness: in the `repo` clause it reads as a
property of `repo` being present, and sorting needs the order as well.

That deletion is also where a line-oriented `grep` lies. The clause wraps
after `naming it`, so the whole clause reads **0** line by line on a file
that holds it, while the short pattern `sorts every worktree` reads 1 and
proves nothing — the trap being that a port which greps for the whole
clause, finds nothing and therefore *adds* lands exactly the duplication
above. Everything counted here was folded first.

**The paragraph was re-wrapped rather than patched**, which is why the
diff reads 33 insertions to 23 deletions where the words alone are 22 to
12: an insertion into a filled paragraph leaves a short line mid-flow.
The whole-file folded equality — this tree's base plus the four declared
word edits equals the tip, with a control omitting one edit that answers
false — is the evidence that the re-wrap changed no word.

**What is deliberately not in this branch**:
[ISS 964](https://github.com/btclib-org/.github/issues/964)'s three
clauses of the same paragraph, filed separately because widening the
target after the branches were briefed is what makes eight copies
disagree. All three are asserted to read 0 at the tip.

`CLAUDE.md` takes the standard's worktree order and advance clause (issue btclib-org/.github#854) (issue btclib-org/.github#919)

Both paragraphs converge on `btclib-org/.github`'s `CLAUDE.md` at
cdb0333. `CLAUDE.md` is named on neither of section 14's two lists and
`tests/verbatim_test.py` there compares no such path, so nothing gates
the copies and no `EXPECTED_DRIFT` entry is owed: what carries the port
is the decision rather than a test. Neither issue is answered by this
tree alone, each being owed by the sibling trees as a population, so
btclib-org/.github#854 and btclib-org/.github#919 are both cited as
issues rather than as work this branch completes.

The worktree paragraph gains the argument for the order of the four
parts, and the sentence about sorting every worktree of one issue
together moves out of the `repo` collision clause and into that
argument. The move is one edit and not two: sorting needs the order as
well as `repo`'s presence, and adding the sentence where the order is
argued without removing it from the `repo` clause would state one fact
twice.

Three substitutions were made to the standard's wording, each asserted
in the edit script to fire exactly once, and each is section 9's rule
that a reference to another repository is qualified: the standard's two
bare references, to issues 255 and 177, become
`btclib-org/.github#255` and `btclib-org/.github#177`, and "an issue
filed in this tracker" becomes "an issue filed in
`btclib-org/.github`'s tracker". Qualifying is mandatory here rather
than stylistic, `gh issue view` answering for both of those numbers in
this repository's own tracker, so a literal copy would point two
citations at unrelated issues.

The advance clause follows btclib-org/.github#886's interim instruction
instead of taking the standard's paragraph whole. The opening sentence
and its reasoning are replaced and the closing sentence now ends
`origin/main`; the mechanism sentence and the pointer to
`CONTRIBUTING.md`'s *Pull requests* stay, the pointer's own `main`
becoming `origin/main`. The paragraph is therefore deliberately not
byte identical to `btclib-org/.github`'s at cdb0333, which is what that
interim instruction asks for.

btclib-org/.github#964's three clauses of these same paragraphs -- the
`env -C ""` sentence, the `wt-review` clause and the sentence opening
the four-part list -- are deliberately not added.

The worktree paragraph is refilled at the width the rest of the file
uses, the insertion having left a short line mid-paragraph.
`git diff --word-diff` is where the re-wrap can be read as changing no
word.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011PgNKwAoV6S7Gvjcizbh6L


Local review: two rounds, one reviewer. Round 1 requested changes on `c0e5b1ab` — the changelog entry and the commit body each carried a claim about an issue's state, which section 9 refuses in an append-only file — and round 2 CLEARED 4551767062b6956a5f9280da6d04d744be6ba3a6, which is this head, on an unmoved base fcec9392. The reviewer declined to re-verify the port at the second sha on a stronger ground than a re-run: `git rev-parse c0e5b1ab:CLAUDE.md 45517670:CLAUDE.md` answers one object twice, so round 1's two-block reconstruction, both whole-file equalities and the ISS 964 zeros carry over by blob identity. It re-derived the seam independently at the new block, read the amended message from the commit object rather than the file, hunted the third site with a pattern wider than the coder's and a live control, and audited every `$?` site in the gate script — finding one broken echo, the one the coder had already disowned. It ran no gate and reports the exit codes as the coder's evidence rather than its own. Gates on that tree, the eight its own `CONTRIBUTING.md` gives, run verbatim and in order under a `set -x` script binding each with `env -C <worktree>` and echoing `EXIT<n>=$?`, the log named for the pushed sha and polled for its terminator: `uv sync`, `uv run ruff check --fix`, `uv run ruff format`, `uv run mypy src/btclib tests .github/scripts`, `uv run pytest`, `uv run pre-commit run --all-files`, `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html`, then `grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'`. The first seven exit 0 — ruff 418 files unchanged, mypy 367 sources, `32281 passed, 43 skipped, 1 xfailed`, coverage 100.00%, pre-commit 42 `Passed` / 1 `Skipped` (`uv-lock`) with whole-log `Failed` 0 and `Attempted` 0, `build succeeded` — and the eighth exits **1, which is its pass**: its polarity is inverted, so it is indistinguishable from a broken pattern and rests entirely on its control, `/usr/bin/grep -rnc 'href="#' docs/build/html/index.html`, which exits 0 with 22 matches. It was also run against the real binary rather than this machine's interactive `grep`, a shell function routing to `ugrep --ignore-files`; both agree, and a planted `href="#./x"` inside the gitignored `docs/build/` was found by both, which refutes the suspicion that `--ignore-files` could manufacture a false pass there. The documentation build on the pushed sha was warm but reports `0 added, 1 changed, 0 removed` and `reading sources… changelog_link`, and a separate genuinely cold build at the same sha reports `[new config] 24 added` and `build succeeded`, so the changelog entry was inside what `-W` judged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PgNKwAoV6S7Gvjcizbh6L

## Summary by Sourcery

Align `CLAUDE.md` with the shared standard for worktree naming and safe main-branch advancement while preserving this repository's interim guidance.

Enhancements:
- Update `CLAUDE.md` to explain the standard worktree naming order and consolidate the sorting guidance in the ordering rationale.
- Clarify the main-branch advancement guidance so local `main` is only advanced to `origin/main` while retaining the existing safety rationale and pull-request guidance.

Documentation:
- Document the worktree naming and main-branch guidance changes in the changelog.