### PR TITLE
`ecc.rangeproof` rebuilds the rings a proof's signature is over (issue #1072)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3028,6 +3028,47 @@ file of the test tree, and no caller acts on it.
   section**: what an exemption there costs now is the digest, so the
   further line is what fails.
 
+### `ecc.rangeproof` rebuilds the rings a proof's signature is over
+
+- **`RangeProof.pubk_rings` answers, from a proof and the value
+  commitment it was written against, the rings
+  `secp256k1_borromean_verify` is handed** (issue #1072). It is
+  `secp256k1_rangeproof_verify_impl` up to that call and no further:
+  every ring commitment the proof states, resolved against the sign bit
+  beside it; the one the proof does not state, recovered as the
+  commitment less `min_value` times the generator and less all the
+  others; and `secp256k1_rangeproof_pub_expand` over them, a ring's keys
+  stepping down by the weight of the digit that ring proves.
+  `RangeProof.sign_key_idx` is that decomposition itself,
+  `secp256k1_range_proveparams`' `secidx` under the name
+  `ecc.borromean.sign` gives the same argument. Nothing here reads `e0`
+  or an `s`, and nothing here signs: verifying a proof, rewinding one
+  and writing one that states a range rather than a value are all still
+  ahead of the module.
+- **What holds it is a sum no octet of a proof carries, and it needs no
+  flagged extension to run.** The key a ring's own digit names is that
+  ring's blinding factor times G; `secp256k1_rangeproof_genrand` answers
+  the last ring's with minus the sum of the rest and
+  `secp256k1_rangeproof_sign_impl` adds the caller's to it, so the keys
+  `sign_key_idx` names add up to `blind * G` -- and `blind` is what
+  every entry of `tests/ecc/_data/zkp_rangeproof_vectors.json` records
+  beside its proof. The published ring commitments cannot be asked
+  instead: each is `sec * G` plus its digit's own multiple of the
+  generator, with `sec` drawn from the chain the caller's nonce seeds,
+  so the value, the exponent and the mantissa do not determine them.
+- **An x resolves under residuosity, and that sum is blind to it.**
+  `secp256k1_ge_set_xquad` takes the y that is a square and
+  `secp256k1_rangeproof_verify_impl` negates it where the sign bit is
+  set, so reading the bit as parity answers a different point wherever
+  the square y is the odd one. The recovered ring commitment absorbs
+  exactly that error, the others' resolution being what it is subtracted
+  from, which is why the round trip back through `_serialize_point` is a
+  test of its own rather than a corollary of the one above. Where a
+  point sits is the same shape of gap: the sum reduces to
+  `sum(digit * weight) == value - min_value`, a scalar equation that
+  fixes no point to a ring, so each stated commitment is asserted at the
+  head of its own.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/ecc/rangeproof.py
+++ b/src/btclib/ecc/rangeproof.py
@@ -11,12 +11,12 @@ writes those octets back.
 
 `sign_public_value` writes one proof, and it is the one that proves no
 range: `exp` is -1, the value is stated in the clear, and the single
-ring holds the key the commitment itself gives. What a reader means by
-a rangeproof is on the far side of it -- the digit decomposition, the
-mantissa, `rangeproof_pub_expand`'s rings, and the squareness bit,
-which is written on a serialized ring commitment and so reaches no
-octet of a proof that carries none. Nothing here verifies a proof or
-rewinds one. Issue #1072 is where the rest of that distance is tracked.
+ring holds the key the commitment itself gives. `RangeProof.pubk_rings`
+rebuilds, from a proof and the value commitment it was written against,
+the rings `secp256k1_borromean_verify` is handed, and
+`RangeProof.sign_key_idx` says which key of each ring a value's own
+digit names. Nothing here verifies a proof or rewinds one. Issue #1072
+is where the rest of that distance is tracked.
 
 Elements and Liquid use this format, and a design starting today would
 choose bulletproofs, which zkp carries as its `bppp` module.
@@ -62,15 +62,29 @@ computed here -- a parse reads it and a serialize writes it back, so
 what a `RangeProof` holds is the octets' own answer -- while
 `_serialize_point` is that function of zkp's, and what
 `sign_public_value` hashes the value commitment and the generator
-under. A stage that resolves an x to a point computes against this
-convention and not the familiar one.
+under. Resolving an x back to a point is the same convention read the
+other way, and `_point_from_ring_commitment` is where this module does
+it: `secp256k1_ge_set_xquad` takes the y that is a square, and
+`secp256k1_rangeproof_verify_impl` negates it where the sign bit says
+the y is not one.
 
-Which points those are, and whether the signature over them verifies,
-this module does not ask: an x here is an integer of the width the
-format fixes. `assert_valid` refuses the headers
-`secp256k1_rangeproof_getheader_impl` refuses, and a body this object
-could not write the octets of; an x that names no point on the curve
-is neither, and a verifier is what turns it down.
+The digit decomposition is `rangeproof_pub_expand`: a ring's keys step
+down from the ring commitment by the weight of the digit that ring
+proves, `10**exp` for the first and four times its predecessor for each
+ring after it. The last ring states no commitment of its own --
+`secp256k1_rangeproof_verify_impl` recovers it as the value commitment
+less `min_value` times the generator and less every ring commitment
+before it, which is the digit a prover does not have to send. So the
+value commitment is what the whole structure hangs from, and it is
+`pubk_rings`'s argument.
+
+An x is an integer of the width the format fixes wherever a proof is
+parsed, serialized or held against itself: `assert_valid` refuses the
+headers `secp256k1_rangeproof_getheader_impl` refuses, and a body this
+object could not write the octets of, and an x naming no point on the
+curve is neither. `pubk_rings` is where an x has to name a point, and
+is what turns down one that does not. Whether the signature over those
+rings verifies, this module does not ask.
 """
 
 from __future__ import annotations
@@ -79,9 +93,9 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from hashlib import sha256
 
-from btclib.alias import BinaryData, Integer, Octets, Point
+from btclib.alias import INF, BinaryData, Integer, Octets, Point
 from btclib.curves import bytes_from_point, mult, scalar_from_prv_key, secp256k1
-from btclib.ecc.borromean import BorromeanSig, _hash
+from btclib.ecc.borromean import BorromeanSig, PubkeyRing, _hash
 from btclib.ecc.pedersen import commit, second_generator
 from btclib.ecc.rfc6979_nonce import _HmacDrbg
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
@@ -231,6 +245,51 @@ def _serialize_point(Q: Point) -> bytes:
     return bytes([0 if residue else 1]) + Q[0].to_bytes(secp256k1.p_size, "big")
 
 
+def _point_from_ring_commitment(x: int, sign: bool) -> Point:
+    """Return the point a ring commitment's x and sign bit name.
+
+    `secp256k1_rangeproof_verify_impl` reads its x through
+    `secp256k1_ge_set_xquad`, which is the y that is a square, and
+    negates the result where the sign bit is set. The parity convention
+    coincides with this one only where the square y is also the even
+    one, so reading the bit that way answers a different point on some x
+    coordinates and the same point on others, with nothing in the octets
+    saying which was read.
+    """
+    y = secp256k1.y_quadratic_residue_var(x)
+    return x, secp256k1.p - y if sign else y
+
+
+def _pub_expand(
+    ring_commitments: Sequence[Point], exp: int, rsizes: Sequence[int]
+) -> tuple[PubkeyRing, ...]:
+    """Return each ring's keys, from the commitment that ring opens at.
+
+    `secp256k1_rangeproof_pub_expand`. A ring's key at position j is its
+    commitment less j times the weight of the digit that ring proves, so
+    the position the prover knows the key of is the digit itself.
+
+    zkp reaches the first weight by doubling: it negates the generator
+    and multiplies by ten as many times as `exp` says, three doublings
+    and an addition each. One scalar multiplication is the same group
+    element, and this tree has one that libsecp256k1 answers where the
+    doubling chain would be Python arithmetic. The quadrupling between
+    rings stays as zkp writes it, needing no scalar at all.
+    """
+    # zkp holds a negative exponent at zero here, `pub_expand` being
+    # reached with the -1 of a proof that states its value
+    base = secp256k1.negate(mult(10 ** max(exp, 0), second_generator(), secp256k1))
+    rings: list[PubkeyRing] = []
+    for i, size in enumerate(rsizes):
+        ring = [ring_commitments[i]]
+        for _ in range(size - 1):
+            ring.append(secp256k1.add_aff_var(ring[-1], base))
+        rings.append(tuple(ring))
+        if i < len(rsizes) - 1:
+            base = secp256k1.double_aff_var(secp256k1.double_aff_var(base))
+    return tuple(rings)
+
+
 @dataclass(frozen=True, init=False)
 class RangeProof:
     """A Confidential Transactions rangeproof, as its octets state it.
@@ -331,6 +390,80 @@ class RangeProof:
             err_msg = f"borromean rings {sig_rsizes} are not the mantissa's"
             err_msg += f" {self.rsizes}"
             raise BTClibValueError(err_msg)
+
+    def pubk_rings(
+        self, commitment: Point, *, check_validity: bool = True
+    ) -> tuple[PubkeyRing, ...]:
+        """Return the rings of keys this proof's signature is over.
+
+        `secp256k1_rangeproof_verify_impl` up to the point where it hands
+        those rings to `secp256k1_borromean_verify`: every ring
+        commitment the proof states, resolved against the residuosity
+        convention the module docstring gives; the one it does not state,
+        recovered from `commitment`; and `_pub_expand` over all of them.
+        Nothing here reads `e0` or an `s`, so a proof whose signature is
+        wrong answers the same rings as one whose signature is right.
+
+        `commitment` is the Pedersen commitment the proof was written
+        against, `ecc.pedersen.commit`'s own point rather than octets --
+        the ones `secp256k1_pedersen_commitment_serialize` hands back
+        carry the residuosity bit too, `secp256k1_pedersen_commitment_save`
+        writing it at `9 ^ is_square(y)` where `_serialize_point` writes
+        `1 ^ is_square(y)`.
+
+        A commitment that leaves the last ring at infinity is refused,
+        as `secp256k1_rangeproof_verify_impl` refuses it where its own
+        `pubs[npub]` lands there: infinity is no public key. So is an x
+        at or past the field prime, which is
+        `secp256k1_fe_set_b32_limit`'s refusal and `Curve.y_var`'s own.
+        """
+        if check_validity:
+            self.assert_valid()
+        secp256k1.require_on_curve(commitment)
+
+        stated = [
+            _point_from_ring_commitment(x, sign)
+            for x, sign in zip(self.ring_commitments, self.signs, strict=True)
+        ]
+        # zkp's own order: the offset and the stated commitments are
+        # accumulated, the sum negated, and the commitment added to it
+        acc = (
+            mult(self.min_value, second_generator(), secp256k1)
+            if self.min_value
+            else INF
+        )
+        for point in stated:
+            acc = secp256k1.add_aff_var(acc, point)
+        last = secp256k1.add_aff_var(commitment, secp256k1.negate(acc))
+        if last == INF:
+            err_msg = "rangeproof last ring commitment is the point at infinity"
+            raise BTClibValueError(err_msg)
+
+        return _pub_expand([*stated, last], self.exp, self.rsizes)
+
+    def sign_key_idx(self, value: int) -> tuple[int, ...]:
+        """Return where in each ring the key of that value sits.
+
+        `secp256k1_range_proveparams`' `secidx`, and
+        `ecc.borromean.sign`'s argument of this name: the base-4 digits
+        of the value less `min_value` over `10**exp`, least significant
+        ring first. A ring of two takes the odd bit an odd mantissa
+        leaves over, and the digit there is below two because the value
+        is within the range the header states.
+
+        The value the proof was written for is what this answers for. A
+        value outside that range, or one the exponent's own scaling
+        cannot reach, is no digit of this proof and is refused.
+        """
+        min_value = self.min_value or 0
+        if not min_value <= value <= self.max_value:
+            err_msg = f"rangeproof value not in {min_value}..{self.max_value}: {value}"
+            raise BTClibValueError(err_msg)
+        v, remainder = divmod(value - min_value, 10 ** max(self.exp, 0))
+        if remainder:
+            err_msg = f"rangeproof value {value} is not the exponent's own multiple"
+            raise BTClibValueError(err_msg)
+        return tuple((v >> 2 * i) & 3 for i in range(len(self.rsizes)))
 
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the header, the sign bits, the commitments and the signature.

--- a/tests/ecc/rangeproof_test.py
+++ b/tests/ecc/rangeproof_test.py
@@ -29,6 +29,14 @@ lands on the same octets. Both shapes that proof has are recorded, the
 one carrying a `min_value` field and the one whose value is zero and
 carries none.
 
+Every entry is asked something further still, and this one needs no
+signature at all: `pubk_rings` and `sign_key_idx`, given the entry's own
+commitment and value, have to name keys that add up to the blinding
+factor the entry records. Nothing in a proof states that sum, and the
+published ring commitments cannot be asked to state it -- each carries a
+blinding factor drawn from the nonce chain, so the value, the exponent
+and the mantissa do not determine them.
+
 The `zkp`-marked tests at the end put the same questions to the library
 itself, and two more the recording cannot answer: that signing again
 with the recorded arguments answers the very octets vendored here, and
@@ -40,9 +48,10 @@ from typing import Any
 
 import pytest
 
-from btclib.curves import secp256k1
+from btclib.curves import mult, secp256k1
 from btclib.ecc import rangeproof
 from btclib.ecc.borromean import BorromeanSig
+from btclib.ecc.pedersen import commit, second_generator
 from btclib.ecc.rangeproof import RangeProof, sign_public_value
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from tests import load, needs_zkp, replace_unchecked, vector_id
@@ -367,6 +376,159 @@ def test_rsizes_are_the_digits_the_mantissa_asks_for() -> None:
         assert RangeProof.parse(_octets(id_)).rsizes == rsizes
 
 
+@pytest.mark.parametrize("vector", _VECTORS, ids=_IDS)
+def test_pubk_rings_open_at_the_recorded_blinding_factor(
+    vector: dict[str, Any],
+) -> None:
+    """The keys a proof's signature is over, checked with no signature read.
+
+    Each ring's key at the value's own digit is that ring's blinding
+    factor times G: `secp256k1_rangeproof_genrand` draws all but the
+    last and answers the last with minus their sum, and
+    `secp256k1_rangeproof_sign_impl` adds the caller's blinding factor
+    to it. So the keys `sign_key_idx` names add up to `blind * G`, which
+    the recording states and no octet of the proof does.
+
+    That sum is what pins the derivation before there is a verifier to
+    pin it. The published ring commitments cannot do it: each is
+    `sec * G` plus its digit's own multiple of the generator, and `sec`
+    comes from the chain the caller's nonce seeds, so the value, the
+    exponent and the mantissa do not determine them.
+
+    What the sum does not say is where a point sits. It reduces to
+    `sum(digit * weight) == value - min_value`, a scalar equation that
+    survives any permutation of the ring commitments across rings, the
+    recovered one included, so each stated commitment's placement is
+    asserted directly rather than inferred from it. The recovered one
+    needs no assertion beside them: with the stated heads, the digits
+    and the weights fixed, the sum leaves it a single group element.
+    """
+    proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
+    commitment = commit(vector["blind"], vector["value"])
+    # the entry's own commitment octets, which zkp writes under the same
+    # residuosity bit at another base: `9 ^ is_square(y)` for a Pedersen
+    # commitment where `_serialize_point` writes `1 ^ is_square(y)`
+    recorded = bytes.fromhex(vector["commitment"])
+    assert rangeproof._serialize_point(commitment) == (
+        bytes([recorded[0] ^ 8]) + recorded[1:]
+    )
+
+    rings = proof.pubk_rings(commitment)
+    assert tuple(len(ring) for ring in rings) == proof.rsizes
+    stated = tuple(
+        rangeproof._point_from_ring_commitment(x, sign)
+        for x, sign in zip(proof.ring_commitments, proof.signs, strict=True)
+    )
+    assert tuple(ring[0] for ring in rings[: len(stated)]) == stated
+    total = None
+    for ring, j in zip(rings, proof.sign_key_idx(vector["value"]), strict=True):
+        total = ring[j] if total is None else secp256k1.add_aff_var(total, ring[j])
+    assert total == mult(vector["blind"], secp256k1.G, secp256k1)
+
+
+@pytest.mark.parametrize("vector", _VECTORS, ids=_IDS)
+def test_sign_key_idx_is_the_value_s_own_base_four_digits(
+    vector: dict[str, Any],
+) -> None:
+    """Digit by digit, least significant ring first, back to the value.
+
+    `secp256k1_range_proveparams` writes `secidx[i] = (v >> (i*2)) & 3`
+    over the value less `min_value` and divided by ten as many times as
+    the exponent says, so weighing each digit by its own ring and
+    summing is what says the decomposition is that one. Each digit is a
+    position the ring it names has, the ring of two an odd mantissa ends
+    with included.
+    """
+    proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
+    sign_key_idx = proof.sign_key_idx(vector["value"])
+    v = sum(digit << 2 * i for i, digit in enumerate(sign_key_idx))
+    assert v * 10 ** max(proof.exp, 0) + (proof.min_value or 0) == vector["value"]
+    assert all(j < size for j, size in zip(sign_key_idx, proof.rsizes, strict=True))
+
+
+def test_a_ring_commitment_x_resolves_against_residuosity() -> None:
+    """`_serialize_point` read the other way, over every x vendored here.
+
+    `secp256k1_ge_set_xquad` answers the y that is a square and
+    `secp256k1_rangeproof_verify_impl` negates it where the sign bit is
+    set, so the round trip through `_serialize_point` is what says the
+    resolution is that serialization's own inverse. Reading the bit as
+    parity would answer a different point wherever the two conventions
+    disagree, and `test_the_sign_bit_is_residuosity_and_not_parity` is
+    where the vendored proofs are shown to carry both cases.
+    """
+    for vector in _VECTORS:
+        proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
+        for x, sign in zip(proof.ring_commitments, proof.signs, strict=True):
+            point = rangeproof._point_from_ring_commitment(x, sign)
+            octets = bytes([sign]) + x.to_bytes(secp256k1.p_size, "big")
+            assert rangeproof._serialize_point(point) == octets
+
+
+def test_sign_key_idx_refuses_a_value_this_proof_has_no_digit_for() -> None:
+    """Outside the range the header states, or between two of its steps."""
+    proof = RangeProof.parse(_octets("padded sign bits"))
+    err_msg = f"rangeproof value not in 1000..{proof.max_value}: "
+    with pytest.raises(BTClibValueError, match=f"{err_msg}999"):
+        proof.sign_key_idx(999)
+    with pytest.raises(BTClibValueError, match=f"{err_msg}{proof.max_value + 1}"):
+        proof.sign_key_idx(proof.max_value + 1)
+
+    # an exponent of 2, so the proof steps by a hundred and says nothing
+    # about what lies between two steps
+    scaled = RangeProof.parse(_octets("scaled exponent"))
+    err_msg = "rangeproof value 100001 is not the exponent's own multiple"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        scaled.sign_key_idx(100001)
+
+
+def test_pubk_rings_refuses_what_names_no_public_key() -> None:
+    """A commitment off the curve, an x on no point, and a ring at infinity.
+
+    The last is the one zkp checks by name: a commitment equal to
+    `min_value` times the generator leaves the single ring of a
+    public-value proof at infinity, and
+    `secp256k1_rangeproof_verify_impl` returns zero where its own
+    `pubs[npub]` lands there.
+    """
+    vector = _vector("odd mantissa")
+    proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
+    commitment = commit(vector["blind"], vector["value"])
+    with pytest.raises(BTClibValueError, match="point not on curve"):
+        proof.pubk_rings((1, 2))
+
+    # 7 is no x-coordinate of this curve, and it is a ring commitment
+    # `assert_valid` takes: what a proof states there is an integer of
+    # the field's width and this is where it has to name a point
+    with pytest.raises(BTClibValueError, match="invalid x-coordinate: 7"):
+        replace_unchecked(
+            proof, ring_commitments=(7, *proof.ring_commitments[1:])
+        ).pubk_rings(commitment)
+
+    public = RangeProof.parse(_octets("public value"))
+    min_value = public.min_value
+    # the entry whose value is not zero, so the field is there to read
+    assert min_value is not None
+    err_msg = "last ring commitment is the point at infinity"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        public.pubk_rings(mult(min_value, second_generator(), secp256k1))
+
+
+def test_pubk_rings_does_not_check_the_proof_twice() -> None:
+    """`check_validity` is `serialize`'s flag and means the same here.
+
+    The derivation reads no field `assert_valid` has not already held
+    against the mantissa, so a caller that has checked the object once
+    says so and gets the same rings.
+    """
+    vector = _vector("odd mantissa")
+    proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
+    commitment = commit(vector["blind"], vector["value"])
+    assert proof.pubk_rings(commitment, check_validity=False) == proof.pubk_rings(
+        commitment
+    )
+
+
 class _FixedDraw:
     """A `_HmacDrbg` whose chain the test wrote.
 
@@ -413,8 +575,8 @@ def test_the_proof_written_carries_no_ring_commitment() -> None:
     bit each, and the public-value proof has a single ring. So what
     `sign_public_value` writes exercises neither the digit
     decomposition nor the residuosity convention on a ring commitment,
-    and that is the distance still ahead of it rather than a property of
-    this test.
+    and the tests above reach both through a proof this module reads
+    rather than one it writes.
     """
     proof = sign_public_value(_BLIND, 100000, _NONCE)
     assert proof.rsizes == (1,)
@@ -620,10 +782,9 @@ def test_zkp_signs_and_verifies_the_proof_this_module_writes() -> None:
     the recording fixes under these same arguments; zero, which it fixes
     under others; and one and the widest the eight-octet field holds,
     which no entry fixes at this exponent. `verify` is asked beside
-    `sign`
-    because the two are different questions -- the first says zkp writes
-    these octets, the second that zkp reads them as the range they
-    state.
+    `sign` because the two are different questions -- the first says zkp
+    writes these octets, the second that zkp reads them as the range
+    they state.
     """
     blind = bytes.fromhex(_BLIND)
     nonce = bytes.fromhex(_NONCE)

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -171,6 +171,7 @@ KEYWORD_ONLY: dict[str, list[str]] = {
     "btclib.ecc.borromean:BorromeanSig.serialize": ["check_validity"],
     "btclib.ecc.rangeproof:RangeProof.__init__": ["check_validity"],
     "btclib.ecc.rangeproof:RangeProof.parse": ["check_validity"],
+    "btclib.ecc.rangeproof:RangeProof.pubk_rings": ["check_validity"],
     "btclib.ecc.rangeproof:RangeProof.serialize": ["check_validity"],
     "btclib.ecc.dsa:Sig.__init__": ["check_validity"],
     "btclib.ecc.dsa:Sig.parse": ["check_validity", "strict"],


### PR DESCRIPTION
Fourth slice of [ISS 1072](https://github.com/btclib-org/btclib/issues/1072),
which stays open. Reading and deriving only — this signs nothing.

`RangeProof.pubk_rings` rebuilds the rings a proof's borromean signature
is over: `_pub_expand`, the digit decomposition, `_point_from_ring_commitment`
and `sign_key_idx`, following `secp256k1_rangeproof_verify_impl` up to the
call it makes into `secp256k1_borromean_verify` and no further.

## The oracle this was planned around does not exist

The plan said the derived ring commitments must equal, ring by ring, what
`parse` reads. That is false, and the branch is built on what replaced it.
A published ring commitment is `sec[i]·G + digit[i]·scale·4**i·H`, and
`sec[i]` comes from `secp256k1_rangeproof_genrand` seeded on the caller's
nonce, so value, exponent and mantissa do not determine it. Measured two
ways: rebuilding the blinding factors from each vendored entry's own nonce
reproduces the published commitment on 21 of 21 rings across the multi-ring
vectors; and the same blind and value under two different nonces gives the
same header and `rsizes` with **no** ring commitment in common.

What is exact, and needs neither a signature nor the nonce chain, is
`Σ_i pubk_rings[i][sign_key_idx[i]] == blind · G` — `genrand` gives the last
ring minus the sum of the rest, and `sign_impl` adds the caller's blind to
it.

## What that sum does not say, and what closes it

The sum reduces to the scalar equation `Σ digit·weight == value − min_value`,
which survives **any** permutation of the ring commitments across rings. So
placement is asserted directly rather than inferred: each stated commitment
is checked at the head of its own ring. The recovered ring needs no
assertion beside them — with the stated heads, the digits and the weights
fixed, the sum leaves it a single group element, and negating it fails on
every vector.

Review found this gap and proposed asserting that the recovered ring is the
one absent from `ring_commitments`. Measured, that catches a rotation and
**not** a swap of two stated commitments, both of which leave the sum
invariant; the positional assertion catches both.

## The trap in this area

zkp's ring-commitment sign bit is **quadratic residuosity, not parity**
(`9 ^ secp256k1_fe_is_square_var` for a commitment, `11 ^ …` for a
generator). The branch never lifts the recorded octets: it builds the point
with `pedersen.commit` and checks the serialization against the record.
Over the vendored vectors the parity reading agrees on exactly the three
proofs that carry **no** ring commitments, so the agreement is vacuous and
a check run on any single-ring proof cannot see the difference.

## Evidence

Every new test was proved against a tamper — no quadrupling between rings,
`base` not negated, scale base two, digits one bit apart, `min_value` offset
dropped, x resolved by parity, `_serialize_point` writing parity — each run
unchained with the module restored byte for byte afterwards.

Review independently transcribed `pub_expand`, `getheader` and `secidx`
from the C with no btclib in it and compared **key by key rather than by the
sum**: 98 keys over the six vendored proofs, all identical, digits matching
on all six. That covers the keys the sum oracle never reads.

## Collateral

[ISS 1904](https://github.com/btclib-org/btclib/issues/1904): `ecc.pedersen`
has no codec for zkp's 33-octet commitment, and the lift is by residuosity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Reconstruct rangeproof Borromean signature rings and expose the corresponding value digit indices without performing signature verification.

New Features:
- Add `RangeProof.pubk_rings` to reconstruct the Borromean-signature public-key rings from a proof and its value commitment.
- Add `RangeProof.sign_key_idx` to derive the value’s base-four digit positions within those rings.

Bug Fixes:
- Resolve rangeproof ring-commitment sign bits using quadratic residuosity, matching zkp rather than interpreting them as point parity.
- Reject invalid commitments, off-curve coordinates, and recovered infinity points during ring reconstruction.

Enhancements:
- Document the rangeproof ring reconstruction and digit-decomposition behavior, including its limits before signature verification.
- Extend keyword-only argument enforcement for `RangeProof.pubk_rings`.

Documentation:
- Document the reconstructed signature rings, residuosity-based point resolution, and digit decomposition in the changelog and rangeproof module documentation.

Tests:
- Add vector-based tests covering reconstructed rings, blinding-factor consistency, digit indices, residuosity round trips, invalid inputs, and validity-check behavior.