### PR TITLE
REVIEWING.md and .gitattributes carry the standard's copies (issue btclib-org/.github#353) (issue btclib-org/.github#1026)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,6 +25,21 @@
 # standard, btclib-org/.github's README.md, is where this rule is
 # recorded.
 #
+# The seam between the two sides has a price of its own: union joins
+# their added lines directly, so the blank line that separated the two
+# blocks is gone, and a block opening with a heading leaves that
+# heading sitting against the line above it. `git rebase` exits 0,
+# nothing conflicts, the tree is clean and each entry's own text is
+# untouched, so the rebase reports nothing. Section 4 of that README.md
+# has the `check-changelog` hook and puts it ahead of the markdownlint
+# autofix, which would otherwise repair the seam before anything named
+# it.
+#
+# Not setting the driver at all is the alternative, and what rejects it
+# is the first paragraph: a branch rebasing over a landing that wrote
+# an entry would resolve that one anchor by hand, in exchange for a
+# seam that hook reports.
+#
 # Both lines are in every repository's copy, a tree carrying no
 # RELEASE_NOTES.md included: section 2 of that README.md gives the
 # release notes to a repository that publishes, and an attribute on a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -948,6 +948,39 @@ documented at release-notes length in the first place, and are still in
   this entry withdraws, and what refuses them there is regularity, which
   the sentence above it already carries.
 
+### `REVIEWING.md` and `.gitattributes` carry `btclib-org/.github`'s copies
+
+- **`REVIEWING.md` above `## This repository in particular` is
+  `btclib-org/.github`'s at `6a47f845` byte for byte** (issue
+  btclib-org/.github#353): section 14 of the organization standard
+  compares the file up to that heading and leaves what stands below it
+  to this tree, so the half above it is replaced whole rather than
+  difference by difference. What it says that the copy it replaces did
+  not: a finding about the wording of prose no user reads is named at
+  the foot of the review rather than filed, on btclib-org/.github#976's
+  authority; `NACK` stands beside `ACK` and `CHANGES REQUESTED` as a
+  verdict, and the ack of record is posted as a review of type COMMENT
+  rather than as a forge approval; and *Re-review* reads the old sha off
+  the previous round's verdict, an amend or a rebase leaving it off the
+  branch. `.github/workflows/claude-review.yml`'s prompt already tells a
+  reviewer that `REVIEWING.md` has the three lines and why a reading
+  ending without one is not a `NACK`, which is a claim about this tree's
+  own copy. Every heading is one the half already carried, so
+  `CONTRIBUTING.md`'s link into *The gates are the evidence* points at a
+  heading that is there.
+- **`.gitattributes` says what the union driver charges at the seam, and
+  what rejects not setting the driver at all** (issue
+  btclib-org/.github#1026): above `## This repository in particular` the
+  file is `btclib-org/.github`'s `.gitattributes` at `6a47f845` byte for
+  byte, and below the heading the `-whitespace` attribute on
+  `src/btclib/mnemonic/_data/electrum_portuguese.txt` is this tree's and
+  unchanged. Union joins the two sides' added lines directly, so a block
+  opening with a heading lands against the line above it while `git
+  rebase` exits 0 and nothing conflicts; `check-changelog` is the hook
+  that paragraph names, and `.pre-commit-config.yaml` here runs it ahead
+  of the `markdownlint-cli2` autofix, which would otherwise repair the
+  seam before anything named it.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -24,11 +24,11 @@ request and no memory of how the last review went. Read the other way
 round, before a pull request is opened, it is what that pull request
 will be answered against.
 
-A review produces comments on a pull request and issues filed against
-the repository. **A reviewer writes nothing to the branch**: no push, no
-amend, no merge. The one commit a review can lead to is the author's own
-click on a suggestion, below, which is theirs to make and theirs to
-decline.
+A review produces a verdict and comments on a pull request, and issues
+filed against the repository. **A reviewer writes nothing to the
+branch**: no push, no amend, no merge. The one commit a review can lead
+to is the author's own click on a suggestion, below, which is theirs to
+make and theirs to decline.
 
 ## The standard an ack is given against
 
@@ -120,8 +120,8 @@ comment about one of them is either wrong or a bug in the hook.
 
 A review notices more than its subject: a defect the diff did not cause,
 a document that has gone stale, a rule the tree quietly stopped
-following. **None of it is a review comment, and every one of it is an
-issue.** File it, and go back to the diff.
+following. **Most of it does not belong as a review comment: file it as
+an issue**, and go back to the diff.
 
 The reason is the author's round trip. A finding they cannot address
 without leaving the subject is a round of review spent on something the
@@ -129,6 +129,17 @@ pull request was not for, and asking for it anyway is how a branch stops
 converging. Filing costs the reviewer one command and loses nothing: the
 defect is recorded, with its evidence, where the next person to touch
 that code will find it.
+
+**Not every finding is filed.** A finding about the *wording* of prose no
+user reads — `CLAUDE.md`, a test's docstring or message, a comment in a
+workflow, a yaml or a toml, a `CHANGELOG.md` entry, a pull request body —
+is named at the foot of the review instead and left there: the diff's
+author fixes it where the diff already touches that file, and otherwise
+the note is the record of it. What is filed stays as above: a defect a
+test or a hook can measure, a decision the standard has to take, or a
+functional defect. btclib-org/.github#976 is where a tracker of prose
+findings about prose was found not to converge, and is the authority for
+this line.
 
 What is *not* collateral, and stays in the review, is what this diff
 introduces or breaks, and what was already wrong and this diff makes
@@ -155,9 +166,9 @@ Both blocks leave their placeholders unquoted, which section 9 of the
 standard asks for: quoted, a paste of the second files an issue whose
 title is the placeholder.
 
-Name the issues filed at the foot of the summary comment, under a line
-saying they are **not** findings against this pull request. Without that
-line the list reads as more things to fix before merging, which is the
+Name the issues filed at the foot of the summary, under a line saying
+they are **not** findings against this pull request. Without that line
+the list reads as more things to fix before merging, which is the
 opposite of what filing them was for.
 
 ## What a finding says
@@ -206,12 +217,9 @@ is what to use when a review leaves more than one.
 The author may apply one directly through the interface, which is why a
 suggestion is offered where a description would do.
 
-Two properties make this the right shape here and not merely a
-convenience: the commit GitHub writes is signed with its web-flow key,
-and `main` requires a valid signature rather than one particular
-signer; and it lands as a commit of its own on top of the branch,
-which is the shape section 11 of the standard asks a correction to take,
-so the shas the review is attached to survive it.
+What makes this the right shape here and not merely a convenience is the
+signature: the commit GitHub writes carries its web-flow key, and `main`
+requires a valid signature rather than one particular signer.
 
 Two properties decide when not to:
 
@@ -366,23 +374,34 @@ a gap.
 
 ## The verdict
 
-Inline comments for the line-anchored findings, then exactly one summary
-comment. **A review that decides whether the pull request lands** ends
-that comment with one of two lines:
+Inline comments for the line-anchored findings, then exactly one
+summary. **A review that decides whether the pull request lands** posts
+that summary to the forge as a review, and ends it with one of three
+lines:
+
+```text
+ACK <sha>
+```
 
 ```text
 CHANGES REQUESTED <sha>
 ```
 
 ```text
-ACK <sha>
+NACK <sha>
 ```
 
-Nothing else is an ack — not "looks good", and not a forge approval by
-the author of the pull request, which section 11 of the standard records
-GitHub as refusing. The ack of record is an approving review and section
-11 says whose; a verdict from anybody else is this comment, and either
-names the sha because an ack belongs to a tree and not to a branch.
+The ack of record carries whichever of the three applies and is posted
+as a review of type COMMENT — `gh pr review --comment` — never as a
+forge approval or a forge request for changes. Section 11 of the
+standard says whose verdict the ack of record is, what each of the three
+concludes, and what forbids the workflow an approval; a forge approval
+is a person's, and it is not the ack.
+
+Every other summary is a comment. Nothing else is an ack — not "looks
+good", and not a forge approval by the author of the pull request, which
+section 11 records GitHub as refusing. Every line names the sha, because
+an ack belongs to a tree and not to a branch.
 
 **A review that does not decide ends without one, and is not an
 unfinished review.** Somebody who reads a diff and says what they found
@@ -392,11 +411,21 @@ having are the ones nobody was assigned. What a pull request lands on is
 the ack of record; every other comment on it is evidence a person weighs
 before pressing.
 
+**A `NACK` is a decision and ending without a verdict is not.** Both
+leave the pull request unacked, which is what makes them easy to read as
+one thing, and they say opposite things: the first concludes, and
+section 11 has what it concludes; the second declines to conclude, which
+is what a reading does. Silence is not a refusal, so a reviewer who
+means to refuse writes the line.
+
 The summary says, in a few lines, what was reviewed — the sha, the gates
 and their exit codes —, lists the blocking findings, and names the
-issues filed. **In a verdict**, no blocking findings and no ack is a
-contradiction: either the finding is blocking or the ack is due. In a
-reading it is neither, the reading having declined to say.
+issues filed. **In a verdict**, `CHANGES REQUESTED` with no blocking
+finding is a contradiction: either the finding is blocking or the ack is
+due. In a reading neither is owed, the reading having declined to say. A
+`NACK` need not carry a blocking finding at all: its ground is the
+change rather than a defect in it, and that ground is what the summary
+states.
 
 And, in either, **what was not checked**: a command that could not be
 run, an issue that could not be read, a part of the tree left unopened.
@@ -413,10 +442,10 @@ before its child, and otherwise the oldest.
 
 ## Re-review
 
-The delta is `git diff <old-sha>..<new-sha>`, and there is one to read
-because section 11 of the standard has corrections added as commits
-rather than amended in: the shas the review was attached to are still
-there.
+The delta is `git diff <old-sha>..<new-sha>`, and the old sha is the one
+the previous round's verdict named. An amend and a rebase each leave it
+off the branch, so it is read from that verdict rather than from the
+branch's history.
 
 - **Resolve every thread the author addressed, and only those.** A
   thread they declined stays open only if it is still blocking; where


### PR DESCRIPTION
Section 14 of the organization standard compares each of these files up
to `## This repository in particular` and leaves what stands below it to
the tree. Both halves above that heading are `btclib-org/.github`'s at
`6a47f845`, byte for byte, and each tail below it is unchanged: this
tree's own review questions in `REVIEWING.md`, and the `-whitespace`
attribute on `src/btclib/mnemonic/_data/electrum_portuguese.txt` in
`.gitattributes`.

The half of `REVIEWING.md` being replaced holds nothing this tree wrote:
every hunk between the two copies is a replacement or an insertion of
the standard's own text, and no heading moves, so `CONTRIBUTING.md`'s
link into *The gates are the evidence* points at a heading that is
there. `.gitattributes` gains two paragraphs and loses nothing.

`.yamllint.yaml`, the third path `tests/verbatim_test.py`'s
`EXPECTED_DRIFT` names, already matches that repository's copy and is
untouched.

Neither issue closes here: `EXPECTED_DRIFT` is a table in
`btclib-org/.github`, and emptying it is a change to that repository.

Advances [ISS 353](https://github.com/btclib-org/.github/issues/353) and
[ISS 1026](https://github.com/btclib-org/.github/issues/1026), and closes
neither here. This is the eighth and last tree of the port; the
`EXPECTED_DRIFT` entries those issues name live in `btclib-org/.github`'s
`tests/verbatim_test.py`, so deleting them is a change to that repository and
follows immediately after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGRFSkPFh8PR4Y3Wr47vb

## Summary by Sourcery

Synchronize the repository’s review documentation and shared attributes with the organization standard while preserving local customization.

New Features:
- Align the repository’s review guidance with the organization standard, including explicit review verdicts, prose-finding handling, and re-review behavior.

Bug Fixes:
- Clarify that review acknowledgements are recorded as comment reviews with explicit SHA-based verdicts rather than forge approvals.

Enhancements:
- Synchronize the shared portions of REVIEWING.md and .gitattributes with btclib-org/.github while preserving repository-specific content.
- Document the distinction between non-decision readings, NACK verdicts, and blocking change requests.

Documentation:
- Update REVIEWING.md and .gitattributes to match the organization-standard copies and clarify repository-specific review practices.

Chores:
- Record the standard-file synchronization in the changelog.