### PR TITLE
`README.md` states the predicate the bindings dispatch asks (closes #2023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -688,6 +688,30 @@ documented at release-notes length in the first place, and are still in
   session state, and a pairing that fails that sentence names the prose
   for what the pairing did.
 
+### `README.md` states the predicate the bindings dispatch asks
+
+- **The *Secrets, and where constant time ends* section made secp256k1,
+  sha256 and a nonce btclib derives sufficient for a delegated
+  signature** (closes #2023), and gave another curve, another hash
+  function or a nonce of the caller's as the ways out of it. Each
+  function it named ands conditions of its own onto
+  `curves.curve._libsecp256k1_serves`, and those differ: `dsa.sign`
+  declines a signature asked for with `lower_s=False` and one carrying a
+  sign-to-contract commitment, `ssa.sign` declines the commitment and
+  takes no nonce at all, and `silent_payments.output_keys` takes none of
+  those arguments. The section gives the predicate and leaves the
+  per-function conditions to `SECURITY.md`, which it already points at.
+- **The runtime switch is named beside the Python arithmetic it selects.**
+  `curves.set_libsecp256k1_serving(serving=False)` and
+  `BTCLIB_NO_LIBSECP256K1` put a process holding the bindings on that
+  arithmetic for every operation, and for `silent_payments.output_keys`,
+  whose guard fixes the curve and passes no hash function, it is the
+  whole of what decides.
+- **The opening paragraph gave the install as what decides**, secp256k1
+  always calling the bindings. The delegation is a runtime switch
+  besides an install, and a call reaches the bindings where its own
+  guard admits them.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/README.md
+++ b/README.md
@@ -80,18 +80,19 @@ of RFC 6979. `tests/_data/README.md` pins each vendored file to the
 upstream commit it was copied from, and says whether the two still match —
 including the few vectors that are btclib's own, having no upstream.
 
-The library is not limited to secp256k1, and for that curve it always
-calls
+The library is not limited to secp256k1, and for that curve it delegates
+to
 [btclib-secp256k1](https://github.com/btclib-org/btclib-secp256k1),
 FFI bindings to Bitcoin Core's optimized C library
-[libsecp256k1](https://github.com/bitcoin-core/secp256k1). They are the
-recommended install and what `pip install "btclib[secp256k1]"` asks for,
-needing one of their wheels or a C toolchain; without them btclib still
-answers, on the Python arithmetic, tens of times more slowly and not in
-constant time — `SECURITY.md` publishes both. That Python arithmetic
-serves every other curve anyway, and the suite validates it against the
-bindings: libsecp256k1 says what the right answer is, being what bitcoin
-consensus relies on.
+[libsecp256k1](https://github.com/bitcoin-core/secp256k1), wherever a
+call's own guard admits them. They are the recommended install and what
+`pip install "btclib[secp256k1]"` asks for, needing one of their wheels
+or a C toolchain; without them, or with the delegation turned off in a
+process that has them, btclib still answers, on the Python arithmetic,
+tens of times more slowly and not in constant time — `SECURITY.md`
+publishes both. That Python arithmetic serves every other curve anyway,
+and the suite validates it against the bindings: libsecp256k1 says what
+the right answer is, being what bitcoin consensus relies on.
 
 Included features are:
 
@@ -249,19 +250,26 @@ may have copied it meanwhile. The constant-time properties are
 libsecp256k1's, and they hold on the C side of the call — not before it,
 and not after.
 
-Not every operation crosses that call. `dsa.sign`, `ssa.sign` and
-`silent_payments.output_keys` reach the bindings for secp256k1 with sha256
-and no nonce of the caller's; another curve, another hash function, or a
-nonce you supply runs the Python arithmetic instead, which the suite
-validates against the bindings but which is not constant-time. So a caller
-whose threat model includes timing should stay on the delegated paths, or
-keep the key out of the process altogether: `btclib.hwi` drives a hardware
-wallet through HWI, behind the same `PsbtSigner` contract a software
-signer answers. `silent_payments.scan_outputs`, BIP352's light-client
-scan, is Python-only regardless: it accepts the shared secret already
-reduced, the shape a light client has and the bindings have no entry
-point for. `scan_transaction_outputs`, its full-node sibling, is not:
-where the bindings serve secp256k1 it reaches them with `b_scan`, the
+Not every operation crosses that call, and what decides is one
+predicate — a process-wide dispatch switch, secp256k1 as the curve,
+and sha256 or no hash function at all — with whatever further
+conditions the call site ands onto it. Those conditions differ from
+one function to the next, and `SECURITY.md` states each of them, for
+`dsa.sign`, `ssa.sign` and `silent_payments.output_keys` alike.
+Whatever that conjunction declines runs the Python arithmetic, which
+the suite validates against the bindings but which is not
+constant-time. A process that has the bindings turns that switch off
+with `curves.set_libsecp256k1_serving(serving=False)`, or with
+`BTCLIB_NO_LIBSECP256K1` in the environment, and every operation here
+is then the Python arithmetic. So a caller whose threat model includes
+timing should stay on the delegated paths, or keep the key out of the
+process altogether: `btclib.hwi` drives a hardware wallet through HWI,
+behind the same `PsbtSigner` contract a software signer answers.
+`silent_payments.scan_outputs`, BIP352's light-client scan, is
+Python-only regardless: it accepts the shared secret already reduced,
+the shape a light client has and the bindings have no entry point for.
+`scan_transaction_outputs`, its full-node sibling, is not: where the
+bindings serve secp256k1 it reaches them with `b_scan`, the
 recipient's scan private key, the same as `output_keys` above — a
 caller holding the transaction itself gets the delegated path a light
 client cannot reach.


### PR DESCRIPTION
`README.md`'s *Secrets, and where constant time ends* section made
secp256k1, sha256 and a nonce btclib derives **sufficient** for a
delegated signature, and gave another curve, another hash function or a
nonce of the caller's as the closed set of ways out of it. The three
functions it named are guarded separately, and none of the three guards
is the one stated:

- `dsa.sign_` ands `nonce is None`, `lower_s` and `commit_hash is None`
  onto `curves.curve._libsecp256k1_serves`;
- `ssa.sign_` ands `commit_hash is None`, and takes no caller-imposed
  nonce at all;
- `silent_payments.output_keys` calls the predicate with the curve fixed
  and no hash function, taking none of those arguments — so of the three
  reasons the sentence gave, none applies to it.

So `dsa.sign(..., lower_s=False)`, and a sign-to-contract signature of
either scheme, answered the sentence's description exactly and ran the
Python arithmetic that `SECURITY.md` publishes as not constant-time.
This is the tree's front page, read by someone deciding whether their
own call is on the delegated path.

The section now gives the **predicate** — the process-wide dispatch
switch, secp256k1 as the curve, and sha256 or no hash function at all —
with the conditions of the call site anded onto it, and leaves those
conditions to `SECURITY.md`, which the section already points at and
which states them argument by argument. That is a rule rather than a
better list: the reader's procedure is the predicate, then the function
looked up where the conditions live. It is also the issue's own second
option under *Done when*, and it matches `btclib.ecc`'s package
docstring (PR #2025), which says in as many words that `README.md`
carries the short form.

The process-wide switch is the condition the old paragraph omitted
altogether, and the one no argument reaches:
`curves.set_libsecp256k1_serving(serving=False)` and
`BTCLIB_NO_LIBSECP256K1` put a process that holds the bindings on the
Python arithmetic for every operation at once.

The opening paragraph is the issue's second *Done when* and carried the
shorter form of the same claim — secp256k1 always calling the bindings,
with the install as the whole of what decides. It says instead that a
call reaches them where its own guard admits them, and that the
delegation turns off at runtime besides.

Review verified the rewrap mechanically rather than by eye: both
paragraphs extracted from base and tip, split to word streams and
compared with `difflib`, with a one-word mutation control. Three real
edits in the opening paragraph and four in the secrets paragraph; every
other word identical, so nothing drifted in the refill.

Gates on `e1918f77`, all four green: lint `pre-commit run --all-files`
exit 0 (47 `Passed`, 0 `Failed`), `pytest` exit 0 (`32603 passed, 78
skipped`, `TOTAL 57179 0 9886 0 100.00%`), `sphinx-build -n -W` exit 0 —
which is the gate that matters here, `README.md` being included in the
docs build by `docs/source/readme_link.md` — the `href="#../"` sweep exit
1 against a positive control of 162 built files that do carry `href="#`,
and `git status --porcelain` empty after each.

Two collateral issues were filed from this branch's review and are not in
its scope: `SECURITY.md`'s own closing sentence still carries the roster
this one removes, and `SECURITY.md` never states that the hash function
is matched by identity, so a `functools.partial(sha256)` reads as
delegated and is not.

closes #2023

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3

## Summary by Sourcery

Clarify the README’s libsecp256k1 dispatch predicate and runtime delegation behavior.

Bug Fixes:
- Correct the README’s description of when secp256k1 bindings are used so it no longer implies that curve, hash, and nonce choices alone determine delegation.

Enhancements:
- Document the unified dispatch predicate, per-function guard conditions, and runtime controls that disable bindings process-wide.
- Clarify that operations falling outside the predicate use Python arithmetic without constant-time guarantees.

Documentation:
- Update the README and changelog to accurately describe conditional libsecp256k1 delegation and its security implications.