### PR TITLE
The gate runs section 4's local hooks (issue btclib-org/.github#965, issue btclib-org/.github#706, issue btclib-org/.github#21, issue btclib-org/.github#843, issue btclib-org/.github#885, issue btclib-org/.github#883)

### DIFF
--- a/.github/scripts/check_changelog.py
+++ b/.github/scripts/check_changelog.py
@@ -1,0 +1,349 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Refuse an open `CHANGELOG.md` section a `merge=union` rebase can break.
+
+`.gitattributes` gives `CHANGELOG.md` `merge=union` so that two branches
+appending an entry at the same anchor do not conflict; btclib-org/.github#21
+prices what that costs and rules that the driver stays and a gate is
+added, and btclib-org/.github#760 is the second way the driver pays for
+it. This is that gate, run once over the file's own open section -- the
+first `## ` heading's, up to the line before the second, or to the end
+of the file where there is no second, section 9 of README.md giving the
+boundary the same way.
+
+Three checks, all of them shapes a `merge=union` rebase produces and a
+`git rebase` exit code does not report:
+
+- a `### ` heading repeated within the section -- measured against real
+  rebases under `merge=union`, not assumed from the driver's name. Two
+  branches each adding their *own* new heading, worded exactly alike,
+  at the section's one shared anchor is *not* this shape: union folds
+  the two into a single entry, one heading and both sides' bullets,
+  with nothing for this check to find -- which is not a fix landing
+  quietly, it is the shape the next check's own blind spot leans on.
+  A heading repeats instead where the matching text does not end up
+  adjacent once the merge is done -- one side's own further entry
+  landing between the two closes the gap that would otherwise let them
+  fold -- or where a single branch's new heading, no second branch or
+  merge required, repeats one already in the section at its own base.
+  `markdownlint-cli2` already refuses a same-level heading repeated
+  anywhere in the file as MD024, `.markdownlint.jsonc` leaving that
+  rule at its own default rather than the `siblings_only`
+  bitcoin-core-rpc's, btclib's and btclib-secp256k1's `CHANGELOG.md`
+  each set for their own, deliberate, per-release repeat; unlike MD022
+  below, MD024 is not autofixable, so a run this check would also catch
+  already fails on it. What this check adds is the line number scoped
+  to the open section and a message naming `merge=union` rather than
+  markdownlint's own generic one;
+- two entries in the section that each `(closes #N)` the same number --
+  btclib-org/btclib#1168 and btclib-org/btclib#1170 is the pair
+  btclib-org/.github#21 opens with, each entry closing the same defect
+  under a number of its own. Scoped to `closes` and not `issue`: an
+  issue this tree's own section 9 lets a branch advance without closing
+  is cited `(issue #N)` by design, and a long-lived issue this
+  repository never rotates out of its one open section is cited that
+  way by several unrelated entries over as many weeks -- measured
+  against this file's own history, which carries that repeat with
+  nothing wrong in it. Closing the same issue twice has no such reading:
+  `closes` names the entry that
+  answers an issue for good, and an issue answered twice is what the
+  driver produces when two branches each believe they are first. A
+  cross-repository citation, `(closes owner/repo#N)`, compares against
+  another written exactly the same rather than against the number
+  alone, since two different trackers numbering their own issues alike
+  name two different issues;
+- a `### ` heading with no blank line above it, which is the byte
+  `merge=union` eats at the seam where two sides' added lines abut
+  (btclib-org/.github#760). `markdownlint-cli2` already reports this as
+  MD022, but only as an autofix note -- "files were modified by this
+  hook" is what a developer's terminal shows, the same sentence it
+  prints for a stray trailing space, naming neither `merge=union` nor
+  the rebase that ate the line. This check is the one thing in the
+  gate that knows the difference and says so.
+
+**What this cannot see.** Two entries citing *different* issue numbers
+that are themselves duplicates of one another -- which is the actual
+shape of #1168/#1170, one of the pair having been filed against an
+issue the other already covered -- needs each number resolved and
+compared through the tracker's own state, `closingIssuesReferences` or
+an issue's `NOT_PLANNED` closure. That is one API call per citation, and
+a `pre-commit` hook that reaches the network is the wrong place to put
+one; btclib-org/.github#21's own ruling says so. Nor does this compare a
+section against its branch's own base to catch a misplacement or a
+revived, previously-refuted paragraph -- reconstruction against the
+base is a discipline for the rebase itself
+(CONTRIBUTING.md's *Committing and rebasing*), not a property of the
+file its tip leaves behind, which is all a `pre-commit` hook ever reads.
+Nor, for the reason the second check gives, does it see two entries that
+merely *advance* the same issue without either closing it -- a tree that
+never releases lives with that shape by design, and refusing it would
+refuse the very entries section 9's *A live claim* asks for.
+
+Three more gaps, none of them the network one above, and none named
+until this file's own review found them:
+
+- the fold the first check leaves alone -- two branches' own
+  identically-worded new headings, described above, united by the
+  driver into one entry -- is exactly what hides a real double-close
+  from the second check too. A citation repeated across one entry's own
+  bullets is not reported by design, and a folded entry reads the same
+  way: two different branches each closing the same issue under the one
+  heading their merge united is indistinguishable, to this script, from
+  one author citing an issue twice in one entry;
+- a section with no `### ` heading at all -- portanode's open section
+  is one, prose bullets straight under the release heading with nothing
+  this file's `_ENTRY_HEADING` matches -- leaves every check here
+  vacuous rather than failing: nothing to repeat, nothing to split into
+  entries, nothing to find a blank line above;
+- two bullets from different entries that a rebase's seam leaves
+  touching, with no blank line between them and no heading in sight.
+  Valid CommonMark reads them as one list either way, so neither
+  `markdownlint-cli2`'s MD022/MD032 nor this file's third check, both
+  keyed on a heading's own blank line, has a line to object to.
+
+A tree with no release carries one open section for the whole file, this
+repository's own `CHANGELOG.md` among them; a tree that releases keeps
+everything from the first `## ` heading to the line before the second as
+open, and does not ask this script about anything a release has already
+closed over.
+
+    python3 .github/scripts/check_changelog.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+_CHANGELOG = _ROOT / "CHANGELOG.md"
+
+_RELEASE_HEADING = re.compile(r"^## .*$", re.MULTILINE)
+_ENTRY_HEADING = re.compile(r"^### (?P<title>.*)$", re.MULTILINE)
+# a parenthetical naming an issue is not always spelled the same way
+# twice in one entry -- "closes #593, issue #571", "issues #327, #339
+# and #342" -- so this reads the whole group once either keyword is
+# found in it, and two more patterns read the keywords and the tokens
+# out of that group separately, a token taking whichever keyword sits
+# nearest before it rather than the group's first
+_CITATION_GROUP = re.compile(
+    r"\((?P<body>[^()]*?\b(?:closes?|issues?)\b[^()]*?)\)",
+    re.IGNORECASE | re.DOTALL,
+)
+_KEYWORD = re.compile(r"\b(closes?|issues?)\b", re.IGNORECASE)
+_CITATION_TOKEN = re.compile(r"(?:[\w.-]+/[\w.-]+)?#\d+")
+# a code span quotes a citation's own shape as an example of prose --
+# this file explains the standard's citation rules -- rather than citing
+# anything itself; stripped before either pattern above ever sees it.
+# Single backticks, not crossing a blank line: this house style's own
+# code spans do not
+_CODE_SPAN = re.compile(r"`[^`\n]*`")
+
+_BLANK_LINE = "\n\n"
+"""Two newlines: the empty line above a heading, read as a literal pair."""
+
+
+def open_section(text: str) -> tuple[str, int]:
+    """Return the file's open section, and the offset it starts at.
+
+    :param text: the whole file.
+    :returns: the text from the first `## ` heading's line to the line
+        before the second, or to the end where there is no second; and
+        the offset into `text` that text begins at.
+    """
+    headings = list(_RELEASE_HEADING.finditer(text))
+    if not headings:
+        return text, 0
+    start = headings[0].end()
+    end = headings[1].start() if len(headings) > 1 else len(text)
+    return text[start:end], start
+
+
+def line_at(text: str, offset: int) -> int:
+    """Return the 1-based line of `text` that `offset` falls on.
+
+    :param text: the whole file the offset is into.
+    :param offset: a character offset into `text`.
+    :returns: the line number.
+    """
+    return text.count("\n", 0, offset) + 1
+
+
+def closing_tokens(body: str) -> set[str]:
+    """Return every issue token a `closes`/`closed` citation names.
+
+    Scoped to that keyword and not to `issue`: section 9 of README.md
+    lets a branch advance an issue under `(issue #N)` without closing
+    it, so the same number recurs wherever a long-lived issue this
+    tree's own open section never rotates out of is answered across
+    several entries over as many weeks -- normal, by that section's own
+    *A live claim* rule, and not what this asks about. A token takes
+    whichever keyword sits nearest before it in its own parenthetical,
+    so `(closes #593, issue #571)` reads only the first as closed. A
+    code span is stripped first, so an entry quoting a citation's shape
+    as an example -- this file explains what one looks like -- is not
+    read as making one of its own.
+
+    :param body: the text to search -- an entry's heading and body both.
+    :returns: each closed token, as written: `#N` or `owner/repo#N`.
+    """
+    body = _CODE_SPAN.sub("", body)
+    tokens: set[str] = set()
+    for group in _CITATION_GROUP.finditer(body):
+        text = group.group("body")
+        keywords = list(_KEYWORD.finditer(text))
+        for token in _CITATION_TOKEN.finditer(text):
+            before = [k for k in keywords if k.start() < token.start()]
+            if before and before[-1].group(1).lower().startswith("close"):
+                tokens.add(token.group(0))
+    return tokens
+
+
+def entries(section: str) -> list[tuple[str | None, str, int]]:
+    """Split the open section into its entries.
+
+    A `### ` heading names one entry, section 9 of README.md's own rule,
+    so a heading and everything under it -- up to the next heading or
+    the section's end -- is one entry. Content above the first heading
+    is a tree whose convention has no `### `, or an open section that
+    has not taken its first entry yet; it is read as a single entry
+    with no title, there being nothing in a heading-less section to say
+    where one such entry ends and the next begins.
+
+    :param section: the open section's own text.
+    :returns: each entry's heading text (`None` where it has none), its
+        own span -- heading line included, where it has one -- and the
+        offset that span starts at within `section`.
+    """
+    headings = list(_ENTRY_HEADING.finditer(section))
+    out: list[tuple[str | None, str, int]] = []
+    preamble_end = headings[0].start() if headings else len(section)
+    preamble = section[:preamble_end]
+    if preamble.strip():
+        out.append((None, preamble, 0))
+    for index, heading in enumerate(headings):
+        end = headings[index + 1].start() if index + 1 < len(headings) else len(section)
+        out.append(
+            (
+                heading.group("title").strip(),
+                section[heading.start() : end],
+                heading.start(),
+            ),
+        )
+    return out
+
+
+def repeated_headings(text: str, section: str, base: int) -> list[str]:
+    """Report a `### ` heading that repeats one already seen.
+
+    :param text: the whole file, for the line numbers reported.
+    :param section: the open section's own text.
+    :param base: the offset `section` starts at within `text`.
+    :returns: one message per repeat.
+    """
+    seen: dict[str, int] = {}
+    problems = []
+    for heading in _ENTRY_HEADING.finditer(section):
+        title = heading.group("title").strip()
+        line = line_at(text, base + heading.start())
+        if title in seen:
+            problems.append(
+                f"line {line}: heading {title!r} repeats the heading at"
+                f" line {seen[title]}",
+            )
+        else:
+            seen[title] = line
+    return problems
+
+
+def duplicate_closes(text: str, section: str, base: int) -> list[str]:
+    """Report two entries of the open section closing the same issue.
+
+    A citation repeated across the bullets of *one* entry is not
+    reported: section 9 of README.md lets a list body make several
+    related claims about the issue its heading answers, each bullet
+    citing it again. What this asks is whether two different entries --
+    two different `### ` headings, or the one heading-less entry
+    against a headed one -- each `(closes #N)` the same issue, which
+    `merge=union` keeping both sides of an append is what produces.
+
+    :param text: the whole file, for the line numbers reported.
+    :param section: the open section's own text.
+    :param base: the offset `section` starts at within `text`.
+    :returns: one message per repeat.
+    """
+    first_seen: dict[str, tuple[str, int]] = {}
+    problems = []
+    for title, body, offset in entries(section):
+        line = line_at(text, base + offset)
+        label = f"heading {title!r}" if title is not None else "the heading-less entry"
+        for token in sorted(closing_tokens(body)):
+            if token in first_seen:
+                other_label, other_line = first_seen[token]
+                problems.append(
+                    f"line {line}: {label} closes {token}, already closed by"
+                    f" {other_label} at line {other_line}",
+                )
+            else:
+                first_seen[token] = (label, line)
+    return problems
+
+
+def unblanked_headings(text: str, section: str, base: int) -> list[str]:
+    """Report a `### ` heading with no blank line directly above it.
+
+    :param text: the whole file, for the line numbers reported.
+    :param section: the open section's own text.
+    :param base: the offset `section` starts at within `text`.
+    :returns: one message per heading found glued to the line above it.
+    """
+    problems = []
+    for heading in _ENTRY_HEADING.finditer(section):
+        pos = heading.start()
+        above = section[max(pos - len(_BLANK_LINE), 0) : pos]
+        if above != _BLANK_LINE:
+            line = line_at(text, base + pos)
+            title = heading.group("title").strip()
+            problems.append(
+                f"line {line}: heading {title!r} has no blank line above"
+                " it -- the seam a merge=union rebase eats",
+            )
+    return problems
+
+
+def problems(text: str) -> list[str]:
+    """Return every way the open section fails the three checks.
+
+    :param text: the whole file.
+    :returns: one message per finding, in the order the checks run.
+    """
+    section, base = open_section(text)
+    return [
+        *repeated_headings(text, section, base),
+        *duplicate_closes(text, section, base),
+        *unblanked_headings(text, section, base),
+    ]
+
+
+def main() -> int:
+    """Report every problem the open section of `CHANGELOG.md` has.
+
+    :returns: 1 where a problem was found, 0 where the section is clean.
+    """
+    found = problems(_CHANGELOG.read_text(encoding="utf-8"))
+    for problem in found:
+        print(f"{_CHANGELOG}: {problem}")
+    if not found:
+        print(
+            f"{_CHANGELOG}: the open section repeats no heading, no two"
+            " entries close the same issue, and no heading has lost its"
+            " blank line.",
+        )
+    return 1 if found else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -289,7 +289,13 @@ repos:
       - id: check-vcs-permalinks
       - id: detect-private-key
       - id: debug-statements
+      # `.github/scripts/check_changelog.py`'s `_BLANK_LINE` carries an
+      # attribute docstring, which this hook reads as a second module
+      # docstring (btclib-org/.github#995). Section 14 of the organization
+      # standard owes that file byte for byte, so the exclusion is the
+      # one place its finding can be answered
       - id: check-docstring-first
+        exclude: ^\.github/scripts/check_changelog\.py$
       # the hook's default, *_test.py, with neither args nor exclude.
       # What it is for is the one failure mode a test suite cannot report
       # on itself -- a file named so that pytest never collects it is not
@@ -416,6 +422,22 @@ repos:
         args: [--write-changes, --force-exclude]
         types: [text]
         stages: [pre-commit, pre-merge-commit, pre-push, manual]
+  # `merge=union` stays on `CHANGELOG.md` (btclib-org/.github#21), and
+  # this is the gate its price bought back -- `.github/scripts/
+  # check_changelog.py`'s own docstring carries what the three checks
+  # catch, what they still cannot, and the alternatives declined
+  # (btclib-org/.github#305, btclib-org/.github#516). It runs ahead of
+  # markdownlint-cli2 below on purpose: that hook's `--fix` repairs the
+  # very seam the third check exists to name, so a hook reading the
+  # file after it would find nothing left to report.
+  - repo: local
+    hooks:
+      - id: check-changelog
+        name: the open CHANGELOG.md repeats no heading, closes no issue twice
+        entry: python3 .github/scripts/check_changelog.py
+        language: system
+        pass_filenames: false
+        files: ^(CHANGELOG\.md|\.github/scripts/check_changelog\.py)$
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.23.2
     hooks:
@@ -532,6 +554,34 @@ repos:
         language: pygrep
         entry: "[A-Za-z0-9]-$"
         types: [markdown]
+      # a placeholder that is a whole argument, in quotes. Section 9 of
+      # the organization standard is the rule and what the quoting costs
+      # a paste; section 4 is where this hook is, which quotes it
+      # exempts, and the three things this pattern cannot see. The
+      # discrimination is read off the line and not off the fence around
+      # it, because a fence-aware pattern has to consume everything
+      # before the match and pygrep then reports the file's first line
+      # and prints the whole prefix. A shell assignment takes no space
+      # around its `=`, so a line carrying one is another language's
+      # value; and a quote inside a quote of the other kind is a nested
+      # program's -- both read off one line, which is also where the
+      # three blind spots come from. Same `\x20` as above, and the same
+      # reason.
+      # `CHANGELOG.md` and `RELEASE_NOTES.md` are out of reach because
+      # section 9 makes them append-only: a refused shape in an entry
+      # that has landed has no repair, and there would be no green state
+      # to reach. `exclude:` selects files and pygrep reads whole ones,
+      # so an exclusion keyed on the older entries alone cannot be
+      # written; and check-useless-excludes asks the pattern to match
+      # some file the hook selects rather than each name in it, which is
+      # what lets a tree with no release notes carry the same line
+      - id: unquoted-placeholder
+        name: a placeholder standing as a whole argument is unquoted
+        language: pygrep
+        entry: |-
+          ^(?![\x20\t]*[A-Za-z_][A-Za-z0-9_.-]*[\x20\t]+=[\x20\t])(?:(?:[^"'\n]|'[^'\n]*')*"<[^<>"'`\n]*>"|(?:[^"'\n]|"[^"\n]*")*'<[^<>"'`\n]*>')
+        types: [markdown]
+        exclude: ^(CHANGELOG|RELEASE_NOTES)\.md$
   # what ruff-format is for Python, on the structured files ruff does not
   # read: yaml, and the jsonc that carries a comment. Before yamllint below,
   # so the linter judges the formatted file and not the one that was typed.
@@ -600,7 +650,7 @@ repos:
   # formats values and leaves comments alone, by design, a formatter that
   # reflowed prose being a formatter that rewrites it.
   # `.{80}\S*[ \t]` reports a line only when whitespace is left past
-  # column 80: a comment whose overflow is one unbroken token is exempt.
+  # byte 80: a comment whose overflow is one unbroken token is exempt.
   # The `#` after optional indent selects a comment and not a long value:
   # `addopts` and `skip` in pyproject.toml are single tokens no width can
   # break, and a value is not prose.
@@ -611,7 +661,7 @@ repos:
   - repo: local
     hooks:
       - id: toml-comment-width
-        name: toml comment width (80 columns, unbreakable links exempt)
+        name: toml comment width (80 bytes, an unbroken final token exempt)
         language: pygrep
         entry: '^(?=[ \t]*#).{80}\S*[ \t]'
         files: \.toml$
@@ -757,6 +807,19 @@ repos:
         language: pygrep
         entry: '\b(text|universal_newlines)=True'
         files: \.py$
+      # section 8 of the organization standard's own acceptance command,
+      # run at the gate: a pragma with nothing after it on its line
+      # carries no reason, for no cover and no branch alike. The `#`
+      # immediately before pragma is what a comment always carries and a
+      # backticked reference to the rule in prose never does, section 8
+      # already saying prose drops it -- so this does not refuse a
+      # docstring quoting the rule, which a pygrep reading one line could
+      # not otherwise tell from a site
+      - id: reasonless-coverage-pragma
+        name: a coverage pragma with no inline reason is refused
+        language: pygrep
+        entry: '#\s*pragma: no (cover|branch)$'
+        types: [python]
   # not the mirrors-mypy hook: it injects --ignore-missing-imports, which
   # turns an unresolved (or misspelled) import into Any, the opposite of
   # strict, and it type checks in an isolated environment, where every

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -53,8 +53,7 @@ rules:
     #     -d '{rules: {line-length: {max: 80}}}'
     max: 100
     # allow-non-breakable-words stays at its default, true: a line that
-    # is one long token has nowhere to break, which is the exemption
-    # MD013 already makes for a bare URL
+    # is one long token has nowhere to break
   # the "---" every yaml file here opens with, one line each. What it buys
   # is that the files answer the question the same way instead of each
   # beginning however its author left it. On line 1, above the header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,50 @@ documented at release-notes length in the first place, and are still in
   sentence is about the tree the audit found: renaming a module inside a
   past-tense description would make it false in the other direction.
 
+### The gate runs section 4's local hooks
+
+- **`reasonless-coverage-pragma` refuses a `#`-comment `pragma: no cover`
+  or `pragma: no branch` with nothing after it on its line** (issue
+  btclib-org/.github#965): the hook's `entry:` and `types:` are
+  `btclib-org/.github`'s at `69a47e6`. Every `no cover` here carried its
+  reason inline already; every `no branch` carried it in the comment
+  above the line, which section 8 names as the rejected alternative the
+  port rewrites, so each of those takes the inline half naming the case
+  and keeps the comment above it.
+- **`unquoted-placeholder` refuses a placeholder standing as a whole
+  argument in quotes, in every markdown file but `CHANGELOG.md` and
+  `RELEASE_NOTES.md`** (issue btclib-org/.github#706): section 9 of the
+  organization standard keeps the rule and section 4 names the quotes
+  the pattern exempts and the three shapes it cannot see; the exclusion
+  is the standard's own, both files being append-only. The tree is green
+  under the hook at the run that adds it.
+- **`check-changelog` refuses a `###` heading repeated in this file's
+  open section, an issue `(closes #N)` by two entries, and a heading
+  with no blank line above it** (issue btclib-org/.github#21):
+  `.github/scripts/check_changelog.py` is `btclib-org/.github`'s at
+  `69a47e6` byte for byte, which section 14 owes every repository, and
+  the hook sits ahead of `markdownlint-cli2`, whose `--fix` repairs the
+  seam the third check names. `pyproject.toml` lets the script print as
+  it lets the scripts beside it: what it prints is its report. The
+  script's `_BLANK_LINE` carries an attribute docstring that
+  `check-docstring-first` reads as a second module docstring
+  (btclib-org/.github#995), so that hook's `exclude:` names the script,
+  the file being owed byte for byte rather than this tree's to edit.
+- **`toml-comment-width`'s `name:` states the pattern's own predicate,
+  an unbroken final token past byte 80** (issue btclib-org/.github#843,
+  issue btclib-org/.github#885): the width is bytes, pygrep matching the
+  pattern against the raw line, and the comment above the hook says
+  "byte 80" where it said "column 80"; the `entry:` is unchanged.
+  v2026.9.10's *`toml-comment-width`'s comment describes the pattern and
+  no other tool* left the `name:` to a decision every tree carrying the
+  hook takes together, and `btclib-org/.github` took it at `51f717e`.
+- **`.yamllint.yaml`'s `allow-non-breakable-words` comment states only
+  the setting's own predicate** (issue btclib-org/.github#883): the
+  clause comparing it to MD013's exemption for a bare URL goes rather
+  than being corrected, which is what btclib-org/.github#883 settled,
+  and the file matches `btclib-org/.github`'s at `69a47e6` byte for
+  byte, which is section 14's comparison.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1194,9 +1194,9 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 # flake8-no-pep420: each of these is a standalone entry point a workflow
-# step invokes with "python .github/scripts/<name>.py", never an import
-# -- the directory holds no __init__.py because it is not a package, and
-# adding one to satisfy this rule would make it look like one
+# step or a hook invokes by path, never an import -- the directory holds
+# no __init__.py because it is not a package, and adding one to satisfy
+# this rule would make it look like one
 ".github/scripts/*.py" = ["INP001"]
 # sphinx imports this one by its own convention, reading docs/source/
 # as a configuration directory rather than a package; the same reason
@@ -1252,6 +1252,11 @@ ignore = [
 # measuring, one line per disagreement found, and the all-clear or count
 # at the end are what a weekly run's log says happened
 ".github/scripts/check_py_arm_authority.py" = ["T201"]
+# and the changelog check, run by the check-changelog hook and read on
+# the terminal of whoever's commit it refused: one line per finding,
+# naming the line and the reason, or the all-clear, is the whole of
+# its report
+".github/scripts/check_changelog.py" = ["T201"]
 # the D rules are not here: a public test function, fixture or method
 # states what it verifies -- the property, the vector, the failure
 # mode -- under the same docstring gate as the library's public

--- a/src/btclib/block/merkle_proof.py
+++ b/src/btclib/block/merkle_proof.py
@@ -81,7 +81,7 @@ def _assert_inner_node_is_not_a_tx(inner_node: bytes) -> None:
     # its own. The comparison stays because that is a property of the
     # parser rather than of this module, and a parser that stopped
     # refusing that shape would need it here
-    if is_a_tx:  # pragma: no branch
+    if is_a_tx:  # pragma: no branch -- what parses round-trips
         err_msg = "inner node of the merkle branch is a valid transaction"
         raise BTClibValueError(err_msg)
 

--- a/src/btclib/number_theory.py
+++ b/src/btclib/number_theory.py
@@ -419,7 +419,7 @@ def tonelli_var(a: int, p: int) -> int:
         # bound is the loop's termination and not a fallback -- there is
         # no value of i to take past it -- which is why nothing follows
         # the loop but the `while` that reads the new t
-        for i in range(1, s):  # pragma: no branch
+        for i in range(1, s):  # pragma: no branch -- a non-residue is ruled out above
             t2i = t2i * t2i % p
             if t2i == 1:
                 # Update next value to iterate

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -746,7 +746,7 @@ def test_the_export_tree_is_walkable_to_its_leaves() -> None:
             # walked twice, and nothing here is -- which is what the
             # `no branch` says, the tree being one and the filter being
             # what would keep a future re-export from doubling the walk
-            if value.__name__ not in seen:  # pragma: no branch
+            if value.__name__ not in seen:  # pragma: no branch -- the tree is one
                 seen.add(value.__name__)
                 frontier.append(value)
     # the root, the nine packages, the nested one, and the modules they

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -407,7 +407,7 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     # one never takes the branch into it. The line itself runs either
     # way; what a flagged run leaves uncovered is the call, and the
     # function it calls (issue #1885)
-    if not ZKP_AVAILABLE:  # pragma: no branch
+    if not ZKP_AVAILABLE:  # pragma: no branch -- the build decides which way it goes
         _skip_what_needs_zkp(
             items
         )  # pragma: no cover -- a flagged build has nothing to skip

--- a/tests/mnemonic/mnemonic_test.py
+++ b/tests/mnemonic/mnemonic_test.py
@@ -325,7 +325,7 @@ def test_load_lang_is_not_a_race() -> None:
             # never false here. It is what keeps the block to the
             # assignment the race needs, another language or the empty
             # value of a failed load being neither
-            if key == "en" and value:  # pragma: no branch
+            if key == "en" and value:  # pragma: no branch -- one language is loaded
                 paused.set()
                 release.wait(10)
             super().__setitem__(key, value)

--- a/tests/psbt/psbt_view_test.py
+++ b/tests/psbt/psbt_view_test.py
@@ -112,7 +112,7 @@ def _read_everything(view: PsbtView) -> None:
     # `no branch` on the loop: every caller is an invalid vector inside
     # `pytest.raises`, so the walk is stopped by the refusal it is there
     # to provoke and never reaches the end of the outputs
-    for i in range(view.output_count):  # pragma: no branch
+    for i in range(view.output_count):  # pragma: no branch -- the refusal stops it
         view.output(i)
 
 

--- a/tests/psbt/silent_payments_test.py
+++ b/tests/psbt/silent_payments_test.py
@@ -140,7 +140,7 @@ def test_every_invalid_psbt_is_refused(vector: dict[str, Any]) -> None:
         # what the enclosing `raises` asserts, so the loop is never
         # exhausted -- the several entries are the checks that must all
         # be reached across the categories, not several to be run here
-        for check in checks:  # pragma: no branch
+        for check in checks:  # pragma: no branch -- the first check refuses
             check(psbt)
     with pytest.raises(BTClibValueError):
         role.assert_as_valid(psbt)

--- a/tests/slip132_test.py
+++ b/tests/slip132_test.py
@@ -162,7 +162,9 @@ def test_slip132_test_vectors() -> None:
         # `no branch`: the three versions above are the three the local
         # vector list holds, so the chain is exhaustive over it and the
         # last arm never falls through
-        elif version == NETWORKS["mainnet"].slip132_p2wpkh_prv:  # pragma: no branch
+        elif (
+            version == NETWORKS["mainnet"].slip132_p2wpkh_prv
+        ):  # pragma: no branch -- the chain is exhaustive over the vectors
             address = b32.p2wpkh(sec_from_xpub)
             assert addr == address
             address = b32.p2wpkh(sec_from_xprv)

--- a/tests/verify_dist_contents_test.py
+++ b/tests/verify_dist_contents_test.py
@@ -438,7 +438,7 @@ def _rules(text: str) -> list[tuple[set[str], set[str]]]:
         # other way out, and the markdown read here has none -- MD012
         # refuses two blank lines in a row, and the flush above is what
         # every list ends on
-        elif paragraph:  # pragma: no branch
+        elif paragraph:  # pragma: no branch -- MD012: no blank with nothing pending
             lead, paragraph = paragraph, []
     return rules
 


### PR DESCRIPTION
`tests/hooks_test.py`'s `LOCAL` in btclib-org/.github names five local
hooks every Python tree owes, and this tree carried two of them. The
three it lacked are added with their `entry:`, `types:` and `exclude:`
byte for byte from btclib-org/.github at 69a47e6, each block's comment
adapted where the original says "README.md" for what is here the
organization standard, and `check-changelog` placed ahead of
`markdownlint-cli2` for the reason its comment gives.
`.github/scripts/check_changelog.py` is the same commit's blob, byte for
byte, and `pyproject.toml` gives it the T201 per-file ignore the scripts
beside it have; the INP001 comment above them says a hook invokes one of
them now, where it said a workflow step invokes each. The script's
`_BLANK_LINE` constant carries a PEP 258 attribute docstring, which
`check-docstring-first` reports as a second module docstring
(btclib-org/.github#995), so that hook takes an `exclude:` naming the
script, the script not being this tree's to change.

`reasonless-coverage-pragma` over the tree named every `no branch` site
and no `no cover` one: each `no cover` carried its reason inline, and
each `no branch` carried it in the comment above the line, which
section 8 of the standard names as the rejected alternative the port
rewrites. Each of those lines takes the inline half naming the case and
keeps the comment above it.

`toml-comment-width` takes the `name:` btclib-org/.github settled at
51f717e, the pattern's own predicate in bytes, and its comment says
"byte 80" where it said "column 80"; the `entry:` is unchanged.
v2026.9.10's entry "`toml-comment-width`'s comment describes the pattern
and no other tool" had left the `name:` to that decision, and the new
entry says so.

`.yamllint.yaml` loses the clause comparing `allow-non-breakable-words`
to MD013's URL exemption, which is what btclib-org/.github#883 settled
by deletion, and the file matches btclib-org/.github's at 69a47e6 byte
for byte.

Measured at e71ec990 before the change: `grep -oE 'id: (toml-comment-
width|decoded-subprocess-encoding|reasonless-coverage-pragma|unquoted-
placeholder|check-changelog)' .pre-commit-config.yaml` answered the
first two only, and `git ls-tree origin/main .github/scripts/` listed no
`check_changelog.py`.

Advances btclib-org/.github#965, btclib-org/.github#706, btclib-org/.github#21, btclib-org/.github#843, btclib-org/.github#885 and btclib-org/.github#883; the check-docstring-first exclusion for the script is btclib-org/.github#995.

Local review: CLEARED at ca74f36349a6139d15b8842d573e2461da20a403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHHtejpqoCR1n2vPSsGjHC

## Summary by Sourcery

Bring the repository's local pre-commit gate into line with the organization standard and enforce safer changelog, markdown, coverage, and configuration conventions.

New Features:
- Add a changelog validation hook that detects duplicate entry headings, repeated closed issues, and missing blank lines in the open changelog section.
- Add local hooks for unquoted markdown placeholders and coverage pragmas without inline reasons.

Bug Fixes:
- Add reasons to all existing no-branch coverage pragmas so they satisfy the new validation hook.

Enhancements:
- Align local hook naming, exclusions, and YAML configuration with the organization-wide standards.
- Clarify the TOML comment-width hook description and remove the outdated yamllint comment comparison.

Build:
- Allow the changelog checker to emit terminal findings under Ruff's per-file rules.

Documentation:
- Document the new local hooks and their changelog validation behavior.