### PR TITLE
`ecc.rangeproof.sign` writes the general rangeproof (issue #1072)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,35 @@ documented at release-notes length in the first place, and are still in
 
 ## v2026.9 (work in progress, not released yet)
 
+### `ecc.rangeproof.sign` writes the rangeproof of a blinded value
+
+- **A Confidential Transactions rangeproof over a range, and not only
+  over a value stated in the clear** (issue #1072). `sign` takes a
+  blinding factor, a value and a nonce, and `min_value`, `exp` and
+  `min_bits` beside them; what comes back is the proof
+  `secp256k1_rangeproof_sign_impl` writes for those arguments, octet
+  for octet. `sign_public_value` is that walk at an exponent of -1.
+- **The header is what the format has room for, not what was asked
+  for.** `secp256k1_range_proveparams` lowers the exponent until the
+  proven range fits a uint64, lowers `min_bits` to the precision the
+  floor leaves, sets the mantissa to the wider of that precision and
+  the bits the rescaled value needs, and rewrites `min_value` to what
+  that value no longer reaches. A `min_value` at the ceiling of the
+  field codes no range at all and writes the exact-value proof; a
+  nonzero floor under a value past `2**63-1`, or a nonzero value over a
+  floor at or past it, is refused.
+- **Each stated ring commitment's sign bit is computed as quadratic
+  residuosity, not parity.** `secp256k1_rangeproof_serialize_point` writes
+  `!secp256k1_fe_is_square_var(&point->y)`, which the `02`/`03` SEC
+  prefix and BIP340's x-only convention disagree with on some points
+  and agree with on others, so the familiar reading writes a proof that
+  verifies nowhere and fails nothing locally.
+- **No message and no `extra_commit`.** A message rides in the buffer
+  the nonce chain is folded with and exists to be read back out, so it
+  belongs with the rewind that reads it; `extra_commit` binds a second
+  commitment nothing here has. Issue #1072 tracks both, and verifying a
+  proof with them.
+
 ### `docs/proposals/cli.md` states no count, and its module list is current
 
 - **The four figures that document stated are gone** (closes #1977),

--- a/src/btclib/ecc/borromean.py
+++ b/src/btclib/ecc/borromean.py
@@ -93,17 +93,18 @@ that remaining distance, filed and decided wanted.
 `RangeProof.parse` takes the flags, the exponent, the mantissa, the
 `min_value`, the sign bits and the ring commitments of such a header,
 and holds the `e0` and the `s` values inside the proof as a
-`BorromeanSig` of this module's. `sign_public_value` writes the proof
-whose ring structure is one ring of one key -- the value in the clear,
-so no digit decomposition and no ring commitment -- and it closes that
-ring on its own rather than through this module. The message format is
-what ``sign_`` answers: a rangeproof hashes the value commitment, the
-generator and the proof's own header, with no pubkey ring in the
-preimage. The ring convention above is still a reason, and beside it
-the challenge `sign_public_value` leaves unreduced and the zero `s` it
-refuses to write, both of which `ecc.rangeproof` states beside the code
-that carries them. Verifying a proof and rewinding one are still
-ahead of it.
+`BorromeanSig` of this module's, and `sign` writes one -- the digit
+decomposition, the ring commitments and the header included.
+
+It closes those rings on its own rather than through this module, and
+`ecc.rangeproof._borromean_sign` is where the differences are stated:
+the ring convention above, the forged `s` values taken from the proof's
+own nonce chain where ``sign_`` draws them, and, in
+`ecc.rangeproof._challenge`, a challenge at or past n abandoning the
+proof where this module reduces it. The message format is shared, a
+rangeproof hashing the value commitment, the generator and the proof's
+own header with no pubkey ring in the preimage. Verifying a proof and
+rewinding one are still ahead of it.
 
 The signing direction is issue #1072's to discharge:
 `zkp.rangeproof.sign` and `zkp.rangeproof.verify` are wrapped, and the
@@ -470,14 +471,14 @@ def sign_(
     preimage that does not reach `pubk_rings` leaves the ring free to be
     swapped for another one under the signature made over it.
 
-    A rangeproof is the caller that wants this, and is why the hash
-    cannot be built from the two arguments here: its preimage is the
-    value commitment, the generator and the proof's own header, with no
-    pubkey ring in it at all, and `ecc.rangeproof` rebuilds the rings
-    from that commitment instead. What this offers that caller is the
-    message format alone: the module docstring above measures what still
-    stands between a signature written here and one
-    `secp256k1_borromean_verify` takes.
+    A rangeproof is where a preimage of that shape comes from: it is
+    the value commitment, the generator and the proof's own header,
+    with no pubkey ring in it at all, and `ecc.rangeproof` rebuilds the
+    rings from that commitment instead. It closes its own rings rather
+    than calling this, for the reasons
+    `ecc.rangeproof._borromean_sign` gives; what stands between a
+    signature written here and one `secp256k1_borromean_verify` takes
+    is the module docstring above.
 
     `pubk_rings` is an argument here as it is in `sign`: the walk
     multiplies by those points, and a hash cannot give them back. So

--- a/src/btclib/ecc/rangeproof.py
+++ b/src/btclib/ecc/rangeproof.py
@@ -2,16 +2,19 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""The Confidential Transactions rangeproof, and the one shape btclib writes.
+"""The Confidential Transactions rangeproof, and what btclib writes of it.
 
 `RangeProof.parse` reads what secp256k1-zkp's `rangeproof` module
 writes -- `secp256k1_rangeproof_sign_impl`,
 `src/modules/rangeproof/rangeproof_impl.h` -- and `RangeProof.serialize`
 writes those octets back.
 
-`sign_public_value` writes one proof, and it is the one that proves no
-range: `exp` is -1, the value is stated in the clear, and the single
-ring holds the key the commitment itself gives. `RangeProof.pubk_rings`
+`sign` writes a proof for a blinded value: `_prove_params` chooses the
+header, the mantissa decides the rings and the value's digits which key
+of each one the prover opens, and `_borromean_sign` closes them.
+`sign_public_value` is that walk at an `exp` of -1, where
+the value is stated in the clear and the single ring holds the key the
+commitment itself gives. `RangeProof.pubk_rings`
 rebuilds, from a proof and the value commitment it was written against,
 the rings `secp256k1_borromean_verify_impl` is handed, and
 `RangeProof.sign_key_idx` says which key of each ring a value's own
@@ -60,12 +63,12 @@ and which `_rsizes` below computes the same way.
 the ring commitment's y is not a square. That is not the even/odd
 convention `curves.bytes_from_point`, BIP340 and the `02`/`03` SEC
 prefix carry, and the two disagree on the vectors
-`tests/ecc/rangeproof_test.py` reads. No ring commitment's bit is
-computed here -- a parse reads it and a serialize writes it back, so
-what a `RangeProof` holds is the octets' own answer -- while what
-`sign_public_value` hashes the value commitment and the generator under
-is `ecc.pedersen._bytes_from_point` at `_RANGEPROOF_TAG`, the codec a
-commitment's octets and a generator's are written with too. Resolving
+`tests/ecc/rangeproof_test.py` reads. `ecc.pedersen._bytes_from_point`
+at `_RANGEPROOF_TAG` is that codec, and every point entering a proof's
+hash goes through it: the value commitment, the generator, and each
+ring commitment `sign` states. A parse reads those bits back and a
+serialize writes them out, so what a `RangeProof` holds is the octets'
+own answer. Resolving
 an x back to a point is that convention read the other way, and
 `ecc.pedersen._point_from_x` is what does it: `secp256k1_ge_set_xquad`
 takes the y that is a square, and `secp256k1_rangeproof_verify_impl`
@@ -98,7 +101,13 @@ from hashlib import sha256
 from typing import NamedTuple
 
 from btclib.alias import INF, BinaryData, Integer, Octets, Point
-from btclib.curves import bytes_from_point, mult, scalar_from_prv_key, secp256k1
+from btclib.curves import (
+    bytes_from_point,
+    double_mult_var,
+    mult,
+    scalar_from_prv_key,
+    secp256k1,
+)
 from btclib.ecc.borromean import BorromeanSig, PubkeyRing, _hash
 from btclib.ecc.pedersen import (
     _RANGEPROOF_TAG,
@@ -117,7 +126,7 @@ from btclib.utils import (
     read_exactly,
 )
 
-__all__ = ["NonceChain", "RangeProof", "sign_public_value"]
+__all__ = ["NonceChain", "RangeProof", "sign", "sign_public_value"]
 
 # the flags octet, as secp256k1_rangeproof_getheader_impl reads it
 _RESERVED = 128
@@ -130,6 +139,12 @@ _EXP_MASK = 31
 _MAX_EXP = 18
 _MAX_MANTISSA = 64
 _UINT64_MAX = 2**64 - 1
+
+# the ceiling `secp256k1_range_proveparams` reads the value and the
+# min_value against, and it reads them against it twice: once to refuse
+# a range whose proven maximum would wrap, and once to decide that the
+# exponent is not worth keeping for a value this large
+_INT64_MAX = 2**63 - 1
 
 # what a min_value field occupies: zkp writes it at a fixed width rather
 # than behind a length, and reads it back the same way
@@ -228,11 +243,11 @@ def _assert_valid_header(exp: int, mantissa: int, min_value: int | None) -> None
 def _header_octets(exp: int, mantissa: int, min_value: int | None) -> bytes:
     """Return the flags octet and the fields its own bits say follow it.
 
-    A function of the header alone, because `sign_public_value` needs
-    these octets before it has a signature to put after them:
+    A function of the header alone, because `sign` needs these octets
+    before it has a signature to put after them:
     `secp256k1_rangeproof_sign_impl` writes the header first and then
-    hashes it, into the nonce chain's seed and into the message the ring
-    is signed over.
+    hashes it, into the nonce chain's seed and into the message the
+    rings are signed over.
     """
     flags = _HAS_NZ_RANGE | exp if mantissa else 0
     if min_value is not None:
@@ -243,6 +258,102 @@ def _header_octets(exp: int, mantissa: int, min_value: int | None) -> bytes:
     if min_value is not None:
         out += min_value.to_bytes(_MIN_VALUE_SIZE, byteorder="big")
     return out
+
+
+class _ProveParams(NamedTuple):
+    """What `secp256k1_range_proveparams` answers for a set of arguments.
+
+    `exp`, `mantissa` and `min_value` are the header the proof carries,
+    and none of the three need be what the caller asked for: the
+    exponent is lowered until the range fits a uint64, the mantissa is
+    raised to the precision asked for, and `min_value` is rewritten to
+    whatever the rescaled value leaves under it.
+
+    `v` is the value the mantissa's digits count, `scale` the `10**exp`
+    each of them weighs, `rsizes` how many keys each ring holds and
+    `sign_key_idx` the digit each ring proves.
+    """
+
+    v: int
+    rsizes: tuple[int, ...]
+    sign_key_idx: tuple[int, ...]
+    min_value: int
+    mantissa: int
+    scale: int
+    exp: int
+
+
+def _prove_params(value: int, min_value: int, exp: int, min_bits: int) -> _ProveParams:
+    """Return the header and the ring structure zkp writes for those arguments.
+
+    `secp256k1_range_proveparams`. What the caller asks for is a
+    request: an exponent buys range at the cost of precision, so it is
+    lowered wherever the range it asks for would not fit a uint64, and
+    `min_bits` buys precision inside whatever range is left, so it is
+    lowered to what the `min_value` already claims. The two limits meet
+    at the exponent, which is why one function answers all of it --
+    reading either from the arguments alone would be reading a request
+    rather than what the proof states.
+
+    A `min_value` at the ceiling of the field is where no range can be
+    coded at all, and the exponent is held at -1 there: what comes back
+    is the proof of an exact value, which is `sign_public_value`'s.
+
+    The refusal below has two arms and they are not symmetric: a
+    nonzero floor under a value past `2**63-1`, or a nonzero value over
+    a floor at or past it. So a value exactly at that ceiling is proven
+    where one a step above it is not, and zkp signs the same octets for
+    it. What both arms guard is zkp's own comment: either end of the
+    range that large leaves the other none, and the maximum the header
+    states would overflow the uint64 a verifier reads it as.
+    """
+    if min_value == _UINT64_MAX:
+        exp = -1
+    if exp < 0:
+        # the exact value, whose one ring holds the single key the
+        # commitment itself gives. zkp writes a zero exponent into its
+        # own out-parameter here and the header carries none, `rsizes[0]`
+        # being 1; -1 is what a `RangeProof` states for that header
+        return _ProveParams(0, (1,), (0,), value, 0, 1, -1)
+
+    if (min_value and value > _INT64_MAX) or (value and min_value >= _INT64_MAX):
+        err_msg = f"rangeproof range {min_value}..{value} does not fit 2**64"
+        raise BTClibValueError(err_msg)
+
+    # precision above what the floor leaves is precision about octets
+    # the header already states
+    max_bits = 64 - min_value.bit_length() if min_value else 64
+    min_bits = min(min_bits, max_bits)
+    # ten is not a power of two, so dividing by ten and writing the
+    # result in base two times ten widens the range the digits reach,
+    # past the 0..2**64 a verifier requires. Rather than work out how
+    # much of the exponent survives that, zkp drops it outright for a
+    # value in the top half of the field or a precision within a few
+    # bits of the whole of it
+    if min_bits > 61 or value > _INT64_MAX:
+        exp = 0
+
+    v = value - min_value
+    # the range the mantissa will have to cover, carried through the
+    # same divisions as the value: it is what says how many of the
+    # exponent's steps there is room for, and the loop ends at the
+    # first one there is not
+    v2 = _UINT64_MAX >> (64 - min_bits) if min_bits else 0
+    reached = 0
+    while reached < exp and v2 <= _UINT64_MAX // 10:
+        v //= 10
+        v2 *= 10
+        reached += 1
+    exp = reached
+
+    scale = 10**exp
+    # the divisions above are what the floor absorbs: whatever the
+    # rescaled value no longer reaches is stated in the clear
+    min_value = value - v * scale
+    mantissa = max(v.bit_length() or 1, min_bits)
+    rsizes = _rsizes(mantissa)
+    sign_key_idx = tuple((v >> 2 * i) & 3 for i in range(len(rsizes)))
+    return _ProveParams(v, rsizes, sign_key_idx, min_value, mantissa, scale, exp)
 
 
 def _pub_expand(
@@ -722,73 +833,209 @@ class RangeProof:
         )
 
 
-def sign_public_value(blind: Integer, value: int, nonce: Octets) -> RangeProof:
-    """Return the proof that states its value in the clear.
+def _challenge(m: bytes, r: bytes, i: int, j: int) -> int:
+    """Return the scalar `secp256k1_borromean_sign` hashes at that position.
 
-    `secp256k1_rangeproof_sign_impl` with an `exp` of -1, which
-    `secp256k1_range_proveparams` answers with one ring holding the
-    single key the commitment itself gives. So this proof asserts no
-    range: it says what the commitment commits to, and that whoever
-    wrote it knows the blinding factor. The mantissa, the digit
-    decomposition, `rangeproof_pub_expand` and the sign bits are all
-    absent from it, a proof carrying one ring commitment per ring but
-    the last and this one having a single ring.
+    `secp256k1_borromean_hash` over the ring's running point and the
+    message, read as a scalar the way `secp256k1_scalar_set_b32` reads
+    one: a digest at or past n raises the overflow flag and zkp
+    abandons the proof, where `ecc.borromean` reduces it and carries
+    on. Reducing here would write a proof
+    `secp256k1_borromean_verify_impl` refuses.
+    """
+    e = int_from_bits(_hash(m, r, i, j, sha256), secp256k1.nlen)
+    if not 0 < e < secp256k1.n:
+        raise BTClibRuntimeError("rangeproof challenge is not a scalar")
+    return e
 
-    A value of zero writes the flags octet and nothing after it; any
-    other writes `min_value` in the eight octets behind bit 5.
 
-    secp256k1 and sha256, which `parse` fixes for the reason it gives.
-    `blind` is a scalar, read through `curves.scalar_from_prv_key`;
-    `value` is what those eight octets carry; `nonce` is the 32 octets
-    `rangeproof_genrand` seeds its chain with.
+def _borromean_sign(
+    m: bytes,
+    pubk_rings: Sequence[PubkeyRing],
+    ks: Sequence[int],
+    secs: Sequence[int],
+    sign_key_idx: Sequence[int],
+    draws: Sequence[Sequence[int]],
+) -> BorromeanSig:
+    """Close every ring over that message, as `secp256k1_borromean_sign` does.
 
-    Deterministic in all three, so what comes back is the octets
-    `zkp.rangeproof.sign` answers for the same arguments -- which is
-    what `tests/ecc/rangeproof_test.py` asks of it, against a vendored
-    proof where the flagged extension is absent and against the library
-    where it is.
+    `ecc.borromean.sign_` is the same walk, differing where a
+    rangeproof cannot follow it. It draws every forged `s` from
+    `secrets`, where here they are `draws` -- what
+    `secp256k1_rangeproof_genrand` derived from the caller's nonce, so
+    that a proof is a function of its arguments and a recipient holding
+    the nonce reads the value back out. And it carries the real
+    signer's `s` as `k + e*q` against a ring walked at `-e`, where zkp
+    walks at `+e` and answers `k - e*sec`: `ecc.borromean`'s module
+    docstring has what one calling `P` where the other calls `-P`
+    costs. `_challenge` is a third such difference.
+
+    `ks[i]` is the nonce ring `i` is closed with, `secs[i]` the scalar
+    its commitment is written under, and `sign_key_idx[i]` the position
+    of the key those two open. The point at every other position is
+    forged from the draw already at it, which is why `draws` is the
+    signature this returns but for one scalar per ring.
+    """
+    s = [list(ring) for ring in draws]
+    e0_preimage = b""
+    for i, (ring, k, j_star) in enumerate(
+        zip(pubk_rings, ks, sign_key_idx, strict=True)
+    ):
+        r = bytes_from_point(mult(k, secp256k1.G, secp256k1), secp256k1)
+        for j in range(j_star + 1, len(ring)):
+            t = double_mult_var(
+                _challenge(m, r, i, j), ring[j], s[i][j], secp256k1.G, secp256k1
+            )
+            r = bytes_from_point(t, secp256k1)
+        e0_preimage += r
+    # the message closes the preimage the ring points opened, which is
+    # `ecc.borromean.sign_`'s order too
+    e0 = sha256(e0_preimage + m).digest()
+
+    for i, (ring, k, j_star) in enumerate(
+        zip(pubk_rings, ks, sign_key_idx, strict=True)
+    ):
+        e = _challenge(m, e0, i, 0)
+        for j in range(j_star):
+            t = double_mult_var(e, ring[j], s[i][j], secp256k1.G, secp256k1)
+            e = _challenge(m, bytes_from_point(t, secp256k1), i, j + 1)
+        s[i][j_star] = (k - e * secs[i]) % secp256k1.n
+        if s[i][j_star] == 0:
+            # a zero s is the one `BorromeanSig` holds and zkp does not
+            # write: `secp256k1_borromean_sign` returns zero on it, and
+            # `secp256k1_borromean_verify_impl` refuses one it is handed
+            raise BTClibRuntimeError("rangeproof signature value is zero")
+    return BorromeanSig(e0, s)
+
+
+def sign(
+    blind: Integer,
+    value: int,
+    nonce: Octets,
+    *,
+    min_value: int = 0,
+    exp: int = 0,
+    min_bits: int = 0,
+) -> RangeProof:
+    """Return the proof that a blinded value lies in a stated range.
+
+    `secp256k1_rangeproof_sign_impl`. The commitment the proof is
+    written against is `ecc.pedersen.commit` over `blind` and `value`,
+    the same point `secp256k1_pedersen_commit` answers, and the range
+    the header states is `_prove_params`' rather than the caller's:
+    `min_value`, `exp` and `min_bits` are what is asked for, and the
+    proof carries what the format has room for.
+
+    `value` and `min_value` are what a uint64 holds and `min_value` no
+    more than `value`, `nonce` the 32 octets `rangeproof_genrand` seeds
+    its chain with, `exp` in -1..18 and `min_bits` in 0..64 -- the
+    bounds `secp256k1_rangeproof_sign_impl` reads before it asks for a
+    header.
+
+    `blind` is a scalar, read through `curves.scalar_from_prv_key`,
+    which refuses at or past n as zkp does and refuses zero where zkp
+    signs one: a zero blinding factor leaves the last ring's own
+    commitment blinded by the chain's factor alone, and zkp turns that
+    down only where the sum vanishes, which is the single-ring proof.
+
+    Deterministic in every one of them, a rangeproof drawing nothing,
+    so what comes back over the arguments both accept is the octets
+    `zkp.rangeproof.sign` answers for those same arguments.
+
+    No message and no `extra_commit`. A message rides in the buffer
+    `_prep` builds, at the head of every ring but the last, and exists
+    to be read back out, so it belongs with the rewind that reads it;
+    `extra_commit` enters the challenge and nothing here has a second
+    commitment to bind. Issue #1072 is where both are tracked.
     """
     blind_int = scalar_from_prv_key(blind, secp256k1)
     if not 0 <= value <= _UINT64_MAX:
         raise BTClibValueError(f"rangeproof value not in 0..2**64-1: {value}")
+    if not 0 <= min_value <= value:
+        err_msg = f"rangeproof min value not in 0..{value}: {min_value}"
+        raise BTClibValueError(err_msg)
+    if not -1 <= exp <= _MAX_EXP:
+        raise BTClibValueError(f"rangeproof exponent not in -1..18: {exp}")
+    if not 0 <= min_bits <= _MAX_MANTISSA:
+        raise BTClibValueError(f"rangeproof min bits not in 0..64: {min_bits}")
     nonce_bytes = bytes_from_octets(nonce, _NONCE_SIZE)
 
-    # zkp sets bit 5 from the value, this path's `min_value` being the
-    # value itself: `min_value ? 32 : 0`, so zero carries no field
-    min_value = value or None
-    header = _header_octets(-1, 0, min_value)
+    params = _prove_params(value, min_value, exp, min_bits)
+    # zkp's `min_value ? 32 : 0`, over the rewritten floor: a range
+    # starting at zero carries no field
+    header = _header_octets(params.exp, params.mantissa, params.min_value or None)
+
+    genp = second_generator()
     points = _bytes_from_point(commit(blind_int, value), _RANGEPROOF_TAG)
-    points += _bytes_from_point(second_generator(), _RANGEPROOF_TAG)
+    points += _bytes_from_point(genp, _RANGEPROOF_TAG)
 
-    # the one draw a single ring takes. `rangeproof_genrand` draws
-    # nothing for the last ring's blinding factor -- that is minus the
-    # sum of the others, and there are no others, so `sec` is zero and
-    # the caller's `blind` is the whole of it -- and one block for the
-    # ring's one public key, which `sign_impl` then moves into the nonce
-    # the ring is closed with. `secp256k1_range_proveparams` answers an
-    # `exp` of -1 with a value of zero at digit zero, which is what
-    # leaves that ring with nothing of `_prep` written into it
-    seed = nonce_bytes + points + header
-    k = _genrand(seed, (1,), _prep((1,), 0, 0)).draws[0][0]
+    chain = _genrand(
+        nonce_bytes + points + header,
+        params.rsizes,
+        _prep(params.rsizes, params.v, params.sign_key_idx[-1]),
+    )
+    # the draw at the true digit is spent as that ring's nonce, so it is
+    # the one `s` per ring the signature overwrites rather than states
+    ks = [ring[j] for ring, j in zip(chain.draws, params.sign_key_idx, strict=True)]
+    secs = list(chain.blinding_factors)
+    # the chain answers the last ring's factor as minus the sum of the
+    # others, so adding the caller's own leaves the whole set summing to
+    # it -- which is what lets a verifier recover the ring commitment
+    # the proof does not state
+    secs[-1] = (secs[-1] + blind_int) % secp256k1.n
+    if secs[-1] == 0:
+        raise BTClibRuntimeError("rangeproof last ring blinding factor is zero")
 
-    m = sha256(points + header).digest()
-    r = bytes_from_point(mult(k, secp256k1.G, secp256k1), secp256k1)
-    e0 = sha256(r + m).digest()
-    # `secp256k1_borromean_sign` over one ring of one key: `e0` hashes
-    # the nonce point and then the message, and the challenge that
-    # closes the ring is `e0`'s own at ring 0, position 0, which
-    # `borromean._hash` is the preimage of. Not reduced modulo n the
-    # way `ecc.borromean` reduces it -- zkp refuses a challenge at or
-    # past n here, and a proof it would not have written is a proof its
-    # verifier does not take
-    e = int_from_bits(_hash(m, e0, 0, 0, sha256), secp256k1.nlen)
-    if not 0 < e < secp256k1.n:
-        raise BTClibRuntimeError("rangeproof challenge is not a scalar")
+    heads = []
+    for i, (sec, j) in enumerate(zip(secs, params.sign_key_idx, strict=True)):
+        # `secp256k1_pedersen_ecmult`: the ring's own blinding factor,
+        # and the digit it proves at the weight of its place
+        head = secp256k1.add_aff_var(
+            mult(sec, secp256k1.G, secp256k1),
+            mult(j * params.scale << 2 * i, genp, secp256k1),
+        )
+        if head == INF:
+            err_msg = "rangeproof ring commitment is the point at infinity"
+            raise BTClibRuntimeError(err_msg)
+        heads.append(head)
 
-    s = (k - e * blind_int) % secp256k1.n
-    if s == 0:
-        # a zero s is the one `BorromeanSig` holds and zkp does not
-        # write: `secp256k1_borromean_sign` returns zero on it, and
-        # `secp256k1_borromean_verify_impl` refuses one it is handed
-        raise BTClibRuntimeError("rangeproof signature value is zero")
-    return RangeProof(-1, 0, min_value, (), (), BorromeanSig(e0, [[s]]))
+    # every ring commitment but the last, which the verifier recovers
+    stated = [_bytes_from_point(head, _RANGEPROOF_TAG) for head in heads[:-1]]
+    m = sha256(points + header + b"".join(stated)).digest()
+    sig = _borromean_sign(
+        m,
+        _pub_expand(heads, params.exp, params.rsizes),
+        ks,
+        secs,
+        params.sign_key_idx,
+        chain.draws,
+    )
+    return RangeProof(
+        params.exp,
+        params.mantissa,
+        params.min_value or None,
+        [bool(octets[0]) for octets in stated],
+        [int.from_bytes(octets[1:], "big") for octets in stated],
+        sig,
+    )
+
+
+def sign_public_value(blind: Integer, value: int, nonce: Octets) -> RangeProof:
+    """Return the proof that states its value in the clear.
+
+    `sign` at an `exp` of -1, which `secp256k1_range_proveparams`
+    answers with one ring holding the single key the commitment itself
+    gives. So this proof asserts no range: it says what the commitment
+    commits to, and that whoever wrote it knows the blinding factor.
+    The mantissa, the digit decomposition, `rangeproof_pub_expand` and
+    the sign bits are all absent from it, a proof carrying one ring
+    commitment per ring but the last and this one having a single ring.
+
+    A value of zero writes the flags octet and nothing after it; any
+    other writes `min_value` in the eight octets behind bit 5, the
+    value being its own floor here.
+
+    A spelling of its own because `min_value`, `exp` and `min_bits`
+    name nothing this proof has: its header is fixed.
+    """
+    return sign(blind, value, nonce, exp=-1)

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -2688,15 +2688,16 @@ from the caller's -- so `sign` called again with an entry's `blind`,
 `nonce`, `value` and `sign arguments` answers that entry's `proof`,
 byte for byte. `test_the_vectors_are_what_zkp_signs_today` is that
 check, so the procedure is a test rather than a note here, and it runs
-wherever the extension does. The same determinism makes the entries
-signed at a negative `exp` an oracle for what btclib writes:
-`sign_public_value` builds those proofs from an entry's own `blind`,
-`value` and `nonce`, and
-`test_sign_public_value_writes_the_octets_zkp_signed` holds it to these
-octets wherever the suite runs, extension or not. Both shapes such a
-proof has are recorded, `public value` carrying a `min_value` field and
-`public value, zero` carrying none, so neither is left to the weekly
-sentinel.
+wherever the extension does. The same determinism makes the entries an
+oracle for what btclib writes: `ecc.rangeproof.sign` builds a proof
+from an entry's own `blind`, `value`, `nonce` and `sign arguments`, and
+`test_sign_writes_the_octets_zkp_signed` holds it to these octets
+wherever the suite runs, extension or not.
+`test_sign_public_value_writes_the_octets_zkp_signed` asks the same of
+the spelling that fixes the exponent for a value stated in the clear,
+and both shapes that proof has are recorded, `public value` carrying a
+`min_value` field and `public value, zero` carrying none, so neither is
+left to the weekly sentinel.
 
 **The `info` key is why a run without the extension still compares
 against something.** Those are `zkp.rangeproof.info`'s own answers for

--- a/tests/ecc/rangeproof_test.py
+++ b/tests/ecc/rangeproof_test.py
@@ -20,15 +20,22 @@ is silent about -- the sign bits, the ring commitments and the
 signature; and that the length the mantissa implies is the length zkp
 wrote.
 
-The entries whose `sign arguments` are an `exp` of -1 are asked one
-thing more, and it is the strongest question in this file:
-`sign_public_value`, given such an entry's own `blind`, `value` and
-`nonce`, has to answer its octets. A rangeproof draws nothing, so those
-three are the whole of what produced the recording, and an
+Every entry is asked one thing more, and it is the strongest question
+in this file: `sign`, given an entry's own `blind`, `value`, `nonce`
+and `sign arguments`, has to answer its octets. A rangeproof draws
+nothing, so those are the whole of what produced the recording, and an
 implementation that agrees with zkp at every step is the only one that
-lands on the same octets. Both shapes that proof has are recorded, the
-one carrying a `min_value` field and the one whose value is zero and
-carries none.
+lands on the same octets. The entries reach the shapes the header can
+take: a blinded range at an exponent the signer kept, one at an
+exponent it raised the mantissa for, an odd mantissa whose last ring
+holds two keys, a `min_value` field with sign bits padded above it, and
+both shapes of the proof that states its value in the clear.
+
+What the recording does not reach is the header a request does not
+get -- an exponent lowered, a `min_bits` clamped, a range refused --
+and those are put to `_prove_params` against numbers
+`secp256k1_range_proveparams` can be read for, with the `zkp`-marked
+tests at the end holding the same arguments to the library.
 
 Every entry is asked something further still, and this one needs no
 signature at all: `pubk_rings` and `sign_key_idx`, given the entry's own
@@ -50,7 +57,7 @@ chain a test writes.
 The `zkp`-marked tests at the end put the same questions to the library
 itself, and two more the recording cannot answer: that signing again
 with the recorded arguments answers the very octets vendored here, and
-that values no entry carries are written the same way.
+that values and headers no entry carries are written the same way.
 """
 
 from io import BytesIO
@@ -69,7 +76,7 @@ from btclib.ecc.pedersen import (
     commit,
     second_generator,
 )
-from btclib.ecc.rangeproof import RangeProof, sign_public_value
+from btclib.ecc.rangeproof import RangeProof, sign, sign_public_value
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from tests import load, needs_zkp, replace_unchecked, vector_id
 
@@ -98,11 +105,15 @@ def _octets(id_: str) -> bytes:
     return bytes.fromhex(_vector(id_)["proof"])
 
 
-# every entry `sign_public_value` can be asked for, and the arguments of
-# one of them, read out of the file rather than repeated as literals: an
-# entry whose `exp` is -1 is the shape this module writes, so the tests
-# below that build a proof instead of reading one ask with arguments the
-# recording names
+# every entry a writer here can be asked for, read out of the file
+# rather than repeated as literals, so the tests below that build a
+# proof instead of reading one ask with arguments the recording names.
+# `sign` takes an entry whose arguments are its own keyword ones, and
+# `sign_public_value` one whose `exp` of -1 is the whole of them
+_WRITABLE = [
+    v for v in _VECTORS if set(v["sign arguments"]) <= {"min_value", "exp", "min_bits"}
+]
+_WRITABLE_IDS = [vector_id(i, v["id"]) for i, v in enumerate(_WRITABLE)]
 _PUBLIC_VALUES = [v for v in _VECTORS if v["sign arguments"] == {"exp": -1}]
 _PUBLIC_VALUE_IDS = [vector_id(i, v["id"]) for i, v in enumerate(_PUBLIC_VALUES)]
 _BLIND = _vector("public value")["blind"]
@@ -178,10 +189,10 @@ def test_the_sign_bit_is_residuosity_and_not_parity() -> None:
     seen = set()
     for vector in _VECTORS:
         proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
-        for sign, x in zip(proof.signs, proof.ring_commitments, strict=True):
+        for sign_bit, x in zip(proof.signs, proof.ring_commitments, strict=True):
             y_residue = secp256k1.y_quadratic_residue_var(x)
-            y = secp256k1.p - y_residue if sign else y_residue
-            seen.add(bool(y & 1) == sign)
+            y = secp256k1.p - y_residue if sign_bit else y_residue
+            seen.add(bool(y & 1) == sign_bit)
     assert seen == {True, False}
 
 
@@ -476,9 +487,9 @@ def test_a_ring_commitment_x_resolves_against_residuosity() -> None:
     """
     for vector in _VECTORS:
         proof = RangeProof.parse(bytes.fromhex(vector["proof"]))
-        for x, sign in zip(proof.ring_commitments, proof.signs, strict=True):
-            point = _point_from_x(x, sign)
-            octets = bytes([sign]) + x.to_bytes(secp256k1.p_size, "big")
+        for x, sign_bit in zip(proof.ring_commitments, proof.signs, strict=True):
+            point = _point_from_x(x, sign_bit)
+            octets = bytes([sign_bit]) + x.to_bytes(secp256k1.p_size, "big")
             assert _bytes_from_point(point, _RANGEPROOF_TAG) == octets
 
 
@@ -791,6 +802,27 @@ def test_a_ring_blinding_factor_that_is_no_scalar_is_redrawn(
     assert chain.draws == ((1, 2), (3, 4))
 
 
+@pytest.mark.parametrize("vector", _WRITABLE, ids=_WRITABLE_IDS)
+def test_sign_writes_the_octets_zkp_signed(vector: dict[str, Any]) -> None:
+    """The recording asked of the writer, over every shape it holds.
+
+    An entry's `blind`, `value`, `nonce` and `sign arguments` are the
+    whole of what produced its proof, so writing them again here has to
+    answer those octets -- the header, the sign bits, the ring
+    commitments and the borromean signature alike.
+    `zkp.rangeproof.verify` accepting the result would say only that it
+    is *a* proof, where this says it is the same one.
+
+    Selected on the `sign arguments` being ones `sign` takes: an entry
+    recorded with a further argument -- an `extra_commit`, which enters
+    the challenge -- is not one it can be held to.
+    """
+    proof = sign(
+        vector["blind"], vector["value"], vector["nonce"], **vector["sign arguments"]
+    )
+    assert proof.serialize().hex() == vector["proof"]
+
+
 @pytest.mark.parametrize("vector", _PUBLIC_VALUES, ids=_PUBLIC_VALUE_IDS)
 def test_sign_public_value_writes_the_octets_zkp_signed(
     vector: dict[str, Any],
@@ -921,6 +953,195 @@ def test_a_zero_signature_value_is_refused(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(rangeproof, "_hash", lambda *_: e.to_bytes(32, "big"))
     with pytest.raises(BTClibRuntimeError, match="signature value is zero"):
         sign_public_value(_BLIND, 1, _NONCE)
+
+
+# what `secp256k1_range_proveparams` answers, argument by argument: each
+# row is `(value, min_value, exp, min_bits)` asked for, the
+# `(exp, mantissa, min_value, max_value)` written, and why the two
+# differ. The written column is what that function computes and not
+# what `_prove_params` answered for it, and the `zkp`-marked test at
+# the end asks the library for the same headers
+_Header = tuple[int, int, int, int]
+_HEADER_CASES: list[tuple[_Header, _Header, str]] = [
+    ((0, 0, 0, 0), (0, 1, 0, 1), "value zero"),
+    ((3, 0, 0, 2), (0, 2, 0, 3), "a single ring"),
+    ((5000, 0, 0, 13), (0, 13, 0, 8191), "odd mantissa"),
+    ((100000, 0, 0, 0), (0, 17, 0, 131071), "mantissa from the value"),
+    ((100000, 0, 5, 0), (5, 1, 0, 100000), "exponent takes the value"),
+    (
+        (100000, 0, 18, 20),
+        (13, 20, 100000, 10485750000000100000),
+        "exponent lowered",
+    ),
+    ((100000, 0, 3, 62), (0, 62, 0, 4611686018427387903), "min bits past 61"),
+    ((2**63, 0, 5, 0), (0, 64, 0, 2**64 - 1), "value past 2**63-1"),
+    ((2**40 + 7, 2**40, 0, 64), (0, 23, 2**40, 1099520016383), "min bits clamped"),
+    ((2**40, 2**40 - 1, 0, 0), (0, 1, 2**40 - 1, 2**40), "a range of one step"),
+    (
+        (2**64 - 1, 2**64 - 1, 0, 0),
+        (-1, 0, 2**64 - 1, 2**64 - 1),
+        "min value at the ceiling",
+    ),
+    ((2**64 - 1, 0, 0, 0), (0, 64, 0, 2**64 - 1), "the whole field"),
+]
+_HEADERS = [
+    pytest.param(arguments, header, id=why) for arguments, header, why in _HEADER_CASES
+]
+
+
+def _written(arguments: _Header) -> RangeProof:
+    value, min_value, exp, min_bits = arguments
+    return sign(_BLIND, value, _NONCE, min_value=min_value, exp=exp, min_bits=min_bits)
+
+
+@pytest.mark.parametrize("arguments, header", _HEADERS)
+def test_the_header_is_what_the_format_has_room_for(
+    arguments: _Header, header: _Header
+) -> None:
+    """What a caller asks for is a request, and the header is the answer.
+
+    `secp256k1_range_proveparams` lowers the exponent until the range
+    it would prove fits a uint64, lowers `min_bits` to the precision
+    the floor leaves, raises the mantissa to that precision where the
+    value needs fewer bits than it, and rewrites `min_value` to what
+    the rescaled value no longer reaches.
+    A `min_value` at the ceiling of the field is where no range can be
+    coded at all, and what comes back there is the proof of an exact
+    value.
+    """
+    proof = _written(arguments)
+    assert (proof.exp, proof.mantissa) == header[:2]
+    assert (proof.min_value or 0, proof.max_value) == header[2:]
+
+
+@pytest.mark.parametrize("arguments, header", _HEADERS)
+def test_a_proof_written_here_opens_at_its_own_blinding_factor(
+    arguments: _Header, header: _Header
+) -> None:
+    """The proof read back against the commitment it was written for.
+
+    Nothing outside the octets states the ring commitments, so what
+    says they are the ones the digits ask for is that the keys
+    `sign_key_idx` names across the rings sum to `blind * G` -- the
+    same question `tests/ecc/rangeproof_fixed_vectors_test.py` puts to
+    proofs zkp published, put here to proofs this module wrote. The
+    value has to lie in the range the header states for those digits to
+    exist at all, which is the first assertion below.
+    """
+    value = arguments[0]
+    proof = _written(arguments)
+    assert header[2] <= value <= proof.max_value
+
+    rings = proof.pubk_rings(commit(_BLIND, value))
+    stated = tuple(
+        _point_from_x(x, sign_bit)
+        for x, sign_bit in zip(proof.ring_commitments, proof.signs, strict=True)
+    )
+    assert tuple(ring[0] for ring in rings[: len(stated)]) == stated
+
+    total = None
+    for ring, j in zip(rings, proof.sign_key_idx(value), strict=True):
+        total = ring[j] if total is None else secp256k1.add_aff_var(total, ring[j])
+    assert total == mult(_BLIND, secp256k1.G, secp256k1)
+
+
+def test_sign_refuses_what_it_has_no_octets_for() -> None:
+    """Each argument against what the format and the curve allow.
+
+    The bounds on the exponent and on `min_bits` are the ones
+    `secp256k1_rangeproof_sign_impl` reads before it asks for a header
+    at all, and so is `min_value` above the value: a floor over the
+    thing it is a floor of proves nothing.
+    """
+    with pytest.raises(BTClibValueError, match="private key not in 1..n-1"):
+        sign(0, 1, _NONCE)
+
+    err_msg = "rangeproof value not in 0..2\\*\\*64-1: "
+    with pytest.raises(BTClibValueError, match=f"{err_msg}-1"):
+        sign(_BLIND, -1, _NONCE)
+    with pytest.raises(BTClibValueError, match=f"{err_msg}18446744073709551616"):
+        sign(_BLIND, 2**64, _NONCE)
+
+    with pytest.raises(BTClibValueError, match="min value not in 0..7: 8"):
+        sign(_BLIND, 7, _NONCE, min_value=8)
+    with pytest.raises(BTClibValueError, match="exponent not in -1..18: 19"):
+        sign(_BLIND, 7, _NONCE, exp=19)
+    with pytest.raises(BTClibValueError, match="exponent not in -1..18: -2"):
+        sign(_BLIND, 7, _NONCE, exp=-2)
+    with pytest.raises(BTClibValueError, match="min bits not in 0..64: 65"):
+        sign(_BLIND, 7, _NONCE, min_bits=65)
+
+    with pytest.raises(BTClibValueError, match="invalid size: 31 bytes instead of 32"):
+        sign(_BLIND, 1, _NONCE[:-2])
+
+
+@pytest.mark.parametrize(
+    "value, min_value",
+    [(2**63, 1), (2**63 - 1, 2**63 - 1)],
+    ids=["value past the sign bit", "min value at it"],
+)
+def test_a_range_leaving_its_other_end_no_room_is_refused(
+    value: int, min_value: int
+) -> None:
+    """`secp256k1_range_proveparams`' own refusal, and it has two arms.
+
+    The digits prove `value - min_value` and the header states the
+    floor, so the largest a proof can assert is the sum of the two, and
+    zkp answers zero rather than write a maximum that would wrap. The
+    arms are a nonzero floor under a value past `2**63-1` and a nonzero
+    value over a floor at or past it, which are not one rule: the
+    control below is a value exactly at that ceiling, which is proven,
+    where the same value a step higher is not.
+    """
+    with pytest.raises(BTClibValueError, match="does not fit 2\\*\\*64"):
+        sign(_BLIND, value, _NONCE, min_value=min_value)
+
+    proof = sign(_BLIND, 2**63 - 1, _NONCE, min_value=1)
+    assert (proof.exp, proof.mantissa, proof.min_value) == (0, 63, 1)
+
+
+def test_a_last_ring_blinding_factor_of_zero_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The caller's blinding factor cancelling the chain's own.
+
+    `secp256k1_rangeproof_sign_impl` adds the caller's to the last
+    ring's and returns zero on a sum of zero: that ring's commitment
+    would then be the digit alone, with nothing blinding it. The chain
+    answers the last factor as minus the sum of the others, so the sum
+    is zero exactly where the caller's blinding factor is that sum, and
+    a chain the test wrote is what puts it -- a nonce whose chain
+    reached it is a one-in-n accident and cannot be chosen.
+    """
+    chain = rangeproof.NonceChain((-int(_BLIND, 16) % secp256k1.n,), ((1, 2, 3, 4),))
+    monkeypatch.setattr(rangeproof, "_genrand", lambda *_: chain)
+    with pytest.raises(BTClibRuntimeError, match="last ring blinding factor is zero"):
+        sign(_BLIND, 3, _NONCE, min_bits=2)
+
+
+def test_a_ring_commitment_at_infinity_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`secp256k1_pedersen_ecmult` landing on infinity, which is no key.
+
+    A ring commitment is its blinding factor times G plus its digit at
+    the weight of its place, and the two cancel only for a blinding
+    factor that is the discrete logarithm of the digit's point. Nobody
+    has one for the generator this module uses -- `second_generator` is
+    derived precisely so that nobody does -- so the generator is put on
+    a known multiple of G here and the blinding factor read off it.
+    """
+    log_of_generator = 12345
+    monkeypatch.setattr(
+        rangeproof,
+        "second_generator",
+        lambda: mult(log_of_generator, secp256k1.G, secp256k1),
+    )
+    # the single ring of a mantissa of two, whose digit is the value
+    blind = -3 * log_of_generator % secp256k1.n
+    err_msg = "ring commitment is the point at infinity"
+    with pytest.raises(BTClibRuntimeError, match=err_msg):
+        sign(blind, 3, _NONCE, min_bits=2)
 
 
 # `pragma: no cover` on every `@needs_zkp` below, the marker being the
@@ -1089,3 +1310,39 @@ def test_the_nonce_chain_answers_proofs_zkp_signs_at_other_shapes() -> None:
         ):
             for j, (a, b) in enumerate(zip(drawn, written, strict=True)):
                 assert (a == b) == (j != sign_key_idx[i])
+
+
+@needs_zkp  # pragma: no cover -- no zkp.rangeproof to sign the same headers
+def test_zkp_signs_and_verifies_the_proofs_this_module_writes() -> None:
+    """The library asked for the octets `sign` answers, header by header.
+
+    The rows of `_HEADERS`, which are where a request and what the
+    format has room for come apart: an exponent lowered, a `min_bits`
+    clamped, a range that swallows the value into its floor. Each is
+    asked three things, and they are three different questions. `sign`
+    says zkp writes these very octets; `verify` says zkp reads them as
+    the range they state, and answers that range; and the same call
+    over a proof with one octet of the signature turned says it is not
+    reading them as a range whatever they are.
+    """
+    blind = bytes.fromhex(_BLIND)
+    nonce = bytes.fromhex(_NONCE)
+    for arguments, header, _ in _HEADER_CASES:
+        value, min_value, exp, min_bits = arguments
+        commitment = zkp_generator.pedersen_commit(blind, value)
+        octets = _written(arguments).serialize()
+        assert octets == zkp_rangeproof.sign(
+            commitment,
+            blind,
+            nonce,
+            value,
+            min_value=min_value,
+            exp=exp,
+            min_bits=min_bits,
+        )
+        assert zkp_rangeproof.info(octets) == header
+        assert zkp_rangeproof.verify(commitment, octets) == header[2:]
+
+        turned = bytearray(octets)
+        turned[-1] ^= 1
+        assert zkp_rangeproof.verify(commitment, bytes(turned)) is None

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -174,6 +174,7 @@ KEYWORD_ONLY: dict[str, list[str]] = {
     "btclib.ecc.rangeproof:RangeProof.parse": ["check_validity"],
     "btclib.ecc.rangeproof:RangeProof.pubk_rings": ["check_validity"],
     "btclib.ecc.rangeproof:RangeProof.serialize": ["check_validity"],
+    "btclib.ecc.rangeproof:sign": ["min_value", "exp", "min_bits"],
     "btclib.ecc.dsa:Sig.__init__": ["check_validity"],
     "btclib.ecc.dsa:Sig.parse": ["check_validity", "strict"],
     "btclib.ecc.dsa:Sig.serialize": ["check_validity"],


### PR DESCRIPTION
Stage 6b of [ISS 1072](https://github.com/btclib-org/btclib/issues/1072):
the general Confidential Transactions rangeproof **writer**. The module
wrote one proof before this, the degenerate one — `sign_public_value`
states its value in the clear and needs neither a digit decomposition
nor a ring commitment.

This advances #1072 rather than closing it. Stage 7 is the rewind, and
that is what closes it.

## What the schedule was, and why it is met

That issue's second blocking question was "How is it verified?", and its
own answer was that the check is running zkp's verifier against btclib's
output, which needs zkp vendored —
btclib-org/btclib-secp256k1#283 — with "**That dependency is the
schedule.**"

That vendoring has happened. `btclib_secp256k1.zkp.rangeproof` at
0.8.0.6 carries `sign`, `verify`, `rewind`, `info` and `max_size`, not
only `borromean_verify`, and the oracle is therefore bidirectional: zkp
signs what this tree must read, and reads what this tree signs. The
native extension is in no published wheel, so it takes the flagged build
`.github/workflows/zkp-oracle.yml` already performs
(`BTCLIB_LIBSECP256K1_ZKP=true`, `--no-binary-package btclib-secp256k1`),
which is where the `zkp`-marked tests here run.

## The evidence

**Byte equality against `zkp.rangeproof.sign`**, which is the only check
that settles this — a rangeproof has no published vector file, and a
wrong answer that looks right is easy across this many stages.

Two independent sweeps, the second written without sight of the first:

| sweep | cases | byte-equal | refused by both | mismatches | asymmetries |
| --- | --- | --- | --- | --- | --- |
| author | 3000 | 1290 | 1710 | **0** | **0** |
| review | 22176 | 14850 | 7326 | **0** | **0** |

"Asymmetries" is the column that matters beside the first: every refusal
falls on the same side in both implementations, differing only in which
check fires first.

The six recorded vectors in `tests/ecc/_data/zkp_rangeproof_vectors.json`
are re-signed through `sign` from each entry's own blinding factor,
value, nonce and arguments, so that test runs **unflagged** too and no
new vendored data was needed. `zkp_rangeproof_fixed_vectors.json`
records no nonce and so cannot be re-signed; the recording file is the
one that can.

Every byte-equal case also satisfies
`zkp_rangeproof.verify(commitment, octets) is not None`, and the
`zkp`-marked test carries a negative control: the last octet of the
signature turned, `verify` returns `None`.

## The parts

- **`_prove_params`** ports `secp256k1_range_proveparams` — the piece
  with no counterpart here, and where a request becomes a header. The
  exponent that comes out is the trip count of the divide-by-ten loop
  rather than the one asked for, `min_bits` is clamped to what the floor
  already claims, and `min_value` is rewritten to what the rescaled
  value no longer reaches.
- **`_borromean_sign`** closes rings as `secp256k1_borromean_sign` does,
  which `ecc.borromean.sign_` cannot be made to do: it walks at `-e`,
  answers `k + e*q`, and draws forged values from `secrets`, where this
  walks at `+e`, answers `k - e*sec`, and takes them from the nonce
  chain. Review checked both sources and agreed unification is not
  available.
- **`_challenge`** refuses a challenge at or past n where
  `ecc.borromean` reduces it, which is `secp256k1_scalar_set_b32`'s own
  behaviour. `ecc.borromean` itself is untouched: parsing both blobs and
  stripping docstrings, the ASTs are equal.
- **`sign_public_value` now delegates** to `sign(..., exp=-1)`. Review
  compared the two implementations over 49 argument triples including
  all six refusal paths: identical in octets, exception type and
  message.

Ring commitment parity is residuosity —
`!secp256k1_fe_is_square_var(y)` — and not the even/odd convention the
rest of this tree uses. Over thirty proofs at `min_bits=20` the sign
bits came out 286 set and 280 clear, and every one of those proofs is
inside the byte-equal set, so both values of the bit are checked against
zkp rather than assumed.

## Scope

No `message` and no `extra_commit`. A message rides in `_prep`'s buffer
to be read back out, so it belongs with the rewind that reads it;
`extra_commit` binds a second commitment nothing here calls.

## Review

One round, `CHANGES REQUESTED` then fixed. Both blocking findings were
prose contradicting the line beneath it, and neither was a defect in the
implementation.

The first is worth recording because of how it arose. The refusal
`(min_value && value > INT64_MAX) || (value && min_value >= INT64_MAX)`
is **asymmetric** — strict `>` on the value arm — so a value exactly at
`2**63-1` over a floor of 1 is proven, and zkp signs the same octets for
it. The brief this work started from stated the symmetric rule; the
implementation measured the C and got it right; and then the symmetric
rule was written into the prose anyway, in **four** places, one of them
`CHANGELOG.md`, which is append-only and would not have been correctable
after landing. Review named two, the author found the other two.

It is now something the suite holds rather than something a docstring
asserts:

```python
proof = sign(_BLIND, 2**63 - 1, _NONCE, min_value=1)
assert (proof.exp, proof.mantissa, proof.min_value) == (0, 63, 1)
```

so the next reader who "corrects" the code to the symmetric rule gets a
red test rather than a plausible diff.

The correction changed prose and added that control: the module's AST
with docstrings stripped is **identical** across it, while the raw
sources differ — so the sweeps and the equivalence check above still
describe the code as it stands.

## Gates

At `f7462203`, in the worktree, exit codes read rather than output
filtered:

```text
pytest      EXIT=0   32480 passed, 31 skipped   TOTAL 56747 0 9826 0 100.00%
precommit   EXIT=0
sphinx      EXIT=0
hrefgrep    EXIT=1 (1 = pass)
```

That worktree is a **flagged** build, so `zkp`-marked tests run there and
are skipped in ordinary CI — a 100% floor carried by a test CI skips is
not a floor. Re-measured with `-m 'not zkp'`: 100.00%, with a
`--collect-only` control proving the deselection was real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H

## Summary by Sourcery

Implement general Confidential Transactions rangeproof signing and validate its serialized output against secp256k1-zkp.

New Features:
- Add general Confidential Transactions rangeproof signing for blinded values with configurable minimum values, exponents, and precision.
- Retain public-value signing as a compatibility wrapper over the general signer.

Bug Fixes:
- Match secp256k1-zkp rangeproof output and validation behavior, including range header adjustments, quadratic-residuosity sign bits, challenge handling, and rejection of unsupported proofs.

Enhancements:
- Implement rangeproof parameter calculation, deterministic nonce-chain ring signing, and ring commitment construction for general proofs.
- Document the supported signing scope, including the current absence of message and extra-commit support.

Documentation:
- Document general rangeproof signing behavior and its compatibility with secp256k1-zkp.

Tests:
- Expand rangeproof coverage with recorded proof reproduction, header normalization, boundary validation, ring commitment checks, and zkp signing and verification parity tests.