### PR TITLE
`ecc.pedersen` reads and writes zkp's 33-octet commitment (closes #1904)

### DIFF
--- a/.github/workflows/zkp-oracle.yml
+++ b/.github/workflows/zkp-oracle.yml
@@ -130,12 +130,13 @@ on:
     # source, read by hand, and not against a proof zkp wrote.
     # `pedersen.py` and its own test file join for the rangeproof oracle,
     # itemized the way `dsa.py` is rather than named whole: of that
-    # module, `second_generator` and `commit` are what
-    # `tests/ecc/pedersen_test.py`'s zkp-marked tests compare against
-    # `zkp.generator`, and the commitment `commit` returns is what
-    # `zkp.rangeproof` then proves, verifies and rewinds. `curves/`,
-    # which `commit` calls and those tests call directly, stays out for
-    # the reason `curves/` stays out above
+    # module, `second_generator`, `commit` and the codec that writes and
+    # reads libsecp256k1-zkp's own octets for a commitment and for a
+    # generator are what `tests/ecc/pedersen_test.py`'s zkp-marked tests
+    # compare against `zkp.generator`, and the commitment `commit`
+    # returns is what `zkp.rangeproof` then proves, verifies and
+    # rewinds. `curves/`, which `commit` calls and those tests call
+    # directly, stays out for the reason `curves/` stays out above
     paths:
       - .github/workflows/zkp-oracle.yml
       - tests/ecc/commit_nonce_test.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3086,6 +3086,36 @@ file of the test tree, and no caller acts on it.
   `KeyError` on the entry rather than an answer about `_verdict`, and
   which entry that is was decided by insertion order.
 
+### `ecc.pedersen` reads and writes libsecp256k1-zkp's 33-octet commitment
+
+- **`btclib.ecc.pedersen` gains `commitment_from_octets`,
+  `bytes_from_commitment`, `generator_from_octets` and
+  `bytes_from_generator`** (closes #1904). `commit` answers a point, and
+  a caller holding the octets an Elements output carries had nothing
+  here to lift them with. What stands between the two is the leading
+  octet: it reports whether y is a quadratic residue, where the `02` and
+  `03` of a SEC compressed point report whether y is odd. Reading it as
+  parity answers the point residuosity answers for some x and its
+  negation for others, and nothing in the octets says which reading
+  wrote them.
+- **The tag is the whole of what the two encodings do not share**, so
+  one private pair writes and reads both:
+  `secp256k1_pedersen_commitment_save` xors the residuosity bit into 9
+  and `secp256k1_generator_serialize` into 11, both in
+  `src/modules/generator/main_impl.h`. `ecc.rangeproof` carries the same
+  bit at a third base, `1 ^` it, in `_serialize_point` and in
+  `_point_from_ring_commitment`, which is the second copy issue #1910
+  is about.
+- **`tests/ecc/pedersen_test.py` calls the module where it carried a
+  writer of its own** for the zkp-marked tests. The commitments vendored
+  in `tests/ecc/_data/zkp_rangeproof_vectors.json` round-trip through
+  the reader, the parity reading is shown to disagree with it, and
+  libsecp256k1-zkp's own fixed vectors for each of the two encodings --
+  `test_generator_fixed_vector` and
+  `test_pedersen_commitment_fixed_vector` in
+  `src/modules/generator/tests_impl.h` -- are read, written back, and
+  held against a point computed here.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/ecc/pedersen.py
+++ b/src/btclib/ecc/pedersen.py
@@ -22,20 +22,50 @@ supplemented with a second random generator H and
 the commitment algorithm is Commit(r,v)=rG+vH.
 It is crucial for H to be Nothing-Up-My-Sleeve (NUMS), i.e.
 the discrete logarithm of H with respect to G must be unknown.
+
+**The octets say residuosity, where a SEC prefix says parity.**
+libsecp256k1-zkp writes a commitment as one octet and then x, and that
+octet reports whether y is a quadratic residue:
+`secp256k1_pedersen_commitment_save` writes
+`9 ^ secp256k1_fe_is_square_var(&ge->y)` and
+`secp256k1_generator_serialize` writes `11 ^` the same bit, both in
+`src/modules/generator/main_impl.h`. `ecc.rangeproof` carries that same
+convention at a third base, `1 ^` it: `_serialize_point` writes what
+`sign_public_value` hashes, and `_point_from_ring_commitment` lifts a
+ring commitment's x against it. Lifting such an octet by the parity the
+`02`/`03` of `curves.point_from_octets` carries answers the same point
+for some x and its negation for others, with nothing in the octets to
+say which reading wrote them, so the two are not one function under two
+names.
+
+The codec below is secp256k1's and takes no `ec`: the tags and the width
+of x are libsecp256k1-zkp's format, and that library is secp256k1's. The
+commitment functions above take one because rG+vH is a sum of points,
+which every curve has.
 """
 
 from functools import lru_cache
 from hashlib import sha256
 
-from btclib.alias import HashF, Integer, Point
+from btclib.alias import HashF, Integer, Octets, Point
 from btclib.curves import Curve, bytes_from_point, double_mult_var, secp256k1
 from btclib.curves.curve import _assert_valid_ec
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
-from btclib.utils import assert_type, int_from_bits, int_from_integer
+from btclib.number_theory import legendre_symbol_var
+from btclib.utils import (
+    assert_type,
+    bytes_from_octets,
+    int_from_bits,
+    int_from_integer,
+)
 
 __all__ = [
     "assert_as_valid",
+    "bytes_from_commitment",
+    "bytes_from_generator",
     "commit",
+    "commitment_from_octets",
+    "generator_from_octets",
     "second_generator",
     "verify",
 ]
@@ -163,3 +193,105 @@ def verify(
         return False
 
     return True
+
+
+# the leading octet of each of libsecp256k1-zkp's two serializations,
+# before the bit that reports the residuosity of y is xored into it.
+# Both tags are odd, so bit 0 of the octet is that bit complemented: it
+# is set exactly where y is not a square, which is what
+# `secp256k1_pedersen_commitment_load` reads to decide whether to negate
+# the point `secp256k1_ge_set_xquad` lifted. An even tag would leave bit
+# 0 the bit itself, and that negation would take the wrong half
+_COMMITMENT_TAG = 9
+_GENERATOR_TAG = 11
+
+
+def _bytes_from_point(Q: Point, tag: int) -> bytes:
+    """Return `tag ^ is_square(y)` and then x, at whichever tag.
+
+    The tag is the whole of what a commitment's octets and a
+    generator's do not share, so what both refuse is asked here rather
+    than once each: a pair that is no point of secp256k1, and the
+    infinity point, which has no x to write.
+
+    The Legendre symbol is what `secp256k1_fe_is_square_var` answers,
+    and each computes it as a gcd rather than as an exponentiation.
+    """
+    secp256k1.require_on_curve(Q)
+    if Q[1] == 0:  # infinity point in affine coordinates
+        raise BTClibValueError("no bytes representation for infinity point")
+
+    residue = legendre_symbol_var(Q[1], secp256k1.p) == 1
+    return bytes([tag ^ int(residue)]) + Q[0].to_bytes(secp256k1.p_size, "big")
+
+
+def _point_from_octets(octets: Octets, tag: int, name: str) -> Point:
+    """Return the point those octets name, lifted by residuosity.
+
+    `secp256k1_pedersen_commitment_parse`'s own refusals, at whichever
+    tag: `(input[0] & 0xFE) != 8` is the leading octet outside the pair,
+    written here against the tag it is given, and
+    `secp256k1_fe_set_b32_limit` with `secp256k1_ge_x_on_curve_var` are
+    an x past p and an x that is the x-coordinate of no point --
+    `y_quadratic_residue_var` refuses those two and says which.
+
+    The lift is `secp256k1_ge_set_xquad` and the negation
+    `secp256k1_pedersen_commitment_load` makes on bit 0: the y that is a
+    square, negated where the octet says y is not one.
+    """
+    octets = bytes_from_octets(octets, secp256k1.p_size + 1)
+    prefix = octets[0]
+    if prefix & 0xFE != tag ^ 1:
+        raise BTClibValueError(f"not a {name}: prefix 0x{prefix:02x}")
+
+    x = int.from_bytes(octets[1:], byteorder="big")
+    y = secp256k1.y_quadratic_residue_var(x)
+    return x, secp256k1.p - y if prefix & 1 else y
+
+
+def bytes_from_commitment(Q: Point) -> bytes:
+    """Return a commitment as libsecp256k1-zkp serializes one.
+
+    `secp256k1_pedersen_commitment_serialize` hands back what
+    `_save` stored: `08` where the y of the commitment is a quadratic
+    residue and `09` where it is not, then x. `curves.bytes_from_point`
+    writes the parity of that same y, so the two answer the same octets
+    only where the y that is a square is also the even one.
+    """
+    return _bytes_from_point(Q, _COMMITMENT_TAG)
+
+
+def commitment_from_octets(octets: Octets) -> Point:
+    """Return the commitment libsecp256k1-zkp's octets name.
+
+    `secp256k1_pedersen_commitment_parse`. An Elements output carries
+    these, and this is the lift a caller holding them makes before
+    calling anything that takes the commitment as a point --
+    `ecc.rangeproof.RangeProof.pubk_rings`, `assert_as_valid`, `verify`.
+    """
+    return _point_from_octets(octets, _COMMITMENT_TAG, "Pedersen commitment")
+
+
+def bytes_from_generator(Q: Point) -> bytes:
+    """Return a generator as libsecp256k1-zkp serializes one.
+
+    `secp256k1_generator_serialize`, which is `bytes_from_commitment`'s
+    octet at another tag: `0a` for a y that is a quadratic residue and
+    `0b` for one that is not. `second_generator` is the generator this
+    library computes; a blinded asset generator is what else this format
+    carries.
+    """
+    return _bytes_from_point(Q, _GENERATOR_TAG)
+
+
+def generator_from_octets(octets: Octets) -> Point:
+    """Return the generator libsecp256k1-zkp's octets name.
+
+    `secp256k1_generator_parse`, whose `(input[0] & 0xFE) != 10` refuses
+    a commitment's own leading octet -- which is what
+    `test_generator_fixed_vector` puts to it in
+    `src/modules/generator/tests_impl.h`. The x is the same octets
+    either way, so the tag is the whole of what keeps the two formats
+    apart.
+    """
+    return _point_from_octets(octets, _GENERATOR_TAG, "generator")

--- a/src/btclib/number_theory.py
+++ b/src/btclib/number_theory.py
@@ -300,11 +300,13 @@ def legendre_symbol_var(a: int, p: int) -> int:
 
     The loop's length follows `a`, where an exponentiation's did not.
     SECURITY.md publishes the Python path as variable-time, and nothing
-    in the tree asks this about a value that has to stay hidden:
-    `curves.curve._is_x_coordinate_var` is the one caller, and what reaches
-    it is a signature's r, the x-coordinate of a serialized xpub, or a
-    candidate x of an ElligatorSwift encoding -- each of them public, and
-    on secp256k1 each answered by the bindings before this is reached.
+    in the tree asks this about a value that has to stay hidden.
+    `curves.curve._is_x_coordinate_var` reaches it for a signature's r,
+    the x-coordinate of a serialized xpub, or a candidate x of an
+    ElligatorSwift encoding, each of them public and on secp256k1 each
+    answered by the bindings before this is reached;
+    `ecc.pedersen` and `ecc.rangeproof` reach it for the residuosity
+    octet of a point they are about to write down.
     """
     _assert_valid_operand(a)
     _assert_valid_modulus(p)

--- a/tests/ecc/pedersen_test.py
+++ b/tests/ecc/pedersen_test.py
@@ -15,19 +15,31 @@ rewinds it back to the value and the blinding factor btclib chose.
 That gives this tree no rangeproof. The proof, its verification and its
 rewind are libsecp256k1-zkp's throughout, and what btclib contributes is
 the commitment they are about: nothing here builds or reads a proof.
+
+The codec is asked three things wherever the suite runs: the fixed
+vectors libsecp256k1-zkp's own C tests hold for each of the two
+serializations; the commitments vendored in
+`tests/ecc/_data/zkp_rangeproof_vectors.json`, which that library wrote
+and which have to go back out as they came in; and the refusals
+`secp256k1_pedersen_commitment_parse` makes. What only the marked tests
+add is that library answering now rather than in a recording:
+`zkp.generator.pedersen_commit` over freshly drawn `(r, v)`, and
+`zkp.generator.h()`.
 """
 
 import secrets
+from collections.abc import Callable
 from hashlib import sha256, sha384
+from typing import Any
 
 import pytest
 
-from btclib.alias import Point
-from btclib.curves import mult, secp256k1
+from btclib.alias import INF, Point
+from btclib.curves import mult, point_from_octets, secp256k1
 from btclib.curves.curve import CURVES
 from btclib.ecc import pedersen
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
-from tests import needs_zkp
+from tests import load, needs_zkp, vector_id
 
 # guarded module scope, the same shape `btclib._libsecp256k1` uses: this
 # file is collected in every job, including the no-bindings one where
@@ -42,6 +54,30 @@ except ImportError:  # pragma: no cover -- only the no-bindings job reaches this
 
 secp256r1 = CURVES["secp256r1"]
 secp384r1 = CURVES["secp384r1"]
+
+# the commitments `zkp.generator.pedersen_commit` wrote for the entries
+# `tests/ecc/rangeproof_test.py` reads: that file records a proof beside
+# the commitment it is about, and the commitment is this module's.
+# `tests/_data/README.md` has how it was recorded
+_VECTORS = load("ecc", "_data", "zkp_rangeproof_vectors.json")
+_IDS = [vector_id(i, v["id"]) for i, v in enumerate(_VECTORS)]
+
+# libsecp256k1-zkp's own fixed vectors for the two serializations, both
+# in `src/modules/generator/tests_impl.h`: `test_generator_fixed_vector`
+# holds the first and `test_pedersen_commitment_fixed_vector` the
+# second, and each parses it, writes it back and compares. They carry
+# one x and one residuosity bit at two tags, so they name one point
+_ZKP_GENERATOR_VECTOR = (
+    "0bc6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
+)
+_ZKP_COMMITMENT_VECTOR = (
+    "09c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
+)
+
+# the pair of leading octets a serialized commitment has, written here
+# rather than read off the module: an assertion that both of them turned
+# up would otherwise move with what it is testing
+_COMMITMENT_OCTETS = {0x08, 0x09}
 
 
 def test_second_generator() -> None:
@@ -168,31 +204,134 @@ def test_commit_blinding_factor_sum() -> None:
         pedersen.commit(r_1 + 3, 9, ec)  # r_1 + 3 == ec.n
 
 
-# libsecp256k1-zkp's own serializations, both in
-# `src/modules/generator/main_impl.h`: `secp256k1_generator_serialize`
-# writes `11 ^ secp256k1_fe_is_square_var(y)` and then the 32 bytes of x,
-# and `secp256k1_pedersen_commitment_serialize` hands back what
-# `secp256k1_pedersen_commitment_save` stored the same way, `9 ^` the same
-# bit. So the leading octet says whether y is a quadratic residue, where a
-# SEC compressed point's says whether y is even: `bytes_from_point` is not
-# the bridge, and `_zkp_octets` below is.
-_ZKP_GENERATOR_TAG = 11
-_ZKP_COMMITMENT_TAG = 9
+def test_the_upstream_fixed_vectors_name_one_point_at_two_tags() -> None:
+    """libsecp256k1-zkp's own vectors, each read and written back.
 
-
-def _zkp_octets(
-    point: Point, tag: int
-) -> bytes:  # pragma: no cover -- only the marked tests below call this
-    """Write a point the way libsecp256k1-zkp serializes one.
-
-    Euler's criterion is what reads the bit the two serializations
-    share: y is a quadratic residue exactly where y**((p-1)/2) is 1.
-
-    Called from the `zkp`-marked tests below alone, hence the pragma.
+    The x is 2G's and the point is not 2G: the y of 2G is a quadratic
+    residue, asserted here rather than stated, and both leading octets
+    report a y that is not one.
     """
-    x, y = point
-    p = secp256k1.p
-    return bytes([tag ^ int(pow(y, (p - 1) // 2, p) == 1)]) + x.to_bytes(32, "big")
+    two_g = mult(2, secp256k1.G, secp256k1)
+    assert secp256k1.y_quadratic_residue_var(two_g[0]) == two_g[1]
+    minus_two_g = secp256k1.negate(two_g)
+
+    generator = bytes.fromhex(_ZKP_GENERATOR_VECTOR)
+    assert pedersen.generator_from_octets(generator) == minus_two_g
+    assert pedersen.bytes_from_generator(minus_two_g) == generator
+
+    commitment = bytes.fromhex(_ZKP_COMMITMENT_VECTOR)
+    assert pedersen.commitment_from_octets(commitment) == minus_two_g
+    assert pedersen.bytes_from_commitment(minus_two_g) == commitment
+
+
+@pytest.mark.parametrize("vector", _VECTORS, ids=_IDS)
+def test_a_vendored_commitment_goes_back_out_as_it_came_in(
+    vector: dict[str, Any],
+) -> None:
+    """Octets libsecp256k1-zkp wrote, read here and written back.
+
+    Each is that library's own answer to
+    `zkp.generator.pedersen_commit`, recorded with the blinding factor
+    and the value that produced it, so the round trip is against a
+    serialization this tree did not write.
+    """
+    octets = bytes.fromhex(vector["commitment"])
+    commitment = pedersen.commitment_from_octets(octets)
+    assert secp256k1.is_on_curve(commitment)
+    assert pedersen.bytes_from_commitment(commitment) == octets
+
+
+def test_the_leading_octet_is_residuosity_and_not_parity() -> None:
+    """The vendored commitments are what says the two readings are two.
+
+    Bit 0 read as the parity of y -- the `02`/`03` a SEC compressed
+    point carries -- lifts some of these commitments to the point
+    residuosity lifts them to and the rest to its negation. What
+    decides is the parity of the y that is a square, a property of the
+    commitment's own x and not of the proof recorded beside it, which
+    is the assertion inside the loop.
+
+    Both outcomes are asserted: it is the agreements that make the
+    wrong reading worth a test, since there the two answer one point
+    and nothing in the octets says which was read.
+    """
+    agreements = set()
+    for vector in _VECTORS:
+        octets = bytes.fromhex(vector["commitment"])
+        by_parity = point_from_octets(bytes([0x02 | octets[0] & 1]) + octets[1:])
+        commitment = pedersen.commitment_from_octets(octets)
+        assert by_parity[0] == commitment[0]
+        agrees = by_parity == commitment
+        assert agrees == (secp256k1.y_quadratic_residue_var(commitment[0]) % 2 == 0)
+        agreements.add(agrees)
+    assert agreements == {True, False}
+
+
+@pytest.mark.parametrize("prefix", [0x00, 0x02, 0x03, 0x04, 0x07, 0x0A, 0x0B, 0x0C])
+def test_a_commitment_refuses_a_leading_octet_outside_its_pair(prefix: int) -> None:
+    """`(input[0] & 0xFE) != 8` is the whole of what the format admits.
+
+    `0a` and `0b` are the generator's own pair, and `0c` is what
+    `test_pedersen_commitment_fixed_vector` puts to
+    `secp256k1_pedersen_commitment_parse`; `02` and `03` are the SEC
+    prefixes for the same x, which is the confusion this codec is here
+    to end.
+    """
+    octets = bytes([prefix]) + bytes.fromhex(_ZKP_COMMITMENT_VECTOR)[1:]
+    with pytest.raises(BTClibValueError, match="not a Pedersen commitment"):
+        pedersen.commitment_from_octets(octets)
+
+
+@pytest.mark.parametrize("prefix", [0x02, 0x03, 0x08, 0x09, 0x0C])
+def test_a_generator_refuses_a_leading_octet_outside_its_pair(prefix: int) -> None:
+    """`(input[0] & 0xFE) != 10`, and `08` is the case zkp's own test makes.
+
+    `test_generator_fixed_vector` flips that vector's leading octet to
+    a commitment's and checks `secp256k1_generator_parse` returns zero.
+    """
+    octets = bytes([prefix]) + bytes.fromhex(_ZKP_GENERATOR_VECTOR)[1:]
+    with pytest.raises(BTClibValueError, match="not a generator"):
+        pedersen.generator_from_octets(octets)
+
+
+def test_a_commitment_refuses_an_x_no_point_of_the_curve_has() -> None:
+    """`secp256k1_fe_set_b32_limit` and `secp256k1_ge_x_on_curve_var`.
+
+    p itself is not a field element, and zero is one that names no
+    point: 7 is not a square modulo p, so nothing squares to 0**3 + 7.
+    """
+    err_msg = r"x-coordinate not in 0\.\.p-1"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        pedersen.commitment_from_octets(b"\x08" + secp256k1.p.to_bytes(32, "big"))
+
+    with pytest.raises(BTClibValueError, match="invalid x-coordinate: 0"):
+        pedersen.commitment_from_octets(b"\x08" + bytes(32))
+
+
+def test_a_commitment_is_as_many_octets_as_it_is() -> None:
+    """One tag and one x, and `bytes_from_octets` is what says so."""
+    octets = bytes.fromhex(_ZKP_COMMITMENT_VECTOR)
+    with pytest.raises(BTClibValueError, match="invalid size: 32 bytes instead of 33"):
+        pedersen.commitment_from_octets(octets[:-1])
+
+
+@pytest.mark.parametrize(
+    "write", [pedersen.bytes_from_commitment, pedersen.bytes_from_generator]
+)
+def test_writing_refuses_what_has_no_x_to_write(
+    write: Callable[[Point], bytes],
+) -> None:
+    """A pair that is no point of secp256k1, and the infinity point.
+
+    `secp256k1_pedersen_commit` does not save the second either: it
+    answers zero where the sum lands there, rather than serializing a
+    point with no x.
+    """
+    with pytest.raises(BTClibValueError, match="point not on curve"):
+        write((1, 2))
+
+    with pytest.raises(BTClibValueError, match="no bytes representation"):
+        write(INF)
 
 
 # `pragma: no cover` on every `@needs_zkp` below, that marker being the
@@ -222,9 +361,10 @@ def test_second_generator_matches_zkp() -> None:
     `test_commit_matches_zkp` below is where the two conventions part.
     """
     H = pedersen.second_generator(secp256k1, sha256)
-    assert _zkp_octets(H, _ZKP_GENERATOR_TAG) == zkp_generator.h()
-    # and not a bridge that answers h() for whatever it is handed
-    assert _zkp_octets(secp256k1.G, _ZKP_GENERATOR_TAG) != zkp_generator.h()
+    assert pedersen.bytes_from_generator(H) == zkp_generator.h()
+    assert pedersen.generator_from_octets(zkp_generator.h()) == H
+    # and not a codec that answers h() for whatever it is handed
+    assert pedersen.bytes_from_generator(secp256k1.G) != zkp_generator.h()
 
 
 @needs_zkp  # pragma: no cover -- no zkp.generator.pedersen_commit to compare against
@@ -235,23 +375,24 @@ def test_commit_matches_zkp() -> None:
     and a value below 2**64; `test_commit_outside_the_zkp_intersection`
     below is what each does at the edges and why they are left out.
 
-    A bridge reading `y & 1` instead writes the same octet as the real
-    one wherever y's parity and its quadratic residuosity agree, so a
-    sample carrying only those cases would report agreement about the
-    wrong convention. Both octets have to turn up, which is what the
-    assertion after the loop asks for.
+    A writer reading `y & 1` instead answers the same octet as
+    `bytes_from_commitment` wherever y's parity and its quadratic
+    residuosity agree, so a sample carrying only those cases would
+    report agreement about the wrong convention. Both octets have to
+    turn up, which is what the assertion after the loop asks for.
     """
     octets_seen = set()
     for _ in range(64):
         r = 1 + secrets.randbelow(secp256k1.n - 1)
         v = secrets.randbelow(2**64)
         commitment = zkp_generator.pedersen_commit(r, v)
-        assert _zkp_octets(pedersen.commit(r, v), _ZKP_COMMITMENT_TAG) == commitment
+        assert pedersen.bytes_from_commitment(pedersen.commit(r, v)) == commitment
+        assert pedersen.commitment_from_octets(commitment) == pedersen.commit(r, v)
         octets_seen.add(commitment[0])
         # another value under the same blinding factor is another point:
         # the agreement above is not a comparison against a constant
         assert zkp_generator.pedersen_commit(r, v ^ 1) != commitment
-    assert octets_seen == {_ZKP_COMMITMENT_TAG, _ZKP_COMMITMENT_TAG ^ 1}
+    assert octets_seen == _COMMITMENT_OCTETS
 
 
 @needs_zkp  # pragma: no cover -- no zkp side to hold each edge against
@@ -271,8 +412,8 @@ def test_commit_outside_the_zkp_intersection() -> None:
     err_msg = r"invalid \(unblinded\) commitment"
     with pytest.raises(BTClibValueError, match=err_msg):
         pedersen.commit(0, 7)
-    assert zkp_generator.pedersen_commit(0, 7) == _zkp_octets(
-        mult(7, H, secp256k1), _ZKP_COMMITMENT_TAG
+    assert zkp_generator.pedersen_commit(0, 7) == pedersen.bytes_from_commitment(
+        mult(7, H, secp256k1)
     )
 
     assert pedersen.verify(n + 5, 7, pedersen.commit(n + 5, 7))
@@ -294,7 +435,7 @@ def test_zkp_rangeproof_over_a_btclib_commitment() -> None:
     recovered from a proof about a point btclib computed.
 
     Both leading octets again, for the reason `test_commit_matches_zkp`
-    gives: a proof rides on the commitment's serialization, so a bridge
+    gives: a proof rides on the commitment's serialization, so a codec
     right on one octet and wrong on the other verifies here and fails
     there.
     """
@@ -302,7 +443,7 @@ def test_zkp_rangeproof_over_a_btclib_commitment() -> None:
     for _ in range(64):
         r = 1 + secrets.randbelow(secp256k1.n - 1)
         v = secrets.randbelow(2**64)
-        commitment = _zkp_octets(pedersen.commit(r, v), _ZKP_COMMITMENT_TAG)
+        commitment = pedersen.bytes_from_commitment(pedersen.commit(r, v))
         octets_seen.add(commitment[0])
         nonce = secrets.token_bytes(32)
         proof = zkp_rangeproof.sign(commitment, r, nonce, v)
@@ -318,7 +459,7 @@ def test_zkp_rangeproof_over_a_btclib_commitment() -> None:
         assert int.from_bytes(blind, "big") == r
         assert value == v
         assert (rewound_min, rewound_max) == (min_value, max_value)
-    assert octets_seen == {_ZKP_COMMITMENT_TAG, _ZKP_COMMITMENT_TAG ^ 1}
+    assert octets_seen == _COMMITMENT_OCTETS
 
 
 @needs_zkp  # pragma: no cover -- no zkp.rangeproof to put a wrong opening to
@@ -327,11 +468,11 @@ def test_zkp_rangeproof_refuses_a_wrong_opening() -> None:
 
     A proof is bound to the value and to the blinding factor the
     commitment was built from, and the rewind to the nonce as well.
-    Flipping the leading octet is the control on the bridge itself: the
+    Flipping the leading octet is the control on the codec itself: the
     flipped octets name the other of the two points sharing that x, and
-    no proof of this commitment is a proof of that one -- so a bridge
-    writing the wrong octet would be verifying a proof about a point
-    `commit` never returned.
+    no proof of this commitment is a proof of that one -- so a writer
+    that put the wrong octet there would be verifying a proof about a
+    point `commit` never returned.
 
     `sign` answers a proof in each of these: what refuses them is
     `verify`, which returns None where a proof does not open its
@@ -339,7 +480,7 @@ def test_zkp_rangeproof_refuses_a_wrong_opening() -> None:
     """
     r = 1 + secrets.randbelow(secp256k1.n - 1)
     v = secrets.randbelow(2**64)
-    commitment = _zkp_octets(pedersen.commit(r, v), _ZKP_COMMITMENT_TAG)
+    commitment = pedersen.bytes_from_commitment(pedersen.commit(r, v))
     nonce = secrets.token_bytes(32)
     proof = zkp_rangeproof.sign(commitment, r, nonce, v)
     assert zkp_rangeproof.verify(commitment, proof) is not None


### PR DESCRIPTION
Closes [ISS 1904](https://github.com/btclib-org/btclib/issues/1904).

`ecc.pedersen` gains a reader and a writer for the 33-octet encoding
secp256k1-zkp gives a Pedersen commitment and an alternative generator:
`commitment_from_octets` / `bytes_from_commitment` (tags `08`/`09`) and
`generator_from_octets` / `bytes_from_generator` (`0a`/`0b`), over one
private pair parameterised by the tag.

`RangeProof.pubk_rings` is the first function here whose argument is a
commitment somebody else wrote — an Elements output carries those octets
— and a caller holding them had to lift them itself.

## The trap this closes

The leading octet is **quadratic residuosity, not parity**. Lifting by
parity answers a different point on half the vendored commitments, and
the caller that gets it wrong gets it wrong silently.

The rule is exact and has nothing to do with a proof's shape: the two
readings agree **iff the quadratic-residue root of x is even**, which
follows in both branches of the sign bit and is a function of x alone.
An earlier reading of this correlated it with single-ring versus
multi-ring proofs; that holds on the six recorded here and is a
coincidence — `exp`, `min_bits` and `min_value` enter the proof, never
the point `rG + vH`.

The test therefore asserts the mechanism inside the loop rather than
naming which vectors disagree.

## Where it lives, and what was rejected

`ecc.pedersen` owns commitments, `second_generator` is the very
generator the second tag serializes, and `ecc.rangeproof` already
imports this module, so the shared pair is reachable from the third base
with no new module and no new import edge.

Rejected: a module under `curves/` (the tags are one library's prefix
for its own objects, not a fact about secp256k1, and the tiebreaker a
curve owns is already `y_quadratic_residue_var`); widening
`curves.point_from_octets` behind a flag (`08` is a different format,
not SEC's `hybrid`); an `ec` parameter (residuosity needs p ≡ 3 mod 4,
and the writer would have had to duplicate the refusal); `parse` /
`serialize` names (`parse` is for octet *streams*; these are
fixed-width).

## Evidence

The refusals are zkp's own two lines rather than a re-derivation, and
review ran the codec instead of reading it: an exhaustive sweep of all
256 leading octets accepts exactly `{08, 09}` and `{0a, 0b}`; both
upstream fixed vectors resolve to −2G, not 2G, since 2G's y is a
quadratic residue and both octets report one that is not; write→read is
the identity over 50 random points at both tags.

The comment defining the tags first stated bit 0's polarity backwards.
It is the bit **complemented** — set exactly where y is not a square —
and the tags being odd is what makes it so. Review verified the
counterfactual over 40 points: with an even tag, bit 0 would be the bit
itself and the negation would take the wrong half, for every point.

## What this removes

`tests/ecc/pedersen_test.py` carried its own implementation of this
convention at both bases, under a `# pragma: no cover`. The tests call
the module now, and the reader direction is asked where only the writer
was.

## Collateral

[ISS 1910](https://github.com/btclib-org/btclib/issues/1910):
`ecc.rangeproof`'s `_point_from_ring_commitment` and `_serialize_point`
are the same convention at a third base and could adopt this module's
private pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Add interoperable libsecp256k1-zkp commitment and generator codecs to ecc.pedersen using the correct quadratic-residuosity encoding convention.

New Features:
- Add readers and writers for libsecp256k1-zkp’s 33-byte Pedersen commitment and generator encodings.

Bug Fixes:
- Correctly interpret zkp commitment prefixes as quadratic-residuosity indicators rather than SEC point-parity indicators.

Enhancements:
- Centralize the zkp point encoding logic in ecc.pedersen and remove the duplicated test-only implementation.

CI:
- Update the zkp oracle workflow coverage to include the new commitment and generator codecs.

Documentation:
- Document the zkp encoding conventions and their distinction from SEC compressed-point prefixes in the changelog.

Tests:
- Add fixed-vector, vendored-commitment round-trip, validation, residuosity-versus-parity, and zkp interoperability tests for both encodings.