### PR TITLE
`SECURITY.md` names the definition its `ecc/dsa.py` citation lands in (closes #2017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -554,6 +554,19 @@ documented at release-notes length in the first place, and are still in
   `COVERAGE_FILE` of a combining job as the arguments of that kind, and
   btclib-org/.github#1021 is where a third one is put to the standard.
 
+### `SECURITY.md` names the definition its `ecc/dsa.py` citation lands in
+
+- **`dsa.Signer.__init__` is written beside the line the citation
+  quotes** (closes #2017): the name, the word `at`, the quotation and
+  then the path and line number, which is the pair
+  `tests/security_citations_test.py` reads. The name was the subject of
+  the sentence instead, behind the spans that check reads, so a rename
+  of the definition left the pointer green.
+- **A dotted name further back than the quotation stays unread by
+  decision.** What the prose leaves there names something the citation
+  does not point into, which no definition holding the cited line
+  answers for; `tests/security_citations_test.py`'s docstring states the rule.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,11 +231,14 @@ Do not use Fable unless explicitly instructed.
   The backticked spans in front of a citation are what it claims: a
   dotted name (`ellswift.xdh`) is matched with `ast` against the
   definition enclosing the cited line, and a quotation of that line —
-  the way musig2.py's sum and dsa.py's `to_bytes` call are written —
-  verbatim against the line itself. A citation carrying both, the name
-  and then the quotation, is held to each of them. A dotted-name anchor
-  is satisfied by any line inside the right function, so a citation that
-  drifts a few lines within its own function still passes on its name.
+  the way musig2.py's sum is written — verbatim against the line itself.
+  A citation carrying both, the name and then the quotation, is held to
+  each of them, which is how dsa.py's `to_bytes` call is written; a name
+  the prose puts further back than the quotation is read by nothing, so a
+  claim about the definition a cited line sits in is written as that pair.
+  A dotted-name anchor is satisfied by any line inside the right function,
+  so a citation that drifts a few lines within its own function still
+  passes on its name.
   `awk 'NR==N' <file>` verified against the claimed content, not against
   which function the line lands in, is still the check for a dotted-name
   citation — a citation landing inside the right function has still been

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -167,15 +167,15 @@ used to teach and to prototype as much as to build:
     function then returns. btclib declines that too, for the reason
     the bullet above already gives: no Python object holding a secret
     is zeroized, on either path, and this one is no exception to it.
-    `dsa.Signer.__init__` crosses the same boundary the other way,
-    once, at construction: the plain `int` `scalar_from_prv_key` already
-    produced becomes a transient `bytes` via
-    `self._q.to_bytes(32, "big")` (`src/btclib/ecc/dsa.py:1363`) on the
-    way into the owned buffer `wipe` overwrites afterwards. That
-    `bytes` is dropped rather than erased, same as the `int` it
-    replaces — one call rather than the buffer's whole lifetime, which
-    is the trade this class exists to make, and stated here for the
-    same reason the other three call sites are
+    `dsa.Signer.__init__` at `self._q.to_bytes(32, "big")`
+    (`src/btclib/ecc/dsa.py:1363`) crosses the same boundary the other
+    way, once, at construction: the plain `int` `scalar_from_prv_key`
+    already produced becomes a transient `bytes` on the way into the
+    owned buffer `wipe` overwrites afterwards. That `bytes` is dropped
+    rather than erased, same as the `int` it replaces — one call rather
+    than the buffer's whole lifetime, which is the trade this class
+    exists to make, and stated here for the same reason the other three
+    call sites are
 - the boundary is not always there, and an install decides whether it
     is. `pip install "btclib[secp256k1]"` -- the spelling README.md and
     the guide give -- installs the bindings, and everything the next

--- a/tests/security_citations_test.py
+++ b/tests/security_citations_test.py
@@ -28,9 +28,12 @@ The prose writes either of those, and it writes both: the name, the
 word `at`, the quotation and then the citation. Both are read, each
 against what it claims -- a quotation in front of a citation takes the
 dotted name in front of *it* as the second anchor of the same citation.
-That adjacency is what holds the two together, so a name the prose puts
-further back than the quotation is a sentence about the definition
-rather than an anchor of the citation, and is not read.
+That adjacency is what holds the two together, so a dotted name the
+prose puts further back than the quotation is not read. A claim about
+the definition a cited line sits in is written as the pair for that
+reason, and what the prose leaves further back names something the
+citation does not point into, which no definition holding the cited
+line answers for.
 
 A path with no line number is held to naming a file that exists, which
 is the whole of what it claims.


### PR DESCRIPTION
[ISS #2017](https://github.com/btclib-org/btclib/issues/2017) reserved a
question, and this branch closes it: the other dotted names `SECURITY.md`
leaves further back than a quotation stay unread, and that is a decision
rather than a gap left behind.

The ground is the file itself, read at `804821cc`. Each of those names —
the subject of the musig2 bullet, the bindings' own `into=` entry points
beside the citation into `bip32.py`, and the callers of the arm
`curve._mult_checked` is — names something the citation it sits behind
does not point into. `_named_defect` answers for the definition holding
the cited line and not for what a sentence is about, so pairing them
would make the check refuse every one that cites a line at all. The
citation carrying no line number is held to naming a file that exists,
which is the whole of what it claims.

What the branch changes:

- **`SECURITY.md`** — one sentence. The citation at
  `src/btclib/ecc/dsa.py:1363` carried the quotation of its line and, several
  backticked spans further back, `dsa.Signer.__init__` as the subject of the
  sentence around it, where the test pairs a citation with the quotation in
  front of it and the dotted name in front of *that*. The name was read by
  nothing: the definition could be renamed, or the citation moved into another
  function keeping its text, with the pointer staying green. The sentence is
  the pair now — `dsa.Signer.__init__` at `self._q.to_bytes(32, "big")`
  (`src/btclib/ecc/dsa.py:1363`) — which is the idiom the same bullet already
  uses for the call sites that read an `into=` buffer into a Python `int`, so
  the shape is the file's own rather than one built around the check.
- **`tests/security_citations_test.py`** — the module docstring says the rule
  rather than the roster, in place of a sentence that permitted a name further
  back to go unchecked.
- **`CLAUDE.md`** — its account follows the file: `dsa.py`'s `to_bytes` call is
  now an instance of a citation carrying both anchors rather than of one
  quoting its line alone.

No executable line changes; the check reads one citation more than it did.

Gates on `5ca5d428`, the rebased tip, all four green: lint `pre-commit run
--all-files` exit 0 (47 `Passed`, 0 `Failed`), `pytest` exit 0 (`32603 passed,
78 skipped`, `TOTAL 57176 0 9884 0 100.00%`), `sphinx-build -n -W` exit 0, the
`href="#../"` sweep exit 1, `git status --porcelain` empty after each.

The rebase onto `efc58c8c` ate the blank line above this branch's `###`
heading, as `merge=union` does; the entry was rebuilt by splicing the block
into `efc58c8c:CHANGELOG.md` rather than taken from the rebase's output, and
the pinned `markdownlint-cli2` invoked directly, check-only, exits 0 on the
committed blob where the same run on a planted control exits 1 naming `MD032`
and `MD022`.

closes #2017

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3

## Summary by Sourcery

Correct the DSA security citation so its function definition and quoted source line are validated as a single pair.

Bug Fixes:
- Align the SECURITY.md DSA citation with its definition anchor so security citation validation detects renames or moves of the referenced function.

Enhancements:
- Clarify the citation-anchor rules and document that dotted names preceding a quotation are intentionally not associated with that citation.

Documentation:
- Update SECURITY.md, CLAUDE.md, and the changelog to describe and demonstrate the corrected citation format and validation behavior.

Tests:
- Refine the security citation test documentation to state how definition and quotation anchors are paired.