### PR TITLE
`ecc.commit_nonce` names secp256k1-zkp for sign-to-contract (closes #1946)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3521,6 +3521,24 @@ name that library and the symbol each of them paraphrases (closes #1932).
   next release falls: the retitle step of that release renames the
   heading, and nothing is bumped meanwhile.
 
+### `ecc.commit_nonce` names secp256k1-zkp for sign-to-contract
+
+- **The module docstring credits BlockstreamResearch/secp256k1-zkp with
+  the sentence it quotes** (closes #1946): the words are
+  `secp256k1_ecdsa_sign_inner`'s in `src/secp256k1.c`, giving the reason
+  a sign-to-contract commitment works only with the default nonce
+  function. bitcoin-core/secp256k1 publishes neither a sign-to-contract
+  header nor a commitment module, so the name the sentence carried sent
+  a reader to a library that has neither.
+- **`_tweak`'s comment on the out-of-range candidate names
+  `secp256k1_ec_commit`** (`src/eccommit_impl.h`), which hashes once and
+  fails where the tweak is refused. Its closing clause names the
+  derivation that fails rather than drawing again, that being what
+  leaves a low-cardinality curve with no tweak; a library name there
+  read as a claim about upstream.
+- **`SECURITY.md`'s citation of `commit_nonce.commit_nonce_` names the
+  line the read sits on.**
+
 ## v2026.9.3
 
 ### Repository

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -145,7 +145,7 @@ used to teach and to prototype as much as to build:
     decision, not an oversight. These call sites read one of those
     straight into a Python `int`: `bip32.__prv_key_derivation`
     (`src/btclib/bip32/bip32.py:842`), `commit_nonce.commit_nonce_`
-    (`src/btclib/ecc/commit_nonce.py:155`) and `taproot._tweaked_prvkey`
+    (`src/btclib/ecc/commit_nonce.py:159`) and `taproot._tweaked_prvkey`
     (`src/btclib/script/taproot.py:479`). A caller-owned buffer can be
     wiped once the call that filled it returns; the `int` it is read
     into cannot be, and outlives the call regardless — the

--- a/src/btclib/ecc/commit_nonce.py
+++ b/src/btclib/ecc/commit_nonce.py
@@ -44,13 +44,14 @@ key only, so two signatures over one message with two commitments have
 nonces differing by e2-e1 -- a value the openings make public. Two ECDSA
 signatures over one message with a known nonce difference are two
 equations in the two unknowns k and the private key, and the same holds
-for BIP340. libsecp256k1's own s2c module states it as the reason it
-refuses a custom nonce function: "an attacker can exfiltrate the secret
-key by signing the same message thrice with different commitments". So
-`commit_entropy_` is not optional garnish, and the two schemes each feed
-it to their nonce derivation before calling `commit_nonce_`: dsa through
-RFC6979's section 3.6 additional data, ssa through BIP340's auxiliary
-randomness.
+for BIP340. secp256k1-zkp states it in `secp256k1_ecdsa_sign_inner`
+(`src/secp256k1.c`) as the reason a sign-to-contract commitment works
+only with the default nonce function: "an attacker can exfiltrate the
+secret key by signing the same message thrice with different
+commitments". So `commit_entropy_` is not optional garnish, and the two
+schemes each feed it to their nonce derivation before calling
+`commit_nonce_`: dsa through RFC6979's section 3.6 additional data, ssa
+through BIP340's auxiliary randomness.
 
 Both hashes are tagged, and the tags are the scheme's: they are what
 keeps a tweak from being read as a challenge, or an ECDSA commitment as a
@@ -114,11 +115,13 @@ def _tweak(
         tweak = int_from_bits(t, ec.nlen)  # candidate tweak
         if 0 < tweak < ec.n:  # acceptable value for tweak
             return tweak  # successful candidate
-        # libsecp256k1 fails here instead of asking the hash again, and
-        # on secp256k1 the two agree: the first candidate is out of range
-        # about once in 2^128. It is the low-cardinality curves that need
-        # a second candidate -- with nlen of 4 bits an out-of-range tweak
-        # is one in three -- and there the reference has no answer at all
+        # secp256k1-zkp's `secp256k1_ec_commit` (`src/eccommit_impl.h`)
+        # fails here instead of asking the hash again, and on secp256k1
+        # the two agree: the first candidate is out of range about once
+        # in 2^128. It is the low-cardinality curves that need a second
+        # candidate -- with nlen of 4 bits an out-of-range tweak is one
+        # in three -- and a derivation that fails rather than drawing
+        # again would refuse one commitment in three
 
 
 def commit_nonce_(


### PR DESCRIPTION
The module docstring quoted a sentence and credited libsecp256k1's own
s2c module with it. The words are the comment above the `VERIFY_CHECK`
in `secp256k1_ecdsa_sign_inner`, `src/secp256k1.c` of
[BlockstreamResearch/secp256k1-zkp](https://github.com/BlockstreamResearch/secp256k1-zkp)
at `037cc6d7`, and they give the reason a sign-to-contract commitment
works only with the default nonce function — which is what the sentence
now says, rather than that the library refuses a custom one: the check
stating it is a `VERIFY_CHECK`, an empty macro where `VERIFY` is
undefined, while the requirement it guards holds either way.

bitcoin-core/secp256k1 at `99ae2312` publishes neither behaviour: its
`include` listing carries no `secp256k1_ecdsa_s2c.h`, and its `src` and
`src/modules` listings carry no commitment file.
`secp256k1_ec_seckey_tweak_add` and `secp256k1_ec_pubkey_tweak_add` are
in that header, so the two comments naming those are unchanged;
`secp256k1_ec_commit` is not.

`_tweak`'s comment took a second repair beyond the name: its closing
clause read "and there the reference has no answer at all", whose
subject was the library the first sentence named, so swapping the name
alone would have left it asserting that upstream libsecp256k1 has no
answer for a low-cardinality curve.

`SECURITY.md`'s citation of `commit_nonce.commit_nonce_` moves to the
line the read sits on, checked with `awk` against the content rather
than left to the gate: the anchor is a dotted name, which
`tests/security_citations_test.py` satisfies from any line inside the
right function.

Gates at `bab6a290`, all three exit 0:

```
TOTAL   56469      0   9772      0  100.00%
Required test coverage of 100.0% reached. Total coverage: 100.00%
====================== 32409 passed, 46 skipped in 28.32s ======================
```

Reviewed locally at `98bba9e9` (CLEARED, no blocking findings); this tip
is that tree rebased onto `f6077e12` with the `merge=union` seam repaired
by reconstruction, plus the two non-blocking nits the review raised — the
citation bullet's wording above, and a ragged docstring rewrap.

closes #1946

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Correct sign-to-contract documentation references and update its security citation.

Enhancements:
- Correct references in sign-to-contract documentation to identify secp256k1-zkp as the source of the cited behavior and clarify the commitment failure semantics.
- Update the security citation for `commit_nonce.commit_nonce_` to its current source line.

Documentation:
- Document the secp256k1-zkp provenance of sign-to-contract nonce requirements and commitment tweak behavior.