### PR TITLE
`ecc.dh` states the timing of the multiplication it delegates (closes #1992)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,33 @@ documented at release-notes length in the first place, and are still in
   padding its last ring leaves. The run and the padding are asserted
   separately, so a rewind answering the run alone fails.
 
+### `ecc.dh` states the timing of the multiplication it delegates
+
+- **The delegated shared point is variable time in the private key**
+  (closes #1992). `secp256k1_ec_pubkey_tweak_mul` reaches
+  `secp256k1_ecmult`, whose windowed NAF holds at most one more digit
+  than the scalar has bits, so the work follows the scalar; the module
+  docstring, `diffie_hellman`'s own and the mutation docstring of
+  `tests/ecc/dh_test.py` said constant time. The delegation is
+  unchanged, and so is what it buys: the speed and libsecp256k1's
+  answer.
+- **`secp256k1_ecmult_const` is the multiplication that is constant
+  time in its scalar, and `secp256k1_ecdh` is what reaches it.**
+  Nothing here calls that entry point, for the reason `ecc.dh`'s module
+  docstring already gave: it hashes the shared point with SHA256, where
+  every derivation here differs.
+- **`SECURITY.md` publishes it among the limitations of the delegated
+  path**, and `README.md` carries the short form. What is published is
+  the shape of the multiplication and not a list of call sites:
+  `curves.curve.mult` delegates every point that is neither the
+  generator nor infinity, so any point a caller supplied, multiplied by
+  a secret scalar, arrives at the same call. `ecc.ellswift.xdh` is not
+  an exception — `secp256k1_ellswift_xdh` multiplies with
+  `secp256k1_ecmult_const_xonly`, which is constant time in its scalar
+  and is not `secp256k1_ecmult_const`. The bindings' own docstrings
+  carry the sentence btclib's came from, and are corrected in
+  btclib-org/btclib-secp256k1#864.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/README.md
+++ b/README.md
@@ -266,6 +266,13 @@ recipient's scan private key, the same as `output_keys` above — a
 caller holding the transaction itself gets the delegated path a light
 client cannot reach.
 
+Crossing that call is not the same as constant time. `mult` sends every
+point that is not the generator to `secp256k1_ec_pubkey_tweak_mul`,
+whose work follows the scalar, so a secret multiplied by a point you
+supplied — the shared point of a key agreement, among others — carries
+no timing guarantee on the delegated path either; `SECURITY.md` has the
+accounting.
+
 What that path does about it is in the names, and it is worth knowing
 before calling one. **A function whose duration follows the value it is
 given ends in `_var`, and the plain name beside it is the one a secret may

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -306,6 +306,37 @@ used to teach and to prototype as much as to build:
     is Bos-Coster, whose shape is the scalars themselves.
     Using it on key material that matters is a choice, and this is the
     notice of it
+- **the delegated multiplication of a point that is not the generator is
+    variable time in its scalar**, and that scalar is a private key.
+    `secp256k1_ec_pubkey_tweak_mul` is the call, and it runs
+    `secp256k1_ecmult`, whose windowed NAF holds at most one more digit
+    than the scalar has bits — so the work follows the scalar rather
+    than the order of the curve. The multiplication libsecp256k1
+    documents as constant time in its scalar is `secp256k1_ecmult_const`;
+    `secp256k1_ecdh` is what reaches it, and nothing here calls that for
+    the reason `btclib.ecc.dh`'s module docstring gives. `ellswift.xdh`
+    is not an exception to that: it is delegated to
+    `secp256k1_ellswift_xdh`, which multiplies with
+    `secp256k1_ecmult_const_xonly` — constant time in its scalar, and a
+    different function from `secp256k1_ecmult_const`. Which call a
+    multiplication takes is decided by its shape and not by the module
+    that writes it: any point a caller supplied, multiplied by a secret
+    scalar, arrives here, `curves.curve.mult` delegating every point
+    that is neither the generator nor infinity —
+    `return _libsecp256k1_multi_mult([m], [Q])`
+    (`src/btclib/curves/curve.py:823`). `dh.diffie_hellman`
+    (`src/btclib/ecc/dh.py:107`) is the one this bullet was written
+    from, and is an example rather than the population: key agreement,
+    a BIP374 discrete-log equality proof and the key generation of
+    BIP38's EC-multiply mode all reach the same multiplication.
+    The other delegations the bullet above names are different calls:
+    a multiple of the generator is `secp256k1_ec_pubkey_create`, which
+    runs `secp256k1_ecmult_gen`, and the tweaking of a key is
+    `secp256k1_ec_seckey_tweak_add` or
+    `secp256k1_keypair_xonly_tweak_add`, which add scalars. Those three
+    are among the entry points libsecp256k1's own `src/ctime_tests.c`
+    declassifies a secret for, and `secp256k1_ec_pubkey_tweak_mul` is
+    named nowhere in that file
 - a sign-to-contract commitment is the signer's to open, and opening it
     twice over one message is safe only because the committed value
     reaches the nonce derivation: that is what keeps two such signatures

--- a/src/btclib/ecc/dh.py
+++ b/src/btclib/ecc/dh.py
@@ -18,9 +18,13 @@ and hashes in one call, and the hash is SHA256 of the compressed shared
 point with no way to change it: libsecp256k1 takes it as a C callback, so
 exposing it would mean calling back into python from the middle of the
 computation. Every ECDH-shaped computation here derives differently, so
-what is delegated is the multiplication -- `keys.pubkey_tweak_mul`, which
-is that same C multiplication, in constant time -- and the derivation
-stays in python:
+what is delegated is the multiplication -- `keys.pubkey_tweak_mul`, and
+not the `secp256k1_ecmult_const` that `ecdh.shared_secret` multiplies
+with: that one is constant time in the scalar, where the
+`secp256k1_ec_pubkey_tweak_mul` under `keys.pubkey_tweak_mul` runs
+`secp256k1_ecmult` and is not. The point is the same either way, and
+what the difference costs is in `diffie_hellman`'s docstring below and
+in SECURITY.md. The derivation stays in python:
 
 - `diffie_hellman` below runs SEC 1's ANSI-X9.63-KDF over the
   x-coordinate, under the hash function the caller passed;
@@ -71,11 +75,17 @@ def diffie_hellman(
 
     http://www.secg.org/sec1-v2.pdf, section 6.1
 
-    The shared point is the multiplication of a point that is not the
-    generator, which is the one case `mult` does not delegate: on
-    secp256k1 it is `secp256k1_ec_pubkey_tweak_mul` that computes it
-    here, at a fraction of what the Python endomorphism path costs and,
-    dU being a secret, in constant time -- which that path is not.
+    The shared point is a point that is not the generator multiplied by
+    a secret, and on secp256k1 `secp256k1_ec_pubkey_tweak_mul` computes
+    it here, at a fraction of what the Python endomorphism path costs.
+    Speed and libsecp256k1's own answer are what that buys, and not a
+    timing property in dU: the call runs `secp256k1_ecmult`, whose
+    windowed NAF holds at most one more digit than the scalar has bits,
+    so the work follows the scalar. `secp256k1_ecmult_const` is the
+    multiplication that is constant time in its scalar, and
+    `secp256k1_ecdh` is what reaches it; SECURITY.md publishes the
+    limitation, and the module docstring above says why nothing here
+    calls that function.
 
     `ecdh.shared_secret` of the bindings is a different function and not
     a substitute: it hashes the compressed shared point with SHA256,

--- a/tests/ecc/dh_test.py
+++ b/tests/ecc/dh_test.py
@@ -148,10 +148,11 @@ def test_a_normal_dU_reaches_the_bindings(monkeypatch: pytest.MonkeyPatch) -> No
     zero for every `dU` below `n`, which is every caller, and the guard
     then falls through to `mult(dU, QV, ec)` instead. That call still
     reaches libsecp256k1: it reduces `dU` on its own and dispatches
-    through `_libsecp256k1_multi_mult`/`pubkey_tweak_mul_sum`, a second
-    constant-time binding rather than the Python endomorphism arithmetic
-    -- so the mutant costs this line's direct entry point and not the
-    constant-time guarantee itself. `ansi_x9_63_kdf` derives the same
+    through `_libsecp256k1_multi_mult`/`pubkey_tweak_mul_sum`, which is
+    a `secp256k1_ec_pubkey_tweak_mul` per term and so the same C
+    multiplication one wrapper further out, rather than the Python
+    endomorphism arithmetic -- so the mutant costs this line's direct
+    entry point and not the delegation. `ansi_x9_63_kdf` derives the same
     bytes off either binding's point, so no assertion on the shared key
     tells the two apart (issue 975); this records the call into
     `pubkey_tweak_mul` instead of the answer it returns, so a mutant that


### PR DESCRIPTION
`ecc.dh` said in three places that the multiplication it delegates for
the shared point is constant time in the scalar. It is not, and the
scalar is a private key.

`secp256k1_ec_pubkey_tweak_mul` runs `secp256k1_ecmult`, whose windowed
NAF holds at most one more digit than the scalar has bits, so the work
follows the scalar. `secp256k1_ecmult_const` is the multiplication
libsecp256k1 documents as constant time in its scalar, and
`secp256k1_ecdh` is what reaches it. `secp256k1_ec_pubkey_tweak_mul` is
named nowhere in `src/ctime_tests.c`, where `secp256k1_ecdh`,
`secp256k1_ec_pubkey_create`, `secp256k1_ec_seckey_tweak_add` and
`secp256k1_keypair_xonly_tweak_add` all are. Read at
`6e2c8bc4ecdc6e71dbe7a368f360d8d453ce435d`, the submodule commit
`btclib-secp256k1` vendors.

The delegation is unchanged and so is what it buys: the speed, and
libsecp256k1's own answer. What goes is the timing guarantee.

`SECURITY.md` gains a bullet among its limitations, and states the rule
rather than a list of call sites -- `curves.curve.mult` delegates every
point that is neither the generator nor infinity, so which call a
multiplication takes is decided by its shape and not by the module that
writes it. `README.md` carries the short form.

Two rounds of local review. The first found that an earlier draft's
three named callers read as a population and were not one -- four more
sites reach the same call with a secret scalar -- and that a citation
had gone stale under an amend. Both are repaired here.

Collateral filed, not fixed here: btclib-org/btclib-secp256k1#864 (the
same sentence at its source, in three sites), #1993, #1994, #1995.

closes #1992

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aVLaHSmcxr35RphKatpLq

## Summary by Sourcery

Correct ECDH timing documentation to disclose that its delegated multiplication is variable time for secret scalars.

Bug Fixes:
- Correct the documentation to state that delegated elliptic-curve multiplication for secret scalars is variable time rather than constant time.

Enhancements:
- Document the timing limitation across the ECDH API, security guidance, README, and changelog while distinguishing delegated multiplication from constant-time libsecp256k1 paths.
- Clarify that the limitation applies broadly to delegated multiplication of non-generator points and update tests to reflect the corrected delegation behavior.

Documentation:
- Add user-facing security guidance describing the variable-time delegated multiplication and its scope.

Tests:
- Update ECDH tests to validate the delegated multiplication path without asserting a false constant-time guarantee.