### PR TITLE
`tests/_data/README.md`'s descriptor vectors pin moves to the path's tip (closes #1916)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3539,6 +3539,23 @@ name that library and the symbol each of them paraphrases (closes #1932).
 - **`SECURITY.md`'s citation of `commit_nonce.commit_nonce_` names the
   line the read sits on.**
 
+### Core's descriptor derivation vectors are pinned at the path's tip
+
+- **`tests/_data/README.md` pins `src/test/descriptor_tests.cpp` at
+  `e2b2f1c5c6f720381b8cc182e750aadd703e4b4f`** (2026-08-25), which is the
+  tip of that path (closes #1916). The revisions this refresh crosses
+  reach no case: the file's `DoCheck` helper takes on an assertion of the
+  canonical serialization, and `DescriptorID` becomes
+  `CompatDescriptorHash`, a rename that reaches each case's
+  named-argument comment and no value in it.
+- **The cases upstream added before them stay out, and the entry says
+  why.** [ISS 1334](https://github.com/btclib-org/btclib/issues/1334)
+  measured btclib against both defects those cases cover -- a `musig()`
+  duplicate-key check that reads distinct participants as the same key
+  when neither of them derives, and a key origin prepended once per
+  expression rather than once per participant -- and found neither in
+  this tree, so `CORE_VECTORS` is owed none of them.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -164,11 +164,13 @@ beside them, the BIP374 csv files, BIP352's
 `send_and_receive_test_vectors.json` and BIP375's
 `bip375_test_vectors.json` on 2026-08-13, and Core's `siphash.json` on
 2026-08-20. BIP375's `bip375_test_vectors.json`, Core's
-`miniscript_fixed_tests.json` pin and `descriptor_tests.cpp` pin, and
-Wycheproof's `ecdsa_secp256k1_sha256_bitcoin_test.json` were pulled again
-on 2026-08-25, each at the tip of its path that day, and Core's
+`miniscript_fixed_tests.json` pin and Wycheproof's
+`ecdsa_secp256k1_sha256_bitcoin_test.json` were pulled again on
+2026-08-25, each at the tip of its path that day, Core's
 `chacha20_vectors.json` and `muhash_vectors.json`, both transcribed from
-`crypto_tests.cpp`, were pulled on 2026-09-03, at the tip of that path.
+`crypto_tests.cpp`, on 2026-09-03, at the tip of that path, and Core's
+`descriptor_tests.cpp` pin on 2026-09-10, at the tip of its path that
+day.
 
 A vector btclib fails is vendored anyway and marked `xfail`, never left
 out: an absent vector hides the defect it would have shown, and
@@ -1322,8 +1324,8 @@ measure.
 ```text
 repo    bitcoin/bitcoin
 path    src/test/descriptor_tests.cpp
-commit  994c17d6c0a1453a1d7cc44ee2bbc49afa2d1155  2026-08-24
-pulled  2026-08-25, rawtr() added 2026-08-06
+commit  e2b2f1c5c6f720381b8cc182e750aadd703e4b4f  2026-08-25
+pulled  2026-09-10, rawtr() added 2026-08-06
 behind  0 revisions; that commit is the tip of the path
 ```
 
@@ -1343,13 +1345,20 @@ The subset is deliberate and is what a refresh would revisit: Core's file
 also holds `CheckUnparsable` cases, which this module has as `UNPARSABLE`
 with btclib's own messages, and the `musig()` cases of BIP390, which are
 transcribed from the BIP itself above rather than from here. Matched
-against the pinned file on 2026-08-06.
+against the file as it stood on 2026-08-06.
 
-Not matched since: the commit above adds five cases -- a `musig()`
-duplicate-key check fix and a PSBT origin-path doubling fix, neither a
-refactor -- which
-[ISS 1334](https://github.com/btclib-org/btclib/issues/1334) tracks,
-including whether btclib's own musig derivation shares either defect.
+The cases upstream added after that comparison are not here, and
+[ISS 1334](https://github.com/btclib-org/btclib/issues/1334) is where
+they were weighed: it measured btclib against both defects they cover --
+a `musig()` duplicate-key check that reads distinct participants as the
+same key when neither of them derives, and a key origin prepended once
+per expression rather than once per participant -- and found neither in
+this tree, so none of those cases is owed here.
+
+The revisions this refresh crosses reach no case: the file's `DoCheck`
+helper takes on an assertion of the canonical serialization, and
+`DescriptorID` becomes `CompatDescriptorHash`, a rename that reaches each
+case's named-argument comment and no value in it.
 
 ### Not vendored as a file: the message types of Core's `NetMsgType`
 

--- a/tests/vendored_data_test.py
+++ b/tests/vendored_data_test.py
@@ -299,7 +299,6 @@ _EXEMPT: dict[str, str] = {
     "p2wsh ops, stack and script-size limits, and the two nestings that reach a": _UPSTREAM_FACT,
     "thousand elements on the stack. `tests/descriptors/miniscript_test.py`": _UPSTREAM_FACT,
     "of the four Core expands from the private form alone, and the two": _UPSTREAM_FACT,
-    "Not matched since: the commit above adds five cases -- a `musig()`": _UPSTREAM_FACT,
     "before. The two hold the same names, compared on 2026-09-03, and the": _UPSTREAM_FACT,
     "directions in `bitcoin/bitcoin#15437`. `src/btclib/p2p/reject.py` says": _UPSTREAM_FACT,
     "but an *interface*, and the two entries are the two halves of it: the": _UPSTREAM_FACT,


### PR DESCRIPTION
`tests/_data/README.md`'s entry for Core's `src/test/descriptor_tests.cpp`
pinned `994c17d6`, which is no longer the tip of that path. It moves to
`e2b2f1c5c6f720381b8cc182e750aadd703e4b4f`, the tip after a fresh fetch, and
`behind  0 revisions` is true again.

The revisions the refresh crosses reach no case. Measured rather than
assumed: `994c17d6` and `e2b2f1c5` both hold 175 `Check`/`CheckUnparsable`
cases, and the range diff pairs to exactly one non-rename change — `DoCheck`'s
own comment. Every `uint256{…}` value appears on both sides of the diff, with
a planted extra value confirming the pairing check can fail. The two commits
crossed are `35d6a60dbf` (*Add ToCanonicalString*) and `e2b2f1c5` (*Rename
DescriptorID to CompatDescriptorHash*), and the entry names both.

The cases upstream added *before* that, after the 2026-08-06 comparison, are
the ones [ISS 1334](https://github.com/btclib-org/btclib/issues/1334) weighed
and found not owed here; the entry now says that it measured them rather than
that it tracks them.

`tests/vendored_data_test.py` loses one `_EXEMPT` key, which the README edit
makes unnecessary — coupled to that edit and nothing else, confirmed by
running the module's own `_NUMERAL`/`_NOT_A_COUNT`/`_EXEMPT` over both blobs:
zero offenders at the tip, and exactly one against the base, which is the
positive control.

Reviewed locally at `9a81cd88` (**CHANGES REQUESTED**) and cleared at
`9517b2c6`. The blocking finding was the branch's own new sentence: read under
the antecedent the paragraph above it fixes, it claimed the range from
2026-08-06 reached no case, which the paragraph directly above it denies. The
commit message and the CHANGELOG bullet had it right; only the README was
wrong, and all three now name the same range — byte-compared, not read for the
gist.

Gates at `458932b8`, all three exit 0:

```
btclib_secp256k1.zkp: no BTCLIB_LIBSECP256K1_ZKP build, so the tests marked zkp skip
TOTAL   56469      0   9772      0  100.00%
Required test coverage of 100.0% reached. Total coverage: 100.00%
====================== 32409 passed, 46 skipped in 29.58s ======================
```

closes #1916

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Refresh Core descriptor vector provenance and align its documentation and validation exemptions with the upstream path tip.

Bug Fixes:
- Update the vendored Core descriptor test vectors to the current tip of their upstream path, restoring the correct zero-revision status and documenting that the intervening revisions do not affect covered cases.

Enhancements:
- Clarify why newer upstream descriptor cases are not vendored based on measured compatibility with the tracked defects.

Documentation:
- Document the refreshed descriptor vector revision, comparison basis, excluded upstream cases, and crossed upstream changes in the README and changelog.

Chores:
- Remove the obsolete vendored-data exemption associated with the previous descriptor-vector explanation.