### PR TITLE
`SECURITY.md` refers to its roster without counting it, and an operation count names what counts it (closes #2038) (closes #2040)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -895,6 +895,59 @@ documented at release-notes length in the first place, and are still in
   stopped matching the run is the required check failing* -- and that
   half is a change to another repository.
 
+### `SECURITY.md` refers to the call sites it names without counting them
+
+- **Two sentences over one roster stated how many call sites it holds**
+  (closes #2038), the roster being the places a binding's output is read
+  straight into a Python `int`: a numeral counting a population of this
+  codebase rather than a structure the sentence closes, which is what
+  `CLAUDE.md` forbids of prose that lands and what no gate reads this
+  file for. The names are in the same sentence and carry it alone, so the
+  numeral goes and nothing is lost.
+- **The second sentence refers back to those call sites, not to *the*
+  others.** "The other call sites" would claim a completeness nothing
+  here holds, where "the call sites above" names the ones the bullet has
+  just named.
+- **One numeral in the file stays.** "Those three" counts the
+  libsecp256k1 entry points the sentence before it names, so it
+  summarises an enumeration that passage closes rather than a roster this
+  library adds to.
+
+### The stated addition and doubling counts name what counts them
+
+- **The figures for what a scalar multiplication costs had no command
+  beside them** (closes #2040), which `CLAUDE.md` asks of a number that
+  lands. `_CountingGroup` in `tests/curves/curve_group_test.py` is what
+  counts them and its docstring carries the command; the figures that are
+  one value for every scalar come back from it exactly, so this is a
+  stated instrument and not a corrected number.
+- **A counting group built the obvious way recodes a digit more at
+  w=4.** With no n to read, `CurveGroup` takes the Hasse bound plen + 1
+  for its scalar_len where `Curve` narrows it to nlen, and a
+  multiplication's digits being ceil(scalar_len / w), a subclass of the
+  group left at that bound gives a 256-bit scalar one digit more at that
+  width: `_mult_regular_window` answers 72 additions and 257 doublings
+  there against the 71 and 253 its docstring states, which reads as prose
+  that drifted. The delta is the `ceil`'s rather than the bound's -- at
+  w=5 and w=6 both bounds recode the same digit count -- and
+  `_mult_endomorphism_secp256k1` passes a scalar_len of its own, so its
+  figures are the same either way. The class takes the curve's own length
+  and says why, and counts doublings beside additions -- the pair a
+  window is made of, and what the property test now asserts a single
+  value of.
+- **`SECURITY.md` states the relation rather than the figures.** What the
+  argument there needs is that the cost is one value for every scalar of
+  the curve, so that the size of a secret is hidden; a figure in a
+  security file invites a reader to take it for a measurement of the
+  library as it stands, and the ranges among those it stated were over a
+  sample whose seed it did not give, which nothing reproduces. The
+  contrast with the plain fixed window stays as the recoding it comes
+  from, ceil(m.bit_length() / w) digits against ceil(nlen / w).
+- **The dispatch comment that offers the interleaved wNAFs as cheaper no
+  longer prices them.** `curves.curve` stated the same unseeded range
+  this entry withdraws, and what refuses them there is regularity, which
+  the sentence above it already carries.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -155,8 +155,8 @@ used to teach and to prototype as much as to build:
     wiped once the call that filled it returns; the `int` it is read
     into cannot be, and outlives the call regardless — the
     `_BIP32KeyData` working copy keeps `prv_key_int` for the whole of
-    a path derivation — so taking the buffer at these three would cost
-    a public signature and buy nothing, short of btclib no longer
+    a path derivation — so taking the buffer at these call sites would
+    cost a public signature and buy nothing, short of btclib no longer
     holding a private key as a Python `int`, which is a change to that
     representation and not to a call site. `ellswift.xdh`
     (`src/btclib/ecc/ellswift.py:365`) is the one of them that returns
@@ -174,8 +174,8 @@ used to teach and to prototype as much as to build:
     owned buffer `wipe` overwrites afterwards. That `bytes` is dropped
     rather than erased, same as the `int` it replaces — one call rather
     than the buffer's whole lifetime, which is the trade this class
-    exists to make, and stated here for the same reason the other three
-    call sites are
+    exists to make, and stated here for the same reason the call sites
+    above are
 - the boundary is not always there, and an install decides whether it
     is. `pip install "btclib[secp256k1]"` -- the spelling README.md and
     the guide give -- installs the bindings, and everything the next
@@ -298,16 +298,16 @@ used to teach and to prototype as much as to build:
     and always `ceil(nlen / w)` of them, and starts the accumulator at a
     table entry rather than at the identity, so every scalar of the curve
     costs the same additions and the same doublings, and its size is
-    hidden as its bits are. Measured over 200 random scalars: 71 additions
-    and 253 doublings for every one of them, where the plain fixed window
-    makes 68 to 70 and 251 to 259; and on secp256k1, whose endomorphism
-    halves the doublings, 79 and 126 for every one of them, where the
-    interleaved wNAFs of the same decomposition make 51 to 64 and 124 to
-    131. Those wNAFs add on a nonzero digit and so once per unit of the
-    recoded weight of the coefficient, which is why they are not what
-    `mult` reaches for; they are what `double_mult_var` and signature
-    verification reach, where the coefficients are a signature and a
-    message hash rather than a secret.
+    hidden as its bits are. The plain fixed window is the contrast: its
+    digits are `ceil(m.bit_length() / w)` of them, so a scalar short of a
+    full top window costs one window less there and its size is what the
+    count shows. On secp256k1, whose endomorphism halves the doublings,
+    the regular windows of its decomposition are uniform the same way.
+    The interleaved wNAFs of that same decomposition add on a nonzero
+    digit and so once per unit of the recoded weight of the coefficient,
+    which is why they are not what `mult` reaches for; they are what
+    `double_mult_var` and signature verification reach, where the
+    coefficients are a signature and a message hash rather than a secret.
 
     What is left is out of reach from pure Python, and is enough to
     matter: the windowed multiplications index a table of precomputed

--- a/src/btclib/curves/curve.py
+++ b/src/btclib/curves/curve.py
@@ -850,7 +850,7 @@ def _mult_checked(m: int, Q: Point | None, ec: Curve, *, prepared: bool) -> Poin
     # of point additions either makes is the same for every scalar, which
     # is what a private key or a nonce arriving here needs and what issue
     # 254 is about -- the endomorphism over interleaved wNAFs would cost
-    # a little less again, with 51 to 64 additions.
+    # a little less again, and would not be regular.
     # Not spelled as _libsecp256k1_serves, though it is the same
     # test today: what decides here is whether the curve has that
     # endomorphism, so switching the bindings off must leave this arm --

--- a/src/btclib/curves/curve_group.py
+++ b/src/btclib/curves/curve_group.py
@@ -1135,9 +1135,10 @@ def _mult_fixed_base(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoint:
     the zero digits: that one holds one table and doubles w times between
     digits, this one holds a table per position and only adds. So a
     256-bit scalar costs `ceil(ec.scalar_len / w)` additions and nothing
-    else -- 43 of them at w=6, against 71 additions and 253 doublings --
-    and the count is the same for every scalar of the curve, which is
-    what the regular window is for and what this keeps.
+    else -- 43 of them at w=6, against the 71 additions and 253 doublings
+    `_mult_regular_window` makes at w=4 -- and the count is the same for every
+    scalar of the curve, which is what the regular window is for and what
+    this keeps.
 
     w=6 by measurement, over 30 random 256-bit scalars on secp256k1, best
     of seven alternating rounds. The window buys time and is paid in
@@ -1344,10 +1345,13 @@ def _mult_regular_window(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoin
     runs one window less. Here the digits are the signed odd ones of
     signed_odd_digits, none of them zero, and there are
     ceil(ec.scalar_len / w) of them whatever m is: one addition and w
-    doublings per window, for every scalar of every size. Measured on
-    secp256k1 over 200 random scalars: 68 to 70 additions and 251 to 259
-    doublings for the fixed window, and 71 and 253 for this one on every
-    one of them.
+    doublings per window, for every scalar of every size. On secp256k1
+    that is 71 additions and 253 doublings at w=4, the same for every
+    scalar and counted at the curve's own scalar_len of 256, where the
+    fixed window's count follows the size of the scalar it is given. What
+    counts them is `_CountingGroup` in tests/curves/curve_group_test.py,
+    which carries the command in its docstring and the reason for that
+    length where it sets it.
 
     Uniformity for free, in other words -- indistinguishable in cost from
     the fixed window over 30 random 256-bit scalars, best of five -- which

--- a/src/btclib/curves/curve_group_2.py
+++ b/src/btclib/curves/curve_group_2.py
@@ -537,11 +537,12 @@ def _mult_endomorphism_secp256k1_var(
     The same decomposition as `_mult_endomorphism_secp256k1`, over
     `_double_mult_w_NAF_var` rather than the regular windows, and the
     faster of the two, by 16%, over 30 random 256-bit scalars, best of
-    five, at w=4. What that 16% buys is 51 to 64 additions and 124 to 131
-    doublings over 200 random scalars, where the regular windows make 79
-    and 126 for every one of them -- a quarter more work for the worst
-    scalar than for the best, and which it is is a property of the
-    scalar.
+    five, at w=4. What that 16% buys is a cost the scalar decides: a wNAF
+    adds on a nonzero digit, so its additions follow the recoded weight of
+    the halves the split makes, where the regular windows make 79
+    additions and 126 doublings for every scalar of the curve -- at w=4,
+    counted by the `_CountingGroup` of tests/curves/curve_group_test.py,
+    whose docstring carries the command.
 
     So nothing signs with this one, and it is here to be measured against
     the other. A verification's coefficients are public and go to

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -426,20 +426,43 @@ def test_add_jac_aff_answers_add_jac_on_every_pair() -> None:
 
 
 class _CountingGroup(CurveGroup):
-    """secp256k1's group, counting the point additions it is asked for.
+    """secp256k1's group, counting the additions and doublings asked of it.
 
     The number of additions is what the scalar used to decide (issue 254),
     and counting them is how the test below says it no longer does: a
     wall-clock timing per multiplication is too noisy to resolve a spread
-    of one addition in seventy, which is why the test counts additions
-    directly instead.
+    of one addition in seventy, which is why the test counts the
+    operations directly instead.
+
+    The docstrings that name this class -- `_mult_regular_window` in
+    `curve_group` and `_mult_endomorphism_secp256k1_var` in
+    `curve_group_2` -- state figures taken here, at the scalar_len set
+    below:
+
+        uv run python -c "
+        from btclib.curves import secp256k1
+        from btclib.curves.curve_group import _mult_regular_window
+        from btclib.curves.curve_group_2 import _mult_endomorphism_secp256k1
+        from tests.curves.curve_group_test import _CountingGroup
+        for mult in (_mult_regular_window, _mult_endomorphism_secp256k1):
+            ec = _CountingGroup()
+            mult(secp256k1.n - 1, secp256k1.GJ, ec, 4)
+            print(mult.__name__, ec.additions, ec.doublings)"
     """
 
     def __init__(self) -> None:
         # secp256k1's own p, a and b, which is the curve every measurement
         # in curve_group's docstrings is taken on
         super().__init__(secp256k1.p, 0, 7)
+        # and its own scalar_len, which the group cannot derive: with no n
+        # to read, CurveGroup takes the Hasse bound plen + 1, where Curve
+        # narrows it to nlen. A multiplication's digits being
+        # ceil(scalar_len / w), a group left at the wider bound recodes one
+        # digit more at w=4, so _mult_regular_window answers 72 and 257
+        # there against the 71 and 253 its docstring states
+        self.scalar_len = secp256k1.scalar_len
         self.additions = 0
+        self.doublings = 0
 
     @override
     def add_jac(self, Q: JacPoint, R: JacPoint) -> JacPoint:
@@ -455,18 +478,30 @@ class _CountingGroup(CurveGroup):
         self.additions += 1
         return super().add_jac_aff(Q, R)
 
+    @override
+    def double_jac(self, Q: JacPoint) -> JacPoint:
+        self.doublings += 1
+        return super().double_jac(Q)
+
 
 def test_regular_window_addition_count_is_the_same_for_every_scalar() -> None:
-    """Issue 254, as the property it is: one count, not a range of them.
+    """Issue 254, as the property it is: one count of each, not a range.
 
     The fixed window over the same scalars is the control, and what varies
     for it is the *size* of the scalar: its digit count is
     ceil(m.bit_length() / w), so it makes one addition and w doublings
     fewer for every window the scalar is short of a full one. Hence the
     scalars of distant sizes here beside the full-length random ones --
-    over 256-bit scalars alone the control would be constant too, a
-    quarter of the 20 the seed picks being needed to reach a shorter
-    digit count at all.
+    over 256-bit scalars alone the control would be constant too, a digit
+    count falling only for a scalar short of a whole window, four bits at
+    w=4.
+
+    Additions and doublings are asserted as the pair a window is made of,
+    one addition and w doublings, so that the doublings are held to the
+    property too rather than only the additions. The control keeps its own
+    assertion on the additions alone: a pair that varies in either member
+    is a weaker statement than the additions varying, and it is the
+    additions the scalar used to decide.
     """
     ec = _CountingGroup()
     rnd = random.Random(0x9EC0DE)
@@ -476,15 +511,16 @@ def test_regular_window_addition_count_is_the_same_for_every_scalar() -> None:
     regular = set()
     fixed = set()
     for m in scalars:
-        ec.additions = 0
+        ec.additions = ec.doublings = 0
         _mult_regular_window(m, secp256k1.GJ, ec, w=4)
-        regular.add(ec.additions)
-        ec.additions = 0
+        regular.add((ec.additions, ec.doublings))
+        ec.additions = ec.doublings = 0
         _mult_fixed_window_var(m, secp256k1.GJ, ec, w=4, cached=False)
-        fixed.add(ec.additions)
+        fixed.add((ec.additions, ec.doublings))
 
     assert len(regular) == 1, regular
     assert len(fixed) > 1, fixed
+    assert len({additions for additions, _ in fixed}) > 1, fixed
 
 
 def test_mult_fixed_base() -> None:


### PR DESCRIPTION
Two issues in one commit, because both edit `SECURITY.md` and two branches
would have collided there — and, silently, on the `CHANGELOG.md` anchor.

**[ISS 2038](https://github.com/btclib-org/btclib/issues/2038)** —
`SECURITY.md:158` said "taking the buffer at **these three**" and `:177`
"for the same reason **the other three** call sites are". One roster,
referred to twice: the call sites reading a binding's output straight into
a Python `int`. Both sentences were *true*; what was wrong is that they
counted a population of this codebase, which is the construction
`6065ade8` removed at `:207` and whose ground was growth. They now name
the call sites instead — "at these call sites", "the same reason the call
sites above are". Not "the other call sites": the definite article in
front of *other* claims a completeness the numeral was not claiming.

`SECURITY.md:357`'s "Those three are among the entry points" is
deliberately untouched. The three it counts are three C functions named in
the sentence immediately before it, so the numeral summarises an
enumeration the passage closes.

**[ISS 2040](https://github.com/btclib-org/btclib/issues/2040)** — four
sites stated a multiplication's additions and doublings with no command
beside them. Every figure was **correct**, so this is not a wrong-number
repair; what was missing is what `CLAUDE.md`'s *A wall clock and a
linter's findings are counts too* requires. Per site: `SECURITY.md` gives
the relation rather than the figure, because the argument there is that the
cost is one value for every scalar of the curve, so a secret's size is
hidden — the figure never carried that, and in a security file it reads as
a measurement of the library as it stands. The three source docstrings keep
their figures, which are the ground for design choices, and gain the width
and the instrument that produces them.

The unseeded ranges stop being ranges rather than gaining a seed: an
endpoint is a property of the sample, and freezing one sample's endpoints
into landed prose would state as a fact what the argument only needs as a
shape.

**Why the missing command was not a formality.** The obvious instrument
gives the wrong answer, and the suite's own was the obvious instrument.
`_CountingGroup` subclassed `CurveGroup(secp256k1.p, 0, 7)`, and
`CurveGroup.__init__` sets `scalar_len = plen + 1` — 257, where
`secp256k1.scalar_len` is 256. At `w=4` that recodes one digit more, so a
natural re-derivation answers 72 and 257 against the published 71 and 253
and reads as one window of drift. The class now sets the curve's own
length, counts doublings beside additions, and carries the command; run as
written it prints `_mult_regular_window 71 253` and
`_mult_endomorphism_secp256k1 79 126`.

The delta is the `ceil`'s and not the bound's — at `w=5` and `w=6` both
lengths recode the same digit count — and
`_mult_endomorphism_secp256k1` passes a `scalar_len` of its own
(`_HALF_LEN`, `curve_group_2.py:529`), so its figures are the same either
way. An earlier draft of this branch generalised past both of those, in
three places including its own commit message; the review caught two and
the author found the third.

`src/btclib/curves/curve.py:853` is edited though neither issue names it:
it carried the same withdrawn figure, and leaving it would have kept that
figure alive in a third file. Three further sites, each needing its own
measurement or decision, are
[ISS 2041](https://github.com/btclib-org/btclib/issues/2041).

## Gates, on `209e147c`, the rebased tip

Rebased from `801e4cf6` onto `fb5ee2da`, and the `merge=union` seam it
produced was repaired by reconstruction rather than by trusting the
rebase's output: the added block was derived from the diff with
`difflib.SequenceMatcher` (53 lines, the first of them the blank the driver
ate), spliced into the new base's blob before the blank preceding the first
*released* `## v` heading — the trap being that the first `## v` is the open
section's own. Stripping the inserted range back out reproduces the base
byte for byte, with a one-line mutation control failing in both directions.
The post-repair diffstat is identical to the pre-rebase one, which is what
says the rebase lost nothing.

- lint exit 0 — 47 `Passed`, 0 `Failed`, and `forbid submodules`
  **Skipped** (no files to check), which is the expected shape for a change
  touching no gitlink; tree clean after
- `pytest` exit 0 — `32606 passed, 78 skipped`, `TOTAL 57233 0 9898 100.00%`
- `sphinx-build -n -W` exit 0; the `href="#../"` sweep exit 1, with a
  planted control the sweep exits 0 on
- pinned `markdownlint-cli2` v0.23.2 check-only exit 0, with the control
  re-planted live against this file: deleting the blank above this branch's
  own heading gives exit 1, `MD032` at 896 and `MD022` at 897

The suite figures moved with the base rather than with this branch, and
that is measured rather than assumed: `fb5ee2da` alone answers
`32606 passed, 78 skipped`, `TOTAL 57226 0 9898`. So this branch
contributes **+0 tests, +7 statements, +0 branches** — the six lines of the
new `double_jac` override and its two assignments, plus one added
assertion.

Reviewed at `19544c4e` (CHANGES REQUESTED, one blocking finding) and
cleared at `1f1966d2`. The only change after the clearance is the rebase
and its seam repair.

closes #2038
closes #2040

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3

## Summary by Sourcery

Clarify security documentation and make scalar-multiplication operation counts reproducible, stable, and accurately tied to their measuring tests.

Bug Fixes:
- Clarify SECURITY.md references so they describe named call sites without unsupported counts or completeness claims.
- Remove unstable scalar-multiplication measurements from security and implementation commentary while preserving the relevant regularity and cost relationships.

Enhancements:
- Document reproducible commands and correct scalar-length handling for operation-count measurements.
- Extend counting tests to track doublings as well as additions and assert uniform operation counts for regular-window multiplication.

Documentation:
- Update the changelog with the rationale for clarifying call-site references and operation-count documentation.

Tests:
- Strengthen curve-group operation-count tests to validate addition and doubling pairs while retaining variation checks for fixed-window multiplication.