### PR TITLE
The hyphen hook reads Python and rst beside markdown (closes btclib-org/.github#921)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -548,12 +548,16 @@ repos:
       # Section 4 of the organization standard is the rule: what such a
       # line renders as, why nothing else here catches it, what this
       # pattern cannot see, and what the measurement was before it was
-      # proposed
+      # proposed. The types are where a build renders prose from --
+      # markdown, and what docutils reads, an rst page and a Python
+      # docstring -- so a comment sharing a Python file with a docstring
+      # is refused alongside it, one line at a time being all pygrep
+      # reads
       - id: no-hyphen-at-end-of-line
         name: a word is not wrapped at its own hyphen
         language: pygrep
         entry: "[A-Za-z0-9]-$"
-        types: [markdown]
+        types_or: [markdown, python, rst]
       # a placeholder that is a whole argument, in quotes. Section 9 of
       # the organization standard is the rule and what the quoting costs
       # a paste; section 4 is where this hook is, which quotes it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -712,6 +712,24 @@ documented at release-notes length in the first place, and are still in
   besides an install, and a call reaches the bindings where its own
   guard admits them.
 
+### The hyphen hook reads Python and rst beside markdown
+
+- **`no-hyphen-at-end-of-line` carries `types_or: [markdown, python, rst]`,
+  under `btclib-org/.github`'s own comment with its `README.md` read as
+  the organization standard, the phrase the comments beside it use for
+  the standard** (closes btclib-org/.github#921): section 4 of the
+  organization standard gives the hook the file types whose prose a
+  build renders, and a docstring reaches that rendering through
+  docutils, which leaves the source break inside the paragraph it
+  builds and lets html collapse it to a space, as it does markdown's
+  join.
+- **The lines the widened hook refused hold their token whole**: the
+  module docstring of `docs/source/conf.py` wrapped its Sphinx URL at
+  `sphinx-`, `curves/curve_group.py`'s function docstrings each wrapped
+  `left-to-right` at one of its own hyphens, and the rest are comments or
+  docstrings across `p2p`, `psbt`, `tx`, `wallet` and the test suite,
+  each rejoined at the word its own hyphen split.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,8 +5,7 @@
 """Configuration file for the Sphinx documentation builder.
 
 For the full list of built-in configuration values, see the
-documentation: https://www.sphinx-
-doc.org/en/master/usage/configuration.html
+documentation: https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
 import re

--- a/src/btclib/curves/curve_group.py
+++ b/src/btclib/curves/curve_group.py
@@ -1265,9 +1265,8 @@ def _mult_fixed_window_var(
 ) -> JacPoint:
     """Scalar multiplication using "fixed window".
 
-    This implementation uses 'multiple-double & add' algorithm, 'left-
-    to-right' window decomposition of the m coefficient, Jacobian
-    coordinates.
+    This implementation uses 'multiple-double & add' algorithm, 'left-to-right'
+    window decomposition of the m coefficient, Jacobian coordinates.
 
     For 256-bit scalars it is suggested to choose w=4 or w=5.
 
@@ -1302,9 +1301,8 @@ def _mult_fixed_window_cached_var(
 ) -> JacPoint:
     """Scalar multiplication using "fixed window" & cached values.
 
-    This implementation uses 'multiple-double & add' algorithm, 'left-
-    to-right' window decomposition of the m coefficient, Jacobian
-    coordinates.
+    This implementation uses 'multiple-double & add' algorithm, 'left-to-right'
+    window decomposition of the m coefficient, Jacobian coordinates.
 
     For 256-bit scalars it is suggested to choose w=4. Thanks to the
     pre-computed values, it just needs addictions.
@@ -1436,9 +1434,8 @@ def _double_mult_var(
 ) -> JacPoint:
     """Double scalar multiplication (u*H + v*Q).
 
-    This implementation uses the Shamir-Strauss algorithm, 'left-to-
-    right' binary decomposition of the u and v coefficients, Jacobian
-    coordinates.
+    This implementation uses the Shamir-Strauss algorithm, 'left-to-right'
+    binary decomposition of the u and v coefficients, Jacobian coordinates.
 
     Strauss algorithm consists of a single 'double & add' loop for the
     parallel calculation of u*H and v*Q, efficiently using a single

--- a/src/btclib/p2p/block_filters.py
+++ b/src/btclib/p2p/block_filters.py
@@ -73,8 +73,8 @@ Core carries commented out.
 headers.** The message holds a previous filter header and a vector of
 hashes; the headers are what a client computes from the two, and BIP157
 sends the hashes precisely so that it has to. Storing the derived headers
-instead would be the question issue #1101 answered for `headers`' always-
-zero transaction count, and the answer is the same: keep what the wire
+instead would be the question issue #1101 answered for `headers`' always-zero
+transaction count, and the answer is the same: keep what the wire
 holds, so that every payload serializes back to the octets it came from.
 `filter_headers` is the derivation, as `Inventory.is_witness` is the
 reading of a bit rather than a second field -- and it is the same

--- a/src/btclib/p2p/limits.py
+++ b/src/btclib/p2p/limits.py
@@ -127,8 +127,8 @@ MAX_ADDRV2_SIZE = 512
 MAX_INV_SZ = 50000
 
 # The most headers one `headers` message carries, Core's
-# src/net_processing.h, whose comment adds what the number is load-
-# bearing for: "We rely on the assumption that if a peer sends less than
+# src/net_processing.h, whose comment adds what the number is load-bearing
+# for: "We rely on the assumption that if a peer sends less than
 # this number, we reached its tip. Changing this value is a protocol
 # upgrade."
 #

--- a/src/btclib/psbt/psbt.py
+++ b/src/btclib/psbt/psbt.py
@@ -3179,8 +3179,8 @@ def finalize(psbt: Psbt, *, solver: InputSolver | None = None) -> Psbt:
     0x07 Finalized scriptSig and 0x08 Finalized scriptWitness and place
     them into the input key-value map.
 
-    All other data except the UTXO and unknown fields in the input key-
-    value map should be dropped from the wire representation. The UTXO
+    All other data except the UTXO and unknown fields in the input key-value
+    map should be dropped from the wire representation. The UTXO
     is kept to allow Transaction Extractors to verify the final network
     serialized transaction. This function does not clear those fields on
     the input it returns: `PsbtIn.serialize` drops them, guarded on the

--- a/src/btclib/tx/tx_context.py
+++ b/src/btclib/tx/tx_context.py
@@ -196,8 +196,8 @@ def assert_sequence_locks(
 def assert_coinbase_maturity(prevouts: Sequence[Coin], spend_height: int) -> None:
     """Refuse a spend of a coinbase output not yet `COINBASE_MATURITY` deep.
 
-    Core's `Consensus::CheckTxInputs`, `bad-txns-premature-spend-of-
-    coinbase` (`src/consensus/tx_verify.cpp`, at
+    Core's `Consensus::CheckTxInputs`, `bad-txns-premature-spend-of-coinbase`
+    (`src/consensus/tx_verify.cpp`, at
     bitcoin/bitcoin@9be056a8a7): `spend_height - coin.height <
     COINBASE_MATURITY`, for whichever of `prevouts` is a coinbase output.
 

--- a/src/btclib/wallet/descriptor_wallet.py
+++ b/src/btclib/wallet/descriptor_wallet.py
@@ -259,8 +259,8 @@ class DescriptorWallet(RangedWallet):
         """Return the position paying to this output, None where none is.
 
         `Descriptor.index_of` per chain, in `branches` order, rather than
-        a comparison written a second time here: it is the same whole-
-        script comparison, it refuses the same spellings that name no
+        a comparison written a second time here: it is the same whole-script
+        comparison, it refuses the same spellings that name no
         output, and it is what bounds the search of a chain that is not
         ranged to the one script it has.
         """

--- a/src/btclib/wallet/key_wallet.py
+++ b/src/btclib/wallet/key_wallet.py
@@ -281,8 +281,8 @@ class BIP32KeyWallet(KeyWallet, RangedWallet):
     `xkey` is the master key, the account key, or any key between the
     two; `der_path` is always the whole account path from the master,
     `m/purpose'/coin_type'/account'`, because the purpose lives at the
-    top of it and is what says whether the addresses are p2pkh, p2wpkh-
-    p2sh, p2wpkh or p2tr. What is left of the path below the key is
+    top of it and is what says whether the addresses are p2pkh, p2wpkh-p2sh,
+    p2wpkh or p2tr. What is left of the path below the key is
     derived once, at construction.
 
     Addresses come from the two unhardened levels BIP44 puts under an

--- a/tests/changelog_immutability_test.py
+++ b/tests/changelog_immutability_test.py
@@ -94,8 +94,8 @@ that heading was checked directly and lacks the bullet too, because each
 commit wrote it under an already-released heading as measured above,
 and nothing has touched it since: the mistake was never a rebase
 disturbing a settled tag, it is what that one commit itself wrote, and
-every tag cut afterwards simply inherited it unchanged. So no already-
-tagged heading can receive a bullet without gaining text its own sealed
+every tag cut afterwards simply inherited it unchanged. So no already-tagged
+heading can receive a bullet without gaining text its own sealed
 tag never had, which is the identical failure this module exists to
 catch, moved rather than fixed. The one heading with no tag to violate
 is the currently open one, `## v2026.9 (work in progress, not released

--- a/tests/script_engine/transactions_test.py
+++ b/tests/script_engine/transactions_test.py
@@ -163,8 +163,8 @@ def legacy_vectors(fname: str) -> list[Any]:
     `_legacy` in the file names would read as a subsetting that never
     happens; nor is the content legacy, 2 valid and 14 invalid vectors
     naming WITNESS in their flags (issue 168). The `legacy` of the test
-    names below is another matter and stays: it distinguishes the pre-
-    taproot validation path these vectors drive from the BIP341 ones
+    names below is another matter and stays: it distinguishes the pre-taproot
+    validation path these vectors drive from the BIP341 ones
     above, and issue 129 cites `test_invalid_legacy` by name.
 
     Nothing is filtered here: skipping whatever `Tx.parse` refuses hides


### PR DESCRIPTION
`no-hyphen-at-end-of-line` carries `types_or: [markdown, python, rst]`,
matching the sibling repositories, with the comment above it carrying
the sentence explaining what the widened types cover. The lines the
widened hook refuses are comments or docstrings, and each is reflowed
at the word its own hyphen split, changing no value.

Closes [ISS 921](https://github.com/btclib-org/.github/issues/921)

Local review: CLEARED at 7120c2d5776b549e05df5702a176b652ba5d054d

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGRFSkPFh8PR4Y3Wr47vb

## Summary by Sourcery

Enforce consistent handling of line-wrapped hyphenated words across Markdown, Python, and reStructuredText prose.

Enhancements:
- Extend the no-hyphen-at-end-of-line pre-commit check to Python and reStructuredText alongside Markdown.
- Reflow comments and docstrings so hyphenated words remain intact across supported prose files.