### PR TITLE
A schedule comment names the `workflow_call` trigger below it (issue btclib-org/.github#1040)

### DIFF
--- a/.github/workflows/os-macos.yml
+++ b/.github/workflows/os-macos.yml
@@ -43,7 +43,8 @@ on:
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
-    # this is reachable through the dispatch below alone
+    # this is reachable through the dispatch below, and through the
+    # workflow_call trigger above it.
     - cron: "4 5 * * 4"
   # lets release.yml gate a publication on this platform too, which is what
   # keeps a weekly sentinel from being the only thing that ever asks

--- a/.github/workflows/os-ubuntu.yml
+++ b/.github/workflows/os-ubuntu.yml
@@ -41,7 +41,8 @@ on:
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
-    # this is reachable through the dispatch below alone
+    # this is reachable through the dispatch below, and through the
+    # workflow_call trigger above it.
     - cron: "4 4 * * 5"
   # lets release.yml gate a publication on these cells too, which is what
   # keeps a weekly sentinel from being the only thing that ever asks

--- a/.github/workflows/os-windows.yml
+++ b/.github/workflows/os-windows.yml
@@ -49,7 +49,8 @@ on:
     # The time is section 10's grid in btclib-org/.github and not this
     # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
-    # this is reachable through the dispatch below alone
+    # this is reachable through the dispatch below, and through the
+    # workflow_call trigger above it.
     - cron: "4 5 * * 5"
   # lets release.yml gate a publication on this platform too, which is what
   # keeps a weekly sentinel from being the only thing that ever asks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,34 @@ documented at release-notes length in the first place, and are still in
   btclib-org/.github#1040 is where that is filed, for this tree and for
   `btclib-secp256k1`.
 
+### A schedule comment names the `workflow_call` trigger below it
+
+- **`os-macos.yml`, `os-ubuntu.yml` and `os-windows.yml` say a branch
+  reaches the workflow through the dispatch below the comment and
+  through the `workflow_call` trigger above that dispatch** (issue
+  btclib-org/.github#1040). Each declares that trigger, and
+  `release.yml` calls each of them in a job with no `if:`, so a
+  `workflow_dispatch` rehearsal reaches them from whatever branch it is
+  dispatched on -- which is what *alone* denied.
+- **The clause is the one btclib-org/.github#736 landed in
+  `links.yml`**, with `workflow_call` where that one says `pull_request`
+  and *above it* where it says *further down*: in each of these files the
+  trigger stands ahead of the dispatch the sentence has just named, where
+  in `links.yml` it follows it. The clause does not name `release.yml`:
+  the comment introducing that trigger already says a call is what lets
+  that workflow gate a publication, and section 9's *One fact in one
+  place* is the reason.
+- **`pypi-install.yml` carries the sentence beside a `workflow_call:`
+  too and keeps it, the claim being true there.** `release.yml`'s
+  `publish-pypi` job requires `github.event_name == 'push'` and the only
+  push that starts that workflow is a `v*` tag, so a rehearsal
+  dispatched from a branch skips it; the `pypi-install` job beside it is
+  gated on `needs.publish-pypi.result == 'success'`, which a skipped job
+  does not give. Run 34723411299, dispatched on a branch, skipped both
+  of those jobs and ran the platform workflows above.
+- **`btclib-secp256k1` owes the same change**, which is why this cites
+  the issue rather than closing it.
+
 ## v2026.9.13
 
 ### `ecc.rangeproof.sign` writes the rangeproof of a blinded value


### PR DESCRIPTION
`os-macos.yml`, `os-ubuntu.yml` and `os-windows.yml` each declare
`workflow_call:` below the comment beside their `cron:`, and
`release.yml` calls each of them in a job with no `if:`, so a
`workflow_dispatch` rehearsal reaches them from whatever branch it is
dispatched on. The clause btclib-org/.github#736 landed in `links.yml`
replaces the word `alone`, with `workflow_call` where that one says
`pull_request` and `above it` where it says `further down`: in these
files the trigger stands ahead of the dispatch the sentence has just
named, where in `links.yml` it follows it.

`pypi-install.yml` keeps the sentence: `release.yml`'s `publish-pypi`
job requires `github.event_name == 'push'` and the only push that
starts that workflow is a `v*` tag, so a dispatch from a branch skips
it, and the `pypi-install` job beside it is gated on
`needs.publish-pypi.result == 'success'`. Run 34723411299 is that pair
skipped on a branch dispatch.

`btclib-secp256k1` owes the same change, so this cites the issue rather
than closing it.

Advances btclib-org/.github#1040.

## The wording is a correction of the decision, not of the branch

The decision on that issue prescribed ISS 736's clause with `workflow_call`
substituted for `pull_request` and *nothing else changing*. Review measured that
that is wrong at these files' geometry: `workflow_call:` stands **above**
`workflow_dispatch:` in all six files of the issue, across both trees, so
*further down* walks a reader past the trigger to `permissions:`. The control is
decisive — in the five files ISS 736's clause landed in the order is reversed
and the comparative is exact (`links.yml` 32/42, `integration-bitcoind.yml`
75/82, `py-arm-authority.yml` 80/81, `vendored-vectors.yml` 37/38,
`zkp-oracle.yml` 66/67). Five for five one way, six for six the other.

The decision was corrected on the issue and this branch amended to it, so the
sibling's three files take `above it` from the start. Both derivations were
`cmp`'d against the committed clauses, with two controls: a tamper
(`above it` → `below it`) and, more to the point, *one substitution only* —
the control that would have passed under the previous derivation and fails now.

## What the branch measured rather than assumed

`pypi-install.yml` keeps its sentence because a read says it may, not because
the change was tedious: `publish-pypi`'s `if:` requires
`github.event_name == 'push'` while `on:` admits only a `v*` tag push, so a
rehearsal skips it and the gated `pypi-install` job with it — confirmed against
run 34723411299, where both are `skipped` and 42 `os-*` cells are `success`.

A census in the other direction accounts for every file carrying the sentence:
eleven, being the three this branch changes, the five already carrying ISS 736's
clause, and three that keep *alone* — each of those three true for a **different**
reason (no caller at all; a `push:` restricted to the default branch; a caller
whose job is gated).

That a hook read the changed files is proved rather than inferred: `Skipped` is
what a filtered-out path prints here, and violations planted on the line the
change writes made `yamllint`, `typos`, `trailing-whitespace` and `actionlint`
name the file and line, after which the plants were reverted and the blobs
hashed back. The tip's sweep for them exits 1 with a control sharing the
property under test.

## Two positional glosses removed rather than corrected

The entry first said the comment naming `release.yml` is "on the next line"; it
is two lines down past an intervening key. Rather than fix the number the branch
removed the locator, so the sentence names a function — *the comment introducing
that trigger* — and cannot age. The same reasoning kept an explicit referent in
the first bullet, where the heading has already bound *it* to the comment.

Three full gate rounds at three shas returned identical counts —
`32608 passed, 78 skipped`, 100.00%, 47 hooks — across four load readings from
3.01 to 10.15 on ten cores, which says more than any single green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGRFSkPFh8PR4Y3Wr47vb

## Summary by Sourcery

Clarify workflow comments so they accurately describe how scheduled platform workflows are triggered.

Enhancements:
- Clarify that the macOS, Ubuntu, and Windows workflows can also be reached through their reusable `workflow_call` trigger, while preserving the existing dispatch guidance where it remains accurate.

Documentation:
- Document the workflow-trigger clarification and its rationale in the changelog, including the distinction from the PyPI installation workflow.