### PR TITLE
Dependencies are refreshed, and neither a floor nor a hold moves with them

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -146,7 +146,7 @@ jobs:
           fi
       - name: Review against REVIEWING.md
         id: review
-        uses: anthropics/claude-code-action@19dda84776b3518d98b8798e591daee763049ed3 # v1.0.220
+        uses: anthropics/claude-code-action@9cdae7f0d995e3ba7c33f226087fdf82a59cd520 # v1.0.223
         # a diff read and a comment posted; a review past this is hung
         # on the API or on its own reasoning, and either way it has
         # written no verdict. On the step rather than on the job for the
@@ -450,6 +450,6 @@ jobs:
             exit 1
           fi
       - name: Answer the mention
-        uses: anthropics/claude-code-action@19dda84776b3518d98b8798e591daee763049ed3 # v1.0.220
+        uses: anthropics/claude-code-action@9cdae7f0d995e3ba7c33f226087fdf82a59cd520 # v1.0.223
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/deps-latest.yml
+++ b/.github/workflows/deps-latest.yml
@@ -120,7 +120,7 @@ jobs:
           # at, a pointer being what this checkout already had.
           fetch-tags: true
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           # a week where nothing moved is a full hit, and a week where
           # something did is the week this job has work to do anyway
@@ -206,7 +206,7 @@ jobs:
           # at, a pointer being what this checkout already had.
           fetch-tags: true
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python }}
@@ -287,7 +287,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: true
       # ImageOS is set by the runner image, not by this workflow, so the
@@ -350,7 +350,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: true
       - name: Upgrade every dependency to its latest release

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -94,7 +94,7 @@ jobs:
           # see the checkout of the coverage job in test.yml
           persist-credentials: false
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: true
       # the same command .readthedocs.yaml runs, CONTRIBUTING.md

--- a/.github/workflows/integration-bitcoind.yml
+++ b/.github/workflows/integration-bitcoind.yml
@@ -161,7 +161,7 @@ jobs:
           # see the checkout of the coverage job in test.yml
           persist-credentials: false
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           # the wheels uv.lock pins do not change between runs, so the
           # cache is the difference between a download and a copy

--- a/.github/workflows/integration-hwi.yml
+++ b/.github/workflows/integration-hwi.yml
@@ -115,7 +115,7 @@ jobs:
           # see the checkout of the coverage job in test.yml
           persist-credentials: false
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: true
       # the signing test spends a regtest coin, so this job needs the
@@ -352,7 +352,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: true
       - name: Install bitcoind

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -113,7 +113,7 @@ jobs:
           # see the checkout of the coverage job in test.yml
           persist-credentials: false
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           # the wheels of the lint group, pre-commit itself among them, and
           # the project environment the mypy hook type checks against

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -314,7 +314,7 @@ jobs:
           persist-credentials: false
       - name: Setup uv
         if: env.SELECTED == 'true'
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           # the wheels uv.lock pins do not change between runs, so the
           # cache is the difference between a download and a copy

--- a/.github/workflows/os-macos.yml
+++ b/.github/workflows/os-macos.yml
@@ -118,7 +118,7 @@ jobs:
           # having copied the option.
           fetch-tags: true
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python }}

--- a/.github/workflows/os-ubuntu.yml
+++ b/.github/workflows/os-ubuntu.yml
@@ -131,7 +131,7 @@ jobs:
           # having copied the option.
           fetch-tags: true
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python }}

--- a/.github/workflows/os-windows.yml
+++ b/.github/workflows/os-windows.yml
@@ -123,7 +123,7 @@ jobs:
           # having copied the option.
           fetch-tags: true
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python }}

--- a/.github/workflows/py-arm-authority.yml
+++ b/.github/workflows/py-arm-authority.yml
@@ -141,7 +141,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: true
           python-version: "3.14"

--- a/.github/workflows/pypi-install.yml
+++ b/.github/workflows/pypi-install.yml
@@ -136,7 +136,7 @@ jobs:
           persist-credentials: false
           sparse-checkout: .github/scripts
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
       # --no-project, so it runs on the interpreter uv fetches and
       # installs nothing: the script takes the standard library alone,
       # which is what lets it run before anything of this project exists
@@ -236,7 +236,7 @@ jobs:
       # Measured on the first run this workflow ever had: seventeen cells
       # green, that one red, and the release it was checking was sound
       - name: Setup uv with Python ${{ matrix.python }}
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           python-version: ${{ matrix.python }}
       # --verbose so the log names the btclib_secp256k1 wheel this cell
@@ -358,7 +358,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Setup uv with Python ${{ matrix.python }}
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           python-version: ${{ matrix.python }}
       # --only-binary on both packages: btclib for the reason

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
       # Spelled out rather than left off: the input defaults to "auto",
       # which means enabled on a GitHub-hosted runner
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: false
       # every other uv command in these workflows passes --locked, which
@@ -311,7 +311,7 @@ jobs:
       # written by a run this one cannot vouch for
       - name: Setup uv
         if: steps.previous.outputs.has-previous == 'true'
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: false
       # griffe runs from PyPI through uvx rather than from a pyproject.toml
@@ -830,7 +830,7 @@ jobs:
       # wrote. There is little to cache here in any case, the step below
       # installing nothing
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: false
       # --no-project, so it runs on the interpreter uv fetches and

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -300,7 +300,7 @@ jobs:
           # repository's own remote with `git fetch --depth=1 --tags`
           fetch-tags: true
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           # the cache holds the wheels uv.lock resolves, which every run
           # of every commit otherwise fetches again
@@ -402,7 +402,7 @@ jobs:
           # included, and `test-passed` waits on both
           fetch-tags: true
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: true
           python-version: "3.14"
@@ -480,7 +480,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: true
           python-version: "3.14"
@@ -561,7 +561,7 @@ jobs:
       # defaults to false for exactly that reason, the same asymmetry
       # `check-newest-bindings` above expresses for the smoke test
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: ${{ !inputs.disable-dist-cache }}
       # what the sdist normalizer and the sbom below read. `uv build`

--- a/.github/workflows/zkp-oracle.yml
+++ b/.github/workflows/zkp-oracle.yml
@@ -198,7 +198,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           enable-cache: true
       # --no-binary-package is what keeps uv from resolving the

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -738,15 +738,16 @@ repos:
   #
   #   uvx zizmor@1.29.0 --persona=auditor --no-progress .github/workflows/
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    # not 1.30.0 yet: its new self-repository audit flags every reusable-
-    # workflow and composite-action reference below that still reads
-    # `uses: ./...`, and its own auto-fix rewrites them to `uses: $/...`.
-    # That syntax is real GitHub, live since July 2026, but actionlint
-    # 1.7.12 (pinned further down) does not parse it and fails every one
-    # of those references as a malformed action reference instead. The
-    # bump waits on whichever lands first: an actionlint release that
-    # understands `$/`, or GitHub's runner requirement (>=2.336.0) making
-    # workspace-relative references the thing to flag instead.
+    # not 1.30.0 yet: its new self-repository audit flags every
+    # reusable-workflow and composite-action reference under
+    # .github/workflows/ that still reads `uses: ./...`, and its own
+    # auto-fix rewrites them to `uses: $/...`. That syntax is real
+    # GitHub, live since July 2026, but actionlint 1.7.12 (pinned above)
+    # does not parse it and fails every one of those references as a
+    # malformed action reference instead. The bump waits on whichever
+    # lands first: an actionlint release that understands `$/`, or
+    # GitHub's runner requirement (>=2.336.0) making workspace-relative
+    # references the thing to flag instead.
     #
     # `autoupdate` offers the newest release on every run, and the marker
     # on the rev line is what declines it: `held-rev` above reads the
@@ -775,7 +776,7 @@ repos:
   # docformatter, flake8, isort, pydocstringformatter, pydocstyle, pylint,
   # pyupgrade, and yesqa
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.6
+    rev: v0.16.7
     hooks:
       - id: ruff-check
         name: ruff check (in place fixes)
@@ -866,7 +867,7 @@ repos:
         pass_filenames: false
         require_serial: true
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.12.12
+    rev: 0.12.13
     hooks:
       # keep uv.lock in sync with pyproject.toml
       - id: uv-lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -981,6 +981,49 @@ documented at release-notes length in the first place, and are still in
   of the `markdownlint-cli2` autofix, which would otherwise repair the
   seam before anything named it.
 
+### Dependencies are refreshed, and neither a floor nor a hold moves
+
+- **`uv lock --upgrade` takes `build` to 1.6.1 and `ruff` to 0.16.7**,
+  and moves nothing else. Neither sibling has anywhere to move to:
+  `uv lock --upgrade-package btclib-secp256k1 --dry-run` and the same for
+  `bitcoin-core-rpc` each detect no lockfile change, so the floors
+  `[project.dependencies]` and `[project.optional-dependencies]` name
+  stay where they are, each coinciding with what the lock pins.
+- **`pre-commit autoupdate` takes `astral-sh/ruff-pre-commit` to v0.16.7
+  and `astral-sh/uv-pre-commit` to 0.12.13.** That hook and `uv.lock`
+  resolve the same ruff, so the lint gate and a bare `uv run ruff`
+  answer alike; `[build-system]`'s `uv_build` range is what the build
+  has to satisfy rather than a pin at the uv hook's rev, and it is
+  unchanged.
+- **The two revisions `autoupdate` also offers are declined by the gate
+  and not only by the comment beside them.** Walked to
+  `zizmorcore/zizmor-pre-commit` v1.30.1 and `regebro/pyroma` 5.1b1, the
+  lint gate exits 1 on `pinned-rev`, on `held-rev` and on `zizmor`
+  itself. `autoupdate` walks past the hold because the marker sits on
+  the `rev:` line it rewrites, leaving a value and a marker that
+  disagree, which is what `held-rev` reads; 5.1b1 is a prerelease,
+  which `pinned-rev` refuses.
+- **zizmor 1.30.1 is what the hold is against** (issue #1563): its
+  `self-repository` audit flags the workspace-relative `uses: ./...`
+  form wherever `.github/workflows/` writes it, and actionlint 1.7.12
+  does not parse the `$/...` form the auto-fix offers in its place.
+- **`astral-sh/setup-uv` moves to v10.1.0**, sha and trailing comment
+  together wherever a workflow sets uv up.
+- **`anthropics/claude-code-action` moves to v1.0.223**, sha and comment
+  together in the review step and in the mention step. Issue #1924 asks
+  this pin for the commit the newest `v1.0.<n>` tag resolves to, peeled
+  from the annotated tag rather than read off `git/ref/tags`; the commits
+  it advances over move the Claude Code release that action installs and
+  the `@anthropic-ai/claude-agent-sdk` its own code runs on, and touch
+  nothing else.
+- **`github/codeql-action` stays at v4.38.0.** Its `releases/latest`
+  answers a `codeql-bundle-` tag, a different naming series rather than
+  a newer release of what is pinned, and the newest `v4` tag is the one
+  the pin carries.
+- **`google/clusterfuzzlite` stays where it is.** `v1` is still the only
+  tag it publishes and still peels to the pinned commit, which the calls
+  `fuzz.yml` carries beside that pin re-derive.
+
 ## v2026.9.10
 
 ### Section 9's comment and placeholder rules land in this tree's own docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -890,7 +890,7 @@ exclude = [
 # `--force-exclude` semantics for that hook. Without it, the named form
 # rewrites a comment's spacing inside a tag-sealed `## v2026.8.27` section,
 # which `tests/changelog_immutability_test.py` then reads as drift (issue
-# #1530). Measured on the pinned ruff 0.16.4: `ruff format --diff --no-cache
+# #1530). Measured on the pinned ruff 0.16.7: `ruff format --diff --no-cache
 # CHANGELOG.md` exits 1 without this key and 0 with it, a control with nothing
 # excluded also exiting 1 so the difference is the exclusion and not a file
 # needing no reformatting. The key lives here rather than under
@@ -978,8 +978,8 @@ extend-select = ["unspecified-encoding"]
 # member" rather than an arbitrary list of the members measured today
 ignore = [
     # ruff's own docs/formatter.md, under "Conflicting lint rules",
-    # fetched at the ruff revision this file and .pre-commit-config.yaml
-    # both pin (v0.16.3): each of these is undone by the formatter's own
+    # fetched at the ruff revision `.pre-commit-config.yaml` pins and
+    # `uv.lock` resolves: each of these is undone by the formatter's own
     # rewriting, so selecting it is a lint failure the next `ruff format`
     # produces again. The list is the vendor's, and does not change with
     # this tree. `incorrect-blank-line-before-class` (D203) needs no

--- a/uv.lock
+++ b/uv.lock
@@ -568,7 +568,7 @@ wheels = [
 
 [[package]]
 name = "build"
-version = "1.6.0"
+version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
@@ -577,9 +577,9 @@ dependencies = [
     { name = "pyproject-hooks" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/b7/1db48a9ce2984842c8c886432ec8a2719613322e868a966ba82a28862f25/build-1.6.0.tar.gz", hash = "sha256:bd2c8afc603e7a2e0ce70e2ea85f0a6d02043bafbd307f5bada0f98669eca5af", size = 113825, upload-time = "2026-08-27T21:01:16.458Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/67/4898a44ea4f3f8e213b0954ec0aa0a16971d62a6212d6ea3931e97115b99/build-1.6.1.tar.gz", hash = "sha256:51cc11666391ab6f092070437ac747002ff46f3e4113a3622177ee6b488bfc53", size = 113427, upload-time = "2026-09-10T07:56:00.417Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/e5/aa1e81b21aea0ce0ba435311837a37d4cb936e7461f9fecac08580073ba9/build-1.6.0-py3-none-any.whl", hash = "sha256:f7aaf1ebbb79178a02ba248bb524f2176b256017e17e8e4bd4289c7b38cc2bad", size = 31187, upload-time = "2026-08-27T21:01:14.957Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/9b/9fb3585dabcd73a1b2a6267f63f62649347c9e6d072c9fde365b105abb2c/build-1.6.1-py3-none-any.whl", hash = "sha256:ecd351a4be9d35a9eaaba244a7687143c9c7d4aea6ac964e7e7ddab20cbcf4e7", size = 31179, upload-time = "2026-09-10T07:55:59.148Z" },
 ]
 
 [[package]]
@@ -2877,27 +2877,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.16.6"
+version = "0.16.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a4/7c/6adb35d70e7c027e308274557901c7e00fb3407750faf3620c184ae058cb/ruff-0.16.6.tar.gz", hash = "sha256:dcf8a73d2ff77e99dde91244b4da16feba7f14e6beeb4015dee7c5a909e99050", size = 4921251, upload-time = "2026-09-03T16:57:29.037Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/bb/5a449b9162e49b139d72f61672bd3ac1d790221f796d3304e2241fff4c58/ruff-0.16.7.tar.gz", hash = "sha256:5f71d004ac1263b22fa39462ac5ae618a4b77d58981af2cc79bf79a29c12b1a6", size = 4924184, upload-time = "2026-09-10T18:04:06.336Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/28/9cc1b79639e284ec103f43c88c644db4eb58cbd0ea1ca11f1193435369ac/ruff-0.16.6-py3-none-linux_armv6l.whl", hash = "sha256:61c368c26bf8e973e5ab14a2772de587bc068ea3f9a277f673380749b4898fb8", size = 10015638, upload-time = "2026-09-03T16:56:40.986Z" },
-    { url = "https://files.pythonhosted.org/packages/71/11/627d342ef727ea7794edf74fe23d60a074b02c3acc2e9436684e782286ca/ruff-0.16.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ecf4f068e2e123e43a26e9db4e19524cc56563912404e83bbfca375757e45a32", size = 10220762, upload-time = "2026-09-03T16:56:44.681Z" },
-    { url = "https://files.pythonhosted.org/packages/43/d9/b75668ce41e4c8d073d18d6d08672ba6906ce45d5c06ea4fdb2e84ce3853/ruff-0.16.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:99b62ea33baf130f50368798d841f0d95527b6d817bf31817b65dd058f1d314c", size = 9835082, upload-time = "2026-09-03T16:56:47.142Z" },
-    { url = "https://files.pythonhosted.org/packages/99/97/123ab10b05cde889c107c20f5a9774955104b5552796a2a8584b089ae8eb/ruff-0.16.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fbf89013f2bb3f6835a6038ff658dc8a1b38c98dc8e724b964168ad4e881876", size = 9949304, upload-time = "2026-09-03T16:56:49.813Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/58/a4a2c59dd2e5b85929c912d9cac3056eb9ee8c7e75e9b9fe3e109174966b/ruff-0.16.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56a67065e22efa6bc4d498299d3bb06c0c90aace8fac2068b5a12f9dc4d8d51d", size = 9840612, upload-time = "2026-09-03T16:56:52.368Z" },
-    { url = "https://files.pythonhosted.org/packages/61/6a/ff8c8626a786c4f49d48ced4a752dadbca65f5263005f9c2416578194694/ruff-0.16.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e25cc89174874b176a157e4428d66761c2c0c006654419bf384f967f361ff1b1", size = 10543465, upload-time = "2026-09-03T16:56:55.089Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/bb/c47535923365f337b82e28192e4e9eef2176511007cfd99a62fc22df5dad/ruff-0.16.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0700580ed5303723cb3c11c2f1d2a8913ce77b7ea86646dddb887f5417a9ba70", size = 11267576, upload-time = "2026-09-03T16:56:57.791Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/50/e5119a5212b5cd63b51e1f4b25e7bd636a6668fc069a3160b108ad7e3c16/ruff-0.16.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15f1d0b6e165a6e56567befb6629f8209271311d990bae0f37e6d065035ef5f3", size = 10781993, upload-time = "2026-09-03T16:57:00.666Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/98/083d8b4ef3c51a0d19db84367791cbe9f44e4b53343d19dfa83556e1cd9a/ruff-0.16.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d72c591a96986ee4268860e2b7235082129ca5e4cb9cbba653a4b57c11893757", size = 10317748, upload-time = "2026-09-03T16:57:03.428Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/29/68f7ff2c5ad95f19f00627ac2de95644e25fe47371ea60b2db1fd952315e/ruff-0.16.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:65a006baa18f33324325814c864daef03541d51564b98c517610ea756ab7003e", size = 10540096, upload-time = "2026-09-03T16:57:06.182Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/f9/79a8f6de85968641d68a7863aeec577551924ef066a990a48ff93167beab/ruff-0.16.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:cd02a7bf1a21a8735228a3e8c95a9dc5cf86bd2a52194f4aaae2a5755b4de0f4", size = 10100494, upload-time = "2026-09-03T16:57:09.194Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/e8/b81a22d9b90c00b892ccf2fa2ac36fa95de4c13ab85aea3e73795cfe4651/ruff-0.16.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:31b36f1e5ad85e0737f09d2be4e512e2e283583c14015da3b9dc07359ac0fc88", size = 9843663, upload-time = "2026-09-03T16:57:12.168Z" },
-    { url = "https://files.pythonhosted.org/packages/39/aa/54f516ec5e5a11c4afdceb1c454ebb054ffb96e4f4a1705580b4346abd35/ruff-0.16.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:61029b4ab4aa723fd3064fab96b1d814492596bf0c792679fffcbde1e1679953", size = 10282461, upload-time = "2026-09-03T16:57:15.077Z" },
-    { url = "https://files.pythonhosted.org/packages/52/0b/38d0aa8aa32372b96dc44f97b22e576c4147808271aab7b2cb1e353d4445/ruff-0.16.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9ac8998457832c2061709d900856b7ad271dace0cb41f346588d540162bfa718", size = 10728808, upload-time = "2026-09-03T16:57:17.797Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/e5/9e274e24eeb027640ffc7442f21239f16d17f47acec15ae34f32e03a5c79/ruff-0.16.6-py3-none-win32.whl", hash = "sha256:0b87d9d16fcb63e8018423ca1d50b7260f15cb2da33e30db4baad4183a948c25", size = 10049212, upload-time = "2026-09-03T16:57:20.55Z" },
-    { url = "https://files.pythonhosted.org/packages/22/31/72472449414223ed1a2da236b992adbb1a2ae59e34794574810f60ce068e/ruff-0.16.6-py3-none-win_amd64.whl", hash = "sha256:10d21c51c3495d8eaea7b703a16592117ea6eb1d649e36335aa965ff1173eb39", size = 10556402, upload-time = "2026-09-03T16:57:23.501Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/07/d781f8f8e1ac24bef9f3269cf62ffb1407ca24c3a8f12e5e22874f90528c/ruff-0.16.6-py3-none-win_arm64.whl", hash = "sha256:7a976c79b958f94e50a022a19f0f8c87387448020935ec14fc74331bd0a7f2c5", size = 10412850, upload-time = "2026-09-03T16:57:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/b2/c80aeeb7f9e469c0d63a85d2f1ab6e1ebfbe10ea7a8d2438b7e09e3ff09e/ruff-0.16.7-py3-none-linux_armv6l.whl", hash = "sha256:727307773e7c7f9181d3ed3a2484186e56c1fa1874255911c74585eb2c7c19f9", size = 10048917, upload-time = "2026-09-10T18:03:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/96/20bb7bcae008004df52afcb7ac83432d4a467f2c17b672fe46d26be231c5/ruff-0.16.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9d61c258deabf58f34c67bd4bb4d939c7f2e6b5f0e59c1cdd1cf771b11cde929", size = 10242929, upload-time = "2026-09-10T18:03:32.706Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b2/f184b0d5abec02db69cfd7e49b688ae0237554528ca777136c613bf36bee/ruff-0.16.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7ab81118df8945e0193d0240712aa4496573595b75185c3636ed825592a0f728", size = 9847245, upload-time = "2026-09-10T18:03:34.509Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2d/db1633a641866ed801e34cc6b60ef236c5e16f9b2124ab1d49cc24a5fe4f/ruff-0.16.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c196c968874fc8019da8e7163de7a1a370f111e2309b4b7dfea0fce950198d0", size = 9961780, upload-time = "2026-09-10T18:03:36.618Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/98/edea21e1a3e38dbbc3bf6bb068b863b3b06184cf8533a4c7dbbe208a89d5/ruff-0.16.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac8c3bd0a7e10ad31e6ce51e7a99f3cb772e69aecdd6b9ea7e99b362f62a62c0", size = 9866337, upload-time = "2026-09-10T18:03:38.805Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/11/a15e60d4c87b214646f116ca9d204475bf993ee1047459bc9a360fd4d6d1/ruff-0.16.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:398d3988edde000b5c75dc1b3f584708da9bc990de069c18909142580fec1af9", size = 10562512, upload-time = "2026-09-10T18:03:40.71Z" },
+    { url = "https://files.pythonhosted.org/packages/29/42/eaff4c9b6d0c7cdf56df313a17e89ae854f5bbc0b0c8f9cce19be0ab7a8f/ruff-0.16.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce05b62b770a8217c4646a9c4139fca00efe8fe5d71f87df2b243ff20d4584d1", size = 11302938, upload-time = "2026-09-10T18:03:42.607Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/43/c75aa59a4ec181fe2ec06cab30e198c1c6d107229a9f008ae3a7c16cabd8/ruff-0.16.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:af1b576fddb9d9ef2ececfb5fadcd6a624b25070ed85e3cfcfe449fc3ff6a7b9", size = 10840857, upload-time = "2026-09-10T18:03:44.604Z" },
+    { url = "https://files.pythonhosted.org/packages/21/33/81f3da371942ea031105ba679d8d6e28ec1660ccd690a45f42d381161356/ruff-0.16.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ce7f8f22df67c93ed96c717f9128eadb797144ac2bad475cf536f31d6100c55", size = 10370001, upload-time = "2026-09-10T18:03:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/0b/6345fb4dbf6dd0ed1cfe5d18391dc9c3f59cc81622a7b0a65b84b3e730ba/ruff-0.16.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:06d0e93d04f392996435ebd600c153f65b47d73fbec2415aa99c5ee5756b3a5f", size = 10548735, upload-time = "2026-09-10T18:03:48.658Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/4d/c5576adf511f92a328e5569dda190ecdd430da51f1a649f3a4a2fd73e21e/ruff-0.16.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:142151a5e7b93c1b11111337142f89dd2fbfee92161225c99a97222f22e32656", size = 10108496, upload-time = "2026-09-10T18:03:50.563Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8c/667d83c16199a17a56adc6b0bd4c3beb5b767a2babcd16a56f76f9be7fd6/ruff-0.16.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e6651f97a342d8b35d54d8991544ca22169b86dc54111cb604666940c431b750", size = 9860136, upload-time = "2026-09-10T18:03:52.621Z" },
+    { url = "https://files.pythonhosted.org/packages/99/75/78d401106731999a1dd20cc5a6961e37e1eb9397a3b589f73f3a5ce146a3/ruff-0.16.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ef140c6eb935fa9a84c9c607dfb2cb1b85843c192e79265b0c54f35f557ea8e5", size = 10286290, upload-time = "2026-09-10T18:03:55.207Z" },
+    { url = "https://files.pythonhosted.org/packages/68/49/56f9c3a8b755df93a0ad318b2147bf4ef5dae9a7e5ec61c460109c67957f/ruff-0.16.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:53e39506a730fadeee0d998ed5946f30671f0db240c6c7c73bdabbe33604bb6f", size = 10745048, upload-time = "2026-09-10T18:03:57.299Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ea/7f9b938a63ece4bec677ad7f9f7fa02df3383db1949ed93a382441c09a87/ruff-0.16.7-py3-none-win32.whl", hash = "sha256:2ea3470fcebcbc5df2fb0c6f3b90333fa9084c534e0111c038fa4a6ab9f1c4b7", size = 10059082, upload-time = "2026-09-10T18:03:59.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/11/480a6973a927aa653e1cead6a6416008640e03a99d05b34c0434b8c6c366/ruff-0.16.7-py3-none-win_amd64.whl", hash = "sha256:7ac26aca826e9e21d0f1cb25b54ac660760a9fdd094d3e4df9848232be98cfc6", size = 10593368, upload-time = "2026-09-10T18:04:01.999Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/4b/51327018d056f0dad2c2238f26d1fb0f53707a9d91b75dea6d1b3039f136/ruff-0.16.7-py3-none-win_arm64.whl", hash = "sha256:aab7f39e2c9df6c596216070f98eef1207b94f8516cca20c808826974971855b", size = 10412401, upload-time = "2026-09-10T18:04:04.098Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`uv lock --upgrade`, `pre-commit autoupdate` and the workflow action pins,
taken together, with the refusals written down rather than left as the
absence of a bump.

`uv lock --upgrade` moves `build` to 1.6.1 and `ruff` to 0.16.7 and
nothing else. No floor moves, and that is measured rather than decided:
`uv lock --upgrade-package btclib-secp256k1 --dry-run` and the same for
`bitcoin-core-rpc` each answer `No lockfile changes detected`, and PyPI
serves 0.8.0.6 and 2026.9.3 as the newest of each — the versions the lock
pins and the versions `>=0.8.0.6` and `>=2026.9.3` name. Floor, lock and
newest release coincide on both siblings.

`pre-commit autoupdate` offers four and two are taken: ruff to v0.16.7,
which is the ruff `uv.lock` now resolves as well, and uv-pre-commit to
0.12.13, which `uv_build>=0.12.0,<0.13` admits. The other two are refused
and the refusal is enforced, not documented: run with autoupdate's walk
left in place, the lint gate exits 1 with `pinned-rev` naming pyroma's
5.1b1 prerelease and `held-rev` naming zizmor's rev line, and zizmor
1.30.1 itself exits 12 — the `self-repository` audit over the twelve
`uses: ./…` references under `.github/workflows/`, which actionlint 1.7.12
cannot parse in the `$/…` form the auto-fix offers instead
([ISS #1563](https://github.com/btclib-org/btclib/issues/1563), open).

`astral-sh/setup-uv` moves to v10.1.0 and `anthropics/claude-code-action`
to v1.0.223, sha and comment together at every site; `github/codeql-action`
and `google/clusterfuzzlite` stay, each for a reason the pin's own
re-derivation gives. Four sentences the pins had already falsified are
corrected — none of them about a version this branch moves.

`RELEASE_NOTES.md` does not move: nothing here reaches a caller.

## Review

Reviewed at fresh context before this pull request was opened. The round
returned **CHANGES REQUESTED** on one blocking finding, and it was a true
one: the CHANGELOG entry said the claude-code-action range moved the
Claude Code release the action installs and "touch nothing else", where
`gh api repos/anthropics/claude-code-action/compare/<old>...<new>` answers
six files — the range also moves `@anthropic-ai/claude-agent-sdk`,
^0.3.267 to ^0.3.270, which is the SDK the action's own TypeScript runs
on. The inertness of that range is the whole ground given for moving the
one privileged pin in this diff, so the sentence understated the move in
the dimension that decides it. Both the entry and the commit body now name
both versions. The reviewer's non-blocking remark about v10.1.0's
checksum-verification item is folded in the same way.

## Gates

Run on `8ef15638`, the rebased and corrected tip, after the rebase voided
the clearance pinned to the pre-rebase sha:

```shell
env -C "$WT" uv run --locked --only-group lint pre-commit run --all-files --show-diff-on-failure
env -C "$WT" uv run --locked pytest
env -C "$WT" uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html
env -C "$WT" grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'   # exit 1 = pass
```

- lint exit 0 — 47 passed, 1 skipped (`forbid submodules`, no files to
  check), clean tree after the run, so no fixer changed anything
- pytest exit 0 — 32606 passed, 78 skipped, `TOTAL 57233 0 9898`, 100.00%
- sphinx exit 0; anchor sweep exit 1, which is the pass, with
  `docs/build/html/index.html` as the positive control that the pattern
  reaches the built files
- packaging arm exit 0 throughout: `uv build`, `normalize_sdist.py`,
  `verify_dist_contents.py`, `generate_sbom.py`, `twine check --strict`,
  `check-wheel-contents`, `pyroma --min 10`
- the `no-bindings` assert exit 0 in both directions — the bindings absent
  under `uv sync --exact --no-default-groups --group harness`, and serving
  again after `uv sync --locked`

The rebase ate the blank line above this branch's `###` heading, as
`merge-tree --write-tree` predicted: the glued-heading detector read 1 on
the fused blob and 0 on both parents, which is what makes the defect the
merge's. Repaired by reconstruction rather than by the rebase's own
output — the added block derived with `difflib.SequenceMatcher` and
spliced into the new base before the blank preceding the first *released*
`## v` heading, the strip-back verified byte for byte against the base
with a mutation control in both directions, and the post-repair diffstat
identical to the pre-rebase one. `markdownlint-cli2` v0.23.2 invoked
directly, check-only, exits 0 on the repaired file and 1 naming
`MD022`/`MD032` on the planted defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3

## Summary by Sourcery

Refresh approved dependencies, hooks, and workflow action pins while preserving incompatible or already-current versions and documenting the decisions.

Enhancements:
- Refresh the project’s Python dependency lockfile and pre-commit hooks while retaining dependency floors and intentionally held revisions.
- Update pinned GitHub Actions for uv setup and Claude Code reviews, while preserving validated pins for CodeQL and ClusterFuzzLite.
- Clarify dependency-refresh decisions and compatibility constraints in the changelog and tooling configuration.

Documentation:
- Document the dependency, hook, and workflow pin refreshes together with the deliberately unchanged versions and their rationale.

Tests:
- Verify linting, tests, documentation builds, packaging checks, and binding exclusion behavior after the dependency refresh.