### PR TITLE
`zkp-oracle.yml` triggers on what decides run-or-skip, and asserts it (closes #1958)

### DIFF
--- a/.github/workflows/zkp-oracle.yml
+++ b/.github/workflows/zkp-oracle.yml
@@ -19,10 +19,10 @@ name: zkp-oracle
 # is why this is `zkp-oracle.yml` rather than a job of theirs.
 #
 # `tests.needs_zkp` is the marker this job selects on, `tests.ZKP_AVAILABLE`
-# the probe that skips it everywhere else: an attribute access on
-# `btclib_secp256k1.zkp.lib`, not the import, which always succeeds --
-# `tests/__init__.py` has the reasoning in full, alongside the existing
-# `bindings` marker's own.
+# the flag that skips it everywhere else, set from a probe that is an
+# attribute access on `btclib_secp256k1.zkp.lib` and not the import,
+# which always succeeds -- `tests/__init__.py` has the reasoning in
+# full, alongside the existing `bindings` marker's own.
 #
 # What it must not do, issue #1679's own words: move any run-time path.
 # Every oracle that issue names compares btclib against
@@ -46,10 +46,9 @@ name: zkp-oracle
 # reading False -- which is what a build that silently kept the
 # unflagged wheel in place (the hazard the sync step's own comment below
 # measures) would do, and it is not a shape `-m`'s own selection can see.
-# What actually closes that gap is the step below the sync, asserting on
-# the same attribute the marker's own probe reads before pytest ever
-# runs -- see its comment for why that one and not the raw extension
-# module.
+# What actually closes that gap is the step below the sync, asserting
+# that flag itself before pytest ever runs -- see its comment for why the
+# flag and not the attribute it is derived from.
 
 on:
   schedule:
@@ -143,9 +142,25 @@ on:
     # compare against `zkp.generator`, and the commitment `commit`
     # returns is what `zkp.rangeproof` then proves, verifies and
     # rewinds. `curves/`, which `commit` calls and those tests call
-    # directly, stays out for the reason `curves/` stays out above
+    # directly, stays out for the reason `curves/` stays out above.
+    # `tests/__init__.py` and `tests/conftest.py` are named for that
+    # same reason read the other way round, shared by every test in the
+    # tree though they are: the first sets `ZKP_AVAILABLE` from the
+    # attribute access the marker's probe makes, the second turns a
+    # False flag into a skip on every `zkp`-marked test, so between them
+    # they decide whether what this job selects runs or skips. A run on
+    # an unflagged build -- every other job here, and a contributor's
+    # own unless they built the extension on purpose -- skips those
+    # tests already, so a change leaving them skipping under the flagged
+    # build reads there exactly as no change at all. Coverage says
+    # nothing either, both arms of the flag carrying a `pragma: no
+    # cover` for the reason issue #1885 records. Where a break in
+    # `curves/` is loud somewhere else, a change to these two that
+    # leaves the marked tests skipping is silent everywhere but here
     paths:
       - .github/workflows/zkp-oracle.yml
+      - tests/__init__.py
+      - tests/conftest.py
       - tests/ecc/borromean_test.py
       - tests/ecc/commit_nonce_test.py
       - tests/ecc/musig2_test.py
@@ -224,19 +239,29 @@ jobs:
       # a link error -- so what this step has to catch is the one thing
       # that would not fail there: the sync succeeding, quietly, against
       # an unflagged extension it already had (the hazard the sync
-      # step's own comment measures). `btclib_secp256k1.zkp.lib` rather
-      # than `_btclib_secp256k1_zkp` directly, the assertion
-      # btclib-secp256k1's own `zkp` job in `test.yml` makes on its own
-      # editable build: that name is the raw extension module one layer
-      # below what matters here, where `zkp.lib` is the exact attribute
-      # `tests.ZKP_AVAILABLE` reads -- so this step fails on precisely
-      # the condition that would otherwise leave `pytest -m zkp` below
-      # selecting the marked tests and skipping every one of them, in
-      # silence
-      - name: Assert the flagged extension is loadable
+      # step's own comment measures). `tests.ZKP_AVAILABLE` and not the
+      # `btclib_secp256k1.zkp.lib` access that flag is derived from, nor
+      # the `_btclib_secp256k1_zkp` extension module a layer below that
+      # again: the flag is what `tests/conftest.py` reads to decide
+      # whether the tests this job selects run or skip, and a change to
+      # how it is derived is the one shape an assertion on the attribute
+      # cannot see. Nothing is lost by asking the flag alone, an
+      # unloadable extension leaving it False.
+      # It also stands in for a switch pytest does not have: nothing
+      # fails a selection every test of which skipped. Exit 5, which the
+      # step below leans on, is not that switch -- it answers a
+      # collection that found nothing, where a selection that collects
+      # and skips exits 0, `pytest -m zkp` on an unflagged build being
+      # that case. Asserting the flag refuses the condition that
+      # produces that state, before pytest is asked anything, so the run
+      # below is not where to look for a guard it does not carry.
+      # `--group test` is what puts `tests/__init__.py`'s own imports in
+      # the environment, and the checkout root a step runs from is what
+      # puts the package on `sys.path`
+      - name: Assert the marked tests will run rather than skip
         run: >
           uv run --locked --no-default-groups --group test
-          python -c "from btclib_secp256k1 import zkp; assert zkp.lib"
+          python -c "import tests; assert tests.ZKP_AVAILABLE"
       # nothing here tolerates pytest's own exit 5 ("no tests ran"): a
       # selection that collects nothing -- a renamed marker, a moved
       # file -- is a real failure, and the step above is what keeps a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3648,6 +3648,26 @@ name that library and the symbol each of them paraphrases (closes #1932).
   `version` message carries, which is `NetworkAddress` rather than what
   a `CAddress` writes.
 
+### `zkp-oracle.yml` triggers on what decides run-or-skip, and asserts it
+
+- **`.github/workflows/zkp-oracle.yml`'s `paths:` filter names
+  `tests/__init__.py` and `tests/conftest.py`** (closes #1958): the first
+  sets `ZKP_AVAILABLE` and the second turns a False flag into a skip on
+  every `zkp`-marked test, so between them they decide whether what this
+  job selects runs or skips. A change leaving them skipping under the
+  flagged build reads as no change at all on an unflagged run, which
+  skips those tests already, and both arms of the flag carry a `pragma:
+  no cover`, so no coverage total moves with them either.
+- **The step before the run asserts `tests.ZKP_AVAILABLE`**, the flag
+  `tests/conftest.py` reads, rather than the `btclib_secp256k1.zkp.lib`
+  access it is derived from: a change to the derivation is the one shape
+  an assertion on that attribute cannot see, and an unloadable extension
+  leaves the flag False, so asking the flag alone loses nothing.
+- **That step's comment names the switch pytest does not have**: a
+  selection every test of which skipped exits 0, where exit 5 answers a
+  collection that found nothing, so the assertion refuses the condition
+  that produces the state instead.
+
 ## v2026.9.3
 
 ### Repository


### PR DESCRIPTION
The `paths:` filter selects on `tests/__init__.py` and
`tests/conftest.py`, the two files deciding whether a `zkp`-marked test
runs or skips. The comment above that list argues wide shared surface
out of it with `curves/` as its example, and the argument runs the other
way for these two: a break in `curves/` reddens the suite before this
job could be asked, where a change that leaves the marked tests skipping
is what an unflagged run looks like anyway, and coverage excludes both
arms of the flag under issue #1885's pragma. The asymmetry is what
puts them on the list, not a difference of degree.

The step below the sync asserts `tests.ZKP_AVAILABLE`, and replaces the
`btclib_secp256k1.zkp.lib` access rather than standing beside it. The
flag is what `tests/conftest.py`'s collection hook reads, and it is
derived from that attribute today, so the older assertion is subsumed:
no build leaving `zkp.lib` unresolvable leaves the flag True. Keeping
both would pin a value that stops deciding anything the day the
derivation moves, which is the defect class this change is about -- the
surviving assertion would then measure a build the suite no longer
consults, and pass. The case for keeping it is that it names the failure
more precisely where the extension itself is missing; the sync step
above already fails loudly on a compile error, and an AssertionError
naming `tests.ZKP_AVAILABLE` points at the file that reads it.

The file's header block separates the flag from the probe it is set
from, the same distinction, in the sentence that introduces both.

Measured in a worktree at adead91c, on this machine's unflagged build:

    uv run --locked --no-default-groups --group test \
      python -c "import tests; print(tests.ZKP_AVAILABLE)"

imports and prints False at exit 0, so `import tests` resolves under
that group set -- the package imports pytest and btclib at module level
and the group installs both, and the checkout root a step runs from is
what puts the package on `sys.path`. The same command with the assert
exits 1, so the assertion is not vacuous. `pytest -m zkp --no-cov` there
exits 0 with every selected test skipped, where a marker matching
nothing exits 5: that pair is why the comment says pytest offers no
switch for the all-skipped case and this assertion stands in for one.


closes #1958

Local review at fresh context: CLEARED
`47671779a18720d255c9d9448cf5171d12dcce76`. The reviewer re-derived both
directions of the assertion, confirmed the exit-0-on-all-skipped versus
exit-5-on-no-match pair against pytest 9.1.1, re-parsed the committed
workflow to check the folded scalar yields the intended one-liner, and
ran the documented docs gate (`-n -W`, `--no-default-groups --group
docs`, plus the `href="#../"` grep with a positive control) itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Make the ZKP oracle workflow validate and monitor the flag that determines whether ZKP-marked tests execute.

Bug Fixes:
- Ensure the ZKP oracle workflow fails when the flagged tests would otherwise be silently skipped on an unflagged build.

Enhancements:
- Align the workflow path triggers and pre-test validation with the shared test flag that determines whether ZKP-marked tests run or skip.

CI:
- Update the ZKP workflow to monitor the test initialization and collection configuration that control ZKP test execution, and assert `tests.ZKP_AVAILABLE` before running the selected tests.

Documentation:
- Document the ZKP oracle workflow trigger and assertion changes in the changelog.