### PR TITLE
`fuzz.yml`'s `# v1` is what the pin convention asks for (closes #1931)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -107,6 +107,24 @@ jobs:
       # cross it -- the disable-line escape hatch that comment describes
       # cannot carry the tag text too, its own regex admitting nothing
       # else on the line
+      #
+      # `v1` is the whole of what that comment can name: it is the only
+      # tag google/clusterfuzzlite publishes, so there is no point release
+      # to name in its place. A major is a name its owner is free to move,
+      # which leaves the comment reading the same on either side of a
+      # bump -- what says whether the pin is current is then the tag and
+      # not the comment:
+      #
+      #   gh api repos/google/clusterfuzzlite/git/refs/tags --paginate \
+      #     --jq '.[].ref'
+      #   gh api repos/google/clusterfuzzlite/commits/v1 --jq .sha
+      #
+      # A tag beyond `v1` is the point release the comment names in its
+      # place; a sha other than the one both steps below carry is `v1`
+      # having moved; either is the day this pin is bumped. The second
+      # call peels the annotated tag to the commit a runner checks out,
+      # where `git/ref/tags/v1` answers the tag object's own sha and pins
+      # nothing that exists in the action's history
       - name: Build fuzzers
         # v1
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3368,6 +3368,20 @@ and `id-token: write`.
   docstring that reasoning is in rather than on each `anti_exfil_*`
   function.
 
+### What a pinned action's comment names where upstream has no point release
+
+`CLAUDE.md` says what a pinned action's comment names: the point
+release, and, where the action's repository publishes only a floating
+major, that tag with the call that peels it beside the pin. A name its
+owner is free to move reads the same on either side of a bump, so what
+answers whether such a pin is current is the tag rather than the comment.
+
+`.github/workflows/fuzz.yml` is where that holds: `v1` is the only tag
+`google/clusterfuzzlite` publishes, so `# v1` above its pins is the
+answer the convention asks for rather than a comment nobody has looked
+at, and the calls that say whether that tag has moved or a point release
+has appeared stand beside them (closes #1931).
+
 ## v2026.9.3
 
 ### Repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,6 +398,20 @@ Do not use Fable unless explicitly instructed.
   `persist-credentials: false`; uv commands pass `--locked`, never
   `--frozen`. `actionlint` and `zizmor` are hooks, and both must stay at
   zero findings.
+- **A pin's comment names the point release, and where the action's
+  repository publishes only a floating major it names that tag with the
+  calls that resolve it beside the pin.** What the comment buys is a
+  legible bump: a point release changes with the sha it names, where a
+  bare major reads the same on either side of one and leaves the sha as
+  the whole of the diff. Where the major is the only tag upstream has,
+  nothing else names the commit, so the comment keeps it and the
+  workflow carries the calls that list the tags and peel the one the
+  comment names: those calls, and not the comment, are what say whether
+  a point release has appeared and whether the pin is still current.
+  Beside is not always trailing: a pin that already fills
+  `.yamllint.yaml`'s width takes the comment on the line above.
+  `.github/workflows/fuzz.yml`'s `google/clusterfuzzlite` pins are both
+  cases at once.
 - **The prose style — tone, comments, docstrings, no history — is
   section 9 of the organization standard**, which
   `CONTRIBUTING.md`'s *Documentation and comments* is the pointer to.


### PR DESCRIPTION
Closes #1931.

`google/clusterfuzzlite` publishes `v1` and no other tag, so the point
release a pin's comment names has nothing to name here. The comment keeps
the major, and `fuzz.yml` carries what the comment cannot: the tag list,
where a point release would appear, and `commits/v1`, which answers
whether the tag still resolves to the sha both steps carry.

Re-derived from the API rather than taken from the issue. `git/refs/tags`
answers `refs/tags/v1` and nothing else; `git/tags/82652fb4...` peels the
tag object to `884713a6c30a92e5e8544c39945cd7cb630abcd1`, the sha both
steps carry; `releases` answers an empty list. `commits/<tag>` peels an
annotated tag by itself, which is why the recipe reaches the commit in one
call rather than two, controlled against `anthropics/claude-code-action`'s
`v1.0.220` — and the tag object's own sha answers HTTP 422, so the two
spellings are not interchangeable.

`CLAUDE.md` gains the case, so that `# v1` reads as the answer the
convention asks for rather than as a pin nobody looked at, and with it the
narrower point that beside is not always trailing: the sha and the
action's name already fill `.yamllint.yaml`'s width, so the comment takes
the line above.

Nothing here runs the workflow, and `zizmor --offline` leaves
`impostor-commit` and `known-vulnerable-actions` unrun, so no local gate
asserts the pinned sha exists; that it does was measured by API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Document how to annotate and verify pinned actions when upstream publishes only a floating major tag.

Enhancements:
- Document the pin-comment convention for actions that publish only a floating major tag, including how to verify tag availability and whether the pinned commit remains current.
- Clarify the convention in the ClusterFuzzLite workflow and repository guidance, including line-wrapping expectations for long pins.

Documentation:
- Record the rationale for using `# v1` with the ClusterFuzzLite pins and the API checks needed to detect tag changes or newly published point releases.