### PR TITLE
Open-section sentences a landing has since made false are superseded (issue btclib-org/.github#946)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -646,6 +646,32 @@ documented at release-notes length in the first place, and are still in
   while the default setup is on — and each now describes a file with an
   aggregate in it.
 
+### Open-section sentences a landing has since made false are superseded
+
+- **This supersedes *`ecc.rangeproof` verifies a proof and rewinds it*
+  above, whose entry says a generator of the caller's is still not taken
+  and that a proof written or read here is written against
+  `ecc.pedersen`'s own second generator** (issue btclib-org/.github#946):
+  issue #1986 is closed, on 2026-09-11. `f0358d56` is what closed it, and
+  *`ecc.pedersen` and `ecc.rangeproof` take the generator they work at*
+  above is its entry -- `ecc.rangeproof`'s entry points take a `gen`, and
+  a proof is written against the generator its caller passes.
+- **This supersedes *The `mention` job's `pull-requests: write` carries
+  its reason* above, whose entry says the other copies are owed the same
+  line** (issue btclib-org/.github#946): btclib-org/.github#915 is
+  closed, on 2026-09-12, and no copy is owed it. `git grep -c 'what
+  posting the reply takes' origin/main --
+  .github/workflows/claude-review.yml` answers `1` in every repository of
+  the organization that carries the file, with `permissions:` in the same
+  pathspec as the control that the search reads.
+- **This supersedes *The issue-form hooks join the `check-jsonschema`
+  block* above, whose entry says the other copies are owed the same
+  pair** (issue btclib-org/.github#946): btclib-org/.github#767 is
+  closed, on 2026-09-12, and no copy is owed it. `git grep -c
+  'check-github-issue-config' origin/main -- .pre-commit-config.yaml`
+  answers `1` in every one of them, and so does the same search for
+  `check-github-issue-forms`.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs


### PR DESCRIPTION
The open section's *`ecc.rangeproof` verifies a proof and rewinds it*
says a generator of the caller's is still not taken and that a proof is
written against `ecc.pedersen`'s own second generator, citing issue
#1986. `f0358d56` gave `ecc.rangeproof`'s entry points a `gen`
parameter, so that sentence is false on `main`. Two more of the same
shape sit above it: *The `mention` job's `pull-requests: write` carries
its reason* says the other copies are owed the same line, and *The
issue-form hooks join the `check-jsonschema` block* says the other
copies are owed the same pair. Issue btclib-org/.github#915 closed on
2026-09-12 and every tree carrying `claude-review.yml` carries the
line; issue btclib-org/.github#767 closed the same day and every tree's
`.pre-commit-config.yaml` names both hooks. Each was measured with
`git grep -c` against every repository of the organization at its own
`origin/main`. The `claude-review.yml` search carries `permissions:`
in the same pathspec as its control; the pre-commit search needed none,
both of its patterns answering non-zero in every tree.

The section is append-only, so a superseding entry at its end is what
section 9's *What a live claim obliges is a change* asks for -- "An
entry found false is worth a superseding entry of its own" -- rather
than the live-claim bullet itself, whose obligation fell on the landing
that moved each population. Each bullet names the entry it supersedes
by heading, paraphrases the sentence rather than quoting it, and gives
the landing or the closure that falsified it.

The site the issue's census names in this tree -- the rangeproof-oracle
sentence citing issue #1679 -- sits under `## v2026.9.10`, released on
2026-09-10, so section 9 has a reader meet it as a record rather than as
a live claim. It is left as published.


Advances [ISS 946](https://github.com/btclib-org/.github/issues/946)

Local review: CLEARED at 2e91bd0924b0cbb4750420b783291e45c288e977

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGRFSkPFh8PR4Y3Wr47vb

## Summary by Sourcery

Record superseding changelog entries for open-section statements invalidated by subsequent changes and issue closures.

Enhancements:
- Add append-only changelog entries that supersede three now-inaccurate open-section claims with their current status and supporting issue or landing references.

Documentation:
- Update the changelog to record that the rangeproof generator claim is obsolete and that the organization-wide workflow and pre-commit hook claims have been fulfilled.