### PR TITLE
An anchor in `SECURITY.md` is chosen by what its sentence claims (closes #2001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -419,6 +419,19 @@ documented at release-notes length in the first place, and are still in
   turns nothing red. The other copies are owed the same line, which is
   why this entry cites the issue rather than closing it.
 
+### An anchor in `SECURITY.md` is chosen by what its sentence claims
+
+- **`bip32.__prv_key_derivation`, `taproot._tweaked_prvkey` and
+  `dh.diffie_hellman` carry a quotation of the line cited, beside the
+  name** (closes #2001). `tests/security_citations_test.py` matches a
+  quotation against that line and a dotted name against the definition
+  holding it, so a name is satisfied by every line of the definition --
+  and each of these holds a Python arm that the sentence around the
+  citation is not about.
+- **`ellswift.xdh` is named rather than quoted**, its sentence being
+  about the function: it returns octets rather than an `int`, and what
+  an `into=` buffer would cost there is `xdh`'s public signature.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -145,10 +145,12 @@ used to teach and to prototype as much as to build:
     `ecdh.shared_secret`, `ellswift.xdh`, `dsa.nonce_rfc6979` and
     `ssa.nonce_bip340`. btclib passes none of them, and that is a
     decision, not an oversight. These call sites read one of those
-    straight into a Python `int`: `bip32.__prv_key_derivation`
+    straight into a Python `int`: `bip32.__prv_key_derivation` at
+    `int.from_bytes(key, byteorder="big", signed=False)`
     (`src/btclib/bip32/bip32.py:842`), `commit_nonce.commit_nonce_` at
     `int.from_bytes(tweaked, byteorder="big", signed=False)`
     (`src/btclib/ecc/commit_nonce.py:158`) and `taproot._tweaked_prvkey`
+    at `int.from_bytes(tweaked, "big")`
     (`src/btclib/script/taproot.py:480`). A caller-owned buffer can be
     wiped once the call that filled it returns; the `int` it is read
     into cannot be, and outlives the call regardless — the
@@ -327,7 +329,8 @@ used to teach and to prototype as much as to build:
     scalar, arrives here, `curves.curve.mult` delegating every point
     that is neither the generator nor infinity —
     `return _libsecp256k1_multi_mult([m], [Q])`
-    (`src/btclib/curves/curve.py:823`). `dh.diffie_hellman`
+    (`src/btclib/curves/curve.py:823`). `dh.diffie_hellman` at
+    `sec = libsecp256k1_keys.pubkey_tweak_mul(`
     (`src/btclib/ecc/dh.py:107`) is the one this bullet was written
     from, and is an example rather than the population: key agreement,
     a BIP374 discrete-log equality proof and the key generation of


### PR DESCRIPTION
`tests/security_citations_test.py` matches a quotation against the line
cited and a dotted name against the definition holding it, so a name is
satisfied by every line of that definition.

`bip32.__prv_key_derivation`, `taproot._tweaked_prvkey` and
`dh.diffie_hellman` sit in sentences about a line: the read of a bindings
buffer into a Python `int` for the first two, the delegated
multiplication of a caller's point by a secret scalar for the third. Each
carries the quotation of that line beside the name, and each of the three
definitions holds a Python arm the name accepts as readily.

`ellswift.xdh` keeps its name. Its sentence is about the function -- the
call site returning octets rather than an `int` -- and about what an
`into=` buffer would cost `xdh`'s public signature.

closes #2001

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3

## Summary by Sourcery

Correct security-documentation citation anchors so each named symbol or quoted line accurately matches the claim made in its sentence.

Bug Fixes:
- Align the `SECURITY.md` citations for private-key derivation, taproot tweaking, and Diffie–Hellman with the specific code lines described by their surrounding sentences.

Enhancements:
- Clarify that the Ellswift `xdh` citation intentionally refers to the function rather than a specific implementation line.

Documentation:
- Update the changelog and security guidance to document the corrected citation anchors and their rationale.