### PR TITLE
`ecc.dsa`'s low-R grinding prose names Core and the bindings (closes #1949)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3599,6 +3599,27 @@ name that library and the symbol each of them paraphrases (closes #1932).
   challenge preimage are read from zkp's source by hand and run in every
   build.
 
+### The low-R grind `btclib.ecc.dsa` delegates is Core's and the bindings'
+
+- **`_grind_low_r`'s docstring names the `btclib_secp256k1` bindings'
+  `dsa._grind` as the implementation the delegated arm reaches** (closes
+  #1949). libsecp256k1 has no grind, so the paragraph's argument for
+  writing the sequence twice does not rest on the delegated grind being
+  the C's own output: both copies of the counter are Python, and what
+  licenses the duplication is the test holding them to the same
+  signature. That docstring also names `sign_`'s dispatch as what decides
+  when this loop is walked, `lower_s=False` included.
+- **`_libsecp256k1_sign_`'s comment names Core's counter and that same
+  `dsa._grind`**, and prices a loop there as btclib's own crossing per
+  attempt rather than as the foreign call, which `dsa._grind` makes per
+  retry itself.
+- **`_abort_unless_checked`'s docstring has the bindings as the subject
+  of the one call that grinds, checks and discriminates**, which is what
+  the rest of its sentence already calls the package holding the parsed
+  objects.
+- **`SECURITY.md`'s citation of `dsa.Signer.__init__` names the line the
+  `to_bytes` call sits on.**
+
 ## v2026.9.3
 
 ### Repository

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -165,7 +165,7 @@ used to teach and to prototype as much as to build:
     `dsa.Signer.__init__` crosses the same boundary the other way,
     once, at construction: the plain `int` `scalar_from_prv_key` already
     produced becomes a transient `bytes` via
-    `self._q.to_bytes(32, "big")` (`src/btclib/ecc/dsa.py:1356`) on the
+    `self._q.to_bytes(32, "big")` (`src/btclib/ecc/dsa.py:1362`) on the
     way into the owned buffer `wipe` overwrites afterwards. That
     `bytes` is dropped rather than erased, same as the `int` it
     replaces — one call rather than the buffer's whole lifetime, which

--- a/src/btclib/ecc/dsa.py
+++ b/src/btclib/ecc/dsa.py
@@ -560,14 +560,17 @@ def _grind_low_r(attempt: Callable[[int], Sig], grind: bool, ec: Curve) -> Sig:
     `extra_entropy[32]` for every counter it reaches, electrum-ecc's
     `counter.to_bytes(32, "little")` and embit's the same.
 
-    The implementation that matters to this file, though, is
-    libsecp256k1's own `grind`: `sign_`'s delegated arm asks for it and
+    The implementation that matters to this file, though, is the
+    bindings' own `dsa._grind`: `sign_`'s delegated arm asks for it and
     the signature it answers with *is* its output, so this loop is what
-    btclib walks where that arm cannot be taken -- a nonce of the
-    caller's, a commitment, a curve of its own, or no bindings at all.
-    The two are held to the same signature by
-    `test_the_delegated_grind_is_the_sequence_the_py_arm_walks`, and
-    that test is why the sequence may be written twice at all.
+    btclib walks where that arm cannot be taken, which `sign_`'s own
+    dispatch decides: a nonce of the caller's, a commitment,
+    `lower_s=False`, a curve or hash function of its own, or no bindings
+    at all. libsecp256k1 has no grind of its own to delegate to, so both
+    copies of the counter are Python: what licenses writing the sequence
+    twice is `test_the_delegated_grind_is_the_sequence_the_py_arm_walks`
+    holding the two to the same signature, and not either of them being
+    in C.
 
     No attempt cap. Core has none, and one would answer an event of
     probability 2**-k with an error a caller can do nothing about; embit
@@ -634,13 +637,13 @@ def _abort_unless_checked(
     """Refuse a signature that does not verify, and say which way it failed.
 
     The rule, not the only place it is obeyed. The delegated arm never
-    reaches this function -- libsecp256k1 grinds, checks and
-    discriminates inside one call, `dsa._checked` there being this rule
-    written in the package that holds the parsed objects. What is shared
-    is therefore the contract and not the code: a bare verification under
-    the signer's own public key, a supplied key taken on trust, and the
-    two causes of a failure told apart rather than guessed at. This is
-    the Python arm's copy of it, and
+    reaches this function -- the bindings grind, check and discriminate
+    inside one call, `dsa._checked` there being this rule written in the
+    package that holds the parsed objects. What is shared is therefore
+    the contract and not the code: a bare verification under the
+    signer's own public key, a supplied key taken on trust, and the two
+    causes of a failure told apart rather than guessed at. This is the
+    Python arm's copy of it, and
     `test_the_two_arms_answer_the_same_refusals` is what holds the two to
     the same exception and the same words.
 
@@ -703,13 +706,16 @@ def _libsecp256k1_sign_(
     # own, no commitment, and lower_s.
     #
     # One call, and that is the whole point of it. Grinding is Core's
-    # `CKey::Sign` counter and libsecp256k1's own `grind` walks the same
-    # sequence, so a loop here would be btclib re-deriving what the
-    # bindings already do -- and would pay a crossing per attempt. What
-    # that is worth is under a microsecond at the draw counts a signature
-    # actually takes, which is small and is the figure rather than the
-    # argument: the argument is that Core's counter stopped being written
-    # twice on the one arm that has a library implementing it.
+    # `CKey::Sign` counter and the bindings' own `dsa._grind` walks the
+    # same sequence, so a loop here would be btclib re-deriving what the
+    # bindings already do -- and would pay btclib's own crossing per
+    # attempt. Not the foreign call: `dsa._grind` is Python too and signs
+    # once per retry, so what one call buys is this boundary crossed once
+    # and not the signing done once. What btclib's own crossing is worth
+    # is under a microsecond at the draw counts a signature actually
+    # takes, which is small and is the figure rather than the argument:
+    # the argument is that the one arm with a package implementing
+    # Core's counter does not write it a second time.
     # The two are held to the same signature by
     # `test_the_delegated_grind_is_the_sequence_the_py_arm_walks`,
     # which is the defence this delegation rests on: identical on 500 of

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -2029,10 +2029,11 @@ def test_a_fault_is_not_reported_as_a_wrong_key() -> None:
 def test_the_delegated_grind_is_the_sequence_the_py_arm_walks() -> None:
     """The defence the delegation rests on, and the reason it is here.
 
-    `sign_` no longer grinds on the delegated arm: libsecp256k1's own
-    `grind` walks Core's `CKey::Sign` counter and so does
+    `sign_` does not grind on the delegated arm: the bindings' own
+    `dsa._grind` walks Core's `CKey::Sign` counter and so does
     `_grind_low_r`, so looping here would re-derive what the bindings
-    already do and pay a crossing per attempt -- two on average.
+    already do and pay btclib's own crossing per attempt -- two on
+    average.
 
     What that costs is Core's sequence living in two places, and it is
     only affordable while the two agree. They are held equal here over
@@ -2068,17 +2069,18 @@ def test_the_delegated_grind_is_the_sequence_the_py_arm_walks() -> None:
 def test_the_delegated_arm_asks_the_bindings_to_verify(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """`verify` reaches `secp256k1_ecdsa_sign` once, as the caller wrote it.
+    """`verify` reaches the bindings' `sign` once, as the caller wrote it.
 
     Nothing before this recorded it: the crossing above shows the two
     arms agree on the signature `grind=True, verify=False` produces, not
     that `verify` is the argument deciding whether a check follows it, or
     that grinding pays for one crossing and not one per attempt (issue
     986). `_grind_low_r`'s own loop is the Python arm's; the delegated
-    arm's grinding is `secp256k1_ecdsa_sign`'s own, which this call does
-    not see -- what it can see, and what this asserts, is that btclib
-    crosses into it once per `sign_` call, whether that call grinds or
-    not.
+    arm's grinding is the bindings' `dsa._grind`, which runs below the
+    `sign` this patches and so is invisible here -- it reaches
+    `secp256k1_ecdsa_sign` once per attempt, where what this counts is
+    btclib crossing into `sign` once per `sign_` call, whether that call
+    grinds or not.
     """
     real_sign = libsecp256k1_dsa.sign
     calls: list[bool] = []
@@ -2097,8 +2099,8 @@ def test_the_delegated_arm_asks_the_bindings_to_verify(
                 calls.clear()
                 dsa.sign_(msg_hash, q, grind=grind, verify=verify)
                 # one crossing, carrying the caller's own verify -- not
-                # zero, which is #982's bill, and not two, which is the
-                # grinding loop this arm no longer walks
+                # zero, which is #982's bill, and not one per attempt,
+                # which is the grinding loop this arm does not walk
                 assert calls == [verify]
 
 


### PR DESCRIPTION
`ecc.dsa`'s prose credited libsecp256k1 with the low-R grinding. The
counter is Bitcoin Core's `CKey::Sign`, and the loop the delegated arm
actually reaches is the `btclib_secp256k1` bindings' Python `dsa._grind`.

**libsecp256k1 has no grind**, measured occurrence by occurrence rather
than by an exit code: over the copy Core vendors at `fc4f35fdce` — whose
tree `080c84ff` resolves in `bitcoin-core/secp256k1` itself, so it is that
repository's own content — every case-insensitive match for `grind` under
`src/secp256k1` is preceded by `val`, and `git grep -niP '(?<!val)grind'`
exits 1. The same command over `src/key.cpp`, same repo and same pathspec
mechanism, returns `bool grind`, `secp256k1_ecdsa_sign` and `// Grind for
low R` — a live positive control on both the pattern and the pathspec, in
the same round.

## Why the noun could not be corrected alone

`_grind_low_r`'s docstring is the file's argument for writing the sequence
twice, and the false name was load-bearing in it: "the signature it
answers with *is* its output" is true of the bindings and false of the C.
Under the old name the duplicated counter read as a C/Python split; in
fact **both** copies are Python, so the whole warrant now rests on the
test that holds the two arms to the same signature — which the paragraph
now says explicitly.

## The review found the repair had missed its own file

`tests/ecc/dsa_test.py` carried the same falsehood in vocabulary the first
sweep was not keyed on — it named `secp256k1_ecdsa_sign` rather than
`libsecp256k1`. The branch had already widened into that file, so the
repair had created a contradiction forty lines from the docstring it
fixed.

That was settled by instrumentation rather than by reading the loop:
counting the bindings' only caller of `secp256k1_ecdsa_sign` against their
`sign`, over the keys and messages the suite drives, gives one crossing
into `sign` per call and 2, 3, 4, 6 calls into the C — once per attempt.

The sweep was then re-keyed on the `secp256k1_*` symbol family as well as
the library name, over every tracked `.py`. Doing so exposed a third hole
in the instrument itself: it split docstrings on blank lines, so a summary
line naming the symbol with no grind word in it hid behind a sibling
paragraph that did match. Its control is a before/after on exactly the
property that broke — run against the pre-repair tree, the new sweep
surfaces the site the old one missed.

**A limit stated rather than dressed up**: planting the old sentence back
does not discriminate, because the repaired docstring legitimately names
`secp256k1_ecdsa_sign` too. The instrument enumerates; reading classifies.
Two blind spots stay open and named — a hyphenated split across a
continuation, planted and confirmed invisible to every folding, and a
credit phrased in vocabulary outside the grind set. The latter is the
question [ISS 1955](https://github.com/btclib-org/btclib/issues/1955)
asks, and this branch is its second live instance.

## A clause deleted rather than reworded

"`secp256k1_ecdsa_sign` answers one draw" was not exactly true —
`secp256k1_ecdsa_sign_inner` carries a `while (1)` retrying on a
degenerate `(r, s)`. Two attempts at a more precise wording both measured
false. Two false attempts is the signal, so the clause went, from the
docstring, from the CHANGELOG bullet, and from the commit message, where
the review caught it surviving.

`SECURITY.md`'s citation of `src/btclib/ecc/dsa.py` moved to `:1362`,
re-derived after the rebase with `awk` against
`self._q.to_bytes(32, "big")` and the previous line as negative control.
It is a quoted-line anchor, so the number is load-bearing.

Gates at `5f4a4c1d`, run after the rebase, all three exit 0:

```
btclib_secp256k1.zkp: no BTCLIB_LIBSECP256K1_ZKP build, so the tests marked zkp skip
TOTAL   56471      0   9772      0  100.00%
Required test coverage of 100.0% reached. Total coverage: 100.00%
====================== 32409 passed, 46 skipped in 29.84s ======================
```

Reviewed locally at `50e15a25` (**CHANGES REQUESTED**) and cleared at
`688204c2`, the reviewer reproducing the tree-wide sweep on its own
instrument rather than accepting the result. This tip is that tree rebased
onto `cc2518ae` with the `merge=union` seam repaired by reconstruction.

closes #1949

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Correct low-R grinding attribution and related documentation and tests across the DSA signing paths.

Bug Fixes:
- Correct attribution of low-R grinding by distinguishing Bitcoin Core's counter from the bindings' Python implementation and clarifying that libsecp256k1 itself does not perform the grind.

Enhancements:
- Align the low-R grinding and verification documentation, comments, and tests with the actual delegation and call-boundary behavior.
- Remove the inaccurate claim that the delegated signing symbol performs exactly one draw per call.
- Update the security citation to the current source line.

Documentation:
- Document the corrected ownership and behavior of low-R grinding in the changelog and relevant source documentation.

Tests:
- Update DSA tests to validate the bindings' signing entry point and the shared grinding sequence without attributing grinding to libsecp256k1.