### PR TITLE
`test.yml` types `pytest` and takes the suite's flags from `pyproject.toml` (closes btclib-org/.github#433)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -315,22 +315,25 @@ jobs:
           # the fail_under comment in pyproject.toml names this version,
           # and the two have to move together
           python-version: "3.14"
-      # `--cov` and nothing after it: what is measured is tool.coverage.run's
-      # source and how it is reported is tool.coverage.report, so naming
-      # either here would be a second copy of a list that already exists --
-      # and the copy a contributor cannot run, this file not being what
-      # anyone types locally. One command, one scope, one report
+      # `pytest` with nothing after it, which is section 8 of the
+      # organization standard: pyproject.toml's addopts carries `--cov`,
+      # tool.coverage.run what is measured, tool.coverage.report how it is
+      # reported and the floor it is gated at. A flag typed here is one a
+      # contributor cannot run, this file not being what anyone types
+      # locally, so the local gate and this one would be two measurements
+      # that can disagree with nothing turning red. One command, one
+      # scope, one report
       - name: Run pytest under coverage
         run: >
           uv run --locked --no-default-groups --group test
-          pytest --cov
+          pytest
         env:
           # not the default `.coverage`: the `coverage-union` job downloads
           # this artifact beside the `no-bindings` job's, and two files
           # named alike would overwrite each other on the runner that
           # combines them. `COVERAGE_FILE` is `--data-file`'s environment
-          # variable, coverage's own, so `pytest --cov` writes here without
-          # a second flag naming what the report step above already reads
+          # variable, coverage's own, so the run writes here without a
+          # second flag naming what the report step above already reads
           # from tool.coverage.run
           COVERAGE_FILE: coverage-data-bindings
       # issue #1002: this run already fails at 100% on its own, unchanged
@@ -360,12 +363,16 @@ jobs:
   # and uv's `--no-group` suppresses a group that was selected, not one
   # another group includes. So the split in pyproject.toml is what this
   # job is, and there is no second lock file.
-  # `--cov --cov-fail-under=0`, not `--no-cov`, since issue #1002: the
+  # `--cov-fail-under=0`, not `--no-cov`, since issue #1002: the
   # delegated arms are still unreachable here by construction, and a
   # report of this run *alone* would still fail the 100% gate for the one
   # reason the run exists to create -- `--cov-fail-under=0` is what keeps
   # this job from being that report, collecting the data without gating
-  # this run on it. The data goes into `coverage-union` below, which
+  # this run on it. It is the one argument this step types, and it is the
+  # job's own rather than a second copy: nothing in pyproject.toml states
+  # it, where `--cov` is in addopts and `[tool.coverage.report]`'s
+  # `fail_under` is the floor this lifts.
+  # The data goes into `coverage-union` below, which
   # gates the union of this run and the `coverage` job's at 100% as well,
   # answering the question this job's own comment used to leave open: a
   # test marked `needs_bindings` too broadly, or a Python arm no test
@@ -413,7 +420,7 @@ jobs:
       - name: Run pytest
         run: >
           uv run --locked --no-default-groups --group harness
-          pytest --cov --cov-fail-under=0
+          pytest --cov-fail-under=0
         env:
           # the `coverage` job's comment on its own `COVERAGE_FILE` is why
           # this is not `.coverage` either: the two artifacts land beside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -534,6 +534,26 @@ documented at release-notes length in the first place, and are still in
   multiplication unless it was the dispatch switch or the curve,
   `_jac_double_mult` asking that predicate itself.
 
+### `test.yml` types `pytest` and takes the suite's flags from `pyproject.toml`
+
+- **The `coverage` job runs `pytest` with nothing after it** (closes
+  btclib-org/.github#433): `addopts` carries `--cov`, so a copy of it in
+  the workflow is a flag a contributor's own `uv run pytest` does not
+  have, and the CI gate and the local gate can stop being the same
+  measurement with nothing turning red. Section 8 of the organization
+  standard is where the flags are put in one file.
+  `CONTRIBUTING.md`'s *Reproducing what CI runs* quotes that job's
+  command verbatim, so it moves with the step.
+- **`--cov-fail-under=0` is the whole of what the `no-bindings` job
+  types**: nothing in `pyproject.toml` names it, so it is that job's own
+  argument rather than a second copy of a tree-wide setting.
+  `[tool.coverage.report]`'s `fail_under` is the floor it lifts for a run
+  whose delegated arms are unreachable by construction, and the
+  instrumentation reaches that job from `addopts` like the `coverage`
+  job's. Section 8 names the `--no-cov` of a platform sentinel and the
+  `COVERAGE_FILE` of a combining job as the arguments of that kind, and
+  btclib-org/.github#1021 is where a third one is put to the standard.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -632,19 +632,20 @@ The `coverage` job, gated by `fail_under` in pyproject.toml:
 
 ```shell
 COVERAGE_FILE=coverage-data-bindings \
-    uv run --locked --no-default-groups --group test pytest --cov
+    uv run --locked --no-default-groups --group test pytest
 ```
 
-What `--cov` measures and how it reports are `tool.coverage.run`'s
-`source` and `tool.coverage.report` in pyproject.toml, so this command
-and the bare `uv run pytest` above are the same measurement: the job
-cannot gate on a scope a contributor's run does not have. The flag is
-written out here even though addopts already carries it, this being the
-job's command verbatim. `COVERAGE_FILE` is `--data-file`'s environment
-variable, coverage's own, and is the job's real step verbatim too, not a
-local-reproduction addition: the two artifacts this job and `no-bindings`
-below produce would overwrite each other under the default `.coverage`
-name once both land in the `coverage-union` job that reads them. The job
+The job types `pytest` and nothing after it, which is section 8 of the
+organization standard: addopts carries `--cov`, and what it measures and
+how it reports are `tool.coverage.run`'s `source` and
+`tool.coverage.report` in pyproject.toml. So this command and the bare
+`uv run pytest` above are the same measurement, the job being unable to
+gate on a scope a contributor's run does not have. `COVERAGE_FILE` is
+`--data-file`'s environment variable, coverage's own, and is the job's
+real step verbatim too, not a local-reproduction addition: the two
+artifacts this job and `no-bindings` below produce would overwrite each
+other under the default `.coverage` name once both land in the
+`coverage-union` job that reads them. The job
 then uploads the data file this command wrote as an artifact, for
 `coverage-union` to read; that step has no command of its own to
 reproduce, being a plain `actions/upload-artifact`.
@@ -665,7 +666,7 @@ uv run --locked --no-default-groups --group harness \
       assert not is_libsecp256k1_serving()"
 COVERAGE_FILE=coverage-data-no-bindings \
     uv run --locked --no-default-groups --group harness \
-    pytest --cov --cov-fail-under=0
+    pytest --cov-fail-under=0
 uv sync
 ```
 
@@ -679,15 +680,18 @@ group includes, so the split in pyproject.toml is what this job is.
 `--group test` in place of `harness` installs the bindings back and runs
 the whole suite with them present, reporting it as a passing no-bindings
 run with nothing to say it was not one.
-`--cov --cov-fail-under=0`, not `--no-cov` (issue #1002): the delegated
-arms are still unreachable in this configuration by construction, so a
-report of this run *alone* would still fail the 100% gate for the one
-reason the run exists to create — `--cov-fail-under=0` collects the data
-without gating this run on it. The tests that hold both implementations
-and compare them carry the `bindings` marker and skip themselves;
-everything else runs. This job's data is uploaded as an artifact too,
-under the name `COVERAGE_FILE` gave it above, so it does not collide
-with the `coverage` job's when both are downloaded into the same job.
+`--cov-fail-under=0`, not `--no-cov` (issue #1002): the delegated arms
+are still unreachable in this configuration by construction, so a report
+of this run *alone* would still fail the 100% gate for the one reason
+the run exists to create — `--cov-fail-under=0` collects the data
+without gating this run on it. It is the one argument the job types, and
+it is the job's own rather than a second copy: nothing in pyproject.toml
+names it, where `--cov` is in addopts. The tests that hold both
+implementations and compare them carry the `bindings` marker and skip
+themselves; everything else runs. This job's data is uploaded as an
+artifact too, under the name `COVERAGE_FILE` gave it above, so it does
+not collide with the `coverage` job's when both are downloaded into the
+same job.
 
 The `coverage-union` job, which combines the two data files above and
 gates their union at 100% as well — beside the `coverage` job's own


### PR DESCRIPTION
The `coverage` job's `--cov` is what `addopts` in `pyproject.toml`
already carries, so it is a flag a contributor's own `uv run pytest`
does not have: the CI gate and the local gate can stop being the same
measurement with nothing turning red. Section 8 of the organization
standard is the rule, and `CONTRIBUTING.md`'s *Reproducing what CI runs*
quotes that job's command verbatim, so the reproduction moves with it.

The `no-bindings` job's `--cov-fail-under=0` stays. Nothing in
`pyproject.toml` names `--cov-fail-under`, measured against
`origin/main` at 804821cc with `fail_under` as the positive control in
the same blob, so it is that job's own argument rather than a second
copy: it lifts `[tool.coverage.report]`'s floor for a run whose
delegated arms are unreachable by construction, which is what
`coverage-union` then gates. That job's command without the flag exits
1 with no failing test, `coverage report` on the same data answering
`Coverage failure: total of 97.98 is less than fail-under=100.00`.
Section 8 names two arguments of that kind and this is a third;
btclib-org/.github#1021 puts that to the standard.


Closes [ISS 433](https://github.com/btclib-org/.github/issues/433)

Local review: CLEARED at d658182281af1e2f33e63bf1481580b6bcb0bdf9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGRFSkPFh8PR4Y3Wr47vb

## Summary by Sourcery

Use pyproject.toml as the single source for shared pytest coverage options while preserving the no-bindings job’s local coverage override.

Enhancements:
- Align the coverage workflow and contributor reproduction commands with pytest options configured in pyproject.toml, while retaining the no-bindings job’s job-specific coverage threshold override.

CI:
- Simplify the coverage and no-bindings CI commands so shared coverage settings come from pyproject.toml and only job-specific flags remain in the workflow.

Documentation:
- Update the changelog and contributing guide to document the revised CI commands and coverage configuration ownership.