### PR TITLE
Release v2026.9.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ Only v2026.8.7 and what follows it are here. The releases before it were
 documented at release-notes length in the first place, and are still in
 [RELEASE_NOTES.md](./RELEASE_NOTES.md) rather than duplicated here.
 
-## v2026.9 (work in progress, not released yet)
+## v2026.10 (work in progress, not released yet)
+
+## v2026.9.13
 
 ### `ecc.rangeproof.sign` writes the rangeproof of a blinded value
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,7 +19,9 @@ behind this file.
 Release names follow *[calendar versioning](https://calver.org/)*:
 full year, short month, short day (YYYY-M-D)
 
-## v2026.9 (work in progress, not released yet)
+## v2026.10 (work in progress, not released yet)
+
+## v2026.9.13
 
 ### Breaking changes
 
@@ -40,7 +42,8 @@ full year, short month, short day (YYYY-M-D)
   answer the same; `btclib.ecc.pedersen.second_generator(ec, hf)` is the
   argument for a curve or a hash function other than the defaults, and
   `btclib.ecc.pedersen.generator_from_seed(seed, blind)` is the other
-  way to make one.
+  way to make one. CHANGELOG.md has why the generator became an
+  argument, and the rest of what this cycle changed.
 
 ## v2026.9.10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ name = "btclib"
 # file. Not a literal in src/btclib/__init__.py for setuptools to import
 # and conf.py to repeat: two declarations are two things a release
 # workflow has to compare before trusting either
-version = "2026.9"
+version = "2026.9.13"
 description = "A library for 'bitcoin cryptography'"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/tests/changelog_immutability_test.py
+++ b/tests/changelog_immutability_test.py
@@ -98,13 +98,13 @@ every tag cut afterwards simply inherited it unchanged. So no already-tagged
 heading can receive a bullet without gaining text its own sealed
 tag never had, which is the identical failure this module exists to
 catch, moved rather than fixed. The one heading with no tag to violate
-is the currently open one, `## v2026.9 (work in progress, not released
-yet)`, in the subsection each bullet already belonged to -- and once
-that cycle is itself tagged, the bullet is part of its tag from day one,
-unlike every prior placement. Each relocated bullet carries its own
-trailing "(shipped in v<version>)", the tag `merge-base --is-ancestor`
-found, so a reader can still tell it apart from what this cycle actually
-added.
+is whichever section is open when the move is made -- the placeholder,
+whose own name the next retitle takes -- in the subsection each bullet
+already belonged to; and once that section is retitled and tagged, the
+bullet is part of its tag from day one, unlike every prior placement.
+Each relocated bullet carries its own trailing "(shipped in
+v<version>)", the tag `merge-base --is-ancestor` found, so a reader can
+still tell it apart from what this cycle actually added.
 
 `v2026.8.7` keeps its exemption, now to `13941fd1` and `0744d3f4` alone:
 `237c86d4`'s bullets, the section's only relocatable content, are gone
@@ -455,7 +455,7 @@ def test_every_exemption_names_a_released_heading_on_disk() -> None:
         " so no case is generated for it and the comparison never applies it"
     )
 
-    bogus = ("CHANGELOG.md", "v2026.9")
+    bogus = ("CHANGELOG.md", "v2026.10")
     assert bogus not in _KNOWN_DRIFT
     planted = {**_KNOWN_DRIFT, bogus: next(iter(_KNOWN_DRIFT.values()))}
     assert _exemptions_naming_no_released_heading(planted) == [bogus]

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "btclib"
-version = "2026.9"
+version = "2026.9.13"
 source = { editable = "." }
 dependencies = [
     { name = "bitcoin-core-rpc" },


### PR DESCRIPTION
The v2026.9 cycle's third release, cut from `main` at `908234a1`.

## What a user has to act on

One breaking change, and it is the only thing in this release that asks a
caller to do anything: **`btclib.ecc.pedersen` and `btclib.ecc.rangeproof`
take the generator they work at** (closes #1986). `pedersen.commit`,
`verify` and `assert_as_valid` take `gen` and no longer take `hf`;
`rangeproof.sign_public_value`, `RangeProof.nonce_chain` and
`RangeProof.pubk_rings` take it too. `pedersen.second_generator()` is the
generator those calls used to derive, so passing it keeps every answer the
same. RELEASE_NOTES.md's section carries the spellings and the migration.

## What moved

The cycle's substance is `ecc.rangeproof`, which now writes, verifies and
rewinds a proof and binds a caller's own octets into one, with the vendored
fixed rangeproofs rewound under the nonces upstream uses; `ecc.pedersen`
gained a generator derived from a seed. Everything else is the prose and the
gates around the libsecp256k1 dispatch — `SECURITY.md`, `README.md`,
`docs/source/guide.rst` and the `curves`/`ecc` comments now state that
dispatch by the predicate its guards test rather than by a roster of call
sites, and several of them gained a test that reads what they cite.

## What did not move

**No floor moves**, and that is measured rather than left alone: for
`btclib-secp256k1` and `bitcoin-core-rpc` the declared floor, `uv.lock` and
the newest release on PyPI are the same version, so there is nothing to
raise a consumer's requirement to. There is no `[tool.uv.sources]` section
and so no direct reference to write back — which matters because PyPI
refuses a direct reference only at `publish-pypi`, after the whole matrix
has built and uploaded.

## The two steps nothing else enforces

**griffe**, against the previous release tag:

```shell
uv run --with griffe griffe check btclib -s . -s src -a v2026.9.10
```

exits 1 with twelve differences over six functions and nothing else: `gen`
added as required to all six, with `hf` removed and `ec` moved in the three
`pedersen` ones. Every one of the six has a bullet in RELEASE_NOTES.md's
breaking-changes list. None of the twelve is one of the shapes griffe
reports for a change no caller can observe — this cycle's output carries no
PEP 604 respelling, no `__version__` line and no constant moved into a
lookup table.

**deps-latest**, dispatched before the tag rather than waited for:
[run 34722990984](https://github.com/btclib-org/btclib/actions/runs/34722990984)
is green on **all 14 jobs**, read per job and not as a verdict: the four
`bindings at latest` cells and the four `dependencies at latest` cells pass
on 3.10 and 3.14 across ubuntu, macos and windows, so the newest
`btclib-secp256k1` release both imports and serves, and `uv lock --upgrade`
finds nothing left to move. Nothing here is future work and nothing blocks:
the refresh that would otherwise show up as drift landed an hour before this
pull request.

The dependency refresh landed ahead of this release rather than being left
for the next Dependabot cycle (PR #2048): `uv lock --upgrade` moved `build`
and `ruff` by a patch each, neither sibling at all, and two pre-commit
revisions were refused with the refusal enforced by the lint gate rather
than documented.

## The placeholder, which is a departure

The next cycle opens as `## v2026.10 (work in progress, not released yet)`
in both files. RELEASING.md's retitle step asks for the cycle of the release
just cut — `2026.9`, and explicitly not the month after it — so this is a
direction from the maintainer rather than the file's rule, recorded with its
cost in ISS #2047: while the placeholder stands, a checkout of `main`
declares a version sorting above the release just cut, `2026.10` above
`2026.9.13`. What it buys is a cycle named correctly if the next release
falls in October, with nothing filed under the heading to move afterwards.
No test decides between the two readings, which is measured rather than
assumed: `tests/declared_version_test.py` uses `2026.10` as its own example
of a *valid* placeholder shape, and `version-check` refuses a tag on a
placeholder rather than a placeholder's month.

## Checked

RELEASE_NOTES.md's and CHANGELOG.md's sections were read against
`git log v2026.9.10..main --oneline` rather than trusted: 36 commits, 41
entry headings, and the only commit with no entry of its own is
`03eac233`, which reopened the cycle and is release mechanics a user does
not see.

## The rehearsal

`workflow_dispatch` on this branch, [run 34723411299](https://github.com/btclib-org/btclib/actions/runs/34723411299),
published `2026.9.13.dev1801` to TestPyPI — the version the workflow mints
from `run*100+attempt`, which is `18*100+1`. Installed and exercised from a
directory belonging to no checkout, it imports and reports that version out
of the uv cache rather than out of a source tree.

The run is **red overall and green where it matters**, which is the expected
shape of a cycle carrying a breaking change: 54 jobs succeeded, four are the
release-only ones that a dispatch skips (`documented`, `publish-pypi`,
`pypi-install`, the release-asset attachment), and the one failure is
`public-api`. Read rather than inferred: its failing step is *Check the
public API against the previous release* with every step before it green,
and its log carries twelve warnings in a 6/3/3 split — six `Parameter was
added as required`, three `Positional parameter was moved`, three `Parameter
was removed` — which is the local griffe result above, at CI's pinned
`griffe==2.2.0`. `public-api` gates nothing: `publish-testpypi`,
`publish-pypi` and `pypi-install` each open their `if:` with `always()`.

## Two sentences this commit falsifies, repaired here

A review round found them, and the repo's rule puts a sentence your own diff
makes false in the diff rather than in a tracker.
`tests/changelog_immutability_test.py`'s module docstring named the open
heading by quoting `## v2026.9 (work in progress, not released yet)`, which
no retitle can leave true; it now names the placeholder by what it is, so the
next retitle will not falsify it again. And the planted key of
`test_every_exemption_names_a_released_heading_on_disk` is `v2026.10` where
it was `v2026.9`, because its own docstring calls that key "the still-open
cycle". The assertion passed either way — measured, with a control showing
`v2026.10` and `v2026.9` both name no released heading while `v2026.9.13` and
`v2026.9.10` do — so what the edit restores is the input the docstring
describes rather than a failure.

`RELEASE_NOTES.md`'s new section also ends by naming CHANGELOG.md, as
`v2026.9.10`'s section does: the workflow lifts the GitHub release body from
this section alone, and the file's own pointer lives in the preamble, outside
it, so a reader arriving at the release had no route to the other forty
entries.

Local gates on `908234a1`:

```shell
env -C "$WT" uv run --locked --only-group lint pre-commit run --all-files --show-diff-on-failure
env -C "$WT" uv run --locked pytest
env -C "$WT" uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html
env -C "$WT" grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'   # exit 1 = pass
```

- lint exit 0 — 47 passed, 1 skipped (`forbid submodules`, no files), clean
  tree after the run
- pytest exit 0 — 32606 passed, 80 skipped, `TOTAL 57233 0 9898`, 100.00%.
  Two skips more than this branch's base, and they are named: `'v2026.9.13'
  is being released and has no tag yet`, which is
  `tests/changelog_immutability_test.py` declining to compare the section
  being cut against a tag that does not exist yet
- sphinx exit 0; anchor sweep exit 1, which is the pass, with
  `docs/build/html/index.html` as the positive control

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3
