### PR TITLE
Every tracked markdown file is held to the paths it cites (closes #1963)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3723,6 +3723,38 @@ name that library and the symbol each of them paraphrases (closes #1932).
   what a citation carries is the repository and the path, both of which
   keep their names, so a paraphrase of a header needs no revision.
 
+### Every tracked markdown file is held to the paths it cites of this tree
+
+- **`tests/markdown_citations_test.py` reads every tracked `*.md`, and a
+  citation of this tree resolves or the suite is red** (closes #1963). A
+  backticked path this tree does not have, whose file name it does have,
+  under a directory it does have, is one of this tree's own files cited
+  where it is not; a path another project owns fails one half or the
+  other. The rule moves here from `tests/vendored_data_test.py`, which
+  keeps the numeral guard `tests/_data/README.md` is its subject for and
+  gives up the `source-exclude` entry the `git ls-files` call earned it.
+- **Both halves are load-bearing over this population, and each is
+  measured by dropping it.** Without the directory half, a path written
+  relative to `src/` or to `src/btclib/` is left to a file name this tree
+  does have -- `CLAUDE.md`'s `curves/curve_group.py`, `RELEASE_NOTES.md`'s
+  `btclib/b58.py`. Without the file name half, another project's tests
+  are left to `tests/`, the directory everyone puts them in --
+  `REVIEWING.md`'s citation of the organization standard's own
+  `tests/verbatim_test.py`, `tests/_data/README.md`'s spesmilo/electrum
+  vector sources.
+- **`_EXEMPT` is what the guard does with the path both halves accept and
+  this tree does not own**: a sibling repository's file whose name and
+  directory this tree also has, or a rename cited by a released
+  `CHANGELOG.md` section, which `changelog_immutability_test.py` holds
+  byte for byte against its own tag and so leaves nobody able to correct
+  the citation where it sits. It is empty, this tree having no such path,
+  and a synthetic control is what says it works on the day one arrives.
+- **A citation broken across the eighty-column wrap is not read**, so the
+  guard's silence about such a path is not a verdict on it. Folding the
+  wrap away first is not the repair: joining the halves with nothing sees
+  a wrapped path and also fuses a command wrapped at a space, which this
+  file carries, while joining them with a space sees neither.
+
 ## v2026.9.3
 
 ### Repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,10 +342,10 @@ source-exclude = [
     "/tests/declared_version_test.py",
     # the same shape once more, over a third thing read through `.git`:
     # this one asks `git ls-files` which paths this repository has, to
-    # hold every path tests/_data/README.md cites of this tree to a file
-    # that is there, and a tree stripped to its tracked files has no
+    # hold every path a tracked markdown file cites of this tree to a
+    # file that is there, and a tree stripped to its tracked files has no
     # index to ask
-    "/tests/vendored_data_test.py",
+    "/tests/markdown_citations_test.py",
     # where `make html` writes, docs/Makefile's BUILDDIR being `build`
     "/docs/build",
     # a cache a linter or type checker writes beside the file it has

--- a/tests/markdown_citations_test.py
+++ b/tests/markdown_citations_test.py
@@ -1,0 +1,289 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Every path a markdown file cites of this tree is one this tree has.
+
+A citation is what a reader follows to check a claim, so one resolving to
+nothing sends whoever follows it looking for a file that is not there.
+The population is every tracked `*.md`, citing being what these files do
+rather than a property of any one of them: `tests/_data/README.md` and
+`CHANGELOG.md` name the module a verdict's values sit in, `CONTRIBUTING.md`
+and `REVIEWING.md` the file a rule lives in, and `CLAUDE.md` the module a
+layer is drawn at.
+
+Whose a cited path is, the tree decides. A list of the paths other
+projects own is a list to keep, and the day a vendored file arrives
+without an entry the red lands on a correct citation. So a cited path
+this tree does not have, whose file name it does have, under a directory
+it does have, is one of this tree's own files cited where it is not, and
+another project's path fails one half or the other. Dropping either half
+reddens citations that are correct:
+
+- without the directory half a path written relative to `src/` or to
+  `src/btclib/` is left to a file name this tree does have, which is
+  `CLAUDE.md`'s `curves/curve_group.py` and `RELEASE_NOTES.md`'s
+  `btclib/b58.py`;
+- without the file name half another project's tests are left to
+  `tests/`, the directory everyone puts them in, which is `REVIEWING.md`'s
+  `tests/verbatim_test.py` -- named in that sentence as the organization
+  standard's own module -- and `tests/_data/README.md`'s spesmilo/electrum
+  vector sources.
+
+A citation broken across the eighty-column wrap is not read at all: the
+character class stops at the newline, so `tests/` ending one line and
+`descriptors_test.py` opening the next is no match, and the sweep's
+silence about such a path is not a verdict on it. Folding the wrap away
+before matching is not the repair, the two foldings being exactly
+complementary: joining the halves with nothing does see a wrapped path,
+and also fuses a *command* wrapped at a space, which `CHANGELOG.md`
+carries -- `pytest` and `tests/ecc/dsa_test.py` on either side of a break
+become one path -- while joining them with a space fuses neither and sees
+neither, a path having no space to be broken at. What keeps that fused
+path from reddening a correct citation today is the directory half alone,
+this tree having no `pytesttests/ecc`, which is luck and not the rule
+(issue #1969). The rule is blind by construction in one more way, and
+that one is deliberate: a cited path whose file name this tree does not
+have anywhere is another project's as far as this reads, whether or not
+it is. A `./` in front of one of this tree's own files is blind the same
+way and for the same reason -- `.` is a directory no `git ls-files` path
+carries, so the directory half excuses `` `./SECURITY.md` ``, which
+CONTRIBUTING.md cites -- and a rename would go unflagged in that
+spelling.
+
+Both halves accept a path another repository owns whose file name *and*
+whose directory this tree also has, and which this tree does not itself
+have -- that last is what `cited - tracked` asks first, so one of our own
+paths cited as somebody else's is not this class. REVIEWING.md cites the
+organization standard's `tests/verbatim_test.py` one file name short of
+it: `tests` is a directory here, so the day this tree gains a
+`verbatim_test.py` anywhere but at `tests/verbatim_test.py` itself, that
+landed citation begins to read as one of ours cited where it is not.
+Landing at that path instead makes it disappear from the sweep rather than
+reddening it, `cited - tracked` being asked first -- silence, and not this
+class. `_EXEMPT` is where such a path goes, keyed on the path with what
+makes it somebody else's beside it. A released `## v<version>` section of
+`CHANGELOG.md` is the other way in: `changelog_immutability_test.py`
+compares it byte for byte against its own tag, so a path renamed after an
+entry cited it cannot be corrected where it is cited, and the exemption is
+the only place that decision can be written down.
+
+A file stating the convention its own citations are written to can be
+held to more than this, and this rule does not stand in for that:
+`tf2_ledger_test.py` resolves `TF2.md`'s paths against `src/btclib/` as
+well as against the root, which is available to it because that ledger
+says which of the two each path is written from.
+
+The module asks `git ls-files` which paths this repository has, so
+`source-exclude` keeps it out of the sdist: a tree stripped to its tracked
+files has no index to ask.
+
+A test rather than a hook, for the reasons `docs_test.py` gives: no
+environment the suite does not already have, every interpreter of the
+matrix rather than one runner, and `tests-passed` gates it without a line
+in any `needs` list.
+"""
+
+import re
+import shutil
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path
+
+_ROOT = Path(__file__).parents[1]
+
+# resolved once, for the reason `declared_version_test.py`'s own `_GIT`
+# is: a bare "git" in a subprocess list is a partial executable path
+_GIT = shutil.which("git") or "git"
+
+# a backticked span of path characters, with a directory in it and a
+# suffix on the name. What the character class leaves out is what makes
+# the span a citation rather than something shaped like one:
+# `bitcoin/bitcoin#15437` is an issue, `api/tx/<txid>` an endpoint, and
+# `tests/tx/_data/*.bin` a set of files rather than one, so none of the
+# three is a path `git ls-files` could answer for
+_CITED_PATH = re.compile(r"`([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+\.[A-Za-z0-9]+)`")
+
+# a path both halves of the rule accept and this tree does not own, with
+# what makes it somebody else's beside it. Empty, the tree having no such
+# path: an entry here records a decision about one citation, where
+# widening the rule to excuse it would excuse the next real defect with it
+_EXEMPT: dict[str, str] = {}
+
+
+def _cited_paths(text: str) -> set[str]:
+    """Every path `text` cites in backticks."""
+    return {match.group(1) for match in _CITED_PATH.finditer(text)}
+
+
+def _tracked() -> set[str]:
+    """Every path this repository tracks."""
+    listed = subprocess.run(  # noqa: S603
+        [_GIT, "ls-files"],
+        cwd=_ROOT,
+        capture_output=True,
+        encoding="utf-8",
+        check=False,
+    )
+    return set(listed.stdout.splitlines())
+
+
+def _misresolved(
+    cited: set[str], tracked: set[str], exempt: Mapping[str, str]
+) -> list[str]:
+    """Return the cited paths naming a file `tracked` holds elsewhere.
+
+    Both halves of a path are read, and each answers one of the two ways
+    another project's path reads like one of ours. A vendored file keeps
+    the name upstream publishes it under, so upstream's own path for it
+    carries our file name and only the directory tells the two apart; and
+    another project's tests sit under `tests/` as ours do, so there only
+    the name does.
+    """
+    names = {path.rsplit("/", 1)[-1] for path in tracked}
+    directories = {path.rsplit("/", 1)[0] for path in tracked if "/" in path}
+    return sorted(
+        path
+        for path in cited - tracked - set(exempt)
+        if path.rsplit("/", 1)[-1] in names and path.rsplit("/", 1)[0] in directories
+    )
+
+
+def _offenders(
+    texts: Mapping[str, str], tracked: set[str], exempt: Mapping[str, str]
+) -> dict[str, list[str]]:
+    """Return what each markdown file of `texts` cites of this tree elsewhere.
+
+    Keyed on the file, a path being followed from the paragraph carrying
+    it: the same wrong path in two files is two corrections.
+    """
+    return {
+        markdown: misresolved
+        for markdown, text in texts.items()
+        if (misresolved := _misresolved(_cited_paths(text), tracked, exempt))
+    }
+
+
+def test_every_path_a_markdown_file_cites_of_this_tree_is_one_this_tree_has() -> None:
+    """A citation is what a reader follows to check a claim.
+
+    A verdict is checked by opening the module holding the values, a rule
+    by opening the file stating it, so a path resolving to nothing leaves
+    the claim standing on nothing a reader can reach.
+    """
+    tracked = _tracked()
+    texts = {
+        path: (_ROOT / path).read_text(encoding="utf-8")
+        for path in sorted(tracked)
+        if path.endswith(".md")
+    }
+    # what a sweep answering zero has to be held to: `git ls-files` gives
+    # an empty set where git is missing, and the pattern can stop matching
+    # without anything else here changing
+    assert "pyproject.toml" in tracked
+    assert {path for text in texts.values() for path in _cited_paths(text)} & tracked
+
+    offenders = _offenders(texts, tracked, _EXEMPT)
+    assert not offenders, (
+        "a markdown file cites a path this tree does not have, under a file"
+        f" name and a directory it does have: {offenders!r}"
+    )
+
+    # an exemption outlives the citation it was written for, and a dead one
+    # excuses nothing while reading as though it did. Set arithmetic rather
+    # than a loop over `_EXEMPT`, which is empty: a loop body no run enters
+    # is uncovered, and the floor is 100%
+    unexempted = {
+        path
+        for text in texts.values()
+        for path in _misresolved(_cited_paths(text), tracked, {})
+    }
+    stale = sorted(set(_EXEMPT) - unexempted)
+    assert not stale, f"_EXEMPT names a path the rule would not flag: {stale}"
+
+
+def test_a_citation_broken_across_the_wrap_is_not_read() -> None:
+    """The limit above, executable rather than stated.
+
+    A fold that made this answer with the path would also fuse the
+    command `CHANGELOG.md` wraps at a space, so a change here is a
+    decision about that trade and not a widening (issue #1969).
+    """
+    assert _cited_paths("the module is `tests/\ndescriptors_test.py`.") == set()
+    assert _cited_paths("the module is `tests/descriptors_test.py`.") == {
+        "tests/descriptors_test.py"
+    }
+
+
+def test_a_path_of_this_tree_is_told_from_a_path_of_another_project() -> None:
+    """The sweep above passes for free if it cannot tell the two apart.
+
+    One synthetic tracked set, and a citation for each arm the rule has:
+    `tests/descriptors_test.py` is this tree's own module at a path this
+    tree does not have and is caught; the same module at its own path is
+    not; Core's `src/test/data/script_tests.json` carries the file name
+    our vendored copy keeps and is left to its directory, which this tree
+    does not have; and electrum's `tests/test_mnemonic.py` sits in a
+    directory this tree does have and is left to its name.
+
+    Two of those arms turn on `tests` being a directory the set has, so
+    the set holds a file directly under it and says so before the sweep
+    runs: without that the caught arm is excused for the wrong reason and
+    the electrum arm proves nothing, neither of which an expectation of an
+    empty list would show. The cited set is read back for the same reason,
+    a pattern that stopped matching leaving nothing for the rule to
+    disagree about.
+    """
+    tracked = {
+        "tests/markdown_citations_test.py",
+        "tests/descriptors/descriptors_test.py",
+        "tests/script_engine/_data/script_tests.json",
+    }
+    assert "tests" in {path.rsplit("/", 1)[0] for path in tracked}
+    cited = _cited_paths(
+        "`tests/descriptors_test.py`, `tests/descriptors/descriptors_test.py`,"
+        " Core's `src/test/data/script_tests.json` and electrum's"
+        " `tests/test_mnemonic.py`."
+    )
+    assert cited == {
+        "tests/descriptors_test.py",
+        "tests/descriptors/descriptors_test.py",
+        "src/test/data/script_tests.json",
+        "tests/test_mnemonic.py",
+    }
+
+    assert _misresolved(cited, tracked, {}) == ["tests/descriptors_test.py"]
+
+
+def test_an_exempt_path_is_excused_and_the_rule_is_left_as_it_is() -> None:
+    """What the guard does with the path both halves accept.
+
+    The tree carries no such path, so this is what says the exemption
+    works on the day one arrives, and it is measured against the same
+    citation unexempted rather than against an empty list, which an
+    exemption that suppressed everything would also answer with.
+    """
+    tracked = {
+        "tests/markdown_citations_test.py",
+        "tests/descriptors/descriptors_test.py",
+    }
+    cited = {"tests/descriptors_test.py", "tests/script_engine/_data/script_tests.json"}
+
+    assert _misresolved(cited, tracked, {}) == ["tests/descriptors_test.py"]
+    assert _misresolved(cited, tracked, {"tests/descriptors_test.py": "why"}) == []
+
+
+def test_a_misresolved_citation_is_reported_under_the_file_citing_it() -> None:
+    """Which paragraph to correct is the file, not the path alone."""
+    tracked = {
+        "tests/markdown_citations_test.py",
+        "tests/descriptors/descriptors_test.py",
+    }
+    texts = {
+        "CONTRIBUTING.md": "the module is `tests/descriptors_test.py`.",
+        "README.md": "the module is `tests/descriptors/descriptors_test.py`.",
+    }
+
+    assert _offenders(texts, tracked, {}) == {
+        "CONTRIBUTING.md": ["tests/descriptors_test.py"]
+    }

--- a/tests/vendored_data_test.py
+++ b/tests/vendored_data_test.py
@@ -72,19 +72,6 @@ nothing here rewraps markdown -- `markdownlint`'s MD013 has no fixer and
 prettier's own hook does not take markdown -- so a correction is
 surgical, and the guards below name the line they are unhappy about.
 
-The other rule is about the paths this README cites rather than the
-numerals it states. A backticked path that reads as this tree's own -- a
-file this tree has, under a directory this tree has -- is a path
-`git ls-files` must confirm, a citation being what a reader follows to
-check a verdict. Neither of the two cheaper rules answers it. The entry's
-own `repo` line does not say whose a path is: the BIP387, BIP390 and Core
-descriptor entries pin bitcoin/bips and bitcoin/bitcoin and cite
-`tests/descriptors/descriptors_test.py` all the same, so a rule reading
-the pin takes every path in those entries for upstream's. A list of the
-paths upstream owns does not either: it is a list to keep, and the day a
-vendored file is added without it the red lands on a correct citation
-(issue #1934).
-
 A test rather than a hook, for the reasons `docs_test.py` gives: no
 environment the suite does not already have, every interpreter of the
 matrix rather than one runner, and `tests-passed` gates it without a line
@@ -92,18 +79,11 @@ in any `needs` list.
 """
 
 import re
-import shutil
-import subprocess
 from pathlib import Path
 
 import pytest
 
-_ROOT = Path(__file__).parents[1]
-_README = _ROOT / "tests" / "_data" / "README.md"
-
-# resolved once, for the reason `declared_version_test.py`'s own `_GIT`
-# is: a bare "git" in a subprocess list is a partial executable path
-_GIT = shutil.which("git") or "git"
+_README = Path(__file__).parents[1] / "tests" / "_data" / "README.md"
 
 # a digit run, or a spelled-out cardinal as a whole word ("one" and "zero"
 # excepted -- see the module docstring)
@@ -677,99 +657,3 @@ def test_a_summary_transcribed_read_needs_a_transcribed_bullet() -> None:
         _summary_transcribed_files(
             "### `tests/_data/kept.json`\n\n## Summary\n\n- identical: `kept.json`.\n"
         )
-
-
-# a backticked span of path characters, with a directory in it and a
-# suffix on the name. What the character class leaves out is what makes
-# the span a citation rather than something shaped like one:
-# `bitcoin/bitcoin#15437` is an issue, `api/tx/<txid>` an endpoint, and
-# `tests/tx/_data/*.bin` a set of files rather than one, so none of the
-# three is a path `git ls-files` could answer for
-_CITED_PATH = re.compile(r"`([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+\.[A-Za-z0-9]+)`")
-
-
-def _cited_paths(text: str) -> set[str]:
-    """Every path `text` cites in backticks."""
-    return {match.group(1) for match in _CITED_PATH.finditer(text)}
-
-
-def _tracked() -> set[str]:
-    """Every path this repository tracks."""
-    listed = subprocess.run(  # noqa: S603
-        [_GIT, "ls-files"],
-        cwd=_ROOT,
-        capture_output=True,
-        encoding="utf-8",
-        check=False,
-    )
-    return set(listed.stdout.splitlines())
-
-
-def _misresolved(cited: set[str], tracked: set[str]) -> list[str]:
-    """Return the cited paths naming a file `tracked` holds elsewhere.
-
-    Both halves of a path are read, and each answers one of the two ways
-    another project's path reads like one of ours. A vendored file keeps
-    the name upstream publishes it under, which the README's own *Naming*
-    section requires, so upstream's path for it carries our basename and
-    only the directory tells the two apart; and another project's tests
-    sit under `tests/` as ours do, so there only the name does.
-    """
-    names = {path.rsplit("/", 1)[-1] for path in tracked}
-    directories = {path.rsplit("/", 1)[0] for path in tracked if "/" in path}
-    return sorted(
-        path
-        for path in cited - tracked
-        if path.rsplit("/", 1)[-1] in names and path.rsplit("/", 1)[0] in directories
-    )
-
-
-def test_every_path_the_readme_cites_of_this_tree_is_one_this_tree_has() -> None:
-    """A citation is what a reader follows to check a verdict.
-
-    An entry that closes on a transcribed verdict states it by naming the
-    module holding the values, so a path resolving to nothing sends
-    whoever re-checks the pin looking for a file that is not there.
-    """
-    cited = _cited_paths(_README.read_text(encoding="utf-8"))
-    tracked = _tracked()
-    # what a sweep answering zero has to be held to: `git ls-files` gives
-    # an empty set where git is missing, and a pattern can stop matching
-    # without anything else here changing
-    assert _README.relative_to(_ROOT).as_posix() in tracked
-    assert cited & tracked
-    offenders = _misresolved(cited, tracked)
-    assert not offenders, (
-        "tests/_data/README.md cites a path this tree does not have, under"
-        f" a name and a directory it does have: {offenders!r}"
-    )
-
-
-def test_a_path_of_this_tree_is_told_from_a_path_of_upstream() -> None:
-    """The check above passes for free if it cannot tell the two apart.
-
-    One synthetic tracked set and four citations against it, which is
-    every arm the rule has: `tests/descriptors_test.py` is this tree's
-    own module at a path this tree does not have and is caught; the same
-    module at its own path is not; Core's `src/test/data/script_tests.json`
-    carries the name our vendored copy keeps and is left to the directory,
-    which this tree does not have; and electrum's `tests/test_mnemonic.py`
-    sits in a directory this tree does have and is left to the name.
-
-    The set holds a file directly under `tests/` because two of those
-    four turn on that directory being one this tree has: without it the
-    caught arm is excused for the wrong reason and the electrum arm
-    proves nothing, which is what the expectation naming the offender --
-    rather than an empty list -- is here to keep visible.
-    """
-    tracked = {
-        "tests/vendored_data_test.py",
-        "tests/descriptors/descriptors_test.py",
-        "tests/script_engine/_data/script_tests.json",
-    }
-    cited = _cited_paths(
-        "`tests/descriptors_test.py`, `tests/descriptors/descriptors_test.py`,"
-        " Core's `src/test/data/script_tests.json` and electrum's"
-        " `tests/test_mnemonic.py`."
-    )
-    assert _misresolved(cited, tracked) == ["tests/descriptors_test.py"]


### PR DESCRIPTION
The citation guard read one file. `tests/markdown_citations_test.py` reads
every tracked `*.md` instead: a backticked path this tree does not have,
whose file name it does have, under a directory it does have, is one of
this tree's own files cited where it is not, and a path another project
owns fails one half or the other.

Its own module rather than `tests/vendored_data_test.py`, which is
`tests/_data/README.md`'s and stays that, keeping the numeral guard and
giving up the `source-exclude` entry the `git ls-files` call earned it.
The new module takes that entry instead, `tests/build_system_test.py`
recognizing the shape -- a `subprocess` call whose argument list opens on
`_GIT` -- and requiring the exclusion, a tree stripped to its tracked
files having no index to ask. Leaving the narrow test where it was would
have put one rule in two places, the wider population containing the
README.

Both halves were re-measured over the wider population rather than
inherited from the one file they were written against, by running the
sweep with each dropped in turn. Without the directory half a path
written relative to `src/` or to `src/btclib/` is left to a file name
this tree does have, and `CLAUDE.md`, `CONTRIBUTING.md`, `RELEASE_NOTES.md`,
`REPOSITORY.md`, `TF2.md`, `tests/README.md`, `docs/source/package-content-policy.md`
and `CHANGELOG.md` all redden on citations that are correct. Without the
file name half another project's tests are left to `tests/`, and
`REVIEWING.md`, `docs/proposals/cli.md`, `tests/README.md`,
`tests/_data/README.md` and `CHANGELOG.md` redden the same way.

The shape both halves accept is a sibling repository's file whose name
and its directory this tree also has, and `REVIEWING.md` cites the
organization standard's `tests/verbatim_test.py` one file name short of
it. `_EXEMPT` keys such a path to what makes it somebody else's, the
shape `tests/vendored_data_test.py` already uses for a line it spares. A
released `CHANGELOG.md` section reaches it from the other side:
`changelog_immutability_test.py` holds one byte for byte against its own
tag, so a path renamed after an entry cited it cannot be corrected where
it is cited. The list is empty, and a control drives an entry through
`_misresolved` against the same citation unexempted, an exemption
suppressing everything answering the empty list too.

The sweep's zero was proved against a positive control before it was
believed: `tests/descriptors_test.py` planted into `CONTRIBUTING.md` and
into `tests/_data/README.md` in turn fails the test naming the file and
the path, and it answers empty with the tree as it stands. Two live
controls ride in the test -- `git ls-files` must answer with a path the
tree certainly has, and the cited set must intersect it -- and a
synthetic control puts one arm of the rule against each of its cases, on
a tracked set that holds a file directly under `tests/` and says so
before the sweep runs, two of those arms turning on that directory.

A citation broken across the eighty-column wrap is not read either, the
character class stopping at the newline, and the docstring states that
rather than claiming a fold. Folding was measured and does not close it:
the two foldings are complementary, joining the halves with nothing
seeing a wrapped path and also fusing `pytest` with `tests/ecc/dsa_test.py`
across the break `CHANGELOG.md` wraps that command at, and joining them
with a space seeing neither, a path having no space to be broken at. The
fused path costs no red today only because this tree has no
`pytesttests/ecc` directory, which is the directory half doing it by luck.
A test pins the limit so that a later fold is a decision about that trade
rather than a widening (issue #1969).

What the rule does not reach is a cited path naming a file this tree has
never had, its file name being what tells another project's path from
ours: `docs/proposals/cli.md`'s `src/btclib/keystore.py` is one, filed as
issue #1967 rather than fixed here. A file that states the convention its
own citations are written to can be held to more, which this does not
stand in for: `tests/tf2_ledger_test.py` resolves `TF2.md`'s paths
against `src/btclib/` as well as against the root.


closes #1963

Local review at fresh context, three rounds: CLEARED
`245fca18f598b99c1d411821ac8f66f7e5537862`. This tip is that tree
rebased onto `4585e467`, with the union seam repaired and one
cross-reference corrected — the reviewer's last non-blocking item, taken
because the rebase reopened the commit anyway.

The reviewer ran the instrument rather than the gates: the sweep answers
empty over every tracked `*.md`; a planted `tests/descriptors_test.py`
reddens three real files; and each half of the rule was re-derived by
dropping the other — the directory clause dropped reddens 8 files on
correct citations, the name clause dropped reddens 5. Neither clause is
decoration.

Two rounds found defects in prose written during the repair, both mine,
and both are why the third round exists. The `_EXEMPT` staleness guard
in the final commit is the reviewer's own construction: set arithmetic
rather than a loop, so an empty `_EXEMPT` leaves no unexecuted body
behind. It was controlled in both directions — a planted dead entry
fails naming the path, and a live entry stays excused while the sweep
stays quiet, which is what proves the `{}` passed to `_misresolved` is
load-bearing.

ISS 1969 is closed on the decision that this guard state its wrap blind
spot rather than fold it away, so this branch deliberately carries no
`closes #1969`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Enforce that tracked Markdown citations resolve to repository files or are explicitly recognized as belonging to another project.

New Features:
- Add a repository-wide guard that validates backticked paths cited by every tracked Markdown file against the repository’s tracked files.
- Support explicit exemptions for valid paths owned by sibling or vendored projects.

Bug Fixes:
- Detect stale or misresolved Markdown citations beyond the previously checked data README, preventing references from silently pointing to nonexistent files.
- Keep released changelog citations compatible with immutable historical entries through explicit exemption handling.

Enhancements:
- Move citation validation out of the vendored-data test and consolidate it in a dedicated Markdown citation test module.
- Add coverage for citation ownership, exemption staleness, reporting by citing file, live controls, and the deliberate line-wrap limitation.

Build:
- Update the source distribution exclusion to omit the new Git-dependent Markdown citation test module.

Documentation:
- Document the repository-wide citation rule, its ownership heuristics, exemptions, and line-wrap behavior in the changelog and test module.

Tests:
- Expand citation validation from a single README to all tracked Markdown files.
- Add synthetic controls proving both filename and directory matching clauses are necessary and that exemptions suppress only intended findings.