### PR TITLE
`compact_blocks`'s two justifications are properties of the format (closes #1883)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3116,6 +3116,21 @@ file of the test tree, and no caller acts on it.
   `src/modules/generator/tests_impl.h` -- are read, written back, and
   held against a point computed here.
 
+### `compact_blocks`'s two justifications are properties of the format
+
+- **The differential-encoding paragraph states what holding the wire's
+  value costs without naming a package that holds it** (closes #1883):
+  never undoing the difference leaves a decoder that agrees with its own
+  encoder and with nothing else, which is a property of BIP152's
+  encoding, where the same cost attributed to another tree is a claim
+  this one cannot check.
+- **`test_a_payload_carries_the_command_bitcoin_core_spells`'s docstring
+  says why the four spellings are asserted**: `Message` looks a command
+  up nowhere, so a misspelling round-trips as well as the real thing and
+  only an assertion against Core's own spelling tells the two apart.
+- **The `sendcmpt` that reached the network is still told in the p2p
+  tests, as the event it was.**
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/p2p/compact_blocks.py
+++ b/src/btclib/p2p/compact_blocks.py
@@ -52,9 +52,9 @@ as a proper transaction-in-block-index in PartiallyDownloadedBlock" --
 one field, two meanings, told apart by which object is holding it.
 Nothing is lost by storing the absolute index: over indexes that
 strictly increase the two are the same sequence written twice, so the
-octets round-trip either way. btclib_node holds the wire's value and
-never undoes the difference, which is a decoder that agrees with its own
-encoder and with nothing else (btclib-org/btclib-node#20).
+octets round-trip either way. Holding the wire's value and never undoing
+the difference leaves a decoder that agrees with its own encoder and
+with nothing else.
 
 **Version 2 alone is implemented, and version 1 is not.** The two differ
 in one field and one hash: version 2 writes the transactions inside

--- a/tests/p2p/compact_blocks_test.py
+++ b/tests/p2p/compact_blocks_test.py
@@ -725,9 +725,13 @@ def test_reconstruct_says_what_it_was_handed_rather_than_reading_a_field() -> No
 
 
 def test_a_payload_carries_the_command_bitcoin_core_spells() -> None:
-    """The four names, which btclib_node misspells two of.
+    """A command is text the format does not check, so it is checked here.
 
-    btclib-org/btclib-node#12 names the two.
+    `Message` looks a command up nowhere, taking any printable ascii, so
+    a misspelling round-trips as well as the real thing and only an
+    assertion against Core's own spelling tells the two apart.
+    `tests/p2p/core_commands_test.py` asks whether a command is one Core
+    declares; which class carries which is asked here.
     """
     assert SendCmpct.command == "sendcmpct"
     assert CmpctBlock.command == "cmpctblock"


### PR DESCRIPTION
Closes [ISS 1883](https://github.com/btclib-org/btclib/issues/1883).

Two present-tense claims about `btclib_node` were each the live
justification for the code beside them, and both were false. Both were
true when they were written, and both cite issues that closed on
2026-08-22.

## The answer, taken once for both

Restate them as properties of the format. Not the past tense, which
section 9's *no history in the prose* bars, and not retirement, which
would drop the reason the comment exists for.

`compact_blocks.py`'s differential-encoding paragraph already carries
the justification twice before it names any tree: BIP152's own Purpose
column for what the field *is*, and Core's `PrefilledTransaction::index`
comment — one field, two meanings, told apart by which object holds it —
for why not to hold the wire's value. Neither dates. What the
`btclib_node` sentence added is the **consequence**, which is already
written as a property; only its subject was a tree.

The test docstring is the same move. "The four names, which
`btclib_node` misspells two of" stood in for the reason the four are
asserted at all, which is a property of the wire: nothing in the format
checks a command, so a misspelling round-trips exactly as well as the
real thing.

## Two things this deliberately does not say

The first draft of the docstring said an assertion against Core's own
spelling is **the only** thing that tells a misspelling apart. That is
false: `tests/p2p/core_commands_test.py` compares every published
`Payload.command` against the transcribed `NetMsgType` tuple and catches
one in these four too.

So the docstring names the kind of check rather than this test, and then
says what this test does that the census cannot: the census takes a
`frozenset` of commands and discards which class held which, so
**swapping** two of the four passes it and fails only here.

That was measured rather than reasoned, twice over. Review re-derived
the census's set arithmetic over the source and ran two mutants: a swap
passes all four census assertions and fails this test alone; a
misspelling fails both.

## The anecdote is not lost

`tests/p2p/core_commands_test.py`, `inventory_test.py` and
`negotiation_test.py` each carry it phrased as an event, in the past
tense the standard admits, and stay true whatever that tree does next.

## Collateral

The same defect at other sites, out of scope here and filed rather than
folded in: [ISS 1915](https://github.com/btclib-org/btclib/issues/1915)
(`payload.py`'s rejected alternative names `btclib_node` as its example,
and that tree now has the shape the bullet recommends),
[ISS 1918](https://github.com/btclib-org/btclib/issues/1918) and
[ISS 1919](https://github.com/btclib-org/btclib/issues/1919).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Describe compact-block encoding and command-spelling guarantees as stable format properties while preserving the relevant protocol history in tests.

Enhancements:
- Make compact-block encoding rationale describe format properties rather than historical implementation details.
- Clarify command-spelling test documentation and distinguish format validation from command-to-class mapping checks.

Chores:
- Record the rationale and retained protocol anecdote in the changelog.