### PR TITLE
Three operation-count comments in curves/ state a relation or a command instead (closes #2041)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,38 @@ documented at release-notes length in the first place, and are still in
   the issue rather than closing it: the `BACKLOG` row keyed on it lives
   in `btclib-org/.github` and is that tree's to narrow.
 
+### Three operation-count comments in `curves/` state a relation or a command instead
+
+- **`curve_group.py`'s tangent-law comment states the relation the
+  argument needs instead of a doubling count**: the spelling is decided
+  in `CurveGroup.__init__` rather than inside `_double_jac_helper`,
+  which every Jacobian doubling reaches -- `double_jac`'s own, and
+  `add_jac`'s and `add_jac_aff`'s when the two points they are given
+  coincide -- which holds at any window width and needs nothing kept in
+  step with one.
+- **`_double_mult_regular_window`'s docstring states its 143 additions
+  and 254 doublings at a stated `w` and `scalar_len`, counted by the
+  `_CountingGroup` instrument `curve_group.py`'s own regular-window
+  figure already cites**, rather than "over 200 random pairs" with no
+  seed; `_CountingGroup`'s own docstring now runs the function and
+  prints the pair. `_double_mult_w_NAF_var`'s range beside it is gone
+  instead of corrected: the docstring's own 101 to 116 carried no seed
+  at all, and re-deriving over the issue's own stated seed
+  (`random.Random(0x2040)`) independently, twice, answered two
+  different pairs of endpoints -- 99 to 117 in the issue, 99 to 116
+  here. A seed does not pin "200 random pairs" on its own, so the
+  endpoints are a property of the script rather than of the function,
+  and what the comparison needs is the relation already beside it: that
+  the wNAF's additions follow the recoded weight of the two coefficients
+  rather than being constant, and that is what stays.
+- **`_additions_by_position`'s docstring stops pricing the pre-issue-906
+  loop it no longer runs.** 512 is the GLV split's own nominal width
+  (four halves of 128 positions) and stands as that rather than as a
+  count the loop made; the 79 answered and 433 not were a property of the
+  coefficients that loop happened to be timed against, not re-derivable
+  without reconstructing code this tree deleted, and CHANGELOG.md's own
+  entry for issue #906 already has them (closes #2041).
+
 ## v2026.9.13
 
 ### `ecc.rangeproof.sign` writes the rangeproof of a blinded value

--- a/src/btclib/curves/curve_group.py
+++ b/src/btclib/curves/curve_group.py
@@ -176,10 +176,12 @@ class CurveGroup:
         self._b = b
         # which spelling of the tangent law _double_jac_helper runs. The
         # curve decides it and a curve does not change, so it is decided
-        # here rather than by a test inside the function a multiplication
-        # calls 253 times: the a*Z^4 term is zero for the k1 family, and
-        # for the a == p - 3 of most catalogued curves it is a difference
-        # of two squares that costs one product instead of three
+        # here rather than by a test inside the function every Jacobian
+        # doubling reaches -- double_jac's own, and add_jac's and
+        # add_jac_aff's when the two points they are given coincide -- the
+        # a*Z^4 term being zero for the k1 family, and the tangent
+        # numerator a difference of two squares for the a == p - 3 of most
+        # catalogued curves, costing one product instead of three
         self._a_is_zero = a == 0
         self._a_is_minus_3 = a == p - 3
         # what add_jac feeds its formula in place of an operand at
@@ -1526,11 +1528,12 @@ def _additions_by_position(
     digit there names -- negated where the digit is, a signed digit naming a
     point and its opposite. What it replaces is every wNAF being asked for a
     digit at every position: a wNAF has one nonzero digit in w+1, so a
-    secp256k1 double multiplication asked 512 questions -- 128 positions
-    over the four halves the GLV split makes -- and answered 79 of them with
-    an addition. The 433 that answered nothing were a `zip` step, a
-    comparison against a `len` recomputed per iteration, and an index that
-    found a zero (issue 906).
+    secp256k1 double multiplication asked a question at every position of all
+    four halves the GLV split makes -- 512 at the split's nominal 128 a half --
+    and most of them were answered by a `zip` step, a comparison against a
+    `len` recomputed per iteration, and an index that found a zero, rather than
+    by an addition (issue 906). CHANGELOG.md has how many of the 512 answered
+    which way, this being a docstring about a loop no longer here.
 
     Read this way round the digits are walked once, where each one was read
     at the position it belongs to and skipped at every other, and the loop
@@ -1549,8 +1552,8 @@ def _additions_by_position(
 
     The gain is CPython's: the loop control this removes is what a tracing
     JIT flattens on its own, and under PyPy the two spellings measure the
-    same. CHANGELOG.md has the figures, this being a docstring and they
-    being about code that is no longer here.
+    same. CHANGELOG.md has the CPython and PyPy figures, this being a
+    docstring and they being about code that is no longer here.
     """
     at_position: list[list[Point]] = [[] for _ in range(max(len(naf) for naf in nafs))]
     for naf, T in zip(nafs, tables, strict=True):

--- a/src/btclib/curves/curve_group_2.py
+++ b/src/btclib/curves/curve_group_2.py
@@ -353,10 +353,12 @@ def _double_mult_regular_window(
     table of signed odd multiples per coefficient, and a loop of w
     doublings and two additions per window, both of them made whatever the
     digits are. So the cost is the same for every pair (u, v) of a given
-    scalar_len -- 143 additions and 254 doublings on secp256k1, over 200
-    random pairs -- where _double_mult_w_NAF_var's is the recoded weight of the
-    two coefficients and is 101 to 116 additions over the same pairs, and
-    this function costs about a tenth less overall.
+    scalar_len -- 143 additions and 254 doublings on secp256k1 at w=4 and
+    scalar_len=256, counted by the `_CountingGroup` of
+    tests/curves/curve_group_test.py, whose docstring carries the command
+    for this function and not for the wNAF one -- where
+    _double_mult_w_NAF_var's cost follows the recoded weight of the two
+    coefficients instead and varies with the pair.
 
     Which is _mult_regular_window's trade, twice: a table of 2^(w-1) points
     per coefficient, and their opposites, to make one addition per window

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -435,19 +435,25 @@ class _CountingGroup(CurveGroup):
     operations directly instead.
 
     The docstrings that name this class -- `_mult_regular_window` in
-    `curve_group` and `_mult_endomorphism_secp256k1_var` in
-    `curve_group_2` -- state figures taken here, at the scalar_len set
-    below:
+    `curve_group`, and `_double_mult_regular_window` and
+    `_mult_endomorphism_secp256k1_var` in `curve_group_2` -- state figures
+    taken here, at the scalar_len set below:
 
         uv run python -c "
         from btclib.curves import secp256k1
         from btclib.curves.curve_group import _mult_regular_window
-        from btclib.curves.curve_group_2 import _mult_endomorphism_secp256k1
+        from btclib.curves.curve_group_2 import (
+            _double_mult_regular_window, _mult_endomorphism_secp256k1)
         from tests.curves.curve_group_test import _CountingGroup
         for mult in (_mult_regular_window, _mult_endomorphism_secp256k1):
             ec = _CountingGroup()
             mult(secp256k1.n - 1, secp256k1.GJ, ec, 4)
-            print(mult.__name__, ec.additions, ec.doublings)"
+            print(mult.__name__, ec.additions, ec.doublings)
+        ec = _CountingGroup()
+        _double_mult_regular_window(
+            secp256k1.n - 1, secp256k1.GJ, secp256k1.n - 2, secp256k1.GJ,
+            ec, w=4, scalar_len=ec.scalar_len)
+        print('_double_mult_regular_window', ec.additions, ec.doublings)"
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
closes #2041

Three operation-count comments in `curves/` stated numbers nothing could
re-derive. Each is now a relation, or a figure with the command that
re-derives it beside it.

- **`curve_group.py`'s tangent-law comment** stated a doubling count tied
  to one window width. It now states the relation the argument needs:
  `_double_jac_helper` is reached by every **Jacobian** doubling —
  `double_jac`'s own, and `add_jac`'s and `add_jac_aff`'s where the two
  points they are given coincide — which holds at any window width. The
  quantifier is scoped to the Jacobian arm because `double_aff_var`
  spells the tangent law itself and reaches neither flag.
- **`_double_mult_regular_window`'s docstring** keeps its 143 additions
  and 254 doublings, now at a stated `w` and `scalar_len` and attributed
  to the `_CountingGroup` of `tests/curves/curve_group_test.py`, whose
  own docstring runs the function and prints the pair.
  `_double_mult_w_NAF_var`'s `101 to 116` range beside it is withdrawn
  rather than re-seeded: it carried no seed, and re-deriving over the
  issue's own stated seed answered different endpoints each time, so the
  endpoints are a property of the script rather than of the function.
- **`_additions_by_position`'s docstring** stops pricing the
  pre-issue-906 loop this tree no longer runs. The 512 stays, named as
  the GLV split's nominal width rather than as a count the loop made;
  the 79 answered and 433 not point at `CHANGELOG.md`'s own entry for
  that issue.

## Review

Five local rounds. Rounds four and five were spent on prose written to
replace what earlier findings removed, not on the original change:

- an over-general quantifier (`every doubling`, false of the affine arm)
- a ratio, `about a tenth less overall`, with no sample and no command —
  measured at 7.6% by operation count, and contradicted by a landed
  sentence in the same file stating `the faster of the two, by 16%` with
  its own sample. Withdrawn rather than restated.
- `a recoding running a digit either way`, false by an order of
  magnitude: 8000 measured GLV halves recode to between 110 and 129
  digits. Withdrawn, and deliberately not replaced by `496 to 516`,
  which nothing in the tree re-derives.

## Gates

Whole documented block, in order, under a shared lock, at `fe93928c`:
`pre-commit` 0, `pytest` 0 (`32622 passed, 78 skipped`, coverage
`100.00%`, floor reached), `sphinx-build -n -W` 0 (`build succeeded`),
root-file anchor grep exit 1 = pass, its pattern proved against a
planted control. Run independently by the reviewer at the same sha, and
by me.

The `CHANGELOG.md` union-driver seam detector answers 0 on the tip and 0
on the base, against 1 on the fused tip tagged during an earlier rebase
as the positive control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn2BerFVJcUtGF8Dm1Amd3
