### PR TITLE
`claude-review.yml` pins claude-code-action at a point release (closes #1924)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -146,7 +146,7 @@ jobs:
           fi
       - name: Review against REVIEWING.md
         id: review
-        uses: anthropics/claude-code-action@fa2b2666b747000bf42767d1f332065b375e3c8f # v1
+        uses: anthropics/claude-code-action@19dda84776b3518d98b8798e591daee763049ed3 # v1.0.220
         # a diff read and a comment posted; a review past this is hung
         # on the API or on its own reasoning, and either way it has
         # written no verdict. On the step rather than on the job for the
@@ -449,6 +449,6 @@ jobs:
             exit 1
           fi
       - name: Answer the mention
-        uses: anthropics/claude-code-action@fa2b2666b747000bf42767d1f332065b375e3c8f # v1
+        uses: anthropics/claude-code-action@19dda84776b3518d98b8798e591daee763049ed3 # v1.0.220
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3256,6 +3256,20 @@ file of the test tree, and no caller acts on it.
   justifications are properties of the format* above, which has the
   event still told there; the rest of that entry stands.
 
+### The `claude-code-action` pin names a point release
+
+`claude-review.yml` pins `anthropics/claude-code-action` at the commit
+`v1.0.220` names, in the review step and in the mention step, with that
+tag as the trailing comment (closes #1924).
+
+The comment beside a pin is what makes a bump reviewable, and `# v1`
+cannot be that: `v1` names whatever commit that repository released
+last, so the comment reads the same before and after the sha moves and
+the diff carries no version at all. Following a name its owner moves is
+what pinning to a sha exists to stop, and it costs more here than
+elsewhere: the two jobs holding this pin run with `pull-requests: write`
+and `id-token: write`.
+
 ## v2026.9.3
 
 ### Repository


### PR DESCRIPTION
Both sites -- the review step and the mention step -- carry
19dda84776b3518d98b8798e591daee763049ed3, the commit the annotated tag
`v1.0.220` peels to, with that tag as the trailing comment in place of
`# v1`.

The sha is not the one the tag ref answers with. `git/ref/tags/v1.0.220`
reports `.object.type` as `tag` and gives the tag object's own sha;
`git/tags/<sha>` peels that to the commit, which is what a runner can
check out. Whoever bumps this pin next picks the tag with

    gh api repos/anthropics/claude-code-action/git/refs/tags \
      --paginate --jq '.[].ref' | grep '^refs/tags/v1\.0\.' \
      | sort -t. -k3,3n | tail -1

and peels it: that API lists refs in lexical order, where `v1.0.99`
sorts after `v1.0.220`, so the last line it prints is not the newest
release.

`compare/v1.0.220...v1` answers `identical`, so naming the point release
does not move the pin past what the floating name resolved to.

Reviewed locally at fresh context before opening: `CLEARED
5e9ffdacc7354805531eb31b6fb1e01e26709e00`, no blocking findings. This
pull request is on its own, as `issues.md`'s *Pull request* requires for
a change to this file: the action validates its own workflow against the
default branch, so its job cannot review the branch that changes it, and
the local review is the whole of the review it gets.

The reviewer re-derived the peel from the API rather than accepting it
-- `v1.0.220` is annotated, so the ref answers a tag object and the
commit is reached through `git/tags/<sha>` -- and resolved **all
eleven** other pins rather than the three it was asked to sample, three
of them annotated, which double as a control on that peel logic. It also
settled, in a sibling repository, the one claim the author had honestly
marked as an inference: `btclib-org/btclib-secp256k1` at `d4781781` is a
single dependabot commit that rewrites `# v4.37.7` and `# v4.37.8` to
`# v4.37.9` while leaving a `# v1` untouched, so the bot does maintain a
point-release comment. This tree could not settle it, holding only two
dependabot commits and both on the `# v1` pin.

The rebase onto `5c37b317` crossed `CHANGELOG.md`'s `merge=union` seam,
which the reviewer had predicted by reading the merged blob rather than
the merge's exit code. Repaired by reconstruction rather than by the
rebase's output: the base blob with this branch's block spliced at the
anchor's index in the base blob's own numbering, the committed blob
`cmp`-identical to it, 286 headings and no blank-line violation, zero
base lines absent. The pinned `markdownlint-cli2` then answered clean,
with a planted control on a copy exiting non-zero and naming MD022 and
MD032 on this branch's own heading.

Nothing here exercises the action. `zizmor` runs `--offline`, which is
what disables `impostor-commit` and `known-vulnerable-actions`, so no
gate in this tree asserts the pinned sha exists; that it does was
measured by API, twice, independently.

closes #1924

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Pin the Claude Code Action workflows to the v1.0.220 point release for a reviewable, stable action version.

Enhancements:
- Pin both Claude Code Action workflow usages to the immutable v1.0.220 commit and identify the point release in their comments.

Chores:
- Document the Claude Code Action point-release pin in the changelog.