### PR TITLE
The rangeproof vectors' reason for existing names the build (closes #1929)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2813,9 +2813,10 @@ file of the test tree, and no caller acts on it.
   distance being closed.
 - **`tests/ecc/_data/zkp_rangeproof_vectors.json` records proofs
   libsecp256k1-zkp signed**, with the arguments that produced them and
-  with what `info` answers for each. The flagged extension exists in
-  `.github/workflows/zkp-oracle.yml`'s job alone, so vendored proofs are
-  what exercise the parser in an ordinary run; the `zkp`-marked tests
+  with what `info` answers for each. The flagged extension is what a
+  btclib-secp256k1 installed from its sdist with
+  `BTCLIB_LIBSECP256K1_ZKP` has, so vendored proofs are what exercise
+  the parser in an unflagged build; the `zkp`-marked tests
   beside them put the same questions to the library, and check that
   signing again with the recorded arguments answers the recorded octets.
 
@@ -3456,6 +3457,18 @@ in its `secp256k1_ecdsa_sign_inner`, the word "opening" is its
 carries no `secp256k1_ecdsa_s2c.h` for either of them to be in. `sign_`'s
 comment on the nonce it refuses and `anti_exfil_host_verify`'s docstring
 name that library and the symbol each of them paraphrases (closes #1932).
+
+### The rangeproof vectors' reason for existing names the build
+
+- **`tests/ecc/rangeproof_test.py`'s module docstring and
+  `tests/_data/README.md`'s entry for the zkp rangeproof vectors name
+  the build that has the flagged extension** (closes #1929): a
+  btclib-secp256k1 installed from its sdist with
+  `BTCLIB_LIBSECP256K1_ZKP`, which is what `tests/__init__.py` names for
+  the `@needs_zkp` pragmas.
+- **The extension is a property of a build and not of a job**, so a
+  contributor who builds it reads a reason that holds on their own
+  machine. No vector, no test and no exclusion moves.
 
 ## v2026.9.3
 

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -2620,10 +2620,10 @@ libsecp256k1-zkp signed for this tree, kept verbatim, beside the
 arguments that produced it and what that library then said about it.
 
 It is here because `tests/ecc/rangeproof_test.py` would otherwise
-measure nothing wherever the suite usually runs: the flagged extension
-those calls need is built in `.github/workflows/zkp-oracle.yml`'s job
-alone, and `btclib.ecc.rangeproof` reads a format no other vector file
-in this tree carries.
+measure nothing in an unflagged build: the flagged extension those
+calls need is what a btclib-secp256k1 installed from its sdist with
+`BTCLIB_LIBSECP256K1_ZKP` has, and `btclib.ecc.rangeproof` reads a
+format no other vector file in this tree carries.
 
 **Recording another is this file's own arguments.** A rangeproof draws
 nothing -- its nonces are the hash chain `rangeproof_genrand` derives

--- a/tests/ecc/rangeproof_test.py
+++ b/tests/ecc/rangeproof_test.py
@@ -8,9 +8,10 @@ The vectors are proofs libsecp256k1-zkp signed, recorded with the
 arguments that produced them and with what `zkp.rangeproof.info`
 answers for each -- `tests/_data/README.md` has the recording and how
 to make another. They are here so that the parser is exercised
-wherever the suite runs: the flagged extension exists in
-`.github/workflows/zkp-oracle.yml`'s job alone, so a test that can only
-ask the library leaves the parser unmeasured in every ordinary run.
+wherever the suite runs: the flagged extension is what a
+btclib-secp256k1 installed from its sdist with `BTCLIB_LIBSECP256K1_ZKP`
+has, so a test that can only ask the library leaves the parser
+unmeasured in an unflagged build.
 
 What the vectors are asked: that a parse of the header says what `info`
 said about the same octets, field for field; that `serialize` writes


### PR DESCRIPTION
Closes #1929.

The flagged `btclib_secp256k1.zkp` extension is a property of a **build**,
not of a job: any environment installing btclib-secp256k1 from its sdist
with `BTCLIB_LIBSECP256K1_ZKP` has it, which is the contributor's machine
ISS 1885 is named for. `tests/ecc/rangeproof_test.py`'s module docstring
and `tests/_data/README.md`'s entry for the zkp rangeproof vectors said
the extension exists in `zkp-oracle.yml`'s job alone; both now name the
build, in the terms `tests/__init__.py` already sets.

The second half of the issue is the work. A line-wise sweep reports the
tree clean of one of the two sites, because the README's occurrence wraps
across a line break — the exact false zero `CLAUDE.md`'s *a failed thing
is loud and an absent thing is silent* warns about. Two whitespace-folded
sweeps over every tracked `.py`, `.md`, `.yml`, `.yaml` and `.toml`, each
shown firing on both sites before the fix, and every other hit read in
its paragraph and left: the six `no-bindings job` pragmas are the
**bindings** guard, where `tests/__init__.py` names a job on purpose.

A third site was found in `CHANGELOG.md`'s **open** section, carrying the
same framing, and it is corrected in place. What settles that a landed
entry there is editable is that the seal is a *tag*:
`tests/changelog_immutability_test.py` makes a released section's own
authority `git show <version>:<path>`, and a *work in progress* section
has none to disagree with. `64f81e1c` is the landed precedent, its own
body reading "Corrected in place, since the bullet has not released yet."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Correct the rangeproof documentation to identify the build configuration that provides the secp256k1-zkp extension.

Enhancements:
- Clarify that the secp256k1-zkp extension is a property of an unflagged or ZKP-enabled build rather than a CI job in the rangeproof documentation and changelog.

Documentation:
- Update rangeproof vector documentation, test module documentation, and the changelog to accurately describe when the ZKP extension is available.