### PR TITLE
A schedule comment names the `pull_request` trigger below it (closes btclib-org/.github#736)

### DIFF
--- a/.github/workflows/integration-bitcoind.yml
+++ b/.github/workflows/integration-bitcoind.yml
@@ -57,7 +57,8 @@ on:
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
-    # this is reachable through the dispatch below alone
+    # this is reachable through the dispatch below, and through the
+    # pull_request trigger further down.
     - cron: "4 5 * * 2"
   # the same trigger set as the other gates: main so that the commit a
   # merge creates is asked the question too -- and so that a cache is

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -24,7 +24,8 @@ on:
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
-    # this is reachable through the dispatch below alone
+    # this is reachable through the dispatch below, and through the
+    # pull_request trigger further down.
     - cron: "4 4 * * 6"
   # the escape hatch, and the way to check a branch before merging a
   # documentation change that adds links

--- a/.github/workflows/py-arm-authority.yml
+++ b/.github/workflows/py-arm-authority.yml
@@ -74,7 +74,8 @@ on:
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
-    # this is reachable through the dispatch below alone
+    # this is reachable through the dispatch below, and through the
+    # pull_request trigger further down.
     - cron: "4 4 * * 4"
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -31,7 +31,8 @@ on:
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
-    # this is reachable through the dispatch below alone
+    # this is reachable through the dispatch below, and through the
+    # pull_request trigger further down.
     - cron: "4 3 * * 1"
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/zkp-oracle.yml
+++ b/.github/workflows/zkp-oracle.yml
@@ -60,7 +60,8 @@ on:
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Only the default branch schedules workflows, so on any other
-    # branch this is reachable through the dispatch below alone
+    # branch this is reachable through the dispatch below, and through
+    # the pull_request trigger further down.
     - cron: "4 2 * * 3"
   workflow_dispatch:
   pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,33 @@ documented at release-notes length in the first place, and are still in
 
 ## v2026.10 (work in progress, not released yet)
 
+### A schedule comment names the `pull_request` trigger below it
+
+- **`integration-bitcoind.yml`, `links.yml`, `py-arm-authority.yml`,
+  `vendored-vectors.yml` and `zkp-oracle.yml` say a branch reaches the
+  workflow through the dispatch below the comment and through the
+  `pull_request` trigger further down** (closes btclib-org/.github#736).
+  Each of them declares that trigger, so *alone* claimed an exclusivity
+  the same file refuses a few lines lower, and it sent a reader asking
+  how to see the run before it lands to a hand dispatch their own pull
+  request had already made unnecessary.
+- **The wording is `btclib-secp256k1`'s**, taken there under this issue
+  at `8b174ce5` and `a7236b9d`. That tree's `codeql.yml` ends the clause
+  *pull_request trigger above*, its `pull_request:` standing ahead of its
+  `schedule:`; here the trigger sits below the comment in each of the
+  files named, which is what *further down* is derived from, file by
+  file.
+- **The other workflow files carrying the sentence are untouched**:
+  `deps-latest.yml`, `integration-hwi.yml`, `os-macos.yml`,
+  `os-ubuntu.yml`, `os-windows.yml` and `pypi-install.yml` declare no
+  `pull_request:` trigger at all, so the contradiction this issue is
+  about does not arise in them. `os-macos.yml`, `os-ubuntu.yml` and
+  `os-windows.yml` each declare `workflow_call:` below that sentence,
+  and `release.yml` calls all three in jobs with no `if:`, which a
+  `workflow_dispatch` rehearsal reaches from any branch:
+  btclib-org/.github#1040 is where that is filed, for this tree and for
+  `btclib-secp256k1`.
+
 ## v2026.9.13
 
 ### `ecc.rangeproof.sign` writes the rangeproof of a blinded value


### PR DESCRIPTION
`integration-bitcoind.yml`, `links.yml`, `py-arm-authority.yml`,
`vendored-vectors.yml` and `zkp-oracle.yml` said, beside their `cron:`,
that on a branch other than the default one the workflow is reachable
through the dispatch below alone. Each of them declares a `pull_request:`
trigger below that comment, so the sentence sent a reader asking how to
see the run before it lands to a hand dispatch their own pull request
had already made unnecessary.

The clause replacing *alone* is `btclib-secp256k1`'s, taken there under
this issue at `8b174ce5` and `a7236b9d`. That tree's `codeql.yml` ends it
*pull_request trigger above*, its `pull_request:` standing ahead of its
`schedule:`; in each file here the trigger sits below the comment, which
is what *further down* is derived from, file by file. Each file keeps its
own line break and indentation, `zkp-oracle.yml` wrapping one word
earlier than the other four.

`deps-latest.yml`, `integration-hwi.yml`, `os-macos.yml`, `os-ubuntu.yml`,
`os-windows.yml` and `pypi-install.yml` carry the same sentence and are
untouched: none of them declares a `pull_request:` trigger, so the
contradiction this issue is about does not arise in them.
`os-macos.yml`, `os-ubuntu.yml` and `os-windows.yml` each declare
`workflow_call:` below that sentence, and `release.yml` calls all three
in jobs with no `if:`, which a `workflow_dispatch` rehearsal reaches from
any branch: btclib-org/.github#1040 is where that is filed, for this tree
and for `btclib-secp256k1`.

No file this branch touches is a path section 14 compares, so no
`EXPECTED_DRIFT` entry is owed.

closes btclib-org/.github#736

## Two rounds, and what each cost

**Round 1 was blocking, and the finding is the sharpest of the campaign: the
branch had committed the defect it was written to fix.** The paragraph above
originally ended *so on a branch other than the default one the dispatch is the
whole of what reaches them* — true of the `on:` block and false as a statement
about reachability, `os-macos.yml`, `os-ubuntu.yml` and `os-windows.yml` each
declaring `workflow_call:` four lines below that very sentence, with
`release.yml:428,432,436` calling all three in jobs with no `if:` and run
34723411299 as the instance. Both carriers were corrected, the commit body as
well as the file: `--amend --no-edit` is how the other survives.

**Round 2 was a rebase, and it is the case the seam arithmetic cannot see.** The
release landed under the branch mid-review, so the entry was appended to a
section that a tag then closed. `merge-tree` fused with **delta 0** — no line
eaten, no conflict, no alarm — and in that fused file the entry sat inside
`## v2026.9.13`, a released section, while the open one sat empty. Every
byte-and-arithmetic check is about whether the block survived intact, and here
it survives perfectly, in the wrong place. What settles it is the enclosing
heading, and that is what both coder and reviewer measured: the entry's nearest
preceding `##` is `## v2026.10 (work in progress, not released yet)`, the
heading occurs once in the file, and deleting the entry's own 27 lines from the
tip's blob reproduces the base's byte for byte, with a window shifted by one as
the control that the comparison can see a difference of that size.

The gate that catches this case existed and was **skipping**, the section having
no tag yet; now that the tag exists it compares, and a planted violation makes
`test_a_released_section_still_matches_its_own_tag[CHANGELOG.md-v2026.9.13]`
fail with the section named rather than a line number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGRFSkPFh8PR4Y3Wr47vb

## Summary by Sourcery

Clarify workflow trigger comments and record the correction in the changelog.

Bug Fixes:
- Correct workflow comments to accurately state that non-default branches can run through both manual dispatch and pull-request triggers.

Documentation:
- Document the workflow comment correction in the unreleased changelog and clarify that unaffected workflows do not define pull-request triggers.