### PR TITLE
The mention job's pull-requests grant carries its reason (issue btclib-org/.github#915)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -427,6 +427,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      # what posting the reply takes
       pull-requests: write
       # the same startup OIDC token the review job above needs
       id-token: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -403,6 +403,22 @@ documented at release-notes length in the first place, and are still in
   is asserted in both directions against libsecp256k1-zkp over a
   generator `zkp.generator.generate` derives.
 
+### The `mention` job's `pull-requests: write` carries its reason
+
+- **`claude-review.yml`'s `mention` job says at its `pull-requests: write`
+  line what the grant is for** (issue btclib-org/.github#915): the
+  `review` job's grant and the `id-token: write` beside this one each
+  carry a reason at their line, and this grant carried none. The
+  sentence is the one `btclib-node` and `btclib-benchmarks` carry above
+  theirs, `# what posting the reply takes`, taken byte for byte so that
+  one reason is not worded two ways across the copies. Section 14 of the
+  organization standard keeps the file out of `tests/verbatim_test.py`'s
+  comparison -- `claude-review.yml` "is owed by every repository section
+  11 governs, and section 15's existence loop is what checks that — not
+  this list" -- so a copy carrying the comment beside one that does not
+  turns nothing red. The other copies are owed the same line, which is
+  why this entry cites the issue rather than closing it.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs


### PR DESCRIPTION
`claude-review.yml`'s `mention` job holds `pull-requests: write` with no
comment above it at f0358d56, where the `review` job's grant and the
`id-token: write` beside it each carry one. The line added is the one
`btclib-node` and `btclib-benchmarks` carry at the same place,
`# what posting the reply takes`, so the `mention` job's `permissions:`
block now hashes equal to theirs. `CHANGELOG.md` takes the entry at the
end of the open section, citing the issue rather than closing it: other
copies of the file are still owed the line.

Advances [ISS 915](https://github.com/btclib-org/.github/issues/915).

Local review: CLEARED at 07dd019dcabb4e273670dc7e352f0ef4401224b0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTU1zzQECW92BNipMctRCw

## Summary by Sourcery

Clarify why the Claude review mention job requires pull-request write access and record the change in the changelog.

Enhancements:
- Document the purpose of the `mention` job’s `pull-requests: write` permission to keep workflow permission annotations consistent.

Documentation:
- Add a changelog entry tracking the workflow permission comment and its related issue.