### PR TITLE
The anti-exfil vectors are pinned in the ledger the weekly run reads (closes #1913)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3170,6 +3170,23 @@ file of the test tree, and no caller acts on it.
   landing it, the heading resolves to no tag, and an entry written in
   that window is evaluated from the tag onward rather than never.
 
+### The anti-exfil vectors are pinned in the ledger the weekly run reads
+
+- **`tests/_data/README.md` gains an entry for
+  `tests/ecc/anti_exfil_test.py`, whose docstring keeps no revision of
+  its own** (closes #1913). The fixture is libsecp256k1-zkp's
+  `ecdsa_s2c_tests` transcribed into python, which is the case
+  `src/btclib/bolt9.py` already has an entry for: a pin in that ledger
+  is re-checked against upstream every week by
+  `.github/workflows/vendored-vectors.yml`, and a pin in a module is
+  re-checked by nobody.
+- **The pin names the tip of `src/modules/ecdsa_s2c/tests_impl.h`**,
+  `72867fd682279ff2c79cf13f4f8d8484048d2527` (2026-08-17), blob
+  `ea0b650d829c87c39908903abe7a5b164e06063c`. Every value the module
+  transcribes -- the columns of `_ZKP_VECTORS`, and the key and the
+  message beside them -- is in that blob, read as the octets of its
+  `0x` arrays.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -2155,6 +2155,49 @@ out, the range the header proves, and the rings the value's digits index.
 [ISS 1072](https://github.com/btclib-org/btclib/issues/1072) is where
 rewinding a proof and verifying one are tracked.
 
+### `tests/ecc/anti_exfil_test.py`
+
+```text
+repo    BlockstreamResearch/secp256k1-zkp
+path    src/modules/ecdsa_s2c/tests_impl.h
+commit  72867fd682279ff2c79cf13f4f8d8484048d2527  2026-08-17
+blob    ea0b650d829c87c39908903abe7a5b164e06063c
+pulled  2026-08-02
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **transcribed**, off `ecdsa_s2c_tests`, the array
+`test_ecdsa_s2c_fixed_vectors` and `test_ecdsa_anti_exfil_signer_commit`
+both walk: `_ZKP_VECTORS` is its rows, column for column -- `s2c_data`,
+`expected_s2c_opening` and `expected_s2c_exfil_opening` -- and
+`_PRV_KEY` and `_MSG_HASH` are the key and the message both functions
+run those rows against. There is no blob to compare, the values
+being `0x` arrays inside C source, so what is checked is that each of
+them is in the pinned blob when those arrays are read as octets rather
+than as text:
+
+```shell
+blob=<the blob this entry gives>
+value=<a hex string the module transcribes>
+```
+
+```shell
+gh api -H 'Accept: application/vnd.github.raw' \
+    "repos/BlockstreamResearch/secp256k1-zkp/git/blobs/${blob:?}" \
+    | python3 -c "import re,sys
+h = ''.join(re.findall(r'0x([0-9a-fA-F]{2})', sys.stdin.read()))
+print(sys.argv[1].lower() in h.lower())" "${value:?}"
+```
+
+Source rather than a data file, and pinned here for what the columns
+settle: a row's openings are one `anti_exfil_host_commit` apart, so the
+module holds the R the device promises and the R its signature carries
+to libsecp256k1-zkp's own octets rather than to btclib run twice. A row
+upstream regenerates is one this tree would go on asserting, which is
+what the pin is read for. The module points here for the revision
+and carries none of its own, which is what puts the pin where the weekly
+workflow reads it.
+
 ## Chain data, not a repository
 
 These are consensus bytes. There is no upstream repository to pin and no
@@ -2660,7 +2703,8 @@ Not checked byte for byte against one:
   `bip67_test_vectors.json`, `bip85_test_vectors.json`,
   `chacha20_vectors.json`, `muhash_vectors.json`,
   `miniscript_fixed_tests.json`, `bolt11_test_vectors.json`, `bolt9.py`,
-  `rfc6979.json`, `zkp_rangeproof_fixed_vectors.json`.
+  `rfc6979.json`, `zkp_rangeproof_fixed_vectors.json`,
+  `anti_exfil_test.py`.
 - chain data, identified by block hash or txid: the blocks and
   transactions under `tests/block/_data/` and `tests/tx/_data/`, and
   `unspendable_script_pub_keys.json`, which is scripts rather than whole

--- a/tests/ecc/anti_exfil_test.py
+++ b/tests/ecc/anti_exfil_test.py
@@ -16,17 +16,13 @@ apart -- and that is exactly the property the handshake stands on, step
 2 and step 4 reaching one nonce. It is checked here against upstream's
 own bytes rather than against btclib run twice.
 
-```text
-repo    BlockstreamResearch/secp256k1-zkp
-path    src/modules/ecdsa_s2c/tests_impl.h
-commit  baac08d207003151d095423487d3954503a52aeb  2026-04-20
-blob    ba4f158c5d5c63b195011cda8c24331e5d21a4d4
-```
-
-Read at master `2af926dc309a673461f0e2da090105c8f05b4505`, whose tree
-carries that blob; the commit above is the tip of the path. The protocol
-rationale quoted in the docstrings is `include/secp256k1_ecdsa_s2c.h` at
-the same master, blob `c931457d6a53ca8aed8189257e7a2ff496fd084c`.
+Which revision of `src/modules/ecdsa_s2c/tests_impl.h` those columns
+are is `tests/_data/README.md`'s entry for this module, beside the
+vendored files, and none is recorded here: a pin in that ledger is what
+`.github/workflows/vendored-vectors.yml` re-checks weekly, opening an
+issue where it is no longer the tip of its path. The protocol rationale
+quoted in `btclib.ecc.dsa`'s docstrings is
+`include/secp256k1_ecdsa_s2c.h` of the same repository.
 """
 
 from hashlib import sha1, sha256


### PR DESCRIPTION
Closes [ISS 1913](https://github.com/btclib-org/btclib/issues/1913).

`tests/ecc/anti_exfil_test.py` pinned the vectors it transcribes — a
repository, a path, a commit and a blob — in its own docstring, where
the weekly check never looks. `.github/workflows/vendored-vectors.yml`
runs over two ledgers and nothing else, and this pin was in neither.

The pin moves to `tests/_data/README.md`, and the module keeps a pointer
at the ledger with no revision of its own, so the two cannot disagree.

## Why the ledger and not a second parser

The ledger's own opening already decided this, for a pin of exactly this
shape:

> `src/btclib/bolt9.py` has an entry too, and it is source rather than
> data: BOLT9's feature table, transcribed into python mappings instead
> of loaded from a file beside the tests. A pin recorded here is
> re-checked against upstream every week and a pin recorded in the
> module is re-checked by nobody, which is the whole of why it is
> written here.

`_ZKP_VECTORS` is `ecdsa_s2c_tests`' own columns transcribed into
python, so it is that case and not a new one. Teaching the check script
to read module docstrings was rejected: a second parser and a second
format for the same four lines.

## It had already drifted, which is the point

Nothing here would have said so. The pinned commit is 2026-04-20; the
tip of the path is `72867fd6`, 2026-08-17 — and **the blob moved with
it**, `ba4f158c` → `ea0b650d`, so the entry was pinned to content that
is no longer at that path.

The transcription itself is unaffected: `ecdsa_s2c_tests` is
byte-identical between the two commits, the drift being an added
function and its registry line. All eight transcribed values —
`_ZKP_VECTORS`' six columns plus `_PRV_KEY` and `_MSG_HASH` — are
present in the new blob read as its `0x` octets, with the old blob as
the positive control and a first-octet-flipped variant absent from both
as the negative one.

`_PRV_KEY` and `_MSG_HASH` are transcribed from the same file and the
issue named neither; the entry covers them.

## The pin names the tip of the path

`72867fd6`, which is what `check_vendored_vectors.py` compares against —
`commits?path=…&per_page=1`. `master`'s tip would make the weekly run
report drift that is not there. That commit happens to be the tip of two
paths, so this entry and the `zkp_rangeproof_fixed_vectors.json` one
look like copies and are not: different paths, different blobs.

## Collateral

[ISS 1916](https://github.com/btclib-org/btclib/issues/1916), a
pre-existing drift this branch does not touch, filed under the title the
workflow itself uses so the scheduled run updates that issue rather than
opening a second.
[ISS 1917](https://github.com/btclib-org/btclib/issues/1917): the module
also carried a revision for the header its docstrings *paraphrase*, and
a paraphrase has no ledger. The revision is gone; where that provenance
belongs is a decision of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Pin the anti-exfil test vectors in the shared ledger used for weekly upstream drift checks.

Bug Fixes:
- Move the anti-exfil test vectors’ upstream provenance into the ledger monitored by the weekly vendored-vector check, preventing the pin from silently drifting.

Enhancements:
- Update the anti-exfil test module to reference the shared provenance ledger instead of maintaining its own revision metadata.
- Record the upstream commit and blob containing the transcribed vectors and document how all relevant values are verified against that source.

Documentation:
- Document the anti-exfil vector provenance and add the test module to the ledger’s tracked vendored sources.
- Add a changelog entry describing the centralized pin and its coverage.