### PR TITLE
`p2p.address` cites what Core does with a `version` message's address (closes #1930)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3620,6 +3620,34 @@ name that library and the symbol each of them paraphrases (closes #1932).
 - **`SECURITY.md`'s citation of `dsa.Signer.__init__` names the line the
   `to_bytes` call sits on.**
 
+### `p2p.address` cites the type Core gives a `version` message's address
+
+- **The paragraph justifying `NetworkAddress` and
+  `TimestampedNetworkAddress` names what Core does with a `version`
+  message's address, where it named `CAddress::SerParams` with
+  `Format::Disk` and `Format::Network`** (closes #1930). `CAddress`
+  reads and writes `nTime` outside both branches of the switch on that
+  parameter, so the timestamp is in the octets whichever `SerParams` the
+  object is given; what the parameter selects is the
+  `stored_format_version` prefix and how V1/V2 is determined. A reader
+  following that citation found a parameter that does not make the
+  difference the paragraph rests on.
+- **`net_processing.cpp` writes and reads a `version` message's address
+  through `CNetAddr::V1` into a `CService`**, the service flags beside
+  it, and an `addr` entry into a `CAddress`. Core answers that
+  difference with a narrower type, which is the answer
+  `Version.addr_recv` and `Addr.addresses` give with a class each.
+- **The citation of Core's test framework names its file and leaves the
+  revision to `TF2.md`**, the form issue #1726 settled. That half is
+  exact: one class with a `with_time` parameter, whose `__init__` sets
+  `self.time = 0`, so an address read out of a `version` message is left
+  holding the zero the sentence after it is about.
+- **The docstring's opening enumeration of `CAddress`'s version-1 octets
+  names the timestamp `SERIALIZE_METHODS` writes in front of the service
+  flags.** Without it that enumeration is the `CService` and the flags a
+  `version` message carries, which is `NetworkAddress` rather than what
+  a `CAddress` writes.
+
 ## v2026.9.3
 
 ### Repository

--- a/src/btclib/p2p/address.py
+++ b/src/btclib/p2p/address.py
@@ -5,25 +5,31 @@
 """Where a peer is, what it offers, and the `addr` message that gossips it.
 
 Bitcoin Core's `CAddress`, of src/protocol.h, in the version-1 encoding
-its `SERIALIZE_METHODS` writes with `Encoding::V1`: eight octets of
-service flags, then the sixteen of address and two of port that
-`CService` writes under it. BIP155's `addrv2` is a different
-encoding of the same idea and is `btclib.p2p.addrv2`, not this module.
+its `SERIALIZE_METHODS` writes with `Encoding::V1` and `Format::Network`:
+four octets of timestamp, eight of service flags, then the sixteen of
+address and two of port that `CService` writes under it. `Format::Disk`
+writes a `stored_format_version` in front of the same fields. BIP155's
+`addrv2` is a different encoding of the same idea and is
+`btclib.p2p.addrv2`, not this module.
 
 **Two classes for what Core's prose calls one structure**, because the
 octets are not the same: a `version` message's two addresses carry no
 timestamp and an `addr` message's carry four octets of one in front. Core
-writes that as a serialization parameter -- `CAddress::SerParams` with
-`Format::Disk`, `Format::Network` -- and its test framework as
-`CAddress.deserialize(f, with_time=True)`. A parameter is where one class
-loses a round trip: the class has the timestamp field whichever way the
-octets were read, so an address parsed out of a `version` message is
-*forced* to a timestamp of zero rather than left without one -- the field
-then says zero where it means absent, and an `addr` entry cannot be told
-from a `version` one by looking at it. Here `Version.addr_recv` is
-annotated `NetworkAddress` and `Addr.addresses` holds
-`TimestampedNetworkAddress`, so putting one where the other belongs is a
-call mypy refuses rather than octets a peer refuses.
+writes that difference as a narrower type rather than as a parameter: an
+`addr` entry is a `CAddress`, whose `SERIALIZE_METHODS` of src/protocol.h
+writes `nTime` whichever `SerParams` it is given, and a `version`
+message's address is a `CService`, written and read through `CNetAddr::V1`
+with the service flags beside it in src/net_processing.cpp. Core's test
+framework takes the other route, one class with a `with_time` parameter,
+in test/functional/test_framework/messages.py, whose revision `TF2.md`
+pins. A parameter is where one class loses a round trip: the class has the
+timestamp field whichever way the octets were read, so an address parsed
+out of a `version` message is *forced* to a timestamp of zero rather than
+left without one -- the field then says zero where it means absent, and an
+`addr` entry cannot be told from a `version` one by looking at it. Here
+`Version.addr_recv` is annotated `NetworkAddress` and `Addr.addresses`
+holds `TimestampedNetworkAddress`, so putting one where the other belongs
+is a call mypy refuses rather than octets a peer refuses.
 
 **The port is big-endian and it is the only field of this protocol that
 is.** Core writes it through `Using<BigEndianFormatter<2>>(obj.port)`,
@@ -217,13 +223,12 @@ def _assert_valid_body(services: int, port: int) -> None:
 class NetworkAddress:
     """Where a peer is and what it offers: (services, ip, port).
 
-    Bitcoin Core's `CService` with the service flags in front of it, in
-    the twenty-six octets a `CAddress` writes under `Encoding::V1` with
-    no timestamp in front -- which is what a `version` message's
-    `addr_recv` and
-    `addr_from` are. `TimestampedNetworkAddress` is the thirty-octet form
-    an `addr` message carries, and the module docstring is why they are
-    two classes.
+    Bitcoin Core's `CService` with the service flags in front of it, in the
+    twenty-six octets that follow a `CAddress`'s timestamp under
+    `Encoding::V1` -- which is what a `version` message's `addr_recv` and
+    `addr_from` are. `TimestampedNetworkAddress` is the thirty-octet form an
+    `addr` message carries, and the module docstring is why they are two
+    classes.
 
     `ip` is an `ipaddress.IPv6Address` and is always sixteen octets, an
     IPv4 peer being `::ffff:a.b.c.d`: `ip.ipv4_mapped` is the v4 address


### PR DESCRIPTION
`src/btclib/p2p/address.py`'s module docstring cited `CAddress::SerParams`
with `Format::Disk` / `Format::Network` as how Bitcoin Core writes the
difference the paragraph is about — a `version` message's addresses
carrying no timestamp and an `addr` message's carrying four octets of one
in front. That parameter does not select the timestamp's presence.

Measured at `bitcoin/bitcoin` `fc4f35fdce`:
`READWRITE(Using<LossyChronoFormatter<uint32_t>>(obj.nTime));` sits
**outside** both arms of the `Format` switch, and the member carries
`//! Always included in serialization.` What the switch selects is
`stored_format_version` on disk versus `params.enc` on the network. Core
does not parse a `version` message's address as a `CAddress` at all: both
sides use `CService` — `vRecv.ignore(8); vRecv >> CNetAddr::V1(addrMe);`
on the read, `CService your_addr` in `PushNodeVersion` on the write, with
Core's own comment calling it "the pre-version-31402 serialization of
your_addr (without nTime)".

The paragraph now names that. `Done when` offered two shapes — name what
Core does, or drop the C++ half — and the first is the one the issue's own
body prefers, because Core's narrower type **agrees** with this module's
two classes. Dropping the C++ half would have deleted the fact the issue
exists to surface, and would additionally have falsified
`pyproject.toml`'s `[tool.typos]` comment, which lists `SerParams` among
the names this tree cites: at the base, that comment and this docstring
were the tree's only two mentions of the name.

The `with_time` sentence — the exact half — now rests on the test-framework
citation alone, in the form ISS 1726 settled: it names
`test/functional/test_framework/messages.py` and leaves the revision to
`TF2.md`, whose pin was re-derived as still the tip of its path.

## Scope beyond the sentence

The docstring's **opening** enumerated `CAddress`'s `Encoding::V1` octets
as service flags, address and port — twenty-six, no timestamp — which is a
contradiction eight lines above a paragraph saying `CAddress` writes
`nTime` whichever `SerParams` it is given. It now reads four of timestamp,
eight of flags, sixteen of address, two of port: thirty, which is what
`TimestampedNetworkAddress`'s own docstring already called it, and what
`SERIALIZE_METHODS` writes. It also names `Format::Network`, the parameter
the enumeration is exact under, and says what `Format::Disk` adds — the
review's point being that once the paragraph below tells a reader
`SerParams` is the thing to think about, leaving it unnamed is more
visible than it was.

`NetworkAddress`'s own docstring said "the twenty-six octets a `CAddress`
writes under `Encoding::V1` with no timestamp in front". True only read as
a subtraction, and the other reading is exactly the belief this branch
removes ten lines above. It now reads "the twenty-six octets that follow a
`CAddress`'s timestamp".

Gates at `9c632672`, all three exit 0, and the docs built in `docs.yml`'s
own form as well as the plain one:

```
TOTAL   56471      0   9772      0  100.00%
Required test coverage of 100.0% reached. Total coverage: 100.00%
====================== 32409 passed, 46 skipped in 30.69s ======================
```

`grep -c 'Format::Network' docs/build/html/btclib.p2p.html` answers 1, so
`automodule` renders the edited text rather than a stale page — which
matters, this being published documentation.

Reviewed locally at `3e8b7e7d` (**CLEARED**), which re-derived every Core
citation independently and verified the `[tool.typos]` counterfactual. This
tip is that tree rebased onto `26723e2b` with the `merge=union` seam
repaired by reconstruction, plus the review's two non-blocking prose items.

closes #1930

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Correct p2p address documentation to accurately describe Bitcoin Core’s serialization and address types.

Bug Fixes:
- Correct the p2p address documentation to accurately distinguish timestamped `addr` message addresses from timestamp-free `version` message addresses according to Bitcoin Core.

Enhancements:
- Clarify the serialized field layout for `CAddress`, `CService`, and the module’s `NetworkAddress` types, including the roles of `Format::Network` and `Format::Disk`.
- Strengthen documentation citations to Bitcoin Core and its functional test framework for the address serialization behavior.

Documentation:
- Update the public p2p address documentation and changelog to reflect Core’s narrower `CService` handling of `version` message addresses and the timestamp included in `CAddress` serialization.