### PR TITLE
`tests/_data/README.md` cites the descriptors module at the path it has (closes #1934)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3668,6 +3668,49 @@ name that library and the symbol each of them paraphrases (closes #1932).
   collection that found nothing, so the assertion refuses the condition
   that produces the state instead.
 
+### `tests/_data/README.md` cites the descriptors module at the path it has
+
+- **Four entries cite `tests/descriptors/descriptors_test.py`, the module
+  this tree has** (closes #1934): BIP387's `multi_a()` vectors, BIP390's
+  `musig()` vectors, `descriptor_checksums.json` and Core's descriptor
+  derivation vectors. Each closes on a verdict, a verdict is checked by
+  opening the module that holds the values, and the path they carried
+  resolved to nothing.
+- **`tests/vendored_data_test.py` holds the README's citations to paths
+  this tree has.** A
+  backticked path this tree does not have, under a file name and a
+  directory it does have, is one of this tree's own files cited where it
+  is not; a path another project owns fails one half or the other --
+  upstream's own directory for a file whose name our vendored copy keeps,
+  and `tests/` for a project that does not name its test modules as we
+  do. Not an exemption list, which the next vendored file makes stale,
+  and not the entry's own `repo` line: the entries carrying these
+  citations pin bitcoin/bips and bitcoin/bitcoin, so reading the pin
+  takes every path in them for upstream's. The module asks `git
+  ls-files` which paths this tree has, so `source-exclude` keeps it out
+  of the sdist beside the modules already there for that: a tree
+  stripped to its tracked files has no index to ask.
+- **Core's descriptor derivation entry names `HARDENED_PUBLIC` rather
+  than counting what is in it**, and
+  `tests/descriptors/descriptors_test.py` counts them nowhere either:
+  of the sites that put a number on them one agreed with the list and
+  the rest did not, and what they counted was this tree's own list,
+  which CLAUDE.md forbids stating. Core's `descriptor_test` flags `HARDENED`
+  cases this tree does not transcribe -- the `wsh(and_v(...))` one, and
+  the `musig()` ones -- so it was never a count of what upstream
+  published.
+- **The module's docstring says which `rawtr()` vectors are read from
+  where**: Core's are read from `descriptor_tests.cpp` and no BIP
+  publishes them, where the `rawtr()` vectors BIP390 does publish are
+  `musig()` ones this module reads from the BIP.
+- **The same entry gives Core's unpublished `musig()` cases a place**
+  (closes #1968): those BIP390 publishes are transcribed from the BIP's
+  own entry above, and those it does not are transcribed from neither,
+  `rawtr(musig(...))` cases being among the second. Read by parsing the
+  `Check()` calls of `descriptor_test` and comparing every spelling each
+  passes against the descriptors BIP390 publishes; a call spanning lines
+  is invisible to a reading keyed on the line its name sits on.
+
 ## v2026.9.3
 
 ### Repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -340,6 +340,12 @@ source-exclude = [
     # declares, and a tree stripped to its tracked files carries no ref
     # store to resolve it in
     "/tests/declared_version_test.py",
+    # the same shape once more, over a third thing read through `.git`:
+    # this one asks `git ls-files` which paths this repository has, to
+    # hold every path tests/_data/README.md cites of this tree to a file
+    # that is there, and a tree stripped to its tracked files has no
+    # index to ask
+    "/tests/vendored_data_test.py",
     # where `make html` writes, docs/Makefile's BUILDDIR being `build`
     "/docs/build",
     # a cache a linter or type checker writes beside the file it has

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -911,11 +911,11 @@ behind  0 revisions; that commit is the tip of the path
 
 Verdict: **transcribed**, and cited inline rather than vendored: they are
 descriptors and scripts read where they are used, in
-`tests/descriptors_test.py`'s `BIP387_VECTORS` and `BIP387_INVALID`. Every
-descriptor of the BIP's Test Vectors section is there with the
-scriptPubKey it produces, at each index the BIP lists, and every invalid
-one with the message btclib refuses it with — two of those refusals
-answering the uncompressed key before the threshold the BIP was
+`tests/descriptors/descriptors_test.py`'s `BIP387_VECTORS` and
+`BIP387_INVALID`. Every descriptor of the BIP's Test Vectors section is
+there with the scriptPubKey it produces, at each index the BIP lists, and
+every invalid one with the message btclib refuses it with — two of those
+refusals answering the uncompressed key before the threshold the BIP was
 illustrating, which the entries say. Each value was matched against the
 pinned text on 2026-08-06.
 
@@ -930,13 +930,13 @@ behind  0 revisions; that commit is the tip of the path
 ```
 
 Verdict: **transcribed**, complete for both lists and cited inline, in
-`tests/descriptors_test.py`'s `BIP390_VECTORS` and `BIP390_INVALID`: the
-six valid descriptors with the scripts they produce at each index listed,
-and all fourteen invalid ones with the message each is refused with. Five
-further invalid cases there are btclib's own, for what the BIP states in
-prose rather than listing — no nesting, no key origin in front of one, at
-least one participant, no x-only participant, and a `musig()` where a tree
-leaf belongs.
+`tests/descriptors/descriptors_test.py`'s `BIP390_VECTORS` and
+`BIP390_INVALID`: the six valid descriptors with the scripts they produce
+at each index listed, and all fourteen invalid ones with the message each
+is refused with. Five further invalid cases there are btclib's own, for
+what the BIP states in prose rather than listing — no nesting, no key
+origin in front of one, at least one participant, no x-only participant,
+and a `musig()` where a tree leaf belongs.
 
 The pin is the tip and it is the day it was taken: that commit is
 `bip390: fix missing parenthesis in test vector`, which closed the last
@@ -1261,9 +1261,9 @@ Verdict: **composed locally**, not vendored. Descriptors appear
 verbatim in the pinned document; none of their checksums does, because
 Core's document does not list them. They were computed with a third
 implementation, `bdk`'s `descriptor::checksum::get_checksum`, as
-`tests/descriptors_test.py` records — which is the point of the file: the
-checksums are an independent oracle, so recomputing them with btclib
-would void the test.
+`tests/descriptors/descriptors_test.py` records — which is the point of
+the file: the checksums are an independent oracle, so recomputing them
+with btclib would void the test.
 
 Nothing to refresh from upstream. A new descriptor needs a checksum from
 somewhere other than btclib.
@@ -1329,12 +1329,13 @@ pulled  2026-09-10, rawtr() added 2026-08-06
 behind  0 revisions; that commit is the tip of the path
 ```
 
-Verdict: **transcribed**, a subset by design. `tests/descriptors_test.py`
-holds the `Check(prv, pub, ...)` cases of the `descriptor_test` case as
-`CORE_VECTORS` — the descriptor in both spellings and the scriptPubKey
-each expands to, at every index the case lists — plus the public spellings
-of the four Core expands from the private form alone, and the two
-`rawtr()` cases, which no BIP publishes and only this file has.
+Verdict: **transcribed**, a subset by design.
+`tests/descriptors/descriptors_test.py` holds the `Check(prv, pub, ...)`
+cases of the `descriptor_test` case as `CORE_VECTORS` — the descriptor in
+both spellings and the scriptPubKey each expands to, at every index the
+case lists — plus the public spellings of those Core expands from the
+private form alone, which are `HARDENED_PUBLIC` there, and the `rawtr()`
+cases, which no BIP publishes and only this file has.
 
 Not vendored as a file because there is no file: the values are literals
 in C++ source, so a copy of it would be a copy of a test program. What
@@ -1343,9 +1344,10 @@ function moves the commit, and the weekly run says so.
 
 The subset is deliberate and is what a refresh would revisit: Core's file
 also holds `CheckUnparsable` cases, which this module has as `UNPARSABLE`
-with btclib's own messages, and the `musig()` cases of BIP390, which are
-transcribed from the BIP itself above rather than from here. Matched
-against the file as it stood on 2026-08-06.
+with btclib's own messages, and `musig()` cases. Those BIP390 publishes
+are transcribed from the BIP itself above rather than from here; those it
+does not -- `rawtr(musig(...))` among them -- are transcribed from
+neither. Matched against the file as it stood on 2026-08-06.
 
 The cases upstream added after that comparison are not here, and
 [ISS 1334](https://github.com/btclib-org/btclib/issues/1334) is where

--- a/tests/descriptors/descriptors_test.py
+++ b/tests/descriptors/descriptors_test.py
@@ -10,8 +10,9 @@ The derivation vectors are Bitcoin Core's own, transcribed from the
 public spelling and the scriptPubKey each expands to, at index 0, 1 and 2
 where the descriptor is ranged. Both spellings are exercised, so a WIF
 and an xprv are checked to reach the script the public key and the xpub
-beside them reach. The two ``rawtr()`` vectors are read there too, no BIP
-having any.
+beside them reach. Core's ``rawtr()`` vectors are read there too, no BIP
+publishing them: the ``rawtr()`` vectors BIP390 does publish are
+``musig()`` ones, and are read from the BIP instead.
 
 Not vendored as files, those and BIP387's and BIP390's alike: the values
 are read out of C++ source and mediawiki prose rather than copied from a
@@ -19,7 +20,7 @@ data file, so what this module cites is the path and the case, and
 `tests/_data/README.md` carries the revision each is pinned to -- which
 is also what the weekly upstream re-check reads.
 
-Four of those descriptors have no public spelling to check, and Core's
+Where one of those descriptors has no public spelling to check, Core's
 own flags say why: HARDENED and DERIVE_HARDENED mark a derivation that
 needs the private key, so Core expands the private form alone and this
 module expects the public one to be refused.
@@ -472,8 +473,8 @@ CORE_VECTORS: list[tuple[str, str | None, list[list[str]]]] = [
     ),
 ]
 
-# the public spelling of the five descriptors that derive hardened: Core
-# flags them HARDENED or DERIVE_HARDENED and expands the private one only
+# the public spelling of the descriptors that derive hardened: Core flags
+# them HARDENED or DERIVE_HARDENED and expands the private one only
 HARDENED_PUBLIC = [
     "rawtr(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH/86'/1'/0'/1/*)",
     "pkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/2147483647'/0)",
@@ -498,9 +499,9 @@ def test_core_derivation_vector(
     addresses are the addresses of those very scripts.
 
     The private material `parse` hands back goes into every expansion,
-    which four of these vectors need and the rest do not: a hardened step
-    under an xprv is the one thing an xpub cannot take, and the four
-    public spellings of those are `HARDENED_PUBLIC` below.
+    which the hardened vectors need and the rest do not: a hardened step
+    under an xprv is the one thing an xpub cannot take, and the public
+    spellings of those are `HARDENED_PUBLIC` below.
     """
     for descriptor in (private, public):
         if descriptor is None:
@@ -526,7 +527,7 @@ def test_hardened_derivation_needs_the_private_key(descriptor: str) -> None:
     """An xpub cannot answer a hardened step, so the descriptor cannot.
 
     Bitcoin Core says the same by expanding only the private spelling of
-    these four, and BIP380 states it as a rule of the language.
+    these, and BIP380 states it as a rule of the language.
     """
     parsed = parse(descriptor)
     with pytest.raises(BTClibValueError, match="hardened derivation"):

--- a/tests/vendored_data_test.py
+++ b/tests/vendored_data_test.py
@@ -72,6 +72,19 @@ nothing here rewraps markdown -- `markdownlint`'s MD013 has no fixer and
 prettier's own hook does not take markdown -- so a correction is
 surgical, and the guards below name the line they are unhappy about.
 
+The other rule is about the paths this README cites rather than the
+numerals it states. A backticked path that reads as this tree's own -- a
+file this tree has, under a directory this tree has -- is a path
+`git ls-files` must confirm, a citation being what a reader follows to
+check a verdict. Neither of the two cheaper rules answers it. The entry's
+own `repo` line does not say whose a path is: the BIP387, BIP390 and Core
+descriptor entries pin bitcoin/bips and bitcoin/bitcoin and cite
+`tests/descriptors/descriptors_test.py` all the same, so a rule reading
+the pin takes every path in those entries for upstream's. A list of the
+paths upstream owns does not either: it is a list to keep, and the day a
+vendored file is added without it the red lands on a correct citation
+(issue #1934).
+
 A test rather than a hook, for the reasons `docs_test.py` gives: no
 environment the suite does not already have, every interpreter of the
 matrix rather than one runner, and `tests-passed` gates it without a line
@@ -79,11 +92,18 @@ in any `needs` list.
 """
 
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
 
-_README = Path(__file__).parents[1] / "tests" / "_data" / "README.md"
+_ROOT = Path(__file__).parents[1]
+_README = _ROOT / "tests" / "_data" / "README.md"
+
+# resolved once, for the reason `declared_version_test.py`'s own `_GIT`
+# is: a bare "git" in a subprocess list is a partial executable path
+_GIT = shutil.which("git") or "git"
 
 # a digit run, or a spelled-out cardinal as a whole word ("one" and "zero"
 # excepted -- see the module docstring)
@@ -247,9 +267,10 @@ _EXEMPT: dict[str, str] = {
     "Two of the BIP's fields are not what their name reads as, and": _UPSTREAM_FACT,
     "the name reads: the DERIVED ENTROPY of application 32' is the second half": _UPSTREAM_FACT,
     "of the 64 bytes, the private key of the xprv, and that of 39' is already": _UPSTREAM_FACT,
-    "one with the message btclib refuses it with — two of those refusals": _UPSTREAM_FACT,
-    "six valid descriptors with the scripts they produce at each index listed,": _UPSTREAM_FACT,
-    "and all fourteen invalid ones with the message each is refused with. Five": _UPSTREAM_FACT,
+    "every invalid one with the message btclib refuses it with — two of those": _UPSTREAM_FACT,
+    "`BIP390_INVALID`: the six valid descriptors with the scripts they produce": _UPSTREAM_FACT,
+    "at each index listed, and all fourteen invalid ones with the message each": _UPSTREAM_FACT,
+    "is refused with. Five further invalid cases there are btclib's own, for": _UPSTREAM_FACT,
     "One of the fourteen is refused for a reason of btclib's own rather than": _UPSTREAM_FACT,
     "vector and the multipath descriptor the two compile to, checked branch by": _UPSTREAM_FACT,
     "key-information vector, byte for byte. Four": _UPSTREAM_FACT,
@@ -298,7 +319,6 @@ _EXEMPT: dict[str, str] = {
     "`multi_a()` of twenty-one keys, the three `and_b()` chains that pass the": _UPSTREAM_FACT,
     "p2wsh ops, stack and script-size limits, and the two nestings that reach a": _UPSTREAM_FACT,
     "thousand elements on the stack. `tests/descriptors/miniscript_test.py`": _UPSTREAM_FACT,
-    "of the four Core expands from the private form alone, and the two": _UPSTREAM_FACT,
     "before. The two hold the same names, compared on 2026-09-03, and the": _UPSTREAM_FACT,
     "directions in `bitcoin/bitcoin#15437`. `src/btclib/p2p/reject.py` says": _UPSTREAM_FACT,
     "but an *interface*, and the two entries are the two halves of it: the": _UPSTREAM_FACT,
@@ -657,3 +677,99 @@ def test_a_summary_transcribed_read_needs_a_transcribed_bullet() -> None:
         _summary_transcribed_files(
             "### `tests/_data/kept.json`\n\n## Summary\n\n- identical: `kept.json`.\n"
         )
+
+
+# a backticked span of path characters, with a directory in it and a
+# suffix on the name. What the character class leaves out is what makes
+# the span a citation rather than something shaped like one:
+# `bitcoin/bitcoin#15437` is an issue, `api/tx/<txid>` an endpoint, and
+# `tests/tx/_data/*.bin` a set of files rather than one, so none of the
+# three is a path `git ls-files` could answer for
+_CITED_PATH = re.compile(r"`([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+\.[A-Za-z0-9]+)`")
+
+
+def _cited_paths(text: str) -> set[str]:
+    """Every path `text` cites in backticks."""
+    return {match.group(1) for match in _CITED_PATH.finditer(text)}
+
+
+def _tracked() -> set[str]:
+    """Every path this repository tracks."""
+    listed = subprocess.run(  # noqa: S603
+        [_GIT, "ls-files"],
+        cwd=_ROOT,
+        capture_output=True,
+        encoding="utf-8",
+        check=False,
+    )
+    return set(listed.stdout.splitlines())
+
+
+def _misresolved(cited: set[str], tracked: set[str]) -> list[str]:
+    """Return the cited paths naming a file `tracked` holds elsewhere.
+
+    Both halves of a path are read, and each answers one of the two ways
+    another project's path reads like one of ours. A vendored file keeps
+    the name upstream publishes it under, which the README's own *Naming*
+    section requires, so upstream's path for it carries our basename and
+    only the directory tells the two apart; and another project's tests
+    sit under `tests/` as ours do, so there only the name does.
+    """
+    names = {path.rsplit("/", 1)[-1] for path in tracked}
+    directories = {path.rsplit("/", 1)[0] for path in tracked if "/" in path}
+    return sorted(
+        path
+        for path in cited - tracked
+        if path.rsplit("/", 1)[-1] in names and path.rsplit("/", 1)[0] in directories
+    )
+
+
+def test_every_path_the_readme_cites_of_this_tree_is_one_this_tree_has() -> None:
+    """A citation is what a reader follows to check a verdict.
+
+    An entry that closes on a transcribed verdict states it by naming the
+    module holding the values, so a path resolving to nothing sends
+    whoever re-checks the pin looking for a file that is not there.
+    """
+    cited = _cited_paths(_README.read_text(encoding="utf-8"))
+    tracked = _tracked()
+    # what a sweep answering zero has to be held to: `git ls-files` gives
+    # an empty set where git is missing, and a pattern can stop matching
+    # without anything else here changing
+    assert _README.relative_to(_ROOT).as_posix() in tracked
+    assert cited & tracked
+    offenders = _misresolved(cited, tracked)
+    assert not offenders, (
+        "tests/_data/README.md cites a path this tree does not have, under"
+        f" a name and a directory it does have: {offenders!r}"
+    )
+
+
+def test_a_path_of_this_tree_is_told_from_a_path_of_upstream() -> None:
+    """The check above passes for free if it cannot tell the two apart.
+
+    One synthetic tracked set and four citations against it, which is
+    every arm the rule has: `tests/descriptors_test.py` is this tree's
+    own module at a path this tree does not have and is caught; the same
+    module at its own path is not; Core's `src/test/data/script_tests.json`
+    carries the name our vendored copy keeps and is left to the directory,
+    which this tree does not have; and electrum's `tests/test_mnemonic.py`
+    sits in a directory this tree does have and is left to the name.
+
+    The set holds a file directly under `tests/` because two of those
+    four turn on that directory being one this tree has: without it the
+    caught arm is excused for the wrong reason and the electrum arm
+    proves nothing, which is what the expectation naming the offender --
+    rather than an empty list -- is here to keep visible.
+    """
+    tracked = {
+        "tests/vendored_data_test.py",
+        "tests/descriptors/descriptors_test.py",
+        "tests/script_engine/_data/script_tests.json",
+    }
+    cited = _cited_paths(
+        "`tests/descriptors_test.py`, `tests/descriptors/descriptors_test.py`,"
+        " Core's `src/test/data/script_tests.json` and electrum's"
+        " `tests/test_mnemonic.py`."
+    )
+    assert _misresolved(cited, tracked) == ["tests/descriptors_test.py"]


### PR DESCRIPTION
Four entries cite `tests/descriptors_test.py`, which this tree does not
have: the module is `tests/descriptors/descriptors_test.py`, and the same
README spells it correctly in the BIP388 entry. The correct path is twelve
characters longer and the file wraps at eighty columns, so each of the
four paragraphs reflows; `tests/vendored_data_test.py`'s `_EXEMPT` pins
its lines verbatim, and its keys are re-read off the reflowed file rather
than computed from the numbers the old ones carried.

The sweep the issue proposes lands as a test, since a rule without the
gate that reads it does not land. The counter-argument -- that a per-path
exemption list is itself a list to maintain -- is answered by keeping no
list: the tree decides. A cited path this tree does not have, whose file
name it does have, under a directory it does have, is one of its own files
cited where it is not. Another project's path fails one half or the other,
and both halves are load-bearing: a vendored file keeps the name upstream
publishes it under, so upstream's path for it carries our basename and
only the directory separates the two, while another project's tests sit
under `tests/` as ours do, so there only the name does.

The entry's own `repo` line cannot decide whose a path is, which is what
the issue's decision proposed and what the tree refutes: all four
citations sit in entries pinning bitcoin/bips or bitcoin/bitcoin, so a
rule reading the pin takes every path in those entries for upstream's and
excuses the defect it was written for.

The sweep's zero was proved against a positive control before it was
believed: with `tests/descriptors_test.py` planted back into the README
the new test fails naming it, and it answers empty with the file as it
stands. Two live controls ride in the test itself -- the README's own path
must be among what `git ls-files` answers, and the cited set must
intersect it -- and a synthetic control puts one arm of the rule against
each of its four cases.

The module asks `git ls-files` what this repository has, so it joins
`source-exclude`: `tests/build_system_test.py` recognizes that shape -- a
`subprocess` call whose argument list opens on `_GIT` -- and requires the
module be kept out of the sdist, a tree stripped to its tracked files
having no index to ask.

Every numeral the two files put on that list is dropped rather than
corrected, and for one reason: each counted this tree. The
four-versus-five is the first. It counted `HARDENED_PUBLIC`, a list in
this tree, and CLAUDE.md's exception is a count of what upstream
published: this is not one, Core's `descriptor_test` flagging `HARDENED`
cases this tree does not transcribe -- the `wsh(and_v(...))` one and the
`musig()` ones. Imported and read back, `HARDENED_PUBLIC` and the
`CORE_VECTORS` entries with no public spelling hold the same descriptors;
of the sites that put a number on them one agreed with the list and the
rest did not, and the disagreement ran inside the module as well as
between it and the README. None states a number now: the entry names
`HARDENED_PUBLIC`, and the module names the flags Core sets on a
derivation that needs the private key, which is what a reader checks
either claim against.

The second is the clause beside it, and `_UPSTREAM_FACT` -- the reason
its `_EXEMPT` entry carried -- says what was wrong with it: "not a count
of this tree". "The two `rawtr()` cases" counted what `CORE_VECTORS`
transcribes, which is fewer than the `rawtr()` cases Core's
`descriptor_test` holds at the pin above, itself fewer than those no BIP
publishes: `rawtr(` reaches one BIP, bip-0390 at `2120121c`, whose
vectors are the `musig()` ones this tree reads from the BIP instead. The
clause names the cases and states no number, so the line needs no
exemption and its `_EXEMPT` entry goes with it.

The same entry accounted for Core's `musig()` cases as BIP390's, and
BIP390 does not publish them all: the entry now says which are read from
the BIP above and that the rest are read from neither, `rawtr(musig(...))`
cases being among the rest. Measured by paren-matching the `Check()`
calls of `descriptor_test` and testing every spelling each passes against
the descriptors BIP390 marks up, rather than by matching the line a call
opens on -- a `Check(` spanning lines is invisible to that, which is how
two readings of this file came to disagree. The extraction carries its
own control both ways: a BIP390 vector is found in the set, and some of
Core's cases match it while others do not.

The module's own docstring said the `rawtr()` vectors it reads are ones
no BIP has, which counted them and was false of the second half: BIP390
publishes `rawtr()` vectors of its own, and this module transcribes them
-- imported and compared against the BIP text at the pin the entry
carries, the `rawtr()` entries of `BIP390_VECTORS` appear there and
Core's do not. The docstring takes the form the README
already uses: Core's are the ones no BIP publishes, and BIP390's are
`musig()` ones read from the BIP.

closes #1968


closes #1934
closes #1968

Local review at fresh context returned CHANGES REQUESTED on
`df07591b` and the findings were applied in the amend: the module
docstring stated a count of this tree (`HARDENED_PUBLIC` holds five, the
docstring said four) and two carriers asserted the module states none.
The reviewer re-derived the BIP390 split under an independent
paren-matched parse and went a step further than the branch did —
expanding the module's `MUSIG_*` constants, the six unmatched Core cases
are absent from this tree's own vectors and the six matched ones
present, so "transcribed from neither" is true of the tree and not only
of the BIP.

Rebased onto `9f5ac894` after the review. The `merge=union` seam above
the new `###` heading was predicted with `git merge-tree --write-tree`
before the rebase, reproduced byte for byte by it, and repaired by
reconstruction; the repaired file is verified on the commit object, and
no heading in it has a non-blank neighbour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Correct descriptor data references and enforce that repository-owned paths cited by the vendored-data README remain valid.

New Features:
- Add validation that README citations resolve to tracked files in this repository without confusing similarly named upstream paths.

Bug Fixes:
- Correct descriptor test module references in the vendored-data README and clarify descriptor-vector provenance and coverage.

Enhancements:
- Replace outdated vector counts with descriptive, source-based statements and update descriptor documentation to distinguish Core and BIP390 vectors.

Build:
- Exclude the git-dependent vendored-data test from source distributions.

Documentation:
- Reflow and update tests/_data/README.md and descriptor test documentation to reflect the correct module path and current vector sources.

Tests:
- Add tracked-path citation checks, synthetic positive controls, and safeguards for the git-based repository inspection.