### PR TITLE
`ecc.rangeproof` verifies a proof and rewinds it (closes #1072)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,40 @@ documented at release-notes length in the first place, and are still in
   and the file matches `btclib-org/.github`'s at `69a47e6` byte for
   byte, which is section 14's comparison.
 
+### `ecc.rangeproof` verifies a proof and rewinds it
+
+- **A proof is checked against the commitment it was written for**
+  (closes #1072). `verify` answers whether it holds and
+  `assert_as_valid` raises the reason;
+  `RangeProof.pubk_rings` already rebuilt the rings
+  `secp256k1_borromean_verify_impl` is handed, and what is added is the
+  walk over them. The range proven stays the proof's own `min_value`
+  and `max_value`, which the header states and a parse reads, where
+  `zkp.rangeproof.verify` answers it from the octets for want of
+  anything else to answer from.
+- **`rewind` reads the value, the blinding factor and the message back
+  out of a proof.** `secp256k1_rangeproof_rewind_inner` is called from
+  inside `secp256k1_rangeproof_verify_impl` and consumes the per-key
+  challenges that walk produced, so verification retaining them is what
+  a rewind is built on rather than a second pass: whoever holds the
+  nonce re-derives the chain over a zeroed buffer, reads the value out
+  of the last ring, recovers the scalars the real signatures were
+  written under, and is refused where what comes back does not open the
+  commitment.
+- **`sign` embeds a message for that rewind to find.** It rides at the head
+  of the buffer the chain is folded with, one scalar per key at the stride
+  the chain indexes them by; the rings before the last are the whole of the
+  room, and a proof of one ring carries none. Where the header states a
+  range, a rewind answers every key of every ring, less the two the last
+  ring spends on the value encoding and on the key its own digit opens.
+  So what comes back is the message and then the zeros behind it, with
+  nothing in a proof saying where one ends.
+- **`extra_commit` and a generator of the caller's are still not taken**
+  (issue #1984, issue #1986). A proof written or read here binds the
+  commitment, the header and the stated ring commitments and nothing
+  outside itself, and it is written against `ecc.pedersen`'s own second
+  generator.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -671,6 +671,14 @@ UNKNWON_DEVICE_TYPE = "UNKNWON_DEVICE_TYPE"
 # `var_onion_option`, which names no feature of the BOLT and reads as a
 # transcription error to anybody checking the table against its source
 var_onion_optin = "var_onion_optin"
+# `secp256k1_borromean_verify_impl`'s own out-parameter, the challenges it
+# saves for a rewind (secp256k1-zkp,
+# src/modules/rangeproof/borromean_impl.h), which
+# src/btclib/ecc/rangeproof.py cites. The hook runs with --write-changes,
+# so without this line it becomes `evaluates`, a word naming nothing in
+# zkp -- a citation a reader would go and fail to find, which is the
+# reason the `ser`/`unser` entries below give
+evalues = "evalues"
 
 [tool.typos.default.extend-words]
 # "nd" is the Neutered Derivation of the bip32 docstrings, as for codespell

--- a/src/btclib/ecc/__init__.py
+++ b/src/btclib/ecc/__init__.py
@@ -6,13 +6,13 @@
 
 **The schemes.** btclib.ecc holds what is built *on* an elliptic curve:
 dsa, ssa, bms and borromean signatures, the MuSig2 aggregation of many
-ssa signers into one, pedersen commitments, the reader for the
-Confidential Transactions rangeproof built over one and the writer for
-the one shape of it that proves no range, the Diffie-Hellman
-key agreement, the BIE1 ECIES built on top of it, the ElligatorSwift encoding
-of a public key with the x-only ECDH on it, the BIP374 proof that two
-points share one discrete logarithm, and the RFC6979, BIP340 and
-sign-to-contract nonces. The curve arithmetic underneath is
+ssa signers into one, pedersen commitments, the Confidential
+Transactions rangeproof built over one and the rewind that reads a
+value, a blinding factor and a message back out of it, the
+Diffie-Hellman key agreement, the BIE1 ECIES built on top of it, the
+ElligatorSwift encoding of a public key with the x-only ECDH on it, the
+BIP374 proof that two points share one discrete logarithm, and the
+RFC6979, BIP340 and sign-to-contract nonces. The curve arithmetic underneath is
 btclib.curves, and the rule between the two is that direction: ecc
 imports curves, never the other way round. The key derivation functions
 the agreement uses are btclib.kdf: a KDF is a hash construction with no

--- a/src/btclib/ecc/borromean.py
+++ b/src/btclib/ecc/borromean.py
@@ -86,27 +86,33 @@ Transactions rangeproof: `rangeproof_impl.h` wraps this signature in a
 digit decomposition, a value commitment and an
 exponent/mantissa/min-value/sign-bits header this module has no
 counterpart for, rebuilding its pubkey rings from that commitment
-where this module takes them as an explicit argument. Issue #1072 is
-that remaining distance, filed and decided wanted.
+where this module takes them as an explicit argument.
 
-`ecc.rangeproof` is where that distance is being closed.
-`RangeProof.parse` takes the flags, the exponent, the mantissa, the
-`min_value`, the sign bits and the ring commitments of such a header,
-and holds the `e0` and the `s` values inside the proof as a
-`BorromeanSig` of this module's, and `sign` writes one -- the digit
-decomposition, the ring commitments and the header included.
+`ecc.rangeproof` is that wrapping. `RangeProof.parse` takes the flags,
+the exponent, the mantissa, the `min_value`, the sign bits and the ring
+commitments of such a header, and holds the `e0` and the `s` values
+inside the proof as a `BorromeanSig` of this module's, and `sign` writes
+one -- the digit decomposition, the ring commitments and the header
+included.
 
 It closes those rings on its own rather than through this module, and
 `ecc.rangeproof._borromean_sign` is where the differences are stated:
 the ring convention above, the forged `s` values taken from the proof's
 own nonce chain where ``sign_`` draws them, and, in
 `ecc.rangeproof._challenge`, a challenge at or past n abandoning the
-proof where this module reduces it. The message format is shared, a
-rangeproof hashing the value commitment, the generator and the proof's
-own header with no pubkey ring in the preimage. Verifying a proof and
-rewinding one are still ahead of it.
+proof where this module reduces it. What the rings are signed over is
+a rangeproof's own: the value commitment, the generator, the proof's
+header and the ring commitments it states, with no pubkey ring in the
+preimage, where `_get_msg_format` below hashes the caller's rings into
+the caller's message.
 
-The signing direction is issue #1072's to discharge:
+`ecc.rangeproof`'s own `_borromean_verify` is the verifying walk.
+Separating it from `assert_as_valid` below are the ring convention, the
+challenge at or past n, that preimage, and the challenges themselves: a
+rangeproof rewind consumes the per-key challenges the walk produces,
+where `verify` below answers a bool. Its own docstring has the refusals
+it makes before the walk goes on from a key.
+
 `zkp.rangeproof.sign` and `zkp.rangeproof.verify` are wrapped, and the
 proof they write and read carries this signature inside it --
 `secp256k1_rangeproof_sign_impl` and

--- a/src/btclib/ecc/rangeproof.py
+++ b/src/btclib/ecc/rangeproof.py
@@ -20,9 +20,26 @@ the rings `secp256k1_borromean_verify_impl` is handed, and
 `RangeProof.sign_key_idx` says which key of each ring a value's own
 digit names. `RangeProof.nonce_chain` derives what
 `secp256k1_rangeproof_genrand` draws for those rings: each ring's
-blinding factor, and the scalar behind each of its keys. Nothing here
-verifies a proof or rewinds one. Issue #1072
-is where the rest of that distance is tracked.
+blinding factor, and the scalar behind each of its keys.
+
+`verify` answers whether a proof holds for a commitment, and
+`assert_as_valid` is the same question raising its reason; the range
+proven is the proof's own `min_value` and `max_value`, which the header
+states and a parse reads. `rewind` is what a recipient holding the
+nonce calls: it answers the blinding factor, the value and the message
+`sign` embedded. Those two are one piece and not two --
+`secp256k1_rangeproof_verify_impl` calls
+`secp256k1_rangeproof_rewind_inner` from inside itself and hands it the
+per-key challenges its own borromean walk produced, commented there as
+used during a rewind alone -- so `_verify_rings` answers the challenges
+where `verify` answers a bool.
+
+Two arguments of zkp's own `sign`, `verify` and `rewind` are absent
+here. `extra_commit`, which binds octets of a caller's outside the
+proof into the challenge, is issue #1984; `gen_bytes`, which names the
+generator the commitment was made under, is issue #1986 -- every call
+below reaches for `second_generator()`, and `ecc.pedersen.commit` takes
+no generator to pass one through either.
 
 Elements and Liquid use this format, and a design starting today would
 choose bulletproofs, which zkp carries as its `bppp` module.
@@ -126,7 +143,16 @@ from btclib.utils import (
     read_exactly,
 )
 
-__all__ = ["NonceChain", "RangeProof", "sign", "sign_public_value"]
+__all__ = [
+    "NonceChain",
+    "RangeProof",
+    "Rewound",
+    "assert_as_valid",
+    "rewind",
+    "sign",
+    "sign_public_value",
+    "verify",
+]
 
 # the flags octet, as secp256k1_rangeproof_getheader_impl reads it
 _RESERVED = 128
@@ -258,6 +284,26 @@ def _header_octets(exp: int, mantissa: int, min_value: int | None) -> bytes:
     if min_value is not None:
         out += min_value.to_bytes(_MIN_VALUE_SIZE, byteorder="big")
     return out
+
+
+def _hashed_prefix(
+    commitment: Point, exp: int, mantissa: int, min_value: int | None
+) -> bytes:
+    """Return the octets a proof's message and its nonce chain open with.
+
+    `secp256k1_rangeproof_sign_impl` writes the value commitment, the
+    generator and the header into the `sha256_m` the rings are signed
+    over, and hands the same three to `secp256k1_rangeproof_genrand`,
+    which seeds its chain with the caller's nonce and then with them.
+    One function because `sign`, `RangeProof.nonce_chain`, `_ring_message`
+    and `rewind` each need exactly these octets, and a proof and the
+    chain behind it are bound to the same three.
+    """
+    return (
+        _bytes_from_point(commitment, _RANGEPROOF_TAG)
+        + _bytes_from_point(second_generator(), _RANGEPROOF_TAG)
+        + _header_octets(exp, mantissa, min_value)
+    )
 
 
 class _ProveParams(NamedTuple):
@@ -423,17 +469,30 @@ def _blocks(seed: bytes) -> Iterator[bytes]:
         yield drbg.generate(secp256k1.n_size)
 
 
-def _prep(rsizes: Sequence[int], v: int, sign_key_idx: int) -> bytes:
+def _message_room(rsizes: Sequence[int]) -> int:
+    """Return how many octets of message those rings carry.
+
+    `secp256k1_rangeproof_sign_impl`'s own bound. A message rides in
+    the draws, one scalar per key at the stride
+    `secp256k1_rangeproof_genrand` indexes them by, and the last ring
+    is where the value encoding sits and where a rewind recovers the
+    blinding factor -- so what is left is every ring before it, and a
+    proof of one ring carries no message at all.
+    """
+    return _RING_STRIDE * secp256k1.n_size * (len(rsizes) - 1)
+
+
+def _prep(rsizes: Sequence[int], v: int, sign_key_idx: int, message: bytes) -> bytes:
     """Return the octets `secp256k1_rangeproof_sign_impl` folds into the draws.
 
-    zkp's `prep`, which is where a message a proof embeds would sit.
-    Nothing here embeds one, so the buffer is zero but for one key of
-    the last ring, and that key is written whether there is a message
-    or not: an octet of 128, seven of zero, and the value the mantissa
-    carries big-endian three times, at the eight octets a `min_value`
-    field occupies and for the same reason, both being a uint64. That
-    is what makes the value readable from the proof by whoever holds
-    the nonce, which is `secp256k1_rangeproof_rewind_inner`.
+    zkp's `prep`: the message at the head of the buffer, and the value
+    encoding at one key of the last ring, which is written whether
+    there is a message or not -- an octet of 128, seven of zero, and
+    the value the mantissa carries big-endian three times, at the eight
+    octets a `min_value` field occupies and for the same reason, both
+    being a uint64. That is what makes the value readable from the
+    proof by whoever holds the nonce, which is
+    `secp256k1_rangeproof_rewind_inner`.
 
     A last ring of one key has no such position, and the public-value
     proof is the one shaped that way -- it states its value in the
@@ -441,8 +500,16 @@ def _prep(rsizes: Sequence[int], v: int, sign_key_idx: int) -> bytes:
     before it where the value's own digit is that one, since the draw
     at the digit's key is spent as a nonce rather than written into
     the proof.
+
+    The two never share a key: `_message_room` ends where the last ring
+    begins, so the value encoding is written over no message octet.
     """
+    room = _message_room(rsizes)
+    if len(message) > room:
+        err_msg = f"rangeproof message is longer than the {room} octets its rings hold"
+        raise BTClibValueError(err_msg)
     prep = bytearray(_RING_STRIDE * secp256k1.n_size * len(rsizes))
+    prep[: len(message)] = message
     if rsizes[-1] > 1:
         j = rsizes[-1] - 1 - (sign_key_idx == rsizes[-1] - 1)
         offset = ((len(rsizes) - 1) * _RING_STRIDE + j) * secp256k1.n_size
@@ -657,6 +724,7 @@ class RangeProof:
         commitment: Point,
         value: int,
         nonce: Octets,
+        message: Octets = b"",
         *,
         check_validity: bool = True,
     ) -> NonceChain:
@@ -686,18 +754,22 @@ class RangeProof:
         has no x to write. The `require_on_curve` above lets it through,
         `(x, 0)` being how this library spells infinity in affine
         coordinates.
+
+        `message` is what `sign` embedded, and it belongs here because
+        the draws carry it: one scalar per key of every ring before the
+        last. `_message_room` bounds it.
         """
         if check_validity:
             self.assert_valid()
         secp256k1.require_on_curve(commitment)
         sign_key_idx = self.sign_key_idx(value)
-        seed = bytes_from_octets(nonce, _NONCE_SIZE)
-        seed += _bytes_from_point(commitment, _RANGEPROOF_TAG)
-        seed += _bytes_from_point(second_generator(), _RANGEPROOF_TAG)
-        seed += _header_octets(self.exp, self.mantissa, self.min_value)
+        seed = bytes_from_octets(nonce, _NONCE_SIZE) + _hashed_prefix(
+            commitment, self.exp, self.mantissa, self.min_value
+        )
 
         v = self._mantissa_value(value)
-        return _genrand(seed, self.rsizes, _prep(self.rsizes, v, sign_key_idx[-1]))
+        prep = _prep(self.rsizes, v, sign_key_idx[-1], bytes_from_octets(message))
+        return _genrand(seed, self.rsizes, prep)
 
     def _mantissa_value(self, value: int) -> int:
         """Return that value in the units the mantissa's digits count.
@@ -916,6 +988,7 @@ def sign(
     min_value: int = 0,
     exp: int = 0,
     min_bits: int = 0,
+    message: Octets = b"",
 ) -> RangeProof:
     """Return the proof that a blinded value lies in a stated range.
 
@@ -942,11 +1015,11 @@ def sign(
     so what comes back over the arguments both accept is the octets
     `zkp.rangeproof.sign` answers for those same arguments.
 
-    No message and no `extra_commit`. A message rides in the buffer
-    `_prep` builds, at the head of every ring but the last, and exists
-    to be read back out, so it belongs with the rewind that reads it;
-    `extra_commit` enters the challenge and nothing here has a second
-    commitment to bind. Issue #1072 is where both are tracked.
+    `message` is embedded for `rewind` to read back out: it rides at the
+    head of the buffer `_prep` builds, one scalar per key of every ring
+    before the last. `_message_room` is what bounds it, and the octets
+    are otherwise those of a proof carrying none. No `extra_commit` and
+    no generator of the caller's, which are issues #1984 and #1986.
     """
     blind_int = scalar_from_prv_key(blind, secp256k1)
     if not 0 <= value <= _UINT64_MAX:
@@ -959,20 +1032,23 @@ def sign(
     if not 0 <= min_bits <= _MAX_MANTISSA:
         raise BTClibValueError(f"rangeproof min bits not in 0..64: {min_bits}")
     nonce_bytes = bytes_from_octets(nonce, _NONCE_SIZE)
+    message_bytes = bytes_from_octets(message)
 
     params = _prove_params(value, min_value, exp, min_bits)
+    genp = second_generator()
     # zkp's `min_value ? 32 : 0`, over the rewritten floor: a range
     # starting at zero carries no field
-    header = _header_octets(params.exp, params.mantissa, params.min_value or None)
-
-    genp = second_generator()
-    points = _bytes_from_point(commit(blind_int, value), _RANGEPROOF_TAG)
-    points += _bytes_from_point(genp, _RANGEPROOF_TAG)
+    prefix = _hashed_prefix(
+        commit(blind_int, value),
+        params.exp,
+        params.mantissa,
+        params.min_value or None,
+    )
 
     chain = _genrand(
-        nonce_bytes + points + header,
+        nonce_bytes + prefix,
         params.rsizes,
-        _prep(params.rsizes, params.v, params.sign_key_idx[-1]),
+        _prep(params.rsizes, params.v, params.sign_key_idx[-1], message_bytes),
     )
     # the draw at the true digit is spent as that ring's nonce, so it is
     # the one `s` per ring the signature overwrites rather than states
@@ -1001,7 +1077,7 @@ def sign(
 
     # every ring commitment but the last, which the verifier recovers
     stated = [_bytes_from_point(head, _RANGEPROOF_TAG) for head in heads[:-1]]
-    m = sha256(points + header + b"".join(stated)).digest()
+    m = sha256(prefix + b"".join(stated)).digest()
     sig = _borromean_sign(
         m,
         _pub_expand(heads, params.exp, params.rsizes),
@@ -1039,3 +1115,296 @@ def sign_public_value(blind: Integer, value: int, nonce: Octets) -> RangeProof:
     name nothing this proof has: its header is fixed.
     """
     return sign(blind, value, nonce, exp=-1)
+
+
+def _borromean_verify(
+    m: bytes, pubk_rings: Sequence[PubkeyRing], sig: BorromeanSig
+) -> tuple[tuple[int, ...], ...]:
+    """Walk every ring back to `e0`, answering the challenge at each key.
+
+    `secp256k1_borromean_verify_impl`, and what comes back is its
+    `evalues` -- the challenges it saves only where a caller asked to
+    rewind. `ecc.borromean.assert_as_valid` is the same walk answering
+    a bool over rings a caller supplies, and differs where a rangeproof
+    cannot follow it: it hashes those rings into a message of its own,
+    it walks at `-e` where zkp walks at `+e`, and it reduces a
+    challenge zkp refuses. `_borromean_sign` states the second of those
+    from the signing side and `_challenge` the third.
+
+    Two refusals of zkp's own, checked before the walk goes on from a
+    key. An `s` of zero, which `BorromeanSig.assert_valid` reads
+    against 0..n-1 and so accepts, and which
+    `secp256k1_borromean_sign` answers zero rather than write. And a
+    ring key at infinity, which is no public key: the walk point
+    `e*Q + s*G` is `s*G` for one, a point the prover chooses, so
+    nothing later in the walk turns it down.
+    """
+    challenges: list[tuple[int, ...]] = []
+    e0_preimage = b""
+    for i, ring in enumerate(pubk_rings):
+        e = _challenge(m, sig.e0, i, 0)
+        ring_challenges: list[int] = []
+        for j, Q in enumerate(ring):
+            s = sig.s[i][j]
+            if s == 0:
+                raise BTClibRuntimeError("rangeproof signature value is zero")
+            if Q == INF:
+                err_msg = "rangeproof ring key is the point at infinity"
+                raise BTClibRuntimeError(err_msg)
+            ring_challenges.append(e)
+            # zkp turns down a walk point at infinity too, and here
+            # `bytes_from_point` is what does: infinity has no octet
+            # encoding, and the next challenge is over one
+            t = double_mult_var(e, Q, s, secp256k1.G, secp256k1)
+            r = bytes_from_point(t, secp256k1)
+            if j != len(ring) - 1:
+                e = _challenge(m, r, i, j + 1)
+            else:
+                e0_preimage += r
+        challenges.append(tuple(ring_challenges))
+    # the message closes the preimage the ring points opened, which is
+    # `_borromean_sign`'s order too
+    if sha256(e0_preimage + m).digest() != sig.e0:
+        raise BTClibRuntimeError("rangeproof signature verification failed")
+    return tuple(challenges)
+
+
+def _ring_message(commitment: Point, proof: RangeProof) -> bytes:
+    """Return the message this proof's rings are signed over.
+
+    `secp256k1_rangeproof_verify_impl` closes the same `sha256_m`
+    `sign` opens: `_hashed_prefix`, then the sign bit and the x of
+    every ring commitment the proof states. Those are the octets
+    already on the wire, which is why they are written out here rather
+    than resolved to points and handed back to `_bytes_from_point`.
+    """
+    stated = b"".join(
+        bytes([sign_bit]) + x.to_bytes(secp256k1.p_size, "big")
+        for x, sign_bit in zip(proof.ring_commitments, proof.signs, strict=True)
+    )
+    prefix = _hashed_prefix(commitment, proof.exp, proof.mantissa, proof.min_value)
+    return sha256(prefix + stated).digest()
+
+
+def _verify_rings(commitment: Point, proof: RangeProof) -> tuple[tuple[int, ...], ...]:
+    """Return the challenge behind every key of a proof that holds.
+
+    `secp256k1_rangeproof_verify_impl`, assembled from what this module
+    already has: `RangeProof.pubk_rings` rebuilds the rings that
+    function hands to `secp256k1_borromean_verify_impl`,
+    `_ring_message` the message they are signed over, and
+    `_borromean_verify` walks them.
+
+    The challenges come back rather than a bool because
+    `secp256k1_rangeproof_rewind_inner` consumes them and is called
+    from inside `verify_impl` itself: a rewind is verification that
+    kept them, so `rewind` calls this and `assert_as_valid` drops what
+    it answers.
+    """
+    return _borromean_verify(
+        _ring_message(commitment, proof), proof.pubk_rings(commitment), proof.sig
+    )
+
+
+def _proof_from(proof: RangeProof | Octets) -> RangeProof:
+    """Return the proof, parsing octets as `RangeProof.parse` reads them."""
+    return proof if isinstance(proof, RangeProof) else RangeProof.parse(proof)
+
+
+def assert_as_valid(commitment: Point, proof: RangeProof | Octets) -> None:
+    """Refuse a proof that does not hold for that commitment.
+
+    `commitment` is the Pedersen commitment the proof was written
+    against, `RangeProof.pubk_rings`'s argument of that name. The range
+    proven is the proof's own `min_value` and `max_value`, which the
+    header states and a parse reads; what this adds is that the header
+    is that commitment's, the last ring commitment being recovered from
+    it and the whole signature walked against the rings that follow. So
+    a commitment a proof holds for opens at some value in
+    `min_value..max_value`.
+
+    `zkp.rangeproof.verify` answers that range instead of a verdict,
+    having only the octets to answer from. `verify` here is the boolean
+    answer, as `ecc.borromean.verify` is to `ecc.borromean.assert_as_valid`.
+    """
+    _ = _verify_rings(commitment, _proof_from(proof))
+
+
+def verify(commitment: Point, proof: RangeProof | Octets) -> bool:
+    """Return whether the proof holds for that commitment."""
+    # ValueError and BTClibRuntimeError, as `ecc.borromean.verify` catches
+    # them and for the reasons `ecc.dsa.verify_` states
+    try:
+        assert_as_valid(commitment, proof)
+    except (ValueError, BTClibRuntimeError):
+        return False
+
+    return True
+
+
+def _recover_x(k: int, e: int, s: int) -> int:
+    """Return the scalar a real signature was written under.
+
+    `secp256k1_rangeproof_recover_x`. `_borromean_sign` answers `k - e*x`
+    at the one key of a ring the prover opens, so `(k - s) / e` is that
+    `x` wherever the `k` behind it is in hand -- which is what holding
+    the nonce buys, the chain drawing it. `e` is a challenge and
+    `_challenge` refuses zero, so the inverse exists.
+    """
+    return (k - s) * pow(e, -1, secp256k1.n) % secp256k1.n
+
+
+def _recover_k(x: int, e: int, s: int) -> int:
+    """Return the nonce a real signature was closed with.
+
+    `secp256k1_rangeproof_recover_k`, the same equation read the other
+    way: `s + x*e`. A rewind takes this rather than `_recover_x` at
+    every ring but the last, where what it wants is the nonce itself --
+    the message is xored into it, and no inversion is needed to get it
+    back.
+    """
+    return (s + x * e) % secp256k1.n
+
+
+def _ch32xor(a: int, b: int) -> bytes:
+    """Return the xor of two scalars, one scalar width wide.
+
+    `secp256k1_rangeproof_ch32xor`, which is how a message and the
+    value encoding both enter and leave the draws.
+    """
+    size = secp256k1.n_size
+    return bytes(
+        x ^ y
+        for x, y in zip(a.to_bytes(size, "big"), b.to_bytes(size, "big"), strict=True)
+    )
+
+
+def _value_encoding(
+    rsizes: Sequence[int], written: Sequence[int], drawn: Sequence[int]
+) -> tuple[int, int] | None:
+    """Return where the last ring carries the value, and the value.
+
+    `secp256k1_rangeproof_rewind_inner`'s own search, and it looks at
+    two keys because `_prep` writes at one of two: the ring's last, or
+    the one before it where the value's own digit is that one. A key
+    whose xor opens with bit 7 set and repeats the same eight octets
+    three times is taken as the encoding, and the value is the last of
+    the three. Where neither key matches this answers None, and `rewind`
+    is what turns that into a refusal.
+    """
+    for j in range(2):
+        position = rsizes[-1] - 1 - j
+        tmp = _ch32xor(written[position], drawn[position])
+        if tmp[0] & 128 and tmp[8:16] == tmp[16:24] == tmp[24:32]:
+            return position, int.from_bytes(tmp[24:32], "big")
+    return None
+
+
+class Rewound(NamedTuple):
+    """What whoever holds a proof's nonce reads back out of it.
+
+    `blind` is the blinding factor the commitment was written under and
+    `value` what it commits to, so the two open the commitment.
+    `message` is what the draws carry: what `sign` embedded, followed by
+    the zeros `_prep` left after it. Nothing in a proof states how long
+    a message was, so the padding is the caller's to know the length of
+    or to strip.
+    """
+
+    blind: int
+    value: int
+    message: bytes
+
+
+def rewind(commitment: Point, proof: RangeProof | Octets, nonce: Octets) -> Rewound:
+    """Return what the author of that proof put in it for its recipient.
+
+    `secp256k1_rangeproof_rewind_inner`, which
+    `secp256k1_rangeproof_verify_impl` calls from inside itself: the
+    proof is verified first, by `_verify_rings`, and the per-key
+    challenges that walk answers are half of what this needs. The other
+    half is the chain re-derived from `nonce` over a `prep` of zeros,
+    which answers the draws themselves -- the proof's own `s` at a
+    forged key is one of those draws with a message octet or the value
+    encoding xored into it, and at the one key a ring opens it is the
+    nonce that key was closed with.
+
+    A single ring of a single key is the public-value proof, and only
+    the blinding factor is recoverable from it: the value is the
+    header's `min_value`, stated in the clear, and there is no second
+    key to carry a message.
+
+    Everywhere else `_value_encoding` reads the value out of the last
+    ring, and two refusals follow it. The position it was found at and
+    the last ring's own digit have to differ -- `_prep` writes the
+    encoding at whichever of the two keys the digit does not take, so a
+    proof stating a value that lands on it states a value it was not
+    written for. And a digit above the last ring's own size names no
+    key of it, which is where an odd mantissa leaves a ring of two.
+
+    The blinding factor is then `_recover_x` at the last ring's digit,
+    less the chain's own factor for that ring: what the ring was signed
+    under is the sum of the two, which is what lets a verifier recover
+    the ring commitment the proof leaves out.
+
+    The message is every remaining key of every ring, the two the last
+    ring spends excepted: the nonce at the key a ring opens, recovered
+    by `_recover_k`, and the stated `s` everywhere else, each xored
+    against the draw behind it. `Rewound.message` has what that buffer
+    holds past the message itself.
+
+    Refused where the value and the blinding factor recovered do not
+    open `commitment`, which is what says the nonce was the proof's
+    own: `secp256k1_rangeproof_verify_impl` rebuilds the commitment
+    from them and compares.
+    """
+    proof = _proof_from(proof)
+    ev = _verify_rings(commitment, proof)
+    rsizes = proof.rsizes
+    seed = bytes_from_octets(nonce, _NONCE_SIZE) + _hashed_prefix(
+        commitment, proof.exp, proof.mantissa, proof.min_value
+    )
+    # the zeroed `prep` `rewind_inner` calls the chain with: what comes
+    # back is then the draws themselves, no message and no value
+    # encoding folded into any of them
+    chain = _genrand(seed, rsizes, bytes(_RING_STRIDE * secp256k1.n_size * len(rsizes)))
+    s = proof.sig.s
+
+    last = len(rsizes) - 1
+    if rsizes == (1,):
+        blind = _recover_x(chain.draws[0][0], ev[0][0], s[0][0])
+        value, message = proof.min_value or 0, b""
+    else:
+        found = _value_encoding(rsizes, s[last], chain.draws[last])
+        if found is None:
+            raise BTClibRuntimeError("rangeproof rewind reads no value encoding")
+        skip1, v = found
+        skip2 = (v >> 2 * last) & 3
+        if skip1 == skip2:
+            raise BTClibRuntimeError("rangeproof rewind reads the value at the digit")
+        if skip2 >= rsizes[last]:
+            raise BTClibRuntimeError(
+                "rangeproof rewind reads a digit the last ring has no key for"
+            )
+        value = v * 10**proof.exp + (proof.min_value or 0)
+        blind = (
+            _recover_x(chain.draws[last][skip2], ev[last][skip2], s[last][skip2])
+            - chain.blinding_factors[last]
+        ) % secp256k1.n
+        message = b"".join(
+            _ch32xor(
+                _recover_k(chain.blinding_factors[i], ev[i][j], s[i][j])
+                if (v >> 2 * i) & 3 == j
+                else s[i][j],
+                chain.draws[i][j],
+            )
+            for i, size in enumerate(rsizes)
+            for j in range(size)
+            if i != last or j not in (skip1, skip2)
+        )
+
+    if double_mult_var(value, second_generator(), blind, secp256k1.G, secp256k1) != (
+        commitment
+    ):
+        raise BTClibRuntimeError("rangeproof rewind does not open the commitment")
+    return Rewound(blind, value, message)

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -2229,11 +2229,12 @@ blob, byte for byte, so the transcription's source is the code the
 bindings run.
 
 The message a rewind also answers is left out, and so is the nonce it is
-read with: what reads this file is a parse.
+read with, so nothing here can be rewound.
 `tests/ecc/rangeproof_fixed_vectors_test.py` asks for the octets back
-out, the range the header proves, and the rings the value's digits index.
-[ISS 1072](https://github.com/btclib-org/btclib/issues/1072) is where
-rewinding a proof and verifying one are tracked.
+out, the range the header proves, the rings the value's digits index,
+and `ecc.rangeproof.verify` against the commitment published beside
+each proof. A rewind is asked of the entries of
+`tests/ecc/_data/zkp_rangeproof_vectors.json`, which record a nonce.
 
 ### `tests/ecc/anti_exfil_test.py`
 

--- a/tests/ecc/rangeproof_fixed_vectors_test.py
+++ b/tests/ecc/rangeproof_fixed_vectors_test.py
@@ -24,10 +24,13 @@ the signer lowered from the one it was asked for; a `min_value` a step
 below the signed ceiling; and the proof of a value stated in the clear
 that zkp itself wrote.
 
-What is asked of them is the parse, the range the header states, and
-the rings the value's digits index. The borromean signature is read
-back byte for byte and not verified, which is
-[ISS 1072](https://github.com/btclib-org/btclib/issues/1072).
+What is asked of them is the parse, the range the header states, the
+rings the value's digits index, and the signature over those rings.
+That last one is the strongest question here and the one no recording
+can be asked as well: the octets were published by the implementation
+this format comes from, so a walk that closes on their own `e0` is this
+module agreeing with zkp. A rewind is the one direction they cannot be
+asked, none of them recording the nonce it was signed under.
 """
 
 from typing import Any
@@ -35,8 +38,13 @@ from typing import Any
 import pytest
 
 from btclib.curves import mult, secp256k1
-from btclib.ecc.pedersen import _point_from_x, bytes_from_commitment, commit
-from btclib.ecc.rangeproof import RangeProof
+from btclib.ecc.pedersen import (
+    _point_from_x,
+    bytes_from_commitment,
+    commit,
+    commitment_from_octets,
+)
+from btclib.ecc.rangeproof import RangeProof, verify
 from tests import load, vector_id
 
 _VECTORS = load("ecc", "_data", "zkp_rangeproof_fixed_vectors.json")
@@ -110,3 +118,26 @@ def test_the_rings_open_at_the_published_blinding_factor(
     for ring, j in zip(rings, proof.sign_key_idx(vector["value"]), strict=True):
         total = ring[j] if total is None else secp256k1.add_aff_var(total, ring[j])
     assert total == mult(vector["blind"], secp256k1.G, secp256k1)
+
+
+@pytest.mark.parametrize("vector", _VECTORS, ids=_IDS)
+def test_the_signature_holds_for_the_published_commitment(
+    vector: dict[str, Any],
+) -> None:
+    """The rings walked back to the `e0` upstream published.
+
+    The commitment is the one published beside the proof, lifted with
+    `ecc.pedersen.commitment_from_octets` rather than recomputed from
+    the blinding factor: everything the walk hangs from is then read
+    out of the vector, the last ring commitment it recovers included.
+
+    A turned octet of the signature beside it, because a walk that
+    accepts everything accepts these too.
+    """
+    commitment = commitment_from_octets(vector["commitment"])
+    octets = bytes.fromhex(vector["proof"])
+    assert verify(commitment, octets)
+
+    turned = bytearray(octets)
+    turned[-1] ^= 1
+    assert not verify(commitment, bytes(turned))

--- a/tests/ecc/rangeproof_test.py
+++ b/tests/ecc/rangeproof_test.py
@@ -54,10 +54,27 @@ and refused no ring member's draw answers every entry here, and each of
 those draws is reached at one in about 2**128. What puts them is a
 chain a test writes.
 
+And every entry is verified and rewound, which the nonce on file is
+what makes possible: `verify` walks the rings `pubk_rings` rebuilds
+back to the `e0` zkp wrote, and `rewind` answers the blinding factor
+and the value the entry records from that nonce alone.
+`zkp_rangeproof_fixed_vectors.json` records no nonce, so a rewind is a
+question only this file's entries can be asked.
+
+The refusals a rewind has are constructed rather than waited for. A
+value encoding for a value the proof was not written for is put in by
+monkeypatching `_prep`, which decides the forged `s` values and nothing
+else, so each such proof is a valid signature that a rewind has to turn
+down: at the last ring's own digit, at a digit an odd mantissa's last
+ring has no key for, and at one that opens no commitment.
+
 The `zkp`-marked tests at the end put the same questions to the library
-itself, and two more the recording cannot answer: that signing again
-with the recorded arguments answers the very octets vendored here, and
-that values and headers no entry carries are written the same way.
+itself, and more the recording cannot answer: that signing again with
+the recorded arguments answers the very octets vendored here, that
+values and headers no entry carries are written the same way, and that
+over a grid of `value`, `min_value`, `exp`, `min_bits` and `message`
+the two implementations write the same octets, refuse the same
+arguments, and each read what the other wrote.
 """
 
 from io import BytesIO
@@ -747,7 +764,7 @@ def test_the_last_ring_carries_the_value_in_one_of_its_draws(
     sign_key_idx = proof.sign_key_idx(value)
     v = proof._mantissa_value(value)
 
-    prep = rangeproof._prep(proof.rsizes, v, sign_key_idx[-1])
+    prep = rangeproof._prep(proof.rsizes, v, sign_key_idx[-1], b"")
     seed = _seed(vector)
     written = rangeproof._genrand(seed, proof.rsizes, prep)
     plain = rangeproof._genrand(seed, proof.rsizes, bytes(len(prep)))
@@ -1144,6 +1161,319 @@ def test_a_ring_commitment_at_infinity_is_refused(
         sign(blind, 3, _NONCE, min_bits=2)
 
 
+# --------------------------------------------------------------------------
+# Verification, and the rewind built on it
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("vector", _VECTORS, ids=_IDS)
+def test_a_recorded_proof_holds_for_its_own_commitment(vector: dict[str, Any]) -> None:
+    """Every entry verified against the commitment its arguments make.
+
+    The proof is octets zkp signed and the commitment is built here from
+    the entry's own blinding factor and value, so what this asks is
+    whether the walk over the rings `pubk_rings` rebuilds closes on the
+    `e0` those octets carry. A commitment to another value is asked
+    beside it: the last ring commitment is recovered from the
+    commitment, so every ring's message changes with it and nothing
+    closes.
+    """
+    commitment = commit(vector["blind"], vector["value"])
+    octets = bytes.fromhex(vector["proof"])
+    rangeproof.assert_as_valid(commitment, octets)
+    assert rangeproof.verify(commitment, octets)
+    assert rangeproof.verify(commitment, RangeProof.parse(octets))
+
+    other = commit(vector["blind"], vector["value"] + 1)
+    assert not rangeproof.verify(other, octets)
+    with pytest.raises(BTClibRuntimeError, match="signature verification failed"):
+        rangeproof.assert_as_valid(other, octets)
+
+
+@pytest.mark.parametrize("vector", _VECTORS, ids=_IDS)
+def test_rewind_reads_a_recorded_proof_back(vector: dict[str, Any]) -> None:
+    """The blinding factor and the value the entry states, from its nonce.
+
+    Every entry carries the nonce it was signed under, which is what
+    makes a rewind a question the suite can put wherever it runs rather
+    than one the flagged extension has to answer.
+    `zkp_rangeproof_fixed_vectors.json` records no nonce and is asked
+    nothing of this kind.
+
+    Nothing was embedded in these, so what the rings carry past the
+    value encoding is the zeros `_prep` left.
+    """
+    commitment = commit(vector["blind"], vector["value"])
+    rewound = rangeproof.rewind(
+        commitment, bytes.fromhex(vector["proof"]), vector["nonce"]
+    )
+    assert rewound.blind == int(vector["blind"], 16)
+    assert rewound.value == vector["value"]
+    assert not any(rewound.message)
+
+
+def test_verify_refuses_a_turned_octet_of_the_signature() -> None:
+    """One bit of the last `s`, which is the mutation a proof has to fail on."""
+    octets = bytearray(_octets("odd mantissa"))
+    commitment = commit(
+        _vector("odd mantissa")["blind"], _vector("odd mantissa")["value"]
+    )
+    assert rangeproof.verify(commitment, bytes(octets))
+    octets[-1] ^= 1
+    assert not rangeproof.verify(commitment, bytes(octets))
+
+
+def test_verify_refuses_a_signature_value_of_zero() -> None:
+    """The one `s` zkp writes none of, and `BorromeanSig` holds.
+
+    `secp256k1_borromean_sign` answers zero rather than put a zero `s`
+    in a proof, and `secp256k1_borromean_verify_impl` turns one down
+    where it is handed it. `BorromeanSig.assert_valid` reads `s` against
+    0..n-1 and so accepts it, which is what leaves the refusal to the
+    walk.
+    """
+    vector = _vector("odd mantissa")
+    proof = RangeProof.parse(_octets("odd mantissa"))
+    zeroed = [list(ring) for ring in proof.sig.s]
+    zeroed[0][0] = 0
+    mutated = replace_unchecked(proof, sig=replace_unchecked(proof.sig, s=zeroed))
+    commitment = commit(vector["blind"], vector["value"])
+    with pytest.raises(BTClibRuntimeError, match="signature value is zero"):
+        rangeproof.assert_as_valid(commitment, mutated)
+    assert not rangeproof.verify(commitment, mutated)
+
+
+def test_verify_refuses_a_ring_key_at_infinity() -> None:
+    """The key `secp256k1_borromean_verify_impl` turns down before its ecmult.
+
+    A ring's key at position j is that ring's commitment less j times
+    the weight of the digit the ring proves, so a stated commitment
+    sitting exactly on one of those multiples leaves a key at infinity.
+    The first ring's second key is the cheapest of them: at an exponent
+    of zero the weight is the generator itself, so the commitment whose
+    octets are the generator's puts it there.
+
+    Nothing later in the walk would turn it down. The point a walk
+    reaches at that key is `e*Q + s*G`, which is `s*G` for a `Q` at
+    infinity -- an ordinary point, and one the prover picks by picking
+    `s`.
+    """
+    vector = _vector("odd mantissa")
+    proof = RangeProof.parse(_octets("odd mantissa"))
+    assert proof.exp == 0
+    octets = _bytes_from_point(second_generator(), _RANGEPROOF_TAG)
+    holed = replace_unchecked(
+        proof,
+        signs=(bool(octets[0]), *proof.signs[1:]),
+        ring_commitments=(
+            int.from_bytes(octets[1:], "big"),
+            *proof.ring_commitments[1:],
+        ),
+    )
+    commitment = commit(vector["blind"], vector["value"])
+    rings = holed.pubk_rings(commitment)
+    assert rings[0][1] == INF
+    with pytest.raises(BTClibRuntimeError, match="ring key is the point at infinity"):
+        rangeproof.assert_as_valid(commitment, holed)
+    assert not rangeproof.verify(commitment, holed)
+
+
+def test_rewind_refuses_a_nonce_that_is_not_the_proof_s() -> None:
+    """A wrong nonce draws a different chain, and no key then reads as a value.
+
+    `_value_encoding` looks at two keys of the last ring and takes
+    neither: the xor of a proof's own `s` with a draw that never wrote
+    it opens with bit 7 clear, or repeats none of its three eight-octet
+    runs. The proof still verifies -- a rewind is what the nonce is for,
+    and nothing else in it depends on one.
+    """
+    vector = _vector("odd mantissa")
+    commitment = commit(vector["blind"], vector["value"])
+    octets = _octets("odd mantissa")
+    assert rangeproof.verify(commitment, octets)
+    with pytest.raises(BTClibRuntimeError, match="reads no value encoding"):
+        rangeproof.rewind(commitment, octets, bytes(32))
+
+
+def _with_encoded_value(monkeypatch: pytest.MonkeyPatch, v: int) -> None:
+    # `_prep` writing an encoding for a value the proof is not written
+    # for, at the key the true value's own digit would have put it at.
+    # A rewind reads that value back and is refused on it; the octets
+    # are a valid signature either way, the buffer deciding only what
+    # the forged `s` values are
+    real_prep = rangeproof._prep
+
+    def fake_prep(rsizes: Any, _v: int, sign_key_idx: int, message: bytes) -> bytes:
+        return real_prep(rsizes, v, sign_key_idx, message)
+
+    monkeypatch.setattr(rangeproof, "_prep", fake_prep)
+
+
+def test_rewind_refuses_a_value_encoding_at_the_last_ring_s_digit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`secp256k1_rangeproof_rewind_inner`'s "value is in wrong position".
+
+    `_prep` writes the encoding at whichever of the last ring's two
+    candidate keys the ring's own digit does not take, so a value whose
+    top digit names the key the encoding was found at is a value the
+    proof was not written for. A mantissa of four gives two rings of
+    four keys: the value three has digits three and zero, so the
+    encoding goes at the last key and a rewind reading a value whose top
+    digit is three lands on it.
+    """
+    _with_encoded_value(monkeypatch, 12)
+    proof = sign(_BLIND, 3, _NONCE, min_bits=4)
+    commitment = commit(_BLIND, 3)
+    assert rangeproof.verify(commitment, proof)
+    with pytest.raises(BTClibRuntimeError, match="reads the value at the digit"):
+        rangeproof.rewind(commitment, proof, _NONCE)
+
+
+def test_rewind_refuses_a_digit_the_last_ring_has_no_key_for(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An odd mantissa ends in a ring of two, which proves one bit.
+
+    A value whose top digit is two or three names a position that ring
+    does not have. zkp indexes its own arrays at that position anyway,
+    and they end before it: `secp256k1_rangeproof_genrand` fills as many
+    as the rings hold keys, and `secp256k1_borromean_verify_impl` saves
+    as many challenges.
+    """
+    _with_encoded_value(monkeypatch, 8)
+    proof = sign(_BLIND, 3, _NONCE, min_bits=3)
+    commitment = commit(_BLIND, 3)
+    assert proof.rsizes == (4, 2)
+    assert rangeproof.verify(commitment, proof)
+    with pytest.raises(BTClibRuntimeError, match="has no key for"):
+        rangeproof.rewind(commitment, proof, _NONCE)
+
+
+def test_rewind_refuses_what_does_not_open_the_commitment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The check `secp256k1_rangeproof_verify_impl` makes after the rewind.
+
+    A value encoding naming a digit that is neither the key it sits at
+    nor the ring's own passes both refusals above, and what comes back
+    is a blinding factor recovered at a key nobody signed at: the pair
+    is arithmetic on forged scalars, and rebuilding the commitment from
+    it is what says so.
+    """
+    _with_encoded_value(monkeypatch, 4)
+    proof = sign(_BLIND, 3, _NONCE, min_bits=4)
+    commitment = commit(_BLIND, 3)
+    assert rangeproof.verify(commitment, proof)
+    with pytest.raises(BTClibRuntimeError, match="does not open the commitment"):
+        rangeproof.rewind(commitment, proof, _NONCE)
+
+
+def test_a_public_value_proof_rewinds_to_its_blinding_factor_alone() -> None:
+    """One ring of one key, and only the blinding factor is recoverable.
+
+    There is no digit to read and no second key to carry a message: the
+    value is the header's own `min_value`, stated in the clear, and what
+    the rewind adds is that whoever holds the nonce also holds the
+    factor the commitment was written under.
+    """
+    proof = sign_public_value(_BLIND, 100000, _NONCE)
+    commitment = commit(_BLIND, 100000)
+    rewound = rangeproof.rewind(commitment, proof, _NONCE)
+    assert rewound == (int(_BLIND, 16), 100000, b"")
+
+
+@pytest.mark.parametrize(
+    "value, min_bits",
+    [(3, 4), (100000, 8), (100000, 20), (2**32, 33)],
+    ids=["two rings", "odd mantissa", "padded sign bits", "wide mantissa"],
+)
+def test_sign_embeds_a_message_rewind_reads_back(value: int, min_bits: int) -> None:
+    """The message written into the draws, and read back out of them.
+
+    What comes back is every octet the rings before the last carry, and
+    whatever the last ring has left once the value encoding and the key
+    its own digit opens are taken out of it -- two keys where it holds
+    four, none where an odd mantissa leaves it holding two: the message
+    first and the zeros `_prep` left after it. Nothing in a proof says
+    where the message ends, which is what makes the padding the
+    caller's to know the length of.
+    """
+    message = b"btclib reads what it writes"
+    proof = sign(_BLIND, value, _NONCE, min_bits=min_bits, message=message)
+    commitment = commit(_BLIND, value)
+    rewound = rangeproof.rewind(commitment, proof, _NONCE)
+    assert rewound.blind == int(_BLIND, 16)
+    assert rewound.value == value
+    assert rewound.message[: len(message)] == message
+    assert not any(rewound.message[len(message) :])
+
+    keys = sum(proof.rsizes)
+    assert len(rewound.message) == secp256k1.n_size * (keys - 2)
+    # the octets are a proof carrying no message everywhere else
+    plain = sign(_BLIND, value, _NONCE, min_bits=min_bits)
+    assert (plain.exp, plain.mantissa, plain.min_value) == (
+        proof.exp,
+        proof.mantissa,
+        proof.min_value,
+    )
+    assert plain.ring_commitments == proof.ring_commitments
+    assert plain.serialize() != proof.serialize()
+
+
+def test_the_nonce_chain_answers_the_draws_of_a_proof_carrying_a_message() -> None:
+    """A message is in the draws, so the chain needs it to answer them.
+
+    Every `s` the signature did not overwrite is the chain's own draw,
+    with the message folded into it at the keys the message reaches,
+    which is the same question that
+    `test_the_nonce_chain_answers_every_s_the_signature_did_not_write`
+    puts to a proof carrying none. The message here is shorter than one
+    scalar, so it reaches the first key of the first ring and no other,
+    and the assertion is over every key either way.
+    """
+    message = b"in the draws"
+    value = 100000
+    proof = sign(_BLIND, value, _NONCE, min_bits=8, message=message)
+    commitment = commit(_BLIND, value)
+    chain = proof.nonce_chain(commitment, value, _NONCE, message)
+    plain = proof.nonce_chain(commitment, value, _NONCE)
+    reached = [
+        (i, j)
+        for i, (a, b) in enumerate(zip(plain.draws, chain.draws, strict=True))
+        for j, (x, y) in enumerate(zip(a, b, strict=True))
+        if x != y
+    ]
+    assert reached == [(0, 0)]
+
+    sign_key_idx = proof.sign_key_idx(value)
+    for i, (drawn, written) in enumerate(zip(chain.draws, proof.sig.s, strict=True)):
+        for j, (a, b) in enumerate(zip(drawn, written, strict=True)):
+            assert (a == b) == (j != sign_key_idx[i])
+
+
+def test_a_message_longer_than_the_rings_hold_is_refused() -> None:
+    """`secp256k1_rangeproof_sign_impl`'s own bound, `128 * (rings - 1)`.
+
+    The last ring carries the value encoding and the key a rewind
+    recovers the blinding factor at, so what is left is every ring
+    before it -- and a proof of a single ring has none, which is what a
+    small `min_bits` and the public-value proof both give.
+    """
+    err_msg = "message is longer than the"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        sign(_BLIND, 1, _NONCE, min_bits=1, message=b"x")
+    with pytest.raises(BTClibValueError, match=err_msg):
+        sign(_BLIND, 3, _NONCE, min_bits=4, message=bytes(129))
+    # the same bound reached through the chain rather than through `sign`
+    proof = sign(_BLIND, 3, _NONCE, min_bits=4)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        proof.nonce_chain(commit(_BLIND, 3), 3, _NONCE, bytes(129))
+    # and what it does hold
+    filled = sign(_BLIND, 3, _NONCE, min_bits=4, message=bytes(128))
+    assert filled.rsizes == (4, 4)
+
+
 # `pragma: no cover` on every `@needs_zkp` below, the marker being the
 # reason: `tests/conftest.py` turns it into a skip in an unflagged
 # build, and excluding what a build cannot execute is what leaves the
@@ -1346,3 +1676,204 @@ def test_zkp_signs_and_verifies_the_proofs_this_module_writes() -> None:
         turned = bytearray(octets)
         turned[-1] ^= 1
         assert zkp_rangeproof.verify(commitment, bytes(turned)) is None
+
+
+# The grid the two `@needs_zkp` sweeps below are taken over, and it is a
+# product rather than a list of interesting cases: what a header comes
+# out as is `secp256k1_range_proveparams`' answer to four arguments at
+# once, so the combinations that matter are the ones nobody would think
+# to write down. Most of the grid is refused by both implementations --
+# a floor above the value, a message longer than the rings hold, a
+# range that would wrap -- and the sweeps assert that agreement rather
+# than skipping past it
+_GRID_VALUES = (
+    0,
+    1,
+    3,
+    42,
+    255,
+    5000,
+    100000,
+    2**32,
+    2**40 + 7,
+    2**63 - 1,
+    2**63,
+    2**64 - 1,
+)
+_GRID = [
+    (min_value, exp, min_bits, message)
+    for min_value in (0, 1000, 2**40, 2**64 - 1)
+    for exp in (-1, 0, 2, 18)
+    for min_bits in (0, 8, 13, 64)
+    for message in (b"", b"btclib embeds this")
+]
+
+
+@needs_zkp  # pragma: no cover -- no zkp.rangeproof to write the proofs read here
+@pytest.mark.parametrize("value", _GRID_VALUES)
+def test_this_module_reads_what_zkp_writes(value: int) -> None:
+    """Proofs the library signed, verified and rewound here.
+
+    Each is asked three things. `verify` says the rings close on the
+    `e0` zkp wrote, over a commitment built here rather than parsed
+    from zkp's octets; the range the header states is the one
+    `zkp.rangeproof.verify` answers; and `rewind` answers the blinding
+    factor, the value and the message `zkp.rangeproof.rewind` answers
+    for the same proof and nonce.
+
+    The message is compared to zkp's own where the two buffers can
+    differ in length: zkp fills a caller's, which
+    `btclib_secp256k1.zkp.rangeproof` sizes at `MAX_MESSAGE_LEN`, where
+    a rewind here answers every octet the rings carry -- 32 for each
+    key that is neither the value encoding nor the one the last ring's
+    digit opens. Only the widest mantissa has more of them than that
+    constant allows, and the assertion says which case is which rather
+    than comparing prefixes and calling it agreement.
+    """
+    blind = bytes.fromhex(_BLIND)
+    nonce = bytes.fromhex(_NONCE)
+    commitment = zkp_generator.pedersen_commit(blind, value)
+    point = commit(_BLIND, value)
+    read = 0
+    for min_value, exp, min_bits, message in _GRID:
+        why = (min_value, exp, min_bits, message)
+        try:
+            octets = zkp_rangeproof.sign(
+                commitment,
+                blind,
+                nonce,
+                value,
+                min_value=min_value,
+                exp=exp,
+                min_bits=min_bits,
+                message=message,
+            )
+        except ValueError:
+            continue
+        read += 1
+        assert rangeproof.verify(point, octets), why
+        proof = RangeProof.parse(octets)
+        assert zkp_rangeproof.verify(commitment, octets) == (
+            proof.min_value or 0,
+            proof.max_value,
+        ), why
+
+        blind_out, value_out, message_out, _, _ = zkp_rangeproof.rewind(
+            commitment, octets, nonce
+        )
+        rewound = rangeproof.rewind(point, octets, nonce)
+        assert rewound.blind == int.from_bytes(blind_out, "big"), why
+        assert rewound.value == value_out, why
+        assert len(message_out) == min(
+            len(rewound.message), zkp_rangeproof.MAX_MESSAGE_LEN
+        ), why
+        assert rewound.message[: len(message_out)] == message_out, why
+        assert rewound.message[: len(message)] == message, why
+    assert read
+
+
+@needs_zkp  # pragma: no cover -- no zkp.rangeproof to read the proofs written here
+@pytest.mark.parametrize("value", _GRID_VALUES)
+def test_zkp_reads_what_this_module_writes(value: int) -> None:
+    """Proofs written here, handed back to the library over the same grid.
+
+    `sign` says zkp writes these very octets, `zkp.rangeproof.verify`
+    that it reads them as the range the header states, and
+    `zkp.rangeproof.rewind` that it recovers from them the blinding
+    factor, the value and the message they were written with -- padded
+    with the zeros `_prep` left, which is what the library answers a
+    caller's buffer with.
+
+    Where the two refuse is asserted rather than skipped: an argument
+    zkp turns down is one this module has to turn down as well, which
+    is most of the grid and is the half a sweep of accepted cases
+    cannot see.
+    """
+    blind = bytes.fromhex(_BLIND)
+    nonce = bytes.fromhex(_NONCE)
+    commitment = zkp_generator.pedersen_commit(blind, value)
+    written = refused = 0
+    for min_value, exp, min_bits, message in _GRID:
+        why = (min_value, exp, min_bits, message)
+        try:
+            octets = zkp_rangeproof.sign(
+                commitment,
+                blind,
+                nonce,
+                value,
+                min_value=min_value,
+                exp=exp,
+                min_bits=min_bits,
+                message=message,
+            )
+        except ValueError:
+            refused += 1
+            with pytest.raises((BTClibValueError, BTClibRuntimeError)):
+                sign(
+                    _BLIND,
+                    value,
+                    _NONCE,
+                    min_value=min_value,
+                    exp=exp,
+                    min_bits=min_bits,
+                    message=message,
+                )
+            continue
+        written += 1
+        proof = sign(
+            _BLIND,
+            value,
+            _NONCE,
+            min_value=min_value,
+            exp=exp,
+            min_bits=min_bits,
+            message=message,
+        )
+        assert proof.serialize() == octets, why
+        assert zkp_rangeproof.verify(commitment, octets) == (
+            proof.min_value or 0,
+            proof.max_value,
+        ), why
+
+        blind_out, value_out, message_out, _, _ = zkp_rangeproof.rewind(
+            commitment, octets, nonce
+        )
+        assert blind_out == blind, why
+        assert value_out == value, why
+        assert message_out[: len(message)] == message, why
+        assert not any(message_out[len(message) :]), why
+    assert written and refused
+
+
+@needs_zkp  # pragma: no cover -- no zkp.rangeproof to put the crafted proofs to
+def test_zkp_refuses_the_rewinds_this_module_refuses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The three crafted proofs above, and a nonce that is not the proof's.
+
+    Each carries a value encoding for a value it was not written for,
+    and each is a valid signature: `zkp.rangeproof.verify` answers the
+    range, which is what says the refusal is the rewind's and not the
+    verification's.
+    """
+    blind = bytes.fromhex(_BLIND)
+    nonce = bytes.fromhex(_NONCE)
+    for encoded, min_bits, header in (
+        (12, 4, (0, 15)),
+        (8, 3, (0, 7)),
+        (4, 4, (0, 15)),
+    ):
+        _with_encoded_value(monkeypatch, encoded)
+        octets = sign(_BLIND, 3, _NONCE, min_bits=min_bits).serialize()
+        monkeypatch.undo()
+        commitment = zkp_generator.pedersen_commit(blind, 3)
+        assert zkp_rangeproof.verify(commitment, octets) == header
+        with pytest.raises(ValueError, match="rewind failed"):
+            zkp_rangeproof.rewind(commitment, octets, nonce)
+
+    octets = _octets("odd mantissa")
+    vector = _vector("odd mantissa")
+    commitment = bytes.fromhex(vector["commitment"])
+    assert zkp_rangeproof.verify(commitment, octets) is not None
+    with pytest.raises(ValueError, match="rewind failed"):
+        zkp_rangeproof.rewind(commitment, octets, bytes(32))

--- a/tests/keyword_only_test.py
+++ b/tests/keyword_only_test.py
@@ -174,7 +174,7 @@ KEYWORD_ONLY: dict[str, list[str]] = {
     "btclib.ecc.rangeproof:RangeProof.parse": ["check_validity"],
     "btclib.ecc.rangeproof:RangeProof.pubk_rings": ["check_validity"],
     "btclib.ecc.rangeproof:RangeProof.serialize": ["check_validity"],
-    "btclib.ecc.rangeproof:sign": ["min_value", "exp", "min_bits"],
+    "btclib.ecc.rangeproof:sign": ["min_value", "exp", "min_bits", "message"],
     "btclib.ecc.dsa:Sig.__init__": ["check_validity"],
     "btclib.ecc.dsa:Sig.parse": ["check_validity", "strict"],
     "btclib.ecc.dsa:Sig.serialize": ["check_validity"],


### PR DESCRIPTION
`verify` answers whether a proof holds for a commitment and
`assert_as_valid` raises the reason, the pair `ecc.borromean` and
`ecc.dsa` both carry. `rewind` answers the blinding factor, the value
and the message its author embedded, and `sign` gains the `message`
argument that puts one there.

Verification and rewind are one piece:
`secp256k1_rangeproof_rewind_inner` is called from inside
`secp256k1_rangeproof_verify_impl` and consumes the per-key challenges
the borromean walk produced, so `_verify_rings` answers those
challenges where `verify` answers a bool. `ecc.borromean.verify` cannot
serve: it hashes caller-supplied rings into a message of its own, walks
at `-e` where zkp walks at `+e`, reduces a challenge zkp refuses, and
throws the challenges away.

The oracle is bidirectional, `zkp`-marked, and swept rather than
sampled: proofs zkp signs over a spread of value, min_value, exp,
min_bits and message are verified and rewound here and compared with
`zkp.rangeproof.rewind`'s own answer, and proofs this module signs are
handed back to `zkp.rangeproof.verify` and `zkp.rangeproof.rewind`. The
refusals are constructed rather than waited for: a mutated proof, a
ring key at infinity, a rewind under the wrong nonce, a value encoding
written at the last ring's own digit, one naming a digit an odd
mantissa's last ring has no key for, and one that opens no commitment.

`extra_commit` stays out and so does a generator of the caller's, which
are [issue #1984](https://github.com/btclib-org/btclib/issues/1984) and
[issue #1986](https://github.com/btclib-org/btclib/issues/1986). What
those two leave the module doing is what `ecc.borromean`'s and
`tests/_data/README.md`'s prose said was still ahead of it, so both are
corrected here rather than left standing.
`tests/ecc/rangeproof_fixed_vectors_test.py` gains the verification of
the proofs libsecp256k1-zkp itself publishes, which needs no nonce and
so runs unflagged.

## Review

Local review at fresh context, three rounds by three reviewers.

Round 1, on the first tip: CHANGES REQUESTED, four findings, **all landed
prose and none a defect in the cryptography**. The reviewer's own sweep —
its constructions, its blinds and nonces, 2500 combinations over 12
message lengths — gave 698 byte-identical writes against
`zkp.rangeproof`, 1802 mutual refusals and **0 mismatches**; it rebuilt
the module's seven refusals independently and read the `genrand`
write-back against the C the bindings vendor.

Rounds 2 and 3 are scoped by a measurement rather than by assertion: with
every docstring stripped, the `ast` of `src/btclib/ecc/rangeproof.py`
hashes the same at all three tips — `e33c6399ed6a0da2`, against
`7d97107c5c66e8c9` for a control with one operand swapped in
`_recover_x` — so no amend touched an executable line of the module round
1 cleared. Round 2 cleared the one piece of new test code
(`test_the_signature_holds_for_the_published_commitment`: six cases, six
turned-octet controls refused by the walk rather than by a parse, thirty
cross pairs refused) and found two prose defects written *inside* round
1's repair. Round 3 was narrow on the lines that repaired those and found two more,
one of them original branch text that all three previous readings had
passed over. Round 4 asked a different question over the whole diff: every finding
of rounds 1 to 3 was a claim of quantity or exhaustiveness in prose
nobody had measured, so the last round censused that class across the
branch's added prose rather than reviewing the latest delta — 101 such
claims over 1049 added lines, 65 of them measured, every CHANGELOG
claim that decides anything among them. It returned three findings,
all prose, none against the code, and they are applied here: the
message-width clause struck at its four sites, `_hashed_prefix`'s
docstring naming the four callers it has rather than three, and the
last ring stated as leaving two keys where it holds four and none
where an odd mantissa leaves it holding two.

## Gates

Run at **`23cc8222`**, base `dd510c62`:

| command | exit |
|---|---|
| `uv run --locked pytest` | **0** — 32541 passed, 31 skipped, `TOTAL 56971 0 9858 0 100.00%` |
| `uv run --locked pytest -m 'not zkp'` | **0** — 32500 passed, 31 skipped, 100.00% |
| `uv run --locked --only-group lint pre-commit run --all-files --show-diff-on-failure` | **0** |
| `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html` | **0** |
| `grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'` | 1 (pass) |

The suite was run in a worktree built with `BTCLIB_LIBSECP256K1_ZKP=true`,
which runs the `zkp`-marked tests CI skips; the `-m 'not zkp'` row is the
floor as CI measures it.

closes #1072

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HotqzmCCqt8cd2QH6fC17H
