### PR TITLE
The issue-form hooks join the check-jsonschema block (issue btclib-org/.github#767)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -684,6 +684,16 @@ repos:
     hooks:
       - id: check-dependabot
       - id: check-readthedocs
+      # .github/ISSUE_TEMPLATE/ is read the same way and by nothing else
+      # here either: a form whose `type:` is misspelt is still yaml, and
+      # the reader who meets it is a person on the New issue page rather
+      # than a run. Each brings its own files: and types: -- config.yml
+      # under that spelling for the first, the directory's yaml that is
+      # neither config.yml nor config.yaml for the second, a markdown
+      # template for neither -- so check-hooks-apply above is what says
+      # this tree still holds one of each
+      - id: check-github-issue-config
+      - id: check-github-issue-forms
   # the workflows are 3, 6 and 8 KB of yaml with expressions in it, and
   # nothing validated them: an unknown key, a typo in a context reference,
   # an action input that does not exist, a job depending on a job that is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -456,6 +456,21 @@ documented at release-notes length in the first place, and are still in
   bindings expose a name is a third question, and neither pin answers
   it.
 
+### The issue-form hooks join the `check-jsonschema` block
+
+- **`check-github-issue-config` and `check-github-issue-forms` run beside
+  `check-dependabot` and `check-readthedocs`, in the `check-jsonschema`
+  block at `rev: 0.38.0`** (issue btclib-org/.github#767): the pair
+  section 4's *schemas* bullet of the organization standard names. Both
+  select under `types: [yaml]` -- `.github/ISSUE_TEMPLATE/config.yml`
+  under that spelling for the first, the directory's other yaml for the
+  second, here `bug_report.yml`, `feature_request.yml` and
+  `question.yml` -- so `check-hooks-apply` finds a file for each. The
+  comment above the pair is `btclib-org/.github`'s own, byte for byte.
+  `config.yml` and the forms validate clean as they stand, so nothing
+  under `ISSUE_TEMPLATE/` moves. The other copies are owed the same pair,
+  which is why this entry cites the issue rather than closing it.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs


### PR DESCRIPTION
`check-github-issue-config` and `check-github-issue-forms` are added to
`.pre-commit-config.yaml`'s `check-jsonschema` block at `rev: 0.38.0`,
after `check-dependabot` and `check-readthedocs`, with
`btclib-org/.github`'s own comment above them byte for byte. Section 4's
*schemas* bullet of the organization standard names the pair.
`.github/ISSUE_TEMPLATE/` here holds `config.yml`, which the first
selects, and `bug_report.yml`, `feature_request.yml` and `question.yml`,
which the second selects; every one of them validates clean, so nothing
under that directory moves. `CHANGELOG.md` carries the entry.

The other repositories of the organization are owed the same pair, so
the issue is cited and left open.

Advances [ISS 767](https://github.com/btclib-org/.github/issues/767).

Local review: CLEARED at fe85ca915aa28cfc48f3c0b60846cc0f2f556a98

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGRFSkPFh8PR4Y3Wr47vb

## Summary by Sourcery

Validate GitHub issue configuration and forms alongside the existing JSON Schema pre-commit checks.

New Features:
- Add GitHub issue configuration and issue-form validation hooks to the pre-commit checks.

Documentation:
- Document the new issue-template validation hooks and their organization-standard alignment in the changelog.