### PR TITLE
A run coverage's configuration never reached is refused (issue btclib-org/.github#443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,52 @@ documented at release-notes length in the first place, and are still in
 - **`btclib-secp256k1` owes the same change**, which is why this cites
   the issue rather than closing it.
 
+### A run coverage's configuration never reached is refused
+
+- **`tests/conftest.py` let a run coverage read no configuration for
+  pass as the gate** (issue btclib-org/.github#443): coverage looks for
+  its configuration in the directory the process started in, so
+  `env -C tests uv run pytest` finds no `fail_under`, no `source` and no
+  `branch = true`, while pytest walks up and reads `pyproject.toml` all
+  the same. That asymmetry is what the hook keys on, rather than the
+  floor's own value, which `pyproject.toml` is the one place for; what
+  it raises is `pytest.UsageError`, which pytest prints without a
+  traceback and exits 4 for, so the exit code says the run measured
+  nothing rather than that something in the tree failed.
+- **The message names the root as the remedy, and `--cov-config` as one
+  that restores the floor and not the file set.** coverage keeps an
+  `omit` pattern that does not open with a wildcard and adds beside it
+  the form it makes absolute against the directory the run started in,
+  so `tests/integration/*` from `tests/` names an integration directory
+  under `tests/tests` and matches nothing. The files under
+  `tests/integration/` are then measured rather than omitted, and those
+  tests skip themselves without `BTCLIB_INTEGRATION`, so what the report
+  gains is the switch rather than a defect -- which is what that `omit`
+  entry's comment in `pyproject.toml` says it is there to keep out.
+  `source` is not what carries this tree: `btclib` is an import name
+  from either directory, and `tests` is a directory at the root and an
+  import name from `tests/` that reaches the same files.
+- **Section 8 of the organization standard leaves a tree to point such a
+  run at its configuration or to make it say it is ungated, and this is
+  the second of the two.** A sentence in `CONTRIBUTING.md` telling a
+  reader to start from the root is the rejected alternative, on the
+  defect being that a plausible spelling switches the floor off in
+  silence: what the sentence buys is a silent failure somebody had been
+  told about.
+- **Left alone are `--no-cov`, `--help`, `--collect-only` and an
+  explicit `--cov-fail-under`, none of them a run held to a floor it
+  cannot see.** `--markers` and `--fixtures` from `tests/` are refused
+  with the rest, that exemption being an enumeration rather than every
+  run pytest-cov leaves ungated. `test.yml` meets the guard from the
+  root either way: its `no-bindings` job names `--cov-fail-under=0`, and
+  `coverage-union` runs `coverage report` and no pytest at all.
+- **`btclib-node`, `bitcoin-core-rpc` and `btclib-benchmarks` are owed
+  the same guard**, btclib-org/.github#443 having taken that decision for
+  the family, and `btclib-secp256k1` landed it at `bd71d7c8`. What lands
+  with the last of them is the sentence recording which limb of section
+  8 the family took, which is why this cites the issue rather than
+  closing it.
+
 ## v2026.9.13
 
 ### `ecc.rangeproof.sign` writes the rangeproof of a blinded value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,14 @@
 Registered once here rather than passed to each `@given`: a settings
 profile is process-wide, and a decorator repeating it on every property
 test is one more place to forget it.
+
+The gate is `coverage_fail_under` and the guard on it. coverage looks
+for its configuration in the directory the process started in, so a run
+started from `tests/` finds no `fail_under`, no `source` and no
+`branch = true`. Section 8 of the organization standard leaves a tree to
+point such a run at its configuration or to make it say it is ungated,
+and this file is the second of the two: such a run is refused
+(btclib-org/.github#443).
 """
 
 import difflib
@@ -14,7 +22,7 @@ import json
 import os
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 import pytest
 from hypothesis import settings
@@ -171,6 +179,86 @@ def coverage_fail_under(
     return configured
 
 
+class CoverageConfiguration(Protocol):
+    """What this file reads of coverage's own configuration object.
+
+    `config_file` is the file coverage took its settings from, and
+    `None` where it took them from none: coverage sets it as it reads
+    one, so the attribute is the run's own answer to whether the
+    configuration reached it, rather than an inference from a value
+    that reached it.
+    """
+
+    config_file: str | None
+
+
+def coverage_configuration(config: pytest.Config) -> CoverageConfiguration | None:
+    """Return the configuration coverage is measuring with, or `None`.
+
+    `None` is the two ways there is nothing to ask about: `--no-cov`,
+    where pytest-cov registers its plugin and returns from `__init__`
+    with the controller left unbuilt, and a run whose plugin was never
+    registered, where `getplugin` hands back `None` -- the same
+    `getattr` default answers for both.
+    """
+    plugin = config.pluginmanager.getplugin("_cov")
+    controller = getattr(plugin, "cov_controller", None)
+    if controller is None:
+        return None
+    # annotated because the plugin manager hands back `Any`, and a
+    # return of that is what mypy's strict mode refuses here
+    measuring: CoverageConfiguration = controller.cov.config
+    return measuring
+
+
+def configuration_went_unread(
+    cov_config: CoverageConfiguration | None,
+    inipath: Path | None,
+    asked: float | None,
+    asked_for_help: bool,
+    collect_only: bool,
+) -> bool:
+    """Return whether a run held to the floor cannot see one.
+
+    A guard and not a sentence in CONTRIBUTING.md. What it catches is a
+    plausible spelling switching the floor off, and a reader told to
+    start from the root is not the run that does not: the sentence
+    leaves the same failure, with somebody having been told about it.
+
+    What it compares is not the threshold. pyproject.toml is the one
+    place the number lives, and a `== 100` here would be the second, so
+    what decides is whether coverage read a file at all against whether
+    pytest read one -- the asymmetry the defect leaves behind, pytest
+    walking up from where it was invoked to find its configuration and
+    coverage looking only where the process started.
+
+    The arguments are plain values rather than `config.option` itself,
+    as `coverage_fail_under` above takes them: reading the run is the
+    hook's, and what is decided here is decided from what it read.
+    """
+    if cov_config is None:
+        return False
+    if asked is not None:
+        # section 8 of the organization standard has the hook never
+        # overruling an explicit `--cov-fail-under`, and a caller who
+        # named the floor has not had one taken away in silence
+        return False
+    if asked_for_help or collect_only:
+        # neither run is held to a floor to begin with: `--help` exits
+        # before a session, and pytest-cov never fails a
+        # `--collect-only` run on the floor whatever its report prints.
+        # The pair is an enumeration rather than every run pytest-cov
+        # leaves ungated, and `--markers` and `--fixtures` are refused
+        # knowingly. Widening it is the rejected alternative: what
+        # would decide the question is whether pytest-cov would have
+        # gated this run, which is no property to read here, so a
+        # longer list is the same guess under more names
+        return False
+    # `inipath` is what the message has to name, so a run pytest read no
+    # configuration for is one this cannot tell anybody anything about
+    return cov_config.config_file is None and inipath is not None
+
+
 def pytest_configure(config: pytest.Config) -> None:
     """Gate a whole run at `fail_under`, and a partial one at nothing.
 
@@ -180,7 +268,29 @@ def pytest_configure(config: pytest.Config) -> None:
     that copy. Writing to `config.option` instead runs without error and
     changes nothing -- the plugin never reads it back, and the run still
     fails on the whole tree's coverage.
+
+    A run coverage's configuration never reached is refused rather than
+    gated, `pytest.UsageError` being what pytest prints without a
+    traceback and exits `4` for -- an exit of its own, so the code says
+    the run measured nothing rather than that something in the tree
+    failed.
     """
+    if configuration_went_unread(
+        coverage_configuration(config),
+        config.inipath,
+        config.option.cov_fail_under,
+        config.option.help,
+        config.option.collectonly,
+    ):
+        raise pytest.UsageError(
+            "coverage read no configuration, so this run is held to no floor"
+            " and measures a different set of files: coverage looks only in"
+            f" the directory the run started in, {Path.cwd()}, and pytest"
+            f" read {config.inipath}. Run from {config.rootpath};"
+            " --cov-config restores the floor and not the file set, a"
+            " relative omit pattern being resolved against the directory"
+            " the run started in."
+        )
     namespace = config.known_args_namespace
     namespace.cov_fail_under = coverage_fail_under(
         config.option.cov_fail_under,

--- a/tests/conftest_test.py
+++ b/tests/conftest_test.py
@@ -16,17 +16,38 @@ on its own: the run that reaches it with a subset selected is, by
 construction, not the run that measures this file. The position of
 `--cov` in addopts is here for the same reason -- it is a property of
 the command line no run of that command line can report on.
+
+The guard beside it is driven the same way, with one exception: the run
+it refuses cannot be the run reporting on it either, so the case it
+exists for is taken in a subprocess started from `tests/`.
 """
 
+import argparse
+import os
 import re
+import subprocess
+import sys
 from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
 
 import pytest
 
-from tests.conftest import REGENERATE, check_golden, coverage_fail_under
+from tests.conftest import (
+    REGENERATE,
+    CoverageConfiguration,
+    check_golden,
+    configuration_went_unread,
+    coverage_configuration,
+    coverage_fail_under,
+    pytest_configure,
+)
 
 MODULE = "something_test.py"
 _ROOT = Path(__file__).parents[1]
+# what pytest reads its own configuration from here, which the guard
+# compares against what coverage read and the message names
+_INIPATH = _ROOT / "pyproject.toml"
 # what pyproject.toml's `testpaths` holds, passed in rather than read:
 # the cases below are about what a command line means against a given
 # `testpaths`, and reading the real one would make them a test of the
@@ -421,3 +442,295 @@ def test_an_explicit_threshold_survives_either_kind_of_run() -> None:
         )
         == 0
     )
+
+
+def _cov_config(config_file: str | None) -> CoverageConfiguration:
+    """Build what the guard reads of coverage's own configuration.
+
+    One attribute is the whole of it: the file coverage took its
+    settings from, `None` where it took them from none.
+    """
+    return cast("CoverageConfiguration", SimpleNamespace(config_file=config_file))
+
+
+def _controller(config_file: str | None) -> object:
+    """Build the controller pytest-cov leaves on its plugin.
+
+    A stand-in reachable by the attribute path `coverage_configuration`
+    walks, and nothing else of one.
+    """
+    return SimpleNamespace(cov=SimpleNamespace(config=_cov_config(config_file)))
+
+
+def _config(
+    file_or_dir: list[str],
+    known: argparse.Namespace,
+    controller: object | None,
+    **asked: object,
+) -> pytest.Config:
+    """Build what `pytest_configure` reads of a `pytest.Config`.
+
+    Building the real thing means starting a second pytest inside this
+    one, so what the hook reads of one is stood in for instead:
+    `config.option`, the copy pytest-cov holds, `testpaths`, the two
+    paths the message names and the plugin the guard walks to.
+
+    `asked` overrides the command line's own defaults, which are the
+    ones a bare run leaves behind.
+    """
+    bare: dict[str, object] = {
+        "cov_fail_under": None,
+        "keyword": "",
+        "markexpr": "",
+        "deselect": None,
+        "ignore": None,
+        "ignore_glob": None,
+        "lf": False,
+        "help": False,
+        "collectonly": False,
+    }
+    option = argparse.Namespace(file_or_dir=file_or_dir, **(bare | asked))
+    plugin = SimpleNamespace(cov_controller=controller)
+    return cast(
+        "pytest.Config",
+        SimpleNamespace(
+            known_args_namespace=known,
+            option=option,
+            getini=lambda _name: _TESTPATHS,
+            rootpath=_ROOT,
+            inipath=_INIPATH,
+            pluginmanager=SimpleNamespace(getplugin=lambda _name: plugin),
+        ),
+    )
+
+
+def test_a_run_coverage_read_a_configuration_for_is_not_refused() -> None:
+    """The guard is silent where the configuration reached the run.
+
+    The gate itself is this case -- `uv run pytest` from the rootdir,
+    where coverage reads pyproject.toml -- so a guard firing here would
+    refuse the run it exists to protect.
+    """
+    assert not configuration_went_unread(
+        _cov_config(str(_INIPATH)), _INIPATH, None, False, False
+    )
+
+
+def test_a_run_coverage_read_no_configuration_for_is_refused() -> None:
+    """A run held to a floor it cannot see is refused.
+
+    This is the defect the guard is for: coverage looks for its
+    configuration in the directory the process started in, so from
+    `tests/` it finds no `fail_under`, no `source` and no
+    `branch = true`, which leaves the run measuring a different set of
+    files against nothing (btclib-org/.github#443). pytest reads its own
+    configuration all the same, and that asymmetry is what the guard
+    keys on.
+    """
+    assert configuration_went_unread(_cov_config(None), _INIPATH, None, False, False)
+
+
+def test_nothing_measuring_is_not_an_ungated_run() -> None:
+    """`--no-cov` is left alone.
+
+    Section 8 of the organization standard has a platform sentinel pass
+    it, and a run measuring no coverage has no configuration to be
+    missing.
+    """
+    assert not configuration_went_unread(None, _INIPATH, None, False, False)
+
+
+def test_an_explicit_threshold_is_not_overruled_by_the_guard() -> None:
+    """`--cov-fail-under` outranks the guard as it does the threshold.
+
+    The standard has the hook never overruling a caller who named the
+    threshold, and the guard is that same hook: what it exists to catch
+    is a floor going off with nobody having asked, which a named one is
+    not. Zero is a threshold somebody asked for, so it has to survive
+    the `is not None` test rather than be read as falsy.
+    """
+    assert not configuration_went_unread(_cov_config(None), _INIPATH, 0, False, False)
+
+
+@pytest.mark.parametrize(
+    "asked_for_help, collect_only",
+    [(True, False), (False, True)],
+    ids=["--help", "--collect-only"],
+)
+def test_a_run_no_floor_applies_to_is_not_refused(
+    asked_for_help: bool, collect_only: bool
+) -> None:
+    """The two runs pytest-cov never gates are left alone.
+
+    `--help` exits before a session, and pytest-cov never fails a
+    `--collect-only` run on the floor whatever its report prints:
+    `pytest_runtestloop` returns ahead of the comparison that raises the
+    exit code, while `pytest_terminal_summary` prints `Required test
+    coverage` either way. Refusing either would answer a question about
+    a floor neither is held to.
+    """
+    assert not configuration_went_unread(
+        _cov_config(None), _INIPATH, None, asked_for_help, collect_only
+    )
+
+
+def test_without_a_configuration_pytest_read_there_is_nothing_to_name() -> None:
+    """The guard needs pytest's own answer, not only coverage's.
+
+    What the message tells a reader is where the configuration pytest
+    found is, so a run that found none leaves it with nothing to say;
+    and the two tools finding none alike is no asymmetry to report.
+    """
+    assert not configuration_went_unread(_cov_config(None), None, None, False, False)
+
+
+def test_no_pytest_cov_plugin_is_nothing_measuring() -> None:
+    """A run without the plugin registered reads as unmeasured.
+
+    pytest-cov registers its plugin only where a `--cov` reached the
+    parser, from addopts here rather than from a command line, and
+    `getplugin` hands back `None` where none did.
+    """
+    config = cast(
+        "pytest.Config",
+        SimpleNamespace(pluginmanager=SimpleNamespace(getplugin=lambda _name: None)),
+    )
+    assert coverage_configuration(config) is None
+
+
+def test_no_cov_leaves_the_controller_unbuilt() -> None:
+    """The plugin without a controller reads as unmeasured too.
+
+    `--no-cov` returns from `CovPlugin.__init__` before `start()`, so
+    the plugin is registered and its `cov_controller` is still `None`:
+    the same `getattr` default answers for that and for no plugin.
+    """
+    config = _config([], argparse.Namespace(cov_fail_under=0.0), None)
+    assert coverage_configuration(config) is None
+
+
+def test_the_configuration_is_the_controllers_own() -> None:
+    """The attribute path to coverage's configuration is pinned.
+
+    The hook is keyed on a path through pytest-cov it does not own: the
+    plugin under `_cov`, its `cov_controller`, that controller's `cov`
+    and the `config` on it. Renaming either of the first two reads as
+    nothing measuring and leaves the guard silent, which is the
+    direction that fails without saying so; renaming what is below them
+    raises instead.
+    """
+    config = _config(
+        [], argparse.Namespace(cov_fail_under=0.0), _controller("/somewhere/setup.cfg")
+    )
+    measuring = coverage_configuration(config)
+
+    assert measuring is not None
+    assert measuring.config_file == "/somewhere/setup.cfg"
+
+
+def test_the_guards_own_names_are_ones_pytest_fills_in(
+    pytestconfig: pytest.Config,
+) -> None:
+    """`help` and `collectonly` are still pytest's own spellings.
+
+    The hook reads them as attributes rather than with a default, both
+    being pytest's own rather than a plugin's, so a rename is an
+    `AttributeError` in `pytest_configure` and not a silent refusal.
+    This run's own configuration is what says they are still there.
+    """
+    absent = [
+        name
+        for name in ("help", "collectonly")
+        if not hasattr(pytestconfig.option, name)
+    ]
+    assert not absent, f"pytest no longer fills in {absent}"
+
+
+def test_the_hook_refuses_a_run_that_cannot_see_its_floor() -> None:
+    """`pytest_configure` raises, and the message names both paths.
+
+    The function above decides; this is what wires it to a run.
+    `pytest.UsageError` is what pytest prints without a traceback and
+    exits `4` for, so the exit code says the run measured nothing rather
+    than that something in the tree failed. The message carries both
+    paths because the asymmetry is the finding: naming only the
+    directory the run started in would leave a reader to guess which
+    configuration was meant.
+    """
+    known = argparse.Namespace(cov_fail_under=0.0)
+    config = _config([], known, _controller(None))
+
+    with pytest.raises(pytest.UsageError) as raised:
+        pytest_configure(config)
+
+    assert str(_INIPATH) in str(raised.value)
+    assert str(_ROOT) in str(raised.value)
+    # --cov-config is named with what it does not restore and never on
+    # its own: a reader sent to it alone gets a run held to the floor
+    # over a different set of files, which is what this message opens by
+    # naming
+    assert "--cov-config restores the floor and not the file set" in str(raised.value)
+    # the raise is ahead of the write, so the copy pytest-cov reads is
+    # left holding what pytest-cov itself put there
+    assert known.cov_fail_under == 0.0
+
+
+def test_a_selection_does_not_excuse_the_configuration_missing() -> None:
+    """Asking for less is refused the same way.
+
+    A selective run is gated at zero by `coverage_fail_under`, so
+    nothing was taken from it -- but `source` and `branch = true` went
+    unread as well, and its report is a measurement of a different set
+    of files. Iterating on one module from inside `tests/` reads a
+    percentage that is not about this tree, which is what the guard says
+    instead. The decision above cannot see a selection at all; the hook
+    is where one arrives, so this is where that is asserted.
+    """
+    config = _config(
+        ["bip32/bip32_test.py"],
+        argparse.Namespace(cov_fail_under=0.0),
+        _controller(None),
+        keyword="derive",
+    )
+
+    with pytest.raises(pytest.UsageError, match="coverage read no configuration"):
+        pytest_configure(config)
+
+
+def test_a_run_started_from_tests_says_it_is_ungated(tmp_path: Path) -> None:
+    """The guard stops a real run started from `tests/`.
+
+    Everything above is the decision driven as a function; this is the
+    invocation the issue is about, and the only case that says the two
+    are wired together -- that `tests/conftest.py` is loaded at all on
+    such a run, and that what it raises reaches whoever typed it. The
+    run costs no collection: `pytest_configure` is ahead of it, so the
+    subprocess is refused before it imports a test module.
+
+    `COVERAGE_FILE` is redirected because pytest-cov erases the data
+    file it is pointed at as it starts, absent `--cov-append`, which
+    would otherwise destroy the data file of the run reading this.
+    """
+    environment = dict(os.environ)
+    environment.pop("PYTEST_ADDOPTS", None)
+    environment["COVERAGE_FILE"] = str(tmp_path / "coverage-data")
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+
+    completed = subprocess.run(
+        [sys.executable, "-m", "pytest", "-p", "no:cacheprovider"],
+        cwd=_ROOT / "tests",
+        env=environment,
+        capture_output=True,
+        encoding="utf-8",
+        check=False,
+        # as no_bindings_test.py's own child has one: a child that hangs
+        # fails as this test rather than holding an xdist worker until
+        # the job's timeout-minutes, which the report would not name
+        timeout=120,
+    )
+
+    assert completed.returncode == pytest.ExitCode.USAGE_ERROR, completed.stderr
+    # pytest writes a usage error to stderr, where nothing of the run's
+    # own output is, so the assertion is on the stream that carries it
+    assert "coverage read no configuration" in completed.stderr
+    assert str(_ROOT) in completed.stderr


### PR DESCRIPTION
coverage looks for its configuration in the directory the process
started in. Measured in this tree with a plugin printing what
`pytest_configure` can see: from the repository root coverage's
`config.config_file` is this tree's `pyproject.toml`, `fail_under` is
100.0, `branch` is true, `source` is `["btclib", "tests"]` and `omit` is
`["*/site-packages/*", "tests/integration/*"]`; from `tests/`
`config_file` is `None`, `fail_under` 0.0, `branch` `False`, `source`
`None` and `omit` empty, while pytest's own `inifile` and `rootdir` are
this tree's either way. That asymmetry is the discriminator, and it
needs no copy of the floor's number.

`tests/conftest.py` refuses such a run with `pytest.UsageError`, whose
message names the directory the run started in, the configuration pytest
read, the root to run from, and what `--cov-config` does not restore.
Measured from `tests/`: exit 4, no traceback, the hook running ahead of
collection.

`--cov-config` is named with that caveat rather than left out, because a
reader not told about it finds it anyway and finds it working. What it
does not restore here is the `omit`: coverage keeps a pattern that does
not open with a wildcard and adds beside it the form it makes absolute
against the process's own cwd (`prep_patterns` in `coverage/files.py`),
so `tests/integration/*` from `tests/` names an integration directory
under `tests/tests` and matches nothing. What `tests/integration/` holds
is then measured rather than omitted, and those tests skip themselves
without `BTCLIB_INTEGRATION`, so the report is a measurement of a
different set of files held to the floor -- measured as the same suite
run both ways at this sha, passing from the root and ending in `FAIL
Required test coverage of 100.0% not reached` from `tests/`. `source` is
not what carries this tree: `btclib` is an import name from either
directory, this tree being src-layout, and `tests` is a directory at the
root and an import name from `tests/` that reaches the same files.

Left alone, each measured from `tests/` at exit 0: `--no-cov`, where
pytest-cov returns from `CovPlugin.__init__` with the controller
unbuilt; `--help`, which exits before a session; `--collect-only`, which
pytest-cov never fails on the floor whatever its report prints, its
`pytest_runtestloop` returning ahead of the comparison that raises the
exit code while `pytest_terminal_summary` prints `Required test
coverage` regardless; and an explicit `--cov-fail-under`, which section
8 has the hook never overruling. Every run started from the root reads
the configuration, so a selective one there is untouched, and so are
`test.yml`'s own two: the `no-bindings` job starts from the root and
names `--cov-fail-under=0`, and `coverage-union` runs `coverage report`
rather than pytest. `--markers` and `--fixtures` from `tests/` are
refused knowingly, measured at exit 4: a longer exemption list is the
same guess under more names, nothing at this hook saying whether
pytest-cov would have gated a run.

`tests/conftest_test.py` drives the decision as a function, taking plain
values as `coverage_fail_under` beside it does rather than a namespace,
and takes the case the issue is about in a subprocess started from
`tests/` -- the run that is refused cannot be the run reporting on it.

The review re-took both tree-dependent measurements rather than accepting them.
`prep_patterns`/`GlobMatcher` driven directly from each directory: from the root
the prepped `omit` matches all six files under `tests/integration/`; from
`tests/` the absolute form becomes `<root>/tests/tests/integration/*` and
matches none. The 322-statement delta re-derives file by file, and two real
`--collect-only` runs differ by exactly the five non-empty integration files and
nothing the other way, with a planted one-line control proving the comparison
can see a difference.

It also read pytest-cov 7.1.0 in the installed package rather than reasoning
about it: `pytest_runtestloop` returns at `plugin.py:371` on `collectonly`,
ahead of `should_fail_under`, while `pytest_terminal_summary` prints the
`Required test coverage` line at `:411-421` with no `collectonly` term. So the
docstring's claim is the accurate one and not the plausible one.

Answers [ISS 443](https://github.com/btclib-org/.github/issues/443) for this
tree; the issue stays open for `btclib-node`, `bitcoin-core-rpc` and
`btclib-benchmarks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGRFSkPFh8PR4Y3Wr47vb

## Summary by Sourcery

Reject coverage runs that cannot see the project configuration instead of allowing them to pass with silently altered coverage behavior.

Bug Fixes:
- Refuse coverage runs started outside the project root when coverage cannot read the project configuration, preventing silent execution with an unintended coverage scope and threshold.

Enhancements:
- Preserve explicit thresholds and non-gated invocations such as --no-cov, --help, and --collect-only while reporting actionable guidance for invalid working-directory runs.

Documentation:
- Document the coverage configuration guard, its remediation, and the related organization-standard decision in the changelog.

Tests:
- Add unit and subprocess coverage for configuration detection, exemptions, error messaging, and runs started from the tests directory.