### PR TITLE
`ecc.rangeproof` derives the chain a proof of more than one ring draws (issue #1072)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3187,6 +3187,42 @@ file of the test tree, and no caller acts on it.
   message beside them -- is in that blob, read as the octets of its
   `0x` arrays.
 
+### `ecc.rangeproof` derives the chain a proof of more than one ring draws
+
+- **`RangeProof.nonce_chain` answers what
+  `secp256k1_rangeproof_genrand` draws for a proof's rings** (issue
+  #1072), as a `NonceChain`: one blinding factor per ring, and one
+  scalar per public key. Nothing here signs -- writing a proof that
+  states a range, verifying one and rewinding one are all still ahead
+  of the module -- and `sign_public_value` takes the one draw its
+  single ring makes from it.
+- **Two acceptance rules, one per kind of draw.** A ring blinding
+  factor at or past n, or zero, sends the chain on for another block,
+  which is what `rfc6979_nonce_` does with a rejected candidate and by
+  the same two HMACs; a ring member's draw there abandons the proof
+  instead. A proof of one ring meets the second alone.
+- **Every ring but the last spends a block before the one it tests.**
+  `genrand` draws into the buffer it overwrites before reading it, so
+  that block's value is discarded and the chain advance it made is not.
+  Skipping it puts the derivation off by a block from the first ring
+  onward, in scalars that are well formed: what says so is a proof zkp
+  signed.
+- **A last ring of more than one key carries the value inside one of
+  its own draws**, where `secp256k1_rangeproof_rewind_inner` reads it
+  back out of the `s` the proof states: an octet of 128, seven of zero,
+  and the value big-endian three times. It goes on the ring's last key,
+  or the one before it where the value's own digit is that one, and
+  folding it in moves no other draw and no blinding factor.
+- **What holds all of it is octets zkp signed, and it needs no flagged
+  extension.** Every ring commitment an entry of
+  `tests/ecc/_data/zkp_rangeproof_vectors.json` states is rebuilt from
+  that entry's `nonce` -- each is its ring's blinding factor times G
+  plus the digit that ring proves times the generator -- and every `s`
+  the signature did not overwrite is the chain's own draw. The entries
+  record proofs of one ring and of several, and both keys the value
+  encoding can land on are among them; what the flagged job adds is the
+  same two questions over mantissas no entry fixes.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/ecc/rangeproof.py
+++ b/src/btclib/ecc/rangeproof.py
@@ -15,7 +15,10 @@ ring holds the key the commitment itself gives. `RangeProof.pubk_rings`
 rebuilds, from a proof and the value commitment it was written against,
 the rings `secp256k1_borromean_verify` is handed, and
 `RangeProof.sign_key_idx` says which key of each ring a value's own
-digit names. Nothing here verifies a proof or rewinds one. Issue #1072
+digit names. `RangeProof.nonce_chain` derives what
+`secp256k1_rangeproof_genrand` draws for those rings: each ring's
+blinding factor, and the scalar behind each of its keys. Nothing here
+verifies a proof or rewinds one. Issue #1072
 is where the rest of that distance is tracked.
 
 Elements and Liquid use this format, and a design starting today would
@@ -89,9 +92,10 @@ rings verifies, this module does not ask.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from hashlib import sha256
+from typing import NamedTuple
 
 from btclib.alias import INF, BinaryData, Integer, Octets, Point
 from btclib.curves import bytes_from_point, mult, scalar_from_prv_key, secp256k1
@@ -108,7 +112,7 @@ from btclib.utils import (
     read_exactly,
 )
 
-__all__ = ["RangeProof", "sign_public_value"]
+__all__ = ["NonceChain", "RangeProof", "sign_public_value"]
 
 # the flags octet, as secp256k1_rangeproof_getheader_impl reads it
 _RESERVED = 128
@@ -130,6 +134,11 @@ _MIN_VALUE_SIZE = 8
 # width every other length here generalizes: `rangeproof_genrand` copies
 # that many octets of the caller's nonce into its seed
 _NONCE_SIZE = 32
+
+# how far apart two rings sit in the octets `sign_impl` hands the nonce
+# chain, which is the widest a ring gets rather than the width of the
+# ring in hand: `genrand` indexes that buffer by `i * 4 + j`
+_RING_STRIDE = 4
 
 
 def _rsizes(mantissa: int) -> tuple[int, ...]:
@@ -290,6 +299,121 @@ def _pub_expand(
     return tuple(rings)
 
 
+class NonceChain(NamedTuple):
+    """What `secp256k1_rangeproof_genrand` answers for one proof's rings.
+
+    `blinding_factors` is one scalar per ring, the one that ring's
+    commitment is written under. Every ring but the last draws its own
+    and the last is minus the sum of those, so once
+    `secp256k1_rangeproof_sign_impl` has added the caller's own to that
+    last one they sum to it -- which is what lets a verifier recover
+    the ring commitment the proof leaves out. What is here is the
+    chain's answer, before that addition.
+
+    `draws` is one scalar per public key, ring-major, the shape
+    `BorromeanSig.s` carries. At the key the value's own digit names,
+    `sign_impl` moves the draw into the nonce it closes that ring with;
+    at every other key the draw is the `s` the proof states.
+    """
+
+    blinding_factors: tuple[int, ...]
+    draws: tuple[tuple[int, ...], ...]
+
+
+def _blocks(seed: bytes) -> Iterator[bytes]:
+    """Yield the blocks of the chain that seed starts, one scalar wide.
+
+    `secp256k1_rfc6979_hmac_sha256_generate` raises a retry flag at the
+    end of every call and performs the K and V update at the start of
+    the next, so every block after the first opens with a reseed. That
+    update is `_HmacDrbg.reseed`, the same two HMACs in the same order
+    that `_rfc6979_nonce_` performs on a rejected candidate.
+    """
+    drbg = _HmacDrbg(seed, sha256)
+    yield drbg.generate(secp256k1.n_size)
+    while True:
+        drbg.reseed()
+        yield drbg.generate(secp256k1.n_size)
+
+
+def _prep(rsizes: Sequence[int], v: int, sign_key_idx: int) -> bytes:
+    """Return the octets `secp256k1_rangeproof_sign_impl` folds into the draws.
+
+    zkp's `prep`, which is where a message a proof embeds would sit.
+    Nothing here embeds one, so the buffer is zero but for one key of
+    the last ring, and that key is written whether there is a message
+    or not: an octet of 128, seven of zero, and the value the mantissa
+    carries big-endian three times, at the eight octets a `min_value`
+    field occupies and for the same reason, both being a uint64. That
+    is what makes the value readable from the proof by whoever holds
+    the nonce, which is `secp256k1_rangeproof_rewind_inner`.
+
+    A last ring of one key has no such position, and the public-value
+    proof is the one shaped that way -- it states its value in the
+    clear anyway. Anywhere else the key is the ring's last, or the one
+    before it where the value's own digit is that one, since the draw
+    at the digit's key is spent as a nonce rather than written into
+    the proof.
+    """
+    prep = bytearray(_RING_STRIDE * secp256k1.n_size * len(rsizes))
+    if rsizes[-1] > 1:
+        j = rsizes[-1] - 1 - (sign_key_idx == rsizes[-1] - 1)
+        offset = ((len(rsizes) - 1) * _RING_STRIDE + j) * secp256k1.n_size
+        prep[offset : offset + secp256k1.n_size] = (
+            bytes([128]) + bytes(7) + v.to_bytes(_MIN_VALUE_SIZE, "big") * 3
+        )
+    return bytes(prep)
+
+
+def _genrand(seed: bytes, rsizes: Sequence[int], prep: bytes) -> NonceChain:
+    """Return the chain `secp256k1_rangeproof_genrand` derives from that seed.
+
+    Two acceptance rules, one per kind of draw. A ring blinding factor
+    at or past n, or zero, sends the chain on for another block, which
+    is what `_rfc6979_nonce_` does with a rejected candidate and by the
+    same two HMACs. A ring member's draw there fails the proof instead:
+    zkp accumulates that into the `ret` it answers with and abandons
+    the proof after the loop, which is the raise here.
+
+    Every ring but the last spends a block before the one it tests, the
+    chain drawing into a buffer it overwrites before reading it. So the
+    value of that block is discarded and the advance it made is not.
+    Skipping it puts the derivation off by a block from the first ring
+    onward, in scalars that are well formed: what says so is a proof
+    zkp signed.
+    """
+    blocks = _blocks(seed)
+    blinding_factors: list[int] = []
+    draws: list[tuple[int, ...]] = []
+    acc = 0
+    for i, size in enumerate(rsizes):
+        if i < len(rsizes) - 1:
+            next(blocks)
+            while True:
+                sec = int.from_bytes(next(blocks), "big")
+                if 0 < sec < secp256k1.n:
+                    break
+            blinding_factors.append(sec)
+            acc = (acc + sec) % secp256k1.n
+        else:
+            blinding_factors.append(-acc % secp256k1.n)
+
+        ring: list[int] = []
+        for j in range(size):
+            offset = (i * _RING_STRIDE + j) * secp256k1.n_size
+            block = zip(
+                next(blocks),
+                prep[offset : offset + secp256k1.n_size],
+                strict=True,
+            )
+            s = int.from_bytes(bytes(a ^ b for a, b in block), "big")
+            if not 0 < s < secp256k1.n:
+                raise BTClibRuntimeError("rangeproof nonce is not a scalar")
+            ring.append(s)
+        draws.append(tuple(ring))
+    return NonceChain(tuple(blinding_factors), tuple(draws))
+
+
 @dataclass(frozen=True, init=False)
 class RangeProof:
     """A Confidential Transactions rangeproof, as its octets state it.
@@ -441,6 +565,67 @@ class RangeProof:
 
         return _pub_expand([*stated, last], self.exp, self.rsizes)
 
+    def nonce_chain(
+        self,
+        commitment: Point,
+        value: int,
+        nonce: Octets,
+        *,
+        check_validity: bool = True,
+    ) -> NonceChain:
+        """Return the scalars this proof's nonce derives.
+
+        `secp256k1_rangeproof_genrand`, seeded as
+        `secp256k1_rangeproof_sign_impl` seeds it: the caller's nonce,
+        then the value commitment and the generator under
+        `_serialize_point`, then the header octets this proof's own
+        exponent, mantissa and `min_value` write. So whoever holds the
+        nonce answers every ring commitment the proof states -- each is
+        its ring's blinding factor times G plus that ring's own digit
+        times the generator -- and every `s` the signature left as the
+        chain drew it.
+
+        `commitment` is the Pedersen commitment the proof was written
+        against, `pubk_rings`'s argument of that name, and `value` what
+        it commits to. The value is read for more than the digits:
+        wherever the last ring holds more than one key, one of them
+        carries the value inside its own draw, so the chain is not a
+        function of the header alone. A value this proof has no digit
+        for is refused, `sign_key_idx`'s own refusal.
+        """
+        if check_validity:
+            self.assert_valid()
+        secp256k1.require_on_curve(commitment)
+        sign_key_idx = self.sign_key_idx(value)
+        seed = bytes_from_octets(nonce, _NONCE_SIZE)
+        seed += _serialize_point(commitment) + _serialize_point(second_generator())
+        seed += _header_octets(self.exp, self.mantissa, self.min_value)
+
+        v = self._mantissa_value(value)
+        return _genrand(seed, self.rsizes, _prep(self.rsizes, v, sign_key_idx[-1]))
+
+    def _mantissa_value(self, value: int) -> int:
+        """Return that value in the units the mantissa's digits count.
+
+        `secp256k1_range_proveparams`' `v`: the value less `min_value`,
+        over ten as many times as the exponent says. The value the
+        proof was written for is what this answers for. A value outside
+        that range, or one the exponent's own scaling cannot reach, is
+        no value of this proof and is refused.
+        """
+        min_value = self.min_value or 0
+        if not min_value <= value <= self.max_value:
+            err_msg = f"rangeproof value not in {min_value}..{self.max_value}: {value}"
+            raise BTClibValueError(err_msg)
+        # mypy reads `int ** int` as `Any`, a negative exponent being
+        # what makes that operator answer a float
+        scale: int = 10 ** max(self.exp, 0)
+        v, remainder = divmod(value - min_value, scale)
+        if remainder:
+            err_msg = f"rangeproof value {value} is not the exponent's own multiple"
+            raise BTClibValueError(err_msg)
+        return v
+
     def sign_key_idx(self, value: int) -> tuple[int, ...]:
         """Return where in each ring the key of that value sits.
 
@@ -451,18 +636,9 @@ class RangeProof:
         leaves over, and the digit there is below two because the value
         is within the range the header states.
 
-        The value the proof was written for is what this answers for. A
-        value outside that range, or one the exponent's own scaling
-        cannot reach, is no digit of this proof and is refused.
+        A value this proof has no digit for is refused.
         """
-        min_value = self.min_value or 0
-        if not min_value <= value <= self.max_value:
-            err_msg = f"rangeproof value not in {min_value}..{self.max_value}: {value}"
-            raise BTClibValueError(err_msg)
-        v, remainder = divmod(value - min_value, 10 ** max(self.exp, 0))
-        if remainder:
-            err_msg = f"rangeproof value {value} is not the exponent's own multiple"
-            raise BTClibValueError(err_msg)
+        v = self._mantissa_value(value)
         return tuple((v >> 2 * i) & 3 for i in range(len(self.rsizes)))
 
     def serialize(self, *, check_validity: bool = True) -> bytes:
@@ -605,15 +781,11 @@ def sign_public_value(blind: Integer, value: int, nonce: Octets) -> RangeProof:
     # sum of the others, and there are no others, so `sec` is zero and
     # the caller's `blind` is the whole of it -- and one block for the
     # ring's one public key, which `sign_impl` then moves into the nonce
-    # the ring is closed with
+    # the ring is closed with. `secp256k1_range_proveparams` answers an
+    # `exp` of -1 with a value of zero at digit zero, which is what
+    # leaves that ring with nothing of `_prep` written into it
     seed = nonce_bytes + points + header
-    k = int.from_bytes(_HmacDrbg(seed, sha256).generate(secp256k1.n_size), "big")
-    if not 0 < k < secp256k1.n:
-        # genrand's answer to a draw it cannot use, not
-        # `rfc6979_nonce`'s: `secp256k1_scalar_set_b32` flags a draw at
-        # or past n, zero is refused beside it, and `sign` returns zero
-        # on either rather than asking the chain again
-        raise BTClibRuntimeError("rangeproof nonce is not a scalar")
+    k = _genrand(seed, (1,), _prep((1,), 0, 0)).draws[0][0]
 
     m = sha256(points + header).digest()
     r = bytes_from_point(mult(k, secp256k1.G, secp256k1), secp256k1)

--- a/src/btclib/ecc/rfc6979_nonce.py
+++ b/src/btclib/ecc/rfc6979_nonce.py
@@ -72,9 +72,9 @@ class _HmacDrbg:
     asks the chain again, and `secp256k1_rangeproof_genrand` does that
     too for the ring blinding factors a proof of more than one ring
     draws, while failing outright on a ring member's own draw.
-    `ecc.rangeproof` takes one draw and it is of that second kind, a
-    single ring drawing no blinding factor at all; it seeds this with a
-    commitment and a proof header rather than with a key and a message.
+    `ecc.rangeproof` meets both, the single-ring proof it writes taking
+    one draw of the second kind alone; it seeds this with a commitment
+    and a proof header rather than with a key and a message.
     secp256k1-zkp's `secp256k1_rfc6979_hmac_sha256` reseeds between
     every pair of draws whichever kind they are.
     """

--- a/tests/ecc/rangeproof_test.py
+++ b/tests/ecc/rangeproof_test.py
@@ -37,6 +37,15 @@ published ring commitments cannot be asked to state it -- each carries a
 blinding factor drawn from the nonce chain, so the value, the exponent
 and the mantissa do not determine them.
 
+The `nonce` is what determines them, and every entry is asked that too:
+`nonce_chain` has to write the ring commitments the proof states, x and
+sign bit, and every `s` the signature did not overwrite. That is the
+whole of `secp256k1_rangeproof_genrand` held to octets zkp wrote, its
+two acceptance rules apart: a chain that redrew no ring blinding factor
+and refused no ring member's draw answers every entry here, and each of
+those draws is reached at one in about 2**128. What puts them is a
+chain a test writes.
+
 The `zkp`-marked tests at the end put the same questions to the library
 itself, and two more the recording cannot answer: that signing again
 with the recorded arguments answers the very octets vendored here, and
@@ -529,20 +538,233 @@ def test_pubk_rings_does_not_check_the_proof_twice() -> None:
     )
 
 
-class _FixedDraw:
-    """A `_HmacDrbg` whose chain the test wrote.
+def _seed(vector: dict[str, Any]) -> bytes:
+    # what `secp256k1_rangeproof_sign_impl` hands the chain, built from
+    # the recording rather than asked of the module: the header octets
+    # are the proof's own prefix, so nothing under test supplies them
+    octets = bytes.fromhex(vector["proof"])
+    return (
+        bytes.fromhex(vector["nonce"])
+        + rangeproof._serialize_point(commit(vector["blind"], vector["value"]))
+        + rangeproof._serialize_point(second_generator())
+        + octets[: _header_size(octets)]
+    )
 
-    `sign_public_value` builds one and asks it once, so a stand-in with
-    a `generate` is the whole of what has to be replaced: the draws
-    below are refused at one in about 2**128 and cannot be reached by
-    choosing a nonce.
+
+class _FixedDraws:
+    """A `_HmacDrbg` whose chain the test wrote, block by block.
+
+    The blocks come back in the order they were given, which is what
+    lets a test put a draw at one step of `_genrand` and a different one
+    at the next: refused draws are reached at one in about 2**128 and
+    cannot be had by choosing a nonce.
     """
 
-    def __init__(self, octets: bytes) -> None:
-        self.octets = octets
+    def __init__(self, *blocks: bytes) -> None:
+        self.blocks = list(blocks)
 
     def generate(self, size: int) -> bytes:
-        return self.octets[:size]
+        return self.blocks.pop(0)[:size]
+
+    def reseed(self) -> None:
+        """Advance nothing: what the chain answers is the list above."""
+
+
+@pytest.mark.parametrize("vector", _VECTORS, ids=_IDS)
+def test_the_nonce_chain_writes_the_ring_commitments_a_proof_states(
+    vector: dict[str, Any],
+) -> None:
+    """Every ring commitment, rebuilt from the nonce that drew its factor.
+
+    A ring commitment is its ring's blinding factor times G plus the
+    digit that ring proves times the generator, and every blinding
+    factor but the last comes off the chain the caller's nonce seeds.
+    So the x coordinates and sign bits a proof states are a function of
+    the recording's `nonce`, which is what
+    `test_pubk_rings_open_at_the_recorded_blinding_factor` cannot ask:
+    that sum holds for any assignment of factors adding up to `blind`.
+
+    The last ring's factor is minus the sum of the others, and
+    `secp256k1_rangeproof_sign_impl` adds the caller's own to it, which
+    is the head `pubk_rings` recovers rather than reads.
+    """
+    proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
+    commitment = commit(vector["blind"], vector["value"])
+    chain = proof.nonce_chain(commitment, vector["value"], vector["nonce"])
+    sign_key_idx = proof.sign_key_idx(vector["value"])
+    scale = 10 ** max(proof.exp, 0)
+
+    heads = []
+    factors = list(chain.blinding_factors)
+    factors[-1] = (factors[-1] + int(vector["blind"], 16)) % secp256k1.n
+    for i, (sec, digit) in enumerate(zip(factors, sign_key_idx, strict=True)):
+        heads.append(
+            secp256k1.add_aff_var(
+                mult(sec, secp256k1.G, secp256k1),
+                mult(digit * scale << 2 * i, second_generator(), secp256k1),
+            )
+        )
+
+    stated = [rangeproof._serialize_point(head) for head in heads[:-1]]
+    assert tuple(int.from_bytes(o[1:], "big") for o in stated) == proof.ring_commitments
+    assert tuple(bool(o[0]) for o in stated) == proof.signs
+    assert tuple(ring[0] for ring in proof.pubk_rings(commitment)) == tuple(heads)
+
+
+@pytest.mark.parametrize("vector", _VECTORS, ids=_IDS)
+def test_the_nonce_chain_answers_every_s_the_signature_did_not_write(
+    vector: dict[str, Any],
+) -> None:
+    """The draws, against the `s` values the proof carries.
+
+    `secp256k1_rangeproof_sign_impl` moves the draw at the key the
+    value's own digit names into the nonce that closes the ring and
+    writes a signature there, and leaves every other draw where it is.
+    So the two agree at exactly the keys `sign_key_idx` does not name,
+    which is what makes the whole chain -- the discarded block of every
+    ring but the last included -- answerable to octets zkp wrote.
+    """
+    proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
+    commitment = commit(vector["blind"], vector["value"])
+    chain = proof.nonce_chain(commitment, vector["value"], vector["nonce"])
+    sign_key_idx = proof.sign_key_idx(vector["value"])
+
+    for i, (drawn, written) in enumerate(zip(chain.draws, proof.sig.s, strict=True)):
+        for j, (a, b) in enumerate(zip(drawn, written, strict=True)):
+            assert (a == b) == (j != sign_key_idx[i])
+
+
+def test_nonce_chain_refuses_a_commitment_that_is_no_point() -> None:
+    """The seed hashes the commitment, and hashing it checks nothing.
+
+    `_serialize_point` asks the y for its residuosity and writes the x,
+    which a pair off the curve answers as readily as a point: absent
+    the check, a commitment naming no public key derives a chain like
+    any other. The refusal is `pubk_rings`' own, on the argument of the
+    same name.
+    """
+    vector = _vector("odd mantissa")
+    proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
+    with pytest.raises(BTClibValueError, match="point not on curve"):
+        proof.nonce_chain((1, 2), vector["value"], vector["nonce"])
+
+
+def test_nonce_chain_does_not_check_the_proof_twice() -> None:
+    """`check_validity` is `pubk_rings`' flag and means the same here.
+
+    The chain reads the mantissa, the exponent and `min_value`, which
+    `assert_valid` has already held against each other, so a caller
+    that has checked the object once says so and gets the same scalars.
+    """
+    vector = _vector("odd mantissa")
+    proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
+    commitment = commit(vector["blind"], vector["value"])
+    assert proof.nonce_chain(
+        commitment, vector["value"], vector["nonce"], check_validity=False
+    ) == proof.nonce_chain(commitment, vector["value"], vector["nonce"])
+
+
+def test_a_ring_but_the_last_spends_a_block_before_the_one_it_keeps() -> None:
+    """The draw `secp256k1_rangeproof_genrand` makes and does not read.
+
+    It draws into the buffer it overwrites before testing it, so the
+    blinding factor of every ring but the last is the second block of
+    its pair and the first is spent on the chain's advance alone. A
+    derivation taking the first is off by a block from that ring
+    onward, which no proof of a single ring can show.
+    """
+    vector = _vector("scaled exponent")
+    proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
+    chain = proof.nonce_chain(
+        commit(vector["blind"], vector["value"]), vector["value"], vector["nonce"]
+    )
+
+    blocks = rangeproof._blocks(_seed(vector))
+    discarded, tested, member = (int.from_bytes(next(blocks), "big") for _ in range(3))
+    assert chain.blinding_factors[0] == tested
+    assert chain.blinding_factors[0] != discarded
+    assert chain.draws[0][0] == member
+
+
+@pytest.mark.parametrize(
+    "id_, key",
+    [("padded sign bits", 3), ("scaled exponent", 2)],
+    ids=["the last key of the ring", "the one before the digit's own"],
+)
+def test_the_last_ring_carries_the_value_in_one_of_its_draws(
+    id_: str, key: int
+) -> None:
+    """`prep`'s value encoding, which is one draw of one ring and no more.
+
+    `secp256k1_rangeproof_sign_impl` writes the value into the octets
+    it hands the chain, and `secp256k1_rangeproof_rewind_inner` reads
+    it back out of the `s` the proof states there. The key is the
+    ring's last, or the one before it where the value's own digit is
+    that one, since the draw at the digit's key is spent as a nonce.
+
+    Fold nothing in and every other draw is what it was: the chain
+    advances on the blocks alone, so what this costs is one `s` of one
+    ring, in a proof that is otherwise byte for byte the same.
+    """
+    vector = _vector(id_)
+    proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
+    value = vector["value"]
+    sign_key_idx = proof.sign_key_idx(value)
+    v = proof._mantissa_value(value)
+
+    prep = rangeproof._prep(proof.rsizes, v, sign_key_idx[-1])
+    seed = _seed(vector)
+    written = rangeproof._genrand(seed, proof.rsizes, prep)
+    plain = rangeproof._genrand(seed, proof.rsizes, bytes(len(prep)))
+
+    moved = [
+        (i, j)
+        for i, ring in enumerate(plain.draws)
+        for j, drawn in enumerate(ring)
+        if drawn != written.draws[i][j]
+    ]
+    assert moved == [(len(proof.rsizes) - 1, key)]
+    assert written.blinding_factors == plain.blinding_factors
+
+    i, j = moved[0]
+    assert written.draws[i][j] == proof.sig.s[i][j]
+    encoding = b"\x80" + bytes(7) + v.to_bytes(8, "big") * 3
+    assert plain.draws[i][j] ^ written.draws[i][j] == int.from_bytes(encoding, "big")
+
+
+def test_a_ring_blinding_factor_that_is_no_scalar_is_redrawn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Genrand's other acceptance rule, the one a single ring never meets.
+
+    A ring blinding factor at or past n, or zero, sends
+    `secp256k1_rangeproof_genrand` back to the chain for another block,
+    where the same draw for a ring member fails the proof outright --
+    which is `test_a_draw_that_is_no_scalar_is_refused_and_not_redrawn`
+    below. The factor of the last ring is drawn from nothing: it is
+    minus the sum of the others, so two rings answer with a pair
+    summing to zero.
+    """
+    accepted = bytes(31) + b"\x07"
+    members = [bytes(31) + bytes([j]) for j in range(1, 5)]
+    monkeypatch.setattr(
+        rangeproof,
+        "_HmacDrbg",
+        lambda *_: _FixedDraws(
+            b"\x11" * 32,
+            bytes(32),
+            secp256k1.n.to_bytes(32, "big"),
+            accepted,
+            *members,
+        ),
+    )
+
+    rsizes = (2, 2)
+    zeroed = bytes(rangeproof._RING_STRIDE * secp256k1.n_size * len(rsizes))
+    chain = rangeproof._genrand(b"", rsizes, zeroed)
+    assert chain.blinding_factors[0] == int.from_bytes(accepted, "big")
+    assert chain.blinding_factors[1] == secp256k1.n - chain.blinding_factors[0]
+    assert chain.draws == ((1, 2), (3, 4))
 
 
 @pytest.mark.parametrize("vector", _PUBLIC_VALUES, ids=_PUBLIC_VALUE_IDS)
@@ -635,7 +857,7 @@ def test_a_draw_that_is_no_scalar_is_refused_and_not_redrawn(
     candidate. A proof written from that next block is one zkp does not
     write.
     """
-    monkeypatch.setattr(rangeproof, "_HmacDrbg", lambda *_: _FixedDraw(draw))
+    monkeypatch.setattr(rangeproof, "_HmacDrbg", lambda *_: _FixedDraws(draw))
     with pytest.raises(BTClibRuntimeError, match="nonce is not a scalar"):
         sign_public_value(_BLIND, 1, _NONCE)
 
@@ -670,7 +892,7 @@ def test_a_zero_signature_value_is_refused(monkeypatch: pytest.MonkeyPatch) -> N
     k = 5
     e = k * pow(int(_BLIND, 16), -1, secp256k1.n) % secp256k1.n
     monkeypatch.setattr(
-        rangeproof, "_HmacDrbg", lambda *_: _FixedDraw(k.to_bytes(32, "big"))
+        rangeproof, "_HmacDrbg", lambda *_: _FixedDraws(k.to_bytes(32, "big"))
     )
     monkeypatch.setattr(rangeproof, "_hash", lambda *_: e.to_bytes(32, "big"))
     with pytest.raises(BTClibRuntimeError, match="signature value is zero"):
@@ -793,3 +1015,52 @@ def test_zkp_signs_and_verifies_the_proof_this_module_writes() -> None:
         octets = sign_public_value(_BLIND, value, _NONCE).serialize()
         assert octets == zkp_rangeproof.sign(commitment, blind, nonce, value, exp=-1)
         assert zkp_rangeproof.verify(commitment, octets) == (value, value)
+
+
+@needs_zkp  # pragma: no cover -- no zkp.rangeproof to sign at other arguments
+def test_the_nonce_chain_answers_proofs_zkp_signs_at_other_shapes() -> None:
+    """The derivation put to rings the recording does not fix.
+
+    Each entry fixes one mantissa, where the library signs at any of
+    them: the mantissas here are none of the entries', so the ring
+    count varies, and with it the digit of the last ring and the key
+    its value encoding lands on.
+    Each proof is asked what an entry is asked -- that the chain writes
+    the ring commitments it states, x and sign bit, and every `s` its
+    signature did not overwrite.
+    """
+    blind = bytes(31) + b"\x0b"
+    for min_bits, exp, value in (
+        (2, 0, 3),
+        (13, 0, 5000),
+        (16, 2, 123400),
+        (52, 0, 2**51),
+    ):
+        nonce = bytes(31) + bytes([min_bits])
+        octets = zkp_rangeproof.sign(
+            zkp_generator.pedersen_commit(blind, value),
+            blind,
+            nonce,
+            value,
+            exp=exp,
+            min_bits=min_bits,
+        )
+        proof = RangeProof.parse(octets)
+        chain = proof.nonce_chain(commit(blind, value), value, nonce)
+        sign_key_idx = proof.sign_key_idx(value)
+        scale = 10 ** max(proof.exp, 0)
+
+        for i, x in enumerate(proof.ring_commitments):
+            head = secp256k1.add_aff_var(
+                mult(chain.blinding_factors[i], secp256k1.G, secp256k1),
+                mult(sign_key_idx[i] * scale << 2 * i, second_generator(), secp256k1),
+            )
+            assert rangeproof._serialize_point(head) == bytes(
+                [proof.signs[i]]
+            ) + x.to_bytes(secp256k1.p_size, "big")
+
+        for i, (drawn, written) in enumerate(
+            zip(chain.draws, proof.sig.s, strict=True)
+        ):
+            for j, (a, b) in enumerate(zip(drawn, written, strict=True)):
+                assert (a == b) == (j != sign_key_idx[i])

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -170,6 +170,7 @@ KEYWORD_ONLY: dict[str, list[str]] = {
     "btclib.ecc.borromean:BorromeanSig.parse": ["check_validity"],
     "btclib.ecc.borromean:BorromeanSig.serialize": ["check_validity"],
     "btclib.ecc.rangeproof:RangeProof.__init__": ["check_validity"],
+    "btclib.ecc.rangeproof:RangeProof.nonce_chain": ["check_validity"],
     "btclib.ecc.rangeproof:RangeProof.parse": ["check_validity"],
     "btclib.ecc.rangeproof:RangeProof.pubk_rings": ["check_validity"],
     "btclib.ecc.rangeproof:RangeProof.serialize": ["check_validity"],


### PR DESCRIPTION
Stage 5 of [ISS 1072](https://github.com/btclib-org/btclib/issues/1072),
which stays open: this derives, and does not yet write.

`ecc.rangeproof` reproduces the chain `secp256k1_rangeproof_genrand`
derives — one blinding factor per ring and one draw per public key —
behind `RangeProof.nonce_chain` and a `NonceChain` named tuple.

## Four facts about that chain, each with a control

The chain is a sequence of HMAC-DRBG draws, and three of the four things
governing it are invisible in any recorded proof. Each was measured by
removing it and watching what stops reproducing.

**Two acceptance rules, not one.** Line 88's `do{…}while(overflow ||
is_zero)` **retries** for a ring blinding factor; line 103's `ret &=
!(overflow || is_zero)` **fails** for a ring member's draw. Neither
shows in a recording — a chain that redrew nothing and refused nothing
answers every vendored entry, each of those draws being reached at one
in about 2^128 — so a chain a test writes is what puts them.

**Line 84 draws a block whose value is discarded and whose chain advance
is not.** Control, with that line removed and nothing else: 0/25, 0/30
and 0/15 forged `s` values reproduce on the three multi-ring vectors,
and 0/8, 0/9, 0/4 stated ring commitments — while the two single-ring
vectors are unaffected, which is what says the control is aimed at the
right arm.

**The retry arm is `reseed()` then `generate()`.** zkp's `generate`
performs the K/V update at the start of every call after the first, so
the `do` loop's second call is that pair, byte for byte
`_HmacDrbg.reseed`.

**`sign_impl` never passes `message == NULL`.** It hands `genrand` a
buffer carrying a value-encoding block — `0x80`, seven zero octets, the
value big-endian three times — XORed into one key's draw, which a rewind
reads the value back out of. Control: exactly **one** forged `s` per
proof wrong, every ring commitment and every other `s` still matching.
Quieter than the others, and not a multi-ring fact: the one-ring vendored
entry carries it.

## `sign_public_value` moves onto the same chain

It took its single draw a second way; now there is one implementation of
the chain in the module. Review measured the octets did not move: over
200 seeds the new derivation and the old agree with 0 mismatches, and
`_prep` for a one-ring proof is 128 zero octets.

## What is not here

Nothing signs. Verifying a proof, rewinding one, and writing one that
states a range rather than a value are still ahead of the module —
stages 6 and 7, where
[ISS 1895](https://github.com/btclib-org/btclib/issues/1895)'s borromean
negation also lands.

## Evidence

Two independent reviews. The first rebuilt the curve, `H`, the header
parse and `_serialize_point` from secp256k1-zkp's own source and ran the
diff's own `_genrand` against them, reproducing every count above with
five controls of its own. A probe asserting the derived factors "sum to
`blind · G`" was discarded rather than reported: it is a tautology of
`sec[last] = -sum` and true under every control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Expose and validate the secp256k1-zkp rangeproof nonce chain without adding proof signing, verification, or rewinding.

New Features:
- Add `RangeProof.nonce_chain`, exposing the rangeproof nonce-chain blinding factors and per-key draws.
- Represent the derivation through a public `NonceChain` result and reuse it for public-value proofs.

Enhancements:
- Model ring-specific nonce derivation, including discarded ring blocks, blinding-factor retries, scalar validation, and embedded value encoding.
- Centralize mantissa value validation and nonce-chain generation for multi-ring and single-ring proofs.

Documentation:
- Document the nonce-chain behavior, its relationship to secp256k1-zkp, and the remaining unsupported proof operations.

Tests:
- Validate reconstructed ring commitments and untouched signature scalars against vendored and independently generated zkp proofs.
- Cover nonce-chain block advancement, value embedding, invalid scalars, invalid commitments, and validity-check behavior.