### PR TITLE
`docs/proposals/cli.md`'s wallet paragraph cites `btclib.wallet` (closes #1967)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3785,6 +3785,23 @@ name that library and the symbol each of them paraphrases (closes #1932).
   not share, the comb doubling between its offsets where a table per
   digit position has nothing to double.
 
+### `docs/proposals/cli.md`'s wallet paragraph cites `btclib.wallet`
+
+- **The paragraph on what a command line is not for cites
+  `btclib.wallet`** (closes #1967), rather than
+  `src/btclib/keystore.py`, a path this tree does not have. The
+  negatives beside it are the wallet package's rather than the
+  library's, and are the ones that package states for itself under
+  *What no wallet here does*, so the proposal repeats no list of its
+  own. The citation names a module and not a `path:line`, which a
+  document still under edit would drift away from.
+- **Two further claims in that document about a withdrawn name are
+  repointed**: `KeyStore.prv_key`, which the tree has only as Electrum's
+  `Old_KeyStore`, becomes `KeyWallet.prv_key`, and the persistence
+  decision the configuration paragraph invokes is `btclib.wallet`'s.
+  Both are present tense and sit outside the surface the document's
+  opening disclaims, so both are claims about the library as it stands.
+
 ## v2026.9.3
 
 ### Repository

--- a/docs/proposals/cli.md
+++ b/docs/proposals/cli.md
@@ -22,13 +22,14 @@ Three audiences, in the order they matter:
    cross-checks against Bitcoin Core's `bitcoin-cli` where both tools
    answer the same question.
 
-What it is not for is being a wallet. `src/btclib/keystore.py` already
-draws that line for the library — no utxo tracking, no balances, no persistence
-to disk, no encryption at rest — and the command line inherits it whole:
-a tool that cannot see the chain cannot spend, and one that writes no
-file cannot remember. Every command is a pure function of its arguments,
-the `fetch` group excepted, and that is the property that makes the whole
-surface testable in process.
+What it is not for is being a wallet. The library's wallets are
+`btclib.wallet`, and that package draws the line for itself under *What no
+wallet here does*: no utxos, no balances, no transaction building, no
+persistence to disk, no encryption at rest. The command line inherits that
+whole: a tool that cannot see the chain cannot spend, and one that writes
+no file cannot remember. Every command is a pure function of its
+arguments, the `fetch` group excepted, and that is the property that makes
+the whole surface testable in process.
 
 ## Electrum as the feature list, not as the shape
 
@@ -405,7 +406,7 @@ Each of the three is named in the help text of the parameter itself, not
 only in the manual page nobody opens. And a command never prints a
 private key it was not explicitly asked for: `keystore address-info`
 reports the derivation path, `keystore prv-key` is the separate request,
-exactly as `AddressInfo` and `KeyStore.prv_key` already split it.
+exactly as `AddressInfo` and `KeyWallet.prv_key` already split it.
 
 ## The framework
 
@@ -671,11 +672,10 @@ reason, never a predicate over what a module exports.
 The `Fetcher` implementations are option sets, not command trees:
 `--rpc-url` with a cookie file for `bitcoind`, `--rest-url` for a node
 started with `-rest`, `--esplora-url` defaulting to `BLOCKSTREAM_INFO`.
-No configuration file. That is the same
-decision `keystore` took for persistence and for the same reason — a
-config file is a format and a search path that outlive the release that
-chose them — and click's environment variables cover the case a file
-would have been for.
+No configuration file. That is the same decision `btclib.wallet` took for
+persistence and for the same reason — a config file is a format and a
+search path that outlive the release that chose them — and click's
+environment variables cover the case a file would have been for.
 
 ## What Electrum has and this will not
 


### PR DESCRIPTION
The paragraph on what a command line is not for cited
`src/btclib/keystore.py` for the line it says the command line inherits,
and this tree has no path of that name. The document's opening disclaims
its own surface as unimplemented, but this clause sits outside that: it
is a claim about the library as it stands, so a reader following it to
see where the wallet line is drawn arrives at nothing.

`btclib.wallet` is where it is drawn. Its `__init__.py` opens on "the
addresses one is holding, and what each was computed from", and the
package remembers what it has handed out and nothing else:

    git grep -in --perl-regexp '\b(balances?|utxos?|unspent)\b' \
        -- 'src/btclib/wallet/*'
    git grep -n --perl-regexp \
        '\b(open\s*\(|json|pickle|shelve|sqlite3|Path)\b' \
        -- 'src/btclib/wallet/*'
    git grep -in --perl-regexp '\b(encrypt|decrypt|password|passphrase)\b' \
        -- 'src/btclib/wallet/*'

The second and third find nothing, each pattern proved by running it
again over `src/btclib/*`, where all three answer. The first answers with
the package's own two statements of the line: `wallet.py`'s "What no
wallet here does" heading, which spells out no utxos, no balances, no
transaction building, no persistence to disk and no encryption at rest,
and `script_wallet.py`'s note that the utxo is among what a wallet does
not know. The package imports nothing that would persist on its behalf.

The negatives are the wallet package's rather than the library's, which
is the scope `wallet.py` states for itself: no wallet *here*.

The rename the citation went stale under reaches two more sentences of
the same document, and both are present tense outside the surface its
opening disclaims. `KeyStore.prv_key` is the split `AddressInfo` is
named beside; the tree has `KeyStore` only as Electrum's
`Old_KeyStore`, in `mnemonic/electrum.py`, and the half being named is
`KeyWallet.prv_key`. The configuration paragraph credits `keystore`
with the persistence decision it follows; that decision and its reason
are `btclib.wallet`'s, at `wallet.py:47-49`. The proposal's own
`keystore` command group is left alone: what a command is called is a
naming decision the document reserves, not a claim about this tree. The
paragraph points at that heading and takes its wording, rather than
keeping a list of its own beside it: two copies of one list drift, and a
proposal is the copy nothing gates.

The citation names a module and not a `path:line`. A `path:line` into a
document still under edit drifts, and no gate reads this file's
citations: the guard being widened in issue #1963 wants a cited path
whose file name the tree does have, which is what tells another
project's paths from ours, and no file here is named `keystore.py`.

closes #1967


closes #1967

Local review at fresh context, three rounds: CLEARED
`a9c06481c4ad650485e4e3583edf3f27b10e846a`; this tip is that tree
rebased onto `d254b1ab` with the union seam repaired, and the delta is
`CHANGELOG.md` alone.

Round one struck a clause claiming `btclib.fetch` is "where a node's
utxo set is read". It is not: `get_tx` is overridden by every backend
and `get_tx_out` by none, and the only two mentions of `/getutxos` and
`gettxout` in the tree are prose arguing against their use. The clause
was deleted rather than replaced — nothing checkable was lost.

The round also found a measurement three of us had run and none had
questioned: `\b(balance|utxo|unspent)\b` cannot match `balances` or
`utxos`, the trailing `\b` needing a non-word character where the `s`
stands. With plurals restored it finds `src/btclib/wallet/wallet.py:44`,
which is the package stating the line itself under *What no wallet here
does* — so the paragraph now points at that heading and takes its
wording rather than keeping a copy of the list one item short of it.

Two further claims about the withdrawn name were folded in on the same
ground: `KeyStore.prv_key`, which this tree has only as Electrum's
`Old_KeyStore`, and a persistence decision credited to `keystore`. The
reviewer found that `AddressInfo`'s own docstring writes
`KeyWallet.prv_key` verbatim, so the repair now quotes the tree's own
spelling.

The proposal's `keystore` **command group** is deliberately untouched.
The criterion is this issue's own: a present-tense claim about the
library as it stands is repointed, a name inside the surface the
document's opening disclaims is not. What a command is called is a
naming decision line 69's "the command path is the import path" turns
into real design work, and issue #357 owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Align the CLI proposal with the library's current wallet implementation and terminology.

Enhancements:
- Update the CLI proposal to accurately reference the current `btclib.wallet` package and its wallet boundaries.
- Correct stale key-management and persistence references to use the library's current terminology and ownership.

Documentation:
- Revise the CLI proposal's wallet, key-management, and configuration claims to reflect the current library structure.