### PR TITLE
The anchor depth, the gate's closure and one codeql clause converge (issue btclib-org/.github#715) (issue btclib-org/.github#634) (issue btclib-org/.github#1028)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -284,7 +284,7 @@ jobs:
       # about today's jobs and not about the shape: a `changes` job, or
       # an `if:` on a job narrower than this one's own, makes a
       # legitimate "skipped" row reachable, and the first run carrying
-      # one is then a red required check with no defect under it and
+      # one is then this job going red with no defect under it and
       # nothing in the tree pointing here. btclib-org/.github#990 is
       # where the aggregates that narrow are swept
       - name: Fail unless every other job of this run succeeded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -843,6 +843,58 @@ documented at release-notes length in the first place, and are still in
   `path:line` citation, pinned verbatim, where an edit anywhere in a
   cited module moves the line number.
 
+### The anchor depth, the gate's closure and one codeql clause converge
+
+- **`docs/source/conf.py`'s `myst_heading_anchors` is 6** (issue
+  btclib-org/.github#715): section 2 of the organization standard makes
+  six every level markdown heads at, which is what makes the number a
+  fixed point rather than a depth re-derived from the files it covers.
+  `CONTRIBUTING.md`'s shared half is ported to every repository by
+  section 14, so a heading added there moves a tree-derived depth in
+  each of them at once, and which tree finds out is whichever carries a
+  link into it. The key is already load-bearing here -- `README.md`
+  links into `CONTRIBUTING.md`'s *Breaking a caller is not an argument*
+  and `CONTRIBUTING.md` into `REVIEWING.md`'s *The gates are the
+  evidence* -- so the widening reaches a depth no link needs today
+  rather than repairing one that was broken. What says the depth is wide
+  enough is a link into a heading and not a comparison of two builds:
+  docutils gives every section an id whatever myst accepts as a target,
+  so the pages this source renders are the same bytes at either value,
+  and would be with a heading at `#####` in them.
+- **`tests/interpreters_test.py` takes the free-threading
+  biconditional's second side from the aggregate's `needs:` closure**
+  (issue btclib-org/.github#634): section 3 of the standard makes the
+  second side the jobs the required check waits on, and names reading
+  the workflow file as the rejected alternative, an interpreter a job
+  outside the closure names being the "it passed somewhere" that section
+  refuses. `test: every job passed` waits on every job `test.yml`
+  declares, so the two readings do not disagree over this tree's own
+  workflow; the workflow text they do disagree over is built in the
+  module, a job the aggregate waits on, one beside it, and one reached
+  only through a block-sequence `needs:`. That third job is what holds
+  the closure's own reading of `needs:` to a block list under the key as
+  well as the flow shapes beside it: with `coverage-union`'s `needs:`
+  rewritten as a block list and a free-threaded job reachable only
+  through it, the flow-only pattern answers `3.14` where the closure
+  runs `3.14t` as well, and a closure short of an edge is short of the
+  jobs behind it.
+- **`.github/workflows/codeql.yml` says this job goes red, not that a
+  required check fails** (issue btclib-org/.github#1028). The comment
+  above *Fail unless every other job of this run succeeded* argues the
+  allowlist into naming `success` and `skipped` both, and that argument
+  is untouched: a `changes` job, or an `if:` narrower than the
+  aggregate's own, makes a legitimate `skipped` row reachable. What was
+  false is the consequence drawn from it. No required context of `main`
+  comes from this workflow, which `REPOSITORY.md` already says in its
+  own words, and the classic `branches/main/protection` endpoint is
+  where that is read -- this repository's rulesets carry no
+  `required_status_checks` rule at all, so a rulesets-only read answers
+  that nothing here is required. The citation advances the issue rather
+  than closing it because the same clause is section 10 of the
+  organization standard's own sentence -- *what says the allowlist has
+  stopped matching the run is the required check failing* -- and that
+  half is a change to another repository.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,9 +67,10 @@ extensions = [
 
 source_suffix = [".rst", ".md"]
 
-# anchors for h1 to h4, which is what makes a link into a heading of
+# anchors down to h6, which is what makes a link into a heading of
 # another root markdown file resolve here: README.md links into
-# CONTRIBUTING.md's "Breaking a caller is not an argument" that way.
+# CONTRIBUTING.md's "Breaking a caller is not an argument" that way, and
+# CONTRIBUTING.md into REVIEWING.md's "The gates are the evidence".
 # Left unset this defaults to 0, myst generates no anchor at all, and
 # the fragment becomes an xref to a target no page has -- -W fails on a
 # link the forge renders correctly, which is what makes the failure
@@ -77,9 +78,23 @@ source_suffix = [".rst", ".md"]
 # is the one GitHub derives from the heading text, so the spelling
 # written for where these files are read is the spelling this build
 # accepts; the id it reaches is the one docutils gives the section, and
-# need not be spelled the same. Four levels, because that is how deep
-# the root markdown files head their sections
-myst_heading_anchors = 4
+# need not be spelled the same.
+#
+# Six is every level markdown heads at, which makes the number a fixed
+# point rather than a value re-derived from files that move -- and part
+# of what such a re-derivation would read belongs to no one tree:
+# section 14 of the organization standard ports CONTRIBUTING.md's shared
+# half into every repository, so a heading added there moves the depth
+# in each of them at once, and which tree finds out is whichever carries
+# a link into it (btclib-org/.github#715).
+#
+# Whether the depth is wide enough is not read off two builds: docutils
+# gives every section an id whatever myst accepts as a target, so the
+# pages this source renders at 4 and at 6 differ by no byte, and would
+# differ by none if a heading here did reach h5. What answers is a link
+# into such a heading: too narrow a depth makes it the same unresolved
+# xref an unset key makes of every one of them
+myst_heading_anchors = 6
 
 # -n on the build (CONTRIBUTING.md's documented command, and docs.yml)
 # turns an unresolved cross-reference into a warning for -W to fail on.

--- a/tests/interpreters_test.py
+++ b/tests/interpreters_test.py
@@ -64,20 +64,67 @@ _PYTHONS = re.compile(
 # -- would drop out of the comparison below in silence, leaving the
 # remaining two to agree with each other and the test green
 _SWEEPS = ("os-macos.yml", "os-ubuntu.yml", "os-windows.yml")
-# the merge gate, which its own header says is one cell rather than a
-# matrix: each job writes the interpreter it runs into itself, as
-# `python-version: "3.14"` or `--python 3.14`, so the gate's interpreters
-# are read as tokens off the file rather than out of a matrix block. A
-# free-threaded build there is a "3.14t" of the same shape. Comments go
-# first, so that a sentence about a sweep's free-threaded cell does not
-# read as the gate running one. The `dist` job is the exception: its
-# `astral-sh/setup-uv` step passes no `python-version:`, and its bare
-# `uv build` and "Smoke-test the wheel" step's `uv venv` take their
-# interpreter from `.python-version` instead of naming it in the job, so
-# a change to that file would move `dist`'s interpreter unseen here
+# the merge gate, and inside it the jobs a landing waits on. Section 3
+# of the organization standard declares a free-threading classifier
+# where the gate exercises that build, a gate being what refuses the
+# landing that breaks it, so what answers below is the aggregate's own
+# `needs:` closure rather than the file: a job of this workflow that no
+# required check waits on reports what a sweep reports, which is the
+# ground that section declines. Reading the file is the alternative that
+# section names as rejected, and it answers the same wherever every job
+# of the gating workflow sits inside the closure; what the closure buys
+# is that a job added outside it does not begin deciding this.
+#
+# Each job of the closure writes the interpreter it runs into itself, as
+# `python-version: "3.14"` or `--python 3.14`, so those interpreters are
+# read as tokens off the job's own block rather than out of a matrix
+# block. A free-threaded build there is a "3.14t" of the same shape.
+# Comments go first, so that a sentence about a sweep's free-threaded
+# cell does not read as the gate running one. Where this read stops is
+# the `dist` job, whose `astral-sh/setup-uv` step passes no
+# `python-version:` and whose bare `uv build` and "Smoke-test the wheel"
+# step's `uv venv` take the interpreter `.python-version` pins instead
+# of naming one in the job, so a change to that file would move `dist`'s
+# interpreter unseen here
 _GATE = _ROOT / ".github/workflows/test.yml"
+# the aggregate, found by the name `main`'s required contexts hold,
+# which is a job's `name:` and not its key
+_AGGREGATE = "test: every job passed"
 _COMMENT = re.compile(r"(?:^|\s)#.*$", re.MULTILINE)
 _INTERPRETER = re.compile(r"\b3\.\d+t?\b")
+# `jobs:` and everything under it: the trigger keys of `on:` sit at the
+# same indent as a job key, so a read that did not cut here would offer
+# `pull_request` to the closure below as though it were a job
+_JOBS = re.compile(r"^jobs:\n(?P<block>.*)\Z", re.MULTILINE | re.DOTALL)
+# a job key at the one indent `jobs:` gives them
+_JOB = re.compile(r"^  (?P<key>[a-z0-9_-]+):$", re.MULTILINE)
+# whatever follows `needs:` on the key's own line, plus the items below
+# it written `      - `, which is the spelling `btclib-secp256k1`
+# carries. The shapes that reads are one job after the key, a flow list
+# there, and a block list indented six.
+#
+# What it does not read, it drops without saying so, and the cases are
+# named because they are not equally bad. A flow list wrapped across
+# lines keeps only what sat on the key line: nothing where the bracket
+# stands alone, the first entry alone where it does not. A block list at
+# any other indent, and a flow list exploded under the key, keep none of
+# it. So does a comment among the items, and that one is this module's
+# own doing -- `_COMMENT` takes one whitespace away with the `#`, so a
+# comment on a line of its own arrives as a short run of spaces, and a
+# trailing comment written with two spaces before the `#` leaves one
+# behind; either ends the run of items where it stands.
+#
+# The empty closure is the loud failure: `_gating` then finds no
+# interpreter and the assertion below fires on it. A closure short of
+# only some of its edges is the quiet one, and it is why the block shape
+# is read rather than the flow ones alone -- a free-threaded build
+# behind a dropped edge goes unseen, and the biconditional below passes
+# on a gate it has not read
+_NEEDS = re.compile(
+    r"^    needs:(?P<inline>[^\n]*)\n(?P<items>(?:^      - \S+\n)*)", re.MULTILINE
+)
+_ITEM = re.compile(r"^      - (?P<key>\S+)$", re.MULTILINE)
+_NAME = re.compile(r'^    name: "?(?P<name>[^"\n]*)"?', re.MULTILINE)
 
 
 def _versions(pattern: re.Pattern[str], text: str) -> tuple[str, ...]:
@@ -101,10 +148,58 @@ def _declared() -> dict[str, tuple[str, ...]]:
     return found
 
 
-def _gate_interpreters() -> tuple[str, ...]:
-    """Return every interpreter the merge gate names outside its comments."""
-    text = _COMMENT.sub("", _GATE.read_text(encoding="utf-8"))
-    return tuple(sorted(set(_INTERPRETER.findall(text))))
+def _jobs(text: str) -> dict[str, str]:
+    """Return each job of a workflow, its comments dropped, keyed by key."""
+    jobs = _JOBS.search(_COMMENT.sub("", text))
+    assert jobs, "the workflow declares no jobs"
+    block = jobs["block"]
+    keys = list(_JOB.finditer(block))
+    bounds = [key.start() for key in keys[1:]] + [len(block)]
+    return {
+        key["key"]: block[key.end() : bound]
+        for key, bound in zip(keys, bounds, strict=True)
+    }
+
+
+def _waits_on(block: str) -> list[str]:
+    """Return the jobs one job's `needs:` names, in whichever shape."""
+    needs = _NEEDS.search(block)
+    if not needs:
+        return []
+    listed = needs["inline"].strip("[] ").replace(",", " ").split()
+    return listed + _ITEM.findall(needs["items"])
+
+
+def _needed(jobs: dict[str, str], key: str) -> set[str]:
+    """Return `key` and every job it waits on, however deep."""
+    found = {key}
+    pending = [key]
+    while pending:
+        for name in _waits_on(jobs[pending.pop()]):
+            if name not in found:
+                found.add(name)
+                pending.append(name)
+    return found
+
+
+def _found(jobs: dict[str, str], closure: set[str]) -> tuple[str, ...]:
+    """Return every interpreter the jobs of `closure` name."""
+    found: set[str] = set()
+    for key in closure:
+        found.update(_INTERPRETER.findall(jobs[key]))
+    return tuple(sorted(found))
+
+
+def _gating() -> tuple[str, ...]:
+    """Return every interpreter the jobs the merge gate waits on name."""
+    jobs = _jobs(_GATE.read_text(encoding="utf-8"))
+    keyed: dict[str, str] = {}
+    for key, block in jobs.items():
+        name = _NAME.search(block)
+        assert name, f"{_GATE.name}'s `{key}` job carries no name"
+        keyed[name["name"]] = key
+    assert _AGGREGATE in keyed, f"{_GATE.name} carries no job named {_AGGREGATE!r}"
+    return _found(jobs, _needed(jobs, keyed[_AGGREGATE]))
 
 
 def _matrix() -> tuple[str, ...]:
@@ -180,18 +275,58 @@ def test_free_threading_is_classified_exactly_when_the_gate_runs_it() -> None:
     The organization standard declares one where the gate exercises the
     free-threaded build: a gate refuses the landing that breaks that
     build, where a sweep runs beside a landing and blocks nothing. So the
-    second side here is test.yml alone and not `_MATRIX` -- the sweeps
-    name "3.14t" as readily as the gate would, and a sweep passing is the
-    ground the standard declines.
+    second side here is the jobs the required check waits on, and not
+    `_MATRIX` -- the sweeps name "3.14t" as readily as the gate would,
+    and a sweep passing is the ground the standard declines.
     """
-    gate = _gate_interpreters()
-    assert gate, "test.yml names no interpreter"
+    gating = _gating()
+    assert gating, f"no job {_AGGREGATE!r} waits on names an interpreter"
     classified = bool(_FREE_THREADING_CLASSIFIER.search(_PYPROJECT))
-    run = [v for v in gate if v.endswith("t")]
+    run = [v for v in gating if v.endswith("t")]
     assert classified == bool(run), (
         f"the free-threading classifier is {'present' if classified else 'absent'}"
-        f" and test.yml names {', '.join(run) or 'no free-threaded interpreter'}"
+        f" and the jobs {_AGGREGATE!r} waits on name"
+        f" {', '.join(run) or 'no free-threaded interpreter'}"
     )
+
+
+def test_a_job_outside_the_closure_answers_for_no_gate() -> None:
+    """The closure and the file are read apart, on text where they differ.
+
+    `test.yml` cannot show the difference: its aggregate waits on every
+    job in it, and every `needs:` it writes is a flow one. So the reading
+    the organization standard rejects agrees with the one it asks for,
+    and a `needs:` shape this module cannot see costs nothing there. The
+    workflow below is where both cost something -- a job the aggregate
+    waits on, one it does not, and one reached only through a block
+    `needs:` -- and each names an interpreter of its own.
+    """
+    text = (
+        "jobs:\n"
+        "  waited-on:\n"
+        "    name: Waited on\n"
+        "    steps:\n"
+        "      - run: uv run --python 3.11 pytest\n"
+        "  beside:\n"
+        "    name: Beside\n"
+        "    steps:\n"
+        "      - run: uv run --python 3.12t pytest\n"
+        "  between:\n"
+        "    name: Between\n"
+        "    needs:\n"
+        "      - waited-on\n"
+        "    steps:\n"
+        "      - run: uv run --python 3.13 pytest\n"
+        "  aggregate:\n"
+        f'    name: "{_AGGREGATE}"\n'
+        "    needs: [between]\n"
+    )
+    jobs = _jobs(text)
+    assert sorted(jobs) == ["aggregate", "beside", "between", "waited-on"]
+    closure = _needed(jobs, "aggregate")
+    assert closure == {"aggregate", "between", "waited-on"}
+    assert _found(jobs, closure) == ("3.11", "3.13")
+    assert _found(jobs, set(jobs)) == ("3.11", "3.12t", "3.13")
 
 
 def test_workflow_files_reads_the_names_github_runs(tmp_path: Path) -> None:


### PR DESCRIPTION
The organization standard settled at b41a9f75 what this tree had been
answering for itself, and the answers land in one branch because
CHANGELOG.md's open section has one append anchor and the file is
merge=union.

docs/source/conf.py sets myst_heading_anchors to 6, and its comment stops
giving a depth read off the tree's own headings as the reason: that is
what section 2 names as the rejected alternative, part of what such a
re-derivation reads being CONTRIBUTING.md's shared half, which section 14
ports into every repository. Two relative links into a heading of another
root markdown file already rest on the key -- README.md into
CONTRIBUTING.md's "Breaking a caller is not an argument" and
CONTRIBUTING.md into REVIEWING.md's "The gates are the evidence" -- so
this widens a setting that is already load-bearing rather than repairing
a broken link. No markdown this build reads heads deeper than ####,
measured by bucketing every '#' of the included files into heading
markers, bare issue references, fragment-like and unclassified and
reading the last bucket by eye, so nothing that resolves today begins or
stops resolving. What proves the key decides anything is a planted
#####-deep heading with a link into it: sphinx-build -n -W exits 1 at 4
naming myst.xref_missing and 0 at 6. A byte comparison of two builds does
not prove it, and the comment says so -- with the planted heading in
place the rendered pages are still identical at 4 and at 6, docutils
giving every section an id whatever myst accepts as a target.

tests/interpreters_test.py reads the free-threading biconditional's
second side off the aggregate's needs: closure rather than off every
interpreter test.yml names, which is the alternative section 3 rejects.
The aggregate is located by the name main's required contexts hold,
"test: every job passed", read back from the classic
branches/main/protection endpoint; it waits on every job that file
declares, so the accepted reading and the rejected one answer alike over
this tree's own workflow. The workflow text they disagree over is built
in the module instead: a job the aggregate waits on, one beside it, and
one reached only through a block-sequence needs:, each naming an
interpreter of its own. That third job is what holds the widened _NEEDS,
which reads a block list under the key as well as the flow shapes beside
it -- measured against test.yml with coverage-union's own needs:
rewritten as a block list and a free-threaded job reachable only through
it, the flow-only pattern answers 3.14 where the closure runs 3.14t as
well, and a closure short of an edge is short of the jobs behind it.

.github/workflows/codeql.yml's comment above "Fail unless every other job
of this run succeeded" said a legitimate skipped row would make a red
required check. It makes this job go red: main's required contexts are
Lint and type-check, Build the documentation, test: every job passed and
Regtest against Bitcoin Core, and REPOSITORY.md says this workflow
carries no required check at all. The reasoning the consequence was drawn
from is untouched, and so is the allowlist, which already names success
and skipped both. The citation advances that issue rather than closing
it: the same clause is section 10 of the organization standard's own
sentence, still there on its main today, and that half is a change to
another repository.

Advances [ISS 715](https://github.com/btclib-org/.github/issues/715),
[ISS 634](https://github.com/btclib-org/.github/issues/634) and
[ISS 1028](https://github.com/btclib-org/.github/issues/1028). It closes none
of them here: the first two are family issues whose last tree this is, and
the third owes a change to the standard's own section 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGRFSkPFh8PR4Y3Wr47vb

## Summary by Sourcery

Align documentation anchors, free-threading gate analysis, and CodeQL messaging with the organization's repository standards.

Bug Fixes:
- Correct the CodeQL workflow comment to describe the job itself going red when an allowed skipped job is encountered, rather than claiming it produces a red required check.

Enhancements:
- Make documentation heading anchors support levels through h6 and clarify the rationale for using a fixed anchor depth.
- Determine free-threading coverage from the merge gate's transitive needs closure instead of every interpreter named anywhere in the workflow.
- Add coverage for workflow job closure traversal, including block-style needs and jobs outside the gate closure.

Documentation:
- Document the anchor-depth, merge-gate closure, and CodeQL comment corrections in the changelog.

Tests:
- Update interpreter classification tests to validate the aggregate job's transitive needs closure and distinguish it from unrelated workflow jobs.