### PR TITLE
The prose around the bindings dispatch states its guard (closes #2015) (closes #2016) (closes #2018)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -567,6 +567,45 @@ documented at release-notes length in the first place, and are still in
   does not point into, which no definition holding the cited line
   answers for; `tests/security_citations_test.py`'s docstring states the rule.
 
+### The prose around the bindings dispatch states its guard
+
+- **The `btclib.ecc` package docstring made secp256k1, sha256 and a
+  nonce btclib derives sufficient for a delegated signature** (closes
+  #2015). `dsa.sign_` ands `nonce is None`, `lower_s` and `commit_hash
+  is None` onto `curves.curve._libsecp256k1_serves`, so a signature
+  asked for with `lower_s=False` and one carrying a sign-to-contract
+  commitment each answer that description and each run the Python
+  arithmetic `SECURITY.md` publishes as not constant-time. What the *Secrets*
+  paragraph gives instead is the predicate -- the process-wide dispatch
+  switch, the curve and the hash function -- with the conditions of the
+  call site anded onto it, and it leaves those conditions to
+  `SECURITY.md`, which the paragraph already points at.
+- **`curves.PreparedPoint`'s docstring gave a deployment without the
+  compiled bindings as what puts a caller on the Python arithmetic**
+  (closes #2016). The first test `_libsecp256k1_serves` makes is the
+  process-wide switch, which `set_libsecp256k1_serving` and
+  `BTCLIB_NO_LIBSECP256K1` move in a process that has the bindings
+  installed: `tests/script_engine/python_path_test.py` clears
+  `curve._libsecp256k1_available` and reruns the consensus vectors
+  under it, skipping where the bindings are absent.
+- **A hash function of the caller's is not a way onto those tables**,
+  which that sentence gave as one. `mult` and `_jac_double_mult` ask
+  the predicate with no hash function, so a verification the hash
+  function alone sent to the Python equation has its multiplication
+  delegated still, and the tables a prepared point handed down are
+  dropped there.
+- **`ssa._assert_as_valid_`'s comment gave a declined verification as
+  the way in** (closes #2018). `sign_` reaches the same function to
+  check the signature it has just written, on a guard of its own --
+  `_libsecp256k1_serves(ec, hf) and commit_hash is None` -- so a BIP340
+  signature carrying a sign-to-contract commitment is verified there.
+  The comment names each reach with the guard that brought it, and
+  leaves what the multiplication does to `_jac_double_mult`.
+- **The clause dating the message-size condition is gone.** The comment
+  above `assert_as_valid_`'s own guard states in the present tense that
+  the curve and the hash function decide the dispatch and the size of
+  the message does not.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/src/btclib/curves/curve.py
+++ b/src/btclib/curves/curve.py
@@ -900,12 +900,21 @@ class PreparedPoint:
       BIP340 alike. Break-even is 22 signatures under the one key, the
       first verification costing several times what a bare key's does.
 
-    Both are the Python arithmetic. On secp256k1 with the bindings
-    available neither is reached -- libsecp256k1 verifies in a fraction
-    of either and holds its own tables -- so what this is for is the
-    Python path: another curve, another hash function, or a deployment
-    without the compiled bindings. Handing one in on the delegated path
-    is not an error and costs nothing; it simply buys nothing.
+    Both are the Python arithmetic, and what puts a call on them is that
+    call's own guard: `_libsecp256k1_serves` -- the process-wide switch,
+    which an installation without the bindings leaves off and which
+    `set_libsecp256k1_serving` and `BTCLIB_NO_LIBSECP256K1` turn off in a
+    process that has them, and the curve -- with whatever that call ands
+    onto it, `mult` taking this arm for a zero scalar besides,
+    libsecp256k1 having no scalar for one. Neither call passes a hash
+    function: a verification's is spent on its own module's guard, and
+    `_jac_double_mult` under that guard asks the predicate again with
+    none, so a hash function the bindings do not serve leaves the
+    multiplication delegated and the tables handed to it unused. Where a
+    call's whole guard holds there is nothing here to reach --
+    libsecp256k1 verifies in a fraction of either arm and holds tables of
+    its own -- so handing a prepared point in on that path is not an
+    error and costs nothing; it simply buys nothing.
 
     Preparing is a caller's word and never inferred, and the memory is
     why: the tables are per distinct point, so a library that memoized

--- a/src/btclib/ecc/__init__.py
+++ b/src/btclib/ecc/__init__.py
@@ -55,13 +55,15 @@ the library with nothing else in sys.modules, which is the order that
 would find it if it did not.
 
 **Secrets.** This is the package a private key is handed to, and what
-holds around it is conditional. A signature of secp256k1 with sha256 and
-a nonce btclib derives is one libsecp256k1 call; another curve, another
-hash function or a nonce of the caller's runs the Python arithmetic,
-which the suite validates against the bindings but which is not
-constant-time. Nor is a Python object holding a secret zeroized, on
-either path. SECURITY.md's limitations section states each condition,
-argument by argument, and README.md carries the short form.
+holds around it is conditional. What decides whether an operation here
+is one libsecp256k1 call is `curves.curve._libsecp256k1_serves` -- the
+process-wide dispatch switch, the curve and the hash function -- with
+the conditions of the call site anded onto it; whatever the conjunction
+declines runs the Python arithmetic, which the suite validates against
+the bindings but which is not constant-time. Nor is a Python object
+holding a secret zeroized, on either path. SECURITY.md's limitations
+section states each condition, argument by argument, and README.md
+carries the short form.
 """
 
 from btclib.ecc import (

--- a/src/btclib/ecc/ssa.py
+++ b/src/btclib/ecc/ssa.py
@@ -868,14 +868,17 @@ def _assert_as_valid_(
 
     # Let K = sG - eQ.
     # in Jacobian coordinates, and through the dispatching double_mult_var of
-    # curves.curve rather than the Python arithmetic under it: what
-    # reaches here is the verification the bindings' own declined, which
-    # is another curve or another hash function -- the size of the message
-    # was the third of those and is not any more -- and on secp256k1 the
-    # multiplication is still theirs, some thirty-five times under the
-    # Python arithmetic. The whole verification follows it, the two lifts
-    # around it -- the r of the signature and the x-only key -- being
-    # theirs as well
+    # curves.curve rather than the Python arithmetic under it. What put a
+    # caller here is that caller's own guard: `assert_as_valid_` asks
+    # `_libsecp256k1_serves` and nothing else, where `sign_` asks it
+    # beside a commitment of its own and reaches this function anyway,
+    # to check the signature it has just written. Whichever guard it was
+    # settles nothing about the multiplication, `_jac_double_mult`
+    # asking the predicate again below: on secp256k1 with the dispatch
+    # on the multiplication is still theirs, some thirty-five times
+    # under the Python arithmetic. The whole verification follows it,
+    # the two lifts around it -- the r of the signature and the x-only
+    # key -- being theirs as well
     KJ = _jac_double_mult(ec.n - c, QJ, s, ec.GJ, ec, fixed)
 
     # The following check is prescribed by BIP340 but it is useless:


### PR DESCRIPTION
Three issues, one shape. Each of the prose sites below gave the
libsecp256k1 dispatch as a list of reasons, or as a condition that is
sufficient when it is not, where what decides is one predicate —
`curves.curve._libsecp256k1_serves`: the process-wide dispatch switch,
the curve, and the hash function — with the conditions of the call site
anded onto it.

**[ISS #2015](https://github.com/btclib-org/btclib/issues/2015) —
`btclib.ecc`'s package docstring.** It made a signature of secp256k1
with sha256 and a nonce btclib derives one libsecp256k1 call.
`dsa.sign_` ands `nonce is None`, `lower_s` and `commit_hash is None`
onto the predicate, so `dsa.sign(..., lower_s=False)` and a signature
carrying a sign-to-contract commitment each answer that description and
each run the Python arithmetic. The paragraph gives the predicate with
the conditions of the call site anded onto it, and leaves those
conditions to `SECURITY.md`, which it already points at.

**[ISS #2016](https://github.com/btclib-org/btclib/issues/2016) —
`curves.PreparedPoint`'s docstring.** It gave a deployment without the
compiled bindings as what puts a caller on the Python arithmetic; the
first test the predicate makes is the process-wide switch, which
`set_libsecp256k1_serving` and `BTCLIB_NO_LIBSECP256K1` move in a
process that has the bindings installed. The same sentence gave another
hash function as a way onto the tables, and it is not one: `mult` and
`_jac_double_mult` ask the predicate with **no** hash function, so a
verification the hash function alone sent to the Python equation has its
multiplication delegated still, and the tables a prepared point handed
down are dropped there.

**[ISS #2018](https://github.com/btclib-org/btclib/issues/2018) —
`ssa._assert_as_valid_`'s comment.** It gave a declined verification as
what reaches it. `sign_` reaches it too, to check the signature it has
just written, its guard being `_libsecp256k1_serves(ec, hf) and
commit_hash is None` — so a BIP340 signature carrying a sign-to-contract
commitment is verified there. The clause dating the message-size
condition is gone; the comment above `assert_as_valid_`'s own guard
states in the present tense that the curve and the hash function decide
the dispatch and the size of the message does not.

Docstrings and `#` comments only — no executable line is touched, and
the diff is `curve.py`, `ecc/__init__.py`, `ssa.py` and a `CHANGELOG.md`
entry.

Gates on `67617f4b`, all four green: lint `pre-commit run --all-files`
exit 0 (47 `Passed`, 0 `Failed`), `pytest` exit 0 (`32603 passed, 78
skipped`, `TOTAL 57176 0 9884 0 100.00%`), `sphinx-build -n -W` exit 0,
the `href="#../"` sweep exit 1, `git status --porcelain` empty after
each.

Rebasing onto `main` ate the blank line above this branch's `###`
heading, which is what `merge=union` does to `CHANGELOG.md`. The entry
was rebuilt by splicing the added block — derived from the diff, not
picked by eye — into the new base's blob, and the pinned
`markdownlint-cli2` invoked directly and check-only exits 0 on the
committed file where the same run on a control with that blank line
deleted exits 1 naming `MD032` and `MD022`.

closes #2015
closes #2016
closes #2018

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3

## Summary by Sourcery

Clarify the conditions governing libsecp256k1 dispatch across ECC signing, verification, and prepared-point operations.

Bug Fixes:
- Correct inaccurate documentation describing when libsecp256k1 handles signing, verification, and point operations.

Enhancements:
- Align ECC, prepared-point, and Schnorr verification prose with the actual dispatch predicate and call-specific guards.
- Clarify that process-wide configuration, curve, hash function, commitments, and other call conditions determine whether Python arithmetic is used.
- Document that message size does not determine dispatch and that verification may still delegate multiplication in certain paths.

Documentation:
- Update package and API docstrings and comments to accurately describe libsecp256k1 dispatch behavior and its security implications.

Chores:
- Add a changelog entry covering the dispatch documentation corrections.