### PR TITLE
`codeql.yml` ends in an aggregate a branch rule can name (closes btclib-org/.github#459)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ name: codeql
 # matters, because the setting does not refuse to let this file run: the
 # analysis completes and the SARIF uploads, and processing then answers
 # "CodeQL analyses from advanced configurations cannot be processed when
-# the default setup is enabled". Both jobs below are therefore red rather
+# the default setup is enabled". Every job below is therefore red rather
 # than absent while the setting is on, so the branch rule stops naming
 # `CodeQL` before the setting goes off rather than after.
 
@@ -98,9 +98,10 @@ on:
 
 # least privilege for the GITHUB_TOKEN: everything running in a job
 # (actions, dependencies, the CodeQL bundle itself) can read the token, so
-# the workflow default must not be able to write to the repository. The
-# analysis job elevates for itself, one elevation on the one job that
-# needs it, which is the shape REPOSITORY.md keeps
+# the workflow default must not be able to write to the repository. A job
+# below that needs more declares it for itself and declares only that --
+# the analysis its `security-events: write`, the aggregate its
+# `actions: read` -- which is the shape REPOSITORY.md keeps
 permissions:
   contents: read
 
@@ -139,16 +140,16 @@ jobs:
     # far above what either language needs; what it bounds is a hung job
     # holding a runner for six hours
     timeout-minutes: 20
-    # the elevation, on the job that needs it and nowhere else: no other
-    # job in this workflow declares permissions, so no other job elevates.
-    # security-events: write is what uploading a SARIF to code scanning
-    # takes, and the whole reason this job cannot run on the read-only
-    # token. actions: read is redundant while this repository is public --
-    # it is what the CodeQL action needs to read run metadata in a
-    # *private* one -- and it is written down so that the file does not
-    # quietly stop working the day the repository stops being public. No
-    # packages: read, which fetching a private CodeQL pack would want and
-    # the default query suite does not.
+    # the elevation, on the job that needs it: security-events: write is
+    # this job's alone, the aggregate below declaring only the read its
+    # own question takes. The write is what uploading a SARIF to code
+    # scanning takes, and the whole reason this job cannot run on the
+    # read-only token. actions: read is redundant while this repository
+    # is public -- it is what the CodeQL action needs to read run
+    # metadata in a *private* one -- and it is written down so that the
+    # file does not quietly stop working the day the repository stops
+    # being public. No packages: read, which fetching a private CodeQL
+    # pack would want and the default query suite does not.
     # The trailing comments below are not that paragraph again for its own
     # sake: zizmor's undocumented-permissions audit reads the line a
     # permission is on and not the prose above the block, so one word there
@@ -214,14 +215,122 @@ jobs:
           # rather than starting again
           category: "/language:${{ matrix.language }}"
 
-  # no aggregate job, where test.yml has one. REPOSITORY.md's "Required
-  # checks on main" states "Never name matrix contexts in the branch
-  # rule": a matrix cell's own name is not a context a branch rule can
-  # bind to safely, so neither `Analyze actions` nor `Analyze python` can
-  # be required on its own, the same reason test.yml needs
-  # `test: every job passed` while lint.yml and docs.yml, each a single
-  # job, need no aggregate of their own. This workflow has none, so
-  # `analyze`'s two matrix cells are the whole of the checks list it
-  # contributes to a commit and neither gates a merge; adding an
-  # aggregate, and naming it in the branch rule, is REPOSITORY.md's own
-  # section to decide
+  # what a branch rule can name, where no cell of the matrix above can
+  # be. REPOSITORY.md's "Required checks on main" states "Never name
+  # matrix contexts in the branch rule": the rule lives outside the
+  # repository, so a context that stops being produced blocks every merge
+  # with nothing here to explain it, and the matrix reports a context per
+  # language, so a rule naming the cells it finds goes silently short the
+  # day a language joins. lint.yml and docs.yml need no aggregate of
+  # their own while each has one job, the job being the context there,
+  # which is the same reason test.yml has one.
+  # Naming this job in the branch rule is a settings change and
+  # REPOSITORY.md's own section to decide; what this job makes is the
+  # option, which a workflow reporting its cells and nothing else does
+  # not have (btclib-org/.github#459)
+  codeql-passed:
+    # the name and not the id is what such a rule matches, and it carries
+    # the workflow on purpose: a context is keyed by name alone, so two
+    # workflows with a job named "every job passed" would produce one
+    # ambiguous check, and test.yml's aggregate is a required check
+    name: "codeql: every job passed"
+    # ordering, and nothing else: nothing in this tree calls this
+    # workflow, so the step below reads the run's own job listing rather
+    # than `needs.*.result`, which is section 10 of the organization
+    # standard's shape for a workflow only ever run directly -- a called
+    # workflow's listing is the caller's run and holds jobs waiting on
+    # this one, which is why test.yml, being release.yml's own call,
+    # keeps `needs`. Here `needs` sequences this job after the matrix and
+    # decides nothing, so a language added above is covered without
+    # touching this
+    needs: [analyze]
+    # not success(): a job whose dependencies failed is skipped, and a
+    # skipped check reports "skipped", which a rule naming this context
+    # counts as satisfied -- the gate has to run to be able to fail. Not
+    # always() either: a run superseded by the concurrency group above is
+    # one the newer run already speaks for, and reaching this job would
+    # turn that cancellation into a red check with no defect behind it.
+    # The draft and closed halves are the analysis job's own condition,
+    # so a draft skips uniformly rather than reporting a failure for an
+    # analysis this workflow declined to run
+    if: >-
+      ${{ !cancelled()
+      && !github.event.pull_request.draft
+      && github.event.action != 'closed' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      # what asking the API for this run's own jobs takes, and the same
+      # read test.yml's aggregate would hold if it ever asked that
+      # question. REPOSITORY.md's "Token permissions" is where the
+      # elevation is read back. The trailing comment repeats it in one
+      # line for the reason the analysis job's block gives: zizmor's
+      # undocumented-permissions audit reads the permission's own line
+      actions: read # the run's job listing, which contents: read misses
+    steps:
+      # `needs.analyze.result` cannot tell a matrix cell that died in
+      # *Set up job* from one that ran and passed (issue #1001); asking
+      # the run's own listing instead reads what actually happened, at
+      # the price of a step per workflow rather than one shared with
+      # test.yml's aggregate, `needs` reaching nothing outside its own
+      # workflow
+      #
+      # the allowlist below names "success" and "skipped", which is what
+      # section 10 asks of a listing step, rather than "success" alone.
+      # Narrowing it reads well against the jobs this file holds -- none
+      # is conditional on what a pull request touched, and a superseded
+      # run skips this job before the step runs -- but that is a claim
+      # about today's jobs and not about the shape: a `changes` job, or
+      # an `if:` on a job narrower than this one's own, makes a
+      # legitimate "skipped" row reachable, and the first run carrying
+      # one is then a red required check with no defect under it and
+      # nothing in the tree pointing here. btclib-org/.github#990 is
+      # where the aggregates that narrow are swept
+      - name: Fail unless every other job of this run succeeded
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # `.status` beside the conclusion so that an unfinished job says
+          # which kind it is: queued and running are one word to
+          # `.conclusion` and two facts to a reader of the log
+          jobs=$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" \
+            --jq '.jobs[] | "\(.conclusion // "unfinished")\t\(.status)\t\(.name)"')
+          # printed before it is judged: the job whose purpose is to be
+          # trusted is the one that has to be able to say what it saw
+          printf '%s\n' "${jobs}"
+          # awk and not grep: a tab in a grep pattern is one
+          # implementation's extension and a literal "t" in another's,
+          # where awk's field separator is POSIX
+          bad=$(printf '%s\n' "${jobs}" |
+            awk -F'\t' '$1 != "success" && $1 != "skipped" && $1 != "unfinished"')
+          unfinished=$(printf '%s\n' "${jobs}" |
+            awk -F'\t' '$1 == "unfinished"' | wc -l | tr -d ' ')
+          # each annotation names the rows it is about, an annotation
+          # being what the checks page shows without the log being
+          # opened. `%0A` is a newline to one, and the tab goes with it:
+          # the columns line up in a log and not in this
+          annotate() {
+            printf '::error::%s' "$1"
+            printf '%s' "$2" | tr '\t' ' ' | awk '{ printf "%%0A%s", $0 }'
+            printf '\n'
+          }
+          verdict=0
+          if [ -n "${bad}" ]; then
+            annotate "these jobs of the run did not succeed:" "${bad}"
+            verdict=1
+          fi
+          # exactly one job of the run may be unfinished, and it is this
+          # one. Counted rather than excluded by name, a name being what
+          # goes stale when this job is renamed -- and none unfinished at
+          # all is refused too, a listing with no job running not being a
+          # listing of the run this step is running in
+          if [ "${unfinished}" -ne 1 ]; then
+            annotate \
+              "this check should be the run's one unfinished job; ${unfinished} are" \
+              "$(printf '%s\n' "${jobs}" | awk -F'\t' '$1 == "unfinished"')"
+            verdict=1
+          fi
+          exit "${verdict}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -606,6 +606,46 @@ documented at release-notes length in the first place, and are still in
   the curve and the hash function decide the dispatch and the size of
   the message does not.
 
+### `codeql.yml` ends in an aggregate a branch rule can name
+
+- **`codeql: every job passed` is the one context this workflow offers a
+  branch rule** (closes btclib-org/.github#459). A cell of the `analyze`
+  matrix is a context per language, and `REPOSITORY.md`'s "Never name
+  matrix contexts in the branch rule" is why none of them may be named:
+  the rule lives outside the repository, so a language joining the matrix
+  falls outside it with nothing red to say so. Whether the rule asks for
+  the aggregate is the `checks` array `REPOSITORY.md` reads back live,
+  which does not name it; what this adds is the option.
+- **The step reads the run's own job listing rather than
+  `needs.*.result`**, which is section 10 of the organization standard's
+  shape for a workflow only ever run directly. `release.yml` calls
+  `test.yml`, so that aggregate keeps `needs` — a called workflow's
+  listing is the caller's run, and holds jobs waiting on the aggregate
+  itself — and nothing in this tree calls `codeql.yml`. What the listing
+  buys beside that is the shape issue #1001 recorded: a matrix cell that
+  dies in *Set up job* is a `failure` row there while
+  `needs.analyze.result` does not carry it.
+- **The allowlist accepts `skipped` beside `success`**, which is what
+  section 10 asks of a listing step. Nothing in this workflow is
+  conditional on what a pull request touched and a superseded run skips
+  the aggregate before its step runs, so a legitimate `skipped` row is
+  unreachable — but that is a claim about the jobs the file holds rather
+  than about the shape, and a `changes` job or an `if:` narrower than the
+  aggregate's own makes it false without anything going red.
+  btclib-org/.github#990 is where the aggregates narrowed to `success`
+  alone are swept.
+- **`REPOSITORY.md` and `CONTRIBUTING.md` said this workflow carried no
+  aggregate a rule could name**, in `REPOSITORY.md`'s *Required checks on
+  main* and *Code scanning* and in `CONTRIBUTING.md`'s *What runs when*;
+  each says what the rule could name and that it does not.
+  `REPOSITORY.md`'s *Token permissions* gains the aggregate's
+  `actions: read`, which is what asking the API for a run's own jobs
+  takes and what `contents: read` does not carry. `codeql.yml`'s own
+  comments said it too, in their own words — no other job elevating,
+  one elevation on the one job that needs it, both jobs below going red
+  while the default setup is on — and each now describes a file with an
+  aggregate in it.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -553,9 +553,10 @@ wall clock is the wait for a slot rather than the suite. `os-macos.yml` and
 queueing and the runner seconds. `codeql` spends against that same
 ceiling on every pull request too now, for the OpenSSF Scorecard's
 `SAST` check rather than for this table's arithmetic — REPOSITORY.md has
-that trade — but it still does not gate the merge, no matrix cell of its
-`analyze` job being nameable in the branch rule on its own and the
-workflow carrying no aggregate that could be. `zizmor` in `lint` reads
+that trade — but it still does not gate the merge: no matrix cell of its
+`analyze` job is nameable in the branch rule on its own, and the
+aggregate that is nameable, `codeql: every job passed`, is a name the
+rule does not ask for. `zizmor` in `lint` reads
 these same workflow files for an injected expression on every pull
 request, which is a different question from what `codeql` asks.
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -106,11 +106,13 @@ the measurement the gate and the weekly sweeps are arranged around.
 `codeql.yml` carries no required check at all. It runs on `main`, on its
 schedule and on every pull request now — the OpenSSF Scorecard's `SAST`
 check is why, and `codeql.yml`'s own `on:` block comment carries that
-story — but neither cell of its `analyze` job's matrix can be named in
-the branch rule on its own, the bullet above being why, and the workflow
-has no aggregate job that could be. The Code scanning section below
-states that in its own terms, at the point where default setup's own
-`CodeQL` context is dropped from the rule instead.
+story — and neither cell of its `analyze` job's matrix can be named in
+the branch rule on its own, the bullet above being why. What the rule
+could name is `codeql: every job passed`, the aggregate at the end of
+that file, whose result is one context however many languages the matrix
+grows to (btclib-org/.github#459). Whether the rule asks for it is the
+`checks` array above, which does not name it: that is a settings change
+and a decision of its own, and the option is what the aggregate makes.
 
 What still reads a branch before it merges, `codeql.yml` itself included
 now, is the workflow half of the same question: `zizmor` is a pre-commit
@@ -192,8 +194,8 @@ rather than a pull request, so only a human can perform them:
 1. merge.
 
 There is no fifth step adding a `codeql.yml` check to the rule: neither
-matrix cell is required, and this workflow carries no aggregate that
-could be either.
+matrix cell may be named in one, and whether `codeql: every job passed`
+is named is *Required checks on main* above, not this exchange.
 
 Step 2 is what makes the setting let go of the analysis. It is not the
 command that enabled default setup and there is no need to keep that one:
@@ -539,10 +541,12 @@ itself needs. `test.yml` has one such declaration of its own, on
 `codeql.yml`'s `analyze` has one: `security-events: write` is
 what uploading a SARIF to code scanning takes, with `actions: read` beside
 it — redundant while this repository is public, and written down so that
-the file does not quietly stop working the day it is not. Every
-workflow's aggregate job needs none of that and declares none of it: one
-elevation per job is the shape to keep — the job that writes releases holds
-no OIDC token, and the job that signs writes no release.
+the file does not quietly stop working the day it is not.
+`codeql.yml`'s `codeql-passed` takes `actions: read` on its own account,
+to ask the run's own job listing back, which `contents: read` does not
+carry; `test.yml`'s aggregate reads `needs` and so declares nothing. One
+elevation per job is the shape to keep — the job that writes releases
+holds no OIDC token, and the job that signs writes no release.
 `vendored-vectors.yml`'s `vectors` job has one such declaration of its
 own: `issues: write`, for the `gh issue create`/`edit`/`close` calls its
 script makes on the tracking issue of each ledger its matrix checks, one


### PR DESCRIPTION
`codeql: every job passed` needs `analyze` and decides over the run's
own job listing, which is section 10's shape for a workflow nothing in
the tree calls; `test.yml`'s aggregate keeps `needs`, `release.yml`
calling it. The allowlist takes `success` and `skipped`, section 10's
own pair, rather than narrowing to `success` on the ground that no job
here can currently report a skip.

The branch rule is unchanged and names no context of this workflow:
that is a settings change and the maintainer's. `REPOSITORY.md` and
`CONTRIBUTING.md` said the workflow had no aggregate a rule could name,
and say what it has instead.


Closes [ISS 459](https://github.com/btclib-org/.github/issues/459)

Local review: CLEARED at 77966dfd01d0ccaa6cf0128072b5cc41db835077

The workflow was dispatched on this branch at this sha: run
[34699818528](https://github.com/btclib-org/btclib/actions/runs/34699818528),
`head_sha` `77966dfd`, completed `success` — `Analyze actions`,
`Analyze python` and `codeql: every job passed` all green, the last
being the context a branch rule would name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGRFSkPFh8PR4Y3Wr47vb

## Summary by Sourcery

Add a branch-rule-compatible aggregate check to the CodeQL workflow and update repository guidance to describe it.

New Features:
- Add a `codeql: every job passed` aggregate check that reports a single branch-rule-compatible context for the CodeQL workflow and validates the workflow run's jobs.

Enhancements:
- Use the workflow run's job listing to detect failed or unexpectedly unfinished CodeQL jobs, including matrix setup failures.
- Allow successful and skipped jobs in aggregate evaluation while excluding cancelled runs from producing a misleading failure.

Documentation:
- Update repository and contributor guidance to document the new CodeQL aggregate context and its optional branch-rule configuration.
- Document the aggregate job's `actions: read` permission and revised workflow behavior.