### PR TITLE
`CLAUDE.md` says which files a test keeps free of a stated count (closes #2035)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -826,6 +826,23 @@ documented at release-notes length in the first place, and are still in
   should reach this file is the other half of the issue and is not
   decided here.
 
+### `CLAUDE.md` says which files a test keeps free of a stated count
+
+- **`CLAUDE.md`'s *Never state how many of anything a file holds* named
+  the tests that enforce it and no file the rule governs without one**
+  (closes #2035): `SECURITY.md` is such a file, so the sentence reads as
+  coverage the suite does not give. That bullet names it, and the reason,
+  where it names the tests.
+- **The instrument that fits the files it does name does not fit this
+  one.** `merge=union` restores a count paragraph on a rebase with
+  nothing in the merge output to say so, and
+  `git check-attr merge -- SECURITY.md` answers `unspecified`. Naming
+  the file in `tests/release_notes_test.py`'s `_FILES` is inert, those
+  patterns being keyed on the paragraph each forbids; a guard of
+  `tests/vendored_data_test.py`'s shape asks for an exemption per
+  `path:line` citation, pinned verbatim, where an edit anywhere in a
+  cited module moves the line number.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,6 +440,24 @@ Do not use Fable unless explicitly instructed.
   RELEASE_NOTES.md, `tests/vendored_data_test.py` for
   `tests/_data/README.md` — failing on a stated count rather than on a
   wrong one.
+
+  `SECURITY.md` is governed by the same rule and kept by hand, which is a
+  decision rather than a gap (issue #2035). What makes a test the
+  instrument for the files above is a defect a reading cannot see: the
+  `merge=union` driver restores a count paragraph on a rebase with
+  nothing in the merge output to say so, and `tests/_data/README.md`'s
+  count is an edit every branch vendoring a vector makes.
+  `git check-attr merge -- SECURITY.md` answers `unspecified`, and its
+  numerals sit in prose rather than at an append point. Naming the file in
+  `tests/release_notes_test.py`'s `_FILES` is the small move and an inert
+  one: those patterns are keyed on the paragraph each forbids, and match
+  nothing here. A guard of `tests/vendored_data_test.py`'s shape asks for
+  an exemption per `path:line` citation and per protocol constant, each
+  pinned verbatim, where an edit anywhere in a cited module moves the
+  line number `tests/security_citations_test.py` reads; and a numeral
+  summarising a roster the sentence itself lists is what a pattern cannot
+  tell from a sentence naming a structure, so the allowlist would carry
+  the judgement rather than check it.
 - **A wall clock and a linter's findings are counts too**, and nothing
   fails on those: pyproject.toml's comments and tests/README.md state
   none, and keeping it that way is by hand. What a comment carries

--- a/tests/release_notes_test.py
+++ b/tests/release_notes_test.py
@@ -39,6 +39,14 @@ from pathlib import Path
 import pytest
 
 _ROOT = Path(__file__).parents[1]
+
+# the files whose `merge=union` driver makes a restored count silent, which
+# is what a test rather than a reading answers for. `SECURITY.md` is
+# governed by the same rule and is not here: `git check-attr merge` answers
+# `unspecified` for it, and the patterns below are keyed on the paragraph
+# each forbids, so naming it adds a guard that cannot fail on it. CLAUDE.md's
+# *Never state how many of anything a file holds* carries that decision
+# (issue #2035)
 _FILES = (_ROOT / "CHANGELOG.md", _ROOT / "RELEASE_NOTES.md")
 
 # The three claims the two files used to make, keyed on the number word


### PR DESCRIPTION
`CLAUDE.md`'s *Never state how many of anything a file holds* named the
tests that enforce it and no file the rule governs without one.
`SECURITY.md` is such a file, so the sentence read as coverage the suite
does not give. The decision is that it stays with the reading, and this is
that decision written where the rule is.

Three grounds, each measured rather than argued:

- **The fitting instrument is inert on its own subject.** All three of
  `tests/release_notes_test.py`'s `_FORBIDDEN` patterns answer `None`
  against the pre-repair `SECURITY.md` (`git show 6065ade8^:SECURITY.md`),
  the file that still said "being four other places a secret meets the
  curve" — while answering true on 4 of 4 `_RESURRECTED` strings. So
  naming the file in `_FILES` would have been green on the exact sentence
  [ISS 2035](https://github.com/btclib-org/btclib/issues/2035) was filed
  for, which is what `test_the_patterns_still_match` exists to refuse.
- **The defect mode that justifies a test for the other two is absent.**
  `git check-attr merge` answers `union` for `CHANGELOG.md` and
  `RELEASE_NOTES.md` and `unspecified` for `SECURITY.md` — one run over
  six paths, so the `unspecified` is discriminated and not a silent zero.
  The silent-restore mechanism a test answers for is not there; what is
  left is staleness, and the paragraph says the file is kept by hand.
- **The working instrument costs an allowlist coupled to another gate.** A
  guard of `tests/vendored_data_test.py`'s shape flags 48 of 481 prose
  lines, 9 of them `path:line` citations, each wanting an exemption pinned
  verbatim — where an edit anywhere in a cited module moves the number
  `tests/security_citations_test.py` then reads.

What lands is a paragraph in `CLAUDE.md`, a comment above
`tests/release_notes_test.py`'s `_FILES` where somebody minded to add a
third file is standing, and one `CHANGELOG.md` entry. 3 files, 43
insertions, 0 deletions; no test function, id or collection count moves.

Gates at `2839272f`, the pushed tip: lint exit 0 (47 `Passed`, 0
`Failed`), tree clean after; `pytest` exit 0, 32605 passed, 78 skipped,
`TOTAL 57179 0 9886 100.00%`; `sphinx-build -n -W` exit 0; the
`href="#../"` sweep exit 1 with a planted control the sweep exits 0 on;
pinned `markdownlint-cli2` v0.23.2 check-only exit 0, and exit 1 naming
`MD032`/`MD022` on a copy with the blank line above this branch's own
heading deleted.

Reviewed at `3dd2efb3` (CLEARED). Two changes since that sha, both prose
and both from the review itself: the reviewer's non-blocking finding on
the `CLAUDE.md` paragraph's closing clause is taken, so the clause no
longer labels a live class of `SECURITY.md` sentences as descriptions the
file carries; and the commit body now points the question it raises at
[ISS 2038](https://github.com/btclib-org/btclib/issues/2038), filed from
this review, rather than settling it here.

closes #2035

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3

## Summary by Sourcery

Document why SECURITY.md remains outside the automated stated-count checks while clarifying the intended scope of the existing test.

Bug Fixes:
- Clarify that SECURITY.md is intentionally maintained manually rather than covered by the count-detection test, addressing issue #2035.

Enhancements:
- Document the rationale for limiting count checks to files where silent restoration or branch-generated edits can introduce defects.
- Add an explanatory comment at the test file allowlist to prevent inappropriate expansion of its scope.

Documentation:
- Update CLAUDE.md with the decision and criteria governing files subject to stated-count checks.
- Record the decision and its rationale in the changelog.