### PR TITLE
Release v2026.9.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ documented at release-notes length in the first place, and are still in
 
 ## v2026.9 (work in progress, not released yet)
 
+## v2026.9.10
+
 ### Section 9's comment and placeholder rules land in this tree's own docs
 
 - **A trailing `#` comment inside a `shell` fence of `CLAUDE.md`,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,8 @@ full year, short month, short day (YYYY-M-D)
 
 ## v2026.9 (work in progress, not released yet)
 
+## v2026.9.10
+
 ### Breaking changes
 
 - **`ssa`'s sign-to-contract tags change** (closes #1680). They were

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ name = "btclib"
 # file. Not a literal in src/btclib/__init__.py for setuptools to import
 # and conf.py to repeat: two declarations are two things a release
 # workflow has to compare before trusting either
-version = "2026.9"
+version = "2026.9.10"
 description = "A library for 'bitcoin cryptography'"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "btclib"
-version = "2026.9"
+version = "2026.9.10"
 source = { editable = "." }
 dependencies = [
     { name = "bitcoin-core-rpc" },


### PR DESCRIPTION
Release **v2026.9.10**.

`pyproject.toml` is where the version is declared once; `uv version`
re-locks `uv.lock` with it, so `version-check`'s `uv lock --check` gate
is satisfied by the same step. The work-in-progress section of both
CHANGELOG.md and RELEASE_NOTES.md is retitled as the release it became,
with the empty placeholder left above it — the cycle is unchanged, so
nothing reopens.

## The breaking-changes list was checked against the API

```shell
uv run --with griffe griffe check btclib -s . -s src -a v2026.9.3
```

Twelve differences, and every one already has a bullet: `PrvKey` and
`Key` losing `BIP32KeyData`, `int_from_prv_key` removed,
`wif_from_prv_key`'s two defaults, `ConsensusParams` gaining
`bip30_unspendable` with the positional move that follows from it, and
`gen_keys` losing `prv_key` with its two moves and two defaults. None is
one of the shapes griffe reports for a change no caller can observe —
no PEP 604 respelling, no `__version__`, no constant moved into a lookup
table. Run three times over the cycle's last twenty-seven landings, with
identical output each time.

## Local gates on this commit

```
pytest                     EXIT=0
TOTAL   56608      0   9794      0  100.00%
Required test coverage of 100.0% reached. Total coverage: 100.00%
32424 passed, 48 skipped in 32.20s
pre-commit run --all-files EXIT=0   (0 "Failed" lines)
sphinx -n -W --no-default-groups --group docs  EXIT=0
grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'  EXIT=1, no output
```

Skips went 46 → 48, and the two are the expected ones:
`changelog_immutability_test.py` reporting `'v2026.9.10' is being
released and has no tag yet`. They unskip when the tag exists.

## Dependencies

Neither sibling floor points above what is published: PyPI serves
`btclib-secp256k1 0.8.0.6` and `bitcoin-core-rpc 2026.9.3`, and both are
the newest release. There is no `[tool.uv.sources]` section, so no
direct reference has to be written back over — the failure that would
otherwise surface only after the whole matrix had built and uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Release v2026.9.10 with updated package metadata, lockfile, and release documentation.

Enhancements:
- Advance the project version to v2026.9.10 and align the dependency lockfile.
- Publish the v2026.9.10 changelog and release notes while retaining the ongoing development placeholder.