### PR TITLE
`ecc.borromean` gains `sign_`, and zkp answers about what it signs (issue #1895)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3470,6 +3470,38 @@ name that library and the symbol each of them paraphrases (closes #1932).
   contributor who builds it reads a reason that holds on their own
   machine. No vector, no test and no exclusion moves.
 
+### `ecc.borromean` gains `sign_`, and zkp answers about what it signs
+
+- **`sign_` is the prepared spelling of `sign`** (issue #1895): it takes
+  the one hash the ring walk binds, where `sign` builds that hash from
+  `msg` and `pubk_rings` with `_get_msg_format` and calls it. A
+  rangeproof is the caller it exists for, its preimage being the value
+  commitment, the generator and the proof's own header, with no pubkey
+  ring in it at all -- a shape the two arguments `sign` takes cannot
+  produce. Binding the rings into the hash is then the caller's, and the
+  docstring says what a signature over one that does not reach them is
+  worth. Every key of every ring is still read as a point of `ec` before
+  anything is signed, which `sign` gets on its way through
+  `_get_msg_format` and the prepared spelling has to ask for.
+- **Whether secp256k1-zkp takes a signature this module writes is
+  measured rather than asserted, and the answer is that it does not.**
+  `zkp.rangeproof.borromean_verify` wraps `secp256k1_borromean_verify`
+  over serialized arguments in the flagged `zkp` extension, and
+  `tests/ecc/borromean_test.py` puts a signature `sign_` wrote to it
+  under a ring and under that same ring negated key by key. Both are
+  refused, and two differences are why. The public key of a ring is the
+  other one of the pair, `s*G - e*Q` here against `s*G + e*P` there
+  (issue #1895), which a negated ring answers. And `e0` takes the
+  message at the other end of its preimage, `hf(m || r_0 || ... ||
+  r_last)` here against `sha256(r_0 || ... || r_last || m)` there
+  (issue #1940), which no ring a verifier is handed can reach, `e0`
+  being written into the signature before any verifier sees it.
+- **The bindings floor moves to 0.8.0.6**, in both of the places
+  `pyproject.toml` states it: that is the release carrying
+  `zkp.rangeproof.borromean_verify`, and the first whose `secp256k1-zkp`
+  submodule is the `fametrano/secp256k1-zkp` fork that wraps a function
+  BlockstreamResearch keeps internal.
+
 ## v2026.9.3
 
 ### Repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,16 @@ secp256k1 = [
     # `BTCLIB_LIBSECP256K1_ZKP=true` set -- `btclib_secp256k1.zkp` is
     # what 0.8.0.5 is, and a floor below it has no such subpackage to
     # build against at all
-    "btclib-secp256k1>=0.8.0.5",
+    # 0.8.0.6 for `zkp.rangeproof.borromean_verify`
+    # (btclib-org/btclib-secp256k1#828), which
+    # `tests/ecc/borromean_test.py` asks whether zkp's verifier takes a
+    # signature `ecc.borromean` wrote. It reads
+    # `secp256k1_borromean_verify`, which stays internal to
+    # BlockstreamResearch's secp256k1-zkp: this release is the first
+    # whose submodule is the `fametrano/secp256k1-zkp` fork that wraps
+    # it, proposed upstream as
+    # `BlockstreamResearch/secp256k1-zkp#373` and unmerged there.
+    "btclib-secp256k1>=0.8.0.6",
 ]
 
 [project.urls]
@@ -202,7 +211,7 @@ pull_requests = "https://github.com/btclib-org/btclib/pulls"
 # refuses the day the two stop agreeing. What the group buys is that no
 # documented command had to grow an `--extra`, and that the job of issue
 # #991 is those same commands with this group left out
-bindings = ["btclib-secp256k1>=0.8.0.5"]
+bindings = ["btclib-secp256k1>=0.8.0.6"]
 # what runs the suite, without what the suite delegates to: `test` is the
 # two together and is what every documented command asks for, while
 # `harness` alone is the environment the no-bindings job of test.yml

--- a/src/btclib/ecc/borromean.py
+++ b/src/btclib/ecc/borromean.py
@@ -45,18 +45,36 @@ function is built directly rather than parsed.
 With the challenge hash aligned too (issue #1070), this module and
 zkp's rangeproof agree over secp256k1 with sha256 on the challenge
 preimage and on the wire layout of the ring signature itself -- the
-primitive, as against the rangeproof built on top of it. That the two
-therefore accept each other's signatures is an assertion, not a
-measurement: the agreement is with zkp's source, read and transcribed
-by hand, which is what `tests/ecc/borromean_test.py` pins, and no test
-here hands a signature to `secp256k1_borromean_verify` or checks one
-that function produced. One direction of it is in reach:
-`zkp.rangeproof.borromean_verify` wraps that function over serialized
-arguments, in the flagged `zkp` extension alone. The other is not --
+primitive, as against the rangeproof built on top of it. They still
+refuse each other's signatures, and `tests/ecc/borromean_test.py`
+measures the direction in reach rather than transcribing it:
+`zkp.rangeproof.borromean_verify` wraps `secp256k1_borromean_verify`
+over serialized arguments in the flagged `zkp` extension, and what is
+put to it there is a signature ``sign_`` wrote, under a ring and under
+that same ring negated key by key.
+
+Two differences stand between the two, and answering either on its own
+still leaves the signature refused. The public key of a ring is the
+other one of the pair: this module recovers a ring point as `s*G -
+e*Q` and gives the real signer `s = k + q*e`, where
+`secp256k1_borromean_verify_impl` recovers `s*G + e*P` and
+`secp256k1_borromean_sign` gives `s = k - sec*e`, so what one calls
+`P` the other calls `-P` and only a ring negated key by key meets the
+equation that closes it (issue #1895). And `e0` takes the message at
+the other end of its preimage: this one is `hf(m || r_0 || ... ||
+r_last)` where zkp's is `sha256(r_0 || ... || r_last || m)`, which no
+ring a verifier is handed can reach, `e0` being written into the
+signature before any verifier sees it (issue #1940).
+
+Verifying is the only direction in reach at all.
 `secp256k1_borromean_sign` is declared `static` in
 `src/modules/rangeproof/borromean.h`, an internal header with no
 counterpart under zkp's `include/`, and `static` is internal linkage,
-so no cffi `cdef` binds it.
+so no cffi `cdef` binds it. Reaching the verifier takes a fork: the
+`secp256k1-zkp` submodule of the bindings is `fametrano/secp256k1-zkp`,
+which declares a wrapper of that name in
+`include/secp256k1_rangeproof.h` and has it proposed upstream as
+`BlockstreamResearch/secp256k1-zkp#373`, unmerged there.
 
 Agreeing on the primitive is not the same as producing a Confidential
 Transactions rangeproof: `rangeproof_impl.h` wraps this signature in a
@@ -73,11 +91,14 @@ and holds the `e0` and the `s` values inside the proof as a
 `BorromeanSig` of this module's. `sign_public_value` writes the proof
 whose ring structure is one ring of one key -- the value in the clear,
 so no digit decomposition and no ring commitment -- and it closes that
-ring on its own rather than through `sign` here, `_get_msg_format`
-being a message format a rangeproof does not have: what it hashes is
-the value commitment, the generator and the proof's own header, with
-no pubkey ring in the preimage. Verifying a proof and rewinding one
-are still ahead of it.
+ring on its own rather than through this module. The message format is
+one reason, and it is what ``sign_`` answers: a rangeproof hashes the
+value commitment, the generator and the proof's own header, with no
+pubkey ring in the preimage. The ring convention and the `e0` preimage
+above are two more, and they are why that function writes an `e0` and
+an `s` of its own; `ecc.rangeproof` names the rest beside the code that
+carries them. Verifying a proof and rewinding one are still ahead of
+it.
 
 The signing direction is issue #1072's to discharge:
 `zkp.rangeproof.sign` and `zkp.rangeproof.verify` are wrapped, and the
@@ -121,6 +142,7 @@ __all__ = [
     "SValues",
     "assert_as_valid",
     "sign",
+    "sign_",
     "verify",
 ]
 
@@ -406,8 +428,23 @@ def _assert_sign_key_idx_in_range(
             raise BTClibValueError(err_msg)
 
 
-def sign(
-    msg: Octets,
+def _assert_valid_pubk_rings(pubk_rings: Sequence[PubkeyRing], ec: Curve) -> None:
+    """Refuse a ring key that is no point of ec.
+
+    The refusal `sign` gets on its way through `_get_msg_format`, which
+    serializes every ring key into the message hash it builds. `sign_`
+    is handed that hash already made, and nothing in the signing walk
+    would look at a key without this: a ring of a single key, signed at
+    its own position, is walked at no forged position at all, so
+    neither of the walk's two loops reaches it.
+    """
+    for pubk_ring in pubk_rings:
+        for Q in pubk_ring:
+            bytes_from_point(Q, ec)
+
+
+def sign_(
+    msg_hash: Octets,
     ks: Sequence[Integer],
     sign_key_idx: Sequence[int],
     sign_keys: Sequence[Integer],
@@ -415,33 +452,40 @@ def sign(
     ec: Curve = secp256k1,
     hf: HashF = sha256,
 ) -> BorromeanSig:
-    """Sign msg with a borromean ring signature, one key per ring.
+    """Sign a prepared message hash, one key per ring.
 
-    https://github.com/ElementsProject/borromean-signatures-writeup
-    https://github.com/Blockstream/borromean_paper/blob/master/borromean_draft_0.01_9ade1e49.pdf
+    `msg_hash` is the value every position of the ring walk hashes,
+    `hf().digest_size` octets of it; `sign` is the spelling that builds
+    one from `msg` and `pubk_rings` with `_get_msg_format`.
 
-    `ks` is one nonce per ring, `sign_key_idx` the position of the real
-    key in each ring, `sign_keys` the real private key of each ring --
-    `sign_keys[i]` signs at `pubk_rings[i][sign_key_idx[i]]` -- and
-    `pubk_rings` the full public rings, real key included.
+    Binding the rings into that hash is the caller's, and it is what a
+    borromean signature proves nothing without: zkp says so of the same
+    argument -- "Message must contain pubkeys or a pubkey commitment",
+    the header comment on `secp256k1_borromean_verify_impl` -- because a
+    preimage that does not reach `pubk_rings` leaves the ring free to be
+    swapped for another one under the signature made over it.
 
-    `ks` and `sign_keys` are scalars, spelled as `Integer` the way `dsa`
-    and `ssa` spell one, and each is read through
-    `curves.scalar_from_prv_key`: in 1..n-1, or refused (issue #1243).
-    `sign_key_idx` is not one of them and stays `int` -- it indexes a
-    ring, and an index is not a scalar written in hex.
-    `sign_key_idx[i]` must be a valid index into `pubk_rings[i]`, refused
-    with `BTClibValueError` naming the ring, the index and the ring's
-    size otherwise -- a ring with no keys has none, whatever the index
-    (issue #1094), and a value the ring's size does not reach either
-    (issue #1095).
+    A rangeproof is the caller that wants this, and is why the hash
+    cannot be built from the two arguments here: its preimage is the
+    value commitment, the generator and the proof's own header, with no
+    pubkey ring in it at all, and `ecc.rangeproof` rebuilds the rings
+    from that commitment instead. What this offers that caller is the
+    message format alone: the module docstring above measures the two
+    differences that still stand between a signature written here and
+    one `secp256k1_borromean_verify` takes.
 
-    A `BorromeanSig`, because that is what it is: the result verifies
-    with `assert_as_valid`/`verify`, serializes with
-    `BorromeanSig.serialize`, and handing back a bare `(bytes,
-    SValues)` tuple would only make the caller build one to do either.
+    `pubk_rings` is an argument here as it is in `sign`: the walk
+    multiplies by those points, and a hash cannot give them back. So
+    what the trailing underscore offers is the preimage the caller has
+    already built, never a ring it has already checked -- every key of
+    every ring is read as a point of `ec` before anything is signed.
+
+    Every other argument is `sign`'s, and is read the way `sign` reads
+    it.
     """
-    msg, m, e = _initialize(msg, pubk_rings, ec, hf)
+    m = bytes_from_octets(msg_hash, hf().digest_size)
+    _assert_valid_pubk_rings(pubk_rings, ec)
+    e = [[0] * len(pubk_ring) for pubk_ring in pubk_rings]
     e0bytes = m
     # drawn uniformly in [0, ec.n), the same distribution the real
     # s-value has once step 2 reduces it: randbits(256) is uniform over
@@ -561,6 +605,50 @@ def sign(
         # so this changes no signature, only what it discloses.
         s[i][j_star] = (k + q_ints[i] * e[i][j_star]) % ec.n
     return BorromeanSig(e0, s, ec)
+
+
+def sign(
+    msg: Octets,
+    ks: Sequence[Integer],
+    sign_key_idx: Sequence[int],
+    sign_keys: Sequence[Integer],
+    pubk_rings: Sequence[PubkeyRing],
+    ec: Curve = secp256k1,
+    hf: HashF = sha256,
+) -> BorromeanSig:
+    """Sign msg with a borromean ring signature, one key per ring.
+
+    https://github.com/ElementsProject/borromean-signatures-writeup
+    https://github.com/Blockstream/borromean_paper/blob/master/borromean_draft_0.01_9ade1e49.pdf
+
+    `ks` is one nonce per ring, `sign_key_idx` the position of the real
+    key in each ring, `sign_keys` the real private key of each ring --
+    `sign_keys[i]` signs at `pubk_rings[i][sign_key_idx[i]]` -- and
+    `pubk_rings` the full public rings, real key included.
+
+    `ks` and `sign_keys` are scalars, spelled as `Integer` the way `dsa`
+    and `ssa` spell one, and each is read through
+    `curves.scalar_from_prv_key`: in 1..n-1, or refused (issue #1243).
+    `sign_key_idx` is not one of them and stays `int` -- it indexes a
+    ring, and an index is not a scalar written in hex.
+    `sign_key_idx[i]` must be a valid index into `pubk_rings[i]`, refused
+    with `BTClibValueError` naming the ring, the index and the ring's
+    size otherwise -- a ring with no keys has none, whatever the index
+    (issue #1094), and a value the ring's size does not reach either
+    (issue #1095).
+
+    `msg` and `pubk_rings` are reduced here to the one hash the ring
+    walk binds, `_get_msg_format`'s; ``sign_`` is the spelling that
+    takes that hash instead, for a caller whose own preimage has
+    another shape.
+
+    A `BorromeanSig`, because that is what it is: the result verifies
+    with `assert_as_valid`/`verify`, serializes with
+    `BorromeanSig.serialize`, and handing back a bare `(bytes,
+    SValues)` tuple would only make the caller build one to do either.
+    """
+    m = _get_msg_format(bytes_from_octets(msg), pubk_rings, ec, hf)
+    return sign_(m, ks, sign_key_idx, sign_keys, pubk_rings, ec, hf)
 
 
 def verify(

--- a/tests/curve_parameter_test.py
+++ b/tests/curve_parameter_test.py
@@ -256,6 +256,17 @@ _CASES = (
         },
     ),
     _Case(
+        "btclib.ecc.borromean.sign_",
+        borromean.sign_,
+        {
+            "msg_hash": _MSG_HASH,
+            "ks": [1, 2],
+            "sign_key_idx": _SIGN_KEY_IDX,
+            "sign_keys": _SIGN_KEYS,
+            "pubk_rings": _PUBK_RINGS,
+        },
+    ),
+    _Case(
         "btclib.ecc.borromean.verify",
         borromean.verify,
         {"msg": _MSG, "sig": _BORROMEAN_SIG, "pubk_rings": _PUBK_RINGS},

--- a/tests/ecc/borromean_test.py
+++ b/tests/ecc/borromean_test.py
@@ -14,15 +14,32 @@ from io import BytesIO
 import pytest
 
 from btclib.alias import Point
-from btclib.curves import Curve, mult, secp256k1
+from btclib.curves import (
+    Curve,
+    bytes_from_point,
+    double_mult_var,
+    mult,
+    secp256k1,
+)
 from btclib.ecc import borromean, dsa
-from btclib.ecc.borromean import BorromeanSig
+from btclib.ecc.borromean import BorromeanSig, _get_msg_format, _hash
 from btclib.exceptions import (
     BorromeanRingError,
     BTClibTypeError,
     BTClibValueError,
 )
+from btclib.utils import int_from_bits
+from tests import needs_zkp
 from tests.curves.curve_test import low_card_curves
+
+# guarded module scope, the same shape `tests/ecc/pedersen_test.py` uses
+# and for its reason: this file is collected in every job, the
+# no-bindings one included, and pytest imports every module it collects
+# before `tests.needs_zkp` can skip anything in it
+try:
+    from btclib_secp256k1.zkp import rangeproof as zkp_rangeproof
+except ImportError:  # pragma: no cover -- only the no-bindings job reaches this
+    zkp_rangeproof = None  # type: ignore[assignment]
 
 
 def test_borromean() -> None:
@@ -223,12 +240,13 @@ def test_challenge_hash_matches_zkps_preimage_order() -> None:
     `src/modules/rangeproof/borromean_impl.h`, read at its current tip
     on 2026-08-20): the point -- or the `e0` closing the rings -- first,
     then the message hash, then the ring index and the position each as
-    4 bytes big-endian (issue #1070). There is no vendored zkp in this
-    tree to call, so this pins that order computed by hand from zkp's
-    documented source rather than from any live cross-check against
-    zkp's own code -- and pins it against a `m || R || i || j` order,
-    which is what this function computed, and what this test would have
-    caught, before #1070.
+    4 bytes big-endian (issue #1070). This pins that order computed by
+    hand from zkp's documented source, and runs in every build, where
+    `test_zkp_reads_this_challenge_and_refuses_this_signature` below
+    puts the same preimage to zkp's own verifier and needs the flagged
+    extension for it. It pins the order against a `m || R || i || j`
+    one, which is what this function computed, and what this test would
+    have caught, before #1070.
     """
     m = hashlib.sha256(b"message hash, pretending to be one").digest()
     r = hashlib.sha256(b"nonce point, or e0, pretending to be one").digest()
@@ -700,3 +718,148 @@ def test_no_statistic_of_s_correlates_with_the_signer_on_a_low_cardinality_curve
     _assert_no_statistic_of_s_correlates_with_the_signer(
         ec, ring_size=4, trials=300, tolerance=0.25
     )
+
+
+def test_sign_signs_the_hash_it_is_handed() -> None:
+    """`sign` is `sign_` over `_get_msg_format`, and nothing else.
+
+    The prepared spelling takes the one hash the ring walk binds, so a
+    caller that computes that hash the way `sign` does gets a signature
+    `verify` accepts -- and one that computes it any other way gets a
+    signature about that other hash, which is the whole of what the
+    argument buys and the whole of what it costs.
+    """
+    keys = [dsa.gen_keys(i) for i in (2, 3)]
+    pubk_rings = [[keys[0][1], keys[1][1]]]
+    msg = b"Borromean ring signature"
+
+    m = _get_msg_format(msg, pubk_rings, secp256k1, sha256)
+    sig = borromean.sign_(m, [1], [0], [keys[0][0]], pubk_rings)
+    assert borromean.verify(msg, sig, pubk_rings)
+
+    # another hash is another message: the signature is valid about it,
+    # and `verify` -- which recomputes `_get_msg_format` from `msg` --
+    # is asking about something else
+    other = _get_msg_format(b"another message", pubk_rings, secp256k1, sha256)
+    sig = borromean.sign_(other, [1], [0], [keys[0][0]], pubk_rings)
+    assert not borromean.verify(msg, sig, pubk_rings)
+    assert borromean.verify(b"another message", sig, pubk_rings)
+
+
+def test_sign_reads_a_prepared_hash_and_a_ring_key() -> None:
+    """Prepared is the hash, never the ring, so both are still checked.
+
+    `sign` reads every ring key on its way through `_get_msg_format`,
+    which `sign_` is handed the output of; a ring of one key signed at
+    its own position is walked at no forged position, so without the
+    check here nothing would look at that key at all.
+    """
+    prv_key, pub_key = dsa.gen_keys(2)
+    m = sha256(b"a prepared message hash").digest()
+
+    with pytest.raises(BTClibValueError, match="point not on curve"):
+        borromean.sign_(m, [1], [0], [prv_key], [[(1, 2)]])
+
+    # and the hash itself, which is hf's digest and not octets of any size
+    with pytest.raises(BTClibValueError, match="invalid size"):
+        borromean.sign_(m + b"\x00", [1], [0], [prv_key], [[pub_key]])
+    with pytest.raises(BTClibTypeError, match="invalid octets type: int"):
+        borromean.sign_(0, [1], [0], [prv_key], [[pub_key]])  # type: ignore[arg-type]
+
+
+def _last_ring_points(
+    m: bytes, sig: BorromeanSig, pubk_rings: list[list[Point]]
+) -> bytes:
+    """Walk each ring forward from sig.e0 and return its last point, joined.
+
+    `assert_as_valid`'s own walk, which hashes these bytes together with
+    `m` to answer whether the signature closes -- repeated here so that
+    the two orders can be compared, since the module hashes them in only
+    one of them.
+    """
+    out = b""
+    for i, pubk_ring in enumerate(pubk_rings):
+        e = int_from_bits(_hash(m, sig.e0, i, 0, sha256), secp256k1.nlen)
+        e %= secp256k1.n
+        points = []
+        for j, Q in enumerate(pubk_ring):
+            point = double_mult_var(-e, Q, sig.s[i][j], secp256k1.G, secp256k1)
+            points.append(bytes_from_point(point, secp256k1))
+            if j != len(pubk_ring) - 1:
+                e = int_from_bits(
+                    _hash(m, points[-1], i, j + 1, sha256), secp256k1.nlen
+                )
+                e %= secp256k1.n
+        out += points[-1]
+    return out
+
+
+def test_e0_hashes_the_message_before_the_ring_points() -> None:
+    """`e0` is `hf(m || r_0 || ... || r_last)`, where zkp's is the reverse.
+
+    secp256k1-zkp writes each ring's last point into its `e0` hash first
+    and the message only after the ring loop ends
+    (`secp256k1_borromean_sign`, `src/modules/rangeproof/borromean_impl.h`),
+    so the two preimages hold the same bytes in the other order. This
+    module is self-consistent -- `assert_as_valid` builds the preimage
+    the way `sign` does -- and a signature written here is one zkp's
+    verifier refuses whatever ring it is given, which is issue #1940 and
+    what `test_zkp_reads_this_challenge_and_refuses_this_signature`
+    below measures.
+    """
+    keys = [dsa.gen_keys(i) for i in (2, 3, 4, 5)]
+    pubk_rings = [[keys[0][1], keys[1][1]], [keys[2][1], keys[3][1]]]
+    msg = b"Borromean ring signature"
+    sig = borromean.sign(msg, [1, 2], [0, 1], [keys[0][0], keys[3][0]], pubk_rings)
+
+    m = _get_msg_format(msg, pubk_rings, secp256k1, sha256)
+    points = _last_ring_points(m, sig, pubk_rings)
+    assert sha256(m + points).digest() == sig.e0
+    assert sha256(points + m).digest() != sig.e0
+
+
+# `pragma: no cover` on the `@needs_zkp` below, the marker being the
+# reason: `tests/conftest.py` turns it into a skip in an unflagged
+# build, and excluding what a build cannot execute is what leaves the
+# floor a measurement of the suite rather than of the build the machine
+# has (issue #1885). The marker's line and not the `def` under it, as
+# `tests/ecc/pedersen_test.py` does and for the reason it gives there.
+@needs_zkp  # pragma: no cover -- no zkp.rangeproof.borromean_verify to ask
+def test_zkp_reads_this_challenge_and_refuses_this_signature() -> None:
+    """A signature `sign_` writes is one zkp's own verifier refuses.
+
+    `zkp.rangeproof.borromean_verify` wraps `secp256k1_borromean_verify`
+    over serialized arguments, so the module docstring's account of
+    where the two implementations part is measured here instead of
+    transcribed.
+
+    The ring closed first is closed under zkp's own two conventions --
+    `e0` over `r || m`, and `s = k - q*e` -- and through this module's
+    `_hash` for the challenge, which is the preimage the two do share.
+    That it verifies is what makes the refusals below statements about
+    the two differences rather than about this call, and that its
+    negation does not verify is zkp holding `s*G + e*P` where this
+    module holds `s*G - e*Q`.
+
+    What `sign_` writes is then refused under the ring and under that
+    ring negated key by key: the negation answers the equation, and
+    `e0` -- already written into the signature -- is still over the
+    other preimage.
+    """
+    prv_key, pub_key = dsa.gen_keys(2)
+    sec = bytes_from_point(pub_key, secp256k1)
+    negated_sec = bytes_from_point((pub_key[0], secp256k1.p - pub_key[1]), secp256k1)
+    m = sha256(b"a message a rangeproof could have built").digest()
+
+    k = 1 + secrets.randbelow(secp256k1.n - 1)
+    r = bytes_from_point(mult(k, secp256k1.G, secp256k1), secp256k1)
+    e0 = sha256(r + m).digest()
+    e = int_from_bits(_hash(m, e0, 0, 0, sha256), secp256k1.nlen) % secp256k1.n
+    s = ((k - prv_key * e) % secp256k1.n).to_bytes(32, "big")
+    assert zkp_rangeproof.borromean_verify(e0, s, m, [sec], [1])
+    assert not zkp_rangeproof.borromean_verify(e0, s, m, [negated_sec], [1])
+
+    sig = borromean.sign_(m, [k], [0], [prv_key], [[pub_key]])
+    s_values = sig.serialize()[sha256().digest_size :]
+    assert not zkp_rangeproof.borromean_verify(sig.e0, s_values, m, [sec], [1])
+    assert not zkp_rangeproof.borromean_verify(sig.e0, s_values, m, [negated_sec], [1])

--- a/uv.lock
+++ b/uv.lock
@@ -419,13 +419,13 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "bitcoin-core-rpc", specifier = ">=2026.9.3" },
-    { name = "btclib-secp256k1", marker = "extra == 'secp256k1'", specifier = ">=0.8.0.5" },
+    { name = "btclib-secp256k1", marker = "extra == 'secp256k1'", specifier = ">=0.8.0.6" },
     { name = "typing-extensions", specifier = ">=4.10" },
 ]
 provides-extras = ["secp256k1"]
 
 [package.metadata.requires-dev]
-bindings = [{ name = "btclib-secp256k1", specifier = ">=0.8.0.5" }]
+bindings = [{ name = "btclib-secp256k1", specifier = ">=0.8.0.6" }]
 check = [
     { name = "check-sdist" },
     { name = "check-wheel-contents" },
@@ -433,7 +433,7 @@ check = [
     { name = "twine" },
 ]
 dev = [
-    { name = "btclib-secp256k1", specifier = ">=0.8.0.5" },
+    { name = "btclib-secp256k1", specifier = ">=0.8.0.6" },
     { name = "check-sdist" },
     { name = "check-wheel-contents" },
     { name = "cosmic-ray" },
@@ -453,7 +453,7 @@ dev = [
     { name = "twine" },
 ]
 docs = [
-    { name = "btclib-secp256k1", specifier = ">=0.8.0.5" },
+    { name = "btclib-secp256k1", specifier = ">=0.8.0.6" },
     { name = "furo" },
     { name = "myst-parser" },
     { name = "sphinx" },
@@ -467,14 +467,14 @@ harness = [
     { name = "pytest-xdist" },
 ]
 lint = [
-    { name = "btclib-secp256k1", specifier = ">=0.8.0.5" },
+    { name = "btclib-secp256k1", specifier = ">=0.8.0.6" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "ruff" },
 ]
 mutation = [{ name = "cosmic-ray" }]
 test = [
-    { name = "btclib-secp256k1", specifier = ">=0.8.0.5" },
+    { name = "btclib-secp256k1", specifier = ">=0.8.0.6" },
     { name = "coverage" },
     { name = "hypothesis" },
     { name = "pytest" },


### PR DESCRIPTION
Issue #1895.

`ecc.borromean` gains `sign_`, taking the message hash directly, with
`sign` refactored onto it — the entry point ISS 1895's decision asks for
so that a rangeproof writer can reach the ring walk without going through
a message format a rangeproof does not have.

**It does not close the issue, and the reason is the branch's own
measurement.** ISS 1895 records that negating the points and the secrets
at `ecc.rangeproof`'s boundary is what makes a btclib signature cross to
`zkp.rangeproof.borromean_verify`. It does not. There is a second
divergence the issue does not name: this module's `e0` preimage is
`hf(m ‖ r…)` where `secp256k1_borromean_sign`'s is `sha256(r… ‖ m)`, and
that changes the `e0` a signature carries rather than the equation a
verifier solves with it, so no choice of ring bridges it. Filed as
issue #1940, which is a wire-format decision rather than a repair.

`test_zkp_reads_this_challenge_and_refuses_this_signature` is that
measurement, under `@needs_zkp`: a ring closed under zkp's two
conventions through btclib's own `_hash` is **accepted**, which proves
the challenge preimage is genuinely shared and that the oracle
discriminates; the same ring negated is refused; and what `sign_` writes
is refused either way. Two planted controls were run and reverted against
it, so neither the acceptance nor the refusals are vacuous.

The bindings floor moves to `btclib-secp256k1>=0.8.0.6` in both
declarations, because the branch calls `borromean_verify`, which that
release adds — not because a newer version exists.

`RELEASE_NOTES.md` does not move: `ecc.borromean` shipped at `v2026.9.3`,
so `sign_` is a name added beside an unchanged `sign`, and `sign`'s output
is byte-identical across the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Expose prepared-hash Borromean signing and verify its interoperability boundaries with secp256k1-zkp.

New Features:
- Add `ecc.borromean.sign_` for signing a caller-provided message hash while preserving `sign` as the message-formatting entry point.

Enhancements:
- Document and measure the incompatibilities between btclib Borromean signatures and secp256k1-zkp verification, including ring-key conventions and challenge preimage ordering.

Build:
- Raise the `btclib-secp256k1` dependency floor to 0.8.0.6 to provide the exposed Borromean verifier binding.

Documentation:
- Update the changelog with the new signing API and the measured zkp interoperability results.

Tests:
- Add coverage for prepared-hash signing, validation of prepared inputs and ring keys, challenge preimage ordering, and zkp verifier acceptance/refusal behavior.