### PR TITLE
`ecc.rangeproof` reaches `ecc.pedersen`'s residuosity codec (closes #1910)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3314,6 +3314,42 @@ and `id-token: write`.
   comment beside the interpreter axis already said of the release
   before it.
 
+### One codec writes and reads libsecp256k1-zkp's residuosity octet
+
+- **`ecc.rangeproof` reaches `ecc.pedersen`'s private pair at its own
+  tag** (closes #1910). zkp xors the bit that reports the residuosity of
+  y into a tag of its own for each thing it serializes:
+  `secp256k1_pedersen_commitment_save` into 9,
+  `secp256k1_generator_serialize` into 11, both in
+  `src/modules/generator/main_impl.h`, and
+  `secp256k1_rangeproof_serialize_point` into 1, in
+  `src/modules/rangeproof/rangeproof_impl.h`. The rangeproof carried
+  that arithmetic itself, so a correction to it reached only the copy it
+  was made in, each side having its own tests. Every tag is odd, which
+  is what makes bit 0 the bit complemented, and the tags now sit
+  together under the comment that says so.
+- **Lifting an x is one function too.** `_point_from_octets` unpacks a
+  tagged octet and calls it, and `RangeProof.pubk_rings` calls it with
+  the bit already in hand, a proof carrying its sign bits in a packed
+  field rather than in front of an x. It answers what
+  `secp256k1_ge_set_xquad` answers, negated where the bit says y is not
+  a square.
+- **The octets are what they were.** `sign_public_value` writes the
+  proof zkp signed for the same arguments, which
+  `tests/ecc/rangeproof_test.py` asks of it against a vendored
+  recording and against the library itself, and the ring commitments of
+  the proofs zkp publishes resolve to the same points, which
+  `tests/ecc/rangeproof_fixed_vectors_test.py` asks.
+- **`RangeProof.nonce_chain` refuses a commitment at infinity.** The
+  shared writer turns down a pair that is no point of secp256k1 and
+  the infinity point. The first is out of reach from `ecc.rangeproof`:
+  `nonce_chain` requires the commitment on the curve before any seed
+  exists, and `sign_public_value` writes points it computed itself.
+  The second is not, `Curve.is_on_curve` answering `True` for `(x, 0)`,
+  which is how a point at infinity is spelled in affine coordinates, so
+  requiring the commitment on the curve is no guard against it.
+  `pubk_rings` is unaffected, writing no point at all.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/ecc/pedersen.py
+++ b/src/btclib/ecc/pedersen.py
@@ -29,10 +29,12 @@ octet reports whether y is a quadratic residue:
 `secp256k1_pedersen_commitment_save` writes
 `9 ^ secp256k1_fe_is_square_var(&ge->y)` and
 `secp256k1_generator_serialize` writes `11 ^` the same bit, both in
-`src/modules/generator/main_impl.h`. `ecc.rangeproof` carries that same
-convention at a third base, `1 ^` it: `_serialize_point` writes what
-`sign_public_value` hashes, and `_point_from_ring_commitment` lifts a
-ring commitment's x against it. Lifting such an octet by the parity the
+`src/modules/generator/main_impl.h`;
+`secp256k1_rangeproof_serialize_point` writes `1 ^` it, in
+`src/modules/rangeproof/rangeproof_impl.h`. That third tag is the base
+`ecc.rangeproof` hashes a point under and lifts a ring commitment's x
+against, and that module reaches the codec below for both rather than
+carrying one of its own. Lifting such an octet by the parity the
 `02`/`03` of `curves.point_from_octets` carries answers the same point
 for some x and its negation for others, with nothing in the octets to
 say which reading wrote them, so the two are not one function under two
@@ -195,13 +197,23 @@ def verify(
     return True
 
 
-# the leading octet of each of libsecp256k1-zkp's two serializations,
-# before the bit that reports the residuosity of y is xored into it.
-# Both tags are odd, so bit 0 of the octet is that bit complemented: it
-# is set exactly where y is not a square, which is what
+# the leading octet of each of libsecp256k1-zkp's serializations, before
+# the bit that reports the residuosity of y is xored into it. Every tag
+# is odd, so bit 0 of the octet is that bit complemented: it is set
+# exactly where y is not a square, which is what
 # `secp256k1_pedersen_commitment_load` reads to decide whether to negate
-# the point `secp256k1_ge_set_xquad` lifted. An even tag would leave bit
-# 0 the bit itself, and that negation would take the wrong half
+# the point `secp256k1_ge_set_xquad` lifted, and what
+# `secp256k1_rangeproof_verify_impl` reads for the same decision. An
+# even tag would leave bit 0 the bit itself, and that negation would
+# take the wrong half.
+#
+# 1 is the tag whose other bits are all zero, so a rangeproof's octet is
+# the residuosity bit alone: `secp256k1_rangeproof_serialize_point`
+# writes `data[0] = !secp256k1_fe_is_square_var(&point->y)`, and a proof
+# carries that bit in a packed field rather than in front of an x, which
+# is why `ecc.rangeproof` calls `_bytes_from_point` and `_point_from_x`
+# and never `_point_from_octets`
+_RANGEPROOF_TAG = 1
 _COMMITMENT_TAG = 9
 _GENERATOR_TAG = 11
 
@@ -209,10 +221,10 @@ _GENERATOR_TAG = 11
 def _bytes_from_point(Q: Point, tag: int) -> bytes:
     """Return `tag ^ is_square(y)` and then x, at whichever tag.
 
-    The tag is the whole of what a commitment's octets and a
-    generator's do not share, so what both refuse is asked here rather
-    than once each: a pair that is no point of secp256k1, and the
-    infinity point, which has no x to write.
+    The tag is the whole of what the encodings do not share, so what
+    they all refuse is asked here rather than once each: a pair that is
+    no point of secp256k1, and the infinity point, which has no x to
+    write.
 
     The Legendre symbol is what `secp256k1_fe_is_square_var` answers,
     and each computes it as a gcd rather than as an exponentiation.
@@ -225,19 +237,30 @@ def _bytes_from_point(Q: Point, tag: int) -> bytes:
     return bytes([tag ^ int(residue)]) + Q[0].to_bytes(secp256k1.p_size, "big")
 
 
+def _point_from_x(x: int, not_square: bool) -> Point:
+    """Return the point x names, with the y the residuosity bit asks for.
+
+    `secp256k1_ge_set_xquad` answers the y that is a square, and the
+    negation is the one `secp256k1_pedersen_commitment_load` makes on
+    bit 0 of a tagged octet and `secp256k1_rangeproof_verify_impl` on a
+    ring commitment's own sign bit. Both refusals are
+    `y_quadratic_residue_var`'s, which says which: an x at or past p,
+    read there through `secp256k1_fe_set_b32_limit`, and an x that is
+    the x-coordinate of no point, which is what `secp256k1_ge_set_xquad`
+    fails on -- `secp256k1_pedersen_commitment_parse` asking
+    `secp256k1_ge_x_on_curve_var` ahead of any lift instead.
+    """
+    y = secp256k1.y_quadratic_residue_var(x)
+    return x, secp256k1.p - y if not_square else y
+
+
 def _point_from_octets(octets: Octets, tag: int, name: str) -> Point:
     """Return the point those octets name, lifted by residuosity.
 
-    `secp256k1_pedersen_commitment_parse`'s own refusals, at whichever
+    `secp256k1_pedersen_commitment_parse`'s own refusal, at whichever
     tag: `(input[0] & 0xFE) != 8` is the leading octet outside the pair,
-    written here against the tag it is given, and
-    `secp256k1_fe_set_b32_limit` with `secp256k1_ge_x_on_curve_var` are
-    an x past p and an x that is the x-coordinate of no point --
-    `y_quadratic_residue_var` refuses those two and says which.
-
-    The lift is `secp256k1_ge_set_xquad` and the negation
-    `secp256k1_pedersen_commitment_load` makes on bit 0: the y that is a
-    square, negated where the octet says y is not one.
+    written here against the tag it is given. The lift, and what else
+    it turns down, are `_point_from_x`'s, on bit 0 of the prefix.
     """
     octets = bytes_from_octets(octets, secp256k1.p_size + 1)
     prefix = octets[0]
@@ -245,8 +268,7 @@ def _point_from_octets(octets: Octets, tag: int, name: str) -> Point:
         raise BTClibValueError(f"not a {name}: prefix 0x{prefix:02x}")
 
     x = int.from_bytes(octets[1:], byteorder="big")
-    y = secp256k1.y_quadratic_residue_var(x)
-    return x, secp256k1.p - y if prefix & 1 else y
+    return _point_from_x(x, bool(prefix & 1))
 
 
 def bytes_from_commitment(Q: Point) -> bytes:

--- a/src/btclib/ecc/rangeproof.py
+++ b/src/btclib/ecc/rangeproof.py
@@ -62,14 +62,14 @@ convention `curves.bytes_from_point`, BIP340 and the `02`/`03` SEC
 prefix carry, and the two disagree on the vectors
 `tests/ecc/rangeproof_test.py` reads. No ring commitment's bit is
 computed here -- a parse reads it and a serialize writes it back, so
-what a `RangeProof` holds is the octets' own answer -- while
-`_serialize_point` is that function of zkp's, and what
-`sign_public_value` hashes the value commitment and the generator
-under. Resolving an x back to a point is the same convention read the
-other way, and `_point_from_ring_commitment` is where this module does
-it: `secp256k1_ge_set_xquad` takes the y that is a square, and
-`secp256k1_rangeproof_verify_impl` negates it where the sign bit says
-the y is not one.
+what a `RangeProof` holds is the octets' own answer -- while what
+`sign_public_value` hashes the value commitment and the generator under
+is `ecc.pedersen._bytes_from_point` at `_RANGEPROOF_TAG`, the codec a
+commitment's octets and a generator's are written with too. Resolving
+an x back to a point is that convention read the other way, and
+`ecc.pedersen._point_from_x` is what does it: `secp256k1_ge_set_xquad`
+takes the y that is a square, and `secp256k1_rangeproof_verify_impl`
+negates it where the sign bit says the y is not one.
 
 The digit decomposition is `rangeproof_pub_expand`: a ring's keys step
 down from the ring commitment by the weight of the digit that ring
@@ -100,10 +100,15 @@ from typing import NamedTuple
 from btclib.alias import INF, BinaryData, Integer, Octets, Point
 from btclib.curves import bytes_from_point, mult, scalar_from_prv_key, secp256k1
 from btclib.ecc.borromean import BorromeanSig, PubkeyRing, _hash
-from btclib.ecc.pedersen import commit, second_generator
+from btclib.ecc.pedersen import (
+    _RANGEPROOF_TAG,
+    _bytes_from_point,
+    _point_from_x,
+    commit,
+    second_generator,
+)
 from btclib.ecc.rfc6979_nonce import _HmacDrbg
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
-from btclib.number_theory import legendre_symbol_var
 from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
@@ -238,35 +243,6 @@ def _header_octets(exp: int, mantissa: int, min_value: int | None) -> bytes:
     if min_value is not None:
         out += min_value.to_bytes(_MIN_VALUE_SIZE, byteorder="big")
     return out
-
-
-def _serialize_point(Q: Point) -> bytes:
-    """Return the encoding a rangeproof hashes a point under.
-
-    `secp256k1_rangeproof_serialize_point`: one octet saying the y is
-    not a square, then the x. The octet is the residuosity the module
-    docstring above distinguishes from parity, so this is not
-    `curves.bytes_from_point` with another name: a proof hashed under
-    the parity convention verifies nowhere, and nothing in the octets
-    says which of the two wrote them.
-    """
-    residue = legendre_symbol_var(Q[1], secp256k1.p) == 1
-    return bytes([0 if residue else 1]) + Q[0].to_bytes(secp256k1.p_size, "big")
-
-
-def _point_from_ring_commitment(x: int, sign: bool) -> Point:
-    """Return the point a ring commitment's x and sign bit name.
-
-    `secp256k1_rangeproof_verify_impl` reads its x through
-    `secp256k1_ge_set_xquad`, which is the y that is a square, and
-    negates the result where the sign bit is set. The parity convention
-    coincides with this one only where the square y is also the even
-    one, so reading the bit that way answers a different point on some x
-    coordinates and the same point on others, with nothing in the octets
-    saying which was read.
-    """
-    y = secp256k1.y_quadratic_residue_var(x)
-    return x, secp256k1.p - y if sign else y
 
 
 def _pub_expand(
@@ -532,8 +508,8 @@ class RangeProof:
         against, `ecc.pedersen.commit`'s own point rather than octets --
         the ones `secp256k1_pedersen_commitment_serialize` hands back
         carry the residuosity bit too, `secp256k1_pedersen_commitment_save`
-        writing it at `9 ^ is_square(y)` where `_serialize_point` writes
-        `1 ^ is_square(y)`.
+        writing it at `9 ^ is_square(y)` where
+        `secp256k1_rangeproof_serialize_point` writes `1 ^ is_square(y)`.
 
         A commitment that leaves the last ring at infinity is refused,
         as `secp256k1_rangeproof_verify_impl` refuses it where its own
@@ -546,7 +522,7 @@ class RangeProof:
         secp256k1.require_on_curve(commitment)
 
         stated = [
-            _point_from_ring_commitment(x, sign)
+            _point_from_x(x, sign)
             for x, sign in zip(self.ring_commitments, self.signs, strict=True)
         ]
         # zkp's own order: the offset and the stated commitments are
@@ -577,8 +553,8 @@ class RangeProof:
 
         `secp256k1_rangeproof_genrand`, seeded as
         `secp256k1_rangeproof_sign_impl` seeds it: the caller's nonce,
-        then the value commitment and the generator under
-        `_serialize_point`, then the header octets this proof's own
+        then the value commitment and the generator at
+        `_RANGEPROOF_TAG`, then the header octets this proof's own
         exponent, mantissa and `min_value` write. So whoever holds the
         nonce answers every ring commitment the proof states -- each is
         its ring's blinding factor times G plus that ring's own digit
@@ -592,13 +568,21 @@ class RangeProof:
         carries the value inside its own draw, so the chain is not a
         function of the header alone. A value this proof has no digit
         for is refused, `sign_key_idx`'s own refusal.
+
+        A commitment at infinity is refused too, where `pubk_rings`
+        answers rings for one: the seed carries the octets
+        `secp256k1_rangeproof_serialize_point` writes, and infinity
+        has no x to write. The `require_on_curve` above lets it through,
+        `(x, 0)` being how this library spells infinity in affine
+        coordinates.
         """
         if check_validity:
             self.assert_valid()
         secp256k1.require_on_curve(commitment)
         sign_key_idx = self.sign_key_idx(value)
         seed = bytes_from_octets(nonce, _NONCE_SIZE)
-        seed += _serialize_point(commitment) + _serialize_point(second_generator())
+        seed += _bytes_from_point(commitment, _RANGEPROOF_TAG)
+        seed += _bytes_from_point(second_generator(), _RANGEPROOF_TAG)
         seed += _header_octets(self.exp, self.mantissa, self.min_value)
 
         v = self._mantissa_value(value)
@@ -773,8 +757,8 @@ def sign_public_value(blind: Integer, value: int, nonce: Octets) -> RangeProof:
     # value itself: `min_value ? 32 : 0`, so zero carries no field
     min_value = value or None
     header = _header_octets(-1, 0, min_value)
-    points = _serialize_point(commit(blind_int, value))
-    points += _serialize_point(second_generator())
+    points = _bytes_from_point(commit(blind_int, value), _RANGEPROOF_TAG)
+    points += _bytes_from_point(second_generator(), _RANGEPROOF_TAG)
 
     # the one draw a single ring takes. `rangeproof_genrand` draws
     # nothing for the last ring's blinding factor -- that is minus the

--- a/tests/ecc/rangeproof_fixed_vectors_test.py
+++ b/tests/ecc/rangeproof_fixed_vectors_test.py
@@ -35,8 +35,7 @@ from typing import Any
 import pytest
 
 from btclib.curves import mult, secp256k1
-from btclib.ecc import rangeproof
-from btclib.ecc.pedersen import bytes_from_commitment, commit
+from btclib.ecc.pedersen import _point_from_x, bytes_from_commitment, commit
 from btclib.ecc.rangeproof import RangeProof
 from tests import load, vector_id
 
@@ -102,7 +101,7 @@ def test_the_rings_open_at_the_published_blinding_factor(
 
     rings = proof.pubk_rings(commitment)
     stated = tuple(
-        rangeproof._point_from_ring_commitment(x, sign)
+        _point_from_x(x, sign)
         for x, sign in zip(proof.ring_commitments, proof.signs, strict=True)
     )
     assert tuple(ring[0] for ring in rings[: len(stated)]) == stated

--- a/tests/ecc/rangeproof_test.py
+++ b/tests/ecc/rangeproof_test.py
@@ -57,10 +57,17 @@ from typing import Any
 
 import pytest
 
+from btclib.alias import INF
 from btclib.curves import mult, secp256k1
 from btclib.ecc import rangeproof
 from btclib.ecc.borromean import BorromeanSig
-from btclib.ecc.pedersen import commit, second_generator
+from btclib.ecc.pedersen import (
+    _RANGEPROOF_TAG,
+    _bytes_from_point,
+    _point_from_x,
+    commit,
+    second_generator,
+)
 from btclib.ecc.rangeproof import RangeProof, sign_public_value
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from tests import load, needs_zkp, replace_unchecked, vector_id
@@ -415,17 +422,17 @@ def test_pubk_rings_open_at_the_recorded_blinding_factor(
     proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
     commitment = commit(vector["blind"], vector["value"])
     # the entry's own commitment octets, which zkp writes under the same
-    # residuosity bit at another base: `9 ^ is_square(y)` for a Pedersen
-    # commitment where `_serialize_point` writes `1 ^ is_square(y)`
+    # residuosity bit at another tag: `9 ^ is_square(y)` for a Pedersen
+    # commitment, `1 ^` it at `_RANGEPROOF_TAG`
     recorded = bytes.fromhex(vector["commitment"])
-    assert rangeproof._serialize_point(commitment) == (
+    assert _bytes_from_point(commitment, _RANGEPROOF_TAG) == (
         bytes([recorded[0] ^ 8]) + recorded[1:]
     )
 
     rings = proof.pubk_rings(commitment)
     assert tuple(len(ring) for ring in rings) == proof.rsizes
     stated = tuple(
-        rangeproof._point_from_ring_commitment(x, sign)
+        _point_from_x(x, sign)
         for x, sign in zip(proof.ring_commitments, proof.signs, strict=True)
     )
     assert tuple(ring[0] for ring in rings[: len(stated)]) == stated
@@ -456,11 +463,11 @@ def test_sign_key_idx_is_the_value_s_own_base_four_digits(
 
 
 def test_a_ring_commitment_x_resolves_against_residuosity() -> None:
-    """`_serialize_point` read the other way, over every x vendored here.
+    """The rangeproof's tag read the other way, over every x vendored here.
 
     `secp256k1_ge_set_xquad` answers the y that is a square and
     `secp256k1_rangeproof_verify_impl` negates it where the sign bit is
-    set, so the round trip through `_serialize_point` is what says the
+    set, so the round trip back to the octets is what says the
     resolution is that serialization's own inverse. Reading the bit as
     parity would answer a different point wherever the two conventions
     disagree, and `test_the_sign_bit_is_residuosity_and_not_parity` is
@@ -469,9 +476,9 @@ def test_a_ring_commitment_x_resolves_against_residuosity() -> None:
     for vector in _VECTORS:
         proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
         for x, sign in zip(proof.ring_commitments, proof.signs, strict=True):
-            point = rangeproof._point_from_ring_commitment(x, sign)
+            point = _point_from_x(x, sign)
             octets = bytes([sign]) + x.to_bytes(secp256k1.p_size, "big")
-            assert rangeproof._serialize_point(point) == octets
+            assert _bytes_from_point(point, _RANGEPROOF_TAG) == octets
 
 
 def test_sign_key_idx_refuses_a_value_this_proof_has_no_digit_for() -> None:
@@ -545,8 +552,8 @@ def _seed(vector: dict[str, Any]) -> bytes:
     octets = bytes.fromhex(vector["proof"])
     return (
         bytes.fromhex(vector["nonce"])
-        + rangeproof._serialize_point(commit(vector["blind"], vector["value"]))
-        + rangeproof._serialize_point(second_generator())
+        + _bytes_from_point(commit(vector["blind"], vector["value"]), _RANGEPROOF_TAG)
+        + _bytes_from_point(second_generator(), _RANGEPROOF_TAG)
         + octets[: _header_size(octets)]
     )
 
@@ -605,7 +612,7 @@ def test_the_nonce_chain_writes_the_ring_commitments_a_proof_states(
             )
         )
 
-    stated = [rangeproof._serialize_point(head) for head in heads[:-1]]
+    stated = [_bytes_from_point(head, _RANGEPROOF_TAG) for head in heads[:-1]]
     assert tuple(int.from_bytes(o[1:], "big") for o in stated) == proof.ring_commitments
     assert tuple(bool(o[0]) for o in stated) == proof.signs
     assert tuple(ring[0] for ring in proof.pubk_rings(commitment)) == tuple(heads)
@@ -635,18 +642,34 @@ def test_the_nonce_chain_answers_every_s_the_signature_did_not_write(
 
 
 def test_nonce_chain_refuses_a_commitment_that_is_no_point() -> None:
-    """The seed hashes the commitment, and hashing it checks nothing.
+    """The commitment is required on the curve, before any seed exists.
 
-    `_serialize_point` asks the y for its residuosity and writes the x,
-    which a pair off the curve answers as readily as a point: absent
-    the check, a commitment naming no public key derives a chain like
-    any other. The refusal is `pubk_rings`' own, on the argument of the
-    same name.
+    The refusal is the explicit one, `pubk_rings`' on the argument of
+    the same name. `_bytes_from_point` would turn the same pair down
+    where the seed is written, so what the explicit check fixes is
+    where the refusal happens rather than whether it happens.
     """
     vector = _vector("odd mantissa")
     proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
     with pytest.raises(BTClibValueError, match="point not on curve"):
         proof.nonce_chain((1, 2), vector["value"], vector["nonce"])
+
+
+def test_nonce_chain_refuses_a_commitment_at_infinity() -> None:
+    """Infinity has no x, and the seed is written from one.
+
+    `is_on_curve` answers `True` for any `(x, 0)`, that being how a
+    point at infinity is spelled in affine coordinates, so the
+    `require_on_curve` above the seed lets it through and
+    `_bytes_from_point` is what turns it down. `match` is on that
+    refusal's own message, the off-curve one above raising a different
+    one from the same method.
+    """
+    vector = _vector("odd mantissa")
+    proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
+    assert secp256k1.is_on_curve(INF)
+    with pytest.raises(BTClibValueError, match="no bytes representation"):
+        proof.nonce_chain(INF, vector["value"], vector["nonce"])
 
 
 def test_nonce_chain_does_not_check_the_proof_twice() -> None:
@@ -1056,7 +1079,7 @@ def test_the_nonce_chain_answers_proofs_zkp_signs_at_other_shapes() -> None:
                 mult(chain.blinding_factors[i], secp256k1.G, secp256k1),
                 mult(sign_key_idx[i] * scale << 2 * i, second_generator(), secp256k1),
             )
-            assert rangeproof._serialize_point(head) == bytes(
+            assert _bytes_from_point(head, _RANGEPROOF_TAG) == bytes(
                 [proof.signs[i]]
             ) + x.to_bytes(secp256k1.p_size, "big")
 


### PR DESCRIPTION
libsecp256k1-zkp reports the residuosity of y in the leading octet of
everything it serializes this way, xoring that bit into a tag of its
own: 9 for a Pedersen commitment, 11 for a generator, 1 for the point a
rangeproof hashes. `ecc.pedersen` writes and reads the first two through
one private pair parameterised by the tag, and `ecc.rangeproof` held the
same arithmetic for the third, so a correction to one was invisible to
the other's tests.

`_bytes_from_point` now takes `_RANGEPROOF_TAG` beside the two tags it
already had, and the lift both readers make -- the y that is a square,
negated where the bit says y is not one -- is `_point_from_x`, which
`_point_from_octets` calls after unpacking a tagged octet and
`RangeProof.pubk_rings` calls with a proof's own sign bit in hand.
`ecc.rangeproof` already imported `ecc.pedersen`, so the branch adds no
import edge.

The octets are unchanged, and were measured so rather than argued: over
every vendored proof, `sign_public_value`, `nonce_chain` and
`RangeProof.pubk_rings` answer byte for byte what a snapshot of
origin/main answers. One behaviour moves. The shared writer refuses a
pair that is no point of secp256k1, which `ecc.rangeproof` does not
reach: `nonce_chain` requires the commitment on the curve before any
seed exists, and `sign_public_value` writes points it computed itself.
It also refuses the infinity point, which `require_on_curve` lets
through, `Curve.is_on_curve` answering `True` for `(x, 0)`. So against
that same snapshot `RangeProof.nonce_chain` answers a `NonceChain` for
a commitment at infinity and raises `BTClibValueError` here, which
`test_nonce_chain_refuses_a_commitment_at_infinity` pins, while
`pubk_rings` answers the same rings in both, writing no point at all.

Reviewed locally at fresh context, twice. The first round found the
entry claiming a safety property the tree does not have -- that no
caller reaches the writer's new refusals -- when `Curve.is_on_curve`
answers `True` for any `(x, 0)`, so `require_on_curve` lets infinity
through and `RangeProof.nonce_chain`, which is public, went from
answering a `NonceChain` to raising. The second round, a different
reviewer at fresh context, answered `CLEARED
e9a1c791add05154c88537eea40893f5b1422e13` after re-deriving that
reachability in two worlds of its own and killing mutant A with the new
test alone.

Two things the second reviewer measured that neither the issue nor the
brief had asked for. It pushed the third mutant further to find what
deleting `nonce_chain`'s own `require_on_curve` actually changes --
observable only when *two* arguments are bad at once, and only in which
message wins -- which is why leaving that test unchanged is right rather
than merely defensible: pinning it would pin argument-validation
ordering as contract. And it settled the pass count structurally without
running pytest: over the whole `tests/` tree the set of `def test_*`
names gains exactly one member and loses none, so `32390 -> 32391` is
arithmetic and not a collection difference.

The rebase onto the dependency refresh shared three paths with what had
just landed, two of them code, and `merge-tree` exited 0 -- the shape
that hides a defect. Measured rather than trusted: that landing renamed
`secp256k1_borromean_verify` to `_impl` in the same two files this
branch rewrites prose in. Counting the two spellings apart, this branch
carried five plain and no `_impl` before the rebase and no plain and
five `_impl` after, so the rename passed cleanly through the rewritten
prose instead of leaving a stale name that would have re-introduced the
collision that landing had just repaired. No duplicated definition in
any of the three files.

The seam was repaired by reconstruction rather than from the rebase's
output, with a planted misplacement control that the whole-file heading
invariant passes and the byte reconstruction fails. The flagged arm was
re-run at the final sha against **0.8.0.6**, which that same landing
brought in under this branch: `assert zkp.lib` first, then 14 passed
with zero skips, then a resync back to unflagged confirmed positively by
the import raising.

closes #1910

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Share the Pedersen residuosity codec with rangeproof functionality to preserve libsecp256k1-zkp-compatible point handling and validation.

Bug Fixes:
- Align rangeproof point serialization and deserialization with libsecp256k1-zkp's residuosity-tagged encoding, fixing incorrect point reconstruction across parity conventions.
- Reject infinity commitments when generating rangeproof nonce chains.

Enhancements:
- Centralize residuosity-based point encoding and x-coordinate lifting in the Pedersen codec for reuse by rangeproof operations.

Documentation:
- Document the shared residuosity codec and rangeproof-specific serialization behavior in the changelog and module documentation.

Tests:
- Add coverage for infinity commitment rejection and update rangeproof vector and serialization tests to exercise the shared codec.