### PR TITLE
The `@needs_zkp` pragmas name the build, not the job (closes #1897)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3223,6 +3223,18 @@ file of the test tree, and no caller acts on it.
   encoding can land on are among them; what the flagged job adds is the
   same two questions over mantissas no entry fixes.
 
+### The `@needs_zkp` pragmas name the build, not the job
+
+- **`tests/ecc/pedersen_test.py` and `tests/ecc/rangeproof_test.py`
+  justify their `pragma: no cover` the way `tests/__init__.py` and
+  `tests/conftest.py` justify theirs** (closes #1897): what turns the
+  marker into a skip is a btclib-secp256k1 installed without
+  `BTCLIB_LIBSECP256K1_ZKP`, and excluding what a build cannot execute
+  is what leaves the floor a measurement of the suite.
+- **A contributor who builds the flagged extension measures coverage in
+  that build too**, so the reason a further `@needs_zkp` test copies has
+  to hold outside CI. No exclusion moves.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/ecc/pedersen_test.py
+++ b/tests/ecc/pedersen_test.py
@@ -335,10 +335,10 @@ def test_writing_refuses_what_has_no_x_to_write(
 
 
 # `pragma: no cover` on every `@needs_zkp` below, that marker being the
-# reason: `ZKP_AVAILABLE` is False in every job that measures coverage,
-# `.github/workflows/zkp-oracle.yml` being the one job where it is True,
-# and that job's own `pytest -m zkp --no-cov` collects no coverage data
-# for any report to combine. The marker's line and not the `def` under
+# reason: `tests/conftest.py` turns it into a skip in an unflagged
+# build, and excluding what a build cannot execute is what leaves the
+# floor a measurement of the suite rather than of the build the machine
+# has (issue #1885). The marker's line and not the `def` under
 # it: `ruff format` reflows a `def` line a comment carries past 88
 # columns, splitting `-> None:` across three lines to hang it, and
 # leaves a decorator line alone.

--- a/tests/ecc/rangeproof_test.py
+++ b/tests/ecc/rangeproof_test.py
@@ -900,10 +900,11 @@ def test_a_zero_signature_value_is_refused(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 # `pragma: no cover` on every `@needs_zkp` below, the marker being the
-# reason: `ZKP_AVAILABLE` is False in every job that measures coverage,
-# and `zkp-oracle.yml`'s own `pytest -m zkp --no-cov` collects none. The
-# marker's line and not the `def` under it, as `tests/ecc/pedersen_test.py`
-# does and for the reason it gives there
+# reason: `tests/conftest.py` turns it into a skip in an unflagged
+# build, and excluding what a build cannot execute is what leaves the
+# floor a measurement of the suite rather than of the build the machine
+# has (issue #1885). The marker's line and not the `def` under it, as
+# `tests/ecc/pedersen_test.py` does and for the reason it gives there
 @needs_zkp  # pragma: no cover -- no zkp.rangeproof to sign the vectors again
 def test_the_vectors_are_what_zkp_signs_today() -> None:
     """Signing again with the recorded arguments answers the recorded octets.


### PR DESCRIPTION
`tests/ecc/pedersen_test.py` and `tests/ecc/rangeproof_test.py` give
their `pragma: no cover` the reason `tests/__init__.py` and
`tests/conftest.py` give theirs: a btclib-secp256k1 installed without
`BTCLIB_LIBSECP256K1_ZKP` is what turns the marker into a skip, and
excluding what a build cannot execute is what leaves the floor a
measurement of the suite.

A contributor who builds the flagged extension measures coverage in that
build too, so a reason stated in terms of CI's jobs leaves that run
without an account of the exclusions it carries (issue #1885). No
exclusion moves; what the edit changes is the reason a further
`@needs_zkp` test copies.

Reviewed locally at fresh context before opening: `CLEARED
5bfedfdb1e954d41a1cd572bc7c55169261309b0`. The replacement clause was
checked byte for byte against `tests/conftest.py`'s own account, with a
control proving the comparison can answer False; the two comments were
word-diffed folded and differ only where they already did; and the
fourteen `@needs_zkp` decorator lines are corroborated by the gate block
itself -- the unflagged run reaches 100.00% with those tests skipped, so
the pragma spans cover the bodies and not merely their own lines.

closes #1897

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Update `@needs_zkp` coverage pragma explanations to describe build capabilities instead of CI jobs.

Enhancements:
- Clarify that `@needs_zkp` coverage exclusions apply to builds without the ZKP extension rather than specific CI jobs, keeping coverage explanations valid for all build configurations.

Documentation:
- Document the updated rationale for ZKP-related coverage pragmas in the changelog.