### PR TITLE
`commit_nonce_test.py`'s `@needs_zkp` comment names the build, not the job (closes #1926)

### DIFF
--- a/tests/ecc/commit_nonce_test.py
+++ b/tests/ecc/commit_nonce_test.py
@@ -240,12 +240,12 @@ def test_libsecp256k1_zkp_fixed_vectors(commit_hash: str, opening: str) -> None:
 # opposite direction. `bytes_from_point`/`point_from_pub_key` do the same
 # for a receipt against zkp's 33-byte compressed opening.
 #
-# `pragma: no cover` on both `@needs_zkp` lines below: an unflagged
-# build skips these tests, and CI's flagged build runs them under
-# `.github/workflows/zkp-oracle.yml`'s `pytest -m zkp --no-cov`, which
-# collects no coverage data for any report to combine. The marker's line
-# and not the `def` under it, as `tests/ecc/pedersen_test.py` does and
-# for the reason it gives there.
+# `pragma: no cover` on every `@needs_zkp` below, the marker being the
+# reason: `tests/conftest.py` turns it into a skip in an unflagged
+# build, and excluding what a build cannot execute is what leaves the
+# floor a measurement of the suite rather than of the build the machine
+# has (issue #1885). The marker's line and not the `def` under it, as
+# `tests/ecc/pedersen_test.py` does and for the reason it gives there.
 @needs_zkp  # pragma: no cover -- no zkp ecdsa_s2c.verify_commit to open the receipt
 def test_dsa_commitment_opens_under_zkp() -> None:
     """A btclib sign-to-contract commitment opens under zkp's own check."""


### PR DESCRIPTION
The comment gave the build as its reason and then named
`.github/workflows/zkp-oracle.yml`'s `pytest -m zkp --no-cov` as well.
It stops at the build now, in `tests/ecc/rangeproof_test.py`'s own
words, which name the marker rather than counting the lines carrying
it: `tests/conftest.py` turns the marker into a skip in an unflagged
build, and excluding what a build cannot execute is what leaves the
floor a measurement of the suite rather than of the build the machine
has.

What CI does with the report a flagged build collects stays in
`tests/__init__.py`, beside the `ZKP_AVAILABLE` guard, stated once for
the whole suite.

No exclusion moves: `uv run --locked pytest` reaches the 100% floor
unflagged, on the same statement and branch totals as the base.

CHANGELOG.md is untouched. Nothing a reader of the library notices
changes, and the rule this comment now follows is the subject of the
v2026.9 entry that landed for issue #1897.

Reviewed locally at fresh context before opening: `CLEARED
2567e47bc46508fb46f2eff11e1e0a12dafecbfe`, the tip this branch carries
unchanged through its rebase -- `tests/ecc/commit_nonce_test.py` is blob
`5cae4112` before and after, and the branch touches no other file.

The reviewer re-derived the claim the change rests on rather than taking
it: `git grep -n 'pragma: no cover'` at three literal shas answers the
same three sites at the same line numbers, so no exclusion moved. It
also rebuilt the folded sweep after finding its own first fold silently
blind to a break at a hyphen, and then looked for a fourth copy of the
CI mechanism under a phrase nobody had tried -- "writes no data file, so
there is nothing for a union to combine" -- which turns up in
`CHANGELOG.md` alone. After this, `tests/__init__.py` is the single
source in code.

closes #1926

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Align the ZKP test coverage guidance with the suite-wide handling of conditionally skipped tests.

Bug Fixes:
- Correct the `@needs_zkp` coverage-exclusion comment to identify the marker as the reason these tests are excluded from unflagged builds.

Enhancements:
- Clarify that coverage exclusions apply to code unavailable in the current build, without changing test coverage behavior or excluded lines.