### PR TITLE
The generator is a branch of the dispatch, not the boundary of it (closes #1994)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,28 @@ documented at release-notes length in the first place, and are still in
   answers with is the group arithmetic rather than an answer the header
   states: `tests/bip32/bip32_test.py` said the header states it.
 
+### The bindings dispatch is stated by its shape, not by a population
+
+- **A comment on `dsa.gen_keys` and the `btclib.curves` census each
+  named a population that is not one** (closes #1994). The generator was
+  "the one multiplication libsecp256k1 is dispatched to", where
+  `curves.curve.mult` delegates every point that is neither the
+  generator nor infinity; and a variable-base multiplication of a secret
+  scalar was `ecc.dh` in this package, where BIP374's proof, the ECDH
+  share of a BIP375 input and the key generation of BIP38's EC-multiply
+  mode each write one too. `SECURITY.md` publishes that population, so
+  neither site restates it. The docstrings of
+  `curves.curve._libsecp256k1_serves` and of `tests/all_test.py`'s export
+  test named the generator the same way, and are repaired with them.
+- **What is kept at the generator is what is true of it alone**, which
+  is the call: `secp256k1_ec_pubkey_create`, constant time in its
+  scalar, where every other point is `secp256k1_ec_pubkey_tweak_mul`.
+- **The issue #849 figure stays with what was measured.** 1.13x is
+  `ecc.dh` with the bindings switched off, and it says nothing about a
+  call it did not time, so the census names `ecc.dh` as the subject of
+  the measurement rather than as the place such a multiplication
+  happens.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/src/btclib/curves/__init__.py
+++ b/src/btclib/curves/__init__.py
@@ -56,8 +56,8 @@ wNAF makes one per bit however wide its table is and however thoroughly
 it is cached, the factor holding over the memoized odd multiples of G at
 w=8, w=10 and w=12 alike. So the arm every key derivation, every BIP32
 child and every signing nonce runs has no variable-time alternative to
-offer. What is left is a variable-base mult with a secret scalar, which
-in this package is ecc.dh: 1.13x on secp256k1 and 1.03x on nistp256, the
+offer. What is left is a variable-base mult with a secret scalar,
+measured over ecc.dh: 1.13x on secp256k1 and 1.03x on nistp256, the
 second being that measurement's own noise. Beside it, the blinded nonce
 inverse is a fraction of a percent of a signature, the projective
 blinding of curve_group._blinded_jac is 1%, and every verification is
@@ -70,8 +70,8 @@ They are implementations of one operation, kept side by side to be measured
 against each other, and a menu of them is not an API: a caller reading them
 would find every way of multiplying a point this package implements and
 nothing to say that mult is the one to use, that it dispatches to
-libsecp256k1 for secp256k1 and the generator, and that _mult_jac_var is
-not the faster alternative its name suggests.
+libsecp256k1 for secp256k1, and that _mult_jac_var is not the faster
+alternative its name suggests.
 
 The underscore says the second thing too, which is what decided it: each
 takes a point it assumes to be on the curve and checks nothing, so a

--- a/src/btclib/curves/curve.py
+++ b/src/btclib/curves/curve.py
@@ -511,8 +511,8 @@ def _libsecp256k1_serves(ec: Curve, hf: HashF | None) -> bool:
 
     Every dispatch to the bindings asks here, so that the predicates
     cannot drift apart the way hand-written copies would; a caller
-    with a further condition of its own -- mult, whose bindings take the
-    generator and a non-zero scalar alone -- ands it on top.
+    with a further condition of its own -- mult, whose bindings take
+    neither a zero scalar nor the point at infinity -- ands it on top.
 
     hf is compared by identity, deliberately: nothing short of running
     the two functions tells sha256 from a look-alike, so a wrapper such

--- a/src/btclib/ecc/dsa.py
+++ b/src/btclib/ecc/dsa.py
@@ -435,9 +435,9 @@ def gen_keys(
         q = scalar_from_prv_key(prv_key, ec)
 
     # mult, not the _mult under it: the scalar is the private key and the
-    # point is the generator, which is the one multiplication libsecp256k1
-    # is dispatched to -- constant time there, and two orders of
-    # magnitude under the Python arithmetic.
+    # point is the generator, which libsecp256k1 multiplies with
+    # secp256k1_ec_pubkey_create -- constant time in the scalar, and two
+    # orders of magnitude under the Python arithmetic.
     # ssa.gen_keys computes this very point the same way
     return q, mult(q, ec=ec)
 

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -395,9 +395,9 @@ def defined_public_names(module: ModuleType) -> set[str]:
 def test_ec_exports_the_curve_api_not_the_benchmark() -> None:
     """One multiplication, not fourteen ways to spell it.
 
-    mult dispatches to libsecp256k1 for secp256k1 and the generator, which
-    is exactly what a caller choosing _mult_jac_var from the same namespace --
-    on the strength of its name -- gives up.
+    mult dispatches to libsecp256k1 for secp256k1, which is exactly what a
+    caller choosing _mult_jac_var from the same namespace -- on the
+    strength of its name -- gives up.
     """
     assert sorted(btclib.curves.__all__) == [
         "CURVES",


### PR DESCRIPTION
Two comments said the generator is the one multiplication libsecp256k1 is
dispatched to. `curves.curve.mult` delegates an arbitrary point as well
-- `return _libsecp256k1_multi_mult([m], [Q])` -- so the generator is a
branch, not the boundary.

`curves/__init__.py`'s census paragraph carried the same shape around
issue #849's figure: "a variable-base mult with a secret scalar, which
in this package is `ecc.dh`". It is not the only one --
`psbt/silent_payments._share_for`, `ecc/dleq.generate_proof` twice and
`bip38.new_key_pair` all multiply a caller-supplied point by a secret.
The figure, though, timed `ecc.dh` with the bindings switched off, and
does not become a figure about those four by widening the sentence
around it. So the attribution stays with what was measured and the
population claim goes: "measured over `ecc.dh`". The benchmark was not
re-run.

`SECURITY.md` already publishes the population, by shape rather than by
module list, so this tree says it once.

The same clause lived in three more places in the same subsystem, one
line each and no separate decision: `_libsecp256k1_serves`'s docstring,
which now states `mult`'s real further conditions (neither a zero scalar
nor the point at infinity), and the two mirrored sentences in
`curves/__init__.py` and `tests/all_test.py`. Repairing one twin and
leaving the others would have left the tree contradicting itself.

closes #1994

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aVLaHSmcxr35RphKatpLq

## Summary by Sourcery

Correct the documentation and tests to accurately describe libsecp256k1 dispatch conditions and the scope of the variable-base multiplication benchmark.

Bug Fixes:
- Correct inaccurate documentation describing libsecp256k1 dispatch as limited to generator-point multiplication.

Enhancements:
- Clarify the actual conditions under which variable-base multiplication uses the bindings.
- Align curve documentation, DSA comments, export tests, and the security census with the measured dispatch behavior.
- Keep benchmark attribution scoped to the ECDH measurement rather than generalizing it to all secret variable-base multiplications.

Documentation:
- Update the changelog and related documentation to describe dispatch by operation shape and preserve the measured ECDH benchmark attribution.

Tests:
- Update the curve export test's dispatch documentation to remove the incorrect generator-specific claim.