### PR TITLE
`_jac_double_mult` names the verification guard (closes #2003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -471,6 +471,24 @@ documented at release-notes length in the first place, and are still in
   under `ISSUE_TEMPLATE/` moves. The other copies are owed the same pair,
   which is why this entry cites the issue rather than closing it.
 
+### `_jac_double_mult` names the guard its callers asked
+
+- **The docstring gave four reasons dsa's and ssa's verifications are
+  on the Python arithmetic, and two of them are conditions of neither**
+  (closes #2003): a BIP340 message that is not 32 bytes, which the gate
+  imposing it no longer exists to impose, and a caller-imposed nonce,
+  which a verification does not take. What stands in a verification's
+  guard is `curves.curve._libsecp256k1_serves` and nothing else, and
+  what the predicate tests is the dispatch switch, the curve and the
+  hash function.
+- **A signer reaches the same function, on a guard of its own**, and
+  the docstring now says so rather than describing the verification's
+  guard as the only way in: a nonce or a sign-to-contract commitment
+  puts `sign_` on the Python arm, which checks the signature it wrote
+  through the same `_assert_as_valid_`. Which reason brought a caller
+  decides nothing about the double multiplication, the predicate being
+  asked again with no hash function.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/src/btclib/curves/curve.py
+++ b/src/btclib/curves/curve.py
@@ -1260,12 +1260,18 @@ def _jac_double_mult(
     """Return u*HJ + v*QJ in Jacobian coordinates, delegated where it can be.
 
     double_mult_var for a caller whose equation is written in projective
-    coordinates: dsa's and ssa's _assert_as_valid_, which are the two
-    verifications the bindings' own decline -- a hash function that is not
-    sha256, a BIP340 message that is not 32 bytes (issue 169), a
-    caller-imposed nonce, another curve -- and which paid a Python
-    double_mult_var underneath whatever the reason, some thirty-five
-    times the delegated one on secp256k1.
+    coordinates, dsa's and ssa's _assert_as_valid_ among them. What put
+    such a caller on the Python arithmetic is that caller's own guard,
+    which is not this function's: a verification asks
+    _libsecp256k1_serves and nothing else, where each module's sign_
+    asks it beside conditions of its own and reaches _assert_as_valid_
+    anyway, to check the signature it has just written. Either way the
+    predicate is asked again below, with no hash function, so what sent
+    a caller here decides nothing about the double multiplication
+    unless it was the dispatch switch or the curve -- a hash function
+    of its own leaves the multiplication delegated. A Python
+    double_mult_var is some thirty-five times the delegated one on
+    secp256k1.
 
     Jacobian in and Jacobian out, rather than those two rewritten in
     affine coordinates, because it is not only their arithmetic that is


### PR DESCRIPTION
The docstring gave the reasons dsa's and ssa's verifications are on the
Python arithmetic as a list: a hash function that is not sha256, a
BIP340 message that is not 32 bytes, a caller-imposed nonce, another
curve. The message size and the nonce are conditions of neither
verification.

`assert_as_valid_` guards the delegated arm with `_libsecp256k1_serves`
and nothing else in both modules -- `src/btclib/ecc/ssa.py:993` and
`src/btclib/ecc/dsa.py:1630` -- and that predicate tests the dispatch
switch, the curve and the hash function
(`src/btclib/curves/curve.py:509`). `libsecp256k1_ssa.verify` takes
BIP340's message of any size, which the comment above the ssa guard
states. Neither `assert_as_valid_` takes a nonce: a verification is
independent of how the signature it checks was made.

What replaces the list is the predicate and what it tests. A list of
reasons reads exhaustive with no quantifier saying so, and the reader it
misleads is the one who follows it rather than the guard.

A verification's guard is not the only way in, and the docstring no
longer reads as though it were. `sign_`'s Python arm checks the
signature it has just written through the same `_assert_as_valid_`
(`src/btclib/ecc/dsa.py:619` and `src/btclib/ecc/ssa.py:574`), and its
own guard does carry conditions beyond the predicate -- a caller's
nonce, `lower_s`, a sign-to-contract commitment
(`src/btclib/ecc/dsa.py:949-953`, `src/btclib/ecc/ssa.py:527`). So a
signature made with a nonce of the caller's does reach the Python
double multiplication; what the old text had wrong was the reach it
attributed that to, and striking the reason outright would have lost a
fact with the error.

The paragraph also says what the docstring left to be inferred: the
predicate is asked again below with no hash function
(`src/btclib/curves/curve.py:1293`), so what sent a caller here decides
nothing about the double multiplication unless it was the dispatch
switch or the curve.

`CHANGELOG.md` takes an entry. That automodule renders no page for a
private name answers whether the docs change, where `CONTRIBUTING.md`
asks whether a reader would notice -- and the reader of this docstring
is the one who opens the function.

The sweep the issue asks for -- whether another docstring or comment in
`src/` states a delegation condition the guards no longer carry --
answers with one site, `src/btclib/ecc/dsa.py:1510-1516`, where a
commitment to check and a caller-imposed nonce are given as reasons
`ecdsa_verify` was declined. It is filed as
[ISS 2007](https://github.com/btclib-org/btclib/issues/2007) rather than
repaired here, `ecc/dsa.py` being neither the file this issue names nor
the subject of its own repair.

closes #2003

closes #2003

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3

## Summary by Sourcery

Clarify the conditions governing delegated and Python elliptic-curve arithmetic in `_jac_double_mult` and record the documentation correction.

Bug Fixes:
- Correct the `_jac_double_mult` documentation to accurately describe the verification guard and remove misleading conditions such as message size and caller-imposed nonces.
- Clarify that signing can also route through Python verification under its own additional conditions.

Documentation:
- Document the dispatch predicate, curve, and hash-function conditions that determine delegated versus Python arithmetic.

Chores:
- Add a changelog entry for the corrected `_jac_double_mult` guard documentation and track the related DSA documentation issue separately.