### PR TITLE
The symbol set states which library it is a set of (closes #1997)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -432,6 +432,30 @@ documented at release-notes length in the first place, and are still in
   about the function: it returns octets rather than an `int`, and what
   an `into=` buffer would cost there is `xdh`'s public signature.
 
+### The vendored symbol set states which library it is a set of
+
+- **`tests/_data/README.md` says which question the set answers**
+  (closes #1997), where the entry gave the reason for `src` over
+  `include` and was silent on which revision. The pin is
+  bitcoin-core/secp256k1's own, and `btclib-secp256k1` builds the
+  library a caller loads from a submodule of that repository, so the
+  two differ in both directions: a name upstream has added since the
+  last bump is in the set and not in that library, and a name upstream
+  has renamed away is in that library and not in the set. The entry
+  carries the call that prints the submodule's revision and the command
+  that names the difference from it.
+- **Upstream is what a credit asks about, and that is what decides the
+  pin.** A credit is followed into bitcoin-core/secp256k1's source, so
+  a set taken from the submodule would keep a renamed-away name and
+  pass a credit landing its reader on a function upstream does not
+  have. Neither direction of the difference is spelled in a `.py` of
+  `src/btclib` or `tests`, so no paragraph here rests on which of the
+  two runs.
+- **`tests/upstream_symbols_test.py`'s docstring carries the choice**,
+  beside the blind spots it already enumerates. Whether the installed
+  bindings expose a name is a third question, and neither pin answers
+  it.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -1599,6 +1599,51 @@ in one under `src`. Nothing is lost at the other end — every name
 `include` declares is spelled in `src` too, the difference being names a
 header comment wraps in prose rather than declares.
 
+The revision is one of bitcoin-core/secp256k1's own, and not the one the
+bindings vendor. `btclib-secp256k1` compiles the library a caller loads
+from a submodule of that repository, so what the suite links is the
+submodule of the release `uv.lock` resolves:
+
+```shell
+version=<the btclib-secp256k1 version `uv.lock` resolves>
+```
+
+```shell
+gh api \
+    "repos/btclib-org/btclib-secp256k1/contents/secp256k1?ref=v${version:?}" \
+    --jq .sha
+```
+
+A name upstream has added since that revision is in this set and not in
+the library the suite runs against, and a name upstream has renamed away
+is in that library and not in this set. The names are what the entry's own
+re-derivation prints when it is run again at the submodule's revision
+and compared with the vendored set. `comm` compares byte for byte on
+input it takes as already sorted, so the vendored side is sorted again
+under the collation the left side is being built in rather than trusted
+to be in it: with the file's own order, a `sort` of another collation
+answers a longer difference, and the `comm` macOS ships prints nothing
+to say so.
+
+```shell
+submodule=<the sha the call above prints>
+symbols=<the path to `tests/_data/secp256k1_symbols.txt`>
+```
+
+```shell
+git grep -ohP '(?<![A-Za-z0-9_])secp256k1_[a-z0-9_]+' "${submodule:?}" \
+    -- src | sort -u | comm -3 - <(sort "${symbols:?}")
+```
+
+Upstream is what the set is of, because that is the read a credit asks
+for: `tests/upstream_symbols_test.py` refuses a credit a reader cannot
+follow, and following one is a read of bitcoin-core/secp256k1's source.
+Pinning to the submodule would answer for the library the bindings ship
+and give that up — a renamed-away name would stay in the set, so a
+credit spelling it would pass and land its reader on a function upstream
+does not have. What neither pin answers is whether the installed
+bindings expose a name, that being a fact about their own surface.
+
 ## Other projects
 
 ### `tests/curves/_data/pubkey.json`

--- a/tests/upstream_symbols_test.py
+++ b/tests/upstream_symbols_test.py
@@ -31,6 +31,19 @@ reminder about; `.github/workflows/vendored-vectors.yml` is what says
 the pin has moved, weekly and outside the suite, the way it does for
 every other pin that README carries.
 
+**The revision pinned there is upstream's own, not the one the bindings
+vendor.** `btclib-secp256k1` builds the library a caller loads from a
+submodule of bitcoin-core/secp256k1, so a name upstream has added since
+that submodule's last bump is in this set and absent from the library
+the suite runs against. Upstream is what a credit asks about: it is
+followed into that repository's source, and the set is of what is there
+to be found. Pinning to the submodule would answer for the library the
+bindings ship and give that up, a name upstream has renamed away
+staying in the set and a credit spelling it passing. Whether the
+installed bindings expose a name is a third question, and neither pin
+answers it. `tests/_data/README.md`'s entry carries the choice and the
+command that names the difference.
+
 **The authority is the library's own `src`, not its `include`.**
 Publishing is a different question from having, and a credit raises the
 second: `curves.curve` names `secp256k1_ge_x_on_curve_var`,


### PR DESCRIPTION
`tests/upstream_symbols_test.py` decides whether a credited
`secp256k1_*` name is real out of `tests/_data/secp256k1_symbols.txt`,
pinned to a revision of bitcoin-core/secp256k1. The library the suite
links is built from a submodule of that repository held by
`btclib-secp256k1`, and the two revisions are not the same one. The
entry gave the reason for `src` over `include` and said nothing about
which of the two the set is of; a reader today infers the second.

The decision is the first: the set is upstream's, and the entry and the
module docstring now say so. A credit is followed into
bitcoin-core/secp256k1's source, which is where a reader can open the
name, so the set has to be of what that repository has. A set taken
from the submodule would answer for the library the bindings ship and
give the following up: a name upstream has renamed away would stay in
it, and a credit spelling it would pass while landing its reader on a
function upstream does not have.

The divergence runs in both directions, measured at the pin (99ae2312,
2026-09-09) against the submodule the locked `btclib-secp256k1`
release carries (6e2c8bc4, upstream's 0.8.0 release preparation of
2026-08-03, and the same revision at that release's tag and at the
bindings' own tip):

  git grep -ohP '(?<![A-Za-z0-9_])secp256k1_[a-z0-9_]+' <rev> -- src \
      | sort -u

run at each revision and compared with `comm`, the vendored side
sorted again rather than trusted to be in the order the comparison
needs: `comm` takes both sides as sorted already, and under a
collation other than the one the file was written in it answers a
longer difference, the `comm` macOS ships saying nothing.

One direction is the `_impl`-suffixed names `src/group_impl.h`
carries, with the parse and serialize names of `src/group.h` beside
them, and four that are neither: `secp256k1_eckey_seckey_tweak_add`
and `secp256k1_eckey_seckey_tweak_mul` of `src/eckey.h`, which are the
far side of the rename this sentence ends on, and
`secp256k1_fe_set_int_unchecked` with the `_impl_` spelling
`src/field.h` defines it to. The other direction is what upstream's
renames left behind, `secp256k1_eckey_privkey_tweak_add` and its
neighbours, which are in the linked library and not in the pin.

Neither direction is spelled in any `.py` of `src/btclib` or `tests`,
swept with `grep -r --include='*.py'` -- the `--include` is
load-bearing, the vendored file sitting under `tests` and otherwise
matching every name against itself. So repinning would redden nothing,
and neither does leaving the pin where it is: the decision is about
what the set is of rather than about a live failure.

What the brief for this issue proposed as the ground for the other
answer -- that the credits are overwhelmingly calls this tree makes --
is refuted by the same sweep: of the names credited in a paragraph
naming the library, most are declared in no header of `include`, so no
build exposes them and no caller reaches them. They are citations of
upstream's own arithmetic, and a reader following one reads source.

Three shapes were refused. Vendoring both sets, or one set and a diff,
doubles the vendored data for a difference no paragraph here depends
on. Repinning this block at the submodule's revision, with the repo
and path it names unchanged, puts its `behind` line past 0, which is
what `.github/scripts/check_vendored_vectors.py` skips: the weekly
report would stop watching the entry. Re-aiming the block at
`btclib-org/btclib-secp256k1`'s own `secp256k1` path keeps `behind` at
0, a submodule bump being the tip of that path, and costs the entry
its provenance: the file is transcribed from bitcoin-core/secp256k1's
`src`, which the block would no longer name.

closes #1997

This closes a question ISS #1997 reserved rather than a defect it
reported. The issue left the decision open -- "Whether the set should
be pinned to the revision the bindings vendor, or stay at upstream's
tip with the divergence stated, is the decision" -- and the ground for
taking the first is that a credit is followed into
bitcoin-core/secp256k1's source, so the set has to be of what that
repository has. What is given up by not repinning is stated in the
entry and in the module docstring rather than left for a reader to
find: a name upstream has added since the submodule's revision is in
this set and absent from the library the suite links, and whether the
installed bindings expose a name is a third question neither pin
answers.

closes #1997

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3

## Summary by Sourcery

Clarify that the secp256k1 symbol set represents upstream bitcoin-core/secp256k1 and document its relationship to the bindings' vendored revision.

Enhancements:
- Document that the vendored secp256k1 symbol set is pinned to upstream bitcoin-core/secp256k1 and is intended to validate references to upstream source rather than the library revision bundled by the bindings.
- Clarify the distinction between upstream symbols, bundled library symbols, and the installed bindings' exposed API, including how to compare the pinned set with the vendored revision.

Documentation:
- Update the symbol-set data documentation and upstream symbol test docstring to explain the set's provenance, scope, and revision differences.