### PR TITLE
`pyproject.toml` reopens the cycle as v2026.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ name = "btclib"
 # file. Not a literal in src/btclib/__init__.py for setuptools to import
 # and conf.py to repeat: two declarations are two things a release
 # workflow has to compare before trusting either
-version = "2026.9.13"
+version = "2026.10"
 description = "A library for 'bitcoin cryptography'"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "btclib"
-version = "2026.9.13"
+version = "2026.10"
 source = { editable = "." }
 dependencies = [
     { name = "bitcoin-core-rpc" },


### PR DESCRIPTION
RELEASING.md's last step, *Open the next cycle's version*, for the release
just cut. `pyproject.toml` declares `2026.10` and `uv.lock` follows, which
`uv version` re-locks itself, so `uv lock --check` is clean with no separate
step — `1 1` on each file and nothing else, the same shape as `03eac233`.

## Why it is not `2026.9`, and what that costs

RELEASING.md's retitle step says the placeholder names the cycle of the
release just cut — `2026.9` here — and names `2026.10` as wrong. The
maintainer directed `2026.10`, and [ISS #2047](https://github.com/btclib-org/btclib/issues/2047) carries the decision with the
cost measured rather than argued: `V('2026.10') > V('2026.9.13')` is `True`
and `V('2026.9') > V('2026.9.13')` is `False`, so while this placeholder
stands a checkout of `main` declares a version *above* the release just cut,
where the documented value would have declared one below it. Nothing
published moves, releases being ordered by their tags; what pays is a bug
report quoting `btclib.__version__` from a checkout rather than from an
index. The release pull request opened `## v2026.10 (work in progress, not
released yet)` in both notes files, so this commit sets the declaration from
the heading, which is what the step asks.

## Why it lands now rather than after the publish finishes

RELEASING.md puts this step last, and its reason is that it must not precede
the tag: `version-check` reads `uv version --short` at tag time, so a
`pyproject.toml` already bumped would have offered it this number instead of
the one being released. That reason is spent — `v2026.9.13` is pushed and
`version-check` completed successfully on it before this branch existed, and
every job in the release run reads the tag's own tree rather than `main`.

What made the ordering worth revisiting is that the window is not inert.
`tests/declared_version_test.py::test_the_declared_version_is_not_another_commits_release`
fails on **every** commit above the release while the declaration still reads
`2026.9.13`, naming that step as the one not taken — so `main` goes red for
whoever pushes next, and a branch in flight is red through no fault of its
own. Measured, not inferred: that module is `12 passed` at the release commit
`92921334`, `1 failed, 11 passed` with a single *empty* commit on top, and
`12 passed` again on this branch at `055c0f57`. The second of those three is
a peer session's measurement, which is also how the case came up; the first
and third are mine.

## Gates

```shell
env -C "$WT" uv run --locked --only-group lint pre-commit run --all-files --show-diff-on-failure
env -C "$WT" uv run --locked pytest
env -C "$WT" uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html
env -C "$WT" grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'   # exit 1 = pass
```

- lint exit 0 — 47 passed, 1 skipped (`forbid submodules`, no files), clean
  tree after the run
- pytest exit 0 — **32608 passed, 78 skipped**, `TOTAL 57233 0 9898`, 100.00%.
  Two *more* passes and two *fewer* skips than the release commit measured
  before the tag existed, and the pair is the same pair: `CHANGELOG.md` and
  `RELEASE_NOTES.md`'s `v2026.9.13` sections now compare against their own tag
  instead of skipping as "being released and has no tag yet"
- sphinx exit 0; anchor sweep exit 1, which is the pass
- `uv lock --check` resolves 126 packages with no change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3

## Summary by Sourcery

Enhancements:
- Advance the declared project version to the next development cycle, keeping the lockfile in sync.