### PR TITLE
`zkp-oracle.yml` triggers on the borromean test file it runs (closes #1956)

### DIFF
--- a/.github/workflows/zkp-oracle.yml
+++ b/.github/workflows/zkp-oracle.yml
@@ -125,9 +125,16 @@ on:
     # `borromean.py` joins for a narrower reason than
     # `pedersen.py`'s below: `BorromeanSig.parse` reads the `e0` and the
     # `s` values inside every proof this oracle parses, and that call
-    # site has no zkp octets to reach it anywhere else --
-    # `tests/ecc/borromean_test.py` holds the wire format against zkp's
-    # source, read by hand, and not against a proof zkp wrote.
+    # site has no zkp octets to reach it anywhere else -- the octets
+    # `tests/ecc/borromean_test.py` hands `parse` are this tree's own.
+    # That file joins on its own account, for the zkp-marked test it
+    # holds: `zkp.rangeproof.borromean_verify` is asked about what
+    # `borromean.sign_` writes, under a ring and under that ring negated
+    # key by key, so which side verifies and which ring the call is
+    # handed are what this job compares there and an edit to either is
+    # an edit to the comparison. The file's other checks of zkp's layout
+    # and of its challenge preimage read zkp's source by hand and run in
+    # every build, so they are not what earns it a place here.
     # `pedersen.py` and its own test file join for the rangeproof oracle,
     # itemized the way `dsa.py` is rather than named whole: of that
     # module, `second_generator`, `commit` and the codec that writes and
@@ -139,6 +146,7 @@ on:
     # directly, stays out for the reason `curves/` stays out above
     paths:
       - .github/workflows/zkp-oracle.yml
+      - tests/ecc/borromean_test.py
       - tests/ecc/commit_nonce_test.py
       - tests/ecc/musig2_test.py
       - tests/ecc/pedersen_test.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3587,6 +3587,18 @@ name that library and the symbol each of them paraphrases (closes #1932).
   message signs and which nonce reaches the guard are both answers to a
   search over `e0`.
 
+### `zkp-oracle.yml` triggers on the borromean test file it runs
+
+- **`.github/workflows/zkp-oracle.yml`'s `paths:` filter names
+  `tests/ecc/borromean_test.py`** (closes #1956): that file holds a
+  `zkp`-marked test, so a pull request changing what it asks of
+  `zkp.rangeproof.borromean_verify` selects this job rather than waiting
+  for the weekly cron.
+- **The comment above the list says what earns the file its place**: the
+  marked test, where the file's pins on zkp's layout and on its
+  challenge preimage are read from zkp's source by hand and run in every
+  build.
+
 ## v2026.9.3
 
 ### Repository


### PR DESCRIPTION
`tests/ecc/borromean_test.py` holds a `zkp`-marked test asking
`zkp.rangeproof.borromean_verify` about what `borromean.sign_` writes, and
the `paths:` filter of the `pull_request` trigger named every other test
file this job runs. A pull request touching only that file selected
nothing and reached the job through the weekly cron alone — which is the
wait the filter's own comment gives as the reason it names dependencies at
all.

The comment above the list is repaired rather than removed. The half that
gives `src/btclib/ecc/borromean.py` its place still holds and was
re-measured: `BorromeanSig.parse` has exactly two call sites in `src/`,
and every call in that test file is fed what `serialize` wrote, a
truncation of it, its hex, or a hand-built `e0` — no zkp octets. What
stopped holding is the clause excluding the file, and it read as the
measurement that decided the exclusion. Deleting the paragraph whole would
have taken `borromean.py`'s own reason with it.

The sweep, with its control: every file under `tests/` carrying the
decorator is on the list once this one is added, and the broader grep for
the marker in any form adds only `tests/__init__.py` (which defines it)
and `tests/conftest.py` (which turns it into a skip). Neither carries a
marked test. The tree contains its own positive control for the shape an
anchored pattern would miss — `tests/script_engine/python_path_test.py`
carries a module-level `pytestmark`, which the anchored form misses and
the substring form catches.

The marked test is deliberately not named. That turned out to matter
within the hour: ISS 1940 landed while this was in review and renamed it.
The comment as written is true on the tree this is rebased onto, which the
review confirmed by re-reading the renamed test.

`tests/conftest.py` and `tests/__init__.py` are a second hole in the same
list, of a different shape — they are what decide whether the selected
tests run or skip, and this job is the only thing that executes their
flagged-build arm. That is
[ISS 1958](https://github.com/btclib-org/btclib/issues/1958), filed
separately with the decision written into it, and it follows this.

Gates at `042e8f6e`, all three exit 0:

```
btclib_secp256k1.zkp: no BTCLIB_LIBSECP256K1_ZKP build, so the tests marked zkp skip
TOTAL   56471      0   9772      0  100.00%
Required test coverage of 100.0% reached. Total coverage: 100.00%
====================== 32409 passed, 46 skipped in 28.77s ======================
```

Whether the new entry actually selects the job on a pull request is
GitHub's evaluation of the filter and was **not** run — `actionlint`
validates syntax only, and this environment has no source build of
`btclib-secp256k1` with `BTCLIB_LIBSECP256K1_ZKP`.

Reviewed locally at `d03e8dfb` (**CLEARED**). This tip is that tree rebased
onto `885f105c` with the `merge=union` seam repaired by reconstruction —
the driver ate the blank line above the new `###` at line 3589, exactly
where the review predicted it from `merge-tree`'s own union-resolved tree
before the rebase was run — plus two non-blocking notes: a commit-message
sentence whose reason expired when ISS 1940 landed, and the subject's verb
aligned with the heading and the branch name.

closes #1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Ensure changes to the Borromean ZKP test select the oracle workflow during pull request validation.

Bug Fixes:
- Update the ZKP oracle workflow path filter so changes to the Borromean test trigger the job instead of waiting for the scheduled run.

Enhancements:
- Clarify the workflow comments explaining why the Borromean test is included in the ZKP oracle coverage.

Documentation:
- Document the corrected workflow trigger in the changelog.