### PR TITLE
`SECURITY.md` states the dispatch conditions its guards test (closes #2028) (closes #2029) (closes #2033) (issue #2035)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,73 @@ documented at release-notes length in the first place, and are still in
   `SECURITY.md`'s "Limitations, not vulnerabilities" keeps the name and
   what the timing claim rests on, and the section points there.
 
+### `SECURITY.md` closes its dispatch account with the predicate, not a roster
+
+- **The closing sentence gave another curve, another hash function or a
+  nonce of the caller's as the ways onto the Python arithmetic** (closes
+  #2028), where the same bullet states more above it: the process-wide
+  switch, which no argument of a caller's reaches; `dsa.sign`, which
+  declines a signature asked for with `lower_s=False` and one carrying a
+  sign-to-contract commitment; and `silent_payments.output_keys`, whose
+  guard fixes the curve and passes no hash function, so nothing a caller
+  passes selects either path for it. What the predicate and a call's own
+  conditions decline is what runs the Python implementation.
+- **The predicate opens the bullet the per-function conditions are anded
+  onto.** `curve._libsecp256k1_serves` asks for the switch, then for the
+  curve, then for the hash function, and this file is where the chain
+  ends: `README.md` and `src/btclib/ecc/__init__.py` state the predicate
+  and leave the conditions here, so a summary in this file cannot answer
+  by pointing on.
+- **The routing sentence of *What belongs here, and what belongs
+  upstream* gave the installation as a term of the decision**, where what
+  decides is the process-wide dispatch switch — an install without the
+  bindings is one state of it — and it folded the conditions of each call
+  site into the arguments of the operation.
+
+### `SECURITY.md` states that the hash function is matched by identity
+
+- **The condition written for each delegated operation is sha256, and
+  the test is `hf is sha256`** (closes #2029), so
+  `functools.partial(sha256)`, or any other wrapper a caller writes to
+  fit an interface, reads as delegated and is on the Python arithmetic
+  this file publishes as not constant-time. The identity is stated where
+  the predicate is, the wrapper named, and the fallback given as silent.
+- **Stated once, and not at each operation that names sha256.** The hash
+  function is a conjunct of the shared predicate rather than a condition
+  a call site ands onto it, so a copy at each operation would put one
+  fact where it is not decided and give it that many places to drift. A
+  reader checking one operation meets it on the way in, the predicate
+  opening the bullet those conditions are written in.
+
+### `SECURITY.md` states `mult`'s delegated arm as its guard tests it
+
+- **The arm was given as every point that is neither the generator nor
+  infinity** (closes #2033), a set of points with no condition in front
+  of it, where the bullet's subject is which multiplications are not
+  constant time and a reader uses it to decide whether their own key
+  agreement is on the C path. `_mult_checked` opens that arm asking for
+  a non-zero reduced scalar and then for the predicate, so a scalar that
+  reduces to zero, a process with the dispatch switch off and any curve
+  but secp256k1 are the Python arithmetic whatever the point is.
+- **The predicate is asked there with no hash function**, which leaves
+  the switch and the curve as the whole of what the predicate decides
+  for this multiplication. The two excepted points are the right two: the
+  generator is a different libsecp256k1 call inside the same arm, and
+  infinity is no public key, so `m*INF` is answered where every other
+  declined multiplication is.
+
+### `SECURITY.md` names the places a secret meets the curve, not how many
+
+- **The roster of call sites where a secret meets the curve stated how
+  many it names** (issue #2035), which `CLAUDE.md` forbids of prose that
+  lands and which no gate reads this file for:
+  `tests/release_notes_test.py` names `CHANGELOG.md` and
+  `RELEASE_NOTES.md`, and the tests that do read `SECURITY.md` read its
+  citations and its links. The names are in the same sentence and carry
+  it alone, so the numeral goes and nothing is lost. Whether that guard
+  should reach this file is the other half of the issue and is not
+  decided here.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,11 +23,11 @@ secp256k1 arithmetic is delegated to
 the Python bindings, and through them to
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1/security/advisories/new)
 itself, which has its own security policy and its own address. Not every
-call: the installation, the curve, the hash function and the arguments
-of the operation decide which, and *Limitations, not vulnerabilities*
-below is where that condition is stated. A flaw in the elliptic curve
-arithmetic, or in how the bindings drive it, most likely belongs to one
-of those.
+call: one predicate decides — a process-wide dispatch switch, the curve
+and the hash function — with whatever further conditions the call site
+ands onto it, and *Limitations, not vulnerabilities* below states each of
+them. A flaw in the elliptic curve arithmetic, or in how the bindings
+drive it, most likely belongs to one of those.
 
 What belongs here is everything btclib does around them:
 
@@ -193,7 +193,19 @@ used to teach and to prototype as much as to build:
     something other than libsecp256k1. With the dispatch off, every
     operation named below is the Python arithmetic, whichever way the
     library was installed
-- not every operation crosses that boundary. `mult`, `double_mult_var` and
+- not every operation crosses that boundary, and one predicate decides
+    whether it can: `curve._libsecp256k1_serves` asks for the switch
+    above, then for secp256k1 as the curve, then for a hash function
+    that is sha256 or absent — `hf is None or hf is sha256`
+    (`src/btclib/curves/curve.py:526`) — with whatever further
+    conditions the call site ands onto it. The hash function is matched
+    by identity rather than by what it computes, so
+    `functools.partial(sha256)`, or any other wrapper a caller writes to
+    fit an interface, is one the predicate declines, and the call it is
+    passed to runs the Python arithmetic — conservative for the
+    arithmetic, silent for the caller. The condition each operation below
+    states as sha256 is that identity.
+    `mult`, `double_mult_var` and
     `multi_mult_var` reach the bindings for secp256k1 and any point of it, a
     zero scalar and the point at infinity excepted — libsecp256k1 has no
     scalar for the one and no public key for the other; `dsa.sign` for
@@ -204,7 +216,7 @@ used to teach and to prototype as much as to build:
     half of `bip32.derive` for secp256k1, the tweaking of a key, the
     shared point of a key agreement, the tweaking of a sign-to-contract
     nonce and the offsetting of a parent key by the left half of an hmac
-    being four other places a secret meets the curve.
+    being other places a secret meets the curve.
     Verification crosses it whole, not only in its multiplication:
     `dsa.verify` and `ssa.verify` are one libsecp256k1 call each, where
     the dispatch is on, for
@@ -264,9 +276,8 @@ used to teach and to prototype as much as to build:
     with `b_scan`, the recipient's scan private key, built once for a
     whole transaction rather than once per input; off that path it falls
     back to `scan_outputs` above and stays Python's alone.
-    Anything else — another
-    curve, another hash function, a nonce of your own — runs the Python
-    implementation, whose scalar multiplication is
+    Whatever the predicate above and a call's own conditions decline
+    runs the Python implementation, whose scalar multiplication is
     a double-and-add in Jacobian coordinates: it is validated against the
     bindings, which are the authority on the answer, but it is not
     constant-time. It tries, which is not the same claim. The Jacobian
@@ -326,9 +337,12 @@ used to teach and to prototype as much as to build:
     different function from `secp256k1_ecmult_const`. Which call a
     multiplication takes is decided by its shape and not by the module
     that writes it: any point a caller supplied, multiplied by a secret
-    scalar, arrives here, `curves.curve.mult` delegating every point
-    that is neither the generator nor infinity in the arm it shares with
-    `PreparedPoint.mult` — `curve._mult_checked` at
+    scalar, arrives here. The arm `curves.curve.mult` shares with
+    `PreparedPoint.mult` asks for a non-zero reduced scalar and then for
+    the predicate above, with no hash function, so the switch and the
+    curve are the whole of what the predicate asks; the generator is a
+    different call inside that arm and infinity is not delegated at
+    all — `curve._mult_checked` at
     `return _libsecp256k1_multi_mult([m], [Q])`
     (`src/btclib/curves/curve.py:823`). `dh.diffie_hellman` at
     `sec = libsecp256k1_keys.pubkey_tweak_mul(`


### PR DESCRIPTION
Four sentences of `SECURITY.md`'s dispatch account, all the same family —
a claim stating a condition as sufficient when it is not. This is the file
every other document defers to for the per-function conditions, so it
could not answer by pointing elsewhere: the repair had to put the
predicate *in* this file.

**[ISS #2028](https://github.com/btclib-org/btclib/issues/2028) — the
closing summary stops enumerating.** It gave "another curve, another hash
function, a nonce of your own", where the same file names more above: the
process-wide switch, `lower_s` and `commit_hash`, and the fact that no
argument at all sends `silent_payments.output_keys` down the Python path.
It now reads *"Whatever the predicate above and a call's own conditions
decline runs the Python implementation"* — the predicate stated once, with
its citation, at the head of the same bullet. The routing sentence at
`:26` got the same treatment, having given "the installation" where a
runtime switch is what decides.

**[ISS #2029](https://github.com/btclib-org/btclib/issues/2029) — the
identity match, stated once.** The file said "with sha256" at four places
and never that the comparison is by identity, so a caller wrapping sha256
read themselves as delegated and was on the non-constant-time path. The
new sentence says so at the head of the bullet, with a bridge — *"The
condition each operation below states as sha256 is that identity"* — and
the four sites are all below it, the nearest four lines away.

Measured rather than asserted, and it came out **stronger than the claim**:
`_libsecp256k1_serves(secp256k1, functools.partial(sha256))` is `False`,
`dsa.sign(..., hf=functools.partial(sha256))` returns a `Sig` with nothing
raised, and review found that signature **byte-identical** to the
delegated one — same `r`, same `s`. So nothing a caller can read
distinguishes the two paths, which is what "silent" means here.

**[ISS #2033](https://github.com/btclib-org/btclib/issues/2033) — `mult`'s
delegated arm in the guard's own order.** It gave "every point that is
neither the generator nor infinity"; the two excepted points are right and
are not the whole guard. `src/btclib/curves/curve.py:810` is `if m and
_libsecp256k1_serves(ec, None):` — the scalar **first**, then the
predicate — and the sentence now says that, with "reduced" licensed by
`:782`.

**[ISS #2035](https://github.com/btclib-org/btclib/issues/2035) — the
prose half only, and the issue stays open.** "being four other places a
secret meets the curve" is now "being other places", and the entry says in
as many words that whether the count-free guard should reach this file —
`tests/release_notes_test.py`'s `_FILES` names `CHANGELOG.md` and
`RELEASE_NOTES.md` only — is the issue's other half and is not decided
here. Note "**other** places" and not "the other places": the definite
article would have traded a stale count for a false exhaustive quantifier.

No executable line changes. The one citation added carries both anchors —
the quotation of `curve.py:526` and the dotted name enclosing it — so the
parametrised citation check reads 17 where it read 15, which is the whole
of the `+2` in the test count.

Gates on `693b518f`, all four green: lint `pre-commit run --all-files` exit
0 (47 `Passed`, 0 `Failed`), `pytest` exit 0 (`32605 passed, 78 skipped`,
`TOTAL 57179 0 9886 0 100.00%`), `sphinx-build -n -W` exit 0, the
`href="#../"` sweep exit 1 against a 135-file positive control, `git status
--porcelain` empty after each.

The branch was rebased twice as siblings landed. Each time the `merge=union`
seam was predicted with `merge-tree` **before** rebasing and repaired by
reconstruction from the new base's blob rather than from the rebase's
output — and the control for the repair was the fused blob itself, so it
carries the defect rather than an imitation: the pinned `markdownlint-cli2`
check-only exits 1 on it naming `MD032` and `MD022` against this branch's
own heading, and 0 on what is committed.

closes #2028
closes #2029
closes #2033

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3

## Summary by Sourcery

Correct `SECURITY.md` so its security guidance accurately states when operations use libsecp256k1 versus Python implementations.

Enhancements:
- Clarify `SECURITY.md`'s libsecp256k1 dispatch predicate, including process-wide switching, curve and hash identity requirements, and operation-specific conditions.
- Document `mult` delegation conditions and remove the unsupported count of secret-related curve call sites.

Documentation:
- Add changelog entries documenting the corrected security dispatch conditions and their affected issues.