### PR TITLE
A `SECURITY.md` citation with no line number carries no anchor (closes #2021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -672,6 +672,22 @@ documented at release-notes length in the first place, and are still in
   answers `1` in every one of them, and so does the same search for
   `check-github-issue-forms`.
 
+### A `SECURITY.md` citation with no line number carries no anchor
+
+- **A dotted name in front of a path cited with no line number was
+  paired with it and checked against nothing** (closes #2021).
+  `_defect` answers before it looks at an anchor wherever the line is
+  empty, so `tests/security_citations_test.py` parametrized that name
+  as a case of its own and passed it whatever it said. A path-only
+  citation carries no anchor now, and what it is held to is naming a
+  file that exists.
+- **Reading the name instead would hold the prose to a claim it does
+  not make.** `btclib.ecc.musig2` in front of the citation of
+  `src/btclib/psbt/musig2.py` names the public API a delegation would
+  grow, where the file cited holds the decision against carrying
+  session state, and a pairing that fails that sentence names the prose
+  for what the pairing did.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/tests/security_citations_test.py
+++ b/tests/security_citations_test.py
@@ -14,8 +14,8 @@ sentence names, and learns that the file's pointers cannot be followed.
 That is worse than a file with no pointers (issue #1690).
 
 The grammar read here is the file's own. A citation is a backticked
-path, with or without a line number, and what it claims is written in
-the backticked spans in front of it:
+path, with or without a line number, and where it carries one, what it
+claims is written in the backticked spans in front of it:
 
 - a dotted name, `dsa.Signer.__init__`, and then the definition holding
   the cited line must be the one named, read off the module's own `ast`;
@@ -36,7 +36,12 @@ citation does not point into, which no definition holding the cited
 line answers for.
 
 A path with no line number is held to naming a file that exists, which
-is the whole of what it claims.
+is the whole of what it claims, so the spans in front of it are not
+read: an anchor is a claim about the line cited, and a citation carrying
+no line gives it nothing to be about. Holding a name to the file beside
+it instead would read a claim the prose does not make -- a sentence
+naming one module and citing the file of another is sound, and a pairing
+that fails it names the prose for what the pairing did.
 
 Two things this does not check. Which line inside a named definition is
 the right one: a dotted name pins the function and leaves every line of
@@ -105,11 +110,18 @@ def _citations(prose: str) -> tuple[tuple[str, str, str], ...]:
     for free. The index is what says there is a span in front at all: a
     negative one reaches the tail of the prose, and would anchor a
     citation to whatever the file happens to end with.
+
+    A citation carrying no line number is returned with no anchor: what
+    it claims is that its file exists, and no span in front of it adds
+    to that.
     """
     spans = _SPAN.findall(prose)
     anchored: list[tuple[str, str, str]] = []
     for index, span in enumerate(spans):
         if not (match := _CITATION.match(span)):
+            continue
+        if not (line := match["line"]):
+            anchored.append(("", match["path"], ""))
             continue
         anchors = [spans[index - 1] if index else ""]
         if (
@@ -118,7 +130,7 @@ def _citations(prose: str) -> tuple[tuple[str, str, str], ...]:
             and _SYMBOL.match(spans[index - 2])
         ):
             anchors.append(spans[index - 2])
-        anchored += [(anchor, match["path"], match["line"] or "") for anchor in anchors]
+        anchored += [(anchor, match["path"], line) for anchor in anchors]
     return tuple(anchored)
 
 
@@ -220,9 +232,7 @@ _SOUND = (
     pytest.param(
         "answer = 1 + 1", "src/control.py", "9", id="the quotation is on the line"
     ),
-    pytest.param(
-        "control.Klass.method", "src/control.py", "", id="a path claims only to exist"
-    ),
+    pytest.param("", "src/control.py", "", id="a path claims only to exist"),
 )
 
 _BROKEN = (
@@ -255,9 +265,10 @@ _CONTROL_PROSE = """\
 (`src/control.py:9`) opens the prose with nothing in front of it, where
 `answer = 1 + 1` (`src/control.py:9`) quotes the line, `Klass.method`
 (`src/control.py:9`) names the definition holding it, `Klass.method` at
-`answer = 1 + 1` (`src/control.py:9`) writes both, and `answer` at
+`answer = 1 + 1` (`src/control.py:9`) writes both, `answer` at
 `answer = 1 + 1` (`src/control.py:9`) puts a span that is no dotted name in
-front of the quotation.
+front of the quotation, and `Klass.method` (`src/control.py`) writes a name
+in front of a path with no line number.
 """
 
 _ANCHORED = (
@@ -267,6 +278,7 @@ _ANCHORED = (
     ("answer = 1 + 1", "src/control.py", "9"),
     ("Klass.method", "src/control.py", "9"),
     ("answer = 1 + 1", "src/control.py", "9"),
+    ("", "src/control.py", ""),
 )
 
 


### PR DESCRIPTION
`SECURITY.md`'s musig2 bullet writes `btclib.ecc.musig2`'s public API
immediately in front of a citation of `src/btclib/psbt/musig2.py` — a
path with no line number — so the pairing
`tests/security_citations_test.py` reads takes that name as the
citation's anchor. `_defect` answers before it looks at an anchor
wherever the line is empty, so the case passed whatever the name said:
`_defect("nonsense.absent", "src/btclib/psbt/musig2.py", "")` answers the
empty string as readily as the name the prose writes. One citation of the
fifteen is that shape, and it was green for the reason a check that reads
nothing is green.

The pairing stops short of such a citation instead. An anchor is a claim
about the line cited, and a citation carrying no line gives it nothing to
be about, so a path-only citation is parametrized with no anchor and is
held to naming a file that exists — which is the whole of what it claims.

**Two repairs were rejected, and both fail a sound sentence.** Reading the
name against the file it names (`_defect("btclib.ecc.musig2",
"src/btclib/psbt/musig2.py", "22")` → *names `btclib.ecc.musig2`, where
line 22 of musig2.py is in `musig2`*) turns the check red on prose that is
correct: the name is the public API a delegation would grow, where the
file cited holds the decision against carrying session state, and no
definition of that file answers for it. Refusing the shape outright costs
the same failure with a blunter message. Either way the prose is what
turns red for what the pairing did.

The docstring's opening sentence gave the spans in front of a citation as
what every citation claims, *either* shape of one. That was true of the
code before this change and is not true after it, so it now says it is the
citation carrying a line whose claim is written there — the sentence a
reader meets first is the one that had to move.

**A repair of a check is unverified until the check is made to fail.** The
control prose gained the shape — `` `Klass.method` (`src/control.py`) `` —
so the tuple it is compared against is what says the anchor is dropped;
with the guard reverted,
`test_the_anchors_of_a_citation_are_the_spans_in_front_of_it` fails with
`At index 6 diff: ('Klass.method', 'src/control.py', '') != ('',
'src/control.py', '')`. Review re-ran that with three further spellings of
the same defect — respelled inside the guard, the guard without its
`continue`, the guard dropping the citation — and the control fails on all
three, so it is not blind to a re-introduction written another way.

Gates on `08d307e2`, all four green: lint `pre-commit run --all-files`
exit 0 (47 `Passed`, 0 `Failed`), `pytest` exit 0 (`32603 passed, 78
skipped`, `TOTAL 57179 0 9886 0 100.00%`), `sphinx-build -n -W` exit 0,
the `href="#../"` sweep exit 1 against a positive control of 162 built
files that do carry `href="#`, `git status --porcelain` empty after each.
The statement and branch counts move by this diff's own three lines and
one `if`; `9886 0`, with no partial branches, is what says both arms of
the new guard are exercised.

closes #2021

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3

## Summary by Sourcery

Correct security citation parsing so path-only citations carry no anchor and are validated solely against the existence of the cited file.

Bug Fixes:
- Treat citations without line numbers as file-existence checks with no anchor, preventing preceding API names from being incorrectly validated as citation claims.

Enhancements:
- Update the security citation grammar and test fixtures to reflect that only line-bearing citations use preceding spans as anchors.

Tests:
- Add coverage ensuring path-only citations produce empty anchors and that the citation parser handles the updated grammar.