### PR TITLE
`CHANGELOG.md` corrects the sealed borromean claim from the open section (closes #1889)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2994,6 +2994,22 @@ file of the test tree, and no caller acts on it.
   that closed later in this same section, where a tree and a sha would
   have stayed true.
 
+### The released `v2026.8.21` borromean entry stays as it was published
+
+- **`CHANGELOG.md`'s `## v2026.8.21` section keeps the clause calling
+  secp256k1-zkp's `rangeproof` module the only other implementation of
+  this construction anything reads** (closes #1889). The clause is
+  false, and issue #1881 carries the code search for `borromean_sign`
+  that refutes it. Correcting it where it stands is what this entry
+  rejects: a released section is the record of what was published, and
+  `tests/changelog_immutability_test.py` holds each one to its own tag.
+- **What an edit there would cost is that gate over the whole section.**
+  The exemption it needs is a `_KNOWN_DRIFT` entry, which is keyed on
+  the section rather than on the edit and marks it `xfail(strict=True)`,
+  so any further line a rebase's `merge=union` resolution puts into
+  `## v2026.8.21` becomes an expected failure as well -- which is the
+  damage that module exists to catch.
+
 ## v2026.9.3
 
 ### Repository


### PR DESCRIPTION
Closes [ISS 1889](https://github.com/btclib-org/btclib/issues/1889).

The false "only other implementation of this construction anything
reads" clause was deleted from the open section by
[PR #1890](https://github.com/btclib-org/btclib/pull/1890). The same
clause also sits in the released, tag-sealed `v2026.8.21` section, where
it is still false and still published.

## The decision, which is the work here

The issue offered two shapes. **This takes a third: `v2026.8.21` stays
byte-identical to its tag, and the correction is a new entry at the end
of the open section.** The record stays the record.

Both alternatives were rejected on measurements, not on taste, and both
measurements were re-derived independently at review:

- **Registering the section as known drift and leaving the text is
  incoherent, not a compromise.** `_KNOWN_DRIFT` marks its cases
  `xfail(strict=True)` and `v2026.8.21` currently *matches* its tag, so
  registering it alone yields `[XPASS(strict)]` and exit 1.
- **Editing the sealed section and registering the drift blinds the gate
  over the whole section.** The exemption is keyed on `(path, version)`
  and the check compares the entire `## v<version>` block byte for byte,
  so it cannot be narrowed to one edit. With the exemption registered, a
  planted bullet 162 lines away from the clause — inside the same
  section, which spans 8582 lines — goes green:

  | configuration | result | exit |
  |---|---|---|
  | damage planted, no exemption | fails on `[CHANGELOG.md-v2026.8.21]` | 1 |
  | damage planted, exemption registered | 11 passed, 18 skipped | 0 |

  That is exactly the `merge=union` rebase damage the module exists to
  catch, and its own docstring records this section having been hit by it
  once already.

Correcting one false clause by blinding the detective control over the
largest sealed section is a bad trade.

## Idiom

Correcting a landed entry from a later entry is house style here, not an
invention: the open section already carries *"An entry cites an issue for
what it records, not for its state"*, five bullets of "This supersedes
*&lt;entry&gt;* above".

## The claim itself

Re-derived rather than inherited: `cslashm/ECPy`'s `borromean-draft.py`
(Python, Apache-2.0, its own `borromean_hash`) and `jbird186/RingCT`'s
`src/rangeproof/borromean.rs` (Rust, MPL-2.0, over Ristretto) both exist
and both say what the entry claims. Verified again at review.

## Mechanical trace

Driving the immutability check over every released heading at this tip,
exactly one fails — `v2026.8.7`, which was already exempt — confirming
`v2026.8.21` was not registered. Every released section is byte-identical
to the base and the open section's base text is a strict prefix of the
tip's: a pure append, nothing above it moved.

## Collateral

[ISS 1901](https://github.com/btclib-org/btclib/issues/1901): the drift
exemption covers a whole section, so further drift in it goes
unreported. Pre-existing, not caused by this change, and a third cost of
the shape this branch rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Document the false borromean implementation claim in a new changelog entry while preserving the byte-for-byte integrity of the released v2026.8.21 section.

Enhancements:
- Document the correction of the false borromean implementation claim while preserving the released v2026.8.21 changelog section unchanged.
- Record the rationale for using a new open-section entry instead of modifying the sealed release history or weakening its immutability checks.

Documentation:
- Add a changelog entry clarifying that the v2026.8.21 borromean claim is false and that the published release record remains immutable.