### PR TITLE
A run says which `btclib_secp256k1` build it measured (closes #1937)

### DIFF
--- a/.github/workflows/zkp-oracle.yml
+++ b/.github/workflows/zkp-oracle.yml
@@ -192,7 +192,18 @@ jobs:
       # already-satisfied venv is keyed on this environment variable,
       # only on the sdist's own content -- measured here, a plain
       # `uv sync --no-binary-package` left a previously installed,
-      # unflagged 0.8.0.5 in place under the flag, saying nothing
+      # unflagged 0.8.0.5 in place under the flag, saying nothing.
+      # The same key is the same key from either side, so the same pair
+      # is what takes an environment back out of this arm: a plain `uv
+      # sync --locked` leaves the flagged extension where it is, and
+      # `uv sync --locked --reinstall-package btclib-secp256k1 --no-cache`
+      # is what puts the published wheel back. The symmetry is written
+      # out here rather than left to be read backwards because the
+      # runner this job gets is fresh either way -- who needs the way
+      # out is whoever copies this step into a worktree, where every
+      # later `uv run pytest` measures the flagged build and says which
+      # one it measured in the line `tests/conftest.py`'s report header
+      # prints (issue #1937)
       - name: Sync the environment, building btclib-secp256k1 from the sdist
         env:
           BTCLIB_LIBSECP256K1_ZKP: "true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3427,6 +3427,26 @@ which of the two it means.
   by their tags. Without the sentence the sort order reads as a defect,
   and repairing it means going back to the month after the release.
 
+### A run says which `btclib_secp256k1` build it measured
+
+- **`tests/conftest.py` names the build in a `pytest_report_header`,
+  under the flagged build and the unflagged one alike** (closes #1937).
+  Which of the two answered decides whether the tests marked `zkp`
+  compare btclib against libsecp256k1-zkp or skip, and a report
+  otherwise carries the answer only where there is a skip: `-ra` names
+  the missing build once per test an unflagged run skips, where a
+  flagged run skips none of them and leaves it to a subtraction over the
+  passed and the skipped totals. The exit code and the coverage total
+  read the same either way. Printing the line under the flagged build
+  alone would leave its absence carrying the other answer, which a
+  report written before the line carries just as well.
+- **`.github/workflows/zkp-oracle.yml` says what the flagged sync's
+  `--reinstall-package` and `--no-cache` undo as well as what they do**:
+  the same pair is what takes an environment back out of that arm, a
+  plain `uv sync --locked` leaving the flagged extension where it is.
+  The runner this job gets is fresh either way, so who needs the way out
+  is whoever copies those two lines into a worktree.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,6 +197,38 @@ def pytest_configure(config: pytest.Config) -> None:
     )
 
 
+def pytest_report_header() -> str:
+    """State which `btclib_secp256k1` build this run measured.
+
+    Beside the interpreter, the rootdir and the plugins pytest already
+    announces there: which of the two builds answered is a fact about
+    the same run, and the report otherwise carries it only where there
+    is a skip. `-ra` names the missing build once per test an unflagged
+    run skips, where a flagged run skips none of them and leaves the
+    answer to a subtraction over the passed and the skipped totals --
+    the exit code, the coverage total and the floor it clears reading
+    the same either way (issue #1937).
+
+    Printed under both builds and not under the flagged one alone,
+    because a line that appears only one way makes its own absence carry
+    the other answer, which a report written before this line carries
+    just as well.
+
+    What it names is what `ZKP_AVAILABLE` measured, whether
+    `btclib_secp256k1.zkp.lib` resolves, so the second arm covers a
+    build made without the flag and an environment without the bindings
+    at all alike. A conditional expression rather than an `if`, which
+    keeps this one statement: the guard in `tests/__init__.py` needs a
+    `pragma` in each of its arms because the build decides which one a
+    run takes, and a branch here would need the same twice over.
+    """
+    return "btclib_secp256k1.zkp: " + (
+        "built with BTCLIB_LIBSECP256K1_ZKP, so the tests marked zkp run"
+        if ZKP_AVAILABLE
+        else "no BTCLIB_LIBSECP256K1_ZKP build, so the tests marked zkp skip"
+    )
+
+
 @pytest.fixture
 def generated_files_dir(request: pytest.FixtureRequest) -> Path:
     """Locate the `_generated_files` directory beside the asking module.


### PR DESCRIPTION
Closes #1937.

A run now says which `btclib_secp256k1` build answered it, once, in
`pytest`'s own session header:

```
btclib_secp256k1.zkp: no BTCLIB_LIBSECP256K1_ZKP build, so the tests marked zkp skip
btclib_secp256k1.zkp: built with BTCLIB_LIBSECP256K1_ZKP, so the tests marked zkp run
```

Both directions, so the line's absence never has to carry meaning: a
block with no such line would otherwise be ambiguous between an
unflagged run and any run predating the line.

The asymmetry it closes is sharper than the issue framed it. Under an
unflagged run `-ra` already names the build in every zkp skip reason; a
flagged run skips none of them, so it was the flagged direction that had
no tell at all — the exit code, the coverage total and the floor it
clears read identically either way.

`.github/workflows/zkp-oracle.yml` gains the reverse of the direction it
already reasons about: the same key is the same key from either side, so
a plain `uv sync --locked` leaves a flagged extension where it is, and
`uv sync --locked --reinstall-package btclib-secp256k1 --no-cache` is
what puts the published wheel back.

The hook needs no `pragma`: a conditional expression is one statement and
coverage.py opens no arc for it, measured against its own parser rather
than assumed, and the 100% floor is the instrument that confirms it.

Verified under the documented gate command in both real builds, nothing
added and nothing removed — a header that command does not print would be
a control that cannot fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Identify the `btclib_secp256k1` build measured by every test run and clarify how the ZKP workflow switches between builds.

New Features:
- Report whether the test run measured the ZKP-enabled or unflagged `btclib_secp256k1` build in pytest's session header.

Bug Fixes:
- Remove ambiguity when determining the measured build, particularly for runs where ZKP tests execute without skips.

CI:
- Document the reverse synchronization steps needed to restore the published package after building the flagged extension in the ZKP oracle workflow.

Documentation:
- Add a changelog entry describing the build identification reported by test runs and the workflow synchronization guidance.