### PR TITLE
`CONTRIBUTING.md` matches the docs gate it describes, and its worked example names a heading that exists (closes #2044, closes #2052)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,24 @@ documented at release-notes length in the first place, and are still in
   8 the family took, which is why this cites the issue rather than
   closing it.
 
+### A root-file link's dead target warns, then falls back to an anchor
+
+- **The docs gate's second step is documented as a second defense, not
+  the only one** (closes #2044). `CONTRIBUTING.md` said MyST emits an
+  anchor on the page it is already on "rather than a warning" for a
+  root-file link it cannot resolve; `MystReferenceResolver` warns
+  unconditionally before that fallback, which is what `-n -W` already
+  fails the build on, and the grep instead guards the fallback node
+  against a regression: `conf.py`'s `suppress_warnings` staying empty,
+  or a myst-parser upgrade no longer warning unconditionally.
+
+### `CONTRIBUTING.md`'s breaking-changes example names a released heading
+
+- **The worked example pointed at `` `v2026.9` ``, a heading that never
+  carried a long breaking-changes list and stops existing at every
+  release** (closes #2052). It now names `` `v2026.8.7` ``, a released
+  heading whose list is long and does not move.
+
 ## v2026.9.13
 
 ### `ecc.rangeproof.sign` writes the rangeproof of a blinded value

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1108,11 +1108,15 @@ grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'
 A link between the root markdown files — `./SECURITY.md` in README.md, the
 spelling GitHub and PyPI need and the one lychee checks — is
 one sphinx cannot resolve on its own, and what MyST emits for a target it
-cannot resolve is an anchor on the page it is already on rather than a
-warning. `docs/source/conf.py` resolves those links and suppresses no
+cannot resolve is a warning, before falling back to an anchor on the page it
+is already on. `docs/source/conf.py` resolves those links and suppresses no
 `myst.xref_missing`, so `-W` fails on the next one that has no target; the
-grep asks the same question of the HTML, where no suppression can hide the
-answer.
+grep asks the same question of the HTML.
+
+The grep is a second defense rather than the only one: `conf.py`'s
+`suppress_warnings` staying empty is a configuration it does not depend on,
+and a myst-parser upgrade could stop warning unconditionally the way the
+pinned one does.
 
 The pattern matches `#../` as well as `#./` because a link to another file
 here begins one of those two ways and no other: `.pre-commit-config.yaml`'s
@@ -1158,7 +1162,7 @@ found six to change, not a trade-off to price. What the measurement is
 for is knowing the blast radius and writing RELEASE_NOTES.md's
 breaking-changes entry, which is how a user is told: read
 [RELEASE_NOTES.md](./RELEASE_NOTES.md) for what that entry looks like,
-and note that `v2026.9`'s list is long on purpose.
+and note that `v2026.8.7`'s list is long on purpose.
 
 The one thing this does not license is a break nobody can act on. An
 entry says the old spelling, the new one, and what a caller does about


### PR DESCRIPTION
Two sentences in `CONTRIBUTING.md`'s *This repository in particular* — this
tree's own half of the file, so neither repair ports anywhere.

Closes #2044
Closes #2052

## What changed

**The docs-gate paragraph said the build is silent where it is loud.** It
claimed that what MyST emits for a target it cannot resolve is an anchor
"rather than a warning" — and then said, one sentence later, that `-W` fails
on the next link with no target. `.github/workflows/docs.yml` had already
recorded the measured account in the opposite direction. The paragraph now
says what the workflow says: the build warns and fails, and the anchor grep
is the **second** defence, against the warning ever stopping — which is the
reason that survives without depending on the build being silent.

**The breaking-changes worked example pointed at a heading that does not
exist.** `` `v2026.9` ``'s section became `v2026.9.13`'s at the release, and
the placeholder above it is now `v2026.10`, so the one worked example the
section offers sent a contributor to a heading `RELEASE_NOTES.md` does not
have. It now names `` `v2026.8.7` ``, which is released, immutable, and
whose breaking-changes list is in fact long. A released heading is what does
not move; the open cycle's own heading is renamed at every release, which is
how the pointer broke.

No count is stated in either repair.

## Evidence

Local review: **CLEARED `f8b1b0d09699a166b510cc47d6e6fe07ef50a3d3`**, at
fresh context, re-verified after the commit-message amend against a
byte-identical tree (`8211cd4ec7068fe36a907b1f6dd437ac4dbb5fb5` at both
shas, and `git diff da3e0d15 <old>` byte-identical to `git diff da3e0d15
<new>`).

Gates, the coder's runs on this tree, as one block under the shared lock:

| gate | exit |
| --- | --- |
| `uv run --locked --only-group lint pre-commit run --all-files --show-diff-on-failure` | 0 |
| `uv run --locked pytest` — `32622 passed, 78 skipped`, `TOTAL 100.00%` | 0 |
| `uv run --locked --no-default-groups --group docs sphinx-build -n -W -b html docs/source docs/build/html` | 0 |
| `grep -rnE 'href="#\.\.?/' docs/build/html --include='*.html'` | 1 (pass) |

The suite's `32608 → 32622` move is `btclib-org/.github#443`'s own tests
arriving in `da3e0d15`, not this branch: the reviewer counted 12 unparametrized
plus one parametrize of two cases in `tests/conftest_test.py`, which is the
`+14`.

The reviewer re-derived ISS 2044's mechanism from the pinned toolchain rather
than from the reproduction: `myst_parser` 5.1.0's `myst_refs.py` logs
`XREF_MISSING` before building the fallback anchor node, and its early return
is reachable only through a `nitpick_ignore` entry of the form
`("myst", target)` — nothing about `-n` reaches it, and `suppress_warnings` is
absent from `conf.py`.

The docs gate was then confirmed to *cover* this branch's file rather than
merely to pass: a dead relative link planted in `CONTRIBUTING.md`, against the
worktree's existing doctree cache, gave `updating environment: 0 added, 1
changed, 0 removed` and exit 1 naming `CONTRIBUTING.md:1614` — so the
`{include}` shim's dependency is tracked and a change here is always re-read.
The file was then restored to byte identity with the commit and the build
returned `build succeeded`.

The merge was measured with the union driver taken out of the way, which is
the only local read that answers what the forge's own merge will do:
`git -c merge.union.driver=false merge-tree origin/main <branch>` exits 0.

`main` was green at `da3e0d15` on all eight push jobs before this landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3

## Summary by Sourcery

Align contributor documentation with the actual docs-link validation behavior and replace its broken release-notes example with a stable released heading.

Bug Fixes:
- Correct the documentation of the Sphinx/MyST docs gate to accurately describe unresolved root-file links as warnings that fail the build, with HTML anchor checking as a secondary safeguard.
- Update the breaking-changes example to reference the existing released `v2026.8.7` heading.

Documentation:
- Document the docs gate behavior and use a stable released heading in `CONTRIBUTING.md`.
- Record the documentation corrections in `CHANGELOG.md`.