### PR TITLE
`pyproject.toml` reopens the v2026.9 cycle, which has now shipped twice

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ name = "btclib"
 # file. Not a literal in src/btclib/__init__.py for setuptools to import
 # and conf.py to repeat: two declarations are two things a release
 # workflow has to compare before trusting either
-version = "2026.9.10"
+version = "2026.9"
 description = "A library for 'bitcoin cryptography'"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "btclib"
-version = "2026.9.10"
+version = "2026.9"
 source = { editable = "." }
 dependencies = [
     { name = "bitcoin-core-rpc" },


### PR DESCRIPTION
RELEASING.md's last step, after v2026.9.10 went out: set
`pyproject.toml`'s `version` to the number the two "work in progress"
sections already carry, so a checkout of `main` between releases reports
itself as work in progress rather than as a release it is not.

Both notes files carry `## v2026.9 (work in progress, not released
yet)`, and `2026.9` is what this sets.

Those two headings have stood since #1504, and the release pull request
left them where they were: v2026.9.10 shipped in the same cycle as
v2026.9.3, so the placeholder was already the right one and the release
only inserted `## v2026.9.10` beneath it. Nothing in the notes reopens —
what is left is the declaration, which the release did move.

**Not `2026.10`.** This cycle is the one where "the cycle just cut" and
"the month after the release" come apart, which is why RELEASING.md
states the rule as the first and calls the second a look-alike:
v2026.9.3 and v2026.9.10 both shipped in September, so taking the month
after would declare a cycle neither notes file has a section for, and
the next change to land would file its entry under a heading the
declared version disagrees with — issue #1458's shape, one file over.

It could not have been folded into the release pull request:
`version-check` reads `uv version --short` at tag time, so a
`pyproject.toml` already bumped would have offered it `2026.9` where the
tag said `2026.9.10`.

`uv version 2026.9` re-locks `uv.lock` itself, which carries the project
version too, so `uv lock --check` is clean with no separate step and the
diff is one line in each of two files.

## Gates

All four run at c5f1fd44, whose tree 32c4fa0b carries unchanged, in the worktree, exit codes read rather than
output filtered:

```text
pytest EXIT=0     TOTAL 56608 0 9794 0 100.00%   32426 passed, 46 skipped
precommit EXIT=0
sphinx EXIT=0
hrefgrep EXIT=1 (1 = pass)
```

The skip count moved from 48 to 46, and the pass count up by the same
two, which is the tag existing: both were
`tests/changelog_immutability_test.py` skipping with `'v2026.9.10' is
being released and has no tag yet`. They are real assertions again now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Reset the project version to 2026.9 after the v2026.9.10 release so main correctly identifies the next work-in-progress cycle.

Bug Fixes:
- Restore the post-release project version to the active v2026.9 work-in-progress cycle instead of leaving it at the shipped v2026.9.10 release.

Build:
- Update the lockfile to keep the project version synchronized with pyproject.toml.