### PR TITLE
An issue's state is the tracker's, and an entry gives a tree and a sha (issue btclib-org/.github#946)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2954,6 +2954,46 @@ file of the test tree, and no caller acts on it.
   rangeproof hashes is the value commitment, the generator and the
   proof's own header.
 
+### An issue's state is the tracker's, and an entry gives a tree and a sha
+
+- **This supersedes *`curve_group.toml` and `mutation.yml` report the
+  curve session as sampled* above, whose entry defers the triage of those
+  survivors to issue #1745** (issue btclib-org/.github#946): that issue is
+  closed, on 2026-09-06. `dd36af56` is what closed it, and what it did is
+  what the deferral owed a reader -- `curve_group.toml`'s header states
+  what the two sessions' survivors are rather than naming an issue that
+  will say.
+- **This supersedes *`zkp-oracle` is an integration sentinel, and is
+  scheduled as one* above, whose entry has `tests/grid_test.py` in
+  `btclib-org/.github` reading a disagreement until both halves land**
+  (issue btclib-org/.github#946): btclib-org/.github#926 is closed, on
+  2026-09-08. This repository took `cron: "4 2 * * 3"` in `8f4450e4` and
+  `btclib-org/.github` took section 10's row in
+  btclib-org/.github@b4fb6b7, which is the pair that sentence was waiting
+  on.
+- **This supersedes *`btclib.electrum`, the Electrum protocol codec, and
+  `ElectrumFetcher`* above, whose entry names issue #1127 as still to be
+  answered for the transport half** (issue btclib-org/.github#946): what
+  that sentence owed a reader is `febc2c47`, which landed the codec, the
+  fetcher and a `LineTransport` declared with no implementation, and the
+  reference alone for the rest, that issue being where the transport and
+  its default are written down. It answered open when read on 2026-09-09,
+  and the tracker is where that answer is current.
+- **This supersedes *`ssa.py`'s sign-to-contract tags switch to
+  `s2c/schnorr/…`* above, whose entry rests the spelling's mutability on
+  bitcoin-core/secp256k1#1140 being unmerged** (issue
+  btclib-org/.github#946): `c2d23636` is where `s2c/schnorr/point` and
+  `s2c/schnorr/data` were frozen here, and what they match is that pull
+  request at its head `49c31379`, which stays checkable whatever it does
+  next. It answered open and unmerged when read on 2026-09-09, on a
+  tracker outside this organization, so nothing here is told when it
+  merges.
+- **One entry above is itself a repair that repeated what it repaired**:
+  *`curve_group.toml` and `mutation.yml` report the curve session as
+  sampled* replaced a deferral to a closed issue with a deferral to one
+  that closed later in this same section, where a tree and a sha would
+  have stayed true.
+
 ## v2026.9.3
 
 ### Repository


### PR DESCRIPTION
Four entries in the open section of `CHANGELOG.md` said what a tracker
held rather than what an issue records, and one of the four was itself a
repair that repeated the defect it was repairing. This adds one entry
that supersedes all four, giving a tree and a sha where each of them
gave a state.

- *`curve_group.toml` and `mutation.yml` report the curve session as
  sampled* deferred the triage of its survivors to `btclib#1745`. That
  issue closed on 2026-09-06 in `dd36af56`, and what `dd36af56` did —
  `curve_group.toml`'s header now stating the two sessions' survivors —
  is what the deferral owed a reader.
- *`zkp-oracle` is an integration sentinel, and is scheduled as one*
  left `tests/grid_test.py` in `btclib-org/.github` reading a
  disagreement until both halves landed. `btclib-org/.github#926` closed
  on 2026-09-08; the halves are `8f4450e4` here and
  `btclib-org/.github@b4fb6b7` there.
- *`btclib.electrum`, the Electrum protocol codec, and
  `ElectrumFetcher`* named `btclib#1127` as still to be answered for the
  transport half. `febc2c47` is what it owed a reader: the codec, the
  fetcher, and a `LineTransport` declared with no implementation.
- *`ssa.py`'s sign-to-contract tags switch to `s2c/schnorr/…`* rested
  the spelling's mutability on `bitcoin-core/secp256k1#1140` being
  unmerged. `c2d23636` is where the two tags were frozen here, and what
  they match is that pull request **at its head `49c31379`** — a sha
  that stays checkable whatever the pull request does next, on a tracker
  outside this organization that tells nothing here when it merges.

Where a state is still the useful fact — `btclib#1127` and
`bitcoin-core/secp256k1#1140` are both open — the entry dates the
reading rather than asserting the state: *it answered open when read on
2026-09-09*. A claim about a reading does not expire.

The fifth bullet is the reflexive one, and it is the reason this entry
is worth its length: the first entry above was itself a repair, and it
replaced a deferral to a closed issue with a deferral to one that closed
later **in this same section**. Nothing else in the file records that,
and bullet 1 alone would not — it says `#1745` is closed, never that the
entry citing it was already an attempt at this fix.

This is `btclib`'s half of `btclib-org/.github#946`, which also owes a
sentence in the standard, so this branch closes nothing.

An issue's state is the tracker's, and an entry gives a tree and a sha (issue btclib-org/.github#946)

The entries superseded here rest a sentence on an issue's state rather
than on what the entry records: the mutation profiles' deferral of a
triage to issue #1745, the zkp-oracle cron's wait on
btclib-org/.github#926, btclib.electrum's naming of issue #1127 as
still to be answered for the transport half, and ssa.py's tag spelling
resting on bitcoin-core/secp256k1#1140 being unmerged. Issue #1745 is
closed, on 2026-09-06, and btclib-org/.github#926 on 2026-09-08, so
those two sentences are already false; the other two answered open when
read on 2026-09-09 and go the same way with nothing in this tree
changing.

CHANGELOG.md is append-only and merge=union, so nothing already written
is edited. The repair is one new entry at the end of the open section,
naming each superseded entry by its heading, paraphrasing the sentence,
and giving what a state claim owed a reader instead: the landing sha
here, the sibling's sha where a second tree was waited on, and the
reference alone where the question is genuinely still written down, with
the reading dated.

The mutation-profile entry was itself a repair, of a deferral to a
closed issue, and it put another issue in the same place; the new entry
says so, that being what makes a tree and a sha the replacement rather
than the next issue in the chain.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011PgNKwAoV6S7Gvjcizbh6L


Reviewed locally at fresh context and **CLEARED at `c393f0f5`**. The reviewer did not re-run the gates and says so, attributing them to the coder's logs which it read rather than to the report's summary of them. What it measured itself: the tip is the base with exactly one 2429-byte insertion and nothing else touched (`tip == base[:174308] + block + base[174308:]`, byte-level from the object store), which is a stronger statement than the `40 0` diffstat and settles the heading-glue question everywhere but at the seam, where the blank line survives; its own scan of the added block with a vocabulary deliberately wider than the coder's found 23 candidate phrases and classified every one by reading — 9 reported speech about append-only entries, 6 dated closures, 3 dated readings, 5 not about an issue's state at all — so no undated assertion of any issue's state survives and the repair does not join the class it repairs; all five referenced states re-read at 2026-09-09T17:23:31Z and each matching what the entry says; and `bitcoin-core/secp256k1#1140`'s own patch at head `49c31379` confirmed to define the two tags byte for byte, after a first grep answered a false zero because that patch spells them per character. Gates on that tree, all nine at `c393f0f5`, from the run's own `$?` echoes in `gates-946-btclib-c393f0f5.log` with its `ALLDONE` terminator: `uv sync`, `uv run ruff check --fix`, `uv run ruff format`, `uv run mypy src/btclib tests .github/scripts`, `uv run pytest` (`32294 passed, 44 skipped, 1 xfailed`, `Required test coverage of 100.0% reached. Total coverage: 100.00%`), `uv run pre-commit run --all-files` (42 lines ending `Passed`, none ending `Failed`) and `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html` — a cold build that read and wrote `changelog_link`, so it crossed this diff through the MyST include, ending `build succeeded.` — each exit 0; then `grep -rnE 'href="#\.\.?/'` over the built HTML exits **1**, which is that gate's pass, with the control `grep -rnc 'href="#' index.html` answering 22 on the same tree so the exit 1 is an absence and not a failed read. A second full run at the pre-rebase sha `91362101` reached the same nine exit codes, so neither run fell and there is no green-after-red pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PgNKwAoV6S7Gvjcizbh6L

## Summary by Sourcery

Replace mutable issue-state claims in the changelog with durable commit, tree, and dated tracker references.

Bug Fixes:
- Correct the changelog’s four issue-state references by recording the relevant commits, sibling-tree changes, or dated tracker readings instead of relying on mutable issue status.

Enhancements:
- Add a consolidated changelog entry explaining the superseded references and identifying the earlier repair that repeated the same state-based defect.

Documentation:
- Update the append-only changelog with durable, verifiable references for completed and still-open work.