### PR TITLE
`ecc.dsa`'s dispatch comments name the guard (closes #2007, #2010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -504,6 +504,36 @@ documented at release-notes length in the first place, and are still in
   sentence around the citation reaches that arm through `mult`, and the
   quotation of the line is unchanged.
 
+### `ecc.dsa`'s dispatch comments name the guard of the reach they are about
+
+- **`lower_s` was missing from the conditions `_sign_recoverable_`'s
+  comment gave for a signature the bindings did not make** (closes
+  #2010), and it is a conjunct of `sign_`'s guard and of
+  `sign_recoverable_`'s alike: a caller asking for the s that was
+  computed signs through that function, on the Python arm. The same
+  list named a sign-to-contract commitment, which is `sign_`'s
+  condition and not the other's -- `sign_recoverable_` takes no
+  commitment at all, and its docstring says why. What the comment gives
+  instead is the guard itself: `curves.curve._libsecp256k1_serves`,
+  which every caller's guard asks, and the conditions each spelling adds
+  beside it.
+- **`_libsecp256k1_sign_`'s comment promised a count its own list did
+  not match**, and states none now. What it lists is what `sign_`'s
+  guard settles before the call, which is the one guard that reaches
+  it.
+- **A commitment to check and a caller-imposed nonce were given as
+  reasons `ecdsa_verify` declined the verification `_assert_as_valid_`
+  answers** (closes #2007): `_assert_commitment_` runs ahead of that
+  dispatch and on both arms, and `assert_as_valid_` takes no nonce, a
+  verification being independent of how the signature it checks was
+  made. Both belong to a signer's guard, which reaches the same function
+  through the check a signer makes on the signature it has just written,
+  so they are attributed there rather than struck. What a verification's
+  guard asks is `curves.curve._libsecp256k1_serves` and nothing else,
+  and what sent a caller in decides nothing about the double
+  multiplication unless it was the dispatch switch or the curve,
+  `_jac_double_mult` asking that predicate itself.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/src/btclib/ecc/dsa.py
+++ b/src/btclib/ecc/dsa.py
@@ -449,11 +449,11 @@ def _sign_recoverable_(
     # a test can explore every value of it on a low-cardinality curve.
     # c is assumed in 0..n-1, q and nonce in 1..n-1
     # Steps numbering follows SEC 1 v.2 section 4.1.3
-    # affine coordinates of K (field elements); mult dispatches the
-    # generator to libsecp256k1 on secp256k1, which is where this
-    # function is reached from whenever the bindings decline the whole
-    # signature -- another hash function, another curve, a nonce the
-    # caller imposed, a sign-to-contract commitment. The nonce is secret,
+    # affine coordinates of K (field elements); mult dispatches the generator
+    # to libsecp256k1 on secp256k1, and what sent a signer here is its caller's
+    # own guard: every one asks `_libsecp256k1_serves`, the free functions
+    # beside it for a nonce nobody imposed, lower_s and, where one is taken, no
+    # sign-to-contract commitment. The nonce is secret,
     # and what multiplies it is regular in it either way: constant-time C
     # on secp256k1, and `_mult_fixed_base` on every other curve, whose
     # additions are the same for every scalar. The affine conversion the
@@ -702,9 +702,9 @@ def _libsecp256k1_sign_(
     verify: bool,
     pub_key: PubKey | None,
 ) -> Sig:
-    # Private function: the caller has asked `_libsecp256k1_serves` and
-    # settled the four things this arm cannot answer -- no nonce of its
-    # own, no commitment, and lower_s.
+    # Private function: `sign_`'s guard has asked `_libsecp256k1_serves`
+    # and settled what this arm cannot answer -- no nonce of the
+    # caller's, no commitment, and lower_s.
     #
     # One call, and that is the whole point of it. Grinding is Core's
     # `CKey::Sign` counter and the bindings' own `dsa._grind` walks the
@@ -1508,12 +1508,18 @@ def _assert_as_valid_(
     v = r * w % ec.n  # 4
     # Let K = u*G + v*Q.
     # the dispatching double_mult_var of curves.curve, not the Python
-    # arithmetic under it: what reaches here is the verification the
-    # bindings' own ecdsa_verify declined -- another hash function, a
-    # commitment to check, a caller-imposed nonce, a curve of its own --
-    # and on secp256k1 the multiplication is theirs all the same, some
-    # thirty-five times under the Python arithmetic, which is the whole
-    # of the gap between the two verifications
+    # arithmetic under it: `_jac_double_mult` decides that again on the
+    # dispatch switch and the curve alone, so a caller declined here for
+    # its hash function still multiplies in C on secp256k1, some
+    # thirty-five times under the Python arithmetic -- the whole of the
+    # gap between the two verifications. What sent a caller here is its
+    # own guard and not this function's: `assert_as_valid_` asks
+    # `_libsecp256k1_serves` and nothing else, a signer checking the
+    # signature it has just written asks that predicate beside whatever
+    # its own spelling takes -- `sign_` a nonce of the caller's, lower_s
+    # and a commitment, `Signer` nothing, its arm settled at
+    # construction -- and `_recover_pub_key_` reaches step 1.6.2 only on
+    # a curve of cofactor above 1, which the predicate declines outright
     KJ = _jac_double_mult(v, QJ, u, ec.GJ, ec, fixed)  # 5
 
     # Fail if infinite(K).


### PR DESCRIPTION
Three comments in `src/btclib/ecc/dsa.py` gave the conditions of a
dispatch as a list of reasons, and no list was the guard. What replaces
each is the guard: `_libsecp256k1_serves`, which every caller's asks,
and beside it whatever conditions that caller's own spelling takes --
the shape `curves.curve._jac_double_mult`'s docstring landed with,
"each module's `sign_` asks it beside conditions of its own"
(`src/btclib/curves/curve.py:1262-1268`).

On the signing side, `_sign_recoverable_`'s comment gave "another hash
function, another curve, a nonce the caller imposed, a sign-to-contract
commitment" as what declines the whole signature. `lower_s` is missing
from it, and it is a conjunct of `sign_`'s guard
(`src/btclib/ecc/dsa.py:949-954`) and of `sign_recoverable_`'s
(`src/btclib/ecc/dsa.py:1166`), so a caller asking for the s that was
computed signs here. The commitment is `sign_`'s condition alone:
`sign_recoverable_` takes none, and says so in its own docstring.

The function has a third reach, which ISS 2010's body does not name and
which re-measuring it found: `Signer.sign_` signs through `_sign_`
(`src/btclib/ecc/dsa.py:1469` and `:526`), and a `Signer`'s arm is
decided once at construction by the predicate alone
(`src/btclib/ecc/dsa.py:1352-1354`), the class taking no nonce, no
`lower_s` override and no commitment. So the predicate is what every
reach shares and the other conditions are the free functions', which is
what the comment now says instead of naming reaches.

`_libsecp256k1_sign_`'s comment promised "the four things this arm
cannot answer" and then listed three. It states no count now, and names
`sign_`'s guard, which is the one that reaches it
(`src/btclib/ecc/dsa.py:955`).

On the verification side, `_assert_as_valid_`'s comment gave a
commitment to check and a caller-imposed nonce as reasons `ecdsa_verify`
declined. `_assert_commitment_` runs ahead of that dispatch and on both
arms (`src/btclib/ecc/dsa.py:1634`), and `assert_as_valid_` takes no
nonce at all: a verification is independent of how the signature it
checks was made. Its guard is `_libsecp256k1_serves` and nothing else
(`src/btclib/ecc/dsa.py:1636`), and that predicate tests the dispatch
switch, the curve and the hash function
(`src/btclib/curves/curve.py:509`).

Those two conditions are a signer's guard's, so they are attributed
there rather than struck: a signer checking the signature it has just
written reaches this function through `_python_verified`
(`src/btclib/ecc/dsa.py:619`), from `sign_` (`:977`) and from
`Signer.sign_` (`:1462`). Public key recovery reaches it as well
(`src/btclib/ecc/dsa.py:2164`), on a curve of cofactor above 1 and so
on one the predicate declines outright (`src/btclib/ecc/dsa.py:2050`),
which the comment now names. None of that decides the multiplication:
`_jac_double_mult` asks `_libsecp256k1_serves` again with no hash
function (`src/btclib/curves/curve.py:1293`), so only the dispatch
switch and the curve carry over.

The sweep both issues ask for reads every comment block and docstring of
`src/` with a parse rather than a grep, and reports each one naming a
dispatch condition beside a word for the delegation -- a shape rather
than a phrase, the two sweeps before it having answered with the arm
each was run over. Its control is the same sweep at `b9913817^`, where
it finds `curves.curve._jac_double_mult`'s roster that ISS 2003 removed.
Two shapes are past it either way, and a later sweep of this kind is
written for them: a block that states a condition with no word for the
delegation beside it, and one that names a reach with none of the
condition words. What it returned carrying the shape is filed rather
than widened into here, `ecc/dsa.py` being the file these two issues
name: [ISS 2015](https://github.com/btclib-org/btclib/issues/2015) for
`btclib.ecc`'s package docstring,
[ISS 2016](https://github.com/btclib-org/btclib/issues/2016) for
`curves.curve.PreparedPoint`'s, and
[ISS 2018](https://github.com/btclib-org/btclib/issues/2018) for the
comment `ecc/ssa.py` carries above the same call this one repairs.

closes #2007
closes #2010

closes #2007
closes #2010

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3

## Summary by Sourcery

Correct `ecc.dsa` dispatch comments so they identify the guards that govern each signing and verification reach.

Bug Fixes:
- Correct dispatch comments in `ecc.dsa` to accurately describe the guards and conditions governing signing and verification paths.

Enhancements:
- Clarify which caller-specific options and shared predicates select the libsecp256k1 or Python implementations, including recoverable signing, verification, signer instances, and public-key recovery.
- Align comments with the actual double-multiplication dispatch behavior and remove an inaccurate count of unsupported signing conditions.

Documentation:
- Document the corrected dispatch-comment behavior and condition attribution in the changelog.