### PR TITLE
What is delegated is stated by its condition, not by a roster (closes #1993, closes #1999)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,6 +291,51 @@ documented at release-notes length in the first place, and are still in
   `taproot` citation keeps its dotted name, which cannot reject a drift
   within `_tweaked_prvkey` either (issue #2001).
 
+### `docs/source/guide.rst` states the delegation by what a caller passes
+
+- **`ssa.sign` and `dsa.sign` dispatch on no message size, and the
+  guide's constant-time bullet said they did** (closes #1993).
+  `ssa.sign` asks `_libsecp256k1_serves(ec, hf) and commit_hash is None`,
+  the bindings' `sign_custom` beside their `sign` taking BIP340's
+  message of any size (issue #169); `dsa.sign`'s guard names no size
+  either. A caller's own nonce, listed in the same sentence, is
+  `dsa.sign`'s condition alone -- `ssa.sign` takes an `aux` and has no
+  nonce to impose.
+- **What the bullet gives instead is what a reader can apply to the
+  call they are about to make**, rather than the operations it named.
+  `curves.curve._libsecp256k1_serves` is the predicate every dispatch
+  asks, and only its curve half is absolute: another curve is the
+  Python path whatever the call. The hash function is a condition of
+  the operations that pass the predicate one, compared there by
+  identity, so a wrapper around `sha256` declines; a guard passing
+  `None` does not consult it at all. `ecc.commit_nonce.commit_nonce_`
+  and `ecc.dh.diffie_hellman` are where the difference shows: each
+  takes an `hf` and asks `_libsecp256k1_serves(ec, None)`, so
+  `hf=sha512` on secp256k1 still delegates the tweak of the secret
+  nonce and the multiplication by the secret scalar. Those
+  per-operation conditions are `SECURITY.md`'s *Limitations, not
+  vulnerabilities* section, which the bullet already links to; the
+  guide gives none of them a second wording.
+
+### `SECURITY.md`'s routing sentence states a condition, not a roster
+
+- **The opening section named three delegated operations where the
+  dispatch is wider** (closes #1999), disagreeing with the same file's
+  *Limitations, not vulnerabilities* bullet, which states the
+  delegation by shape -- `curves.curve.mult` delegates every point that
+  is neither the generator nor infinity. What routes a report is the
+  condition, so that is what the sentence gives: the installation, the
+  curve, the hash function and the arguments of the operation, with
+  that section named as where it is spelled out. Nothing of it is
+  restated.
+- **A `libsecp256k1_*.*` grep is a floor and not the surface.** It
+  reads a call made through one of the bindings' modules and misses
+  every one made through a flat alias, `curves.curve`'s generator arm
+  and `_libsecp256k1_multi_mult` among them.
+  `src/btclib/_libsecp256k1.py` binds both kinds, being the one module
+  that imports the bindings at runtime, so the surface is read there
+  rather than matched for.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,14 +18,16 @@ equally welcome.
 
 ## What belongs here, and what belongs upstream
 
-Signing, verification and generator multiplication on secp256k1 are
-delegated to
+secp256k1 arithmetic is delegated to
 [btclib-secp256k1](https://github.com/btclib-org/btclib-secp256k1/security/advisories/new),
 the Python bindings, and through them to
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1/security/advisories/new)
-itself, which has its own security policy and its own address. A flaw in
-the elliptic curve arithmetic, or in how the bindings drive it, most
-likely belongs to one of those.
+itself, which has its own security policy and its own address. Not every
+call: the installation, the curve, the hash function and the arguments
+of the operation decide which, and *Limitations, not vulnerabilities*
+below is where that condition is stated. A flaw in the elliptic curve
+arithmetic, or in how the bindings drive it, most likely belongs to one
+of those.
 
 What belongs here is everything btclib does around them:
 

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -40,10 +40,15 @@ particular btclib does **not**:
   use it with a key that holds value: private keys live in ordinary,
   immutable python objects that are never zeroized, and — the least
   obvious limitation — **not every operation reaches the constant-time
-  C library**. secp256k1 signing and generator multiplication are
-  delegated to the libsecp256k1 bindings; another curve, another hash
-  function, a nonce of your own, or a message that is not 32 bytes takes
-  the pure python path instead, which is double-and-add and makes no
+  C library**. With the bindings installed, what you pass decides
+  whether a given call does. A curve other than secp256k1 takes the
+  pure python path whatever the call; on secp256k1 an operation may
+  carry a further condition of its own, and that section gives them.
+  The hash function is one of those conditions rather than a second
+  absolute: where an operation has one, ``sha256`` itself is what
+  counts and ``functools.partial(sha256)`` is not it; where an
+  operation has none, hashing with something else leaves the call
+  delegated. The pure python path is double-and-add and makes no
   attempt to be constant-time
 
 .. warning::


### PR DESCRIPTION
Two summaries of what this tree delegates, each a roster, each read
before the one that is correct. `SECURITY.md`'s *Limitations, not
vulnerabilities* bullet already states the delegation by shape, so the
file disagreed with itself.

**`SECURITY.md:20` is a routing rule**, and routing does not need a
population -- it needs the reader to know that secp256k1 arithmetic is
somebody else's code. It now names the condition and points at the
section that states it. The qualifier stays: unqualified, "secp256k1
arithmetic is delegated" would be a new false claim, an install without
the bindings, the runtime switch, `musig2.nonce_gen` and a caller's
nonce all being on the Python path.

**`docs/source/guide.rst` is a guide**, so the abstraction alone would
have been the worse answer. What a reader can apply to their own call is
`curves.curve._libsecp256k1_serves`: a curve other than secp256k1 takes
the pure python path whatever the call, and on secp256k1 an operation
may carry a further condition of its own. `functools.partial(sha256)` is
named, the predicate comparing `hf is sha256` by identity.

The hash function is one of those conditions and not a second absolute,
which is what the first draft of this got wrong: a guard passing `None`
does not consult it at all, so `commit_nonce.commit_nonce_` with
`hf=sha512` still delegates the tweak of a secret nonce, and
`dh.diffie_hellman` with `hf=sha512` still delegates the multiplication
by a secret scalar. Stating otherwise under-counted the delegation,
which is the defect #1999 was filed about.

`ssa.sign` no longer gates on a 32-byte message, and has not since
issue #169: `sign_custom` beside `sign` takes BIP340's message of any
length, so every length reaches the C. The guide was the last place
still stating the withdrawn condition, nothing reading it.

closes #1993
closes #1999

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aVLaHSmcxr35RphKatpLq

## Summary by Sourcery

Document secp256k1 delegation according to the conditions that govern each caller and operation.

Bug Fixes:
- Correct documentation that overstated or mischaracterized the conditions under which secp256k1 operations are delegated, including the withdrawn message-length restriction for `ssa.sign`.
- Clarify that operations such as nonce commitment and Diffie–Hellman remain delegated with non-SHA256 hash functions when their dispatch conditions permit it.

Enhancements:
- Align `SECURITY.md` and the user guide around caller- and operation-dependent delegation conditions instead of fixed operation rosters.
- Update the guide to explain how curve, hash-function, installation, and operation arguments determine whether libsecp256k1 is used.

Documentation:
- Revise security-routing guidance to direct readers to the detailed delegation limitations while avoiding an incomplete list of delegated operations.
- Update the delegation section of the user guide with caller-applicable conditions and remove the obsolete 32-byte message requirement.