### PR TITLE
Both anchors of a `SECURITY.md` citation are held (closes #2009)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -489,6 +489,21 @@ documented at release-notes length in the first place, and are still in
   decides nothing about the double multiplication, the predicate being
   asked again with no hash function.
 
+### A citation in `SECURITY.md` is held to every anchor written for it
+
+- **A dotted name in front of a quoted line is read** (closes #2009).
+  `tests/security_citations_test.py` took the span immediately in front
+  of a citation and no other, so where the prose writes the name, the
+  word `at`, the quotation and then the citation, the quotation was the
+  anchor and the name was checked against nothing. Both are now read,
+  the name against the definition holding the cited line and the
+  quotation against the line itself.
+- **The citation at `src/btclib/curves/curve.py:823` names
+  `curve._mult_checked`**, which is the definition that line sits in:
+  the arm `curves.curve.mult` and `PreparedPoint.mult` share. The
+  sentence around the citation reaches that arm through `mult`, and the
+  quotation of the line is unchanged.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,16 +228,16 @@ Do not use Fable unless explicitly instructed.
   does skip.
 - **`tests/security_citations_test.py` checks every `path:line` citation
   `SECURITY.md` carries, but a symbol anchor pins only the function.**
-  The anchor is the backticked span in front of a citation: a dotted
-  name (`dsa.Signer.__init__`) is matched with `ast` against the
-  definition enclosing the cited line, while a citation that quotes its
-  line instead of naming a symbol — the way musig2.py's sum and dsa.py's
-  `to_bytes` call do — is matched verbatim against that line. A
-  dotted-name anchor is satisfied by any line inside the right function,
-  which is most of what `SECURITY.md` cites, so a citation that drifts a
-  few lines within its own function still passes there. `awk 'NR==N'
-  <file>` verified against the claimed content, not against which
-  function the line lands in, is still the check for a dotted-name
+  The backticked spans in front of a citation are what it claims: a
+  dotted name (`ellswift.xdh`) is matched with `ast` against the
+  definition enclosing the cited line, and a quotation of that line —
+  the way musig2.py's sum and dsa.py's `to_bytes` call are written —
+  verbatim against the line itself. A citation carrying both, the name
+  and then the quotation, is held to each of them. A dotted-name anchor
+  is satisfied by any line inside the right function, so a citation that
+  drifts a few lines within its own function still passes on its name.
+  `awk 'NR==N' <file>` verified against the claimed content, not against
+  which function the line lands in, is still the check for a dotted-name
   citation — a citation landing inside the right function has still been
   off by several lines; a quoted-line citation already gets that from
   the gate.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -327,7 +327,8 @@ used to teach and to prototype as much as to build:
     multiplication takes is decided by its shape and not by the module
     that writes it: any point a caller supplied, multiplied by a secret
     scalar, arrives here, `curves.curve.mult` delegating every point
-    that is neither the generator nor infinity —
+    that is neither the generator nor infinity in the arm it shares with
+    `PreparedPoint.mult` — `curve._mult_checked` at
     `return _libsecp256k1_multi_mult([m], [Q])`
     (`src/btclib/curves/curve.py:823`). `dh.diffie_hellman` at
     `sec = libsecp256k1_keys.pubkey_tweak_mul(`

--- a/tests/security_citations_test.py
+++ b/tests/security_citations_test.py
@@ -14,9 +14,8 @@ sentence names, and learns that the file's pointers cannot be followed.
 That is worse than a file with no pointers (issue #1690).
 
 The grammar read here is the file's own. A citation is a backticked
-path, with or without a line number, and its anchor is the backticked
-span in front of it -- the prose puts one there either way it writes a
-citation:
+path, with or without a line number, and what it claims is written in
+the backticked spans in front of it:
 
 - a dotted name, `dsa.Signer.__init__`, and then the definition holding
   the cited line must be the one named, read off the module's own `ast`;
@@ -25,14 +24,22 @@ citation:
   cited. Whitespace is flowed on both sides, the eighty-column wrap of
   the markdown being a fact of the margin and not of the code.
 
+The prose writes either of those, and it writes both: the name, the
+word `at`, the quotation and then the citation. Both are read, each
+against what it claims -- a quotation in front of a citation takes the
+dotted name in front of *it* as the second anchor of the same citation.
+That adjacency is what holds the two together, so a name the prose puts
+further back than the quotation is a sentence about the definition
+rather than an anchor of the citation, and is not read.
+
 A path with no line number is held to naming a file that exists, which
 is the whole of what it claims.
 
 Two things this does not check. Which line inside a named definition is
 the right one: a dotted name pins the function and leaves every line of
 it equally acceptable, so a citation that drifts within its own function
-passes here -- a citation wanting the stricter check quotes its line
-instead of naming its function. And whether the sentence around a
+passes on its name -- a citation wanting the stricter check quotes its
+line, beside the name or in place of it. And whether the sentence around a
 citation is true of the line it points at, which no test can read; what
 this keeps true is that the pointer still points at the code the
 sentence was written about.
@@ -86,18 +93,33 @@ def _prose() -> str:
     return _flow("\n".join(lines))
 
 
-_SPANS = _SPAN.findall(_prose())
-# each span paired with the span in front of it, and the first with
-# nothing: `strict=False` is what drops the head that has no span after
-# it. A citation opening the file carries an empty anchor, and `_defect`
-# refuses that rather than checking a line against nothing -- the empty
-# string is in every line, so a fall-through here would pass a citation
-# for free
-_CITATIONS = tuple(
-    (anchor, match["path"], match["line"] or "")
-    for anchor, span in zip(["", *_SPANS], _SPANS, strict=False)
-    if (match := _CITATION.match(span))
-)
+def _citations(prose: str) -> tuple[tuple[str, str, str], ...]:
+    """Return every citation of the prose, once for each anchor in front of it.
+
+    A citation opening the prose carries an empty anchor, and `_defect`
+    refuses that rather than checking a line against nothing -- the empty
+    string is in every line, so a fall-through here would pass a citation
+    for free. The index is what says there is a span in front at all: a
+    negative one reaches the tail of the prose, and would anchor a
+    citation to whatever the file happens to end with.
+    """
+    spans = _SPAN.findall(prose)
+    anchored: list[tuple[str, str, str]] = []
+    for index, span in enumerate(spans):
+        if not (match := _CITATION.match(span)):
+            continue
+        anchors = [spans[index - 1] if index else ""]
+        if (
+            not _SYMBOL.match(anchors[0])
+            and index > 1
+            and _SYMBOL.match(spans[index - 2])
+        ):
+            anchors.append(spans[index - 2])
+        anchored += [(anchor, match["path"], match["line"] or "") for anchor in anchors]
+    return tuple(anchored)
+
+
+_CITATIONS = _citations(_prose())
 
 
 def _enclosing(source: Path, lineno: int) -> str:
@@ -187,40 +209,75 @@ class Klass:
 
 _SOUND = (
     pytest.param(
-        "control.Klass.method", "control.py", "9", id="the name holds the line"
+        "control.Klass.method", "src/control.py", "9", id="the name holds the line"
     ),
     pytest.param(
-        "Klass.method", "control.py", "9", id="the name is a tail of the definition"
+        "Klass.method", "src/control.py", "9", id="the name is a tail of the definition"
     ),
     pytest.param(
-        "answer = 1 + 1", "control.py", "9", id="the quotation is on the line"
+        "answer = 1 + 1", "src/control.py", "9", id="the quotation is on the line"
     ),
     pytest.param(
-        "control.Klass.method", "control.py", "", id="a path claims only to exist"
+        "control.Klass.method", "src/control.py", "", id="a path claims only to exist"
     ),
 )
 
 _BROKEN = (
     pytest.param(
-        "control.Klass.other", "control.py", "9", id="a name that does not hold it"
+        "control.Klass.other", "src/control.py", "9", id="a name that does not hold it"
     ),
-    pytest.param("control.Klass", "control.py", "1", id="a line in no definition"),
-    pytest.param("answer = 2 + 2", "control.py", "9", id="a quotation not on the line"),
+    pytest.param("control.Klass", "src/control.py", "1", id="a line in no definition"),
     pytest.param(
-        "control.Klass.method", "control.py", "99", id="a line the file lacks"
+        "answer = 2 + 2", "src/control.py", "9", id="a quotation not on the line"
     ),
     pytest.param(
-        "control.Klass.method", "control.py", "0", id="a line below the first"
+        "control.Klass.method", "src/control.py", "99", id="a line the file lacks"
     ),
-    pytest.param("control.Klass.method", "absent.py", "1", id="a file that is gone"),
-    pytest.param("", "control.py", "9", id="a citation with nothing in front of it"),
+    pytest.param(
+        "control.Klass.method", "src/control.py", "0", id="a line below the first"
+    ),
+    pytest.param(
+        "control.Klass.method", "src/absent.py", "1", id="a file that is gone"
+    ),
+    pytest.param(
+        "", "src/control.py", "9", id="a citation with nothing in front of it"
+    ),
+)
+
+
+# the prose the anchoring controls read, written here for the reason the
+# module above is: prose taken from SECURITY.md would stop controlling
+# the pairing the day that file stopped writing one of these shapes
+_CONTROL_PROSE = """\
+(`src/control.py:9`) opens the prose with nothing in front of it, where
+`answer = 1 + 1` (`src/control.py:9`) quotes the line, `Klass.method`
+(`src/control.py:9`) names the definition holding it, `Klass.method` at
+`answer = 1 + 1` (`src/control.py:9`) writes both, and `answer` at
+`answer = 1 + 1` (`src/control.py:9`) puts a span that is no dotted name in
+front of the quotation.
+"""
+
+_ANCHORED = (
+    ("", "src/control.py", "9"),
+    ("answer = 1 + 1", "src/control.py", "9"),
+    ("Klass.method", "src/control.py", "9"),
+    ("answer = 1 + 1", "src/control.py", "9"),
+    ("Klass.method", "src/control.py", "9"),
+    ("answer = 1 + 1", "src/control.py", "9"),
 )
 
 
 @pytest.fixture
 def control(tmp_path: Path) -> Path:
-    """Write the module the controls cite, and answer its directory."""
-    (tmp_path / "control.py").write_text(_CONTROL_SOURCE, encoding="utf-8")
+    """Write the module the controls cite, and answer the root it sits under.
+
+    Under a directory of its own, because `_CITATION` asks a path for a
+    slash -- which is what keeps a dotted name from reading as one -- and
+    the prose the pairing is controlled with is read through that pattern.
+    """
+    source = tmp_path / "src" / "control.py"
+    source.parent.mkdir()
+    source.write_text(_CONTROL_SOURCE, encoding="utf-8")
     return tmp_path
 
 
@@ -247,6 +304,28 @@ def test_every_citation_answers_for_what_it_names(
     """
     defect = _defect(anchor, path, line)
     assert not defect, f"{_SECURITY.name} {defect}"
+
+
+def test_the_anchors_of_a_citation_are_the_spans_in_front_of_it() -> None:
+    """Every shape the prose writes, against what the pairing reads off it.
+
+    The equality is of the whole tuple, order included: a citation
+    writing both forms is read twice, and which anchor is dropped is
+    exactly what a pairing gets wrong.
+    """
+    assert _citations(_CONTROL_PROSE) == _ANCHORED
+
+
+def test_a_name_wrong_beside_a_right_quotation_is_named(control: Path) -> None:
+    """The two claims of one citation are held one at a time.
+
+    The quotation is on the line cited and the name is of another
+    definition, so a pairing stopping at the span in front of the
+    citation answers that this citation is sound.
+    """
+    quoted, named = _citations("`Klass.other` at `answer = 1 + 1` (`src/control.py:9`)")
+    assert not _defect(*quoted, control)
+    assert _defect(*named, control)
 
 
 @pytest.mark.parametrize("anchor, path, line", _SOUND)


### PR DESCRIPTION
**This closes a question ISS #2009 reserved, rather than a defect it
reported.** The issue set out both answers and took neither: "whether
the pairing should take **both** spans in front of a citation where the
first is a dotted name and the second a quotation, and hold each against
what it claims, or whether an unchecked name beside a quotation is the
intended cost of choosing the stricter anchor."

The branch takes the first, and the ground is measured rather than
preferred. The name-and-quotation shape is not a one-off: it was absent
at `v2026.8.27`, stood twice before `bcc0f586`, and stands five times
now, so option two would document a hole the tree's own preference for
the stricter anchor is enlarging. And the hole already held a false
claim — `SECURITY.md` named `curves.curve.mult` in front of a citation
to `src/btclib/curves/curve.py:823`, a line inside `curve._mult_checked`
that `mult` and `PreparedPoint.mult` reach through. The name was never
true of that line and landed green because nothing read it; the gate
extended here refuses it, and the sentence now names the arm.

**The cut-back, if the answer is unwanted**, is the pairing alone: the
two-span branch of `_citations` and its two controls come out, and what
remains is the `curve._mult_checked` correction, which is true either
way, and a module docstring saying that a name beside a quotation is
unchecked. The gate would be back where it was without the prose having
to be reverted with it.

The boundary is adjacency, and that is a decision too: reading three to
five spans back would newly read true sentences and refuse them, which
the module docstring now states rather than leaves implicit.
`SECURITY.md:170`'s `dsa.Signer.__init__`, five spans from its citation,
is left unread and filed as ISS #2017.

`tests/security_citations_test.py` paired a citation with the backticked
span immediately in front of it and with no other. Where the prose
writes the dotted name, the word `at`, the quotation of the line and
then the citation, that span is the quotation, and the name behind it
was passed to nothing.

A quotation anchoring a citation now takes the dotted name in front of
it as that citation's second anchor, and each is held against what it
claims: the name against the definition holding the cited line, read off
the module's own `ast`, the quotation against the line itself. Adjacency
is what holds the pair together, so a name the prose puts further back
than the quotation is a sentence about the definition rather than an
anchor, and is not read.

The extended pairing refuses the citation naming `curves.curve.mult` at
`src/btclib/curves/curve.py:823`: that line is in `curve._mult_checked`,
the arm `mult` and `PreparedPoint.mult` share. `SECURITY.md` names that
arm beside the quotation the citation already carried.

The controls run the pairing over prose of their own rather than over
`SECURITY.md`, which would stop controlling it the day the file stopped
writing one of the shapes. One of them is a name that is wrong beside a
quotation that is right, the shape a pairing stopping at the span in
front of the citation reports as sound. The module the controls cite
moves under a directory, so that the path they write is one `_CITATION`
parses: the pattern asks a path for a slash, which is what keeps a
dotted name from reading as a citation.

`CLAUDE.md`'s account of the check follows it: the spans in front of a
citation rather than the span, and no quantifier over how much of
`SECURITY.md` either shape accounts for.

closes #2009

closes #2009

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3

## Summary by Sourcery

Hold every immediately adjacent anchor in `SECURITY.md` citations against the code claim it represents.

New Features:
- Validate both a dotted symbol name and an adjacent quoted line when they jointly anchor a `SECURITY.md` citation.

Bug Fixes:
- Correct the security citation for the elliptic-curve multiplication implementation and prevent citations with a wrong symbol beside a correct quotation from passing validation.

Enhancements:
- Define citation-anchor pairing around immediate adjacency and document the resulting validation behavior.

Documentation:
- Update `CLAUDE.md` and `CHANGELOG.md` to describe multi-anchor citation validation.

Tests:
- Add focused coverage for citation anchor pairing and independently validating a symbol name against a quoted line.