### PR TITLE
`btclib.p2p` argues from the format, not from a consumer (closes #1919)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3235,6 +3235,27 @@ file of the test tree, and no caller acts on it.
   that build too**, so the reason a further `@needs_zkp` test copies has
   to hold outside CI. No exclusion moves.
 
+### `btclib.p2p`'s justifications are properties of the format
+
+- **The prose under `src/btclib/p2p/` and the tests that drive it argue
+  from the wire format and from Bitcoin Core, naming no package
+  downstream of this one** (closes #1919): section 9's *a package
+  upstream of another does not name the one downstream* is what decides
+  it, and `docs/source/btclib.p2p.rst` renders those docstrings for a
+  reader who has no such package. Each passage already carried the
+  format-level reason before it named anyone, so what goes is the
+  subject and what stays is the consequence.
+- **`tests/block/build_test.py` attributes the genesis message and
+  pubkey to Bitcoin Core's `CreateGenesisBlock`**,
+  `src/kernel/chainparams.cpp` being where both sit as literals.
+- **The `sendcmpt` anecdote is retired from the p2p tests**: it is an
+  event in another tree, where what it illustrates -- `Message` looks a
+  command up nowhere, so a misspelling round-trips as well as the real
+  thing -- is a property of this one, and is what those tests now say.
+  This supersedes the last bullet of *`compact_blocks`'s two
+  justifications are properties of the format* above, which has the
+  event still told there; the rest of that entry stands.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/p2p/address.py
+++ b/src/btclib/p2p/address.py
@@ -15,15 +15,15 @@ octets are not the same: a `version` message's two addresses carry no
 timestamp and an `addr` message's carry four octets of one in front. Core
 writes that as a serialization parameter -- `CAddress::SerParams` with
 `Format::Disk`, `Format::Network` -- and its test framework as
-`CAddress.deserialize(f, with_time=True)`. A parameter is what btclib_node
-has too, and it is where that implementation loses a round trip: a
-`NetworkAddress` parsed with `version_msg=True` is *forced* to `time=0`
-rather than left without one, so the field says zero where it means
-absent, and an `addr` entry cannot be told from a `version` one by looking
-at it. Here `Version.addr_recv` is annotated `NetworkAddress` and
-`Addr.addresses` holds `TimestampedNetworkAddress`, so putting one where
-the other belongs is a call mypy refuses rather than octets a peer
-refuses.
+`CAddress.deserialize(f, with_time=True)`. A parameter is where one class
+loses a round trip: the class has the timestamp field whichever way the
+octets were read, so an address parsed out of a `version` message is
+*forced* to a timestamp of zero rather than left without one -- the field
+then says zero where it means absent, and an `addr` entry cannot be told
+from a `version` one by looking at it. Here `Version.addr_recv` is
+annotated `NetworkAddress` and `Addr.addresses` holds
+`TimestampedNetworkAddress`, so putting one where the other belongs is a
+call mypy refuses rather than octets a peer refuses.
 
 **The port is big-endian and it is the only field of this protocol that
 is.** Core writes it through `Using<BigEndianFormatter<2>>(obj.port)`,
@@ -39,14 +39,12 @@ other.
 `::ffff:a.b.c.d` -- ten NUL octets, two 0xff, then the four of the v4
 address -- is what a v4 peer is on the wire, and the sixteen octets are
 what is held here rather than a narrower form plus a tag for which it is.
-That is the second thing btclib_node departs from and the second round
-trip it loses: it stores four octets for a v4 address and sixteen for a
-v6 one, so an IPv6 address that happens to begin with the mapping prefix
-parses back as the IPv4 address it is not, and its own test works around
-the collision with an unexplained `49`. `ipaddress.IPv6Address` is
-`.packed` in one direction and the constructor in the other, exactly and
-for every value, and `.ipv4_mapped` is what answers the question the tag
-was for.
+The narrower form is what loses a round trip: four octets for a v4
+address and sixteen for a v6 one makes an IPv6 address that happens to
+begin with the mapping prefix parse back as the IPv4 address it is not.
+`ipaddress.IPv6Address` is `.packed` in one direction and the
+constructor in the other, exactly and for every value, and
+`.ipv4_mapped` is what answers the question the tag was for.
 """
 
 from __future__ import annotations

--- a/src/btclib/p2p/addrv2.py
+++ b/src/btclib/p2p/addrv2.py
@@ -111,17 +111,17 @@ all; a `.onion` name is SHA3-256 and a checksum over them, and a
 
 **`network_address`, `addr_entry` and `peer_from_addr_entry` are the
 translation to and from `btclib.p2p.address`'s two classes, and
-`can_addrv1` is the question a caller asks first.** btclib-node holds a
-peer as a `NetworkAddressV2` -- BIP155's record being the only encoding
-wide enough for every network a peer can be on -- and still speaks `addr`
-to a peer that has not sent `sendaddrv2`, so it wrote the translation.
-Each is a function of the two types this package already owns and of the
-BIP that relates them, which is why it belongs here rather than beside a
-socket: `network_address` refuses a network `addr` cannot carry, on
-`can_addrv1`'s own question, and `addr_entry` and `peer_from_addr_entry`
-are what stand on either side of that refusal, adding and reading the
-timestamp `TimestampedNetworkAddress` carries and `NetworkAddressV2`
-already has.
+`can_addrv1` is the question a caller asks first.** BIP155's record is
+the only encoding wide enough for every network a peer can be on, so it
+is what a peer is held in, and `addr` is still what a peer that has not
+sent `sendaddrv2` is spoken to in: the translation is what stands
+between the two. Each is a function of the two types this package
+already owns and of the BIP that relates them, which is why it belongs
+here rather than beside a socket: `network_address` refuses a network
+`addr` cannot carry, on `can_addrv1`'s own question, and `addr_entry`
+and `peer_from_addr_entry` are what stand on either side of that
+refusal, adding and reading the timestamp `TimestampedNetworkAddress`
+carries and `NetworkAddressV2` already has.
 """
 
 from __future__ import annotations

--- a/src/btclib/p2p/data.py
+++ b/src/btclib/p2p/data.py
@@ -65,10 +65,9 @@ read where it is used, which is where `Tx.serialize` reads its own.
 **`TxPayload` and `BlockPayload`, and the suffix is the point.** These
 are the only payload types whose command names a class this library
 already has, and `from btclib.p2p import Tx` shadowing `btclib.tx.Tx` is
-a collision a caller pays for silently. btclib_node has it -- its
-`p2p/messages/data.py` declares `Tx` and `Block` and imports btclib's as
-`TxData` and `BlockData` -- and it is the reader of the two modules
-together who cannot then say which is which.
+a collision a caller pays for silently: a module wanting both has to
+import one of the two under another name, and its reader cannot then say
+which name is which.
 
 **Nothing here bounds a message length.**
 `btclib.p2p.limits.MAX_PROTOCOL_MESSAGE_LENGTH` is the envelope's,

--- a/src/btclib/p2p/limits.py
+++ b/src/btclib/p2p/limits.py
@@ -19,15 +19,15 @@ consensus rule, so none of them is in `btclib.consensus` -- and
 is, which is the coincidence this module exists to keep from becoming an
 import.
 
-An envelope without `MAX_PROTOCOL_MESSAGE_LENGTH` is what btclib_node has
--- `verify_headers` reads the four octets and waits for `24 +
-payload_len` with nothing between the peer's number and the buffer -- and
-the bound is the difference between refusing such a header at once and
-holding whatever the peer dribbles in against a length it will never
-reach. Every count bound here has the same shape one layer up: `parse`
-reads the count before it builds anything, where btclib_node's own
-message classes loop over whatever `var_int.parse` allowed them, and
-btclib's var_int cap is 33,554,432.
+An envelope without `MAX_PROTOCOL_MESSAGE_LENGTH` reads the four octets
+of the length field and waits for `24 + payload_len`, with nothing
+between the peer's number and the buffer, and the bound is the
+difference between refusing such a header at once and holding whatever
+the peer dribbles in against a length it will never reach. Every count
+bound here has the same shape one layer up: `parse` reads the count
+before it builds anything, where a `parse` that loops over whatever
+`var_int.parse` allowed it is bounded only by btclib's var_int cap,
+33,554,432.
 
 Not every name here is checked by something, and BIP157's are where the
 difference shows: a bound on a *range* whose far end is a block hash

--- a/src/btclib/p2p/message.py
+++ b/src/btclib/p2p/message.py
@@ -103,14 +103,13 @@ class Message:
     one and where that decision is argued.
 
     It is a field of the message and not something a connection puts in
-    front of it, which is where this departs from btclib_node: there
-    `messages.add_headers` writes the other three fields and
-    `p2p.connection.Connection._send` prepends the magic, so what the
-    codec serializes is not a message and is not what its own
-    `verify_headers` reads back -- that one indexes the length at 16,
-    which is where it sits once the magic is there. One header across two
-    layers is also the one shape unavailable to a package that holds no
-    connection.
+    front of it. A header split across two layers -- a codec writing the
+    other three fields, whatever sends them prepending the magic -- means
+    the codec never serializes a message: the length field sits twelve
+    octets into what it writes and sixteen into the header that reaches
+    the wire, so the two layers index one header differently. One header
+    across two layers is also the one shape unavailable to a package that
+    holds no connection.
 
     `command` is the message type as text, "version" or "verack", without
     the NUL padding the wire puts after it, and an unknown one round-trips

--- a/src/btclib/p2p/payload.py
+++ b/src/btclib/p2p/payload.py
@@ -22,13 +22,13 @@ reason for the one above (issue #1098):
   command would stop being octets and start being an error. The envelope
   round-tripping what it does not recognize is the property that let it
   be written before any of this, and a table is what takes it away.
-- **payload classes alone, with the caller writing the command**, which
-  is btclib_node's shape: `add_headers("addr", payload)` is a string
-  literal inside each `serialize`, and nothing anywhere compares it with
-  the table the receiving side dispatches on. That is how `"sendcmpt"`
-  and `"cmptblock"` -- both misspelled, both sent to the whole network --
-  survive there. One constant per class, used by both directions, is the
-  whole of the difference.
+- **payload classes alone, with the caller writing the command**: the
+  command is then a string literal wherever a message is built, and
+  nothing anywhere compares it with the table the receiving side
+  dispatches on. A misspelling in one of those literals serializes as
+  readily as the real thing and matches no branch on the receiving side.
+  One constant per class, used by both directions, is the whole of the
+  difference.
 
 **There is no reverse of `to_message` here, and the asymmetry is the
 decision rather than an omission.** Writing a message needs no table: the

--- a/tests/block/build_test.py
+++ b/tests/block/build_test.py
@@ -15,10 +15,10 @@ node agrees with, not merely one that agrees with `Block.assert_valid`.
 
 `test_build_block_reproduces_mainnet_s_genesis` is the third such vector,
 and the one every network shares the coinbase shape of -- the same
-message and the same pubkey `btclib_node.chains.create_genesis` and
-Bitcoin Core's own source both carry. `build_coinbase` cannot build it:
-the genesis predates BIP34, so its script_sig commits to no height at
-all. What the test measures is `build_block`'s own header assembly,
+message and the same pubkey Bitcoin Core's own `CreateGenesisBlock`
+carries, in `src/kernel/chainparams.cpp`. `build_coinbase` cannot build
+it: the genesis predates BIP34, so its script_sig commits to no height
+at all. What the test measures is `build_block`'s own header assembly,
 which is the half a genesis-block builder would still lean on --
 ISS 1602 is where the rest of that decision lives.
 """
@@ -219,10 +219,9 @@ def test_build_block_reproduces_mainnet_s_genesis() -> None:
 
     BIP34 is not in force at height zero, so the genesis commits to no
     height at all. The same message and pubkey `bitcoin/bitcoin`'s own
-    genesis carries, reproduced from `btclib_node.chains.create_genesis`'s
-    own constants; what this checks is build_block's header assembly,
-    over a hand-built coinbase, against the hash `NETWORKS["mainnet"]`
-    ships.
+    genesis carries, which its `CreateGenesisBlock` holds as literals;
+    what this checks is build_block's header assembly, over a hand-built
+    coinbase, against the hash `NETWORKS["mainnet"]` ships.
     """
     script_sig = script.serialize(
         [

--- a/tests/consensus_test.py
+++ b/tests/consensus_test.py
@@ -328,8 +328,7 @@ def test_taproot_is_on_from_the_genesis_block_of_every_chain() -> None:
 
     Core turns the three on for every block and names the blocks that
     fail them one by one, so a table of activation heights has no row
-    for taproot to be wrong about -- which is the value btclib-node's
-    own copy records as a date rather than a height.
+    for taproot to be wrong about.
     """
     for row in CONSENSUS_PARAMS.values():
         assert row.script_flags_at(0) & ScriptFlag.TAPROOT

--- a/tests/imports_test.py
+++ b/tests/imports_test.py
@@ -166,8 +166,6 @@ def test_the_codec_does_not_pay_for_the_rpc_package() -> None:
     one. It is arithmetic and text -- it imports `functools` and nothing
     else -- where `socket.inet_pton`, which is the other way to write the
     same conversion, would put the C library's resolver behind a codec.
-    btclib_node uses `socket.inet_pton`, and it is a package that does
-    open connections.
     """
     package_name = "'bitcoin_core_rpc'"
     transport_cost = "'urllib.request'"

--- a/tests/integration/p2p_test.py
+++ b/tests/integration/p2p_test.py
@@ -27,10 +27,10 @@ makes of it -- an unparsable message is one
 
 What this does not do is complete the handshake: nothing here sends a
 `verack` back, and the connection is closed once Core's own has been
-read. `btclib-org/btclib-node#374` is where the two-way exchange, the
-connection promoting, and a synced tip are already exercised, against
-that repository's own connection loop -- reproducing it here would only
-say that loop still works, not this library's wire format.
+read. The two-way exchange, the connection promoting and a synced tip
+are a connection loop's behaviour rather than a wire format's, and this
+library holds no connection loop -- driving one here would say that loop
+still works and nothing about the octets.
 """
 
 from __future__ import annotations

--- a/tests/name_contract_test.py
+++ b/tests/name_contract_test.py
@@ -107,8 +107,8 @@ _CAN_ADDRV1_ASKS_CAPACITY_NOT_VALIDITY = (
     "`is_addrv1` would name the encoding rather than the question asked of"
     " it -- whether an `addr` message, which has no field for the network"
     " id, has room for this peer at all. `can_` is issue #1581's own name"
-    " for it and btclib-node's before that, and it is what `network_address`"
-    " asks first before refusing on the same question"
+    " for it, and it is what `network_address` asks first before refusing"
+    " on the same question"
 )
 
 _ENGLISH_PREDICATE: dict[str, str] = {

--- a/tests/p2p/address_test.py
+++ b/tests/p2p/address_test.py
@@ -132,10 +132,10 @@ def test_an_ipv4_address_has_one_object_however_it_is_spelled() -> None:
     """Every spelling of one peer builds the one address.
 
     The alternative -- holding four octets and a tag for a v4 address and
-    sixteen for a v6 one -- is what btclib_node does, and it makes
-    `::ffff:10.0.0.1` and `10.0.0.1` two objects with one serialization,
-    so a set of peers holds the same peer twice and a round trip is not
-    the identity. Sixteen octets throughout is the answer.
+    sixteen for a v6 one -- makes `::ffff:10.0.0.1` and `10.0.0.1` two
+    objects with one serialization, so a set of peers holds the same peer
+    twice and a round trip is not the identity. Sixteen octets throughout
+    is the answer.
     """
     mapped = NetworkAddress(0, "10.0.0.1", 8333)
     spellings = (
@@ -334,8 +334,7 @@ def test_the_count_is_bounded_before_anything_is_built() -> None:
 
     The count is the peer's to choose and btclib's own `var_int.parse`
     allows 33,554,432 of them, so a parser that builds first turns nine
-    octets into as many thirty-octet objects -- which is what
-    btclib_node's `Addr.deserialize` does. The refusal here reads the
+    octets into as many thirty-octet objects. The refusal here reads the
     count and stops, with no payload behind it at all, and it does not
     answer to `check_validity`.
     """

--- a/tests/p2p/core_commands_test.py
+++ b/tests/p2p/core_commands_test.py
@@ -10,8 +10,7 @@ no table of them, which is `btclib/p2p/payload.py`'s decision (issue
 Core's is what `src/protocol.h` declares, and the two are separately
 valid: only reading them together says they have drifted. A message type
 Core adds is one nothing here is red about, and a command misspelled here
-round-trips as well as the real thing -- which is how btclib_node came to
-send `sendcmpt` to the whole network.
+round-trips as well as the real thing.
 
 Core's set is transcribed below rather than read from a checkout of it.
 A test that goes and fetches its own input has a verdict that depends on

--- a/tests/p2p/data_test.py
+++ b/tests/p2p/data_test.py
@@ -343,10 +343,9 @@ def test_the_package_publishes_neither_tx_nor_block() -> None:
 
     `from btclib.p2p import *` must not bind a `Tx` other than
     `btclib.tx.Tx`, and the command a payload travels under is where the
-    unsuffixed name would have come from. btclib_node's
-    `p2p/messages/data.py` declares both and imports btclib's as `TxData`
-    and `BlockData`, which is the collision this avoids rather than
-    renames.
+    unsuffixed name would have come from. A module wanting both would
+    have to import one of them under another name, which is the collision
+    the suffix avoids rather than renames.
     """
     published = set(btclib.p2p.__all__)
     assert {"TxPayload", "BlockPayload"} <= published

--- a/tests/p2p/handshake_test.py
+++ b/tests/p2p/handshake_test.py
@@ -124,8 +124,9 @@ def test_an_absent_relay_flag_is_not_a_refusal_to_relay() -> None:
     peer that omits it is asking for transactions. `is_relay_requested`
     is that reading; `relay` is the field, and a caller reading the field
     for the answer says the opposite of the protocol for every peer that
-    omitted it -- which is the bug btclib_node has, its
-    `int.from_bytes(b"", "little")` answering zero.
+    omitted it. A parser that decodes the absent octet rather than
+    leaving the field `None` says it too, `int.from_bytes(b"", "little")`
+    being zero.
     """
     assert Version(relay=None).is_relay_requested is True
     assert Version(relay=True).is_relay_requested is True

--- a/tests/p2p/inventory_test.py
+++ b/tests/p2p/inventory_test.py
@@ -278,9 +278,10 @@ def test_the_command_each_class_travels_under() -> None:
 
     One constant per class, read by both directions, is what keeps the
     name a payload serializes under and the name a caller matches on from
-    drifting apart -- which is how btclib_node came to send `"sendcmpt"`
-    and `"cmptblock"` to the whole network, both misspelled and neither
-    compared with anything.
+    drifting apart. `tests/p2p/core_commands_test.py` asks whether a
+    command is one Core declares; which class carries which is asked
+    here, so a swap between two of Core's own spellings passes that
+    census.
     """
     # `Any`, because `Payload` declares no `parse` and no two of these
     # answer with the same type: `tests/p2p/payload_test.py` reads the

--- a/tests/p2p/negotiation_test.py
+++ b/tests/p2p/negotiation_test.py
@@ -22,8 +22,7 @@ here reuses.
 
 What is worth asserting instead is what this module decides: that each
 command is spelled the way Bitcoin Core's `NetMsgType` spells it -- a
-misspelling round-trips as well as the real thing, which is how
-btclib_node sent "sendcmpt" to the whole network -- that a `feefilter`
+misspelling round-trips as well as the real thing -- that a `feefilter`
 outside the money range is parsed rather than refused, Core asking
 `MoneyRange` about a value it has already read, and that a
 `sendtxrcncl` version below BIP330's floor of 1 is parsed rather than

--- a/tests/p2p/payload_test.py
+++ b/tests/p2p/payload_test.py
@@ -140,9 +140,10 @@ def test_a_payload_knows_the_command_that_carries_it(payload: Payload) -> None:
     """The constant is on the class, so the two directions read one name.
 
     Which is the whole of what a payload type adds to an ordinary wire
-    class here: btclib_node writes the command as a string literal inside
-    each `serialize` and dispatches on a separate table, and two of its
-    literals are misspellings nothing compares against.
+    class here: writing the command as a string literal inside each
+    `serialize` and dispatching on a separate table puts one name in two
+    places with nothing comparing them, so a misspelling in either is
+    invisible to both.
     """
     command = type(payload).command
     assert isinstance(command, str)


### PR DESCRIPTION
Section 9's "a package upstream of another does not name the one
downstream" decides this: btclib is upstream of btclib-node, so a
justification here that rests on that tree is a cross-reference the
reader of this package does not have, and `docs/source/btclib.p2p.rst`
renders the module docstrings among them.

Each passage already stated the format-level reason before it named
anyone, so what goes is the subject and what stays is the consequence,
written as a property: one class carrying the timestamp field forces a
zero where two classes leave it absent; a narrower address form plus a
tag cannot round-trip `::ffff:a.b.c.d`; an envelope with no length bound
waits on the peer's own number with nothing between it and the buffer;
and a command written at the call site is compared with nothing.

`tests/p2p/inventory_test.py`'s docstring takes the shape `e157baf5`
settled on in the file next door: `tests/p2p/core_commands_test.py` asks
whether a command is one Core declares, and which class carries which is
asked here. A misspelled `Inv.command` fails that census, so the test
does not claim to be the only thing that catches a drift; `Inv.command`
and `GetData.command` swapped leaves the published set unchanged, and
the census and `tests/p2p/payload_test.py` both pass on it.

Measured at btclib-node 4ad69581, every present-tense claim removed here
was already false of that tree: `verify_headers` is nowhere in it,
`add_headers` is a chainstate method over headers,
`src/btclib_node/p2p/messages/` declares no `Tx` or `Block`, the address
classes are btclib's own, `socket.inet_pton` appears nowhere, taproot is
recorded as on from the genesis block, and `connection.py` reads
`payload.command` under a comment saying the payload names its own
command -- which is the shape `payload.py`'s rejected alternative argues
for rather than against.

The genesis constants `tests/block/build_test.py` reproduces are
attributed to Bitcoin Core's `CreateGenesisBlock` instead: at
`33a363ea25` its `src/kernel/chainparams.cpp` holds the message and the
pubkey as literals.

`tests/integration/p2p_test.py` keeps the reason for its scope boundary
and loses the issue number behind it, what it declines to drive being a
connection loop's behaviour rather than a wire format's.
`tests/name_contract_test.py` keeps issue #1581 as `can_`'s provenance.

CHANGELOG.md is untouched apart from the new entry: its occurrences are
records of what changes did, and released sections are sealed by their
tag.

Reviewed locally at fresh context before opening: `CLEARED
a53a86e04a5c2cb3e933332c71214e1d6d0a70cc`. The reviewer re-measured the
two constructions itself rather than taking them: misspelling
`Inv.command` reddens four tests, two of them `core_commands_test.py`'s
census; swapping `Inv.command` with `GetData.command` reddens only
`inventory_test.py`'s two, which is what the new docstring claims and no
more. It ruled on the agentless sentence in `addrv2.py` and found the
downstream tree states the same fact with itself as the subject, so
after this each tree states the half it owns.

The rebase onto `5dd503f3` crossed `CHANGELOG.md`'s `merge=union` seam.
The result is not the rebase's output: `CHANGELOG.md` was rebuilt as the
new base's blob with this branch's block spliced back in at the index
the anchor holds in the base blob's own numbering, and the committed
blob `cmp`s identical to that reconstruction. The rebase had eaten one
blank line and nothing else. Four controls, including a planted
misplacement that the whole-file heading invariant passes and the byte
reconstruction fails -- which is what proves the reconstruction is not
position-blind. The pinned `markdownlint-cli2` was then invoked directly
and answered clean, with a planted control on a copy exiting non-zero
and naming MD022 and MD032 on this branch's own heading, so the clean
answer is a real pass and not a file the tool never opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Make btclib.p2p documentation and test rationale self-contained by grounding it in wire-format properties and Bitcoin Core conventions.

Enhancements:
- Rewrite btclib.p2p documentation and test rationale to describe wire-format properties and Bitcoin Core behavior without relying on downstream package references.
- Clarify payload command ownership, address round-trip guarantees, message length validation, and parser boundaries as intrinsic protocol design properties.
- Align test documentation with the distinct responsibilities of Core command coverage and payload-to-command mapping.

Documentation:
- Update the changelog to record the package-independent p2p rationale and attribute genesis constants to Bitcoin Core.

Tests:
- Refine p2p and related test docstrings to remove downstream implementation anecdotes while preserving the intended scope and behavioral guarantees.