### PR TITLE
SECURITY.md cites the line that reads a buffer into a Python int (closes #1995)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,22 @@ documented at release-notes length in the first place, and are still in
   the measurement rather than as the place such a multiplication
   happens.
 
+### `SECURITY.md` cites the line that reads a buffer into a Python `int`
+
+- **The read is at `src/btclib/ecc/commit_nonce.py:158` and at
+  `src/btclib/script/taproot.py:480`** (closes #1995). The citations
+  named the blank line after the first, and the `prvkey_tweak_add` call
+  that fills the buffer ahead of the second; the sentence around them is
+  about the read.
+- **The anchor in front of the `commit_nonce` citation is the quoted
+  line rather than `commit_nonce.commit_nonce_`.**
+  `tests/security_citations_test.py` matches a dotted name against the
+  definition holding the cited line, which a line elsewhere in that
+  definition satisfies too, and matches a quotation against the line
+  itself, so that citation fails on a drift the name passes. The
+  `taproot` citation keeps its dotted name, which cannot reject a drift
+  within `_tweaked_prvkey` either (issue #2001).
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -144,9 +144,10 @@ used to teach and to prototype as much as to build:
     `ssa.nonce_bip340`. btclib passes none of them, and that is a
     decision, not an oversight. These call sites read one of those
     straight into a Python `int`: `bip32.__prv_key_derivation`
-    (`src/btclib/bip32/bip32.py:842`), `commit_nonce.commit_nonce_`
-    (`src/btclib/ecc/commit_nonce.py:159`) and `taproot._tweaked_prvkey`
-    (`src/btclib/script/taproot.py:479`). A caller-owned buffer can be
+    (`src/btclib/bip32/bip32.py:842`), `commit_nonce.commit_nonce_` at
+    `int.from_bytes(tweaked, byteorder="big", signed=False)`
+    (`src/btclib/ecc/commit_nonce.py:158`) and `taproot._tweaked_prvkey`
+    (`src/btclib/script/taproot.py:480`). A caller-owned buffer can be
     wiped once the call that filled it returns; the `int` it is read
     into cannot be, and outlives the call regardless — the
     `_BIP32KeyData` working copy keeps `prv_key_int` for the whole of


### PR DESCRIPTION
`SECURITY.md` cited `commit_nonce.py:159`, a blank line. The read into a
Python `int` the sentence is about is at `:158`.

The gate could not see it. `tests/security_citations_test.py` matches a
dotted-name anchor with `ast` against the definition enclosing the cited
line, so any line inside the right function satisfies it and a citation
drifts within its own function while staying green. Measured, over one
wrong-but-in-function line (`commit_nonce.py:160`) and one command:

- dotted anchor -- exit 0, 9 passed
- quoted line as the anchor -- exit 1, naming the quotation and what
  line 160 actually reads

So the citation now quotes `int.from_bytes(tweaked, byteorder="big",
signed=False)` and keeps `commit_nonce.commit_nonce_` as prose. Three
citations in the file already use that form.

The same sentence cited `taproot.py:479`, the `prvkey_tweak_add` call
that fills the buffer, where its two siblings both name the
`int.from_bytes` that reads it -- which is what the sentence claims of
all three. Corrected to `:480`. Its anchor stays a dotted name, so it is
right today and unprotected still: that is issue #2001, filed with both
exit codes of the pair above.

closes #1995

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aVLaHSmcxr35RphKatpLq

## Summary by Sourcery

Correct the security documentation citations for buffer reads converted into Python integers.

Bug Fixes:
- Correct the SECURITY.md citations for the buffer-to-integer reads in commit_nonce.py and taproot.py.

Enhancements:
- Strengthen the commit_nonce citation by quoting the exact int.from_bytes line so line drift within the function is detected.

Documentation:
- Update the security guidance to identify the exact source lines associated with the cited integer reads.

Chores:
- Document the citation correction and remaining taproot citation validation limitation in the changelog.