### PR TITLE
`tests/_data/README.md`'s header example names secp256k1-zkp (closes #1965)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3711,6 +3711,18 @@ name that library and the symbol each of them paraphrases (closes #1932).
   passes against the descriptors BIP390 publishes; a call spanning lines
   is invisible to a reading keyed on the line its name sits on.
 
+### Which library `tests/_data/README.md`'s header example names
+
+- **The example is `include/secp256k1_ecdsa_s2c.h` of
+  BlockstreamResearch/secp256k1-zkp** (closes #1965), the attribution
+  `btclib.ecc.dsa`'s `anti_exfil_host_commit` docstring carries for that
+  header. bitcoin-core/secp256k1 publishes no sign-to-contract header,
+  and the kinds of upstream prose listed beside the example named a
+  libsecp256k1 header alone, so the example read as one of those.
+- **The list names a kind of prose and the citation names the library**:
+  what a citation carries is the repository and the path, both of which
+  keep their names, so a paraphrase of a header needs no revision.
+
 ## v2026.9.3
 
 ### Repository

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -28,14 +28,15 @@ upstream to pin, and nothing to compare against but ourselves —
 `BTCLIB_REGENERATE_GOLDEN=1 uv run pytest` rewrites them on purpose.
 
 Upstream prose that btclib *paraphrases* has no entry here either: a
-BIP's reasoning, a Core comment, a libsecp256k1 header's rationale are
+BIP's reasoning, a Core comment, a C library header's rationale are
 cited in the docstring or the comment that paraphrases them, and a
 paraphrase admits no byte comparison, so there is nothing for the weekly
 job to ask. What such a citation carries is decided by what it names. A
-file needs no revision -- the path keeps its name, and a reader who opens
-it reads the reasoning upstream holds now, which is what a paraphrase
-sends them for -- and `btclib.ecc.dsa`'s anti-exfil docstrings cite
-`include/secp256k1_ecdsa_s2c.h` that way. A line needs one: a line number
+file needs no revision -- the repository and the path keep their names,
+and a reader who opens it reads the reasoning upstream holds now, which
+is what a paraphrase sends them for -- and `btclib.ecc.dsa`'s anti-exfil
+docstrings cite `include/secp256k1_ecdsa_s2c.h` of
+BlockstreamResearch/secp256k1-zkp that way. A line needs one: a line number
 is the one thing that moves under a file that keeps its name, so without
 a revision the citation degrades into pointing at whatever now occupies
 it. The revision sits in the citation or in the module docstring that


### PR DESCRIPTION
The paraphrase paragraph gave `include/secp256k1_ecdsa_s2c.h` as its
example beside a list of kinds naming a libsecp256k1 header alone, so the
example read as libsecp256k1's. `include` answers otherwise:
bitcoin-core/secp256k1 carries no `secp256k1_ecdsa_s2c.h` at 99ae2312,
its tip the day this was read, and BlockstreamResearch/secp256k1-zkp
carries one at 037cc6d7. Neither sha is a revision this tree pins: the
reading is of the two libraries, not of a pinned build, which is why the
prose that lands names no sha at all.

The example now carries the repository, the spelling `btclib.ecc.dsa`'s
`anti_exfil_host_commit` docstring already uses for that header. The list
of kinds names a C library header rather than one library's: the tree's
two `include/` header citations are this one and `ecc.borromean`'s
`include/secp256k1_rangeproof.h`, and bitcoin-core/secp256k1 publishes
neither.

The paragraph's own subject carries it: what a citation names is the
repository and the path, and a repository keeps its name as a path does,
so a paraphrase still needs no revision.

closes #1965


closes #1965

Local review at fresh context: CLEARED
`a808d66da774cf0657cbe614359d43ad4dd5a059`. This tip is that tree with
two message-only amends on top — `git rev-parse HEAD^{tree}` is
unchanged, so the gates and the clearance still apply.

The reviewer re-derived both `include` listings, read every `secp256k1`
hit in `tests/_data/README.md` in its own paragraph rather than as a
line match, and checked `tests/vendored_data_test.py`'s `_EXEMPT` in both
directions: none of the changed README lines is a key, and all 278 keys
are still present verbatim at both the old and the new base.

Two corrections came out of the round and are in this body rather than
the tree. The commit message had said `include` "at the revisions this
tree pins": `99ae2312` is pinned nowhere in this repository — it is
bitcoin-core/secp256k1's tip the day it was read — so that clause is
now accurate about what it is. The prose that actually lands names no
sha at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Correct the upstream library attribution for the anti-exfiltration header example and clarify citation guidance for paraphrased C library documentation.

Bug Fixes:
- Clarify that the anti-exfiltration header citation in `tests/_data/README.md` refers to `BlockstreamResearch/secp256k1-zkp`.
- Update the README guidance to identify C library headers by repository and path rather than implying they belong to libsecp256k1.

Documentation:
- Document the repository attribution and revision guidance for paraphrased upstream header citations.

Chores:
- Record the documentation correction in the changelog.