### PR TITLE
`RELEASING.md`'s placeholder is the open cycle's own heading (closes #1941)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3411,6 +3411,22 @@ its example naming the month after the release rather than the cycle the
 two headings are open at; issue #1941 is where that step is made to say
 which of the two it means.
 
+### `RELEASING.md`'s placeholder is the open cycle's own heading
+
+- **The *Open the next cycle's version* step says which cycle
+  `pyproject.toml` carries between releases, and its example is one where
+  the two readings of it differ** (closes #1941). The placeholder is the
+  number the `## v<cycle> (work in progress, not released yet)` headings
+  of CHANGELOG.md and RELEASE_NOTES.md already carry, so after `2026.9.3`
+  it is `2026.9` and not `2026.10`. The example it replaces, `2026.9`
+  after `2026.8.4`, is what both readings answer, so it could not tell
+  the rule from its alternative.
+- **The step states that such a placeholder sorts below the newest
+  release under PEP 440, and why that is the rule working rather than
+  failing**: it names a cycle and not a release, and releases are ordered
+  by their tags. Without the sentence the sort order reads as a defect,
+  and repairing it means going back to the month after the release.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -613,15 +613,37 @@ to `deps-latest`'s own result.
    of this one. Actions → pypi-install → Run workflow is for asking between
    those runs, with no particular version in mind.
 
-1. Open the next cycle's version: set a generic next version without
-   the day (e.g. after 2026.8.4, use 2026.9) in pyproject.toml, through
-   a pull request like any other. The two "work in progress" sections
-   this step used to create are already there, the retitle step above
-   having made them in the release's own pull request. What stays here
-   is the version, which cannot move earlier with them: `version-check`
+1. Open the next cycle's version: set `pyproject.toml`'s `version` to the
+   number the two "work in progress" sections already carry, through a
+   pull request like any other. The retitle step above opens those
+   sections in the release's own pull request, so
+   `## v<cycle> (work in progress, not released yet)` is standing in
+   CHANGELOG.md and RELEASE_NOTES.md by the time this step runs, and what
+   is set here is that same cycle: one value, pyproject.toml being the
+   file it reaches last. It cannot reach it any earlier — `version-check`
    reads `uv version --short` at tag time, and a pyproject.toml already
-   bumped would offer it the next cycle's number instead of the one
-   being released.
+   bumped would offer it the next cycle's number instead of the one being
+   released.
+
+   **The placeholder is that cycle, not the month after the release.**
+   After `2026.9.3` it is `2026.9`, which is what those two headings say,
+   and it is not `2026.10`. The two readings name the same month for as
+   long as a cycle holds a single release, which is what makes "the month
+   after" look like the rule; a cycle that ships twice separates them.
+   Taking the month after would also declare a cycle neither notes file
+   has a section for, so the next change to land would file its entry
+   under a heading the declared version disagrees with — issue #1458's
+   shape one file over.
+
+   `2026.9` sorts below `2026.9.3` under PEP 440, which follows from the
+   rule rather than arguing against it: a placeholder names the cycle
+   whose notes the tree is accumulating, not a release, and releases are
+   ordered by their tags — and `version-check` refuses a tag on the
+   placeholder shape (*Which version string is which* above). What a
+   reader can trip on is that `pip install --upgrade btclib` in an
+   environment holding such a checkout resolves to the published release,
+   which is the right answer for anybody who did not mean to be running a
+   working tree.
 
    Those two sections are where the next release's notes accumulate, one
    landed change at a time, and the merge step above is what reads them


### PR DESCRIPTION
Closes #1941.

`RELEASING.md`'s *Open the next cycle's version* says which of its two
readings it means: the placeholder is the cycle the two "work in
progress" headings name, not the month after the release. Its example is
replaced rather than extended, because the old one — after `2026.8.4`,
use `2026.9` — gives the same answer under both readings and so cannot
tell the rule from its alternative.

The practice is exceptionless and was re-derived rather than asserted:
over every commit on `main` touching `pyproject.toml` or `CHANGELOG.md`,
falling back to `HISTORY.md` where `RELEASE_NOTES.md` does not exist yet,
the declared version equals the topmost "work in progress" heading
wherever a placeholder is in force. The reviewer re-ran it independently
on 1035 commits with a positive control aimed one heading lower, which
reports a disagreement on every row that has one.

The step also records the PEP 440 consequence, so that nobody later reads
the sort order as a defect and reintroduces the month-after rule to
repair it: `2026.9` sorts below `2026.9.3`, deliberately, because a
placeholder names a cycle and the tags are what order releases —
`version-check` refuses a two-component tag outright, so nothing will
ever be released at one.

`pyproject.toml` is untouched here. The value is set on ISS 1927's
branch, which has landed; this is the rule behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Clarify the release workflow so version placeholders consistently identify the currently open cycle and are not mistaken for release versions.

Enhancements:
- Clarify that the release placeholder version must match the cycle named by the open work-in-progress headings rather than the month following the release.
- Document the intentional PEP 440 ordering of cycle placeholders below released versions and explain why it does not indicate an error.

Documentation:
- Update the release procedure and changelog to define the next-cycle placeholder rule with a distinguishing example and explain its version-ordering implications.