### PR TITLE
`README.md` states the timing of a delegated multiplication (closes #2026)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -730,6 +730,35 @@ documented at release-notes length in the first place, and are still in
   docstrings across `p2p`, `psbt`, `tx`, `wallet` and the test suite,
   each rejoined at the word its own hyphen split.
 
+### `README.md` states the timing of a delegated multiplication
+
+- **The *Secrets, and where constant time ends* section gave `mult` as
+  sending every point that is not the generator to
+  `secp256k1_ec_pubkey_tweak_mul`** (closes #2026), which asserts the
+  delegation for those points instead of resting on it. The arm
+  `curves.curve._mult_checked` delegates from is behind
+  `curves.curve._libsecp256k1_serves`, a nonzero scalar and a point that
+  is not infinity, so the predicate stated one paragraph above decides
+  the call before any point does. The sentence rests on the delegation
+  now, and `mult` stays its subject: where that conjunction delegates a
+  `mult` of a point that is not the generator, its work follows the
+  scalar.
+- **The subject is a `mult` and not whatever the conjunction
+  delegates.** `ellswift.xdh` guards on the same predicate
+  (`src/btclib/ecc/ellswift.py:364`) and delegates a secret times a
+  point the caller encoded, so a claim about every delegation would
+  cover it — and what it delegates to is `secp256k1_ellswift_xdh`, whose
+  `secp256k1_ecmult_const_xonly` is constant time in the scalar.
+  `SECURITY.md` states that call and this one apart, and the README
+  sentence carries the scope that keeps them apart.
+- **The C entry point is named where the accounting is.** What that arm
+  calls is the bindings' `keys.pubkey_tweak_mul_sum`, whose terms are
+  `secp256k1_ec_pubkey_tweak_mul` and whose sum is
+  `secp256k1_ec_pubkey_combine`, so a reader grepping the tree for the
+  name the section carried does not find it at the call.
+  `SECURITY.md`'s "Limitations, not vulnerabilities" keeps the name and
+  what the timing claim rests on, and the section points there.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/README.md
+++ b/README.md
@@ -274,12 +274,12 @@ recipient's scan private key, the same as `output_keys` above — a
 caller holding the transaction itself gets the delegated path a light
 client cannot reach.
 
-Crossing that call is not the same as constant time. `mult` sends every
-point that is not the generator to `secp256k1_ec_pubkey_tweak_mul`,
-whose work follows the scalar, so a secret multiplied by a point you
-supplied — the shared point of a key agreement, among others — carries
-no timing guarantee on the delegated path either; `SECURITY.md` has the
-accounting.
+Crossing that call is not the same as constant time. Where that
+conjunction delegates a `mult` of a point that is not the generator, its
+work follows the scalar, so a secret multiplied by a point you supplied —
+the shared point of a key agreement, among others — carries no timing
+guarantee on the delegated path either; `SECURITY.md` has the accounting,
+and which call a multiplication takes is part of it.
 
 What that path does about it is in the names, and it is worth knowing
 before calling one. **A function whose duration follows the value it is


### PR DESCRIPTION
`README.md`'s constant-time paragraph said `mult` "sends every point that
is not the generator to `secp256k1_ec_pubkey_tweak_mul`" — asserting that
a set of points **is** delegated, where `src/btclib/curves/curve.py:810`
enters the delegated arm only `if m and _libsecp256k1_serves(ec, None)`
and then `if Q[1]:`. A zero scalar, the point at infinity, and anything
the dispatch predicate declines never reach it.

The sentence now takes the delegation as its premise instead of asserting
it, and keeps a subject:

> Where that conjunction delegates a `mult` of a point that is not the
> generator, its work follows the scalar […] `SECURITY.md` has the
> accounting, and which call a multiplication takes is part of it.

"That conjunction" is the predicate the paragraph above already states,
landed by PR #2032 — the process-wide dispatch switch, the curve, the hash
function, with the call site's own conditions anded on — so the conditions
are stated once and not restated. The one class of point still named is a
rule rather than a roster: `curve.py:812` sends the generator to
`secp256k1_ec_pubkey_create` and `:822-823` sends everything else to
`pubkey_tweak_mul_sum`, two C entry points differing over exactly that.

**The first attempt at this repair was rejected in review, and the reason
is worth recording.** Dropping the subject made the claim quantify over
every delegation, and `ecc.ellswift.xdh` is a counterexample inside this
tree: same predicate at `src/btclib/ecc/ellswift.py:364`, a secret times a
caller-supplied non-generator point, delegated to `secp256k1_ellswift_xdh`,
which multiplies with `secp256k1_ecmult_const_xonly` — whose own header at
libsecp256k1 reads "Constant time in the value of q, but not any other
inputs." `SECURITY.md` already excepts it by name, which is what
established that a sentence of that shape sweeps it in unless excepted. So
a repair of a narrow false universal had produced a wider one, in the
over-warning direction.

The timing claim the paragraph rests on was re-derived rather than
inherited, twice independently: `secp256k1_ec_pubkey_tweak_mul` →
`secp256k1_eckey_pubkey_tweak_mul` → `secp256k1_ecmult` →
`secp256k1_ecmult_strauss_wnaf`, the variable-time wNAF and not
`ecmult_const`.

The `CHANGELOG.md` entry carries the scope's reason, so the next editor
reading it sees what widening the subject would cost.

Gates on `8adb18d8`, all four green: lint `pre-commit run --all-files`
exit 0 (47 `Passed`, 0 `Failed`), `pytest` exit 0 (`32603 passed, 78
skipped`, `TOTAL 57179 0 9886 0 100.00%`), `sphinx-build -n -W` exit 0 —
`README.md` being in the docs build via `docs/source/readme_link.md` — the
`href="#../"` sweep exit 1 against a planted control the same grep exits 0
on, and `git status --porcelain` empty after each.

The `merge=union` seam was predicted before the rebase, reproduced by it
byte for byte, and repaired by reconstruction from the new base's blob; the
pinned `markdownlint-cli2` check-only exits 0 on the committed file and 1
on a control with the blank line above the heading deleted, naming `MD032`
and `MD022`.

closes #2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3

## Summary by Sourcery

Correct the documented timing guarantees for delegated point multiplication and preserve the distinction between applicable multiplication paths.

Bug Fixes:
- Correct the README’s constant-time documentation so it scopes variable-time delegated multiplication claims to the applicable `mult` path instead of asserting delegation for every non-generator point.

Enhancements:
- Clarify that the specific multiplication call affects the timing guarantee and retain the distinction from Ellswift XDH behavior.

Documentation:
- Update the changelog with the rationale and scope of the corrected timing documentation.