### PR TITLE
`RELEASING.md` says which cycle the new heading names (closes #1944)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3502,6 +3502,25 @@ name that library and the symbol each of them paraphrases (closes #1932).
   submodule is the `fametrano/secp256k1-zkp` fork that wraps a function
   BlockstreamResearch keeps internal.
 
+### `RELEASING.md`'s new cycle heading names the release just cut
+
+- **The retitle step says which number the "work in progress" section it
+  opens takes** (closes #1944): the cycle of the release being cut, the
+  `YYYY.M` of the version the section it is opened above was just
+  retitled to. The number was left to whoever was cutting the release,
+  and that heading is the one place the cycle is decided now that *Open
+  the next cycle's version* reads `pyproject.toml`'s placeholder off it.
+- **The step gives the reason the choice is not free**: a heading naming a
+  month that has not arrived makes a checkout of `main` declare a version
+  sorting above every release that ships before that month does, `2026.10`
+  above `2026.9.10`. A heading that ends up a month behind the release it
+  names is corrected at the next retitle, where one naming a month ahead
+  stands for the whole cycle.
+- **It says that a cycle running past the end of its month is not a case
+  to plan for**, so that the rule is not read as a claim about when the
+  next release falls: the retitle step of that release renames the
+  heading, and nothing is bumped meanwhile.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -315,6 +315,26 @@ to `deps-latest`'s own result.
    that precedes the tag's, and the tag always carries a day where the
    placeholder never does, so the two forms cannot collide.
 
+   **That new heading names the cycle of the release being cut** — the
+   `YYYY.M` of the version the section just retitled now carries, so
+   retitling to `v2026.9.3` opens `## v2026.9 (work in progress, not
+   released yet)`. It is not a guess at the month the next release will
+   fall in. *Open the next cycle's version* below sets `pyproject.toml`
+   from this heading and records that the placeholder sorts below the
+   release just cut, which holds because the month it names has come; a
+   heading naming a month that has not makes a checkout of `main`
+   declare a version sorting above every release that ships before that
+   month arrives, `2026.10` above `2026.9.10`. The asymmetry is the
+   rule: a heading that ends up a month behind the release it names is
+   corrected at the next retitle, where one naming a month ahead stands
+   for the whole cycle and nothing reports it.
+
+   So a cycle running past the end of its month costs nothing and is not
+   a case to plan for. The retitle step of *that* release renames this
+   heading to the version being cut then, exactly as this one renames
+   the section it is opened above, and nothing is bumped while the cycle
+   runs.
+
 1. Run `uv run pre-commit run --all-files` and `uv run pytest --cov`,
    follow docs/README.rst to check that the documentation builds, and get
    the above onto `main` through the usual pull request. The local gates


### PR DESCRIPTION
Closes #1944.

`RELEASING.md`'s retitle step said to start the next cycle's "work in
progress" section and never which number that section takes. It now says:
the heading names the cycle of the release being cut — the `YYYY.M` of the
version the section it is opened above was just retitled to — and not a
guess at the month the next release will fall in.

The two data points the issue measures are not two applications of one
undocumented rule. `c7b992fe` opened `v2026.9` after `v2026.8.21`, a guess
that the next release would fall in September; it fell on 2026-08-26, and
`171435c2` retitled that very section to `v2026.8.26`. The guess was
falsified and the retitle absorbed it. The section opened after `v2026.9.3`
is `v2026.9`, the month of the release, which cannot be wrong the same way.

The guess has a cost even though the retitle corrects it, and that is why
the choice is not free. Since ISS 1941 makes `pyproject.toml`'s placeholder
follow this heading, a heading naming a future month makes a checkout
*declare* a version sorting above every release that ships before it —
`2026.10 > 2026.9.10` — for as long as the guess stands. A heading naming
the month of the release just cut can never do that.

The second half is what keeps the rule from being read as a claim about
when the next release falls: if a cycle runs past the end of its month,
the retitle step of *that* release renames the heading, exactly as this one
renames the section it is opened above.

No test: a test asserting the month would be asserting the guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Clarify how release-cycle headings are numbered to prevent future-month version placeholders from sorting ahead of released versions.

Enhancements:
- Clarify the release procedure so each new work-in-progress heading names the cycle of the release just cut, rather than predicting the next release month.
- Document the version-ordering consequences of future-month headings and how cycles that extend past a month are handled.

Documentation:
- Update the changelog and releasing guide with the clarified cycle-heading rule and its rationale.