### PR TITLE
`ecc.dsa`'s sign-to-contract prose names secp256k1-zkp (closes #1932)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3447,6 +3447,16 @@ which of the two it means.
   The runner this job gets is fresh either way, so who needs the way out
   is whoever copies those two lines into a worktree.
 
+### Which library `btclib.ecc.dsa`'s sign-to-contract prose names
+
+Sign-to-contract is BlockstreamResearch/secp256k1-zkp's: the
+`VERIFY_CHECK` that binds a commitment to the default nonce function is
+in its `secp256k1_ecdsa_sign_inner`, the word "opening" is its
+`secp256k1_ecdsa_s2c_opening`, and bitcoin-core/secp256k1's `include/`
+carries no `secp256k1_ecdsa_s2c.h` for either of them to be in. `sign_`'s
+comment on the nonce it refuses and `anti_exfil_host_verify`'s docstring
+name that library and the symbol each of them paraphrases (closes #1932).
+
 ## v2026.9.3
 
 ### Repository

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -165,7 +165,7 @@ used to teach and to prototype as much as to build:
     `dsa.Signer.__init__` crosses the same boundary the other way,
     once, at construction: the plain `int` `scalar_from_prv_key` already
     produced becomes a transient `bytes` via
-    `self._q.to_bytes(32, "big")` (`src/btclib/ecc/dsa.py:1355`) on the
+    `self._q.to_bytes(32, "big")` (`src/btclib/ecc/dsa.py:1356`) on the
     way into the owned buffer `wipe` overwrites afterwards. That
     `bytes` is dropped rather than erased, same as the `int` it
     replaces — one call rather than the buffer's whole lifetime, which

--- a/src/btclib/ecc/dsa.py
+++ b/src/btclib/ecc/dsa.py
@@ -908,9 +908,10 @@ def sign_(
     # untweaked nonce is a function of the message and the key alone and
     # two commitments over one message hand out the private key -- see
     # commit_nonce. A nonce of the caller's leaves nowhere to put it, so
-    # it is refused rather than silently not committed to; libsecp256k1
-    # spells the same rule as a VERIFY_CHECK that s2c goes with the
-    # default nonce function and no other
+    # it is refused rather than silently not committed to;
+    # BlockstreamResearch/secp256k1-zkp spells the same rule as a
+    # VERIFY_CHECK in `secp256k1_ecdsa_sign_inner` that s2c goes with
+    # the default nonce function and no other
     if commit_hash is not None and nonce is not None:
         raise BTClibValueError("a commitment derives its own nonce")
 
@@ -1893,7 +1894,8 @@ def anti_exfil_host_verify(
     not a signature. Which ``verify_`` already does in one call, both
     checks running against the same r.
 
-    receipt is the R of step 2, what libsecp256k1 calls the opening.
+    receipt is the R of step 2, what secp256k1-zkp's
+    `secp256k1_ecdsa_s2c_opening` holds.
     False and not an exception for everything that fails, as ``verify_``
     answers: a rho of the wrong size is a rho this commitment does
     not open to.


### PR DESCRIPTION
Closes #1932.

Sign-to-contract is BlockstreamResearch/secp256k1-zkp's `ecdsa_s2c`
module. `sign_`'s comment on the nonce a commitment refuses paraphrases
the `VERIFY_CHECK` in that library's `secp256k1_ecdsa_sign_inner`, and
`anti_exfil_host_verify`'s docstring takes the word *opening* from its
`secp256k1_ecdsa_s2c_opening`; bitcoin-core/secp256k1's `include/`
carries no `secp256k1_ecdsa_s2c.h`, so the name both of them gave sent a
reader to a library that has neither.

What settled the scope is a whitespace-folded sweep of the whole file
rather than the issue's list of sites — the issue's own checklist said
"**both** sites", and that count was the defect, being satisfiable while
a third stayed wrong. `dsa.py` wraps at eighty columns, so a line-wise
`git grep` answers with neither: the comment's name and its `s2c` sit on
different lines, and the docstring's line carries no s2c vocabulary at
all. The sweep folds two ways, whitespace collapsed and comment
continuation deleted, because a token split *mid-word* across a `#`
rejoins only under the second.

The edits move the line `SECURITY.md` cites for `dsa.Signer.__init__`,
which `tests/security_citations_test.py` matches verbatim against the
line the citation names, so that citation is renumbered with them and
re-read against its content rather than by arithmetic.

No code changed: with comments dropped, the token streams differ in one
docstring and the docstring-stripped AST is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Correct the sign-to-contract documentation references and keep the associated security citation accurate.

Bug Fixes:
- Correct references in sign-to-contract documentation to identify BlockstreamResearch/secp256k1-zkp and the corresponding symbols.

Documentation:
- Clarify the libraries and functions referenced by `btclib.ecc.dsa` sign-to-contract prose and record the correction in the changelog.

Chores:
- Update the security citation to reflect the shifted source line.