### PR TITLE
`ecc.borromean`'s `e0` hashes the ring points before the message (closes #1940, #1895)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3556,6 +3556,37 @@ name that library and the symbol each of them paraphrases (closes #1932).
   expression rather than once per participant -- and found neither in
   this tree, so `CORE_VECTORS` is owed none of them.
 
+### `ecc.borromean`'s `e0` hashes the ring points before the message
+
+- **`sign_`, `sign` and `assert_as_valid` build `e0` over `r_0 || ... ||
+  r_last || m`** (closes #1940): the order `secp256k1_borromean_sign`
+  writes its own `sha256_e0` in and `secp256k1_borromean_verify_impl`
+  recomputes it in, each ring's last point as the ring loop closes that
+  ring and the message once the loop ends. The signing site and the
+  verifying site move together, so nothing this module signs is refused
+  by it. RELEASE_NOTES.md has what a holder of an older signature is
+  left with.
+- **`zkp.rangeproof.borromean_verify` takes what `sign_` writes**
+  (closes #1895), under the ring negated key by key, over one ring of
+  one key and over several rings alike. `tests/ecc/borromean_test.py`
+  asks the flagged extension, and keeps beside that question the control
+  it needs: a ring closed by hand under zkp's own conventions, which the
+  same call verifies under its plain ring and refuses under the
+  negation, so an answer about `sign_` is an answer about the signature
+  rather than about the call.
+- **Negating the ring is what a caller reaching for that verifier is
+  left to do**: this module recovers a ring point as `s*G - e*Q` where
+  `secp256k1_borromean_verify_impl` recovers `s*G + e*P`, so what one
+  calls `P` the other calls `-P`. `ecc.rangeproof.sign_public_value`
+  goes on closing its own ring, and `ecc.borromean`'s module docstring
+  says what that would still cost beyond the negation.
+- **The low-cardinality inputs `tests/ecc/borromean_test.py` signs with
+  are `e0`'s to decide**: the challenge that opens each ring is
+  `_hash(m, e0, i, 0)`, and a curve of small order makes a zero
+  challenge a one-in-n event rather than a `2**-255` one, so which
+  message signs and which nonce reaches the guard are both answers to a
+  search over `e0`.
+
 ## v2026.9.3
 
 ### Repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -260,6 +260,19 @@ full year, short month, short day (YYYY-M-D)
   offering `payment_secret` at bit 15 meets `basic_mpp`'s dependency as
   one requiring it at bit 14 does.
 
+- **`borromean.sign` and `borromean.assert_as_valid` compute a different
+  `e0`** (closes #1940). The preimage has been `m || r_0 || ... ||
+  r_last` since `v2023.7.12`, the message hash before the ring points;
+  it is `r_0 || ... || r_last || m` now, matching secp256k1-zkp's
+  `rangeproof` module.
+
+  Act on it if you hold a borromean signature this module wrote:
+  re-signing is the whole of the migration, and nothing else is on
+  offer. There is no version byte in the wire format to switch on, and
+  `sign` and `assert_as_valid` compute the preimage the same way every
+  time, so no argument makes either of them read an older signature.
+  CHANGELOG.md has why the break was worth paying.
+
 ### Worth knowing, though nothing raises
 
 - **`psbt_signer_contract.optional_protocols` returns `OptionalProtocols`,

--- a/src/btclib/ecc/borromean.py
+++ b/src/btclib/ecc/borromean.py
@@ -24,6 +24,16 @@ switch on, `sign` and `assert_as_valid` compute this hash the same way
 every time, and RELEASE_NOTES.md's breaking-changes list has the
 "before" and "after" this cost.
 
+`e0` is `hf(r_0 || ... || r_last || m)`, the order
+`secp256k1_borromean_sign` writes its own `sha256_e0` in: each ring's
+last point as the ring loop closes that ring, the message once the loop
+ends, and `secp256k1_borromean_verify_impl` recomputes it the same way
+(issue #1940). No ring a verifier is handed reaches it -- `e0` is
+written into the signature before any verifier sees it -- so a
+signature carrying an `e0` over any other order is refused here and
+there alike, and RELEASE_NOTES.md's breaking-changes list has what
+settling on this one cost.
+
 `_get_msg_format` was checked against zkp too, in the same issue, and
 has nothing to align with: zkp's rangeproof never hashes a caller's
 message together with caller-supplied pubkey rings the way this
@@ -42,29 +52,24 @@ always, as `ssa.Sig.parse` reads BIP340's one curve: the serialization
 does not name either, so a `BorromeanSig` on another curve or hash
 function is built directly rather than parsed.
 
-With the challenge hash aligned too (issue #1070), this module and
-zkp's rangeproof agree over secp256k1 with sha256 on the challenge
-preimage and on the wire layout of the ring signature itself -- the
-primitive, as against the rangeproof built on top of it. They still
-refuse each other's signatures, and `tests/ecc/borromean_test.py`
-measures the direction in reach rather than transcribing it:
-`zkp.rangeproof.borromean_verify` wraps `secp256k1_borromean_verify`
-over serialized arguments in the flagged `zkp` extension, and what is
-put to it there is a signature ``sign_`` wrote, under a ring and under
-that same ring negated key by key.
+This module and zkp's rangeproof therefore agree over secp256k1 with
+sha256 on both challenge preimages and on the wire layout of the ring
+signature itself -- the primitive, as against the rangeproof built on
+top of it. That `secp256k1_borromean_verify` then takes what ``sign_``
+writes is measured rather than asserted:
+`zkp.rangeproof.borromean_verify` wraps it over serialized arguments in
+the flagged `zkp` extension, and `tests/ecc/borromean_test.py` puts a
+signature to it under a ring and under that same ring negated key by
+key, over one ring of one key and over several rings alike. The negated
+ring is the one it takes.
 
-Two differences stand between the two, and answering either on its own
-still leaves the signature refused. The public key of a ring is the
-other one of the pair: this module recovers a ring point as `s*G -
-e*Q` and gives the real signer `s = k + q*e`, where
-`secp256k1_borromean_verify_impl` recovers `s*G + e*P` and
-`secp256k1_borromean_sign` gives `s = k - sec*e`, so what one calls
-`P` the other calls `-P` and only a ring negated key by key meets the
-equation that closes it (issue #1895). And `e0` takes the message at
-the other end of its preimage: this one is `hf(m || r_0 || ... ||
-r_last)` where zkp's is `sha256(r_0 || ... || r_last || m)`, which no
-ring a verifier is handed can reach, `e0` being written into the
-signature before any verifier sees it (issue #1940).
+Negating the ring is what a crossing signature asks for, and what it
+answers is the public key of a ring being the other one of the pair: this
+module recovers a ring point as `s*G - e*Q` and gives the real signer
+`s = k + q*e`, where `secp256k1_borromean_verify_impl` recovers `s*G +
+e*P` and `secp256k1_borromean_sign` gives `s = k - sec*e`, so what one
+calls `P` the other calls `-P`, and only a ring negated key by key
+meets the equation that closes it (issue #1895).
 
 Verifying is the only direction in reach at all.
 `secp256k1_borromean_sign` is declared `static` in
@@ -92,13 +97,13 @@ and holds the `e0` and the `s` values inside the proof as a
 whose ring structure is one ring of one key -- the value in the clear,
 so no digit decomposition and no ring commitment -- and it closes that
 ring on its own rather than through this module. The message format is
-one reason, and it is what ``sign_`` answers: a rangeproof hashes the
-value commitment, the generator and the proof's own header, with no
-pubkey ring in the preimage. The ring convention and the `e0` preimage
-above are two more, and they are why that function writes an `e0` and
-an `s` of its own; `ecc.rangeproof` names the rest beside the code that
-carries them. Verifying a proof and rewinding one are still ahead of
-it.
+what ``sign_`` answers: a rangeproof hashes the value commitment, the
+generator and the proof's own header, with no pubkey ring in the
+preimage. The ring convention above is still a reason, and beside it
+the challenge `sign_public_value` leaves unreduced and the zero `s` it
+refuses to write, both of which `ecc.rangeproof` states beside the code
+that carries them. Verifying a proof and rewinding one are still
+ahead of it.
 
 The signing direction is issue #1072's to discharge:
 `zkp.rangeproof.sign` and `zkp.rangeproof.verify` are wrapped, and the
@@ -470,9 +475,9 @@ def sign_(
     value commitment, the generator and the proof's own header, with no
     pubkey ring in it at all, and `ecc.rangeproof` rebuilds the rings
     from that commitment instead. What this offers that caller is the
-    message format alone: the module docstring above measures the two
-    differences that still stand between a signature written here and
-    one `secp256k1_borromean_verify` takes.
+    message format alone: the module docstring above measures what still
+    stands between a signature written here and one
+    `secp256k1_borromean_verify` takes.
 
     `pubk_rings` is an argument here as it is in `sign`: the walk
     multiplies by those points, and a hash cannot give them back. So
@@ -486,7 +491,7 @@ def sign_(
     m = bytes_from_octets(msg_hash, hf().digest_size)
     _assert_valid_pubk_rings(pubk_rings, ec)
     e = [[0] * len(pubk_ring) for pubk_ring in pubk_rings]
-    e0bytes = m
+    e0bytes = b""
     # drawn uniformly in [0, ec.n), the same distribution the real
     # s-value has once step 2 reduces it: randbits(256) is uniform over
     # [0, 2**256), not over the scalars, and the two ranges diverge by
@@ -567,6 +572,10 @@ def sign_(
                 t = double_mult_var(-e[i][j], pubk_ring[j], s[i][j], ec.G, ec)
                 r = _bytes_from_ring_point(t, ec, i, j)
         e0bytes += r
+    # the message closes the preimage the ring points opened, which is
+    # where `secp256k1_borromean_sign` writes it into its own `sha256_e0`:
+    # after the ring loop, not before it (issue #1940)
+    e0bytes += m
     hasher = hf()
     hasher.update(e0bytes)
     e0 = hasher.digest()
@@ -736,7 +745,7 @@ def assert_as_valid(
     _assert_matches_pubk_rings(pubk_rings, sig.s)
 
     msg, m, e = _initialize(msg, pubk_rings, ec, hf)
-    e0bytes = m
+    e0bytes = b""
 
     for i, pubk_ring in enumerate(pubk_rings):
         keys_size = len(pubk_ring)
@@ -759,6 +768,8 @@ def assert_as_valid(
                     raise BorromeanRingError(err_msg, i, j + 1)
             else:
                 e0bytes += r
+    # the message last, the order ``sign_`` writes it in
+    e0bytes += m
     hasher = hf()
     hasher.update(e0bytes)
     e0_prime = hasher.digest()

--- a/tests/ecc/borromean_test.py
+++ b/tests/ecc/borromean_test.py
@@ -242,7 +242,7 @@ def test_challenge_hash_matches_zkps_preimage_order() -> None:
     then the message hash, then the ring index and the position each as
     4 bytes big-endian (issue #1070). This pins that order computed by
     hand from zkp's documented source, and runs in every build, where
-    `test_zkp_reads_this_challenge_and_refuses_this_signature` below
+    `test_zkp_verifies_this_signature_under_the_negated_ring` below
     puts the same preimage to zkp's own verifier and needs the flagged
     extension for it. It pins the order against a `m || R || i || j`
     one, which is what this function computed, and what this test would
@@ -321,13 +321,12 @@ def test_another_hash_function_gives_another_signature() -> None:
 
 
 # a message per curve, because a low-cardinality curve makes the corner
-# case below a one-in-n event rather than a 2**-255 one: on ec17_13 the
-# messages 0 and 1 hit a zero e and cannot be signed at all, which is the
-# next test
+# case below a one-in-n event rather than a 2**-255 one: on ec13_19 the
+# message 0 hits a zero e and cannot be signed at all
 ROUND_TRIP_MSG = {
     "ec13_11": 0,
-    "ec13_19": 0,
-    "ec17_13": 2,
+    "ec13_19": 1,
+    "ec17_13": 0,
     "ec17_23": 0,
     "ec19_13": 0,
     "ec19_23": 0,
@@ -387,7 +386,7 @@ def test_a_zero_e_is_a_one_in_n_event_on_a_low_cardinality_curve() -> None:
 
     # step 2, the e derived from e0
     with pytest.raises(BorromeanRingError, match=err_msg) as excinfo:
-        borromean.sign(b"\x00\x00\x00\x00", [3], [0], [1], [[Q1]], ec=ec)
+        borromean.sign(b"\x00\x00\x00\x00", [1], [0], [1], [[Q1]], ec=ec)
     assert (excinfo.value.ring, excinfo.value.position) == (0, 0)
 
     # step 1, the e derived from the nonce's own point
@@ -794,18 +793,22 @@ def _last_ring_points(
     return out
 
 
-def test_e0_hashes_the_message_before_the_ring_points() -> None:
-    """`e0` is `hf(m || r_0 || ... || r_last)`, where zkp's is the reverse.
+def test_e0_hashes_the_ring_points_before_the_message() -> None:
+    """`e0` is `hf(r_0 || ... || r_last || m)`, secp256k1-zkp's own order.
 
-    secp256k1-zkp writes each ring's last point into its `e0` hash first
-    and the message only after the ring loop ends
-    (`secp256k1_borromean_sign`, `src/modules/rangeproof/borromean_impl.h`),
-    so the two preimages hold the same bytes in the other order. This
-    module is self-consistent -- `assert_as_valid` builds the preimage
-    the way `sign` does -- and a signature written here is one zkp's
-    verifier refuses whatever ring it is given, which is issue #1940 and
-    what `test_zkp_reads_this_challenge_and_refuses_this_signature`
-    below measures.
+    `secp256k1_borromean_sign` writes each ring's last point into its
+    `sha256_e0` inside the ring loop and the message only once that loop
+    ends (`src/modules/rangeproof/borromean_impl.h`), and
+    `secp256k1_borromean_verify_impl` recomputes it the same way. This
+    pins that order computed by hand, and runs in every build, where
+    `test_zkp_verifies_this_signature_under_the_negated_ring` below puts
+    a signature written under it to zkp's own verifier and needs the
+    flagged extension for it (issue #1940).
+
+    The swapped preimage holds the same bytes, so asserting against it
+    is what makes the first assertion one about their order rather than
+    about their content. `assert_as_valid` builds the preimage the way
+    ``sign_`` does, which is what the round trips above measure.
     """
     keys = [dsa.gen_keys(i) for i in (2, 3, 4, 5)]
     pubk_rings = [[keys[0][1], keys[1][1]], [keys[2][1], keys[3][1]]]
@@ -814,8 +817,8 @@ def test_e0_hashes_the_message_before_the_ring_points() -> None:
 
     m = _get_msg_format(msg, pubk_rings, secp256k1, sha256)
     points = _last_ring_points(m, sig, pubk_rings)
-    assert sha256(m + points).digest() == sig.e0
-    assert sha256(points + m).digest() != sig.e0
+    assert sha256(points + m).digest() == sig.e0
+    assert sha256(m + points).digest() != sig.e0
 
 
 # `pragma: no cover` on the `@needs_zkp` below, the marker being the
@@ -825,26 +828,31 @@ def test_e0_hashes_the_message_before_the_ring_points() -> None:
 # has (issue #1885). The marker's line and not the `def` under it, as
 # `tests/ecc/pedersen_test.py` does and for the reason it gives there.
 @needs_zkp  # pragma: no cover -- no zkp.rangeproof.borromean_verify to ask
-def test_zkp_reads_this_challenge_and_refuses_this_signature() -> None:
-    """A signature `sign_` writes is one zkp's own verifier refuses.
+def test_zkp_verifies_this_signature_under_the_negated_ring() -> None:
+    """A signature `sign_` writes is one zkp's own verifier takes.
 
     `zkp.rangeproof.borromean_verify` wraps `secp256k1_borromean_verify`
-    over serialized arguments, so the module docstring's account of
-    where the two implementations part is measured here instead of
+    over serialized arguments, so the module docstring's account of what
+    the two implementations share is measured here instead of
     transcribed.
 
-    The ring closed first is closed under zkp's own two conventions --
-    `e0` over `r || m`, and `s = k - q*e` -- and through this module's
-    `_hash` for the challenge, which is the preimage the two do share.
-    That it verifies is what makes the refusals below statements about
-    the two differences rather than about this call, and that its
-    negation does not verify is zkp holding `s*G + e*P` where this
-    module holds `s*G - e*Q`.
+    The ring closed first is closed by hand under zkp's own `e0` over
+    `r || m` and its `s = k - q*e`, and through this module's `_hash`
+    for the challenge. That it verifies is what makes the answers below
+    statements about what ``sign_`` wrote rather than about this call,
+    and that its negation does not verify is zkp holding `s*G + e*P`
+    where this module holds `s*G - e*Q`.
 
-    What `sign_` writes is then refused under the ring and under that
-    ring negated key by key: the negation answers the equation, and
-    `e0` -- already written into the signature -- is still over the
-    other preimage.
+    What ``sign_`` writes is then refused under the ring and taken under
+    that ring negated key by key. The negation is the whole of the
+    distance between the two: `e0` is over the preimage zkp recomputes
+    (issue #1940), and the public key of a ring is the other one of the
+    pair (issue #1895).
+
+    Several rings follow, which is the shape a rangeproof asks for: `e0`
+    takes each ring's last point in the ring-major order the s-values
+    are written in, and a single ring of a single key leaves no boundary
+    between rings for that order to be wrong at.
     """
     prv_key, pub_key = dsa.gen_keys(2)
     sec = bytes_from_point(pub_key, secp256k1)
@@ -862,4 +870,19 @@ def test_zkp_reads_this_challenge_and_refuses_this_signature() -> None:
     sig = borromean.sign_(m, [k], [0], [prv_key], [[pub_key]])
     s_values = sig.serialize()[sha256().digest_size :]
     assert not zkp_rangeproof.borromean_verify(sig.e0, s_values, m, [sec], [1])
-    assert not zkp_rangeproof.borromean_verify(sig.e0, s_values, m, [negated_sec], [1])
+    assert zkp_rangeproof.borromean_verify(sig.e0, s_values, m, [negated_sec], [1])
+
+    keys = [dsa.gen_keys(i) for i in (3, 4, 5)]
+    rings = [[keys[0][1], keys[1][1]], [keys[2][1]]]
+    ks = [1 + secrets.randbelow(secp256k1.n - 1) for _ in rings]
+    multi = borromean.sign_(m, ks, [1, 0], [keys[1][0], keys[2][0]], rings)
+    s_multi = multi.serialize()[sha256().digest_size :]
+    plain = [bytes_from_point(Q, secp256k1) for ring in rings for Q in ring]
+    negated = [
+        bytes_from_point((Q[0], secp256k1.p - Q[1]), secp256k1)
+        for ring in rings
+        for Q in ring
+    ]
+    rsizes = [len(ring) for ring in rings]
+    assert not zkp_rangeproof.borromean_verify(multi.e0, s_multi, m, plain, rsizes)
+    assert zkp_rangeproof.borromean_verify(multi.e0, s_multi, m, negated, rsizes)


### PR DESCRIPTION
**This closes a question ISS 1940 reserved rather than answering it.**
That issue was filed rather than taken because a change to the octets a
signature is made of is a decision, and the decision is: take the break.

The grounds, in order of weight. `ecc.borromean`'s own module docstring
already claimed an agreement with secp256k1-zkp that measurement
refutes, so one of the two had to move and the prose was the thing
asserting the false half. PR #1070 was the same break in the same module
and was taken. Leaving it freezes
[ISS 1072](https://github.com/btclib-org/btclib/issues/1072)'s rangeproof
writer out of `ecc.borromean` permanently, since it cannot close a ring
this module will not verify. And no BIP fixes the byte order, so zkp's
implementation *is* the specification here.

**The cut-back, if the answer is unwanted**: revert `e0`'s preimage to
`hf(m || r…)` in the two places that build it — `sign_` and
`assert_as_valid` — and leave ISS 1072's writer closing its rings by
hand.

## What changed

`e0` hashed the message first where `secp256k1_borromean_sign` hashes it
last. The preimage is now `hf(r… || m)`, in both places that build it, so
a signature this module writes verifies against zkp's own verifier once
the ring is negated key by key.

## The acceptance criterion, measured against the real oracle

ISS 1895 landed a `@needs_zkp` test that asked
`zkp.rangeproof.borromean_verify` about a signature `ecc.borromean.sign_`
wrote, and recorded a refusal. It now records acceptance. Measured at the
landing sha under a flagged `BTCLIB_LIBSECP256K1_ZKP` build:

```
zkp.lib: <Lib object for '_btclib_secp256k1_zkp'>
15 passed in 6.26s
```

Zero skipped, which is the number that matters: a selection whose every
test skips exits 0 just as a passing one does.

The four assertions, before and after, against the same oracle:

| | before | after |
|---|---|---|
| hand-built ring under zkp's convention, plain | True | True |
| the same, negated | False | False |
| what `sign_` writes, plain | False | False |
| what `sign_` writes, negated | **False** | **True** |

The second row is what makes the fourth informative rather than vacuous.
Two rings of sizes `[2, 1]` were added, because one ring of one key has
no boundary and so cannot see whether `e0` accumulates the ring points in
the ring-major order the s-values are written in; the review added a
control reordering the negated keys across that boundary and confirmed it
goes False.

## Full gates at `d01a940b`, flagged build

```
btclib_secp256k1.zkp: built with BTCLIB_LIBSECP256K1_ZKP, so the tests marked zkp run
TOTAL   56471      0   9772      0  100.00%
Required test coverage of 100.0% reached. Total coverage: 100.00%
====================== 32424 passed, 31 skipped in 28.05s ======================
```

pre-commit and `sphinx-build -W` exit 0; `git status --porcelain` empty
after all three.

## Migration

None is owed, and that was checked rather than assumed: no vendored
vector and no golden file in this tree holds a borromean signature.
`ecc.rangeproof` imports `BorromeanSig`, `PubkeyRing` and `_hash` and
never `sign_` or `assert_as_valid`, and
`rangeproof_fixed_vectors_test.py` reads the signature back byte for byte
without verifying it. The break is exactly as wide as stated.

Reviewed locally at `fcbe567d` (**CLEARED**), which independently
reproduced the flip in both directions and measured the wire break
itself: a signature written by the old module and handed to the new one
is refused, and the same octets are accepted by the old one. This tip is
that tree rebased onto `b9d6b306` with the `merge=union` seam repaired by
reconstruction, plus the review's two non-blocking prose findings — an
over-claim the same docstring goes on to deny, and a cross-reference
naming neither the test nor the curve it meant.

Closes #1940
Closes #1895

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Make Borromean signatures hash ring points before the message in `e0` to match secp256k1-zkp compatibility requirements.

Bug Fixes:
- Align Borromean `e0` computation with secp256k1-zkp so signatures produced by this module are accepted by the zkp verifier when rings are represented with the corresponding negated keys.

Enhancements:
- Update Borromean documentation and migration notes to describe the changed signature preimage and its compatibility impact.

Tests:
- Update `e0` ordering coverage and add zkp-backed verification checks for single- and multi-ring signatures, including ring-order controls.