### PR TITLE
`ecc.rangeproof` writes the proof that states its value in the clear (issue #1072)

### DIFF
--- a/.github/workflows/zkp-oracle.yml
+++ b/.github/workflows/zkp-oracle.yml
@@ -106,16 +106,23 @@ on:
     # concatenation, already exhaustively checked by BIP340's own
     # vectors, not the sort of surface a MuSig2-specific oracle exists to
     # cover a second time.
-    # `rangeproof.py` and its own test file join for the parser oracle,
-    # and so does the vector file beside them: those tests check the
-    # recording itself -- signing again with an entry's own arguments
-    # has to answer that entry's proof -- so an edit to the json is an
-    # edit to what this job verifies, which is not true of any other
-    # vector file here. The module is named whole, as `musig2.py` is:
-    # `parse`, `serialize`, `assert_valid` and the two properties are
-    # all of it, and the marked tests read every one of them against
-    # `zkp.rangeproof.info` and against the octets `zkp.rangeproof.sign`
-    # answers. `borromean.py` joins for a narrower reason than
+    # `rangeproof.py` and its own test file join for the parser and the
+    # writer, and so does the vector file beside them: those tests check
+    # the recording itself -- signing again with an entry's own
+    # arguments has to answer that entry's proof -- so an edit to the
+    # json is an edit to what this job verifies, which is not true of
+    # any other vector file here. The module is named whole, as
+    # `musig2.py` is: `parse`, `serialize`, `assert_valid`, the two
+    # properties and `sign_public_value` are all of it, and the marked
+    # tests read every one of them against `zkp.rangeproof.info`,
+    # against the octets `zkp.rangeproof.sign` answers, and against what
+    # `zkp.rangeproof.verify` makes of a proof this tree wrote.
+    # `rfc6979_nonce.py` holds the K and V machine `sign_public_value`
+    # seeds its chain with, and stays out for a reason of its own beside
+    # the one given for it above: that writer's octets are held to a
+    # vendored proof in every ordinary run, so a change there reddens
+    # the suite before this job could be asked about it.
+    # `borromean.py` joins for a narrower reason than
     # `pedersen.py`'s below: `BorromeanSig.parse` reads the `e0` and the
     # `s` values inside every proof this oracle parses, and that call
     # site has no zkp octets to reach it anywhere else --

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2908,6 +2908,52 @@ file of the test tree, and no caller acts on it.
   are compared against that tree rather than against an issue's
   quotation of one.
 
+### `ecc.rangeproof` writes the proof that states its value in the clear
+
+- **`btclib.ecc.rangeproof` adds `sign_public_value`** (issue #1072),
+  which writes `secp256k1_rangeproof_sign_impl`'s `exp = -1` proof: the
+  value in the clear, one ring holding the single key the commitment
+  itself gives, and no ring commitment at all, a proof carrying one per
+  ring but the last. So it asserts no range, and the digit
+  decomposition, the mantissa, `rangeproof_pub_expand` and the
+  squareness bit -- which is written on a serialized ring commitment --
+  are all still ahead of the module, as are verifying a proof and
+  rewinding one.
+- **What holds it is byte identity with the proof libsecp256k1-zkp
+  signs, and that runs without the flagged extension.** A rangeproof
+  draws nothing, its nonce being the chain `rangeproof_genrand` derives
+  from the caller's, so the `public value` entry of
+  `tests/ecc/_data/zkp_rangeproof_vectors.json` states the whole of what
+  produced its octets and writing them again has to answer that
+  recording. `zkp.rangeproof.verify` accepting the result would say only
+  that it is a proof. Both shapes the proof has are recorded, one
+  carrying a `min_value` field and one whose value is zero and carries
+  none, so neither waits on `.github/workflows/zkp-oracle.yml`'s job;
+  what that job adds is the same comparison over values no entry fixes,
+  and `verify` reading back the range.
+- **`ecc.rfc6979_nonce` gains `_HmacDrbg`, RFC6979 section 3.2's K and V
+  machine**, which `rfc6979_nonce_` and the rangeproof's nonce chain
+  both seed. Two things stay with each caller rather than moving into
+  it. What makes a draw acceptable, where
+  `secp256k1_rangeproof_genrand` alone has two answers: a candidate
+  outside 1..n-1 sends `rfc6979_nonce_` back to the chain, and sends
+  genrand back too for the ring blinding factors a proof of more than
+  one ring draws, where a ring member's own draw makes it fail outright
+  -- the only kind a single ring takes, so `sign_public_value` fails
+  with it. And when to reseed:
+  `secp256k1_rfc6979_hmac_sha256_generate` reseeds between every pair of
+  draws where RFC6979 reseeds after a rejected candidate alone. No nonce
+  this library derives moves.
+- **The challenge is not reduced modulo n where `ecc.borromean` reduces
+  it**: `secp256k1_borromean_sign` reads it through
+  `secp256k1_scalar_set_b32` and returns zero on a hash at or past n, so
+  reducing would write a proof `secp256k1_borromean_verify` refuses.
+  `sign_public_value` closes its one ring itself rather than through
+  `borromean.sign` for a second reason as well -- `_get_msg_format`
+  hashes a caller's message together with the pubkey rings, and what a
+  rangeproof hashes is the value commitment, the generator and the
+  proof's own header.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/ecc/__init__.py
+++ b/src/btclib/ecc/__init__.py
@@ -7,7 +7,8 @@
 **The schemes.** btclib.ecc holds what is built *on* an elliptic curve:
 dsa, ssa, bms and borromean signatures, the MuSig2 aggregation of many
 ssa signers into one, pedersen commitments, the reader for the
-Confidential Transactions rangeproof built over one, the Diffie-Hellman
+Confidential Transactions rangeproof built over one and the writer for
+the one shape of it that proves no range, the Diffie-Hellman
 key agreement, the BIE1 ECIES built on top of it, the ElligatorSwift encoding
 of a public key with the x-only ECDH on it, the BIP374 proof that two
 points share one discrete logarithm, and the RFC6979, BIP340 and

--- a/src/btclib/ecc/borromean.py
+++ b/src/btclib/ecc/borromean.py
@@ -66,13 +66,18 @@ counterpart for, rebuilding its pubkey rings from that commitment
 where this module takes them as an explicit argument. Issue #1072 is
 that remaining distance, filed and decided wanted.
 
-`ecc.rangeproof` is the part of it that reads: `RangeProof.parse`
-takes the flags, the exponent, the mantissa, the `min_value`, the sign
-bits and the ring commitments of such a header, and holds the `e0` and
-the `s` values inside the proof as a `BorromeanSig` of this module's.
-It writes no proof, verifies none and rewinds none, so what the digit
-decomposition, the pubkey rings and the nonce chain are for is still
-ahead of it.
+`ecc.rangeproof` is where that distance is being closed.
+`RangeProof.parse` takes the flags, the exponent, the mantissa, the
+`min_value`, the sign bits and the ring commitments of such a header,
+and holds the `e0` and the `s` values inside the proof as a
+`BorromeanSig` of this module's. `sign_public_value` writes the proof
+whose ring structure is one ring of one key -- the value in the clear,
+so no digit decomposition and no ring commitment -- and it closes that
+ring on its own rather than through `sign` here, `_get_msg_format`
+being a message format a rangeproof does not have: what it hashes is
+the value commitment, the generator and the proof's own header, with
+no pubkey ring in the preimage. Verifying a proof and rewinding one
+are still ahead of it.
 
 btclib-org/btclib-secp256k1#828 asks the bindings for borromean over
 serialized arguments, which is what would discharge the assertion in

--- a/src/btclib/ecc/rangeproof.py
+++ b/src/btclib/ecc/rangeproof.py
@@ -2,27 +2,34 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""The Confidential Transactions rangeproof, read from its octets.
+"""The Confidential Transactions rangeproof, and the one shape btclib writes.
 
 `RangeProof.parse` reads what secp256k1-zkp's `rangeproof` module
 writes -- `secp256k1_rangeproof_sign_impl`,
 `src/modules/rangeproof/rangeproof_impl.h` -- and `RangeProof.serialize`
-writes those octets back. Reading is the whole of what is here: nothing
-in this module proves a range, verifies a proof or rewinds one, and the
-pieces those need -- the digit decomposition, `rangeproof_pub_expand`'s
-rings and `rangeproof_genrand`'s nonce chain -- have no counterpart in
-this tree yet. Issue #1072 is where the rest of that distance is
-tracked.
+writes those octets back.
+
+`sign_public_value` writes one proof, and it is the one that proves no
+range: `exp` is -1, the value is stated in the clear, and the single
+ring holds the key the commitment itself gives. What a reader means by
+a rangeproof is on the far side of it -- the digit decomposition, the
+mantissa, `rangeproof_pub_expand`'s rings, and the squareness bit,
+which is written on a serialized ring commitment and so reaches no
+octet of a proof that carries none. Nothing here verifies a proof or
+rewinds one. Issue #1072 is where the rest of that distance is tracked.
 
 Elements and Liquid use this format, and a design starting today would
 choose bulletproofs, which zkp carries as its `bppp` module.
 
-Reading before writing, because reading is the direction with an
-oracle: every header field here is one `zkp.rangeproof.info` answers
-for over the same octets, and what that call is silent about -- the
-sign bits, the ring commitments and the signature -- is pinned by the
-octets going back out unchanged. The first artefact a writer could be
-judged by is a whole proof.
+Each direction is held to what can hold it. A parse answers to
+`zkp.rangeproof.info`, field for field over the same octets, and what
+that call is silent about -- the sign bits, the ring commitments and
+the signature -- to the octets going back out unchanged. The writer
+answers to something stronger, and that is what makes this the shape to
+write first: a rangeproof draws nothing, its nonce being the hash chain
+`rangeproof_genrand` derives from the caller's, so the octets are a
+function of the arguments and the proof zkp signs for those same
+arguments is the answer, byte for byte.
 
 `secp256k1_rangeproof_sign_impl` writes, in order:
 
@@ -50,11 +57,13 @@ which `_rsizes` below computes the same way.
 the ring commitment's y is not a square. That is not the even/odd
 convention `curves.bytes_from_point`, BIP340 and the `02`/`03` SEC
 prefix carry, and the two disagree on the vectors
-`tests/ecc/rangeproof_test.py` reads. Nothing here computes the bit --
-a parse reads it and a serialize writes it back -- so what a
-`RangeProof` holds is the octets' own answer; a stage that resolves an
-x to a point computes against this convention and not the familiar
-one.
+`tests/ecc/rangeproof_test.py` reads. No ring commitment's bit is
+computed here -- a parse reads it and a serialize writes it back, so
+what a `RangeProof` holds is the octets' own answer -- while
+`_serialize_point` is that function of zkp's, and what
+`sign_public_value` hashes the value commitment and the generator
+under. A stage that resolves an x to a point computes against this
+convention and not the familiar one.
 
 Which points those are, and whether the signature over them verifies,
 this module does not ask: an x here is an integer of the width the
@@ -68,14 +77,24 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from hashlib import sha256
 
-from btclib.alias import BinaryData
-from btclib.curves import secp256k1
-from btclib.ecc.borromean import BorromeanSig
-from btclib.exceptions import BTClibValueError
-from btclib.utils import assert_no_trailing, bytesio_from_binarydata, read_exactly
+from btclib.alias import BinaryData, Integer, Octets, Point
+from btclib.curves import bytes_from_point, mult, scalar_from_prv_key, secp256k1
+from btclib.ecc.borromean import BorromeanSig, _hash
+from btclib.ecc.pedersen import commit, second_generator
+from btclib.ecc.rfc6979_nonce import _HmacDrbg
+from btclib.exceptions import BTClibRuntimeError, BTClibValueError
+from btclib.number_theory import legendre_symbol_var
+from btclib.utils import (
+    assert_no_trailing,
+    bytes_from_octets,
+    bytesio_from_binarydata,
+    int_from_bits,
+    read_exactly,
+)
 
-__all__ = ["RangeProof"]
+__all__ = ["RangeProof", "sign_public_value"]
 
 # the flags octet, as secp256k1_rangeproof_getheader_impl reads it
 _RESERVED = 128
@@ -92,6 +111,11 @@ _UINT64_MAX = 2**64 - 1
 # what a min_value field occupies: zkp writes it at a fixed width rather
 # than behind a length, and reads it back the same way
 _MIN_VALUE_SIZE = 8
+
+# what a nonce occupies, and it is zkp's own 32 rather than the scalar
+# width every other length here generalizes: `rangeproof_genrand` copies
+# that many octets of the caller's nonce into its seed
+_NONCE_SIZE = 32
 
 
 def _rsizes(mantissa: int) -> tuple[int, ...]:
@@ -171,6 +195,40 @@ def _assert_valid_header(exp: int, mantissa: int, min_value: int | None) -> None
         raise BTClibValueError(err_msg)
 
     _ = _max_value(exp, mantissa, min_value or 0)
+
+
+def _header_octets(exp: int, mantissa: int, min_value: int | None) -> bytes:
+    """Return the flags octet and the fields its own bits say follow it.
+
+    A function of the header alone, because `sign_public_value` needs
+    these octets before it has a signature to put after them:
+    `secp256k1_rangeproof_sign_impl` writes the header first and then
+    hashes it, into the nonce chain's seed and into the message the ring
+    is signed over.
+    """
+    flags = _HAS_NZ_RANGE | exp if mantissa else 0
+    if min_value is not None:
+        flags |= _HAS_MIN
+    out = bytes([flags])
+    if mantissa:
+        out += bytes([mantissa - 1])
+    if min_value is not None:
+        out += min_value.to_bytes(_MIN_VALUE_SIZE, byteorder="big")
+    return out
+
+
+def _serialize_point(Q: Point) -> bytes:
+    """Return the encoding a rangeproof hashes a point under.
+
+    `secp256k1_rangeproof_serialize_point`: one octet saying the y is
+    not a square, then the x. The octet is the residuosity the module
+    docstring above distinguishes from parity, so this is not
+    `curves.bytes_from_point` with another name: a proof hashed under
+    the parity convention verifies nowhere, and nothing in the octets
+    says which of the two wrote them.
+    """
+    residue = legendre_symbol_var(Q[1], secp256k1.p) == 1
+    return bytes([0 if residue else 1]) + Q[0].to_bytes(secp256k1.p_size, "big")
 
 
 @dataclass(frozen=True, init=False)
@@ -284,14 +342,7 @@ class RangeProof:
         if check_validity:
             self.assert_valid()
 
-        flags = _HAS_NZ_RANGE | self.exp if self.mantissa else 0
-        if self.min_value is not None:
-            flags |= _HAS_MIN
-        out = bytes([flags])
-        if self.mantissa:
-            out += bytes([self.mantissa - 1])
-        if self.min_value is not None:
-            out += self.min_value.to_bytes(_MIN_VALUE_SIZE, byteorder="big")
+        out = _header_octets(self.exp, self.mantissa, self.min_value)
 
         signs = bytearray(_sign_octets(len(self.rsizes)))
         for i, sign in enumerate(self.signs):
@@ -376,3 +427,79 @@ class RangeProof:
             sig,
             check_validity=check_validity,
         )
+
+
+def sign_public_value(blind: Integer, value: int, nonce: Octets) -> RangeProof:
+    """Return the proof that states its value in the clear.
+
+    `secp256k1_rangeproof_sign_impl` with an `exp` of -1, which
+    `secp256k1_range_proveparams` answers with one ring holding the
+    single key the commitment itself gives. So this proof asserts no
+    range: it says what the commitment commits to, and that whoever
+    wrote it knows the blinding factor. The mantissa, the digit
+    decomposition, `rangeproof_pub_expand` and the sign bits are all
+    absent from it, a proof carrying one ring commitment per ring but
+    the last and this one having a single ring.
+
+    A value of zero writes the flags octet and nothing after it; any
+    other writes `min_value` in the eight octets behind bit 5.
+
+    secp256k1 and sha256, which `parse` fixes for the reason it gives.
+    `blind` is a scalar, read through `curves.scalar_from_prv_key`;
+    `value` is what those eight octets carry; `nonce` is the 32 octets
+    `rangeproof_genrand` seeds its chain with.
+
+    Deterministic in all three, so what comes back is the octets
+    `zkp.rangeproof.sign` answers for the same arguments -- which is
+    what `tests/ecc/rangeproof_test.py` asks of it, against a vendored
+    proof where the flagged extension is absent and against the library
+    where it is.
+    """
+    blind_int = scalar_from_prv_key(blind, secp256k1)
+    if not 0 <= value <= _UINT64_MAX:
+        raise BTClibValueError(f"rangeproof value not in 0..2**64-1: {value}")
+    nonce_bytes = bytes_from_octets(nonce, _NONCE_SIZE)
+
+    # zkp sets bit 5 from the value, this path's `min_value` being the
+    # value itself: `min_value ? 32 : 0`, so zero carries no field
+    min_value = value or None
+    header = _header_octets(-1, 0, min_value)
+    points = _serialize_point(commit(blind_int, value))
+    points += _serialize_point(second_generator())
+
+    # the one draw a single ring takes. `rangeproof_genrand` draws
+    # nothing for the last ring's blinding factor -- that is minus the
+    # sum of the others, and there are no others, so `sec` is zero and
+    # the caller's `blind` is the whole of it -- and one block for the
+    # ring's one public key, which `sign_impl` then moves into the nonce
+    # the ring is closed with
+    seed = nonce_bytes + points + header
+    k = int.from_bytes(_HmacDrbg(seed, sha256).generate(secp256k1.n_size), "big")
+    if not 0 < k < secp256k1.n:
+        # genrand's answer to a draw it cannot use, not
+        # `rfc6979_nonce`'s: `secp256k1_scalar_set_b32` flags a draw at
+        # or past n, zero is refused beside it, and `sign` returns zero
+        # on either rather than asking the chain again
+        raise BTClibRuntimeError("rangeproof nonce is not a scalar")
+
+    m = sha256(points + header).digest()
+    r = bytes_from_point(mult(k, secp256k1.G, secp256k1), secp256k1)
+    e0 = sha256(r + m).digest()
+    # `secp256k1_borromean_sign` over one ring of one key: `e0` hashes
+    # the nonce point and then the message, and the challenge that
+    # closes the ring is `e0`'s own at ring 0, position 0, which
+    # `borromean._hash` is the preimage of. Not reduced modulo n the
+    # way `ecc.borromean` reduces it -- zkp refuses a challenge at or
+    # past n here, and a proof it would not have written is a proof its
+    # verifier does not take
+    e = int_from_bits(_hash(m, e0, 0, 0, sha256), secp256k1.nlen)
+    if not 0 < e < secp256k1.n:
+        raise BTClibRuntimeError("rangeproof challenge is not a scalar")
+
+    s = (k - e * blind_int) % secp256k1.n
+    if s == 0:
+        # a zero s is the one `BorromeanSig` holds and zkp does not
+        # write: `secp256k1_borromean_sign` returns zero on it, and
+        # `secp256k1_borromean_verify` refuses one it is handed
+        raise BTClibRuntimeError("rangeproof signature value is zero")
+    return RangeProof(-1, 0, min_value, (), (), BorromeanSig(e0, [[s]]))

--- a/src/btclib/ecc/rfc6979_nonce.py
+++ b/src/btclib/ecc/rfc6979_nonce.py
@@ -61,6 +61,57 @@ def challenge_(
     return int_from_bits(msg_hash, ec.nlen) % ec.n
 
 
+class _HmacDrbg:
+    """RFC6979 section 3.2's K and V machine, seeded with octets.
+
+    Sections 3.2.b to 3.2.g are the seeding, 3.2.h.2 is `generate`, and
+    the K and V update between two draws is `reseed`. Neither when to
+    reseed nor what makes a draw acceptable is settled here, and the
+    second is not one rule per caller:
+    `_rfc6979_nonce_` below reseeds after a candidate outside 1..n-1 and
+    asks the chain again, and `secp256k1_rangeproof_genrand` does that
+    too for the ring blinding factors a proof of more than one ring
+    draws, while failing outright on a ring member's own draw.
+    `ecc.rangeproof` takes one draw and it is of that second kind, a
+    single ring drawing no blinding factor at all; it seeds this with a
+    commitment and a proof header rather than with a key and a message.
+    secp256k1-zkp's `secp256k1_rfc6979_hmac_sha256` reseeds between
+    every pair of draws whichever kind they are.
+    """
+
+    def __init__(self, seed: bytes, hf: HashF) -> None:
+        self.hf = hf
+        hf_size = hf().digest_size
+        self.v = b"\x01" * hf_size  # 3.2.b
+        self.k = b"\x00" * hf_size  # 3.2.c
+
+        self.k = hmac.new(self.k, self.v + b"\x00" + seed, hf).digest()  # 3.2.d
+        self.v = hmac.new(self.k, self.v, hf).digest()  # 3.2.e
+        self.k = hmac.new(self.k, self.v + b"\x01" + seed, hf).digest()  # 3.2.f
+        self.v = hmac.new(self.k, self.v, hf).digest()  # 3.2.g
+
+    def generate(self, size: int) -> bytes:
+        """Return that many octets, whole hash outputs cut to length.
+
+        `secp256k1_rfc6979_hmac_sha256_generate` sets its retry flag at
+        the end of every call and runs `reseed`'s update at the start of
+        every call after the first, so a caller mirroring
+        `secp256k1_rangeproof_genrand` over more than one draw calls
+        `reseed` between them. Leaving that to the caller is what lets
+        `_rfc6979_nonce_` reseed only where RFC6979 says to.
+        """
+        t = b""  # 3.2.h.1
+        while len(t) < size:  # 3.2.h.2
+            self.v = hmac.new(self.k, self.v, self.hf).digest()
+            t += self.v
+        return t[:size]
+
+    def reseed(self) -> None:
+        """Advance K and V: 3.2.h.3's step, and zkp's between two draws."""
+        self.k = hmac.new(self.k, self.v + b"\x00", self.hf).digest()
+        self.v = hmac.new(self.k, self.v, self.hf).digest()
+
+
 def _rfc6979_nonce_(
     c: int, q: int, ec: Curve, hf: HashF, extra_entropy: bytes | None
 ) -> int:
@@ -84,20 +135,8 @@ def _rfc6979_nonce_(
     # less entropy -- so a caller holding either passes it unchanged
     bprvbm = q_bytes + c_bytes + (extra_entropy or b"")
 
-    hf_size = hf().digest_size
-    v = b"\x01" * hf_size  # 3.2.b
-    k = b"\x00" * hf_size  # 3.2.c
-
-    k = hmac.new(k, v + b"\x00" + bprvbm, hf).digest()  # 3.2.d
-    v = hmac.new(k, v, hf).digest()  # 3.2.e
-    k = hmac.new(k, v + b"\x01" + bprvbm, hf).digest()  # 3.2.f
-    v = hmac.new(k, v, hf).digest()  # 3.2.g
-
+    drbg = _HmacDrbg(bprvbm, hf)
     while True:  # 3.2.h
-        t = b""  # 3.2.h.1
-        while len(t) < ec.n_size:  # 3.2.h.2
-            v = hmac.new(k, v, hf).digest()
-            t += v
         # reducing the hash mod n -- whether the whole of it or its
         # leftmost nlen bits -- would introduce a bias, which is why
         # neither is done here.
@@ -107,11 +146,11 @@ def _rfc6979_nonce_(
         # However, if the order n is sufficiently close to 2^hf_len,
         # then the bias is not observable: e.g.
         # for secp256k1 and sha256 1-n/2^256 it is about 1.27*2^-128
-        nonce = int_from_bits(t, ec.nlen)  # candidate nonce           # 3.2.h.3
+        candidate = drbg.generate(ec.n_size)
+        nonce = int_from_bits(candidate, ec.nlen)  # candidate nonce    # 3.2.h.3
         if 0 < nonce < ec.n:  # acceptable values for nonce
             return nonce  # successful candidate
-        k = hmac.new(k, v + b"\x00", hf).digest()
-        v = hmac.new(k, v, hf).digest()
+        drbg.reseed()
 
 
 def rfc6979_nonce_(

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -2527,7 +2527,15 @@ from the caller's -- so `sign` called again with an entry's `blind`,
 `nonce`, `value` and `sign arguments` answers that entry's `proof`,
 byte for byte. `test_the_vectors_are_what_zkp_signs_today` is that
 check, so the procedure is a test rather than a note here, and it runs
-wherever the extension does.
+wherever the extension does. The same determinism makes the entries
+signed at a negative `exp` an oracle for what btclib writes:
+`sign_public_value` builds those proofs from an entry's own `blind`,
+`value` and `nonce`, and
+`test_sign_public_value_writes_the_octets_zkp_signed` holds it to these
+octets wherever the suite runs, extension or not. Both shapes such a
+proof has are recorded, `public value` carrying a `min_value` field and
+`public value, zero` carrying none, so neither is left to the weekly
+sentinel.
 
 **The `info` key is why a run without the extension still compares
 against something.** Those are `zkp.rangeproof.info`'s own answers for

--- a/tests/ecc/_data/zkp_rangeproof_vectors.json
+++ b/tests/ecc/_data/zkp_rangeproof_vectors.json
@@ -85,5 +85,22 @@
       "min value": 0,
       "max value": 102300
     }
+  },
+  {
+    "id": "public value, zero",
+    "blind": "0606060606060606060606060606060606060606060606060606060606060606",
+    "nonce": "8686868686868686868686868686868686868686868686868686868686868686",
+    "value": 0,
+    "sign arguments": {
+      "exp": -1
+    },
+    "commitment": "09f006a18d5653c4edf5391ff23a61f03ff83d237e880ee61187fa9f379a028e0a",
+    "proof": "0056c634523225ab6a836f68398144623aea3b109692387f62fcf934f37605c2c71bc9a94acf0e13113a4f9ddf2aaab3e0b8a28d3ed3ab5da585730008b610c426",
+    "info": {
+      "exp": -1,
+      "mantissa": 0,
+      "min value": 0,
+      "max value": 0
+    }
   }
 ]

--- a/tests/ecc/rangeproof_test.py
+++ b/tests/ecc/rangeproof_test.py
@@ -19,9 +19,20 @@ is silent about -- the sign bits, the ring commitments and the
 signature; and that the length the mantissa implies is the length zkp
 wrote.
 
+The entries whose `sign arguments` are an `exp` of -1 are asked one
+thing more, and it is the strongest question in this file:
+`sign_public_value`, given such an entry's own `blind`, `value` and
+`nonce`, has to answer its octets. A rangeproof draws nothing, so those
+three are the whole of what produced the recording, and an
+implementation that agrees with zkp at every step is the only one that
+lands on the same octets. Both shapes that proof has are recorded, the
+one carrying a `min_value` field and the one whose value is zero and
+carries none.
+
 The `zkp`-marked tests at the end put the same questions to the library
-itself, and one more the recording needs: that signing again with the
-recorded arguments answers the very octets vendored here.
+itself, and two more the recording cannot answer: that signing again
+with the recorded arguments answers the very octets vendored here, and
+that values no entry carries are written the same way.
 """
 
 from io import BytesIO
@@ -30,9 +41,10 @@ from typing import Any
 import pytest
 
 from btclib.curves import secp256k1
+from btclib.ecc import rangeproof
 from btclib.ecc.borromean import BorromeanSig
-from btclib.ecc.rangeproof import RangeProof
-from btclib.exceptions import BTClibValueError
+from btclib.ecc.rangeproof import RangeProof, sign_public_value
+from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from tests import load, needs_zkp, replace_unchecked, vector_id
 
 # guarded module scope, the same shape `tests/ecc/pedersen_test.py` uses:
@@ -52,8 +64,23 @@ _HAS_NZ_RANGE = 64
 _HAS_MIN = 32
 
 
+def _vector(id_: str) -> dict[str, Any]:
+    return next(v for v in _VECTORS if v["id"] == id_)
+
+
 def _octets(id_: str) -> bytes:
-    return bytes.fromhex(next(v for v in _VECTORS if v["id"] == id_)["proof"])
+    return bytes.fromhex(_vector(id_)["proof"])
+
+
+# every entry `sign_public_value` can be asked for, and the arguments of
+# one of them, read out of the file rather than repeated as literals: an
+# entry whose `exp` is -1 is the shape this module writes, so the tests
+# below that build a proof instead of reading one ask with arguments the
+# recording names
+_PUBLIC_VALUES = [v for v in _VECTORS if v["sign arguments"] == {"exp": -1}]
+_PUBLIC_VALUE_IDS = [vector_id(i, v["id"]) for i, v in enumerate(_PUBLIC_VALUES)]
+_BLIND = _vector("public value")["blind"]
+_NONCE = _vector("public value")["nonce"]
 
 
 def _header_size(octets: bytes) -> int:
@@ -340,6 +367,154 @@ def test_rsizes_are_the_digits_the_mantissa_asks_for() -> None:
         assert RangeProof.parse(_octets(id_)).rsizes == rsizes
 
 
+class _FixedDraw:
+    """A `_HmacDrbg` whose chain the test wrote.
+
+    `sign_public_value` builds one and asks it once, so a stand-in with
+    a `generate` is the whole of what has to be replaced: the draws
+    below are refused at one in about 2**128 and cannot be reached by
+    choosing a nonce.
+    """
+
+    def __init__(self, octets: bytes) -> None:
+        self.octets = octets
+
+    def generate(self, size: int) -> bytes:
+        return self.octets[:size]
+
+
+@pytest.mark.parametrize("vector", _PUBLIC_VALUES, ids=_PUBLIC_VALUE_IDS)
+def test_sign_public_value_writes_the_octets_zkp_signed(
+    vector: dict[str, Any],
+) -> None:
+    """The vendored entries, asked of this module rather than of the library.
+
+    A rangeproof draws nothing, so an entry's `blind`, `value` and
+    `nonce` are the whole of what produced its proof: writing them again
+    here has to answer those octets. `zkp.rangeproof.verify` accepting
+    the result would say only that it is *a* proof, where this says it
+    is the same one.
+
+    Selected on the `sign arguments` rather than by name, so an entry
+    recorded later with exactly an `exp` of -1 is asked this too. Exact
+    equality and not the `exp` alone: `sign_public_value` takes a
+    blinding factor, a value and a nonce, so an entry recorded with any
+    further argument -- an `extra_commit`, which enters the challenge --
+    is not one it can be held to.
+    """
+    proof = sign_public_value(vector["blind"], vector["value"], vector["nonce"])
+    assert proof.serialize().hex() == vector["proof"]
+
+
+def test_the_proof_written_carries_no_ring_commitment() -> None:
+    """One ring, so there is nothing for a squareness bit to be written on.
+
+    A proof carries one ring commitment per ring but the last, one sign
+    bit each, and the public-value proof has a single ring. So what
+    `sign_public_value` writes exercises neither the digit
+    decomposition nor the residuosity convention on a ring commitment,
+    and that is the distance still ahead of it rather than a property of
+    this test.
+    """
+    proof = sign_public_value(_BLIND, 100000, _NONCE)
+    assert proof.rsizes == (1,)
+    assert proof.signs == ()
+    assert proof.ring_commitments == ()
+    assert tuple(len(ring) for ring in proof.sig.s) == (1,)
+
+
+def test_a_public_value_of_zero_carries_no_min_value_field() -> None:
+    """`min_value ? 32 : 0` is zkp's own flag, and here the value is the min.
+
+    So a public value of zero writes the flags octet, the `e0` and the
+    one `s` with no eight-octet field between them, which is also the
+    shortest buffer `secp256k1_rangeproof_sign_impl` accepts. That zkp
+    writes those octets is the `public value, zero` entry's to say, and
+    the test above is where it says it; what is here is the shape, read
+    off the object rather than off the recording.
+    """
+    vector = _vector("public value, zero")
+    proof = sign_public_value(vector["blind"], vector["value"], vector["nonce"])
+    octets = proof.serialize()
+    assert proof.min_value is None
+    assert octets[0] == 0
+    assert len(octets) == 1 + 32 + 32
+    assert RangeProof.parse(octets).serialize() == octets
+
+
+def test_sign_public_value_refuses_what_it_has_no_octets_for() -> None:
+    """Each argument against what the format and the curve allow."""
+    with pytest.raises(BTClibValueError, match="private key not in 1..n-1"):
+        sign_public_value(0, 1, _NONCE)
+
+    err_msg = "rangeproof value not in 0..2\\*\\*64-1: "
+    with pytest.raises(BTClibValueError, match=f"{err_msg}-1"):
+        sign_public_value(_BLIND, -1, _NONCE)
+    with pytest.raises(BTClibValueError, match=f"{err_msg}18446744073709551616"):
+        sign_public_value(_BLIND, 2**64, _NONCE)
+
+    with pytest.raises(BTClibValueError, match="invalid size: 31 bytes instead of 32"):
+        sign_public_value(_BLIND, 1, _NONCE[:-2])
+
+
+@pytest.mark.parametrize(
+    "draw",
+    [bytes(32), secp256k1.n.to_bytes(32, "big")],
+    ids=["zero", "at n"],
+)
+def test_a_draw_that_is_no_scalar_is_refused_and_not_redrawn(
+    draw: bytes, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`genrand`'s rule and not RFC6979's, which is why they are two rules.
+
+    `secp256k1_scalar_set_b32` flags a draw at or past n, refuses zero
+    beside it, and `secp256k1_rangeproof_sign_impl` returns zero on
+    either -- where `rfc6979_nonce` asks the same chain for its next
+    candidate. A proof written from that next block is one zkp does not
+    write.
+    """
+    monkeypatch.setattr(rangeproof, "_HmacDrbg", lambda *_: _FixedDraw(draw))
+    with pytest.raises(BTClibRuntimeError, match="nonce is not a scalar"):
+        sign_public_value(_BLIND, 1, _NONCE)
+
+
+@pytest.mark.parametrize(
+    "challenge",
+    [bytes(32), secp256k1.n.to_bytes(32, "big")],
+    ids=["zero", "at n"],
+)
+def test_a_challenge_that_is_no_scalar_is_refused(
+    challenge: bytes, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same refusal a step later, where `ecc.borromean` makes none.
+
+    `secp256k1_borromean_sign` reads its challenge through
+    `secp256k1_scalar_set_b32` too and returns zero on the flag, where
+    `borromean.sign` takes the hash modulo n and carries on. Reducing
+    here would write a proof `secp256k1_borromean_verify` refuses.
+    """
+    monkeypatch.setattr(rangeproof, "_hash", lambda *_: challenge)
+    with pytest.raises(BTClibRuntimeError, match="challenge is not a scalar"):
+        sign_public_value(_BLIND, 1, _NONCE)
+
+
+def test_a_zero_signature_value_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    """There is one challenge that makes k - e*blind vanish, and zkp refuses it.
+
+    Both halves are handed in, that challenge being k over the blinding
+    factor: `secp256k1_borromean_sign` returns zero rather than write
+    the s, and `secp256k1_borromean_verify` refuses one it is handed.
+    """
+    k = 5
+    e = k * pow(int(_BLIND, 16), -1, secp256k1.n) % secp256k1.n
+    monkeypatch.setattr(
+        rangeproof, "_HmacDrbg", lambda *_: _FixedDraw(k.to_bytes(32, "big"))
+    )
+    monkeypatch.setattr(rangeproof, "_hash", lambda *_: e.to_bytes(32, "big"))
+    with pytest.raises(BTClibRuntimeError, match="signature value is zero"):
+        sign_public_value(_BLIND, 1, _NONCE)
+
+
 # `pragma: no cover` on every `@needs_zkp` below, the marker being the
 # reason: `ZKP_AVAILABLE` is False in every job that measures coverage,
 # and `zkp-oracle.yml`'s own `pytest -m zkp --no-cov` collects none. The
@@ -435,3 +610,25 @@ def test_zkp_refuses_what_this_parse_refuses() -> None:
     assert zkp_rangeproof.info(octets + b"\x00") == whole
     assert zkp_rangeproof.verify(commitment, octets[:65]) is None
     assert zkp_rangeproof.verify(commitment, octets + b"\x00") is None
+
+
+@needs_zkp  # pragma: no cover -- no zkp.rangeproof to sign the same arguments
+def test_zkp_signs_and_verifies_the_proof_this_module_writes() -> None:
+    """The library asked for the octets `sign_public_value` answers.
+
+    Four values under one blinding factor and one nonce: 100000, which
+    the recording fixes under these same arguments; zero, which it fixes
+    under others; and one and the widest the eight-octet field holds,
+    which no entry fixes at this exponent. `verify` is asked beside
+    `sign`
+    because the two are different questions -- the first says zkp writes
+    these octets, the second that zkp reads them as the range they
+    state.
+    """
+    blind = bytes.fromhex(_BLIND)
+    nonce = bytes.fromhex(_NONCE)
+    for value in (0, 1, 100000, 2**64 - 1):
+        commitment = zkp_generator.pedersen_commit(blind, value)
+        octets = sign_public_value(_BLIND, value, _NONCE).serialize()
+        assert octets == zkp_rangeproof.sign(commitment, blind, nonce, value, exp=-1)
+        assert zkp_rangeproof.verify(commitment, octets) == (value, value)


### PR DESCRIPTION
Third slice of [ISS 1072](https://github.com/btclib-org/btclib/issues/1072),
which stays open: this writes one proof shape, not the rangeproof.

`sign_public_value` writes `secp256k1_rangeproof_sign_impl`'s `exp = -1`
proof — the value in the clear, one ring holding the single key the
commitment itself gives. The digit decomposition, the mantissa,
`rangeproof_pub_expand`, the squareness bit, verifying and rewinding all
stay ahead of the module.

The boundary was drawn once and redrawn: the degenerate proof cannot be
written without the nonce chain, which the coder established by
rebuilding all 73 octets from `hashlib`, `hmac` and hand-written curve
arithmetic rather than by argument. So `ecc.rfc6979_nonce._HmacDrbg` is
extracted and shared rather than copied, with what the two callers
disagree on left above it.

They disagree twice, and the second disagreement cost this branch a
round. `secp256k1_rangeproof_genrand` has two acceptance rules, not one:
it asks the chain again for a ring blinding factor outside 1..n-1, and
fails outright on a ring member's own draw. Only the second is what a
single ring takes. An earlier revision stated the failing rule as a
property of the whole function; the review caught it, and the arm it got
wrong is the one a later slice of this issue will write from this same
docstring.

The retry arm is not merely analogous to `_rfc6979_nonce_`'s, it is the
identical operation sequence — zkp's `generate` performs the K/V update
at the start of every call after the first, so the `do` loop's second
`generate` is a `reseed()` followed by a `generate()`. Verified as one
retry iteration against `reseed(); generate()` with block, K and V all
identical, and over twelve successive draws, each with a control that
fails without the reseed.

## What the check is

Byte identity with the entries of
`tests/ecc/_data/zkp_rangeproof_vectors.json` recorded at an `exp` of
-1, and it needs no flagged extension: a rangeproof draws nothing, so an
entry's `blind`, `value` and `nonce` are the whole of what produced its
octets. Both shapes are recorded — one carrying a `min_value` field, one
whose value is zero and carries none — so neither waits on the weekly
sentinel. The zkp-marked test adds the same comparison over values no
entry fixes at that exponent, and `zkp.rangeproof.verify` reading the
range back.

Every nonce this library already derived is the octets it was before,
over each curve in `CURVES` and five hash functions: 2700 pairs, no
disagreement, plus RFC 6979 appendix A.2's 50 vectors.

## Landing note

`CHANGELOG.md` carries `merge=union`, and the rebase onto `d34f9f7d` ate
the blank line above this branch's `###` heading — invisible to `git
diff`, `range-diff` and `--numstat`. It was answered with `git
merge-tree --write-tree` *before* the rebase was paid for, repaired, and
verified by two instruments: the whole-file invariant and a byte
reconstruction. The seam check ran before the gates, since
`markdownlint-cli2 --fix` repairs a glued heading silently and reports
`Passed` on the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Implement writing and validation coverage for the secp256k1-zkp exp = -1 rangeproof that reveals a committed value.

New Features:
- Add deterministic support for writing secp256k1-zkp rangeproofs that expose a committed value using the exp = -1 proof shape.
- Share an RFC6979 HMAC-DRBG implementation between standard nonce generation and rangeproof signing.

Enhancements:
- Match secp256k1-zkp nonce, challenge, and signature validity behavior for public-value proofs, including rejecting invalid scalar draws and zero signature values.
- Refine rangeproof documentation and expose the new writer through the ECC package documentation.

CI:
- Expand the ZKP oracle workflow to cover rangeproof writing and the shared nonce implementation.

Documentation:
- Document the public-value rangeproof format, its limitations, and compatibility with secp256k1-zkp.

Tests:
- Add vector, structural, invalid-input, edge-case, and optional ZKP interoperability tests for public-value rangeproof signing.
- Verify that existing RFC6979 nonce outputs remain unchanged across curves and hash functions.