### PR TITLE
`docs/proposals/cli.md` states no count, and its module list is current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,34 @@ documented at release-notes length in the first place, and are still in
 
 ## v2026.9 (work in progress, not released yet)
 
+### `docs/proposals/cli.md` states no count, and its module list is current
+
+- **The four figures that document stated are gone** (closes #1977),
+  and each sentence keeps the claim they sat in front of. The
+  `rootxprv`/`mxprv` argument was "at 53 occurrences of `rootxprv` and
+  51 of `mxprv` over library and tests"; over that same scope the tree
+  answers 43 and 16, so one of the two was wrong by roughly three
+  times. Those are occurrences of the whole word, which is
+  `git grep -oh --perl-regexp '\brootxprv\b' -- src tests | wc -l` and
+  its `mxprv` twin. Both halves of that command carry the figure:
+  `git grep -E` drops `\b` in silence and answers zero, and counting
+  matching lines rather than occurrences answers 113 and 61 instead.
+  What the sentence is actually about -- two names for one object, and
+  `mxprv` the one matching the `m/...` notation -- needs no arithmetic
+  in front of it. The `__all__` paragraph stated two more,
+  "the twenty-two at the top level" and "the fifty-nine below the
+  packages", and those are worse than drifted: the sentence is past
+  tense, describing the tree before any module declared an `__all__`,
+  so nothing re-derives them and nothing can.
+- **`descriptors` and `keystore` leave that paragraph's list of
+  top-level modules**, which named them to illustrate what "at the top
+  level" meant. `descriptors` is a package now, and there is no
+  `keystore` at all -- the package is `btclib.wallet`. The five that
+  remain, `b58`, `b32`, `network`, `amount` and `fee`, are each still a
+  `src/btclib/*.py`. They are dropped rather than repointed because the
+  sentence is about the tree the audit found: renaming a module inside a
+  past-tense description would make it false in the other direction.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/docs/proposals/cli.md
+++ b/docs/proposals/cli.md
@@ -271,15 +271,14 @@ bodies, and the three modules whose only finding is a rename are issues:
 \#335 `base58`, #336 `descriptors`, #337 `tx` with the psbt trio. #338 asks
 the question none of them can answer.
 
-The larger gap was that no module declared an `__all__` at all — the
-twenty-two at the top level, `b58`, `b32`, `descriptors`, `keystore`,
-`network`, `amount`, `fee` and the rest, and the fifty-nine below the
-packages. There "public" was a naming convention rather than a
-declaration, and a command line reading the library's own word for it
-would have been the first thing to depend on the difference. Issue #338
-asked which of the two the library meant, and the answer is a declaration
-everywhere: the contract above, with `btclib.__all__` the root a walker
-starts from.
+The larger gap was that no module declared an `__all__` at all — neither
+the ones at the top level, `b58`, `b32`, `network`, `amount`, `fee` and
+the rest, nor the ones below the packages. There "public" was a naming
+convention rather than a declaration, and a command line reading the
+library's own word for it would have been the first thing to depend on
+the difference. Issue #338 asked which of the two the library meant, and
+the answer is a declaration everywhere: the contract above, with
+`btclib.__all__` the root a walker starts from.
 
 ## Renamings worth making
 
@@ -309,10 +308,10 @@ the audit above.
    same stutter and the same remedy at the import site. `extract_tx`
    keeps its noun, which names what comes out rather than what goes in.
 1. **One name for the master extended key.** `bip32.rootxprv_from_seed`
-   against `mnemonic.*.mxprv_from_mnemonic`, at 53 occurrences of
-   `rootxprv` and 51 of `mxprv` over library and tests: two names for one
-   object, not a stray. `mxprv` is the one that matches the `m/...`
-   notation the derivation paths already use.
+   against `mnemonic.*.mxprv_from_mnemonic`, both spellings alive across
+   library and tests: two names for one object, not a stray. `mxprv` is
+   the one that matches the `m/...` notation the derivation paths already
+   use.
 1. **`mnemonic.dispatch` stops being a name.** The module says how it
    works rather than what it answers; its two functions belong in
    `mnemonic.__all__` beside the rest, and the module drops out of it.


### PR DESCRIPTION
`docs/proposals/cli.md` stated four counts. Section 9 of the
organization standard is that nothing states how many of anything a file
holds, and `CLAUDE.md` gives the reason: a count drifts, silently,
because nothing re-derives it.

closes #1977

## The occurrence counts

The item read "at 53 occurrences of `rootxprv` and 51 of `mxprv` over
library and tests". Over that same scope the tree answers 43 and 16:

```shell
git grep -oh --perl-regexp '\brootxprv\b' origin/main -- src tests | wc -l
git grep -oh --perl-regexp '\bmxprv\b'    origin/main -- src tests | wc -l
```

Tree-wide it is 56 and 22. Neither reading gives 53 and 51, and `mxprv`
is out by roughly three times on the scope the sentence itself names.
Both halves of that command carry the figure: `-oh` counts occurrences,
where counting matching lines answers 113 and 61 instead. The CHANGELOG
entry carries the command beside the numbers for that reason.

`--perl-regexp` rather than `-E` is load-bearing — `git grep -E` drops
`\b` silently and answers zero, which `CLAUDE.md` records — so both
controls were run: `\bzzzz\b` answers 0, and `\bdef\b` over `src`
answers 2264.

The claim under the number is untouched: two names for one object, and
`mxprv` the one matching the `m/...` notation.

## The `__all__` counts, and two names in that list

"the twenty-two at the top level" and "the fifty-nine below the
packages" are worse than drifted. That sentence is past tense — it
describes the tree before any module declared an `__all__` — so nothing
re-derives those figures and nothing can. A count describing a state the
tree has left is unfalsifiable by measurement and reads to a later
reader exactly like a claim about now.

`descriptors` and `keystore` leave the list, which named them to
illustrate what "at the top level" meant. `descriptors` is a package,
and `git ls-files 'src/btclib/keystore*'` answers nothing — the package
is `btclib.wallet`. The five that remain are each still a
`src/btclib/*.py`.

They are **dropped rather than repointed** on purpose. PR #1975
repointed three `keystore` references in this same file, and each was a
present-tense claim about the library as it stands; this one is inside a
past-tense description of what the audit found, where renaming a module
would make the sentence false in the other direction. In the tree the
audit read, `git ls-tree e7c88dc3 btclib/` shows `keystore.py` and
`descriptors.py` really were top-level modules — pre-`src`-layout — so
the original list was accurate and only the illustration has expired.

## One thing deliberately not done

The document still proposes a `keystore` **command** — `keystore
address-info`, `keystore prv-key`, and the row in the command table.
Renaming a proposed command is a design decision the proposal owns, not
a citation repair, so this pull request does not make it. It was filed
as ISS #1980 and closed *not planned*: the name belongs to the command
line being proposed, which does not exist yet, and asserts nothing false
about `btclib.wallet`.

## Gates

All four at 930ccbc3, rebased onto `03eac233`, in the worktree, exit
codes read rather than output filtered:

```text
pytest EXIT=0     TOTAL 56608 0 9794 0 100.00%   32426 passed, 46 skipped
precommit EXIT=0
sphinx EXIT=0
hrefgrep EXIT=1 (1 = pass)
```

Two earlier runs failed and are disclosed rather than dropped. The first
was `precommit EXIT=1` on `docs/proposals/cli.md:276:81
MD013/line-length [Expected: 80; Actual: 95]`, my rewrap having joined
two lines. The second was `pytest EXIT=1` on
`tests/declared_version_test.py::test_the_declared_version_is_not_another_commits_release`,
after PR #1978 landed underneath this branch: the base still declared
`2026.9.10` while `v2026.9.10` resolves to another commit, which is that
test doing exactly its job. The rebase onto `03eac233` is what answered
it, and `CHANGELOG.md`'s blob is byte-identical across it —
`merge-tree --write-tree` exited 0 both with the union driver and with
`-c merge.union.driver=false`, main having moved only `pyproject.toml`
and `uv.lock`.

The CHANGELOG seam was checked with a planted control rather than on the
detector's silence: deleting the blank line above the new `###` makes
`awk 'NR>1 && /^#{2,3} / && prev != "" {print NR": "$0} {prev=$0}'` print
that heading, and the file as committed prints nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Remove outdated counts and module references from the CLI proposal so its documentation remains accurate without relying on manually maintained figures.

Bug Fixes:
- Remove stale occurrence counts from the CLI proposal and update its module examples to reflect the current package layout.

Enhancements:
- Preserve the proposal's historical description while removing outdated top-level module names and unsupported numeric claims.

Documentation:
- Update the CLI proposal and changelog to document the removal of drift-prone counts and obsolete module references.